### PR TITLE
docs: update all repository URLs from SysManager to SystemManager

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
         Thanks for taking the time to report a bug!
 
         Before you open this, please search the
-        [existing issues](https://github.com/laurentiu021/SysManager/issues?q=is%3Aissue)
+        [existing issues](https://github.com/laurentiu021/SystemManager/issues?q=is%3Aissue)
         to avoid duplicates. If you found a similar one, add details there instead.
 
         **Never include passwords, tokens, or personal data in screenshots or logs.**

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question / general discussion
-    url: https://github.com/laurentiu021/SysManager/discussions
+    url: https://github.com/laurentiu021/SystemManager/discussions
     about: For how-to questions, help setting things up, or open-ended discussion.
   - name: Report a security vulnerability
-    url: https://github.com/laurentiu021/SysManager/security/advisories/new
+    url: https://github.com/laurentiu021/SystemManager/security/advisories/new
     about: Please report security issues privately, not as a public issue. See SECURITY.md for details.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,7 @@ body:
         Thanks for thinking about how to improve SysManager!
 
         Before you open this, please search the
-        [existing issues](https://github.com/laurentiu021/SysManager/issues?q=is%3Aissue)
+        [existing issues](https://github.com/laurentiu021/SystemManager/issues?q=is%3Aissue)
         to avoid duplicates. Small, focused suggestions land faster than
         large open-ended ones.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -148,7 +148,7 @@ retained). The in-app Console mirrors the same stream per tab.
 
 ## Updates
 
-`UpdateService` hits `api.github.com/repos/laurentiu021/SysManager/releases`
+`UpdateService` hits `api.github.com/repos/laurentiu021/SystemManager/releases`
 at startup and on demand. Downloads land in
 `%LOCALAPPDATA%\SysManager\updates\SysManager-{version}.exe` with size
 checksum so re-opening the app doesn't re-download a good copy. The "Install"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ follows, and what to expect when you open a pull request.
   spec for this project.
 - 📚 **Improve docs** — typos, clearer wording, fresh screenshots, better
   examples. Doc-only PRs are merged fast.
-- 🛠 **Fix a bug or implement a feature** — see [open issues](https://github.com/laurentiu021/SysManager/issues).
+- 🛠 **Fix a bug or implement a feature** — see [open issues](https://github.com/laurentiu021/SystemManager/issues).
   Please comment on the issue before starting significant work so we
   don't both build the same thing.
 
@@ -47,7 +47,7 @@ follows, and what to expect when you open a pull request.
 **Clone and build**
 
 ```powershell
-git clone https://github.com/laurentiu021/SysManager.git
+git clone https://github.com/laurentiu021/SystemManager.git
 cd SysManager
 dotnet build -c Debug
 ```

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ battery health, process management with built-in descriptions, startup
 control, shortcut cleanup, app blocking, install alerts, and a friendly
 Event Log viewer — all in one WPF desktop app.
 
-[![CI](https://github.com/laurentiu021/SysManager/actions/workflows/ci.yml/badge.svg)](https://github.com/laurentiu021/SysManager/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/laurentiu021/SysManager/branch/main/graph/badge.svg)](https://codecov.io/gh/laurentiu021/SysManager)
-[![Release](https://img.shields.io/github/v/release/laurentiu021/SysManager?display_name=tag&sort=semver)](https://github.com/laurentiu021/SysManager/releases/latest)
-[![Downloads](https://img.shields.io/github/downloads/laurentiu021/SysManager/total)](https://github.com/laurentiu021/SysManager/releases)
-[![Issues](https://img.shields.io/github/issues/laurentiu021/SysManager)](https://github.com/laurentiu021/SysManager/issues)
+[![CI](https://github.com/laurentiu021/SystemManager/actions/workflows/ci.yml/badge.svg)](https://github.com/laurentiu021/SystemManager/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/laurentiu021/SystemManager/branch/main/graph/badge.svg)](https://codecov.io/gh/laurentiu021/SystemManager)
+[![Release](https://img.shields.io/github/v/release/laurentiu021/SystemManager?display_name=tag&sort=semver)](https://github.com/laurentiu021/SystemManager/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/laurentiu021/SystemManager/total)](https://github.com/laurentiu021/SystemManager/releases)
+[![Issues](https://img.shields.io/github/issues/laurentiu021/SystemManager)](https://github.com/laurentiu021/SystemManager/issues)
 ![Platform](https://img.shields.io/badge/platform-Windows%2010%2B-blue)
 ![.NET](https://img.shields.io/badge/.NET-8.0-512BD4)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
@@ -334,7 +334,7 @@ long-running operation, so you always know which tab is working.
 
 ## Download
 
-Grab `SysManager.exe` from the [latest release](https://github.com/laurentiu021/SysManager/releases/latest)
+Grab `SysManager.exe` from the [latest release](https://github.com/laurentiu021/SystemManager/releases/latest)
 and double-click it. The executable is self-contained — no installer, no .NET
 runtime required.
 
@@ -356,7 +356,7 @@ recommended mitigation — see [SECURITY.md](SECURITY.md) for details.
 Prerequisites: Windows 10 or newer and the [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0).
 
 ```powershell
-git clone https://github.com/laurentiu021/SysManager.git
+git clone https://github.com/laurentiu021/SystemManager.git
 cd SysManager
 dotnet run --project SysManager/SysManager/SysManager.csproj
 ```
@@ -403,15 +403,15 @@ Windows 10 / 11 x64 machine.
 
 Found something broken? Missing a feature you'd love to have?
 
-- 🐛 **Bugs** — [open an issue](https://github.com/laurentiu021/SysManager/issues/new?template=bug_report.yml)
+- 🐛 **Bugs** — [open an issue](https://github.com/laurentiu021/SystemManager/issues/new?template=bug_report.yml)
   using the bug report template.
-- 💡 **Features** — [open an issue](https://github.com/laurentiu021/SysManager/issues/new?template=feature_request.yml)
+- 💡 **Features** — [open an issue](https://github.com/laurentiu021/SystemManager/issues/new?template=feature_request.yml)
   using the feature request template.
 - 💬 **Questions and how-to's** — use
-  [Discussions](https://github.com/laurentiu021/SysManager/discussions) instead
+  [Discussions](https://github.com/laurentiu021/SystemManager/discussions) instead
   of issues for anything open-ended.
 - 🔒 **Security vulnerabilities** — please report privately via the
-  [Security tab](https://github.com/laurentiu021/SysManager/security/advisories/new).
+  [Security tab](https://github.com/laurentiu021/SystemManager/security/advisories/new).
   See [SECURITY.md](SECURITY.md) for the full policy.
 
 The **About** tab inside the app has a "Copy environment info" helper that

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ available.
 Instead, use one of these private channels:
 
 1. **GitHub private vulnerability reporting** (preferred) —
-   go to the [Security tab](https://github.com/laurentiu021/SysManager/security)
+   go to the [Security tab](https://github.com/laurentiu021/SystemManager/security)
    of this repo and click **"Report a vulnerability"**. Only the maintainer
    sees the report.
 2. **Email** the maintainer at the address on the

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -7,10 +7,10 @@ useful. Here's where to go depending on what you need.
 
 | Kind of question                                    | Go here                                                               |
 | --------------------------------------------------- | --------------------------------------------------------------------- |
-| "How do I...?" / "Is this possible?"                | [Discussions › Q&A](https://github.com/laurentiu021/SysManager/discussions) |
-| "This feature would be useful"                      | [Feature request issue](https://github.com/laurentiu021/SysManager/issues/new?template=feature_request.yml) |
-| "Something is broken"                               | [Bug report issue](https://github.com/laurentiu021/SysManager/issues/new?template=bug_report.yml) |
-| "I found a security problem"                        | [Security Advisory](https://github.com/laurentiu021/SysManager/security/advisories/new) (private) · see [SECURITY.md](SECURITY.md) |
+| "How do I...?" / "Is this possible?"                | [Discussions › Q&A](https://github.com/laurentiu021/SystemManager/discussions) |
+| "This feature would be useful"                      | [Feature request issue](https://github.com/laurentiu021/SystemManager/issues/new?template=feature_request.yml) |
+| "Something is broken"                               | [Bug report issue](https://github.com/laurentiu021/SystemManager/issues/new?template=bug_report.yml) |
+| "I found a security problem"                        | [Security Advisory](https://github.com/laurentiu021/SystemManager/security/advisories/new) (private) · see [SECURITY.md](SECURITY.md) |
 | "I want to contribute code or docs"                 | [CONTRIBUTING.md](CONTRIBUTING.md) |
 
 ## Before you open an issue
@@ -18,7 +18,7 @@ useful. Here's where to go depending on what you need.
 A few quick things that make bug reports land faster:
 
 1. **Check the latest release** — visit
-   [Releases](https://github.com/laurentiu021/SysManager/releases/latest)
+   [Releases](https://github.com/laurentiu021/SystemManager/releases/latest)
    and make sure you're on the newest build. Many reports turn out to be
    fixed already.
 2. **Search existing issues** — same topic may already be open or closed.

--- a/SysManager/SysManager.IntegrationTests/AboutViewUiTests.cs
+++ b/SysManager/SysManager.IntegrationTests/AboutViewUiTests.cs
@@ -1,5 +1,5 @@
 // SysManager · AboutViewUiTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows;

--- a/SysManager/SysManager.IntegrationTests/AdminElevationVmTests.cs
+++ b/SysManager/SysManager.IntegrationTests/AdminElevationVmTests.cs
@@ -1,5 +1,5 @@
 // SysManager · AdminElevationVmTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.IntegrationTests/AllViewModelsSweepTests.cs
+++ b/SysManager/SysManager.IntegrationTests/AllViewModelsSweepTests.cs
@@ -1,5 +1,5 @@
 // SysManager · AllViewModelsSweepTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.IntegrationTests/CleanupCategoryTests.cs
+++ b/SysManager/SysManager.IntegrationTests/CleanupCategoryTests.cs
@@ -1,5 +1,5 @@
 // SysManager · CleanupCategoryTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.IntegrationTests/CleanupViewModelExtendedTests.cs
+++ b/SysManager/SysManager.IntegrationTests/CleanupViewModelExtendedTests.cs
@@ -1,5 +1,5 @@
 // SysManager · CleanupViewModelExtendedTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.IntegrationTests/ConvertersTests.cs
+++ b/SysManager/SysManager.IntegrationTests/ConvertersTests.cs
@@ -1,5 +1,5 @@
 // SysManager · ConvertersTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Globalization;

--- a/SysManager/SysManager.IntegrationTests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DashboardViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · DashboardViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.IntegrationTests/DataModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DataModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · DataModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.ComponentModel;

--- a/SysManager/SysManager.IntegrationTests/DeepCleanupViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DeepCleanupViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · DeepCleanupViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager.IntegrationTests/DeepCleanupViewUiTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DeepCleanupViewUiTests.cs
@@ -1,5 +1,5 @@
 // SysManager · DeepCleanupViewUiTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows;

--- a/SysManager/SysManager.IntegrationTests/DiskHealthReportTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DiskHealthReportTests.cs
@@ -1,5 +1,5 @@
 // SysManager · DiskHealthReportTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.ComponentModel;

--- a/SysManager/SysManager.IntegrationTests/DiskHealthServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DiskHealthServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · DiskHealthServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.IntegrationTests/EventExplainerTests.cs
+++ b/SysManager/SysManager.IntegrationTests/EventExplainerTests.cs
@@ -1,5 +1,5 @@
 // SysManager · EventExplainerTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.IntegrationTests/EventLogQueryOptionsTests.cs
+++ b/SysManager/SysManager.IntegrationTests/EventLogQueryOptionsTests.cs
@@ -1,5 +1,5 @@
 // SysManager · EventLogQueryOptionsTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.IntegrationTests/EventLogServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/EventLogServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · EventLogServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.IntegrationTests/FixedDriveServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/FixedDriveServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · FixedDriveServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.IntegrationTests/HealthAnalyzerExtendedTests.cs
+++ b/SysManager/SysManager.IntegrationTests/HealthAnalyzerExtendedTests.cs
@@ -1,5 +1,5 @@
 // SysManager · HealthAnalyzerExtendedTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.IntegrationTests/HealthAnalyzerTests.cs
+++ b/SysManager/SysManager.IntegrationTests/HealthAnalyzerTests.cs
@@ -1,5 +1,5 @@
 // SysManager · HealthAnalyzerTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.IntegrationTests/HealthDiagnosticTests.cs
+++ b/SysManager/SysManager.IntegrationTests/HealthDiagnosticTests.cs
@@ -1,5 +1,5 @@
 // SysManager · HealthDiagnosticTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.ComponentModel;

--- a/SysManager/SysManager.IntegrationTests/InfrastructureTests.cs
+++ b/SysManager/SysManager.IntegrationTests/InfrastructureTests.cs
@@ -1,5 +1,5 @@
 // SysManager · InfrastructureTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager.IntegrationTests/LargeFileScannerTests.cs
+++ b/SysManager/SysManager.IntegrationTests/LargeFileScannerTests.cs
@@ -1,5 +1,5 @@
 // SysManager · LargeFileScannerTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager.IntegrationTests/LightTouchViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/LightTouchViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · LightTouchViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.IntegrationTests/LogsViewModelExtendedTests.cs
+++ b/SysManager/SysManager.IntegrationTests/LogsViewModelExtendedTests.cs
@@ -1,5 +1,5 @@
 // SysManager · LogsViewModelExtendedTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · MainWindowViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.ViewModels;

--- a/SysManager/SysManager.IntegrationTests/MemoryTestServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MemoryTestServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · MemoryTestServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.IntegrationTests/PingMonitorEdgeTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PingMonitorEdgeTests.cs
@@ -1,5 +1,5 @@
 // SysManager · PingMonitorEdgeTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.IntegrationTests/PingMonitorServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PingMonitorServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · PingMonitorServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.IntegrationTests/PingMonitorStressTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PingMonitorStressTests.cs
@@ -1,5 +1,5 @@
 // SysManager · PingMonitorStressTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.IntegrationTests/PingTargetTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PingTargetTests.cs
@@ -1,5 +1,5 @@
 // SysManager · PingTargetTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.ComponentModel;

--- a/SysManager/SysManager.IntegrationTests/PowerShellRunnerDebugTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PowerShellRunnerDebugTests.cs
@@ -1,5 +1,5 @@
 // SysManager · PowerShellRunnerDebugTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
@@ -1,5 +1,5 @@
 // SysManager · PowerShellRunnerTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager.IntegrationTests/QaAuditTests.cs
+++ b/SysManager/SysManager.IntegrationTests/QaAuditTests.cs
@@ -1,5 +1,5 @@
 // SysManager · QaAuditTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager.IntegrationTests/QaResilienceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/QaResilienceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · QaResilienceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager.IntegrationTests/StaHelper.cs
+++ b/SysManager/SysManager.IntegrationTests/StaHelper.cs
@@ -1,5 +1,5 @@
 // SysManager · StaHelper
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 namespace SysManager.IntegrationTests;

--- a/SysManager/SysManager.IntegrationTests/SystemHealthMultiDriveTests.cs
+++ b/SysManager/SysManager.IntegrationTests/SystemHealthMultiDriveTests.cs
@@ -1,5 +1,5 @@
 // SysManager · SystemHealthMultiDriveTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.IntegrationTests/SystemHealthViewModelExtendedTests.cs
+++ b/SysManager/SysManager.IntegrationTests/SystemHealthViewModelExtendedTests.cs
@@ -1,5 +1,5 @@
 // SysManager · SystemHealthViewModelExtendedTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.IntegrationTests/SystemHealthViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/SystemHealthViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · SystemHealthViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.IntegrationTests/SystemInfoServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/SystemInfoServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · SystemInfoServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.IntegrationTests/TestCollections.cs
+++ b/SysManager/SysManager.IntegrationTests/TestCollections.cs
@@ -1,5 +1,5 @@
 // SysManager · TestCollections
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 namespace SysManager.IntegrationTests;

--- a/SysManager/SysManager.IntegrationTests/TracerouteMonitorServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/TracerouteMonitorServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · TracerouteMonitorServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.IntegrationTests/TracerouteServiceExtendedTests.cs
+++ b/SysManager/SysManager.IntegrationTests/TracerouteServiceExtendedTests.cs
@@ -1,5 +1,5 @@
 // SysManager · TracerouteServiceExtendedTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.IntegrationTests/TracerouteServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/TracerouteServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · TracerouteServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.IntegrationTests/UpdateServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/UpdateServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · UpdateServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.IntegrationTests/ViewModelBaseTests.cs
+++ b/SysManager/SysManager.IntegrationTests/ViewModelBaseTests.cs
@@ -1,5 +1,5 @@
 // SysManager · ViewModelBaseTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.ComponentModel;

--- a/SysManager/SysManager.IntegrationTests/WindowsUpdateAutoCheckTests.cs
+++ b/SysManager/SysManager.IntegrationTests/WindowsUpdateAutoCheckTests.cs
@@ -1,5 +1,5 @@
 // SysManager · WindowsUpdateAutoCheckTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.IntegrationTests/WindowsUpdateViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/WindowsUpdateViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · WindowsUpdateViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager.Tests/AboutViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AboutViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · AboutViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.Tests/AdminHelperTests.cs
+++ b/SysManager/SysManager.Tests/AdminHelperTests.cs
@@ -1,5 +1,5 @@
 // SysManager · AdminHelperTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Helpers;

--- a/SysManager/SysManager.Tests/AppAlertsViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppAlertsViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · AppAlertsViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/AppBlockerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppBlockerViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · AppBlockerViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/AppPackageTests.cs
+++ b/SysManager/SysManager.Tests/AppPackageTests.cs
@@ -1,5 +1,5 @@
 // SysManager · AppPackageTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.ComponentModel;

--- a/SysManager/SysManager.Tests/AppUpdatesViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppUpdatesViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · AppUpdatesViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager.Tests/BatteryHealthViewModelTests.cs
+++ b/SysManager/SysManager.Tests/BatteryHealthViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · BatteryHealthViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.ViewModels;

--- a/SysManager/SysManager.Tests/BatteryServiceTests.cs
+++ b/SysManager/SysManager.Tests/BatteryServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · BatteryServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/CleanupCategoryHumanSizeBulkTests.cs
+++ b/SysManager/SysManager.Tests/CleanupCategoryHumanSizeBulkTests.cs
@@ -1,5 +1,5 @@
 // SysManager · CleanupCategoryHumanSizeBulkTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/CleanupResultTests.cs
+++ b/SysManager/SysManager.Tests/CleanupResultTests.cs
@@ -1,5 +1,5 @@
 // SysManager · CleanupResultTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/CleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/CleanupViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · CleanupViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager.Tests/ConsoleViewModelConcurrencyTests.cs
+++ b/SysManager/SysManager.Tests/ConsoleViewModelConcurrencyTests.cs
@@ -1,5 +1,5 @@
 // SysManager · ConsoleViewModelConcurrencyTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/ConsoleViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ConsoleViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · ConsoleViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/ConverterTests.cs
+++ b/SysManager/SysManager.Tests/ConverterTests.cs
@@ -1,5 +1,5 @@
 // SysManager · ConverterTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Globalization;

--- a/SysManager/SysManager.Tests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DashboardViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · DashboardViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.Tests/DeepCleanupServiceTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · DeepCleanupServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager.Tests/DeepCleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · DeepCleanupViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager.Tests/DiskAnalyzerServiceTests.cs
+++ b/SysManager/SysManager.Tests/DiskAnalyzerServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · DiskAnalyzerServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager.Tests/DiskAnalyzerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DiskAnalyzerViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · DiskAnalyzerViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager.Tests/DiskHealthReportTests.cs
+++ b/SysManager/SysManager.Tests/DiskHealthReportTests.cs
@@ -1,5 +1,5 @@
 // SysManager · DiskHealthReportTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/DiskHealthServiceTests.cs
+++ b/SysManager/SysManager.Tests/DiskHealthServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · DiskHealthServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager.Tests/DriversViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DriversViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · DriversViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager.Tests/DuplicateFileServiceTests.cs
+++ b/SysManager/SysManager.Tests/DuplicateFileServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · DuplicateFileServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager.Tests/DuplicateFileViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DuplicateFileViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · DuplicateFileViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager.Tests/EnumCoverageTests.cs
+++ b/SysManager/SysManager.Tests/EnumCoverageTests.cs
@@ -1,5 +1,5 @@
 // SysManager · EnumCoverageTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/EventExplainerExtendedTests.cs
+++ b/SysManager/SysManager.Tests/EventExplainerExtendedTests.cs
@@ -1,5 +1,5 @@
 // SysManager · EventExplainerExtendedTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/EventLogServiceTests.cs
+++ b/SysManager/SysManager.Tests/EventLogServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · EventLogServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager.Tests/FixedDriveServiceTests.cs
+++ b/SysManager/SysManager.Tests/FixedDriveServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · FixedDriveServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager.Tests/FriendlyEventEntryDisplayTests.cs
+++ b/SysManager/SysManager.Tests/FriendlyEventEntryDisplayTests.cs
@@ -1,5 +1,5 @@
 // SysManager · FriendlyEventEntryDisplayTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/FriendlyEventEntryExtendedTests.cs
+++ b/SysManager/SysManager.Tests/FriendlyEventEntryExtendedTests.cs
@@ -1,5 +1,5 @@
 // SysManager · FriendlyEventEntryExtendedTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.ComponentModel;

--- a/SysManager/SysManager.Tests/FriendlyEventEntryTests.cs
+++ b/SysManager/SysManager.Tests/FriendlyEventEntryTests.cs
@@ -1,5 +1,5 @@
 // SysManager · FriendlyEventEntryTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/GatewayHelperTests.cs
+++ b/SysManager/SysManager.Tests/GatewayHelperTests.cs
@@ -1,5 +1,5 @@
 // SysManager · GatewayHelperTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Helpers;

--- a/SysManager/SysManager.Tests/HealthAnalyzerTests.cs
+++ b/SysManager/SysManager.Tests/HealthAnalyzerTests.cs
@@ -1,5 +1,5 @@
 // SysManager · HealthAnalyzerTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/HealthDiagnosticTests.cs
+++ b/SysManager/SysManager.Tests/HealthDiagnosticTests.cs
@@ -1,5 +1,5 @@
 // SysManager · HealthDiagnosticTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/IconExtractorServiceTests.cs
+++ b/SysManager/SysManager.Tests/IconExtractorServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · IconExtractorServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.Tests/LargeFileScannerTests.cs
+++ b/SysManager/SysManager.Tests/LargeFileScannerTests.cs
@@ -1,5 +1,5 @@
 // SysManager · LargeFileScannerTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager.Tests/LogServiceSanitizeTests.cs
+++ b/SysManager/SysManager.Tests/LogServiceSanitizeTests.cs
@@ -1,5 +1,5 @@
 // SysManager · LogServiceSanitizeTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.Tests/LogsViewModelExtendedTests.cs
+++ b/SysManager/SysManager.Tests/LogsViewModelExtendedTests.cs
@@ -1,5 +1,5 @@
 // SysManager · LogsViewModelExtendedTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager.Tests/LogsViewModelTests.cs
+++ b/SysManager/SysManager.Tests/LogsViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · LogsViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager.Tests/MarkdownTextBlockTests.cs
+++ b/SysManager/SysManager.Tests/MarkdownTextBlockTests.cs
@@ -1,5 +1,5 @@
 // SysManager · MarkdownTextBlockTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager.Tests/ModelRecordTests.cs
+++ b/SysManager/SysManager.Tests/ModelRecordTests.cs
@@ -1,5 +1,5 @@
 // SysManager · ModelRecordTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/NavGroupTests.cs
+++ b/SysManager/SysManager.Tests/NavGroupTests.cs
@@ -1,5 +1,5 @@
 // SysManager · NavGroupTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.ViewModels;

--- a/SysManager/SysManager.Tests/NetworkRepairResultTests.cs
+++ b/SysManager/SysManager.Tests/NetworkRepairResultTests.cs
@@ -1,5 +1,5 @@
 // SysManager · NetworkRepairResultTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/NetworkRepairViewModelTests.cs
+++ b/SysManager/SysManager.Tests/NetworkRepairViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · NetworkRepairViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.ViewModels;

--- a/SysManager/SysManager.Tests/NetworkSharedStateTests.cs
+++ b/SysManager/SysManager.Tests/NetworkSharedStateTests.cs
@@ -1,5 +1,5 @@
 // SysManager · NetworkSharedStateTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/OperationLockServiceTests.cs
+++ b/SysManager/SysManager.Tests/OperationLockServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · OperationLockServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.Tests/PerformanceProfileTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceProfileTests.cs
@@ -1,5 +1,5 @@
 // SysManager · PerformanceProfileTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/PerformanceServiceExtendedTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceServiceExtendedTests.cs
@@ -1,5 +1,5 @@
 // SysManager · PerformanceServiceExtendedTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.Tests/PerformanceServiceTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · PerformanceServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · PerformanceViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.Tests/PingTargetTests.cs
+++ b/SysManager/SysManager.Tests/PingTargetTests.cs
@@ -1,5 +1,5 @@
 // SysManager · PingTargetTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/PingViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PingViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · PingViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.ViewModels;

--- a/SysManager/SysManager.Tests/PlaceholderViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PlaceholderViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · PlaceholderViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.ViewModels;

--- a/SysManager/SysManager.Tests/PowerShellLineTests.cs
+++ b/SysManager/SysManager.Tests/PowerShellLineTests.cs
@@ -1,5 +1,5 @@
 // SysManager · PowerShellLineTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/PowerShellRunnerTests.cs
+++ b/SysManager/SysManager.Tests/PowerShellRunnerTests.cs
@@ -1,5 +1,5 @@
 // SysManager · PowerShellRunnerTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager.Tests/ProcessDescriptionServiceTests.cs
+++ b/SysManager/SysManager.Tests/ProcessDescriptionServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · ProcessDescriptionServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.Tests/ProcessManagerServiceTests.cs
+++ b/SysManager/SysManager.Tests/ProcessManagerServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · ProcessManagerServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/ProcessManagerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ProcessManagerViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · ProcessManagerViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.ViewModels;

--- a/SysManager/SysManager.Tests/ReleaseNoteTests.cs
+++ b/SysManager/SysManager.Tests/ReleaseNoteTests.cs
@@ -1,5 +1,5 @@
 // SysManager · ReleaseNoteTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.ViewModels;
@@ -32,7 +32,7 @@ public class ReleaseNoteTests
             Title = "Bug fixes",
             PublishedAt = "22 Apr 2026",
             Body = "Fixed crash on startup",
-            Url = "https://github.com/laurentiu021/SysManager/releases/tag/v0.5.2",
+            Url = "https://github.com/laurentiu021/SystemManager/releases/tag/v0.5.2",
             IsCurrent = true
         };
         Assert.Equal("v0.5.2", n.Version);

--- a/SysManager/SysManager.Tests/ServiceManagerServiceTests.cs
+++ b/SysManager/SysManager.Tests/ServiceManagerServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · ServiceManagerServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/ShortcutCleanerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ShortcutCleanerViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · ShortcutCleanerViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/SpeedTestViewModelTests.cs
+++ b/SysManager/SysManager.Tests/SpeedTestViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · SpeedTestViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.ViewModels;

--- a/SysManager/SysManager.Tests/StaHelper.cs
+++ b/SysManager/SysManager.Tests/StaHelper.cs
@@ -1,5 +1,5 @@
 // SysManager · StaHelper
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 namespace SysManager.Tests;

--- a/SysManager/SysManager.Tests/StartupServiceTests.cs
+++ b/SysManager/SysManager.Tests/StartupServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · StartupServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/StartupToggleTests.cs
+++ b/SysManager/SysManager.Tests/StartupToggleTests.cs
@@ -1,5 +1,5 @@
 // SysManager · StartupToggleTests — tests for SetEnabled toggle logic
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/StartupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/StartupViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · StartupViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.ViewModels;

--- a/SysManager/SysManager.Tests/SystemHealthViewModelTests.cs
+++ b/SysManager/SysManager.Tests/SystemHealthViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · SystemHealthViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager.Tests/SystemSnapshotTests.cs
+++ b/SysManager/SysManager.Tests/SystemSnapshotTests.cs
@@ -1,5 +1,5 @@
 // SysManager · SystemSnapshotTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/TargetPresetTests.cs
+++ b/SysManager/SysManager.Tests/TargetPresetTests.cs
@@ -1,5 +1,5 @@
 // SysManager · TargetPresetTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/TestCollections.cs
+++ b/SysManager/SysManager.Tests/TestCollections.cs
@@ -1,5 +1,5 @@
 // SysManager · TestCollections
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 namespace SysManager.Tests;

--- a/SysManager/SysManager.Tests/TracerouteHopTests.cs
+++ b/SysManager/SysManager.Tests/TracerouteHopTests.cs
@@ -1,5 +1,5 @@
 // SysManager · TracerouteHopTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/TracerouteViewModelTests.cs
+++ b/SysManager/SysManager.Tests/TracerouteViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · TracerouteViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.ViewModels;

--- a/SysManager/SysManager.Tests/UninstallerDescribeFailureTests.cs
+++ b/SysManager/SysManager.Tests/UninstallerDescribeFailureTests.cs
@@ -1,5 +1,5 @@
 // SysManager · UninstallerDescribeFailureTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.ViewModels;

--- a/SysManager/SysManager.Tests/UninstallerServiceTests.cs
+++ b/SysManager/SysManager.Tests/UninstallerServiceTests.cs
@@ -1,5 +1,5 @@
 // SysManager · UninstallerServiceTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager.Tests/UninstallerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/UninstallerViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · UninstallerViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.Tests/UpdateServiceParseVersionBulkTests.cs
+++ b/SysManager/SysManager.Tests/UpdateServiceParseVersionBulkTests.cs
@@ -1,5 +1,5 @@
 // SysManager · UpdateServiceParseVersionBulkTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Services;

--- a/SysManager/SysManager.Tests/ViewModelBaseTests.cs
+++ b/SysManager/SysManager.Tests/ViewModelBaseTests.cs
@@ -1,5 +1,5 @@
 // SysManager · ViewModelBaseTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.ViewModels;

--- a/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
+++ b/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
@@ -1,5 +1,5 @@
 // SysManager · WindowsUpdateViewModelTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager.Tests/WingetParserDeepTests.cs
+++ b/SysManager/SysManager.Tests/WingetParserDeepTests.cs
@@ -1,5 +1,5 @@
 // SysManager · WingetParserDeepTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager.UITests/AppFixture.cs
+++ b/SysManager/SysManager.UITests/AppFixture.cs
@@ -1,5 +1,5 @@
 // SysManager · AppFixture
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Diagnostics;

--- a/SysManager/SysManager.UITests/DashboardTabUiTests.cs
+++ b/SysManager/SysManager.UITests/DashboardTabUiTests.cs
@@ -1,5 +1,5 @@
 // SysManager · DashboardTabUiTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 namespace SysManager.UITests;

--- a/SysManager/SysManager.UITests/LogsTabUiTests.cs
+++ b/SysManager/SysManager.UITests/LogsTabUiTests.cs
@@ -1,5 +1,5 @@
 // SysManager · LogsTabUiTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using FlaUI.Core.AutomationElements;

--- a/SysManager/SysManager.UITests/NetworkTabUiTests.cs
+++ b/SysManager/SysManager.UITests/NetworkTabUiTests.cs
@@ -1,5 +1,5 @@
 // SysManager · NetworkTabUiTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using FlaUI.Core.AutomationElements;

--- a/SysManager/SysManager.UITests/OtherTabsUiTests.cs
+++ b/SysManager/SysManager.UITests/OtherTabsUiTests.cs
@@ -1,5 +1,5 @@
 // SysManager · OtherTabsUiTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 namespace SysManager.UITests;

--- a/SysManager/SysManager.UITests/SmokeUiTests.cs
+++ b/SysManager/SysManager.UITests/SmokeUiTests.cs
@@ -1,5 +1,5 @@
 // SysManager · SmokeUiTests
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using FlaUI.Core.AutomationElements;

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <Application x:Class="SysManager.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/App.xaml.cs
+++ b/SysManager/SysManager/App.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager — Windows system monitoring toolkit
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Diagnostics;

--- a/SysManager/SysManager/AssemblyInfo.cs
+++ b/SysManager/SysManager/AssemblyInfo.cs
@@ -1,8 +1,8 @@
 // SysManager — Windows system monitoring toolkit
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 // Author : laurentiu021
-// Source : https://github.com/laurentiu021/SysManager
+// Source : https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;

--- a/SysManager/SysManager/Helpers/AdminHelper.cs
+++ b/SysManager/SysManager/Helpers/AdminHelper.cs
@@ -1,5 +1,5 @@
 // SysManager · AdminHelper
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Diagnostics;

--- a/SysManager/SysManager/Helpers/GatewayHelper.cs
+++ b/SysManager/SysManager/Helpers/GatewayHelper.cs
@@ -1,5 +1,5 @@
 // SysManager · GatewayHelper
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Net.NetworkInformation;

--- a/SysManager/SysManager/Helpers/KnownFolders.cs
+++ b/SysManager/SysManager/Helpers/KnownFolders.cs
@@ -1,5 +1,5 @@
 // SysManager · KnownFolders
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager/Helpers/MarkdownTextBlock.cs
+++ b/SysManager/SysManager/Helpers/MarkdownTextBlock.cs
@@ -1,5 +1,5 @@
 // SysManager · MarkdownTextBlock — lightweight markdown-to-Inlines for TextBlock
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Text.RegularExpressions;

--- a/SysManager/SysManager/Helpers/OutputKindToBrushConverter.cs
+++ b/SysManager/SysManager/Helpers/OutputKindToBrushConverter.cs
@@ -1,5 +1,5 @@
 // SysManager · OutputKindToBrushConverter
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Globalization;

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <Window x:Class="SysManager.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager — MainWindow shell
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows;

--- a/SysManager/SysManager/Models/AppInstallEntry.cs
+++ b/SysManager/SysManager/Models/AppInstallEntry.cs
@@ -1,5 +1,5 @@
 // SysManager · AppInstallEntry — model for a detected application install
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/Models/AppPackage.cs
+++ b/SysManager/SysManager/Models/AppPackage.cs
@@ -1,5 +1,5 @@
 // SysManager · AppPackage
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/Models/BatteryInfo.cs
+++ b/SysManager/SysManager/Models/BatteryInfo.cs
@@ -1,5 +1,5 @@
 // SysManager · BatteryInfo — model for battery health data
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/Models/BlockedApp.cs
+++ b/SysManager/SysManager/Models/BlockedApp.cs
@@ -1,5 +1,5 @@
 // SysManager · BlockedApp — model for a blocked application
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/Models/BrokenShortcut.cs
+++ b/SysManager/SysManager/Models/BrokenShortcut.cs
@@ -1,5 +1,5 @@
 // SysManager · BrokenShortcut — model for a broken .lnk file
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/Models/CleanupCategory.cs
+++ b/SysManager/SysManager/Models/CleanupCategory.cs
@@ -1,5 +1,5 @@
 // SysManager · CleanupCategory / LargeFileEntry models
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/Models/DiskHealthReport.cs
+++ b/SysManager/SysManager/Models/DiskHealthReport.cs
@@ -1,5 +1,5 @@
 // SysManager · DiskHealthReport
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/Models/DiskUsageEntry.cs
+++ b/SysManager/SysManager/Models/DiskUsageEntry.cs
@@ -1,5 +1,5 @@
 // SysManager · DiskUsageEntry — model for disk space analysis
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/Models/DriverEntry.cs
+++ b/SysManager/SysManager/Models/DriverEntry.cs
@@ -1,5 +1,5 @@
 // SysManager · DriverEntry — model for installed drivers
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 namespace SysManager.Models;

--- a/SysManager/SysManager/Models/DuplicateFileGroup.cs
+++ b/SysManager/SysManager/Models/DuplicateFileGroup.cs
@@ -1,5 +1,5 @@
 // SysManager · DuplicateFileGroup — model for duplicate file results
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/Models/FriendlyEventEntry.cs
+++ b/SysManager/SysManager/Models/FriendlyEventEntry.cs
@@ -1,5 +1,5 @@
 // SysManager · FriendlyEventEntry
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/Models/HealthDiagnostic.cs
+++ b/SysManager/SysManager/Models/HealthDiagnostic.cs
@@ -1,5 +1,5 @@
 // SysManager · HealthDiagnostic
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/Models/InstalledApp.cs
+++ b/SysManager/SysManager/Models/InstalledApp.cs
@@ -1,5 +1,5 @@
 // SysManager · InstalledApp — model for installed applications
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Media;

--- a/SysManager/SysManager/Models/NetworkRepairResult.cs
+++ b/SysManager/SysManager/Models/NetworkRepairResult.cs
@@ -1,5 +1,5 @@
 // SysManager · NetworkRepairResult
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 namespace SysManager.Models;

--- a/SysManager/SysManager/Models/PerformanceProfile.cs
+++ b/SysManager/SysManager/Models/PerformanceProfile.cs
@@ -1,5 +1,5 @@
 // SysManager · PerformanceProfile — model for performance mode settings
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/Models/PingSample.cs
+++ b/SysManager/SysManager/Models/PingSample.cs
@@ -1,5 +1,5 @@
 // SysManager · PingSample
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 namespace SysManager.Models;

--- a/SysManager/SysManager/Models/PingTarget.cs
+++ b/SysManager/SysManager/Models/PingTarget.cs
@@ -1,5 +1,5 @@
 // SysManager · PingTarget
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/Models/PowerShellOutput.cs
+++ b/SysManager/SysManager/Models/PowerShellOutput.cs
@@ -1,5 +1,5 @@
 // SysManager · PowerShellOutput
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 namespace SysManager.Models;

--- a/SysManager/SysManager/Models/ProcessEntry.cs
+++ b/SysManager/SysManager/Models/ProcessEntry.cs
@@ -1,5 +1,5 @@
 // SysManager · ProcessEntry — model for running processes
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Media;

--- a/SysManager/SysManager/Models/ServiceEntry.cs
+++ b/SysManager/SysManager/Models/ServiceEntry.cs
@@ -1,5 +1,5 @@
 // SysManager · ServiceEntry
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/Models/SpeedTestResult.cs
+++ b/SysManager/SysManager/Models/SpeedTestResult.cs
@@ -1,5 +1,5 @@
 // SysManager · SpeedTestResult
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 namespace SysManager.Models;

--- a/SysManager/SysManager/Models/StartupEntry.cs
+++ b/SysManager/SysManager/Models/StartupEntry.cs
@@ -1,5 +1,5 @@
 // SysManager · StartupEntry — model for startup items
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Media;

--- a/SysManager/SysManager/Models/SystemSnapshot.cs
+++ b/SysManager/SysManager/Models/SystemSnapshot.cs
@@ -1,5 +1,5 @@
 // SysManager · SystemSnapshot
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 namespace SysManager.Models;

--- a/SysManager/SysManager/Models/TargetPreset.cs
+++ b/SysManager/SysManager/Models/TargetPreset.cs
@@ -1,5 +1,5 @@
 // SysManager · TargetPreset
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 namespace SysManager.Models;

--- a/SysManager/SysManager/Models/TargetRole.cs
+++ b/SysManager/SysManager/Models/TargetRole.cs
@@ -1,5 +1,5 @@
 // SysManager · TargetRole
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 namespace SysManager.Models;

--- a/SysManager/SysManager/Models/TracerouteHop.cs
+++ b/SysManager/SysManager/Models/TracerouteHop.cs
@@ -1,5 +1,5 @@
 // SysManager · TracerouteHop
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/Models/UpdateEntry.cs
+++ b/SysManager/SysManager/Models/UpdateEntry.cs
@@ -1,5 +1,5 @@
 // SysManager · UpdateEntry — model for Windows Update entries
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 namespace SysManager.Models;

--- a/SysManager/SysManager/Services/AppAlertService.cs
+++ b/SysManager/SysManager/Services/AppAlertService.cs
@@ -1,5 +1,5 @@
 // SysManager · AppAlertService — monitors for new application installations
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.Concurrent;

--- a/SysManager/SysManager/Services/AppBlockerService.cs
+++ b/SysManager/SysManager/Services/AppBlockerService.cs
@@ -1,5 +1,5 @@
 // SysManager · AppBlockerService — block/unblock apps via IFEO registry
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager/Services/BatteryService.cs
+++ b/SysManager/SysManager/Services/BatteryService.cs
@@ -1,5 +1,5 @@
 // SysManager · BatteryService — reads battery health via WMI
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Management;

--- a/SysManager/SysManager/Services/DeepCleanupService.cs
+++ b/SysManager/SysManager/Services/DeepCleanupService.cs
@@ -1,5 +1,5 @@
 // SysManager · DeepCleanupService — safe-by-design scanner & cleaner
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager/Services/DiskAnalyzerService.cs
+++ b/SysManager/SysManager/Services/DiskAnalyzerService.cs
@@ -1,5 +1,5 @@
 // SysManager · DiskAnalyzerService — folder-level disk space analysis
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager/Services/DiskHealthService.cs
+++ b/SysManager/SysManager/Services/DiskHealthService.cs
@@ -1,5 +1,5 @@
 // SysManager · DiskHealthService
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Management;

--- a/SysManager/SysManager/Services/DuplicateFileService.cs
+++ b/SysManager/SysManager/Services/DuplicateFileService.cs
@@ -1,5 +1,5 @@
 // SysManager · DuplicateFileService — find duplicate files by content hash
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager/Services/EventExplainer.cs
+++ b/SysManager/SysManager/Services/EventExplainer.cs
@@ -1,5 +1,5 @@
 // SysManager · EventExplainer
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager/Services/EventLogService.cs
+++ b/SysManager/SysManager/Services/EventLogService.cs
@@ -1,5 +1,5 @@
 // SysManager · EventLogService
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Diagnostics.Eventing.Reader;

--- a/SysManager/SysManager/Services/FixedDriveService.cs
+++ b/SysManager/SysManager/Services/FixedDriveService.cs
@@ -1,5 +1,5 @@
 // SysManager · FixedDriveService — enumerate internal NTFS/ReFS volumes
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager/Services/HealthAnalyzer.cs
+++ b/SysManager/SysManager/Services/HealthAnalyzer.cs
@@ -1,5 +1,5 @@
 // SysManager · HealthAnalyzer
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager/Services/IconExtractorService.cs
+++ b/SysManager/SysManager/Services/IconExtractorService.cs
@@ -1,5 +1,5 @@
 // SysManager · IconExtractorService — extract exe/file icons for display
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.Concurrent;

--- a/SysManager/SysManager/Services/LargeFileScanner.cs
+++ b/SysManager/SysManager/Services/LargeFileScanner.cs
@@ -1,5 +1,5 @@
 // SysManager · LargeFileScanner — read-only biggest-files discovery
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager/Services/LogService.cs
+++ b/SysManager/SysManager/Services/LogService.cs
@@ -1,5 +1,5 @@
 // SysManager · LogService
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager/Services/MemoryTestService.cs
+++ b/SysManager/SysManager/Services/MemoryTestService.cs
@@ -1,5 +1,5 @@
 // SysManager · MemoryTestService
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Diagnostics;

--- a/SysManager/SysManager/Services/NetworkRepairService.cs
+++ b/SysManager/SysManager/Services/NetworkRepairService.cs
@@ -1,5 +1,5 @@
 // SysManager · NetworkRepairService
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using SysManager.Models;

--- a/SysManager/SysManager/Services/OperationLockService.cs
+++ b/SysManager/SysManager/Services/OperationLockService.cs
@@ -1,5 +1,5 @@
 // SysManager · OperationLockService — prevents conflicting concurrent operations
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.Concurrent;

--- a/SysManager/SysManager/Services/PerformanceService.cs
+++ b/SysManager/SysManager/Services/PerformanceService.cs
@@ -1,5 +1,5 @@
 // SysManager · PerformanceService — manages power plans and performance tweaks
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager/Services/PingMonitorService.cs
+++ b/SysManager/SysManager/Services/PingMonitorService.cs
@@ -1,5 +1,5 @@
 // SysManager · PingMonitorService
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.Concurrent;

--- a/SysManager/SysManager/Services/PowerShellRunner.cs
+++ b/SysManager/SysManager/Services/PowerShellRunner.cs
@@ -1,5 +1,5 @@
 // SysManager · PowerShellRunner
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/Services/ProcessDescriptionService.cs
+++ b/SysManager/SysManager/Services/ProcessDescriptionService.cs
@@ -1,5 +1,5 @@
 // SysManager · ProcessDescriptionService — built-in process description database
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager/Services/ProcessManagerService.cs
+++ b/SysManager/SysManager/Services/ProcessManagerService.cs
@@ -1,5 +1,5 @@
 // SysManager · ProcessManagerService — enumerate and manage running processes
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Diagnostics;

--- a/SysManager/SysManager/Services/ServiceManagerService.cs
+++ b/SysManager/SysManager/Services/ServiceManagerService.cs
@@ -1,5 +1,5 @@
 // SysManager · ServiceManagerService
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.ServiceProcess;

--- a/SysManager/SysManager/Services/ShortcutCleanerService.cs
+++ b/SysManager/SysManager/Services/ShortcutCleanerService.cs
@@ -1,5 +1,5 @@
 // SysManager · ShortcutCleanerService — scans for broken .lnk shortcuts
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -1,5 +1,5 @@
 // SysManager · SpeedTestService
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Diagnostics;

--- a/SysManager/SysManager/Services/StartupService.cs
+++ b/SysManager/SysManager/Services/StartupService.cs
@@ -1,5 +1,5 @@
 // SysManager · StartupService — enumerate and toggle startup items
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Runtime.InteropServices;

--- a/SysManager/SysManager/Services/SystemInfoService.cs
+++ b/SysManager/SysManager/Services/SystemInfoService.cs
@@ -1,5 +1,5 @@
 // SysManager · SystemInfoService
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Management;

--- a/SysManager/SysManager/Services/TracerouteMonitorService.cs
+++ b/SysManager/SysManager/Services/TracerouteMonitorService.cs
@@ -1,5 +1,5 @@
 // SysManager · TracerouteMonitorService
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.Concurrent;

--- a/SysManager/SysManager/Services/TracerouteService.cs
+++ b/SysManager/SysManager/Services/TracerouteService.cs
@@ -1,5 +1,5 @@
 // SysManager · TracerouteService
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Diagnostics;

--- a/SysManager/SysManager/Services/UninstallerService.cs
+++ b/SysManager/SysManager/Services/UninstallerService.cs
@@ -1,5 +1,5 @@
 // SysManager · UninstallerService — list and uninstall apps via winget
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Text.RegularExpressions;

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -1,5 +1,5 @@
 // SysManager · UpdateService — GitHub releases client
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager/Services/WingetService.cs
+++ b/SysManager/SysManager/Services/WingetService.cs
@@ -1,5 +1,5 @@
 // SysManager · WingetService
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Text.RegularExpressions;

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -19,8 +19,8 @@
     <Product>SysManager</Product>
     <Copyright>Copyright (c) 2026 laurentiu021</Copyright>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
-    <PackageProjectUrl>https://github.com/laurentiu021/SysManager</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/laurentiu021/SysManager</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/laurentiu021/SystemManager</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · AboutViewModel — version info + update check + install
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · AppAlertsViewModel — monitors and alerts on new app installations
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/ViewModels/AppBlockerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppBlockerViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · AppBlockerViewModel — block/unblock applications from running
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · AppUpdatesViewModel
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/ViewModels/BatteryHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BatteryHealthViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · BatteryHealthViewModel — battery health tab
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · CleanupViewModel
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager/ViewModels/ConsoleViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ConsoleViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · ConsoleViewModel
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · DashboardViewModel
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · DeepCleanupViewModel — opt-in cleanup + read-only large files
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · DiskAnalyzerViewModel — disk space breakdown
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/ViewModels/DriversViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DriversViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · DriversViewModel
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · DuplicateFileViewModel — find duplicate files
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · LogsViewModel
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · MainWindowViewModel
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/ViewModels/NavGroup.cs
+++ b/SysManager/SysManager/ViewModels/NavGroup.cs
@@ -1,5 +1,5 @@
 // SysManager · NavGroup
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/ViewModels/NavItem.cs
+++ b/SysManager/SysManager/ViewModels/NavItem.cs
@@ -1,5 +1,5 @@
 // SysManager · NavItem
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.ComponentModel;

--- a/SysManager/SysManager/ViewModels/NetworkRepairViewModel.cs
+++ b/SysManager/SysManager/ViewModels/NetworkRepairViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · NetworkRepairViewModel
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows;

--- a/SysManager/SysManager/ViewModels/NetworkSharedState.cs
+++ b/SysManager/SysManager/ViewModels/NetworkSharedState.cs
@@ -1,5 +1,5 @@
 // SysManager · NetworkSharedState
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.Concurrent;

--- a/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · PerformanceViewModel — performance mode tab
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Security;

--- a/SysManager/SysManager/ViewModels/PingViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PingViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · PingViewModel
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/ViewModels/PlaceholderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PlaceholderViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · PlaceholderViewModel
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 namespace SysManager.ViewModels;

--- a/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · ProcessManagerViewModel — running process list with kill
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · ServicesViewModel
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · ShortcutCleanerViewModel — find and remove broken shortcuts
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · SpeedTestViewModel
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/ViewModels/StartupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StartupViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · StartupViewModel — manage programs that run at boot
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · SystemHealthViewModel
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.IO;

--- a/SysManager/SysManager/ViewModels/TracerouteViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TracerouteViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · TracerouteViewModel
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · UninstallerViewModel — uninstall apps via winget
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/ViewModels/ViewModelBase.cs
+++ b/SysManager/SysManager/ViewModels/ViewModelBase.cs
@@ -1,5 +1,5 @@
 // SysManager · ViewModelBase
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -1,5 +1,5 @@
 // SysManager · WindowsUpdateViewModel
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.ObjectModel;

--- a/SysManager/SysManager/Views/AboutView.xaml
+++ b/SysManager/SysManager/Views/AboutView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.AboutView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -44,7 +44,7 @@
                                 <TextBlock Text="MIT" Margin="8,0,24,0" Foreground="{StaticResource TextSecondary}" FontSize="12"/>
                                 <TextBlock Text="SOURCE" Style="{StaticResource Caption}"/>
                                 <TextBlock Margin="8,0,0,0" FontSize="12">
-                                    <Hyperlink Command="{Binding OpenRepoCommand}" Foreground="{StaticResource Accent}">github.com/laurentiu021/SysManager</Hyperlink>
+                                    <Hyperlink Command="{Binding OpenRepoCommand}" Foreground="{StaticResource Accent}">github.com/laurentiu021/SystemManager</Hyperlink>
                                 </TextBlock>
                             </StackPanel>
                         </StackPanel>

--- a/SysManager/SysManager/Views/AboutView.xaml.cs
+++ b/SysManager/SysManager/Views/AboutView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · AboutView — version info + update management UI
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 
 using System.Windows.Controls;
 

--- a/SysManager/SysManager/Views/AppAlertsView.xaml
+++ b/SysManager/SysManager/Views/AppAlertsView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.AppAlertsView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/AppAlertsView.xaml.cs
+++ b/SysManager/SysManager/Views/AppAlertsView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · AppAlertsView — app installation alerts UI
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/AppBlockerView.xaml
+++ b/SysManager/SysManager/Views/AppBlockerView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.AppBlockerView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/AppBlockerView.xaml.cs
+++ b/SysManager/SysManager/Views/AppBlockerView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · AppBlockerView — application blocker UI
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.AppUpdatesView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml.cs
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · AppUpdatesView.xaml
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/BatteryHealthView.xaml
+++ b/SysManager/SysManager/Views/BatteryHealthView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.BatteryHealthView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/BatteryHealthView.xaml.cs
+++ b/SysManager/SysManager/Views/BatteryHealthView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · BatteryHealthView — battery health UI
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.CleanupView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/CleanupView.xaml.cs
+++ b/SysManager/SysManager/Views/CleanupView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · CleanupView.xaml
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/ConsoleView.xaml
+++ b/SysManager/SysManager/Views/ConsoleView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.ConsoleView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/ConsoleView.xaml.cs
+++ b/SysManager/SysManager/Views/ConsoleView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · ConsoleView.xaml
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Collections.Specialized;

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.DashboardView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/DashboardView.xaml.cs
+++ b/SysManager/SysManager/Views/DashboardView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · DashboardView.xaml
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/DeepCleanupView.xaml
+++ b/SysManager/SysManager/Views/DeepCleanupView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.DeepCleanupView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">

--- a/SysManager/SysManager/Views/DeepCleanupView.xaml.cs
+++ b/SysManager/SysManager/Views/DeepCleanupView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · DeepCleanupView.xaml
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/DiskAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/DiskAnalyzerView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.DiskAnalyzerView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/DiskAnalyzerView.xaml.cs
+++ b/SysManager/SysManager/Views/DiskAnalyzerView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · DiskAnalyzerView — disk space analysis UI
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/DriversView.xaml
+++ b/SysManager/SysManager/Views/DriversView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.DriversView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/DriversView.xaml.cs
+++ b/SysManager/SysManager/Views/DriversView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · DriversView.xaml
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/DuplicateFileView.xaml
+++ b/SysManager/SysManager/Views/DuplicateFileView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.DuplicateFileView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/DuplicateFileView.xaml.cs
+++ b/SysManager/SysManager/Views/DuplicateFileView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · DuplicateFileView — duplicate file finder UI
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.LogsView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">

--- a/SysManager/SysManager/Views/LogsView.xaml.cs
+++ b/SysManager/SysManager/Views/LogsView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · LogsView.xaml
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/NetworkRepairView.xaml
+++ b/SysManager/SysManager/Views/NetworkRepairView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.NetworkRepairView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">

--- a/SysManager/SysManager/Views/NetworkRepairView.xaml.cs
+++ b/SysManager/SysManager/Views/NetworkRepairView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · NetworkRepairView.xaml
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/PerformanceView.xaml
+++ b/SysManager/SysManager/Views/PerformanceView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.PerformanceView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/PerformanceView.xaml.cs
+++ b/SysManager/SysManager/Views/PerformanceView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · PerformanceView — performance mode UI
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows;

--- a/SysManager/SysManager/Views/PingView.xaml
+++ b/SysManager/SysManager/Views/PingView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.PingView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/PingView.xaml.cs
+++ b/SysManager/SysManager/Views/PingView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · PingView.xaml
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/PlaceholderView.xaml
+++ b/SysManager/SysManager/Views/PlaceholderView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.PlaceholderView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">

--- a/SysManager/SysManager/Views/PlaceholderView.xaml.cs
+++ b/SysManager/SysManager/Views/PlaceholderView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · PlaceholderView
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.ProcessManagerView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml.cs
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · ProcessManagerView — process manager UI
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.ServicesView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/ServicesView.xaml.cs
+++ b/SysManager/SysManager/Views/ServicesView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · ServicesView
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.ShortcutCleanerView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml.cs
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · ShortcutCleanerView — broken shortcut cleaner UI
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/SpeedTestView.xaml
+++ b/SysManager/SysManager/Views/SpeedTestView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.SpeedTestView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">

--- a/SysManager/SysManager/Views/SpeedTestView.xaml.cs
+++ b/SysManager/SysManager/Views/SpeedTestView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · SpeedTestView.xaml
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.StartupView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/StartupView.xaml.cs
+++ b/SysManager/SysManager/Views/StartupView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · StartupView — startup manager UI
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.SystemHealthView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/SystemHealthView.xaml.cs
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · SystemHealthView.xaml
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/TracerouteView.xaml
+++ b/SysManager/SysManager/Views/TracerouteView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.TracerouteView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/TracerouteView.xaml.cs
+++ b/SysManager/SysManager/Views/TracerouteView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · TracerouteView.xaml
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.UninstallerView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/UninstallerView.xaml.cs
+++ b/SysManager/SysManager/Views/UninstallerView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · UninstallerView — uninstaller UI
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -1,4 +1,4 @@
-<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SysManager · License: MIT -->
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.WindowsUpdateView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml.cs
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml.cs
@@ -1,5 +1,5 @@
 // SysManager · WindowsUpdateView.xaml
-// Author: laurentiu021 · https://github.com/laurentiu021/SysManager
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Windows.Controls;

--- a/TESTING.md
+++ b/TESTING.md
@@ -46,7 +46,7 @@ dotnet test SysManager/SysManager.UITests/SysManager.UITests.csproj -c Release
 ## Coverage
 
 Coverage is collected automatically on CI via `coverlet` and uploaded to
-[Codecov](https://codecov.io/gh/laurentiu021/SysManager). The badge in
+[Codecov](https://codecov.io/gh/laurentiu021/SystemManager). The badge in
 `README.md` reflects the latest `main` branch result.
 
 To generate a local coverage report:


### PR DESCRIPTION
Update all references to the old repository URL (laurentiu021/SysManager) to the new URL (laurentiu021/SystemManager) across all files: author headers, badges, documentation links, issue templates, and support files.

293 files updated.