### PR TITLE
docs: add CodeQL and review-service badges, fix CHANGELOG versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.35.9] - 2026-05-08
+
 ### Changed
 - **Code quality** — refactored implicit `foreach` filters to explicit LINQ
   `.Where()` calls across 7 files (GatewayHelper, FixedDriveService,
   AppAlertService, DeepCleanupService, LargeFileScanner,
   ProcessDescriptionService, ShortcutCleanerViewModel). Resolves CodeQL
   `cs/linq/missed-where` alerts.
+
+## [0.35.8] - 2026-05-08
 
 ### Fixed
 - **Ping chart** — fixed chart visual collapse that occurred after 2–5 seconds

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ control, shortcut cleanup, app blocking, install alerts, and a friendly
 Event Log viewer — all in one WPF desktop app.
 
 [![CI](https://github.com/laurentiu021/SystemManager/actions/workflows/ci.yml/badge.svg)](https://github.com/laurentiu021/SystemManager/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/laurentiu021/SystemManager/actions/workflows/codeql.yml/badge.svg)](https://github.com/laurentiu021/SystemManager/actions/workflows/codeql.yml)
 [![codecov](https://codecov.io/gh/laurentiu021/SystemManager/branch/main/graph/badge.svg)](https://codecov.io/gh/laurentiu021/SystemManager)
+[![CodeRabbit](https://img.shields.io/badge/CodeRabbit-AI%20Reviews-blue?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0id2hpdGUiIGQ9Ik0xMiAyQzYuNDggMiAyIDYuNDggMiAxMnM0LjQ4IDEwIDEwIDEwIDEwLTQuNDggMTAtMTBTMTcuNTIgMiAxMiAyem0wIDE4Yy00LjQyIDAtOC0zLjU4LTgtOHMzLjU4LTggOC04IDggMy41OCA4IDgtMy41OCA4LTggOHoiLz48L3N2Zz4=)](https://coderabbit.ai)
 [![Release](https://img.shields.io/github/v/release/laurentiu021/SystemManager?display_name=tag&sort=semver)](https://github.com/laurentiu021/SystemManager/releases/latest)
 [![Downloads](https://img.shields.io/github/downloads/laurentiu021/SystemManager/total)](https://github.com/laurentiu021/SystemManager/releases)
 [![Issues](https://img.shields.io/github/issues/laurentiu021/SystemManager)](https://github.com/laurentiu021/SystemManager/issues)


### PR DESCRIPTION
## Summary

- Added **CodeQL** workflow badge to README (shows scan status)
- Added a third-party review-service badge to the README badge row (shields.io custom badge)
- Fixed CHANGELOG: moved entries from [Unreleased] to proper version sections (v0.35.9 and v0.35.8)

No code changes — docs only.
