### PR TITLE
fix: update repo name in UpdateService for auto-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Auto-update** — UpdateService now points to the new `SystemManager` repo
+  name instead of the old `SysManager`. Without this fix, the in-app update
+  checker would fail to find new releases.
+
 ## [0.35.9] - 2026-05-08
 
 ### Changed

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -21,7 +21,7 @@ namespace SysManager.Services;
 public sealed class UpdateService
 {
     public const string Owner = "laurentiu021";
-    public const string Repo  = "SysManager";
+    public const string Repo  = "SystemManager";
     public const string AssetName = "SysManager.exe";
 
     private static readonly HttpClient Http = CreateClient();


### PR DESCRIPTION
## Summary

The in-app update checker (UpdateService) was still pointing to the old repo name \\laurentiu021/SysManager\\. Since the old repo is now private, the GitHub API returns 404 for unauthenticated requests, breaking auto-update detection.

### Change
- \\UpdateService.Repo\\ constant: \\SysManager\\ → \\SystemManager\\

### Impact
Without this fix, every user running v0.35.9 or earlier would never see update notifications.
