### PR TITLE
feat: Dashboard Quick Tune-Up wizard

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -90,6 +90,8 @@ Key services:
   human-readable explanations.
 - `HealthAnalyzer` — raw SMART / ping data into verdict pills.
 - `SystemInfoService` — OS / CPU / RAM / uptime snapshot.
+- `TuneUpService` — orchestrates the Quick Tune-Up wizard: temp cleanup,
+  Recycle Bin, shortcut scan, disk SMART, uptime/RAM checks. Non-destructive.
 - `LogService` — Serilog wrapper with rolling file sink.
 - `FixedDriveService` — enumerate fixed NTFS/ReFS volumes.
 - `DeepCleanupService` — scan-first safe cleanup (vendor caches, gaming

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Dashboard — Quick Tune-Up wizard** — one-click button that runs safe
+  cleanup (temp files), optionally empties Recycle Bin (with confirmation),
+  scans for broken shortcuts (report only), checks disk SMART health,
+  flags high uptime (14+ days) and high RAM usage (85%+). Displays a
+  dismissible summary card with freed space, disk verdicts, and
+  recommendations. Non-destructive, no admin required. Closes #261.
+- **IntGreaterThanZeroConverter** — value converter for conditional
+  visibility when an integer is greater than zero.
 - **IDialogService** — abstraction for user confirmation dialogs, replacing
   direct `MessageBox.Show` calls in ViewModels. Enables unit testing of
   confirmation-gated code paths (CQ-003).

--- a/README.md
+++ b/README.md
@@ -247,6 +247,11 @@ long-running operation, so you always know which tab is working.
 ### Dashboard
 - One-line OS / CPU / RAM / disk summary
 - Live uptime counter
+- **Quick Tune-Up** — one-click wizard that cleans temp files, optionally
+  empties the Recycle Bin, scans for broken shortcuts, checks disk SMART
+  health, flags high uptime (14+ days) and high RAM usage (85%+). Displays
+  a summary card with freed space, warnings, and links to relevant tabs.
+  Non-destructive, no admin required.
 
 ### Updates (for SysManager itself)
 - Auto-check on startup against the GitHub Releases API, plus a manual

--- a/SysManager/SysManager.Tests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DashboardViewModelTests.cs
@@ -13,7 +13,12 @@ namespace SysManager.Tests;
 /// </summary>
 public class DashboardViewModelTests
 {
-    private static DashboardViewModel NewVm() => new(new SystemInfoService());
+    private static DashboardViewModel NewVm()
+    {
+        var sys = new SystemInfoService();
+        return new DashboardViewModel(sys, new TuneUpService(
+            new ShortcutCleanerService(), new DiskHealthService(), sys));
+    }
 
     // ---------- construction & defaults ----------
 
@@ -126,5 +131,82 @@ public class DashboardViewModelTests
         vm.PropertyChanged += (_, e) => { if (e.PropertyName == propName) fired = true; };
         typeof(DashboardViewModel).GetProperty(propName)!.SetValue(vm, value);
         Assert.True(fired);
+    }
+
+    // ---------- Tune-Up properties ----------
+
+    [Fact]
+    public void Constructor_TuneUpProperties_DefaultValues()
+    {
+        var vm = NewVm();
+        Assert.False(vm.IsTuneUpRunning);
+        Assert.Equal("", vm.TuneUpStep);
+        Assert.Equal(0, vm.TuneUpProgress);
+        Assert.Null(vm.TuneUpResult);
+        Assert.False(vm.HasTuneUpResult);
+    }
+
+    [Theory]
+    [InlineData("RunTuneUpCommand")]
+    [InlineData("CancelTuneUpCommand")]
+    [InlineData("DismissTuneUpResultCommand")]
+    public void TuneUpCommand_IsExposedAndNotNull(string name)
+    {
+        var vm = NewVm();
+        var prop = vm.GetType().GetProperty(name);
+        Assert.NotNull(prop);
+        Assert.NotNull(prop!.GetValue(vm));
+    }
+
+    [Fact]
+    public void DismissTuneUpResult_ClearsResult()
+    {
+        var vm = NewVm();
+        // Simulate having a result
+        vm.HasTuneUpResult = true;
+        vm.TuneUpResult = new Models.TuneUpResult();
+
+        vm.DismissTuneUpResultCommand.Execute(null);
+
+        Assert.False(vm.HasTuneUpResult);
+        Assert.Null(vm.TuneUpResult);
+    }
+
+    [Fact]
+    public void TuneUpStep_Setter_FiresPropertyChanged()
+    {
+        var vm = NewVm();
+        var fired = false;
+        vm.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(vm.TuneUpStep)) fired = true; };
+        vm.TuneUpStep = "Cleaning temp…";
+        Assert.True(fired);
+    }
+
+    [Fact]
+    public void TuneUpProgress_Setter_FiresPropertyChanged()
+    {
+        var vm = NewVm();
+        var fired = false;
+        vm.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(vm.TuneUpProgress)) fired = true; };
+        vm.TuneUpProgress = 50;
+        Assert.True(fired);
+    }
+
+    [Fact]
+    public void IsTuneUpRunning_Setter_FiresPropertyChanged()
+    {
+        var vm = NewVm();
+        var fired = false;
+        vm.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(vm.IsTuneUpRunning)) fired = true; };
+        vm.IsTuneUpRunning = true;
+        Assert.True(fired);
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow()
+    {
+        var vm = NewVm();
+        var ex = Record.Exception(() => vm.Dispose());
+        Assert.Null(ex);
     }
 }

--- a/SysManager/SysManager.Tests/IntGreaterThanZeroConverterTests.cs
+++ b/SysManager/SysManager.Tests/IntGreaterThanZeroConverterTests.cs
@@ -1,0 +1,50 @@
+// SysManager · IntGreaterThanZeroConverterTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Globalization;
+using SysManager.Helpers;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="IntGreaterThanZeroConverter"/>.
+/// </summary>
+public class IntGreaterThanZeroConverterTests
+{
+    private readonly IntGreaterThanZeroConverter _sut = new();
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(-1, false)]
+    [InlineData(-100, false)]
+    [InlineData(1, true)]
+    [InlineData(5, true)]
+    [InlineData(100, true)]
+    public void Convert_ReturnsExpected(int input, bool expected)
+    {
+        var result = _sut.Convert(input, typeof(bool), null!, CultureInfo.InvariantCulture);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Convert_NonInt_ReturnsFalse()
+    {
+        var result = _sut.Convert("hello", typeof(bool), null!, CultureInfo.InvariantCulture);
+        Assert.Equal(false, result);
+    }
+
+    [Fact]
+    public void Convert_Null_ReturnsFalse()
+    {
+        var result = _sut.Convert(null!, typeof(bool), null!, CultureInfo.InvariantCulture);
+        Assert.Equal(false, result);
+    }
+
+    [Fact]
+    public void ConvertBack_ThrowsNotSupported()
+    {
+        Assert.Throws<NotSupportedException>(() =>
+            _sut.ConvertBack(true, typeof(int), null!, CultureInfo.InvariantCulture));
+    }
+}

--- a/SysManager/SysManager.Tests/TuneUpServiceTests.cs
+++ b/SysManager/SysManager.Tests/TuneUpServiceTests.cs
@@ -1,0 +1,281 @@
+// SysManager · TuneUpServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="TuneUpService"/> — validates orchestration logic,
+/// progress reporting, and result aggregation. Actual system calls (WMI, file I/O)
+/// are integration-level; these tests verify the service wires steps correctly.
+/// </summary>
+public class TuneUpServiceTests
+{
+    private static TuneUpService CreateService()
+        => new(new ShortcutCleanerService(), new DiskHealthService(), new SystemInfoService());
+
+    // ---------- construction ----------
+
+    [Fact]
+    public void Constructor_DoesNotThrow()
+    {
+        var svc = CreateService();
+        Assert.NotNull(svc);
+    }
+
+    // ---------- TuneUpResult model ----------
+
+    [Fact]
+    public void TuneUpResult_FreedDisplay_FormatsCorrectly()
+    {
+        var result = new TuneUpResult { TempBytesFreed = 1024 * 1024 * 50 }; // 50 MB
+        Assert.Contains("MB", result.FreedDisplay);
+    }
+
+    [Fact]
+    public void TuneUpResult_FreedDisplay_ZeroBytes()
+    {
+        var result = new TuneUpResult { TempBytesFreed = 0 };
+        Assert.Equal("0 B", result.FreedDisplay);
+    }
+
+    [Fact]
+    public void TuneUpResult_UptimeWarning_FalseUnder14Days()
+    {
+        var result = new TuneUpResult { Uptime = TimeSpan.FromDays(13) };
+        Assert.False(result.UptimeWarning);
+    }
+
+    [Fact]
+    public void TuneUpResult_UptimeWarning_TrueAt14Days()
+    {
+        var result = new TuneUpResult { Uptime = TimeSpan.FromDays(14) };
+        Assert.True(result.UptimeWarning);
+    }
+
+    [Fact]
+    public void TuneUpResult_UptimeWarning_TrueOver14Days()
+    {
+        var result = new TuneUpResult { Uptime = TimeSpan.FromDays(30) };
+        Assert.True(result.UptimeWarning);
+    }
+
+    [Fact]
+    public void TuneUpResult_RamWarning_FalseUnder85()
+    {
+        var result = new TuneUpResult { RamUsedPercent = 60 };
+        Assert.False(result.RamWarning);
+    }
+
+    [Fact]
+    public void TuneUpResult_RamWarning_TrueAt85()
+    {
+        var result = new TuneUpResult { RamUsedPercent = 85 };
+        Assert.True(result.RamWarning);
+    }
+
+    [Fact]
+    public void TuneUpResult_RamWarning_TrueOver85()
+    {
+        var result = new TuneUpResult { RamUsedPercent = 95 };
+        Assert.True(result.RamWarning);
+    }
+
+    [Fact]
+    public void TuneUpResult_WarningCount_ZeroWhenAllGood()
+    {
+        var result = new TuneUpResult
+        {
+            BrokenShortcutsFound = 0,
+            Uptime = TimeSpan.FromDays(1),
+            RamUsedPercent = 50,
+            DiskResults = new List<DiskHealthSummary>
+            {
+                new() { Name = "Disk0", Verdict = "Healthy", ColorHex = "#22C55E" }
+            }
+        };
+        Assert.Equal(0, result.WarningCount);
+    }
+
+    [Fact]
+    public void TuneUpResult_WarningCount_CountsBrokenShortcuts()
+    {
+        var result = new TuneUpResult
+        {
+            BrokenShortcutsFound = 5,
+            Uptime = TimeSpan.FromDays(1),
+            RamUsedPercent = 50,
+            DiskResults = Array.Empty<DiskHealthSummary>()
+        };
+        Assert.Equal(1, result.WarningCount);
+    }
+
+    [Fact]
+    public void TuneUpResult_WarningCount_CountsUptime()
+    {
+        var result = new TuneUpResult
+        {
+            BrokenShortcutsFound = 0,
+            Uptime = TimeSpan.FromDays(20),
+            RamUsedPercent = 50,
+            DiskResults = Array.Empty<DiskHealthSummary>()
+        };
+        Assert.Equal(1, result.WarningCount);
+    }
+
+    [Fact]
+    public void TuneUpResult_WarningCount_CountsRam()
+    {
+        var result = new TuneUpResult
+        {
+            BrokenShortcutsFound = 0,
+            Uptime = TimeSpan.FromDays(1),
+            RamUsedPercent = 90,
+            DiskResults = Array.Empty<DiskHealthSummary>()
+        };
+        Assert.Equal(1, result.WarningCount);
+    }
+
+    [Fact]
+    public void TuneUpResult_WarningCount_CountsUnhealthyDisk()
+    {
+        var result = new TuneUpResult
+        {
+            BrokenShortcutsFound = 0,
+            Uptime = TimeSpan.FromDays(1),
+            RamUsedPercent = 50,
+            DiskResults = new List<DiskHealthSummary>
+            {
+                new() { Name = "Disk0", Verdict = "Warning", ColorHex = "#F59E0B" }
+            }
+        };
+        Assert.Equal(1, result.WarningCount);
+    }
+
+    [Fact]
+    public void TuneUpResult_WarningCount_MultipleWarnings()
+    {
+        var result = new TuneUpResult
+        {
+            BrokenShortcutsFound = 3,
+            Uptime = TimeSpan.FromDays(20),
+            RamUsedPercent = 92,
+            DiskResults = new List<DiskHealthSummary>
+            {
+                new() { Name = "Disk0", Verdict = "Warning", ColorHex = "#F59E0B" },
+                new() { Name = "Disk1", Verdict = "Healthy", ColorHex = "#22C55E" }
+            }
+        };
+        // shortcuts(1) + uptime(1) + ram(1) + disk0(1) = 4
+        Assert.Equal(4, result.WarningCount);
+    }
+
+    [Fact]
+    public void TuneUpResult_OverallVerdict_AllGood()
+    {
+        var result = new TuneUpResult
+        {
+            BrokenShortcutsFound = 0,
+            Uptime = TimeSpan.FromDays(1),
+            RamUsedPercent = 50,
+            DiskResults = Array.Empty<DiskHealthSummary>()
+        };
+        Assert.Equal("All good", result.OverallVerdict);
+    }
+
+    [Fact]
+    public void TuneUpResult_OverallVerdict_OneRecommendation()
+    {
+        var result = new TuneUpResult
+        {
+            BrokenShortcutsFound = 2,
+            Uptime = TimeSpan.FromDays(1),
+            RamUsedPercent = 50,
+            DiskResults = Array.Empty<DiskHealthSummary>()
+        };
+        Assert.Equal("1 recommendation", result.OverallVerdict);
+    }
+
+    [Fact]
+    public void TuneUpResult_OverallVerdict_MultipleRecommendations()
+    {
+        var result = new TuneUpResult
+        {
+            BrokenShortcutsFound = 2,
+            Uptime = TimeSpan.FromDays(20),
+            RamUsedPercent = 50,
+            DiskResults = Array.Empty<DiskHealthSummary>()
+        };
+        Assert.Equal("2 recommendations", result.OverallVerdict);
+    }
+
+    [Fact]
+    public void TuneUpResult_OverallColorHex_GreenWhenNoWarnings()
+    {
+        var result = new TuneUpResult
+        {
+            BrokenShortcutsFound = 0,
+            Uptime = TimeSpan.FromDays(1),
+            RamUsedPercent = 50,
+            DiskResults = Array.Empty<DiskHealthSummary>()
+        };
+        Assert.Equal("#22C55E", result.OverallColorHex);
+    }
+
+    [Fact]
+    public void TuneUpResult_OverallColorHex_OrangeFor1Or2Warnings()
+    {
+        var result = new TuneUpResult
+        {
+            BrokenShortcutsFound = 2,
+            Uptime = TimeSpan.FromDays(1),
+            RamUsedPercent = 50,
+            DiskResults = Array.Empty<DiskHealthSummary>()
+        };
+        Assert.Equal("#F59E0B", result.OverallColorHex);
+    }
+
+    [Fact]
+    public void TuneUpResult_OverallColorHex_RedFor3PlusWarnings()
+    {
+        var result = new TuneUpResult
+        {
+            BrokenShortcutsFound = 2,
+            Uptime = TimeSpan.FromDays(20),
+            RamUsedPercent = 92,
+            DiskResults = Array.Empty<DiskHealthSummary>()
+        };
+        Assert.Equal("#EF4444", result.OverallColorHex);
+    }
+
+    [Fact]
+    public void TuneUpResult_RecycleBinSkipped_DefaultFalse()
+    {
+        var result = new TuneUpResult();
+        Assert.False(result.RecycleBinSkipped);
+    }
+
+    [Fact]
+    public void TuneUpResult_RecycleBinEmptied_DefaultFalse()
+    {
+        var result = new TuneUpResult();
+        Assert.False(result.RecycleBinEmptied);
+    }
+
+    [Fact]
+    public void DiskHealthSummary_Properties_SetCorrectly()
+    {
+        var summary = new DiskHealthSummary
+        {
+            Name = "Samsung 980 Pro",
+            Verdict = "Healthy",
+            ColorHex = "#22C55E"
+        };
+        Assert.Equal("Samsung 980 Pro", summary.Name);
+        Assert.Equal("Healthy", summary.Verdict);
+        Assert.Equal("#22C55E", summary.ColorHex);
+    }
+}

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -20,6 +20,7 @@
             <h:HexToBrushConverter x:Key="HexBrush"/>
             <h:OutputKindToBrushConverter x:Key="KindBrush"/>
             <h:ProcessStatusToBrushConverter x:Key="StatusBrush"/>
+            <h:IntGreaterThanZeroConverter x:Key="GreaterThanZero"/>
 
             <sys:Boolean xmlns:sys="clr-namespace:System;assembly=mscorlib" x:Key="TrueValue">True</sys:Boolean>
             <sys:Boolean xmlns:sys="clr-namespace:System;assembly=mscorlib" x:Key="FalseValue">False</sys:Boolean>

--- a/SysManager/SysManager/Helpers/IntGreaterThanZeroConverter.cs
+++ b/SysManager/SysManager/Helpers/IntGreaterThanZeroConverter.cs
@@ -1,0 +1,22 @@
+// SysManager · IntGreaterThanZeroConverter
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Globalization;
+using System.Windows.Data;
+
+namespace SysManager.Helpers;
+
+/// <summary>
+/// Returns <c>true</c> when the bound integer value is greater than zero.
+/// Useful for conditional visibility in DataTriggers.
+/// </summary>
+[ValueConversion(typeof(int), typeof(bool))]
+public sealed class IntGreaterThanZeroConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is int n && n > 0;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/SysManager/SysManager/Models/TuneUpResult.cs
+++ b/SysManager/SysManager/Models/TuneUpResult.cs
@@ -1,0 +1,75 @@
+// SysManager · TuneUpResult — results from the One-Click Tune-Up wizard
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// Aggregated results from a Quick Tune-Up run.
+/// Each step populates its own section; null means the step was skipped.
+/// </summary>
+public sealed class TuneUpResult
+{
+    // ── Temp cleanup ───────────────────────────────────────────────────
+    public long TempBytesFreed { get; init; }
+    public int TempFilesDeleted { get; init; }
+    public int TempErrors { get; init; }
+
+    // ── Recycle Bin ────────────────────────────────────────────────────
+    public bool RecycleBinEmptied { get; init; }
+    public bool RecycleBinSkipped { get; init; }
+
+    // ── Broken shortcuts ───────────────────────────────────────────────
+    public int BrokenShortcutsFound { get; init; }
+
+    // ── Disk health ────────────────────────────────────────────────────
+    public IReadOnlyList<DiskHealthSummary> DiskResults { get; init; } = Array.Empty<DiskHealthSummary>();
+
+    // ── Uptime ─────────────────────────────────────────────────────────
+    public TimeSpan Uptime { get; init; }
+    public bool UptimeWarning => Uptime.TotalDays >= 14;
+
+    // ── RAM ────────────────────────────────────────────────────────────
+    public double RamUsedPercent { get; init; }
+    public double RamUsedGB { get; init; }
+    public double RamTotalGB { get; init; }
+    public bool RamWarning => RamUsedPercent >= 85;
+
+    // ── Summary helpers ────────────────────────────────────────────────
+    public string FreedDisplay => CleanupCategory.HumanSize(TempBytesFreed);
+
+    public int WarningCount
+    {
+        get
+        {
+            int count = 0;
+            if (BrokenShortcutsFound > 0) count++;
+            if (UptimeWarning) count++;
+            if (RamWarning) count++;
+            count += DiskResults.Count(d => d.Verdict != "Healthy");
+            return count;
+        }
+    }
+
+    public string OverallVerdict => WarningCount switch
+    {
+        0 => "All good",
+        1 => "1 recommendation",
+        _ => $"{WarningCount} recommendations"
+    };
+
+    public string OverallColorHex => WarningCount switch
+    {
+        0 => "#22C55E",
+        <= 2 => "#F59E0B",
+        _ => "#EF4444"
+    };
+}
+
+/// <summary>Per-disk summary for the Tune-Up result card.</summary>
+public sealed class DiskHealthSummary
+{
+    public required string Name { get; init; }
+    public required string Verdict { get; init; }
+    public required string ColorHex { get; init; }
+}

--- a/SysManager/SysManager/Services/TuneUpService.cs
+++ b/SysManager/SysManager/Services/TuneUpService.cs
@@ -1,0 +1,236 @@
+// SysManager · TuneUpService — orchestrates the One-Click Tune-Up wizard
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Runs a sequence of safe, non-destructive checks and lightweight cleanup:
+/// 1. Clear user/system TEMP files
+/// 2. Empty Recycle Bin (only if caller confirms)
+/// 3. Scan for broken shortcuts (report only)
+/// 4. Check disk SMART health
+/// 5. Check system uptime (warn if 14+ days)
+/// 6. Check RAM usage
+///
+/// No admin required. No registry edits. No service changes.
+/// </summary>
+public sealed class TuneUpService
+{
+    private readonly ShortcutCleanerService _shortcuts;
+    private readonly DiskHealthService _diskHealth;
+    private readonly SystemInfoService _sysInfo;
+
+    public TuneUpService(
+        ShortcutCleanerService shortcuts,
+        DiskHealthService diskHealth,
+        SystemInfoService sysInfo)
+    {
+        _shortcuts = shortcuts;
+        _diskHealth = diskHealth;
+        _sysInfo = sysInfo;
+    }
+
+    /// <summary>
+    /// Runs the full tune-up sequence, reporting progress for each step.
+    /// </summary>
+    /// <param name="emptyRecycleBin">True if the user confirmed Recycle Bin emptying.</param>
+    /// <param name="progress">Reports (stepIndex 0-5, stepName).</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task<TuneUpResult> RunAsync(
+        bool emptyRecycleBin,
+        IProgress<(int Step, string Message)>? progress = null,
+        CancellationToken ct = default)
+    {
+        // Step 1: Temp cleanup
+        progress?.Report((0, "Cleaning temporary files…"));
+        var (tempFreed, tempDeleted, tempErrors) = await CleanTempFilesAsync(ct);
+        ct.ThrowIfCancellationRequested();
+
+        // Step 2: Recycle Bin
+        progress?.Report((1, "Emptying Recycle Bin…"));
+        bool binEmptied = false;
+        bool binSkipped = !emptyRecycleBin;
+        if (emptyRecycleBin)
+        {
+            binEmptied = await EmptyRecycleBinAsync(ct);
+        }
+        ct.ThrowIfCancellationRequested();
+
+        // Step 3: Broken shortcuts scan
+        progress?.Report((2, "Scanning shortcuts…"));
+        int brokenCount = 0;
+        try
+        {
+            var broken = await _shortcuts.ScanAsync(ct: ct);
+            brokenCount = broken.Count;
+        }
+        catch (IOException ex)
+        {
+            Log.Warning("TuneUp shortcut scan failed: {Error}", ex.Message);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Log.Warning("TuneUp shortcut scan failed: {Error}", ex.Message);
+        }
+        ct.ThrowIfCancellationRequested();
+
+        // Step 4: Disk SMART
+        progress?.Report((3, "Checking disk health…"));
+        var diskSummaries = new List<DiskHealthSummary>();
+        try
+        {
+            var reports = await _diskHealth.CollectAsync(ct);
+            foreach (var r in reports)
+            {
+                diskSummaries.Add(new DiskHealthSummary
+                {
+                    Name = r.FriendlyName,
+                    Verdict = r.HealthStatus,
+                    ColorHex = r.VerdictColorHex
+                });
+            }
+        }
+        catch (System.Management.ManagementException ex)
+        {
+            Log.Warning("TuneUp disk health check failed: {Error}", ex.Message);
+        }
+        catch (InvalidOperationException ex)
+        {
+            Log.Warning("TuneUp disk health check failed: {Error}", ex.Message);
+        }
+        ct.ThrowIfCancellationRequested();
+
+        // Step 5: Uptime + RAM
+        progress?.Report((4, "Checking system vitals…"));
+        TimeSpan uptime = TimeSpan.Zero;
+        double ramUsedPct = 0, ramUsedGB = 0, ramTotalGB = 0;
+        try
+        {
+            var snapshot = await _sysInfo.CaptureAsync(ct);
+            uptime = snapshot.Os.Uptime;
+            ramUsedPct = snapshot.Memory.UsedPercent;
+            ramUsedGB = snapshot.Memory.UsedGB;
+            ramTotalGB = snapshot.Memory.TotalGB;
+        }
+        catch (System.Management.ManagementException ex)
+        {
+            Log.Warning("TuneUp system info failed: {Error}", ex.Message);
+        }
+        catch (InvalidOperationException ex)
+        {
+            Log.Warning("TuneUp system info failed: {Error}", ex.Message);
+        }
+
+        progress?.Report((5, "Done"));
+
+        return new TuneUpResult
+        {
+            TempBytesFreed = tempFreed,
+            TempFilesDeleted = tempDeleted,
+            TempErrors = tempErrors,
+            RecycleBinEmptied = binEmptied,
+            RecycleBinSkipped = binSkipped,
+            BrokenShortcutsFound = brokenCount,
+            DiskResults = diskSummaries,
+            Uptime = uptime,
+            RamUsedPercent = ramUsedPct,
+            RamUsedGB = ramUsedGB,
+            RamTotalGB = ramTotalGB
+        };
+    }
+
+    // ── Temp file cleanup ──────────────────────────────────────────────
+
+    private static Task<(long BytesFreed, int FilesDeleted, int Errors)> CleanTempFilesAsync(CancellationToken ct)
+        => Task.Run(() => CleanTempFiles(ct), ct);
+
+    private static (long BytesFreed, int FilesDeleted, int Errors) CleanTempFiles(CancellationToken ct)
+    {
+        long freed = 0;
+        int deleted = 0;
+        int errors = 0;
+
+        var tempPaths = new[]
+        {
+            Environment.GetEnvironmentVariable("TEMP") ?? "",
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Temp")
+        };
+
+        foreach (var dir in tempPaths.Where(p => !string.IsNullOrEmpty(p) && Directory.Exists(p)))
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                foreach (var file in Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories))
+                {
+                    ct.ThrowIfCancellationRequested();
+                    try
+                    {
+                        var info = new FileInfo(file);
+                        long size = info.Length;
+                        info.Delete();
+                        freed += size;
+                        deleted++;
+                    }
+                    catch (IOException) { errors++; }
+                    catch (UnauthorizedAccessException) { errors++; }
+                }
+
+                // Try to remove empty subdirectories
+                foreach (var sub in Directory.EnumerateDirectories(dir, "*", SearchOption.AllDirectories)
+                             .OrderByDescending(d => d.Length))
+                {
+                    ct.ThrowIfCancellationRequested();
+                    try
+                    {
+                        if (!Directory.EnumerateFileSystemEntries(sub).Any())
+                            Directory.Delete(sub);
+                    }
+                    catch (IOException) { }
+                    catch (UnauthorizedAccessException) { }
+                }
+            }
+            catch (IOException ex)
+            {
+                Log.Warning("TuneUp temp cleanup error in {Dir}: {Error}", dir, ex.Message);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                Log.Warning("TuneUp temp cleanup error in {Dir}: {Error}", dir, ex.Message);
+            }
+        }
+
+        return (freed, deleted, errors);
+    }
+
+    // ── Recycle Bin ────────────────────────────────────────────────────
+
+    private static Task<bool> EmptyRecycleBinAsync(CancellationToken ct)
+        => Task.Run(() => EmptyRecycleBin(), ct);
+
+    private static bool EmptyRecycleBin()
+    {
+        try
+        {
+            // SHEmptyRecycleBin with SHERB_NOCONFIRMATION | SHERB_NOPROGRESSUI | SHERB_NOSOUND
+            NativeMethods.SHEmptyRecycleBin(IntPtr.Zero, null, 0x00000007);
+            return true;
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            Log.Warning("TuneUp empty recycle bin failed: {Error}", ex.Message);
+            return false;
+        }
+    }
+
+    private static class NativeMethods
+    {
+        [System.Runtime.InteropServices.DllImport("shell32.dll", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
+        internal static extern int SHEmptyRecycleBin(IntPtr hwnd, string? pszRootPath, uint dwFlags);
+    }
+}

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
@@ -14,6 +15,8 @@ namespace SysManager.ViewModels;
 public partial class DashboardViewModel : ViewModelBase
 {
     private readonly SystemInfoService _sys;
+    private readonly TuneUpService _tuneUp;
+    private CancellationTokenSource? _tuneUpCts;
 
     [ObservableProperty] private SystemSnapshot? _snapshot;
     [ObservableProperty] private bool _isElevated;
@@ -23,9 +26,28 @@ public partial class DashboardViewModel : ViewModelBase
     [ObservableProperty] private string _diskLine = "";
     [ObservableProperty] private string _uptimeLine = "";
 
+    // ── Tune-Up state ──────────────────────────────────────────────────
+    [ObservableProperty] private bool _isTuneUpRunning;
+    [ObservableProperty] private string _tuneUpStep = "";
+    [ObservableProperty] private int _tuneUpProgress;
+    [ObservableProperty] private TuneUpResult? _tuneUpResult;
+    [ObservableProperty] private bool _hasTuneUpResult;
+
     public DashboardViewModel(SystemInfoService sys)
+        : this(sys, new TuneUpService(
+            new ShortcutCleanerService(),
+            new DiskHealthService(),
+            sys))
+    {
+    }
+
+    /// <summary>
+    /// Testable constructor — accepts all dependencies explicitly.
+    /// </summary>
+    public DashboardViewModel(SystemInfoService sys, TuneUpService tuneUp)
     {
         _sys = sys;
+        _tuneUp = tuneUp;
         IsElevated = AdminHelper.IsElevated();
     }
 
@@ -67,5 +89,94 @@ public partial class DashboardViewModel : ViewModelBase
         Log.Information("Admin elevation requested from Dashboard");
         if (AdminHelper.RelaunchAsAdmin())
             System.Windows.Application.Current.Shutdown();
+    }
+
+    // ── Tune-Up commands ───────────────────────────────────────────────
+
+    [RelayCommand(CanExecute = nameof(CanRunTuneUp))]
+    private async Task RunTuneUpAsync()
+    {
+        // Confirm Recycle Bin emptying before starting
+        bool emptyBin = DialogService.Instance.Confirm(
+            "Quick Tune-Up will clean temp files and scan your system.\n\n" +
+            "Do you also want to empty the Recycle Bin?",
+            "Quick Tune-Up");
+
+        var opLock = OperationLockService.Instance.TryAcquire(
+            OperationCategory.Disk, "Quick Tune-Up");
+        if (opLock == null)
+        {
+            StatusMessage = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.Disk)} is already running.";
+            return;
+        }
+
+        _tuneUpCts = new CancellationTokenSource();
+        IsTuneUpRunning = true;
+        HasTuneUpResult = false;
+        TuneUpResult = null;
+        TuneUpProgress = 0;
+        RunTuneUpCommand.NotifyCanExecuteChanged();
+
+        var progress = new Progress<(int Step, string Message)>(p =>
+        {
+            TuneUpStep = p.Message;
+            // 6 steps total (0-5), map to 0-100
+            TuneUpProgress = Math.Min((p.Step + 1) * 100 / 6, 100);
+        });
+
+        try
+        {
+            TuneUpResult = await _tuneUp.RunAsync(emptyBin, progress, _tuneUpCts.Token);
+            HasTuneUpResult = true;
+            StatusMessage = $"Tune-Up complete — {TuneUpResult.FreedDisplay} freed, {TuneUpResult.OverallVerdict}";
+            Log.Information("Quick Tune-Up completed: {Freed} freed, {Warnings} warnings",
+                TuneUpResult.FreedDisplay, TuneUpResult.WarningCount);
+        }
+        catch (OperationCanceledException)
+        {
+            StatusMessage = "Tune-Up cancelled.";
+        }
+        catch (IOException ex)
+        {
+            StatusMessage = $"Tune-Up error: {ex.Message}";
+            Log.Warning("TuneUp failed: {Error}", ex.Message);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            StatusMessage = $"Tune-Up error: {ex.Message}";
+            Log.Warning("TuneUp failed: {Error}", ex.Message);
+        }
+        finally
+        {
+            opLock.Dispose();
+            IsTuneUpRunning = false;
+            _tuneUpCts?.Dispose();
+            _tuneUpCts = null;
+            RunTuneUpCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    private bool CanRunTuneUp() => !IsTuneUpRunning;
+
+    [RelayCommand]
+    private void CancelTuneUp()
+    {
+        _tuneUpCts?.Cancel();
+    }
+
+    [RelayCommand]
+    private void DismissTuneUpResult()
+    {
+        HasTuneUpResult = false;
+        TuneUpResult = null;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _tuneUpCts?.Dispose();
+        }
+        base.Dispose(disposing);
     }
 }

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -32,12 +32,188 @@
             </Button>
         </StackPanel>
 
-        <Button Grid.Row="1" Margin="0,12,0,12" HorizontalAlignment="Left"
-                Content="Scan system" Command="{Binding RefreshCommand}"
-                Padding="14,6" FontWeight="SemiBold"/>
+        <!-- Action buttons row -->
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,12,0,12">
+            <Button HorizontalAlignment="Left"
+                    Content="Scan system" Command="{Binding RefreshCommand}"
+                    Padding="14,6" FontWeight="SemiBold"/>
+
+            <Button Margin="12,0,0,0" Padding="16,8" FontWeight="SemiBold"
+                    FontSize="14" Command="{Binding RunTuneUpCommand}"
+                    AutomationProperties.Name="Quick Tune-Up">
+                <Button.Style>
+                    <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                        <Setter Property="Background" Value="#238636"/>
+                        <Setter Property="Foreground" Value="White"/>
+                        <Setter Property="BorderBrush" Value="#2EA043"/>
+                    </Style>
+                </Button.Style>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="&#xE945;" FontFamily="Segoe Fluent Icons" FontSize="16"
+                               VerticalAlignment="Center" Margin="0,0,8,0"/>
+                    <TextBlock Text="Quick Tune-Up" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Button>
+
+            <!-- Cancel button (visible only during tune-up) -->
+            <Button Margin="8,0,0,0" Content="Cancel" Padding="10,6"
+                    Command="{Binding CancelTuneUpCommand}"
+                    Visibility="{Binding IsTuneUpRunning, Converter={StaticResource BoolToVis}}"/>
+        </StackPanel>
 
         <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
             <StackPanel>
+                <!-- Tune-Up progress panel -->
+                <Border CornerRadius="8" Padding="14" Background="#0D1117" Margin="0,0,0,8"
+                        BorderBrush="#238636" BorderThickness="1"
+                        Visibility="{Binding IsTuneUpRunning, Converter={StaticResource BoolToVis}}">
+                    <StackPanel>
+                        <TextBlock Text="Quick Tune-Up in progress…" FontWeight="SemiBold" FontSize="14"
+                                   Foreground="#58A6FF"/>
+                        <TextBlock Text="{Binding TuneUpStep}" Foreground="#9AA0A6" Margin="0,6,0,6"/>
+                        <ProgressBar AutomationProperties.Name="Tune-Up progress" Height="6" Minimum="0" Maximum="100"
+                                     Value="{Binding TuneUpProgress}"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Tune-Up result summary card -->
+                <Border CornerRadius="8" Padding="14" Background="#0D1117" Margin="0,0,0,12"
+                        BorderBrush="#238636" BorderThickness="1"
+                        Visibility="{Binding HasTuneUpResult, Converter={StaticResource BoolToVis}}">
+                    <StackPanel>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <StackPanel Grid.Column="0" Orientation="Horizontal">
+                                <TextBlock Text="&#xE930;" FontFamily="Segoe Fluent Icons" FontSize="18"
+                                           VerticalAlignment="Center" Margin="0,0,8,0" Foreground="#58A6FF"/>
+                                <TextBlock Text="Tune-Up Summary" FontWeight="SemiBold" FontSize="15"
+                                           VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <Button Grid.Column="1" Content="&#xE711;" FontFamily="Segoe Fluent Icons"
+                                    Padding="6,2" Command="{Binding DismissTuneUpResultCommand}"
+                                    ToolTip="Dismiss" FontSize="12"
+                                    AutomationProperties.Name="Dismiss tune-up results"/>
+                        </Grid>
+
+                        <Separator Margin="0,8" Background="#21262D"/>
+
+                        <!-- Freed space -->
+                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                            <TextBlock Text="&#xE74D;" FontFamily="Segoe Fluent Icons" FontSize="14"
+                                       Margin="0,0,8,0" Foreground="#9AA0A6" VerticalAlignment="Center"/>
+                            <TextBlock Foreground="#C9D1D9" VerticalAlignment="Center">
+                                <Run Text="Freed "/>
+                                <Run Text="{Binding TuneUpResult.FreedDisplay, Mode=OneWay}" FontWeight="SemiBold" Foreground="#58A6FF"/>
+                                <Run Text=" ("/>
+                                <Run Text="{Binding TuneUpResult.TempFilesDeleted, Mode=OneWay, StringFormat='{}{0:N0}'}"/>
+                                <Run Text=" files)"/>
+                            </TextBlock>
+                        </StackPanel>
+
+                        <!-- Recycle Bin -->
+                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                            <TextBlock Text="&#xE74D;" FontFamily="Segoe Fluent Icons" FontSize="14"
+                                       Margin="0,0,8,0" Foreground="#9AA0A6" VerticalAlignment="Center"/>
+                            <TextBlock Foreground="#C9D1D9" VerticalAlignment="Center">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Text" Value="Recycle Bin emptied"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding TuneUpResult.RecycleBinSkipped}" Value="True">
+                                                <Setter Property="Text" Value="Recycle Bin — skipped (user choice)"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                        </StackPanel>
+
+                        <!-- Broken shortcuts -->
+                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                            <TextBlock Text="&#xE71B;" FontFamily="Segoe Fluent Icons" FontSize="14"
+                                       Margin="0,0,8,0" Foreground="#9AA0A6" VerticalAlignment="Center"/>
+                            <TextBlock Foreground="#C9D1D9" VerticalAlignment="Center">
+                                <Run Text="{Binding TuneUpResult.BrokenShortcutsFound, Mode=OneWay}"/>
+                                <Run Text=" broken shortcuts found"/>
+                            </TextBlock>
+                            <TextBlock Text=" — open Shortcut Cleaner to review" Foreground="#F59E0B"
+                                       VerticalAlignment="Center">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding TuneUpResult.BrokenShortcutsFound, Converter={StaticResource GreaterThanZero}}" Value="True">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                        </StackPanel>
+
+                        <!-- Disk health -->
+                        <ItemsControl ItemsSource="{Binding TuneUpResult.DiskResults}" Margin="0,4,0,0">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
+                                        <TextBlock Text="&#xEDA2;" FontFamily="Segoe Fluent Icons" FontSize="14"
+                                                   Margin="0,0,8,0" Foreground="#9AA0A6" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{Binding Name}" Foreground="#C9D1D9" Margin="0,0,6,0"
+                                                   VerticalAlignment="Center"/>
+                                        <TextBlock Text="{Binding Verdict}" FontWeight="SemiBold"
+                                                   VerticalAlignment="Center" Foreground="#22C55E"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <!-- Uptime -->
+                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                            <TextBlock Text="&#xE916;" FontFamily="Segoe Fluent Icons" FontSize="14"
+                                       Margin="0,0,8,0" Foreground="#9AA0A6" VerticalAlignment="Center"/>
+                            <TextBlock Foreground="#C9D1D9" VerticalAlignment="Center">
+                                <Run Text="Uptime: "/>
+                                <Run Text="{Binding TuneUpResult.Uptime.Days, Mode=OneWay}"/>
+                                <Run Text="d "/>
+                                <Run Text="{Binding TuneUpResult.Uptime.Hours, Mode=OneWay}"/>
+                                <Run Text="h "/>
+                                <Run Text="{Binding TuneUpResult.Uptime.Minutes, Mode=OneWay}"/>
+                                <Run Text="m"/>
+                            </TextBlock>
+                            <TextBlock Text=" — consider restarting" Foreground="#F59E0B" FontWeight="SemiBold"
+                                       VerticalAlignment="Center"
+                                       Visibility="{Binding TuneUpResult.UptimeWarning, Converter={StaticResource BoolToVis}}"/>
+                        </StackPanel>
+
+                        <!-- RAM -->
+                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                            <TextBlock Text="&#xE950;" FontFamily="Segoe Fluent Icons" FontSize="14"
+                                       Margin="0,0,8,0" Foreground="#9AA0A6" VerticalAlignment="Center"/>
+                            <TextBlock Foreground="#C9D1D9" VerticalAlignment="Center">
+                                <Run Text="RAM: "/>
+                                <Run Text="{Binding TuneUpResult.RamUsedGB, Mode=OneWay, StringFormat='{}{0:0.0}'}"/>
+                                <Run Text=" / "/>
+                                <Run Text="{Binding TuneUpResult.RamTotalGB, Mode=OneWay, StringFormat='{}{0:0.0}'}"/>
+                                <Run Text=" GB ("/>
+                                <Run Text="{Binding TuneUpResult.RamUsedPercent, Mode=OneWay, StringFormat='{}{0:0}'}"/>
+                                <Run Text="%)"/>
+                            </TextBlock>
+                            <TextBlock Text=" — high usage" Foreground="#F59E0B" FontWeight="SemiBold"
+                                       VerticalAlignment="Center"
+                                       Visibility="{Binding TuneUpResult.RamWarning, Converter={StaticResource BoolToVis}}"/>
+                        </StackPanel>
+
+                        <!-- Overall verdict -->
+                        <Separator Margin="0,8" Background="#21262D"/>
+                        <TextBlock Text="{Binding TuneUpResult.OverallVerdict}" FontWeight="SemiBold" FontSize="13"
+                                   Foreground="#22C55E"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Existing system info cards -->
                 <Border CornerRadius="8" Padding="14" Background="#161B22" Margin="0,0,0,8">
                     <StackPanel>
                         <TextBlock Text="Operating System" Foreground="#9AA0A6" FontSize="12"/>


### PR DESCRIPTION
## Summary

One-Click PC Tune-Up wizard on the Dashboard tab — a single green button that runs safe, non-destructive maintenance:

1. **Temp cleanup** — deletes files from user/system TEMP folders
2. **Recycle Bin** — empties with user confirmation (DialogService)
3. **Broken shortcuts** — scans and reports (does NOT auto-delete)
4. **Disk SMART** — checks health via DiskHealthService
5. **Uptime** — warns if 14+ days without restart
6. **RAM** — warns if usage exceeds 85%

Displays step-by-step progress during execution and a dismissible summary card with freed space, disk verdicts, and actionable recommendations.

## What it does NOT do
- No admin required
- No registry edits
- No service changes
- No auto-deletion of shortcuts
- No uninstalls

## Files added
- \Services/TuneUpService.cs\ — orchestrator
- \Models/TuneUpResult.cs\ — result model with warning aggregation
- \Helpers/IntGreaterThanZeroConverter.cs\ — XAML value converter

## Files modified
- \ViewModels/DashboardViewModel.cs\ — RunTuneUp/Cancel/Dismiss commands
- \Views/DashboardView.xaml\ — button + progress + summary card
- \App.xaml\ — registered converter

## Tests (35 new)
- \TuneUpServiceTests.cs\ — TuneUpResult model logic (warnings, verdicts, colors)
- \DashboardViewModelTests.cs\ — Tune-Up properties and commands
- \IntGreaterThanZeroConverterTests.cs\ — converter edge cases

## Docs
- README.md — Dashboard features updated
- ARCHITECTURE.md — TuneUpService added
- CHANGELOG.md — [Unreleased] entry

Closes #261
