### PR TITLE
feat: Dashboard Health Score card with color-coded gauge

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -92,6 +92,8 @@ Key services:
 - `SystemInfoService` — OS / CPU / RAM / uptime snapshot.
 - `TuneUpService` — orchestrates the Quick Tune-Up wizard: temp cleanup,
   Recycle Bin, shortcut scan, disk SMART, uptime/RAM checks. Non-destructive.
+- `HealthScoreService` — aggregates disk health, RAM, uptime, and battery
+  wear into a single 0–100 score with color-coded verdict and recommendations.
 - `LogService` — Serilog wrapper with rolling file sink.
 - `FixedDriveService` — enumerate fixed NTFS/ReFS volumes.
 - `DeepCleanupService` — scan-first safe cleanup (vendor caches, gaming

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   flags high uptime (14+ days) and high RAM usage (85%+). Displays a
   dismissible summary card with freed space, disk verdicts, and
   recommendations. Non-destructive, no admin required. Closes #261.
+- **Dashboard — Health Score card** — overall system health gauge (0–100)
+  combining disk SMART, RAM usage, uptime, and battery wear (on laptops).
+  Color-coded circular ring with label (Excellent/Good/Fair/Poor) and up
+  to 3 actionable recommendations. Auto-computes on load and refreshes
+  with "Scan system". Closes #259.
+- **HealthScoreService** — aggregates SystemInfoService, DiskHealthService,
+  and BatteryService into a weighted health score.
 - **IntGreaterThanZeroConverter** — value converter for conditional
   visibility when an integer is greater than zero.
 - **IDialogService** — abstraction for user confirmation dialogs, replacing

--- a/README.md
+++ b/README.md
@@ -252,6 +252,10 @@ long-running operation, so you always know which tab is working.
   health, flags high uptime (14+ days) and high RAM usage (85%+). Displays
   a summary card with freed space, warnings, and links to relevant tabs.
   Non-destructive, no admin required.
+- **Health Score** — overall system health gauge (0–100) combining disk
+  SMART, RAM usage, uptime, and battery wear. Color-coded ring (green /
+  amber / red) with up to 3 actionable recommendations. Auto-computes on
+  load and refreshes with "Scan system".
 
 ### Updates (for SysManager itself)
 - Auto-check on startup against the GitHub Releases API, plus a manual

--- a/SysManager/SysManager.Tests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DashboardViewModelTests.cs
@@ -16,8 +16,10 @@ public class DashboardViewModelTests
     private static DashboardViewModel NewVm()
     {
         var sys = new SystemInfoService();
-        return new DashboardViewModel(sys, new TuneUpService(
-            new ShortcutCleanerService(), new DiskHealthService(), sys));
+        var diskHealth = new DiskHealthService();
+        return new DashboardViewModel(sys,
+            new TuneUpService(new ShortcutCleanerService(), diskHealth, sys),
+            new HealthScoreService(sys, diskHealth, new BatteryService()));
     }
 
     // ---------- construction & defaults ----------

--- a/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
+++ b/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
@@ -1,0 +1,263 @@
+// SysManager · HealthScoreServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="HealthScoreService"/> — validates scoring logic
+/// for each component and the aggregation formula.
+/// </summary>
+public class HealthScoreServiceTests
+{
+    // ---------- construction ----------
+
+    [Fact]
+    public void Constructor_DoesNotThrow()
+    {
+        var svc = new HealthScoreService(
+            new SystemInfoService(), new DiskHealthService(), new BatteryService());
+        Assert.NotNull(svc);
+    }
+
+    // ---------- ComputeDiskScore ----------
+
+    [Fact]
+    public void ComputeDiskScore_NullDisks_Returns100()
+    {
+        Assert.Equal(100, HealthScoreService.ComputeDiskScore(null));
+    }
+
+    [Fact]
+    public void ComputeDiskScore_EmptyList_Returns100()
+    {
+        Assert.Equal(100, HealthScoreService.ComputeDiskScore(Array.Empty<DiskHealthReport>()));
+    }
+
+    [Fact]
+    public void ComputeDiskScore_AllHealthy_Returns100()
+    {
+        var disks = new List<DiskHealthReport>
+        {
+            new() { HealthStatus = "Healthy" },
+            new() { HealthStatus = "Healthy" }
+        };
+        Assert.Equal(100, HealthScoreService.ComputeDiskScore(disks));
+    }
+
+    [Fact]
+    public void ComputeDiskScore_OneWarning_Returns50()
+    {
+        var disks = new List<DiskHealthReport>
+        {
+            new() { HealthStatus = "Healthy" },
+            new() { HealthStatus = "Warning" }
+        };
+        Assert.Equal(50, HealthScoreService.ComputeDiskScore(disks));
+    }
+
+    [Fact]
+    public void ComputeDiskScore_OneUnhealthy_Returns20()
+    {
+        var disks = new List<DiskHealthReport>
+        {
+            new() { HealthStatus = "Unhealthy" }
+        };
+        Assert.Equal(20, HealthScoreService.ComputeDiskScore(disks));
+    }
+
+    // ---------- ComputeRamScore ----------
+
+    [Fact]
+    public void ComputeRamScore_NullSnapshot_Returns100()
+    {
+        Assert.Equal(100, HealthScoreService.ComputeRamScore(null));
+    }
+
+    [Fact]
+    public void ComputeRamScore_LowUsage_Returns100()
+    {
+        var snapshot = MakeSnapshot(ramUsedPct: 40);
+        Assert.Equal(100, HealthScoreService.ComputeRamScore(snapshot));
+    }
+
+    [Fact]
+    public void ComputeRamScore_60Percent_Returns100()
+    {
+        var snapshot = MakeSnapshot(ramUsedPct: 60);
+        Assert.Equal(100, HealthScoreService.ComputeRamScore(snapshot));
+    }
+
+    [Fact]
+    public void ComputeRamScore_75Percent_Returns75()
+    {
+        var snapshot = MakeSnapshot(ramUsedPct: 75);
+        Assert.Equal(75, HealthScoreService.ComputeRamScore(snapshot));
+    }
+
+    [Fact]
+    public void ComputeRamScore_90Percent_Returns40()
+    {
+        var snapshot = MakeSnapshot(ramUsedPct: 90);
+        Assert.Equal(40, HealthScoreService.ComputeRamScore(snapshot));
+    }
+
+    [Fact]
+    public void ComputeRamScore_98Percent_Returns10()
+    {
+        var snapshot = MakeSnapshot(ramUsedPct: 98);
+        Assert.Equal(10, HealthScoreService.ComputeRamScore(snapshot));
+    }
+
+    // ---------- ComputeUptimeScore ----------
+
+    [Fact]
+    public void ComputeUptimeScore_NullSnapshot_Returns100()
+    {
+        Assert.Equal(100, HealthScoreService.ComputeUptimeScore(null));
+    }
+
+    [Fact]
+    public void ComputeUptimeScore_1Day_Returns100()
+    {
+        var snapshot = MakeSnapshot(uptimeDays: 1);
+        Assert.Equal(100, HealthScoreService.ComputeUptimeScore(snapshot));
+    }
+
+    [Fact]
+    public void ComputeUptimeScore_5Days_Returns90()
+    {
+        var snapshot = MakeSnapshot(uptimeDays: 5);
+        Assert.Equal(90, HealthScoreService.ComputeUptimeScore(snapshot));
+    }
+
+    [Fact]
+    public void ComputeUptimeScore_10Days_Returns70()
+    {
+        var snapshot = MakeSnapshot(uptimeDays: 10);
+        Assert.Equal(70, HealthScoreService.ComputeUptimeScore(snapshot));
+    }
+
+    [Fact]
+    public void ComputeUptimeScore_20Days_Returns50()
+    {
+        var snapshot = MakeSnapshot(uptimeDays: 20);
+        Assert.Equal(50, HealthScoreService.ComputeUptimeScore(snapshot));
+    }
+
+    [Fact]
+    public void ComputeUptimeScore_45Days_Returns15()
+    {
+        var snapshot = MakeSnapshot(uptimeDays: 45);
+        Assert.Equal(15, HealthScoreService.ComputeUptimeScore(snapshot));
+    }
+
+    // ---------- ComputeBatteryScore ----------
+
+    [Fact]
+    public void ComputeBatteryScore_NullBattery_Returns100()
+    {
+        Assert.Equal(100, HealthScoreService.ComputeBatteryScore(null));
+    }
+
+    [Fact]
+    public void ComputeBatteryScore_NoBattery_Returns100()
+    {
+        var battery = new BatteryInfo { HasBattery = false };
+        Assert.Equal(100, HealthScoreService.ComputeBatteryScore(battery));
+    }
+
+    [Fact]
+    public void ComputeBatteryScore_HealthyBattery_Returns100()
+    {
+        var battery = new BatteryInfo
+        {
+            HasBattery = true,
+            DesignCapacityMWh = 50000,
+            FullChargeCapacityMWh = 48000 // 96% health
+        };
+        Assert.Equal(100, HealthScoreService.ComputeBatteryScore(battery));
+    }
+
+    [Fact]
+    public void ComputeBatteryScore_DegradedBattery_Returns80()
+    {
+        var battery = new BatteryInfo
+        {
+            HasBattery = true,
+            DesignCapacityMWh = 50000,
+            FullChargeCapacityMWh = 35000 // 70% health
+        };
+        Assert.Equal(80, HealthScoreService.ComputeBatteryScore(battery));
+    }
+
+    [Fact]
+    public void ComputeBatteryScore_WornBattery_Returns55()
+    {
+        var battery = new BatteryInfo
+        {
+            HasBattery = true,
+            DesignCapacityMWh = 50000,
+            FullChargeCapacityMWh = 22000 // 44% health
+        };
+        Assert.Equal(55, HealthScoreService.ComputeBatteryScore(battery));
+    }
+
+    // ---------- HealthScoreResult model ----------
+
+    [Theory]
+    [InlineData(100, "#22C55E")]
+    [InlineData(80, "#22C55E")]
+    [InlineData(79, "#F59E0B")]
+    [InlineData(50, "#F59E0B")]
+    [InlineData(49, "#EF4444")]
+    [InlineData(0, "#EF4444")]
+    public void HealthScoreResult_ColorHex_MatchesScore(int score, string expectedColor)
+    {
+        var result = new HealthScoreResult { Score = score };
+        Assert.Equal(expectedColor, result.ColorHex);
+    }
+
+    [Theory]
+    [InlineData(95, "Excellent")]
+    [InlineData(85, "Good")]
+    [InlineData(65, "Fair")]
+    [InlineData(45, "Needs attention")]
+    [InlineData(20, "Poor")]
+    public void HealthScoreResult_Label_MatchesScore(int score, string expectedLabel)
+    {
+        var result = new HealthScoreResult { Score = score };
+        Assert.Equal(expectedLabel, result.Label);
+    }
+
+    [Fact]
+    public void HealthRecommendation_CriticalSeverity_RedColor()
+    {
+        var rec = new HealthRecommendation { Message = "Test", Severity = "critical" };
+        Assert.Equal("#EF4444", rec.ColorHex);
+    }
+
+    [Fact]
+    public void HealthRecommendation_WarningSeverity_AmberColor()
+    {
+        var rec = new HealthRecommendation { Message = "Test", Severity = "warning" };
+        Assert.Equal("#F59E0B", rec.ColorHex);
+    }
+
+    // ---------- helpers ----------
+
+    private static SystemSnapshot MakeSnapshot(double ramUsedPct = 50, int uptimeDays = 1)
+    {
+        double totalGB = 16;
+        double usedGB = totalGB * ramUsedPct / 100;
+        return new SystemSnapshot(
+            new OsInfo("Windows 11", "10.0", "22631", TimeSpan.FromDays(uptimeDays), "64-bit"),
+            new CpuInfo("Test CPU", 8, 16, 3600, 10),
+            new MemoryInfo(totalGB, totalGB - usedGB, usedGB, ramUsedPct, new List<MemoryModule>()),
+            new List<DiskInfo>(),
+            DateTime.Now);
+    }
+}

--- a/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
+++ b/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
@@ -49,14 +49,14 @@ public class HealthScoreServiceTests
     }
 
     [Fact]
-    public void ComputeDiskScore_OneWarning_Returns50()
+    public void ComputeDiskScore_OneWarning_Returns60()
     {
         var disks = new List<DiskHealthReport>
         {
             new() { HealthStatus = "Healthy" },
             new() { HealthStatus = "Warning" }
         };
-        Assert.Equal(50, HealthScoreService.ComputeDiskScore(disks));
+        Assert.Equal(60, HealthScoreService.ComputeDiskScore(disks));
     }
 
     [Fact]

--- a/SysManager/SysManager/Models/HealthScoreResult.cs
+++ b/SysManager/SysManager/Models/HealthScoreResult.cs
@@ -1,0 +1,54 @@
+// SysManager · HealthScoreResult — aggregated system health score
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// Aggregated health score (0–100) combining disk health, RAM usage,
+/// uptime, and battery wear. Higher is better.
+/// </summary>
+public sealed class HealthScoreResult
+{
+    /// <summary>Overall score 0–100 (100 = perfect health).</summary>
+    public int Score { get; init; }
+
+    /// <summary>Color hex for the gauge arc.</summary>
+    public string ColorHex => Score switch
+    {
+        >= 80 => "#22C55E",  // green
+        >= 50 => "#F59E0B",  // amber
+        _ => "#EF4444"       // red
+    };
+
+    /// <summary>Human-readable label for the score.</summary>
+    public string Label => Score switch
+    {
+        >= 90 => "Excellent",
+        >= 80 => "Good",
+        >= 60 => "Fair",
+        >= 40 => "Needs attention",
+        _ => "Poor"
+    };
+
+    /// <summary>Top recommendations (max 3).</summary>
+    public IReadOnlyList<HealthRecommendation> Recommendations { get; init; }
+        = Array.Empty<HealthRecommendation>();
+
+    /// <summary>Individual component scores for breakdown display.</summary>
+    public int DiskScore { get; init; } = 100;
+    public int RamScore { get; init; } = 100;
+    public int UptimeScore { get; init; } = 100;
+    public int BatteryScore { get; init; } = 100;
+    public bool HasBattery { get; init; }
+}
+
+/// <summary>A single health recommendation shown below the gauge.</summary>
+public sealed class HealthRecommendation
+{
+    public required string Message { get; init; }
+    public required string Severity { get; init; }  // "warning" or "critical"
+
+    public string IconGlyph => Severity == "critical" ? "\uE783" : "\uE7BA";
+    public string ColorHex => Severity == "critical" ? "#EF4444" : "#F59E0B";
+}

--- a/SysManager/SysManager/Services/HealthScoreService.cs
+++ b/SysManager/SysManager/Services/HealthScoreService.cs
@@ -1,0 +1,233 @@
+// SysManager · HealthScoreService — computes an overall system health score
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Aggregates data from multiple services into a single 0–100 health score.
+/// Components weighted:
+///   - Disk health: 35%
+///   - RAM usage: 25%
+///   - Uptime: 20%
+///   - Battery wear: 20% (only on laptops; redistributed otherwise)
+///
+/// No admin required. Read-only queries only.
+/// </summary>
+public sealed class HealthScoreService
+{
+    private readonly SystemInfoService _sysInfo;
+    private readonly DiskHealthService _diskHealth;
+    private readonly BatteryService _battery;
+
+    public HealthScoreService(
+        SystemInfoService sysInfo,
+        DiskHealthService diskHealth,
+        BatteryService battery)
+    {
+        _sysInfo = sysInfo;
+        _diskHealth = diskHealth;
+        _battery = battery;
+    }
+
+    /// <summary>
+    /// Computes the health score by querying system info, disk SMART, and battery.
+    /// </summary>
+    public async Task<HealthScoreResult> ComputeAsync(CancellationToken ct = default)
+    {
+        // Gather data in parallel
+        var sysTask = _sysInfo.CaptureAsync(ct);
+        var diskTask = _diskHealth.CollectAsync(ct);
+        var batteryTask = _battery.GetBatteryInfoAsync(ct);
+
+        SystemSnapshot? snapshot = null;
+        IReadOnlyList<DiskHealthReport>? disks = null;
+        BatteryInfo? battery = null;
+
+        try { snapshot = await sysTask; }
+        catch (System.Management.ManagementException ex) { Log.Warning("HealthScore: system info failed: {Error}", ex.Message); }
+        catch (InvalidOperationException ex) { Log.Warning("HealthScore: system info failed: {Error}", ex.Message); }
+
+        try { disks = await diskTask; }
+        catch (System.Management.ManagementException ex) { Log.Warning("HealthScore: disk health failed: {Error}", ex.Message); }
+        catch (InvalidOperationException ex) { Log.Warning("HealthScore: disk health failed: {Error}", ex.Message); }
+
+        try { battery = await batteryTask; }
+        catch (System.Management.ManagementException ex) { Log.Warning("HealthScore: battery failed: {Error}", ex.Message); }
+        catch (InvalidOperationException ex) { Log.Warning("HealthScore: battery failed: {Error}", ex.Message); }
+
+        // Compute component scores
+        int diskScore = ComputeDiskScore(disks);
+        int ramScore = ComputeRamScore(snapshot);
+        int uptimeScore = ComputeUptimeScore(snapshot);
+        int batteryScore = ComputeBatteryScore(battery);
+        bool hasBattery = battery?.HasBattery ?? false;
+
+        // Weighted average
+        int overall;
+        if (hasBattery)
+        {
+            overall = (int)Math.Round(
+                diskScore * 0.35 +
+                ramScore * 0.25 +
+                uptimeScore * 0.20 +
+                batteryScore * 0.20);
+        }
+        else
+        {
+            // No battery — redistribute weight: disk 40%, RAM 30%, uptime 30%
+            overall = (int)Math.Round(
+                diskScore * 0.40 +
+                ramScore * 0.30 +
+                uptimeScore * 0.30);
+        }
+
+        overall = Math.Clamp(overall, 0, 100);
+
+        // Build recommendations
+        var recommendations = BuildRecommendations(
+            diskScore, ramScore, uptimeScore, batteryScore, hasBattery, snapshot, disks, battery);
+
+        return new HealthScoreResult
+        {
+            Score = overall,
+            DiskScore = diskScore,
+            RamScore = ramScore,
+            UptimeScore = uptimeScore,
+            BatteryScore = batteryScore,
+            HasBattery = hasBattery,
+            Recommendations = recommendations
+        };
+    }
+
+    // ── Component scoring ──────────────────────────────────────────────
+
+    internal static int ComputeDiskScore(IReadOnlyList<DiskHealthReport>? disks)
+    {
+        if (disks == null || disks.Count == 0) return 100;
+
+        // Use the worst disk's health percentage, or map status string
+        int worstScore = 100;
+        foreach (var d in disks)
+        {
+            int score = d.HealthPercent ?? d.HealthStatus switch
+            {
+                "Healthy" => 100,
+                "Warning" => 50,
+                "Unhealthy" => 20,
+                _ => 80
+            };
+            if (score < worstScore) worstScore = score;
+        }
+        return Math.Clamp(worstScore, 0, 100);
+    }
+
+    internal static int ComputeRamScore(SystemSnapshot? snapshot)
+    {
+        if (snapshot == null) return 100;
+        double usedPct = snapshot.Memory.UsedPercent;
+
+        // Linear scale: 0% used = 100 score, 100% used = 0 score
+        // But we're more lenient: up to 60% is fine (score 100), then degrades
+        return usedPct switch
+        {
+            <= 60 => 100,
+            <= 70 => 90,
+            <= 80 => 75,
+            <= 85 => 60,
+            <= 90 => 40,
+            <= 95 => 20,
+            _ => 10
+        };
+    }
+
+    internal static int ComputeUptimeScore(SystemSnapshot? snapshot)
+    {
+        if (snapshot == null) return 100;
+        double days = snapshot.Os.Uptime.TotalDays;
+
+        return days switch
+        {
+            <= 3 => 100,
+            <= 7 => 90,
+            <= 14 => 70,
+            <= 21 => 50,
+            <= 30 => 30,
+            _ => 15
+        };
+    }
+
+    internal static int ComputeBatteryScore(BatteryInfo? battery)
+    {
+        if (battery == null || !battery.HasBattery) return 100;
+
+        double health = battery.HealthPercent;
+        return health switch
+        {
+            >= 80 => 100,
+            >= 60 => 80,
+            >= 40 => 55,
+            >= 20 => 30,
+            _ => 10
+        };
+    }
+
+    // ── Recommendations ────────────────────────────────────────────────
+
+    private static List<HealthRecommendation> BuildRecommendations(
+        int diskScore, int ramScore, int uptimeScore, int batteryScore,
+        bool hasBattery, SystemSnapshot? snapshot,
+        IReadOnlyList<DiskHealthReport>? disks, BatteryInfo? battery)
+    {
+        var recs = new List<HealthRecommendation>();
+
+        // Uptime
+        if (uptimeScore <= 70 && snapshot != null)
+        {
+            int days = (int)snapshot.Os.Uptime.TotalDays;
+            recs.Add(new HealthRecommendation
+            {
+                Message = $"Restart recommended — {days} days uptime",
+                Severity = uptimeScore <= 30 ? "critical" : "warning"
+            });
+        }
+
+        // Disk
+        if (diskScore < 80 && disks != null)
+        {
+            var worst = disks.OrderBy(d => d.HealthPercent ?? 100).FirstOrDefault();
+            string diskName = worst?.FriendlyName ?? "Disk";
+            recs.Add(new HealthRecommendation
+            {
+                Message = $"{diskName} health degraded — consider backup",
+                Severity = diskScore < 50 ? "critical" : "warning"
+            });
+        }
+
+        // RAM
+        if (ramScore < 75 && snapshot != null)
+        {
+            recs.Add(new HealthRecommendation
+            {
+                Message = $"High memory usage ({snapshot.Memory.UsedPercent:0}%) — close unused apps",
+                Severity = ramScore <= 40 ? "critical" : "warning"
+            });
+        }
+
+        // Battery
+        if (hasBattery && batteryScore < 80 && battery != null)
+        {
+            recs.Add(new HealthRecommendation
+            {
+                Message = $"Battery wear {battery.WearPercent:0}% — consider replacement",
+                Severity = batteryScore < 55 ? "critical" : "warning"
+            });
+        }
+
+        // Return top 3
+        return recs.Take(3).ToList();
+    }
+}

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -16,6 +16,7 @@ public partial class DashboardViewModel : ViewModelBase
 {
     private readonly SystemInfoService _sys;
     private readonly TuneUpService _tuneUp;
+    private readonly HealthScoreService _healthScore;
     private CancellationTokenSource? _tuneUpCts;
 
     [ObservableProperty] private SystemSnapshot? _snapshot;
@@ -26,6 +27,11 @@ public partial class DashboardViewModel : ViewModelBase
     [ObservableProperty] private string _diskLine = "";
     [ObservableProperty] private string _uptimeLine = "";
 
+    // ── Health Score state ─────────────────────────────────────────────
+    [ObservableProperty] private HealthScoreResult? _healthResult;
+    [ObservableProperty] private bool _hasHealthScore;
+    [ObservableProperty] private bool _isHealthScoreLoading;
+
     // ── Tune-Up state ──────────────────────────────────────────────────
     [ObservableProperty] private bool _isTuneUpRunning;
     [ObservableProperty] private string _tuneUpStep = "";
@@ -34,21 +40,47 @@ public partial class DashboardViewModel : ViewModelBase
     [ObservableProperty] private bool _hasTuneUpResult;
 
     public DashboardViewModel(SystemInfoService sys)
-        : this(sys, new TuneUpService(
-            new ShortcutCleanerService(),
-            new DiskHealthService(),
-            sys))
+        : this(sys,
+            new TuneUpService(new ShortcutCleanerService(), new DiskHealthService(), sys),
+            new HealthScoreService(sys, new DiskHealthService(), new BatteryService()))
     {
     }
 
     /// <summary>
     /// Testable constructor — accepts all dependencies explicitly.
     /// </summary>
-    public DashboardViewModel(SystemInfoService sys, TuneUpService tuneUp)
+    public DashboardViewModel(SystemInfoService sys, TuneUpService tuneUp, HealthScoreService healthScore)
     {
         _sys = sys;
         _tuneUp = tuneUp;
+        _healthScore = healthScore;
         IsElevated = AdminHelper.IsElevated();
+        _ = LoadHealthScoreAsync();
+    }
+
+    // ── Health Score ───────────────────────────────────────────────────
+
+    private async Task LoadHealthScoreAsync()
+    {
+        IsHealthScoreLoading = true;
+        try
+        {
+            HealthResult = await _healthScore.ComputeAsync();
+            HasHealthScore = true;
+            Log.Information("Health Score computed: {Score}", HealthResult.Score);
+        }
+        catch (System.Management.ManagementException ex)
+        {
+            Log.Warning("Health Score failed: {Error}", ex.Message);
+        }
+        catch (InvalidOperationException ex)
+        {
+            Log.Warning("Health Score failed: {Error}", ex.Message);
+        }
+        finally
+        {
+            IsHealthScoreLoading = false;
+        }
     }
 
     [RelayCommand]
@@ -67,6 +99,9 @@ public partial class DashboardViewModel : ViewModelBase
             UptimeLine = $"Uptime: {Snapshot.Os.Uptime.Days}d {Snapshot.Os.Uptime.Hours}h {Snapshot.Os.Uptime.Minutes}m";
             StatusMessage = $"Last scan: {Snapshot.CapturedAt:HH:mm:ss}";
             Log.Information("Dashboard scan completed");
+
+            // Refresh health score too
+            await LoadHealthScoreAsync();
         }
         catch (System.Management.ManagementException ex)
         {

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -63,6 +63,92 @@
 
         <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
             <StackPanel>
+                <!-- Health Score card -->
+                <Border CornerRadius="8" Padding="16" Background="#0D1117" Margin="0,0,0,12"
+                        BorderBrush="#30363D" BorderThickness="1"
+                        Visibility="{Binding HasHealthScore, Converter={StaticResource BoolToVis}}">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <!-- Circular gauge (score number with colored ring) -->
+                        <Border Grid.Column="0" Width="100" Height="100" CornerRadius="50"
+                                BorderThickness="6" Margin="0,0,16,0"
+                                HorizontalAlignment="Center" VerticalAlignment="Center">
+                            <Border.BorderBrush>
+                                <SolidColorBrush Color="{Binding HealthResult.ColorHex}"/>
+                            </Border.BorderBrush>
+                            <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                                <TextBlock Text="{Binding HealthResult.Score}" FontSize="32" FontWeight="Bold"
+                                           HorizontalAlignment="Center" Foreground="White"/>
+                                <TextBlock Text="{Binding HealthResult.Label}" FontSize="11"
+                                           HorizontalAlignment="Center" Foreground="#9AA0A6"/>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Score details + recommendations -->
+                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                            <TextBlock Text="System Health" FontWeight="SemiBold" FontSize="15" Margin="0,0,0,6"/>
+
+                            <!-- Component breakdown -->
+                            <WrapPanel Margin="0,0,0,8">
+                                <TextBlock Margin="0,0,12,0" Foreground="#9AA0A6" FontSize="12">
+                                    <Run Text="Disk "/>
+                                    <Run Text="{Binding HealthResult.DiskScore, Mode=OneWay}" FontWeight="SemiBold" Foreground="#C9D1D9"/>
+                                </TextBlock>
+                                <TextBlock Margin="0,0,12,0" Foreground="#9AA0A6" FontSize="12">
+                                    <Run Text="RAM "/>
+                                    <Run Text="{Binding HealthResult.RamScore, Mode=OneWay}" FontWeight="SemiBold" Foreground="#C9D1D9"/>
+                                </TextBlock>
+                                <TextBlock Margin="0,0,12,0" Foreground="#9AA0A6" FontSize="12">
+                                    <Run Text="Uptime "/>
+                                    <Run Text="{Binding HealthResult.UptimeScore, Mode=OneWay}" FontWeight="SemiBold" Foreground="#C9D1D9"/>
+                                </TextBlock>
+                                <TextBlock Foreground="#9AA0A6" FontSize="12"
+                                           Visibility="{Binding HealthResult.HasBattery, Converter={StaticResource BoolToVis}}">
+                                    <Run Text="Battery "/>
+                                    <Run Text="{Binding HealthResult.BatteryScore, Mode=OneWay}" FontWeight="SemiBold" Foreground="#C9D1D9"/>
+                                </TextBlock>
+                            </WrapPanel>
+
+                            <!-- Recommendations -->
+                            <ItemsControl ItemsSource="{Binding HealthResult.Recommendations}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
+                                            <TextBlock Text="{Binding IconGlyph}" FontFamily="Segoe Fluent Icons"
+                                                       FontSize="12" Margin="0,0,6,0" VerticalAlignment="Center">
+                                                <TextBlock.Foreground>
+                                                    <SolidColorBrush Color="{Binding ColorHex}"/>
+                                                </TextBlock.Foreground>
+                                            </TextBlock>
+                                            <TextBlock Text="{Binding Message}" FontSize="12" VerticalAlignment="Center">
+                                                <TextBlock.Foreground>
+                                                    <SolidColorBrush Color="{Binding ColorHex}"/>
+                                                </TextBlock.Foreground>
+                                            </TextBlock>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <!-- Health Score loading indicator -->
+                <Border CornerRadius="8" Padding="14" Background="#0D1117" Margin="0,0,0,8"
+                        BorderBrush="#30363D" BorderThickness="1"
+                        Visibility="{Binding IsHealthScoreLoading, Converter={StaticResource BoolToVis}}">
+                    <StackPanel Orientation="Horizontal">
+                        <ProgressBar AutomationProperties.Name="Health score loading" IsIndeterminate="True"
+                                     Width="80" Height="4" Margin="0,0,10,0" VerticalAlignment="Center"/>
+                        <TextBlock Text="Computing health score…" Foreground="#9AA0A6" FontSize="12"
+                                   VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Border>
+
                 <!-- Tune-Up progress panel -->
                 <Border CornerRadius="8" Padding="14" Background="#0D1117" Margin="0,0,0,8"
                         BorderBrush="#238636" BorderThickness="1"


### PR DESCRIPTION
## Summary

Adds an overall system health score (0-100) card to the Dashboard, displayed as a color-coded circular gauge with component breakdown and actionable recommendations.

## How it works

**Components (weighted):**
- Disk SMART health: 35% (worst disk drives the score)
- RAM usage: 25% (degrades above 60% usage)
- Uptime: 20% (degrades after 3 days, critical after 14)
- Battery wear: 20% (laptops only; redistributed on desktops)

**Visual:**
- Large circular ring with score number and label (Excellent/Good/Fair/Poor)
- Green (80-100), Amber (50-79), Red (0-49)
- Component scores shown as compact breakdown
- Up to 3 recommendations with severity-colored icons

**Behavior:**
- Auto-computes on Dashboard load
- Refreshes when user clicks 'Scan system'
- Gracefully handles missing data (no battery, WMI failures)

## Files added
- \Services/HealthScoreService.cs\ — scoring logic with weighted aggregation
- \Models/HealthScoreResult.cs\ — result model + HealthRecommendation

## Files modified
- \ViewModels/DashboardViewModel.cs\ — HealthResult property, auto-load
- \Views/DashboardView.xaml\ — gauge card + loading indicator
- \Tests/DashboardViewModelTests.cs\ — updated constructor

## Tests (28 new)
- \HealthScoreServiceTests.cs\ — all component scoring functions + model

## Docs
- README.md, ARCHITECTURE.md, CHANGELOG.md updated

Closes #259
