### PR TITLE
feat: About changelog link, Drivers/Startup hide system entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Windows toast notifications when RAM > 90%, uptime > 14 days, or disk
   health degrades. Right-click context menu with Show / Exit. Uses
   H.NotifyIcon.Wpf 2.2.1. Closes #262.
+- **About — Changelog link** — new "View Changelog" button opens the
+  GitHub CHANGELOG.md in the browser. Closes #232.
+- **Drivers — Hide system drivers** — toggle to filter out Microsoft /
+  Windows drivers from the list, showing only third-party drivers.
+  Closes #234.
+- **Startup Manager — Hide Windows entries** — toggle to filter out
+  Microsoft / Windows startup items that should not be disabled.
+  Closes #238.
 - **IntGreaterThanZeroConverter** — value converter for conditional
   visibility when an integer is greater than zero.
 - **IDialogService** — abstraction for user confirmation dialogs, replacing

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -205,6 +205,9 @@ public partial class AboutViewModel : ViewModelBase
     private void OpenRepo() => OpenUrl($"https://github.com/{UpdateService.Owner}/{UpdateService.Repo}");
 
     [RelayCommand]
+    private void OpenChangelog() => OpenUrl($"https://github.com/{UpdateService.Owner}/{UpdateService.Repo}/blob/main/CHANGELOG.md");
+
+    [RelayCommand]
     private void OpenLicense() => OpenUrl($"https://github.com/{UpdateService.Owner}/{UpdateService.Repo}/blob/main/LICENSE");
 
     /// <summary>

--- a/SysManager/SysManager/ViewModels/DriversViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DriversViewModel.cs
@@ -65,7 +65,6 @@ public partial class DriversViewModel : ViewModelBase
             finally { _runner.LineReceived -= Capture; }
 
             ParseDriverJson(json.ToString());
-            ApplyFilter();
             Summary = $"{_allDrivers.Count} drivers found" +
                       (HideSystemDrivers ? $" ({DriverCount} shown, system drivers hidden)." : ".");
             StatusMessage = "Done";
@@ -117,6 +116,8 @@ public partial class DriversViewModel : ViewModelBase
             Log.Warning("Failed to parse driver JSON: {Error}", ex.Message);
             StatusMessage = "Parse error — some drivers may not be shown.";
         }
+
+        ApplyFilter();
     }
 
     private void ApplyFilter()

--- a/SysManager/SysManager/ViewModels/DriversViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DriversViewModel.cs
@@ -17,16 +17,20 @@ public partial class DriversViewModel : ViewModelBase
 {
     private readonly PowerShellRunner _runner;
     private CancellationTokenSource? _cts;
+    private readonly List<DriverEntry> _allDrivers = new();
 
     public ObservableCollection<DriverEntry> Drivers { get; } = new();
 
     [ObservableProperty] private int _driverCount;
     [ObservableProperty] private string _summary = "Click List drivers to scan installed drivers.";
+    [ObservableProperty] private bool _hideSystemDrivers;
 
     public DriversViewModel(PowerShellRunner runner)
     {
         _runner = runner;
     }
+
+    partial void OnHideSystemDriversChanged(bool value) => ApplyFilter();
 
     [RelayCommand]
     private async Task ListDriversAsync()
@@ -35,6 +39,7 @@ public partial class DriversViewModel : ViewModelBase
         IsProgressIndeterminate = true;
         StatusMessage = "Scanning installed drivers…";
         Drivers.Clear();
+        _allDrivers.Clear();
         _cts?.Dispose();
         _cts = new CancellationTokenSource();
 
@@ -60,8 +65,9 @@ public partial class DriversViewModel : ViewModelBase
             finally { _runner.LineReceived -= Capture; }
 
             ParseDriverJson(json.ToString());
-            DriverCount = Drivers.Count;
-            Summary = $"{DriverCount} drivers found.";
+            ApplyFilter();
+            Summary = $"{_allDrivers.Count} drivers found" +
+                      (HideSystemDrivers ? $" ({DriverCount} shown, system drivers hidden)." : ".");
             StatusMessage = "Done";
         }
         catch (OperationCanceledException) { StatusMessage = "Cancelled."; }
@@ -103,7 +109,7 @@ public partial class DriversViewModel : ViewModelBase
                 DriverDate = ParseCimDate(el.TryGetProperty("DriverDate", out var dd) ? dd : default),
             }))
             {
-                Drivers.Add(entry);
+                _allDrivers.Add(entry);
             }
         }
         catch (JsonException ex)
@@ -112,6 +118,27 @@ public partial class DriversViewModel : ViewModelBase
             StatusMessage = "Parse error — some drivers may not be shown.";
         }
     }
+
+    private void ApplyFilter()
+    {
+        Drivers.Clear();
+        var filtered = HideSystemDrivers
+            ? _allDrivers.Where(d => !IsSystemDriver(d))
+            : _allDrivers;
+
+        foreach (var d in filtered)
+            Drivers.Add(d);
+
+        DriverCount = Drivers.Count;
+        if (_allDrivers.Count > 0)
+            Summary = HideSystemDrivers
+                ? $"{_allDrivers.Count} drivers found ({DriverCount} shown, system drivers hidden)."
+                : $"{_allDrivers.Count} drivers found.";
+    }
+
+    private static bool IsSystemDriver(DriverEntry d)
+        => d.Manufacturer.Contains("Microsoft", StringComparison.OrdinalIgnoreCase) ||
+           d.Manufacturer.Contains("Windows", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// CIM dates come as "/Date(ticks)/" strings in JSON.

--- a/SysManager/SysManager/ViewModels/StartupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StartupViewModel.cs
@@ -18,6 +18,7 @@ namespace SysManager.ViewModels;
 public partial class StartupViewModel : ViewModelBase
 {
     private readonly StartupService _service = new();
+    private readonly List<StartupEntry> _allEntries = new();
 
     public ObservableCollection<StartupEntry> Entries { get; } = new();
 
@@ -25,11 +26,14 @@ public partial class StartupViewModel : ViewModelBase
     [ObservableProperty] private int _disabledCount;
     [ObservableProperty] private int _totalCount;
     [ObservableProperty] private string _scanSummary = "Click Scan to discover startup items.";
+    [ObservableProperty] private bool _hideWindowsEntries;
 
     public StartupViewModel()
     {
         _ = InitAsync();
     }
+
+    partial void OnHideWindowsEntriesChanged(bool value) => ApplyFilter();
 
     private async Task InitAsync()
     {
@@ -46,15 +50,16 @@ public partial class StartupViewModel : ViewModelBase
         try
         {
             var items = await _service.ScanAsync();
+            _allEntries.Clear();
             Entries.Clear();
             foreach (var item in items.OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase))
             {
                 item.Icon = IconExtractorService.GetIcon(item.Command);
-                Entries.Add(item);
+                _allEntries.Add(item);
             }
 
-            UpdateCounts();
-            StatusMessage = $"Found {TotalCount} startup items.";
+            ApplyFilter();
+            StatusMessage = $"Found {_allEntries.Count} startup items.";
         }
         catch (InvalidOperationException ex)
         {
@@ -132,4 +137,22 @@ public partial class StartupViewModel : ViewModelBase
         TotalCount = Entries.Count;
         ScanSummary = $"{EnabledCount} enabled · {DisabledCount} disabled · {TotalCount} total";
     }
+
+    private void ApplyFilter()
+    {
+        Entries.Clear();
+        var filtered = HideWindowsEntries
+            ? _allEntries.Where(e => !IsWindowsEntry(e))
+            : _allEntries;
+
+        foreach (var item in filtered)
+            Entries.Add(item);
+
+        UpdateCounts();
+    }
+
+    private static bool IsWindowsEntry(StartupEntry entry)
+        => entry.Publisher.Contains("Microsoft", StringComparison.OrdinalIgnoreCase) ||
+           entry.Command.Contains(@"\Windows\", StringComparison.OrdinalIgnoreCase) ||
+           entry.Command.Contains(@"\Microsoft\", StringComparison.OrdinalIgnoreCase);
 }


### PR DESCRIPTION
## Summary

Three small UX improvements in one PR:

### 1. About — View Changelog button (#232)
New \OpenChangelog\ command opens the GitHub CHANGELOG.md directly in the browser, giving users full visibility into what changed between versions.

### 2. Drivers — Hide system drivers toggle (#234)
New \HideSystemDrivers\ checkbox filters out Microsoft/Windows drivers from the list, showing only third-party drivers (NVIDIA, AMD, Realtek, etc.). Makes it easier to find relevant drivers.

### 3. Startup Manager — Hide Windows entries toggle (#238)
New \HideWindowsEntries\ checkbox filters out Microsoft/Windows startup items that should not be disabled. Helps users focus on third-party apps they can safely manage.

## Implementation
- Both filters use a backing \_allEntries\ / \_allDrivers\ list + \ApplyFilter()\ pattern
- Filter state is reactive via \partial void OnXxxChanged\ (CommunityToolkit.Mvvm)
- Summary labels update to show filtered count vs total

## Files modified
- \ViewModels/AboutViewModel.cs\ — OpenChangelog command
- \ViewModels/DriversViewModel.cs\ — HideSystemDrivers + ApplyFilter
- \ViewModels/StartupViewModel.cs\ — HideWindowsEntries + ApplyFilter
- \CHANGELOG.md\

Closes #232, Closes #234, Closes #238
