### PR TITLE
fix: auto-update now performs in-place self-replace with SHA256 verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   confirmation-gated code paths (CQ-003).
 
 ### Fixed
+- **Auto-update** — "Install" now performs a true in-place update: verifies
+  SHA256 hash of the downloaded build, writes an updater script that waits
+  for the current process to exit, copies the new executable over the old
+  one, and restarts. Previously it only launched the new exe from a temp
+  folder without replacing the original. Closes #240.
 - **Disk Health** — `TemperatureColorHex` returns grey (#9AA0A6) for drives
   without temperature sensors instead of misleading red (QA-004).
 - **Battery Health** — `HealthPercent` clamped to 0–100, `WearPercent`

--- a/README.md
+++ b/README.md
@@ -267,7 +267,9 @@ long-running operation, so you always know which tab is working.
 - Background download of the new build with a progress bar. If the
   download is blocked, a "Manual download" button opens GitHub in the
   browser.
-- One-click "Install" launches the new build and hands off cleanly.
+- SHA256 hash verification before install — blocks corrupted downloads.
+- One-click "Install" replaces the running executable in-place and
+  restarts automatically (no manual file copying needed).
 - Full release-note history pulled live from GitHub.
 
 ## Screenshots

--- a/SysManager/SysManager.Tests/AboutViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AboutViewModelTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using SysManager.Services;
 using SysManager.ViewModels;
 
@@ -140,11 +141,36 @@ public class AboutViewModelTests
     }
 
     [Fact]
-    public void InstallUpdateCommand_WithoutDownload_SetsErrorStatus()
+    public async Task InstallUpdateCommand_WithoutDownload_SetsErrorStatus()
     {
         var vm = new AboutViewModel { DownloadedPath = null };
-        vm.InstallUpdateCommand.Execute(null);
+        await vm.InstallUpdateCommand.ExecuteAsync(null);
         Assert.Contains("No downloaded", vm.DownloadStatus, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task InstallUpdateCommand_WithFakePath_SetsNoFileStatus()
+    {
+        var vm = new AboutViewModel { DownloadedPath = @"C:\nonexistent\fake.exe" };
+        await vm.InstallUpdateCommand.ExecuteAsync(null);
+        Assert.Contains("No downloaded", vm.DownloadStatus, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task InstallUpdateCommand_WithPathButNoRelease_SetsNoReleaseStatus()
+    {
+        // Create a temp file to simulate a downloaded exe
+        var tmp = Path.GetTempFileName();
+        try
+        {
+            var vm = new AboutViewModel { DownloadedPath = tmp };
+            await vm.InstallUpdateCommand.ExecuteAsync(null);
+            Assert.Contains("No release info", vm.DownloadStatus, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(tmp);
+        }
     }
 
     [Fact]

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -362,30 +362,102 @@ public partial class AboutViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void InstallUpdate()
+    private async Task InstallUpdateAsync()
     {
         if (string.IsNullOrWhiteSpace(DownloadedPath) || !File.Exists(DownloadedPath))
         {
             DownloadStatus = "No downloaded file to install.";
             return;
         }
+
+        if (_latest == null)
+        {
+            DownloadStatus = "No release info available.";
+            return;
+        }
+
+        // Step 1: Verify SHA256 hash before installing.
+        DownloadStatus = "Verifying file integrity...";
+        var (verified, expected, actual) = await _updates.VerifyHashAsync(_latest, DownloadedPath);
+        if (!verified)
+        {
+            DownloadStatus = expected != null && actual != null
+                ? $"SHA256 mismatch — file may be corrupted. Expected: {expected[..12]}… Got: {actual[..12]}…"
+                : "Hash verification failed — file may be corrupted. Try downloading again.";
+            return;
+        }
+
+        // Step 2: Determine current executable path.
+        var currentExe = Environment.ProcessPath;
+        if (string.IsNullOrWhiteSpace(currentExe) || !File.Exists(currentExe))
+        {
+            DownloadStatus = "Cannot determine current executable path.";
+            return;
+        }
+
+        // Step 3: Write an updater script that waits for this process to exit,
+        // copies the new exe over the old one, then launches the new version.
         try
         {
+            var pid = Environment.ProcessId;
+            var scriptPath = Path.Combine(
+                Path.GetDirectoryName(DownloadedPath)!,
+                "update.cmd");
+
+            var script = $"""
+                @echo off
+                title SysManager Updater
+                echo Waiting for SysManager to close...
+                :wait
+                tasklist /FI "PID eq {pid}" 2>NUL | find /I "{pid}" >NUL
+                if not errorlevel 1 (
+                    timeout /t 1 /nobreak >NUL
+                    goto wait
+                )
+                echo Applying update...
+                copy /Y "{DownloadedPath}" "{currentExe}" >NUL
+                if errorlevel 1 (
+                    echo Update failed — could not copy file. Press any key to exit.
+                    pause >NUL
+                    exit /b 1
+                )
+                echo Starting SysManager...
+                start "" "{currentExe}"
+                del "%~f0"
+                """;
+
+            await File.WriteAllTextAsync(scriptPath, script);
+
+            DownloadStatus = "Installing update — SysManager will restart...";
+
             Process.Start(new ProcessStartInfo
             {
-                FileName = DownloadedPath,
-                UseShellExecute = true  // lets UAC prompt if needed
+                FileName = "cmd.exe",
+                Arguments = $"/C \"{scriptPath}\"",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden
             });
-            // Close the current instance so the new one takes over.
+
+            // Give the script a moment to start before we exit.
+            await Task.Delay(500);
             System.Windows.Application.Current?.Shutdown();
+        }
+        catch (IOException ex)
+        {
+            DownloadStatus = $"Update failed: {ex.Message}";
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            DownloadStatus = $"Update failed (access denied): {ex.Message}. Try running as administrator.";
         }
         catch (InvalidOperationException ex)
         {
-            DownloadStatus = $"Couldn't launch installer: {ex.Message}";
+            DownloadStatus = $"Update failed: {ex.Message}";
         }
         catch (System.ComponentModel.Win32Exception ex)
         {
-            DownloadStatus = $"Couldn't launch installer: {ex.Message}";
+            DownloadStatus = $"Update failed: {ex.Message}";
         }
     }
 


### PR DESCRIPTION
## Summary

Auto-update previously only launched the new exe from a temp folder without replacing the running executable. Users ended up with the old version on next restart.

## Changes

- **AboutViewModel.InstallUpdateAsync** — now performs a true in-place update:
  1. Verifies SHA256 hash of the downloaded build against the release .sha256 asset
  2. Writes an updater batch script that waits for the current process to exit
  3. Copies the new exe over the original executable path
  4. Restarts SysManager from the original location
  5. Updater script self-deletes after completion
- Handles access-denied gracefully (suggests running as administrator)
- Test updated to async + 2 new tests for edge cases (fake path, no release info)
- README updated to reflect SHA256 verification and in-place replacement
- CHANGELOG updated

## Files changed

- \SysManager/ViewModels/AboutViewModel.cs\ — InstallUpdate → InstallUpdateAsync with full self-replace logic
- \SysManager.Tests/AboutViewModelTests.cs\ — async test + 2 new edge-case tests
- \README.md\ — Updates section clarified
- \CHANGELOG.md\ — Fixed entry added

## Testing

- Build: 0 errors (main + tests)
- Unit tests cover: null path, non-existent path, no release info scenarios
- Full update flow requires manual testing (process replacement)

Closes #240
