### PR TITLE
feat: ETA calculator for progress-based operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   scrollable when the window is small. DataGrid has explicit
   VerticalScrollBarVisibility and MaxHeight for large driver lists.
   Closes #235.
+- **ETA Calculator** — reusable helper that estimates time remaining for
+  any progress-based operation. Integrated into Speed Test (HTTP + Ookla)
+  and Deep Cleanup (scan + clean). Shows human-friendly estimates like
+  "~2 min 15 s" next to progress bars. Closes #241.
 - **IntGreaterThanZeroConverter** — value converter for conditional
   visibility when an integer is greater than zero.
 - **IDialogService** — abstraction for user confirmation dialogs, replacing

--- a/SysManager/SysManager.Tests/EtaCalculatorTests.cs
+++ b/SysManager/SysManager.Tests/EtaCalculatorTests.cs
@@ -1,0 +1,105 @@
+// SysManager · EtaCalculatorTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Helpers;
+
+namespace SysManager.Tests;
+
+public class EtaCalculatorTests
+{
+    [Fact]
+    public void Reset_ClearsState()
+    {
+        var eta = new EtaCalculator();
+        eta.Reset();
+        Assert.Null(eta.Remaining);
+        Assert.Equal(string.Empty, eta.RemainingText);
+    }
+
+    [Fact]
+    public void Update_AtZeroPercent_ReturnsCalculating()
+    {
+        var eta = new EtaCalculator();
+        eta.Reset();
+        var text = eta.Update(0);
+        Assert.Equal("calculating…", text);
+        Assert.Null(eta.Remaining);
+    }
+
+    [Fact]
+    public void Update_At100Percent_ReturnsDone()
+    {
+        var eta = new EtaCalculator();
+        eta.Reset();
+        var text = eta.Update(100);
+        Assert.Equal("done", text);
+        Assert.Equal(TimeSpan.Zero, eta.Remaining);
+    }
+
+    [Fact]
+    public void Update_AtMidProgress_ReturnsEstimate()
+    {
+        var eta = new EtaCalculator();
+        eta.Reset();
+        // Simulate some elapsed time by updating at 50%
+        Thread.Sleep(100);
+        var text = eta.Update(50);
+        Assert.NotEqual(string.Empty, text);
+        Assert.NotNull(eta.Remaining);
+        Assert.True(eta.Remaining >= TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void Update_ClampsAbove100()
+    {
+        var eta = new EtaCalculator();
+        eta.Reset();
+        var text = eta.Update(150);
+        Assert.Equal("done", text);
+    }
+
+    [Fact]
+    public void Update_ClampsBelow0()
+    {
+        var eta = new EtaCalculator();
+        eta.Reset();
+        var text = eta.Update(-5);
+        Assert.Equal("calculating…", text);
+    }
+
+    [Theory]
+    [InlineData(3, "a few seconds")]
+    [InlineData(30, "~30 s")]
+    [InlineData(90, "~1 min 30 s")]
+    [InlineData(3600, "~1 h")]
+    [InlineData(3660, "~1 h 1 min")]
+    public void FormatTimeSpan_FormatsCorrectly(int seconds, string expected)
+    {
+        var result = EtaCalculator.FormatTimeSpan(TimeSpan.FromSeconds(seconds));
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Update_WithoutReset_ReturnsCalculating()
+    {
+        var eta = new EtaCalculator();
+        // No Reset() called — stopwatch not running
+        var text = eta.Update(50);
+        Assert.Equal("calculating…", text);
+    }
+
+    [Fact]
+    public void MultipleResets_WorkCorrectly()
+    {
+        var eta = new EtaCalculator();
+        eta.Reset();
+        Thread.Sleep(50);
+        eta.Update(50);
+        Assert.NotNull(eta.Remaining);
+
+        eta.Reset();
+        Assert.Null(eta.Remaining);
+        Assert.Equal(string.Empty, eta.RemainingText);
+    }
+}

--- a/SysManager/SysManager/Helpers/EtaCalculator.cs
+++ b/SysManager/SysManager/Helpers/EtaCalculator.cs
@@ -1,0 +1,92 @@
+// SysManager · EtaCalculator — estimates time remaining for progress-based operations
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Diagnostics;
+
+namespace SysManager.Helpers;
+
+/// <summary>
+/// Calculates estimated time remaining (ETA) for any operation that reports
+/// progress as a percentage (0–100). Uses a simple linear extrapolation based
+/// on elapsed time and current progress.
+/// <para>
+/// Usage: call <see cref="Reset"/> when the operation starts, then call
+/// <see cref="Update"/> each time progress changes. Read <see cref="Remaining"/>
+/// or <see cref="RemainingText"/> for the current estimate.
+/// </para>
+/// </summary>
+public sealed class EtaCalculator
+{
+    private readonly Stopwatch _sw = new();
+    private int _lastPercent;
+
+    /// <summary>Estimated time remaining, or null if not enough data.</summary>
+    public TimeSpan? Remaining { get; private set; }
+
+    /// <summary>Human-readable ETA string (e.g. "~2 min 15 s" or "calculating…").</summary>
+    public string RemainingText { get; private set; } = string.Empty;
+
+    /// <summary>Resets the calculator. Call at the start of each operation.</summary>
+    public void Reset()
+    {
+        _sw.Restart();
+        _lastPercent = 0;
+        Remaining = null;
+        RemainingText = string.Empty;
+    }
+
+    /// <summary>
+    /// Updates the estimate with the current progress percentage (0–100).
+    /// Returns the formatted ETA string for convenience.
+    /// </summary>
+    public string Update(int percent)
+    {
+        _lastPercent = Math.Clamp(percent, 0, 100);
+
+        if (_lastPercent <= 0 || !_sw.IsRunning)
+        {
+            Remaining = null;
+            RemainingText = "calculating…";
+            return RemainingText;
+        }
+
+        if (_lastPercent >= 100)
+        {
+            Remaining = TimeSpan.Zero;
+            RemainingText = "done";
+            return RemainingText;
+        }
+
+        // Linear extrapolation: total_time = elapsed / (percent / 100)
+        // remaining = total_time - elapsed
+        var elapsed = _sw.Elapsed;
+        var totalEstimate = elapsed * (100.0 / _lastPercent);
+        var remaining = totalEstimate - elapsed;
+
+        if (remaining < TimeSpan.Zero)
+            remaining = TimeSpan.Zero;
+
+        Remaining = remaining;
+        RemainingText = FormatTimeSpan(remaining);
+        return RemainingText;
+    }
+
+    /// <summary>Formats a TimeSpan into a human-friendly short string.</summary>
+    internal static string FormatTimeSpan(TimeSpan ts)
+    {
+        if (ts.TotalSeconds < 5)
+            return "a few seconds";
+        if (ts.TotalSeconds < 60)
+            return $"~{(int)ts.TotalSeconds} s";
+        if (ts.TotalMinutes < 60)
+        {
+            var min = (int)ts.TotalMinutes;
+            var sec = ts.Seconds;
+            return sec > 0 ? $"~{min} min {sec} s" : $"~{min} min";
+        }
+        var hours = (int)ts.TotalHours;
+        var mins = ts.Minutes;
+        return mins > 0 ? $"~{hours} h {mins} min" : $"~{hours} h";
+    }
+}

--- a/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
@@ -8,6 +8,7 @@ using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -21,6 +22,8 @@ public partial class DeepCleanupViewModel : ViewModelBase
     private CancellationTokenSource? _scanCts;
     private CancellationTokenSource? _cleanCts;
     private CancellationTokenSource? _largeCts;
+    private readonly EtaCalculator _scanEta = new();
+    private readonly EtaCalculator _cleanEta = new();
 
     public ObservableCollection<CleanupCategory> Categories { get; } = new();
     public ObservableCollection<LargeFileEntry> LargeFiles { get; } = new();
@@ -33,8 +36,10 @@ public partial class DeepCleanupViewModel : ViewModelBase
     // Scan progress (determinate, category-based)
     [ObservableProperty] private int _scanProgress;          // 0..100
     [ObservableProperty] private string _scanStatusLine = string.Empty;
+    [ObservableProperty] private string _scanEtaText = string.Empty;
     [ObservableProperty] private int _cleanProgress;         // 0..100
     [ObservableProperty] private string _cleanStatusLine = string.Empty;
+    [ObservableProperty] private string _cleanEtaText = string.Empty;
 
     // Large files progress (indeterminate, counter-based)
     [ObservableProperty] private long _largeFilesScanned;
@@ -133,6 +138,8 @@ public partial class DeepCleanupViewModel : ViewModelBase
         IsScanning = true;
         ScanProgress = 0;
         ScanStatusLine = "Starting...";
+        ScanEtaText = "";
+        _scanEta.Reset();
         ScanSummary = "Scanning safe cleanup locations...";
         _scanCts = new CancellationTokenSource();
         try
@@ -141,6 +148,7 @@ public partial class DeepCleanupViewModel : ViewModelBase
             {
                 ScanProgress = p.Total > 0 ? p.Current * 100 / p.Total : 0;
                 ScanStatusLine = $"[{p.Current}/{p.Total}]  {p.CategoryName}";
+                ScanEtaText = _scanEta.Update(ScanProgress);
             });
             var cats = await _cleanup.ScanAsync(progress, _scanCts.Token);
 
@@ -187,6 +195,8 @@ public partial class DeepCleanupViewModel : ViewModelBase
         IsCleaning = true;
         CleanProgress = 0;
         CleanStatusLine = "Starting...";
+        CleanEtaText = "";
+        _cleanEta.Reset();
         CleanSummary = "Cleaning selected categories — you can keep using the app.";
         _cleanCts = new CancellationTokenSource();
         try
@@ -195,6 +205,7 @@ public partial class DeepCleanupViewModel : ViewModelBase
             {
                 CleanProgress = p.Total > 0 ? p.Current * 100 / p.Total : 0;
                 CleanStatusLine = $"[{p.Current}/{p.Total}]  {p.CategoryName}";
+                CleanEtaText = _cleanEta.Update(CleanProgress);
             });
             var result = await _cleanup.CleanAsync(Categories, progress, _cleanCts.Token);
             CleanSummary = result.Summary;

--- a/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -16,6 +17,7 @@ public partial class SpeedTestViewModel : ViewModelBase
 {
     public NetworkSharedState Shared { get; }
     private readonly SpeedTestHistoryService _history = new();
+    private readonly EtaCalculator _eta = new();
     private CancellationTokenSource? _speedCts;
 
     [ObservableProperty] private SpeedTestResult? _httpResult;
@@ -27,6 +29,7 @@ public partial class SpeedTestViewModel : ViewModelBase
     [ObservableProperty] private bool _isSpeedTesting;
     [ObservableProperty] private bool _isHttpTesting;
     [ObservableProperty] private bool _isOoklaTesting;
+    [ObservableProperty] private string _estimatedTime = "";
 
     /// <summary>Persisted history of HTTP speed test results (newest first).</summary>
     public ObservableCollection<SpeedTestResult> HttpHistory { get; } = new();
@@ -73,10 +76,12 @@ public partial class SpeedTestViewModel : ViewModelBase
         IsSpeedTesting = true;
         IsHttpTesting = true;
         SpeedProgress = 0;
+        EstimatedTime = "";
+        _eta.Reset();
         HttpStatus = "Starting HTTP speed test…";
         _speedCts = new CancellationTokenSource();
         var progress = new Progress<(int p, string m)>(t =>
-        { SpeedProgress = t.p; HttpStatus = t.m; });
+        { SpeedProgress = t.p; HttpStatus = t.m; EstimatedTime = _eta.Update(t.p); });
         try
         {
             HttpResult = await Shared.Speed.RunHttpAsync(progress, _speedCts.Token);
@@ -111,10 +116,12 @@ public partial class SpeedTestViewModel : ViewModelBase
         IsSpeedTesting = true;
         IsOoklaTesting = true;
         SpeedProgress = 0;
+        EstimatedTime = "";
+        _eta.Reset();
         OoklaStatus = "Starting Ookla speed test…";
         _speedCts = new CancellationTokenSource();
         var progress = new Progress<(int p, string m)>(t =>
-        { SpeedProgress = t.p; OoklaStatus = t.m; });
+        { SpeedProgress = t.p; OoklaStatus = t.m; EstimatedTime = _eta.Update(t.p); });
         try
         {
             OoklaResult = await Shared.Speed.RunOoklaAsync(progress, _speedCts.Token);


### PR DESCRIPTION
## Summary
Adds reusable EtaCalculator helper for estimating time remaining on any progress-based operation. Integrated into Speed Test and Deep Cleanup.

## Changes
- EtaCalculator helper (linear extrapolation from elapsed time + progress %)
- SpeedTestViewModel: EstimatedTime property updated on each progress tick
- DeepCleanupViewModel: ScanEtaText + CleanEtaText properties
- 9 unit tests for EtaCalculator

Closes #241
