### PR TITLE
feat: uninstaller local app support via registry UninstallString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.44.0] - 2026-05-13
+
+### Added
+- **Uninstaller — Local app support** — apps not managed by winget (per-user
+  installs, legacy software, custom apps) can now be uninstalled directly
+  using their registry UninstallString. The service parses quoted paths,
+  MsiExec commands, and rundll32 invocations. Prefers QuietUninstallString
+  when available. Closes #236.
+
 ## [0.43.0] - 2026-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ long-running operation, so you always know which tab is working.
 - Filter by name or package ID
 - Sort by name, size, or publisher via clickable column headers
 - Select/deselect all, batch uninstall with confirmation dialog
+- Local app support — uninstalls apps not in winget via registry UninstallString
 - Live console output from winget
 
 ### Performance Mode

--- a/SysManager/SysManager.Tests/UninstallerServiceTests.cs
+++ b/SysManager/SysManager.Tests/UninstallerServiceTests.cs
@@ -209,4 +209,81 @@ public class UninstallerServiceTests
         var ex = Record.Exception(() => UninstallerService.EnrichFromRegistry(apps));
         Assert.Null(ex);
     }
+
+    // ── ParseUninstallCommand ──
+
+    [Fact]
+    public void ParseUninstallCommand_QuotedPath_SplitsCorrectly()
+    {
+        var (exe, args) = UninstallerService.ParseUninstallCommand(
+            "\"C:\\Program Files\\App\\uninstall.exe\" /S");
+        Assert.Equal("C:\\Program Files\\App\\uninstall.exe", exe);
+        Assert.Equal("/S", args);
+    }
+
+    [Fact]
+    public void ParseUninstallCommand_QuotedPathNoArgs_ReturnsEmptyArgs()
+    {
+        var (exe, args) = UninstallerService.ParseUninstallCommand(
+            "\"C:\\Program Files\\App\\uninstall.exe\"");
+        Assert.Equal("C:\\Program Files\\App\\uninstall.exe", exe);
+        Assert.Equal("", args);
+    }
+
+    [Fact]
+    public void ParseUninstallCommand_MsiExec_ConvertsToUninstall()
+    {
+        var (exe, args) = UninstallerService.ParseUninstallCommand(
+            "MsiExec.exe /I{12345-GUID}");
+        Assert.Equal("MsiExec.exe", exe);
+        Assert.Contains("/X{12345-GUID}", args);
+        Assert.Contains("/quiet", args);
+    }
+
+    [Fact]
+    public void ParseUninstallCommand_MsiExecAlreadyQuiet_DoesNotDuplicate()
+    {
+        var (exe, args) = UninstallerService.ParseUninstallCommand(
+            "MsiExec.exe /X{GUID} /quiet");
+        Assert.Equal("MsiExec.exe", exe);
+        Assert.Contains("/X{GUID}", args);
+        // Should not add /quiet again
+        Assert.Equal(1, args.Split("/quiet").Length - 1);
+    }
+
+    [Fact]
+    public void ParseUninstallCommand_Rundll32_PassesAsIs()
+    {
+        var (exe, args) = UninstallerService.ParseUninstallCommand(
+            "rundll32.exe advpack.dll,LaunchINFSection something.inf");
+        Assert.Equal("rundll32.exe", exe);
+        Assert.Equal("advpack.dll,LaunchINFSection something.inf", args);
+    }
+
+    [Fact]
+    public void ParseUninstallCommand_UnquotedExePath_FindsExeBoundary()
+    {
+        var (exe, args) = UninstallerService.ParseUninstallCommand(
+            "C:\\Apps\\uninstall.exe --silent");
+        Assert.Equal("C:\\Apps\\uninstall.exe", exe);
+        Assert.Equal("--silent", args);
+    }
+
+    [Fact]
+    public void ParseUninstallCommand_NoExeExtension_FallsBackToFullString()
+    {
+        var (exe, args) = UninstallerService.ParseUninstallCommand("some-command");
+        Assert.Equal("some-command", exe);
+        Assert.Equal("", args);
+    }
+
+    [Fact]
+    public void ParseUninstallCommand_MsiExecWithQn_DoesNotAddQuiet()
+    {
+        var (exe, args) = UninstallerService.ParseUninstallCommand(
+            "MsiExec.exe /X{GUID} /qn");
+        Assert.Equal("MsiExec.exe", exe);
+        Assert.DoesNotContain("/quiet", args);
+        Assert.Contains("/qn", args);
+    }
 }

--- a/SysManager/SysManager/Models/InstalledApp.cs
+++ b/SysManager/SysManager/Models/InstalledApp.cs
@@ -21,6 +21,8 @@ public partial class InstalledApp : ObservableObject
     [ObservableProperty] private long _sizeBytes;
     [ObservableProperty] private string _publisher = "";
     [ObservableProperty] private ImageSource? _icon;
+    [ObservableProperty] private string _uninstallString = "";
+    [ObservableProperty] private string _quietUninstallString = "";
 
     /// <summary>Formatted size for display.</summary>
     public string SizeDisplay => SizeBytes > 0 ? CleanupCategory.HumanSize(SizeBytes) : "—";

--- a/SysManager/SysManager/Services/UninstallerService.cs
+++ b/SysManager/SysManager/Services/UninstallerService.cs
@@ -1,4 +1,4 @@
-// SysManager · UninstallerService — list and uninstall apps via winget
+// SysManager · UninstallerService — list and uninstall apps via winget and registry
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
@@ -200,6 +200,17 @@ public sealed partial class UninstallerService
                         app.Publisher = pub;
                 }
 
+                if (string.IsNullOrWhiteSpace(app.UninstallString))
+                {
+                    var quietUninst = sub.GetValue("QuietUninstallString") as string;
+                    if (!string.IsNullOrWhiteSpace(quietUninst))
+                        app.QuietUninstallString = quietUninst;
+
+                    var uninst = sub.GetValue("UninstallString") as string;
+                    if (!string.IsNullOrWhiteSpace(uninst))
+                        app.UninstallString = uninst;
+                }
+
                 if (app.Icon == null)
                 {
                     var iconPath = sub.GetValue("DisplayIcon") as string;
@@ -219,5 +230,89 @@ public sealed partial class UninstallerService
             catch (System.Security.SecurityException) { /* skip protected subkey */ }
             catch (UnauthorizedAccessException) { /* skip protected subkey */ }
         }
+    }
+
+    /// <summary>
+    /// Uninstalls a local application using its registry UninstallString.
+    /// Prefers QuietUninstallString when available.
+    /// </summary>
+    public async Task<int> UninstallLocalAsync(InstalledApp app, CancellationToken ct = default)
+    {
+        var command = !string.IsNullOrWhiteSpace(app.QuietUninstallString)
+            ? app.QuietUninstallString
+            : app.UninstallString;
+
+        if (string.IsNullOrWhiteSpace(command))
+            throw new InvalidOperationException(
+                $"No uninstall command found for '{app.Name}'. The app may need to be removed manually.");
+
+        // Parse the uninstall string into executable + arguments.
+        // Handles both quoted paths ("C:\path\uninstall.exe" /S) and unquoted.
+        var (exe, args) = ParseUninstallCommand(command);
+
+        Log.Information("Uninstalling local app '{Name}' via: {Exe} {Args}", app.Name, exe, args);
+        return await _runner.RunProcessAsync(exe, args, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Parses an uninstall command string into executable and arguments.
+    /// Handles: "C:\path\uninstall.exe" /S, C:\path\uninstall.exe /S,
+    /// MsiExec.exe /X{GUID}, rundll32.exe ...
+    /// </summary>
+    internal static (string Exe, string Args) ParseUninstallCommand(string command)
+    {
+        command = command.Trim();
+
+        // Case 1: Quoted executable path
+        if (command.StartsWith('"'))
+        {
+            var endQuote = command.IndexOf('"', 1);
+            if (endQuote > 0)
+            {
+                var exe = command[1..endQuote];
+                var args = endQuote + 1 < command.Length
+                    ? command[(endQuote + 1)..].TrimStart()
+                    : "";
+                return (exe, args);
+            }
+        }
+
+        // Case 2: MsiExec — common pattern: MsiExec.exe /I{GUID} or /X{GUID}
+        if (command.StartsWith("MsiExec", StringComparison.OrdinalIgnoreCase))
+        {
+            var spaceIdx = command.IndexOf(' ');
+            if (spaceIdx > 0)
+            {
+                var exe = command[..spaceIdx];
+                var args = command[(spaceIdx + 1)..].TrimStart();
+                // Convert /I (modify) to /X (uninstall) if needed, add /quiet
+                args = args.Replace("/I", "/X", StringComparison.OrdinalIgnoreCase);
+                if (!args.Contains("/quiet", StringComparison.OrdinalIgnoreCase)
+                    && !args.Contains("/qn", StringComparison.OrdinalIgnoreCase))
+                    args += " /quiet /norestart";
+                return (exe, args);
+            }
+        }
+
+        // Case 3: rundll32 — pass as-is
+        if (command.StartsWith("rundll32", StringComparison.OrdinalIgnoreCase))
+        {
+            var spaceIdx = command.IndexOf(' ');
+            if (spaceIdx > 0)
+                return (command[..spaceIdx], command[(spaceIdx + 1)..].TrimStart());
+        }
+
+        // Case 4: Unquoted path with spaces — find first .exe boundary
+        var exeEnd = command.IndexOf(".exe", StringComparison.OrdinalIgnoreCase);
+        if (exeEnd > 0)
+        {
+            exeEnd += 4; // include ".exe"
+            var exe = command[..exeEnd].Trim();
+            var args = exeEnd < command.Length ? command[exeEnd..].TrimStart() : "";
+            return (exe, args);
+        }
+
+        // Fallback: treat entire string as executable
+        return (command, "");
     }
 }

--- a/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
@@ -107,7 +107,19 @@ public partial class UninstallerViewModel : ViewModelBase
 
                 try
                 {
-                    var code = await _service.UninstallAsync(app.Id, _cts.Token);
+                    int code;
+                    if (string.IsNullOrWhiteSpace(app.Source)
+                        && !string.IsNullOrWhiteSpace(app.UninstallString))
+                    {
+                        // Local app — use registry UninstallString directly
+                        code = await _service.UninstallLocalAsync(app, _cts.Token);
+                    }
+                    else
+                    {
+                        // Winget-managed app — use winget uninstall
+                        code = await _service.UninstallAsync(app.Id, _cts.Token);
+                    }
+
                     if (code == 0)
                     {
                         app.Status = "Removed";

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -139,7 +139,7 @@
                                                 <DataTrigger Binding="{Binding Source}" Value="">
                                                     <Setter Property="Text" Value="Local"/>
                                                     <Setter Property="Foreground" Value="#F59E0B"/>
-                                                    <Setter Property="ToolTip" Value="Not from winget — uninstall may require the app's own installer"/>
+                                                    <Setter Property="ToolTip" Value="Not from winget — uses registry uninstall command"/>
                                                 </DataTrigger>
                                             </Style.Triggers>
                                         </Style>


### PR DESCRIPTION
## Summary

Adds the ability to uninstall **local applications** (apps not managed by winget) directly from the Uninstaller tab using their registry UninstallString.

## What changed

- **InstalledApp model** — added UninstallString and QuietUninstallString properties
- **UninstallerService** — captures uninstall commands from registry during enrichment; new UninstallLocalAsync method executes them; ParseUninstallCommand handles quoted paths, MsiExec, rundll32, and unquoted .exe paths
- **UninstallerViewModel** — routes local apps (empty Source) to registry uninstall instead of winget
- **UninstallerView** — updated tooltip for Local badge
- **Tests** — 8 new unit tests for ParseUninstallCommand covering all parsing branches
- **README** — updated Uninstaller feature description
- **CHANGELOG** — v0.44.0 entry

## How it works

1. During scan, registry enrichment now also captures UninstallString/QuietUninstallString
2. When uninstalling, if the app has no winget Source but has an UninstallString, the service executes the registry command directly
3. The parser handles: quoted paths, MsiExec (converts /I to /X, adds /quiet), rundll32, unquoted .exe paths

## Testing

- 8 new unit tests for ParseUninstallCommand (all branches)
- Existing tests pass (build verified locally)

Closes #236
