### PR TITLE
feat: introduce Dependency Injection container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.45.0] - 2026-05-13
+
+### Added
+- **Dependency Injection container** — introduced
+  `Microsoft.Extensions.DependencyInjection` for service and ViewModel
+  lifetime management. All services (PowerShellRunner, SystemInfoService,
+  WingetService, TrayIconService) are now shared singletons resolved from
+  the container. MainWindowViewModel resolves child VMs from DI at runtime,
+  falls back to manual creation in tests. Closes #255.
+
 ## [0.44.0] - 2026-05-13
 
 ### Added

--- a/SysManager/SysManager/App.xaml.cs
+++ b/SysManager/SysManager/App.xaml.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Threading;
+using Microsoft.Extensions.DependencyInjection;
 using SysManager.Services;
 
 namespace SysManager;
@@ -18,6 +19,9 @@ public partial class App : Application
 
     // Guard against cascading error dialogs — show at most one at a time.
     private static int _errorDialogActive;
+
+    /// <summary>The DI service provider for the application.</summary>
+    public static IServiceProvider? Services { get; private set; }
 
     /// <summary>The shared tray icon service instance.</summary>
     public TrayIconService? TrayService => _trayService;
@@ -50,11 +54,16 @@ public partial class App : Application
 
         LogService.Init();
 
+        // ── Build DI container ─────────────────────────────────────────
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.ConfigureServices();
+        Services = serviceCollection.BuildServiceProvider();
+
         // Don't shutdown when main window is hidden (tray mode)
         ShutdownMode = ShutdownMode.OnExplicitShutdown;
 
-        // Initialize tray icon service
-        _trayService = new TrayIconService(new SystemInfoService());
+        // Initialize tray icon service from DI
+        _trayService = Services.GetRequiredService<TrayIconService>();
 
         DispatcherUnhandledException += OnUi;
         AppDomain.CurrentDomain.UnhandledException += OnDomain;

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -1,0 +1,60 @@
+// SysManager · ServiceRegistration — DI container configuration
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using Microsoft.Extensions.DependencyInjection;
+using SysManager.Services;
+using SysManager.ViewModels;
+
+namespace SysManager;
+
+/// <summary>
+/// Registers all services and ViewModels in the DI container.
+/// Called once at application startup from <see cref="App.OnStartup"/>.
+/// </summary>
+public static class ServiceRegistration
+{
+    public static IServiceCollection ConfigureServices(this IServiceCollection services)
+    {
+        // ── Core services (Singleton — one shared instance) ─────────────
+        services.AddSingleton<PowerShellRunner>();
+        services.AddSingleton<SystemInfoService>();
+        services.AddSingleton<WingetService>();
+        services.AddSingleton<TrayIconService>();
+        services.AddSingleton<UpdateService>();
+        services.AddSingleton<ShortcutCleanerService>();
+        services.AddSingleton<DiskHealthService>();
+        services.AddSingleton<BatteryService>();
+        services.AddSingleton<TuneUpService>();
+        services.AddSingleton<HealthScoreService>();
+
+        // ── ViewModels (Singleton — one instance per tab) ──────────────
+        services.AddSingleton<DashboardViewModel>();
+        services.AddSingleton<AppUpdatesViewModel>();
+        services.AddSingleton<WindowsUpdateViewModel>();
+        services.AddSingleton<SystemHealthViewModel>();
+        services.AddSingleton<CleanupViewModel>();
+        services.AddSingleton<DeepCleanupViewModel>();
+        services.AddSingleton<DuplicateFileViewModel>();
+        services.AddSingleton<DiskAnalyzerViewModel>();
+        services.AddSingleton<ProcessManagerViewModel>();
+        services.AddSingleton<BatteryHealthViewModel>();
+        services.AddSingleton<UninstallerViewModel>();
+        services.AddSingleton<PerformanceViewModel>();
+        services.AddSingleton<StartupViewModel>();
+        services.AddSingleton<NetworkSharedState>();
+        services.AddSingleton<PingViewModel>();
+        services.AddSingleton<TracerouteViewModel>();
+        services.AddSingleton<SpeedTestViewModel>();
+        services.AddSingleton<NetworkRepairViewModel>();
+        services.AddSingleton<DriversViewModel>();
+        services.AddSingleton<LogsViewModel>();
+        services.AddSingleton<AboutViewModel>();
+        services.AddSingleton<ServicesViewModel>();
+        services.AddSingleton<AppAlertsViewModel>();
+        services.AddSingleton<ShortcutCleanerViewModel>();
+        services.AddSingleton<AppBlockerViewModel>();
+
+        return services;
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="H.NotifyIcon.Wpf" Version="2.2.1" />
     <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="ModernWpfUI" Version="0.9.6" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -5,6 +5,7 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 using SysManager.Helpers;
 using SysManager.Services;
@@ -37,21 +38,21 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     public ServicesViewModel Services { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
-    public PlaceholderViewModel WipWindowsFeatures { get; }
-    public PlaceholderViewModel WipResourceHistory { get; }
+    public PlaceholderViewModel WipWindowsFeatures { get; private set; } = null!;
+    public PlaceholderViewModel WipResourceHistory { get; private set; } = null!;
     public AppAlertsViewModel AppAlerts { get; }
-    public PlaceholderViewModel WipPrivacyMonitor { get; }
+    public PlaceholderViewModel WipPrivacyMonitor { get; private set; } = null!;
     public ShortcutCleanerViewModel ShortcutCleaner { get; }
-    public PlaceholderViewModel WipFileShredder { get; }
-    public PlaceholderViewModel WipDnsChanger { get; }
-    public PlaceholderViewModel WipHostsEditor { get; }
-    public PlaceholderViewModel WipBulkInstaller { get; }
+    public PlaceholderViewModel WipFileShredder { get; private set; } = null!;
+    public PlaceholderViewModel WipDnsChanger { get; private set; } = null!;
+    public PlaceholderViewModel WipHostsEditor { get; private set; } = null!;
+    public PlaceholderViewModel WipBulkInstaller { get; private set; } = null!;
     public AppBlockerViewModel AppBlocker { get; }
-    public PlaceholderViewModel WipPrivacySettings { get; }
-    public PlaceholderViewModel WipContextMenu { get; }
-    public PlaceholderViewModel WipRestorePoints { get; }
-    public PlaceholderViewModel WipScheduledMaintenance { get; }
-    public PlaceholderViewModel WipSystemReport { get; }
+    public PlaceholderViewModel WipPrivacySettings { get; private set; } = null!;
+    public PlaceholderViewModel WipContextMenu { get; private set; } = null!;
+    public PlaceholderViewModel WipRestorePoints { get; private set; } = null!;
+    public PlaceholderViewModel WipScheduledMaintenance { get; private set; } = null!;
+    public PlaceholderViewModel WipSystemReport { get; private set; } = null!;
 
     /// <summary>Grouped sidebar tree (9 categories).</summary>
     public ObservableCollection<NavGroup> NavGroups { get; } = new();
@@ -64,49 +65,100 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     [ObservableProperty] private bool _isElevated;
     [ObservableProperty] private string _elevationBadge = "";
 
+    /// <summary>
+    /// Parameterless constructor — used by XAML designer and tests.
+    /// When DI container is available (runtime), resolves child VMs from it.
+    /// When not available (tests/designer), creates dependencies manually.
+    /// </summary>
     public MainWindowViewModel()
     {
-        var sysInfo = new SystemInfoService();
-        var winget = new WingetService(new PowerShellRunner());        Dashboard = new DashboardViewModel(sysInfo);
-        AppUpdates = new AppUpdatesViewModel(winget);
-        WindowsUpdate = new WindowsUpdateViewModel(new PowerShellRunner());
-        SystemHealth = new SystemHealthViewModel(sysInfo);
-        Cleanup = new CleanupViewModel(new PowerShellRunner());
-        DeepCleanup = new DeepCleanupViewModel();
-        DuplicateFile = new DuplicateFileViewModel();
-        DiskAnalyzer = new DiskAnalyzerViewModel();
-        ProcessManager = new ProcessManagerViewModel();
-        BatteryHealth = new BatteryHealthViewModel();
-        Uninstaller = new UninstallerViewModel(new PowerShellRunner());
-        Performance = new PerformanceViewModel(new PowerShellRunner());
-        Startup = new StartupViewModel();
-        NetworkShared = new NetworkSharedState();
-        Ping = new PingViewModel(NetworkShared);
-        Traceroute = new TracerouteViewModel(NetworkShared);
-        SpeedTest = new SpeedTestViewModel(NetworkShared);
-        NetworkRepair = new NetworkRepairViewModel(NetworkShared);
-        Drivers = new DriversViewModel(new PowerShellRunner());
-        Logs = new LogsViewModel();
-        About = new AboutViewModel();
-        Services = new ServicesViewModel();
+        var sp = App.Services;
+        if (sp != null)
+        {
+            // Runtime path — resolve from DI container (shared singletons)
+            Dashboard = sp.GetRequiredService<DashboardViewModel>();
+            AppUpdates = sp.GetRequiredService<AppUpdatesViewModel>();
+            WindowsUpdate = sp.GetRequiredService<WindowsUpdateViewModel>();
+            SystemHealth = sp.GetRequiredService<SystemHealthViewModel>();
+            Cleanup = sp.GetRequiredService<CleanupViewModel>();
+            DeepCleanup = sp.GetRequiredService<DeepCleanupViewModel>();
+            DuplicateFile = sp.GetRequiredService<DuplicateFileViewModel>();
+            DiskAnalyzer = sp.GetRequiredService<DiskAnalyzerViewModel>();
+            ProcessManager = sp.GetRequiredService<ProcessManagerViewModel>();
+            BatteryHealth = sp.GetRequiredService<BatteryHealthViewModel>();
+            Uninstaller = sp.GetRequiredService<UninstallerViewModel>();
+            Performance = sp.GetRequiredService<PerformanceViewModel>();
+            Startup = sp.GetRequiredService<StartupViewModel>();
+            NetworkShared = sp.GetRequiredService<NetworkSharedState>();
+            Ping = sp.GetRequiredService<PingViewModel>();
+            Traceroute = sp.GetRequiredService<TracerouteViewModel>();
+            SpeedTest = sp.GetRequiredService<SpeedTestViewModel>();
+            NetworkRepair = sp.GetRequiredService<NetworkRepairViewModel>();
+            Drivers = sp.GetRequiredService<DriversViewModel>();
+            Logs = sp.GetRequiredService<LogsViewModel>();
+            About = sp.GetRequiredService<AboutViewModel>();
+            Services = sp.GetRequiredService<ServicesViewModel>();
+            AppAlerts = sp.GetRequiredService<AppAlertsViewModel>();
+            ShortcutCleaner = sp.GetRequiredService<ShortcutCleanerViewModel>();
+            AppBlocker = sp.GetRequiredService<AppBlockerViewModel>();
+        }
+        else
+        {
+            // Test/designer path — create dependencies manually
+            var runner = new PowerShellRunner();
+            var sysInfo = new SystemInfoService();
+            var winget = new WingetService(runner);
 
+            Dashboard = new DashboardViewModel(sysInfo);
+            AppUpdates = new AppUpdatesViewModel(winget);
+            WindowsUpdate = new WindowsUpdateViewModel(runner);
+            SystemHealth = new SystemHealthViewModel(sysInfo);
+            Cleanup = new CleanupViewModel(runner);
+            DeepCleanup = new DeepCleanupViewModel();
+            DuplicateFile = new DuplicateFileViewModel();
+            DiskAnalyzer = new DiskAnalyzerViewModel();
+            ProcessManager = new ProcessManagerViewModel();
+            BatteryHealth = new BatteryHealthViewModel();
+            Uninstaller = new UninstallerViewModel(runner);
+            Performance = new PerformanceViewModel(runner);
+            Startup = new StartupViewModel();
+            NetworkShared = new NetworkSharedState();
+            Ping = new PingViewModel(NetworkShared);
+            Traceroute = new TracerouteViewModel(NetworkShared);
+            SpeedTest = new SpeedTestViewModel(NetworkShared);
+            NetworkRepair = new NetworkRepairViewModel(NetworkShared);
+            Drivers = new DriversViewModel(runner);
+            Logs = new LogsViewModel();
+            About = new AboutViewModel();
+            Services = new ServicesViewModel();
+            AppAlerts = new AppAlertsViewModel();
+            ShortcutCleaner = new ShortcutCleanerViewModel();
+            AppBlocker = new AppBlockerViewModel();
+        }
+
+        InitPlaceholders();
+        InitNavigation();
+    }
+
+    private void InitPlaceholders()
+    {
         // ── WIP placeholders for planned features ──────────────────────
         WipWindowsFeatures = new PlaceholderViewModel("Windows Features", "Toggle Windows optional features on or off.", "388");
         WipResourceHistory = new PlaceholderViewModel("Resource History", "Historical CPU, RAM, GPU and temperature graphs.", "377");
-        AppAlerts = new AppAlertsViewModel();
         WipPrivacyMonitor = new PlaceholderViewModel("Privacy Monitor", "Monitor and alert on webcam, microphone, and location access.", "380");
-        ShortcutCleaner = new ShortcutCleanerViewModel();
         WipFileShredder = new PlaceholderViewModel("File Shredder", "Securely delete files beyond recovery.", "386");
         WipDnsChanger = new PlaceholderViewModel("DNS Changer", "Quickly switch DNS servers for any network adapter.", "382");
         WipHostsEditor = new PlaceholderViewModel("Hosts Editor", "Edit the Windows hosts file with a friendly UI.", "382");
         WipBulkInstaller = new PlaceholderViewModel("Bulk Installer", "Install multiple applications at once via winget.", "387");
-        AppBlocker = new AppBlockerViewModel();
         WipPrivacySettings = new PlaceholderViewModel("Privacy Settings", "Windows debloat and privacy toggles.", "384");
         WipContextMenu = new PlaceholderViewModel("Context Menu", "Manage right-click context menu entries.", "385");
         WipRestorePoints = new PlaceholderViewModel("Restore Points", "Create and manage system restore points.", "383");
         WipScheduledMaintenance = new PlaceholderViewModel("Scheduled Maintenance", "Automate cleanup and maintenance tasks.", "383");
         WipSystemReport = new PlaceholderViewModel("System Report", "Comprehensive system info export.", "389");
+    }
 
+    private void InitNavigation()
+    {
         IsElevated = AdminHelper.IsElevated();
         ElevationBadge = IsElevated ? "Administrator" : "Standard user";
         Title = IsElevated ? "SysManager — Administrator" : "SysManager";


### PR DESCRIPTION
## Summary

Introduces Microsoft.Extensions.DependencyInjection as the application's service container, replacing manual 
ew instantiation of services and ViewModels.

## What changed

- **ServiceRegistration.cs** (new) — extension method registering all services and VMs as singletons
- **App.xaml.cs** — builds IServiceProvider on startup, exposes App.Services static accessor
- **MainWindowViewModel** — resolves child VMs from DI at runtime; falls back to manual creation for tests/designer
- **SysManager.csproj** — added Microsoft.Extensions.DependencyInjection 8.0.1

## Key improvements

- **PowerShellRunner**: 1 shared singleton instead of 6 separate instances
- **SystemInfoService**: 1 shared singleton instead of 2 separate instances
- **TrayIconService**: resolved from DI (shares SystemInfoService with Dashboard/SystemHealth)
- **All ViewModels**: registered as singletons, resolved consistently
- **Tests**: continue working via parameterless constructor (no DI dependency)

## Design decisions

- XAML still creates MainWindowViewModel via parameterless constructor (avoids StartupUri changes)
- Parameterless constructor checks App.Services — uses DI at runtime, manual creation in tests
- PlaceholderViewModels remain inline (not in DI — they're simple value objects)
- No interface extraction yet (separate future PR)

## Testing

- Both projects build with 0 errors
- Existing tests pass (parameterless constructor path unchanged)

Closes #255
