### PR TITLE
feat: Windows optional features toggle tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.46.0] - 2026-05-13
+
+### Added
+- **Windows Features tab** — list, enable, and disable Windows optional
+  features (Hyper-V, WSL, .NET 3.5, Telnet, etc.) directly from SysManager.
+  Features are categorized (Virtualization, Networking, Development, Media,
+  Legacy). Toggle requires admin. Shows reboot-required status. Includes
+  search/filter. Closes #5.
+
 ## [0.45.0] - 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ implemented; 12 are work-in-progress placeholders marked with ⚙️:
 | Group | Tabs |
 |-------|------|
 | 🏠 Dashboard | Dashboard |
-| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features ⚙️ |
+| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features |
 | 📊 Monitor | Process Manager · Resource History ⚙️ · App Alerts · Privacy Monitor ⚙️ |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · File Shredder ⚙️ |
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
@@ -141,6 +141,14 @@ long-running operation, so you always know which tab is working.
 - Sort by name, publisher, or status via clickable column headers
 - Shows name, publisher, command, and enabled/disabled status
 - Open file location in Explorer
+
+### Windows Features
+- Lists all Windows optional features with current state (Enabled/Disabled)
+- Toggle enable/disable per feature with confirmation dialog
+- Categorized: Virtualization, Networking, Development, Media & Print, Legacy
+- Shows reboot-required status after toggling
+- Search/filter across all features
+- Requires administrator privileges for modifications
 
 ### Duplicate File Finder
 - Two-pass scan: group by size, then SHA-256 hash only size-matched files

--- a/SysManager/SysManager.Tests/WindowsFeaturesTests.cs
+++ b/SysManager/SysManager.Tests/WindowsFeaturesTests.cs
@@ -1,0 +1,132 @@
+// SysManager · WindowsFeaturesTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.Services;
+using SysManager.ViewModels;
+using Xunit;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="WindowsFeaturesService"/> and <see cref="WindowsFeaturesViewModel"/>.
+/// </summary>
+public class WindowsFeaturesTests
+{
+    // ── ParseFeatureList ──
+
+    [Fact]
+    public void ParseFeatureList_EmptyInput_ReturnsEmpty()
+    {
+        var result = WindowsFeaturesService.ParseFeatureList(new List<string>());
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ParseFeatureList_ValidLines_ParsesCorrectly()
+    {
+        var lines = new List<string>
+        {
+            "Microsoft-Hyper-V-All|Enabled",
+            "TelnetClient|Disabled",
+            "NetFx3|Enabled"
+        };
+
+        var result = WindowsFeaturesService.ParseFeatureList(lines);
+
+        Assert.Equal(3, result.Count);
+        var hyperV = result.First(f => f.Name == "Microsoft-Hyper-V-All");
+        Assert.True(hyperV.IsEnabled);
+        Assert.Equal("Virtualization", hyperV.Category);
+
+        var telnet = result.First(f => f.Name == "TelnetClient");
+        Assert.False(telnet.IsEnabled);
+        Assert.Equal("Networking", telnet.Category);
+    }
+
+    [Fact]
+    public void ParseFeatureList_SkipsBlankLines()
+    {
+        var lines = new List<string>
+        {
+            "",
+            "  ",
+            "SomeFeature|Disabled",
+            ""
+        };
+
+        var result = WindowsFeaturesService.ParseFeatureList(lines);
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void ParseFeatureList_SkipsInvalidLines()
+    {
+        var lines = new List<string>
+        {
+            "NoSeparator",
+            "|Enabled",
+            "ValidFeature|Disabled"
+        };
+
+        var result = WindowsFeaturesService.ParseFeatureList(lines);
+        Assert.Single(result);
+        Assert.Equal("ValidFeature", result[0].Name);
+    }
+
+    // ── CategorizeFeature ──
+
+    [Theory]
+    [InlineData("Microsoft-Hyper-V-All", "Virtualization")]
+    [InlineData("VirtualMachinePlatform", "Virtualization")]
+    [InlineData("Microsoft-Windows-Subsystem-Linux", "Virtualization")]
+    [InlineData("Containers", "Virtualization")]
+    [InlineData("Windows-Sandbox", "Virtualization")]
+    [InlineData("TelnetClient", "Networking")]
+    [InlineData("IIS-WebServer", "Networking")]
+    [InlineData("SMB1Protocol", "Networking")]
+    [InlineData("NetFx3", "Development")]
+    [InlineData("Microsoft-Windows-Developer-Mode", "Development")]
+    [InlineData("OpenSSH-Client", "Development")]
+    [InlineData("MediaPlayback", "Media & Print")]
+    [InlineData("Printing-XPSServices-Features", "Media & Print")]
+    [InlineData("DirectPlay", "Legacy")]
+    [InlineData("SomeRandomFeature", "Other")]
+    public void CategorizeFeature_AssignsCorrectCategory(string featureName, string expected)
+    {
+        Assert.Equal(expected, WindowsFeature.CategorizeFeature(featureName));
+    }
+
+    [Fact]
+    public void CategorizeFeature_NullOrEmpty_ReturnsOther()
+    {
+        Assert.Equal("Other", WindowsFeature.CategorizeFeature(null!));
+        Assert.Equal("Other", WindowsFeature.CategorizeFeature(""));
+        Assert.Equal("Other", WindowsFeature.CategorizeFeature("   "));
+    }
+
+    // ── HumanizeName ──
+
+    [Theory]
+    [InlineData("Microsoft-Hyper-V-All", "Microsoft Hyper V All")]
+    [InlineData("TelnetClient", "TelnetClient")]
+    [InlineData("Some_Feature_Name", "Some Feature Name")]
+    public void HumanizeName_ReplacesDelimiters(string input, string expected)
+    {
+        Assert.Equal(expected, WindowsFeaturesService.HumanizeName(input));
+    }
+
+    // ── ViewModel ──
+
+    [Fact]
+    public void ViewModel_InitialState_IsCorrect()
+    {
+        var vm = new WindowsFeaturesViewModel(new PowerShellRunner());
+        Assert.Empty(vm.AllFeatures);
+        Assert.Empty(vm.FilteredFeatures);
+        Assert.Equal("", vm.FilterText);
+        Assert.Equal(0, vm.FeatureCount);
+        Assert.False(vm.PendingReboot);
+    }
+}

--- a/SysManager/SysManager/Models/WindowsFeature.cs
+++ b/SysManager/SysManager/Models/WindowsFeature.cs
@@ -1,0 +1,55 @@
+// SysManager · WindowsFeature — model for Windows optional features
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SysManager.Models;
+
+/// <summary>
+/// Represents a Windows optional feature with its current state.
+/// </summary>
+public partial class WindowsFeature : ObservableObject
+{
+    [ObservableProperty] private string _name = "";
+    [ObservableProperty] private string _displayName = "";
+    [ObservableProperty] private bool _isEnabled;
+    [ObservableProperty] private bool _requiresReboot;
+    [ObservableProperty] private string _category = "Other";
+    [ObservableProperty] private string _status = "";
+
+    /// <summary>Category assignment based on feature name patterns.</summary>
+    public static string CategorizeFeature(string featureName)
+    {
+        if (string.IsNullOrWhiteSpace(featureName)) return "Other";
+
+        var name = featureName.ToUpperInvariant();
+
+        if (name.Contains("HYPER") || name.Contains("VIRTUAL") ||
+            name.Contains("CONTAINER") || name.Contains("SANDBOX") ||
+            name.Contains("WSL") || name.Contains("LINUX"))
+            return "Virtualization";
+
+        if (name.Contains("IIS") || name.Contains("INTERNET") ||
+            name.Contains("TFTP") || name.Contains("TELNET") ||
+            name.Contains("SMB") || name.Contains("NFS") ||
+            name.Contains("SNMP") || name.Contains("RIP"))
+            return "Networking";
+
+        if (name.Contains("NETFX") || name.Contains(".NET") ||
+            name.Contains("DEVELOPER") || name.Contains("POWERSHELL") ||
+            name.Contains("OPENSSH") || name.Contains("BASH"))
+            return "Development";
+
+        if (name.Contains("MEDIA") || name.Contains("PRINT") ||
+            name.Contains("XPS") || name.Contains("PDF") ||
+            name.Contains("SCAN") || name.Contains("FAX"))
+            return "Media & Print";
+
+        if (name.Contains("LEGACY") || name.Contains("DIRECTPLAY") ||
+            name.Contains("INDEXING") || name.Contains("WORK"))
+            return "Legacy";
+
+        return "Other";
+    }
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -53,6 +53,8 @@ public static class ServiceRegistration
         services.AddSingleton<ServicesViewModel>();
         services.AddSingleton<AppAlertsViewModel>();
         services.AddSingleton<ShortcutCleanerViewModel>();
+        services.AddSingleton<WindowsFeaturesService>();
+        services.AddSingleton<WindowsFeaturesViewModel>();
         services.AddSingleton<AppBlockerViewModel>();
 
         return services;

--- a/SysManager/SysManager/Services/WindowsFeaturesService.cs
+++ b/SysManager/SysManager/Services/WindowsFeaturesService.cs
@@ -1,0 +1,161 @@
+// SysManager · WindowsFeaturesService — list and toggle Windows optional features
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Text.RegularExpressions;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Wraps PowerShell commands to list, enable, and disable Windows optional features.
+/// Requires administrator privileges for enable/disable operations.
+/// </summary>
+public sealed partial class WindowsFeaturesService
+{
+    private readonly PowerShellRunner _runner;
+
+    public WindowsFeaturesService(PowerShellRunner runner) => _runner = runner;
+
+    /// <summary>
+    /// Lists all Windows optional features with their current state.
+    /// Uses Get-WindowsOptionalFeature -Online.
+    /// </summary>
+    public async Task<List<WindowsFeature>> ListFeaturesAsync(CancellationToken ct = default)
+    {
+        var captured = new List<string>();
+        void Collect(PowerShellLine l)
+        {
+            if (l.Kind == OutputKind.Output) captured.Add(l.Text);
+        }
+
+        _runner.LineReceived += Collect;
+        try
+        {
+            await _runner.RunProcessAsync("powershell",
+                "-NoProfile -Command \"Get-WindowsOptionalFeature -Online | " +
+                "Select-Object FeatureName, State | " +
+                "ForEach-Object { $_.FeatureName + '|' + $_.State }\"", ct);
+        }
+        finally { _runner.LineReceived -= Collect; }
+
+        return ParseFeatureList(captured);
+    }
+
+    /// <summary>
+    /// Enables a Windows optional feature. Requires admin.
+    /// Returns true if successful, false otherwise.
+    /// </summary>
+    public async Task<(bool Success, bool RebootRequired)> EnableFeatureAsync(
+        string featureName, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(featureName) || !FeatureNamePattern().IsMatch(featureName))
+            throw new ArgumentException("Invalid feature name.", nameof(featureName));
+
+        Log.Information("Enabling Windows feature: {Feature}", featureName);
+
+        var captured = new List<string>();
+        void Collect(PowerShellLine l)
+        {
+            if (l.Kind == OutputKind.Output) captured.Add(l.Text);
+        }
+
+        _runner.LineReceived += Collect;
+        try
+        {
+            var code = await _runner.RunProcessAsync("powershell",
+                $"-NoProfile -Command \"Enable-WindowsOptionalFeature -Online " +
+                $"-FeatureName '{featureName}' -NoRestart -All | " +
+                $"Select-Object RestartNeeded | ForEach-Object {{ $_.RestartNeeded }}\"", ct);
+
+            var reboot = captured.Any(l =>
+                l.Contains("True", StringComparison.OrdinalIgnoreCase));
+
+            return (code == 0, reboot);
+        }
+        finally { _runner.LineReceived -= Collect; }
+    }
+
+    /// <summary>
+    /// Disables a Windows optional feature. Requires admin.
+    /// Returns true if successful, false otherwise.
+    /// </summary>
+    public async Task<(bool Success, bool RebootRequired)> DisableFeatureAsync(
+        string featureName, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(featureName) || !FeatureNamePattern().IsMatch(featureName))
+            throw new ArgumentException("Invalid feature name.", nameof(featureName));
+
+        Log.Information("Disabling Windows feature: {Feature}", featureName);
+
+        var captured = new List<string>();
+        void Collect(PowerShellLine l)
+        {
+            if (l.Kind == OutputKind.Output) captured.Add(l.Text);
+        }
+
+        _runner.LineReceived += Collect;
+        try
+        {
+            var code = await _runner.RunProcessAsync("powershell",
+                $"-NoProfile -Command \"Disable-WindowsOptionalFeature -Online " +
+                $"-FeatureName '{featureName}' -NoRestart | " +
+                $"Select-Object RestartNeeded | ForEach-Object {{ $_.RestartNeeded }}\"", ct);
+
+            var reboot = captured.Any(l =>
+                l.Contains("True", StringComparison.OrdinalIgnoreCase));
+
+            return (code == 0, reboot);
+        }
+        finally { _runner.LineReceived -= Collect; }
+    }
+
+    /// <summary>Parses the pipe-delimited feature list output.</summary>
+    internal static List<WindowsFeature> ParseFeatureList(List<string> lines)
+    {
+        var features = new List<WindowsFeature>();
+
+        foreach (var line in lines)
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+
+            var parts = line.Split('|', 2);
+            if (parts.Length < 2) continue;
+
+            var name = parts[0].Trim();
+            var state = parts[1].Trim();
+
+            if (string.IsNullOrWhiteSpace(name)) continue;
+
+            var isEnabled = state.Equals("Enabled", StringComparison.OrdinalIgnoreCase);
+
+            features.Add(new WindowsFeature
+            {
+                Name = name,
+                DisplayName = HumanizeName(name),
+                IsEnabled = isEnabled,
+                Category = WindowsFeature.CategorizeFeature(name)
+            });
+        }
+
+        return features.OrderBy(f => f.Category)
+                       .ThenBy(f => f.DisplayName)
+                       .ToList();
+    }
+
+    /// <summary>
+    /// Converts PascalCase feature names to human-readable form.
+    /// e.g. "Microsoft-Hyper-V-All" → "Microsoft Hyper-V All"
+    /// </summary>
+    internal static string HumanizeName(string featureName)
+    {
+        return featureName.Replace('-', ' ').Replace('_', ' ');
+    }
+
+    /// <summary>
+    /// Validates feature names: alphanumeric, hyphens, underscores, dots. Max 128 chars.
+    /// </summary>
+    [GeneratedRegex(@"^[\w.\-]{1,128}$")]
+    private static partial Regex FeatureNamePattern();
+}

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -38,7 +38,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     public ServicesViewModel Services { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
-    public PlaceholderViewModel WipWindowsFeatures { get; private set; } = null!;
+    public WindowsFeaturesViewModel WindowsFeatures { get; }
     public PlaceholderViewModel WipResourceHistory { get; private set; } = null!;
     public AppAlertsViewModel AppAlerts { get; }
     public PlaceholderViewModel WipPrivacyMonitor { get; private set; } = null!;
@@ -101,6 +101,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             AppAlerts = sp.GetRequiredService<AppAlertsViewModel>();
             ShortcutCleaner = sp.GetRequiredService<ShortcutCleanerViewModel>();
             AppBlocker = sp.GetRequiredService<AppBlockerViewModel>();
+            WindowsFeatures = sp.GetRequiredService<WindowsFeaturesViewModel>();
         }
         else
         {
@@ -134,6 +135,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             AppAlerts = new AppAlertsViewModel();
             ShortcutCleaner = new ShortcutCleanerViewModel();
             AppBlocker = new AppBlockerViewModel();
+            WindowsFeatures = new WindowsFeaturesViewModel(runner);
         }
 
         InitPlaceholders();
@@ -143,7 +145,6 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private void InitPlaceholders()
     {
         // ── WIP placeholders for planned features ──────────────────────
-        WipWindowsFeatures = new PlaceholderViewModel("Windows Features", "Toggle Windows optional features on or off.", "388");
         WipResourceHistory = new PlaceholderViewModel("Resource History", "Historical CPU, RAM, GPU and temperature graphs.", "377");
         WipPrivacyMonitor = new PlaceholderViewModel("Privacy Monitor", "Monitor and alert on webcam, microphone, and location access.", "380");
         WipFileShredder = new PlaceholderViewModel("File Shredder", "Securely delete files beyond recovery.", "386");
@@ -183,7 +184,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             new NavItem { Id = "nav-performance",       Label = "Performance Mode",  Glyph = "\uE945", Content = Performance,        ViewType = typeof(Views.PerformanceView) },
             new NavItem { Id = "nav-services",          Label = "Services",          Glyph = "\uE912", Content = Services,           ViewType = typeof(Views.ServicesView) },
             new NavItem { Id = "nav-startup",           Label = "Startup Manager",   Glyph = "\uE7B5", Content = Startup,            ViewType = typeof(Views.StartupView) },
-            new NavItem { Id = "nav-windows-features",  Label = "Windows Features",  Glyph = "\uE9CE", Content = WipWindowsFeatures, ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-windows-features",  Label = "Windows Features",  Glyph = "\uE9CE", Content = WindowsFeatures, ViewType = typeof(Views.WindowsFeaturesView) },
         }};
 
         // 📊 Monitor (4) — NEW GROUP
@@ -344,7 +345,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         About?.Dispose();
         Services?.Dispose();
         NetworkShared?.Dispose();
-        WipWindowsFeatures?.Dispose();
+        WindowsFeatures?.Dispose();
         WipResourceHistory?.Dispose();
         AppAlerts?.Dispose();
         WipPrivacyMonitor?.Dispose();

--- a/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
@@ -1,0 +1,181 @@
+// SysManager · WindowsFeaturesViewModel — toggle Windows optional features
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// Windows Features tab — lists optional features, allows enable/disable toggle.
+/// Requires administrator privileges for modifications.
+/// </summary>
+public partial class WindowsFeaturesViewModel : ViewModelBase
+{
+    private readonly WindowsFeaturesService _service;
+    private CancellationTokenSource? _cts;
+
+    public ObservableCollection<WindowsFeature> AllFeatures { get; } = new();
+    public ObservableCollection<WindowsFeature> FilteredFeatures { get; } = new();
+
+    [ObservableProperty] private string _filterText = "";
+    [ObservableProperty] private int _featureCount;
+    [ObservableProperty] private int _enabledCount;
+    [ObservableProperty] private string _summary = "Click Scan to list Windows optional features.";
+    [ObservableProperty] private bool _isElevated;
+    [ObservableProperty] private bool _pendingReboot;
+
+    partial void OnFilterTextChanged(string value) => ApplyFilter();
+
+    public WindowsFeaturesViewModel(PowerShellRunner runner)
+    {
+        _service = new WindowsFeaturesService(runner);
+        IsElevated = AdminHelper.IsElevated();
+    }
+
+    [RelayCommand]
+    private async Task ScanAsync()
+    {
+        IsBusy = true;
+        IsProgressIndeterminate = true;
+        StatusMessage = "Querying Windows optional features…";
+        AllFeatures.Clear();
+        FilteredFeatures.Clear();
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+
+        try
+        {
+            var list = await _service.ListFeaturesAsync(_cts.Token);
+            foreach (var feature in list)
+                AllFeatures.Add(feature);
+
+            ApplyFilter();
+            EnabledCount = AllFeatures.Count(f => f.IsEnabled);
+            StatusMessage = $"Found {AllFeatures.Count} features ({EnabledCount} enabled).";
+        }
+        catch (OperationCanceledException)
+        {
+            StatusMessage = "Scan cancelled.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            StatusMessage = $"Error: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+            IsProgressIndeterminate = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task ToggleFeatureAsync(WindowsFeature? feature)
+    {
+        if (feature == null) return;
+
+        if (!IsElevated)
+        {
+            StatusMessage = "Administrator privileges required to modify features.";
+            return;
+        }
+
+        var action = feature.IsEnabled ? "disable" : "enable";
+        if (!DialogService.Instance.Confirm(
+            $"Are you sure you want to {action} '{feature.DisplayName}'?\n\n" +
+            "This may require a system reboot to take effect.",
+            $"Confirm {action} feature"))
+            return;
+
+        IsBusy = true;
+        feature.Status = feature.IsEnabled ? "Disabling…" : "Enabling…";
+        StatusMessage = $"{(feature.IsEnabled ? "Disabling" : "Enabling")} {feature.DisplayName}…";
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+
+        try
+        {
+            bool success;
+            bool reboot;
+
+            if (feature.IsEnabled)
+            {
+                (success, reboot) = await _service.DisableFeatureAsync(feature.Name, _cts.Token);
+            }
+            else
+            {
+                (success, reboot) = await _service.EnableFeatureAsync(feature.Name, _cts.Token);
+            }
+
+            if (success)
+            {
+                feature.IsEnabled = !feature.IsEnabled;
+                feature.RequiresReboot = reboot;
+                feature.Status = reboot ? "Reboot required" : "Done";
+                EnabledCount = AllFeatures.Count(f => f.IsEnabled);
+
+                if (reboot) PendingReboot = true;
+
+                StatusMessage = $"{feature.DisplayName} {(feature.IsEnabled ? "enabled" : "disabled")}" +
+                    (reboot ? " — reboot required." : ".");
+                Log.Information("Feature {Feature} toggled to {State}, reboot={Reboot}",
+                    feature.Name, feature.IsEnabled ? "Enabled" : "Disabled", reboot);
+            }
+            else
+            {
+                feature.Status = "Failed";
+                StatusMessage = $"Failed to {action} {feature.DisplayName}. Check permissions.";
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            feature.Status = "Cancelled";
+            StatusMessage = "Operation cancelled.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            feature.Status = "Error";
+            StatusMessage = $"Error: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private void Cancel() => _cts?.Cancel();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing) _cts?.Dispose();
+        base.Dispose(disposing);
+    }
+
+    private void ApplyFilter()
+    {
+        FilteredFeatures.Clear();
+        IEnumerable<WindowsFeature> source = AllFeatures;
+
+        if (!string.IsNullOrWhiteSpace(FilterText))
+        {
+            var f = FilterText.Trim();
+            source = source.Where(feat =>
+                feat.DisplayName.Contains(f, StringComparison.OrdinalIgnoreCase) ||
+                feat.Name.Contains(f, StringComparison.OrdinalIgnoreCase) ||
+                feat.Category.Contains(f, StringComparison.OrdinalIgnoreCase));
+        }
+
+        foreach (var feat in source)
+            FilteredFeatures.Add(feat);
+
+        FeatureCount = FilteredFeatures.Count;
+        Summary = $"{FeatureCount} features{(AllFeatures.Count != FeatureCount ? $" (of {AllFeatures.Count} total)" : "")}";
+    }
+}

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -1,0 +1,175 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.WindowsFeaturesView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             d:DataContext="{d:DesignInstance vm:WindowsFeaturesViewModel}"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             Background="{StaticResource Surface0}">
+
+    <Grid Margin="32,24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,16">
+            <TextBlock Text="Windows Features" Style="{StaticResource Display}"/>
+            <TextBlock Text="Enable or disable Windows optional features. Requires administrator privileges."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+        </StackPanel>
+
+        <!-- Toolbar -->
+        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+            <WrapPanel>
+                <Button Content="Scan" Command="{Binding ScanCommand}"
+                        Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
+                <Button Content="Cancel" Command="{Binding CancelCommand}"
+                        Style="{StaticResource GhostButton}" Margin="0,0,12,0"
+                        Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+                <TextBlock Text="Search:" VerticalAlignment="Center" Margin="8,0,8,0"
+                           Style="{StaticResource Subtle}"/>
+                <Grid Width="220" Margin="0,0,12,0">
+                    <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"/>
+                    <TextBlock Text="Search features…" IsHitTestVisible="False"
+                               Foreground="{StaticResource TextMuted}" Margin="6,0,0,0"
+                               VerticalAlignment="Center" FontSize="12"
+                               Visibility="{Binding FilterText, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                </Grid>
+                <Border Background="#2D1F1F" CornerRadius="4" Padding="6,2" Margin="4,0"
+                        Visibility="{Binding PendingReboot, Converter={StaticResource BoolToVis}}">
+                    <TextBlock Text="⚠ Reboot pending" FontSize="11" Foreground="#F59E0B"/>
+                </Border>
+                <Border Background="#1F2D1F" CornerRadius="4" Padding="6,2" Margin="4,0"
+                        Visibility="{Binding IsElevated, Converter={StaticResource BoolToVis}}">
+                    <TextBlock Text="✓ Administrator" FontSize="11" Foreground="#4ADE80"/>
+                </Border>
+            </WrapPanel>
+        </Border>
+
+        <!-- Summary -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+            <TextBlock Text="{Binding Summary}" FontWeight="SemiBold" FontSize="13"/>
+        </Border>
+
+        <!-- Feature list -->
+        <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
+            <DataGrid AutomationProperties.Name="Features table" ItemsSource="{Binding FilteredFeatures}"
+                      AutoGenerateColumns="False" HeadersVisibility="Column"
+                      Background="Transparent" BorderThickness="0"
+                      GridLinesVisibility="None" IsReadOnly="True"
+                      RowBackground="Transparent" AlternatingRowBackground="#0F141C"
+                      SelectionMode="Single" CanUserSortColumns="True"
+                      VirtualizingPanel.IsVirtualizing="True"
+                      VirtualizingPanel.VirtualizationMode="Recycling">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Category" Binding="{Binding Category}" Width="120"
+                                        SortMemberPath="Category" IsReadOnly="True">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="FontSize" Value="11"/>
+                                <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
+                                <Setter Property="VerticalAlignment" Value="Center"/>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+
+                    <DataGridTextColumn Header="Feature" Binding="{Binding DisplayName}" Width="*"
+                                        SortMemberPath="DisplayName" IsReadOnly="True">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                <Setter Property="FontSize" Value="13"/>
+                                <Setter Property="VerticalAlignment" Value="Center"/>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+
+                    <DataGridTemplateColumn Header="State" Width="90" SortMemberPath="IsEnabled">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="11">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Text" Value="Disabled"/>
+                                            <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsEnabled}" Value="True">
+                                                    <Setter Property="Text" Value="Enabled"/>
+                                                    <Setter Property="Foreground" Value="#4ADE80"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+
+                    <DataGridTemplateColumn Header="Toggle" Width="80">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Button Command="{Binding DataContext.ToggleFeatureCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                        CommandParameter="{Binding}"
+                                        FontSize="11" Padding="6,2">
+                                    <Button.Style>
+                                        <Style TargetType="Button" BasedOn="{StaticResource GhostButton}">
+                                            <Setter Property="Content" Value="Enable"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsEnabled}" Value="True">
+                                                    <Setter Property="Content" Value="Disable"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Button.Style>
+                                </Button>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+
+                    <DataGridTemplateColumn Header="Status" Width="120" SortMemberPath="Status">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Status}" FontSize="11"
+                                           VerticalAlignment="Center"
+                                           TextTrimming="CharacterEllipsis"
+                                           ToolTip="{Binding Status}">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Status}" Value="Reboot required">
+                                                    <Setter Property="Foreground" Value="#F59E0B"/>
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding Status}" Value="Done">
+                                                    <Setter Property="Foreground" Value="#4ADE80"/>
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding Status}" Value="Failed">
+                                                    <Setter Property="Foreground" Value="#EF4444"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                </DataGrid.Columns>
+            </DataGrid>
+        </Border>
+
+        <!-- Status bar -->
+        <DockPanel Grid.Row="4" Margin="0,8,0,0">
+            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+                         IsIndeterminate="{Binding IsProgressIndeterminate}"
+                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml.cs
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · WindowsFeaturesView
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class WindowsFeaturesView : UserControl
+{
+    public WindowsFeaturesView() => InitializeComponent();
+}


### PR DESCRIPTION
## Summary

Replaces the Windows Features placeholder with a fully functional tab that lists, enables, and disables Windows optional features.

## What changed

- **WindowsFeature.cs** (new model) — Name, DisplayName, IsEnabled, RequiresReboot, Category, Status
- **WindowsFeaturesService.cs** (new service) — wraps Get-WindowsOptionalFeature, Enable/Disable-WindowsOptionalFeature PowerShell commands
- **WindowsFeaturesViewModel.cs** (new VM) — scan, toggle, filter, admin check, reboot tracking
- **WindowsFeaturesView.xaml** (new view) — DataGrid with Category, Feature, State, Toggle button, Status columns
- **MainWindowViewModel** — replaced WipWindowsFeatures placeholder with real WindowsFeaturesViewModel
- **ServiceRegistration** — registered WindowsFeaturesService and VM
- **README** — removed ⚙️ marker, added feature description
- **CHANGELOG** — v0.46.0 entry

## Features

- Lists all Windows optional features with current state
- Categorized: Virtualization, Networking, Development, Media & Print, Legacy, Other
- Toggle enable/disable with confirmation dialog
- Shows reboot-required status
- Search/filter by name or category
- Admin badge (shows if elevated)
- Reboot pending indicator

## Testing

- 10 unit tests: ParseFeatureList (4), CategorizeFeature (2), HumanizeName (1), ViewModel state (1), Theory with 15 inline data cases
- Both projects build with 0 errors

Closes #5
