### PR TITLE
feat!: migrate to .NET 9 + fix DI cross-talk + minor fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup .NET 8 SDK
+      - name: Setup .NET 9 SDK
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Cache NuGet packages
         uses: actions/cache@v5
@@ -92,10 +92,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup .NET 8 SDK
+      - name: Setup .NET 9 SDK
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Restore
         run: dotnet restore SysManager/SysManager.UITests/SysManager.UITests.csproj

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup .NET 8 SDK
+      - name: Setup .NET 9 SDK
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref }}
 
-      - name: Setup .NET 8 SDK
+      - name: Setup .NET 9 SDK
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Extract tag version
         id: version

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-SysManager is a tabbed WPF desktop app on .NET 8, written in C# 12. It follows
+SysManager is a tabbed WPF desktop app on .NET 9, written in C# 13. It follows
 a standard MVVM layout with a thin service layer that wraps Windows APIs,
 PowerShell, and external CLIs (winget, Ookla `speedtest`). It's gamer-focused:
 network presets for CS2 / PUBG / Streaming and safe cleanup for Steam / Epic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.47.0] - 2026-05-13
+
+### Changed
+- **Migrate to .NET 9** — all projects now target `net9.0-windows`. CI
+  workflows updated to use .NET 9 SDK. `Microsoft.Extensions.DependencyInjection`
+  bumped to 9.0.4. Closes #257.
+- **DI: PowerShellRunner is now Transient** — each ViewModel gets its own
+  instance to prevent LineReceived event cross-talk between tabs.
+
+### Fixed
+- **Uninstaller** — filter out entries with names shorter than 2 characters
+  (eliminates empty rows from winget list parsing edge cases).
+- **Process Manager** — explicitly enable column resizing (`CanUserResizeColumns`).
+- **Windows Features** — show "Not elevated" warning badge when not running
+  as Administrator.
+- **SpeedTestService** — suppress SYSLIB0057 obsolete warning for
+  `CreateFromSignedFile` (no .NET 9 replacement for Authenticode verification).
+
 ## [0.46.0] - 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ recommended mitigation — see [SECURITY.md](SECURITY.md) for details.
 
 ## Build from source
 
-Prerequisites: Windows 10 or newer and the [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0).
+Prerequisites: Windows 10 or newer and the [.NET 9 SDK](https://dotnet.microsoft.com/download/dotnet/9.0).
 
 ```powershell
 git clone https://github.com/laurentiu021/SystemManager.git
@@ -447,7 +447,7 @@ and elevation state in a format ready to paste into a bug report.
 
 ## Tech stack
 
-- .NET 8 (WPF, C# 12)
+- .NET 9 (WPF, C# 13)
 - CommunityToolkit.Mvvm for MVVM plumbing
 - ModernWpfUI for the modern title bar
 - LiveCharts2 for the real-time latency chart

--- a/SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj
+++ b/SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>

--- a/SysManager/SysManager.Tests/SysManager.Tests.csproj
+++ b/SysManager/SysManager.Tests/SysManager.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>

--- a/SysManager/SysManager.UITests/SysManager.UITests.csproj
+++ b/SysManager/SysManager.UITests/SysManager.UITests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -16,8 +16,10 @@ public static class ServiceRegistration
 {
     public static IServiceCollection ConfigureServices(this IServiceCollection services)
     {
-        // ── Core services (Singleton — one shared instance) ─────────────
-        services.AddSingleton<PowerShellRunner>();
+        // ── Core services ──────────────────────────────────────────────
+        // PowerShellRunner is Transient — each consumer gets its own instance
+        // to avoid LineReceived event cross-talk between tabs.
+        services.AddTransient<PowerShellRunner>();
         services.AddSingleton<SystemInfoService>();
         services.AddSingleton<WingetService>();
         services.AddSingleton<TrayIconService>();

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -329,7 +329,9 @@ public sealed class SpeedTestService
         {
             try
             {
+#pragma warning disable SYSLIB0057 // CreateFromSignedFile is obsolete — no direct replacement for Authenticode verification
                 var cert = System.Security.Cryptography.X509Certificates.X509Certificate.CreateFromSignedFile(exe);
+#pragma warning restore SYSLIB0057
                 if (cert == null || !cert.Subject.Contains("Ookla", StringComparison.OrdinalIgnoreCase))
                     Log.Warning("Ookla speedtest.exe Authenticode subject mismatch: {Subject}", cert?.Subject ?? "none");
                 else

--- a/SysManager/SysManager/Services/UninstallerService.cs
+++ b/SysManager/SysManager/Services/UninstallerService.cs
@@ -109,7 +109,7 @@ public sealed partial class UninstallerService
             var source = idxSource > 0 ? Slice(idxSource, -1) : "";
 
             if (string.IsNullOrWhiteSpace(id)) continue;
-            if (string.IsNullOrWhiteSpace(name)) continue;
+            if (string.IsNullOrWhiteSpace(name) || name.Length < 2) continue;
 
             apps.Add(new InstalledApp
             {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
@@ -36,7 +36,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="H.NotifyIcon.Wpf" Version="2.2.1" />
     <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
     <PackageReference Include="ModernWpfUI" Version="0.9.6" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -58,6 +58,7 @@
                       GridLinesVisibility="None" IsReadOnly="True"
                       RowBackground="Transparent" AlternatingRowBackground="#0F141C"
                       SelectionMode="Single" CanUserSortColumns="True"
+                      CanUserResizeColumns="True"
                       VirtualizingPanel.IsVirtualizing="True"
                       VirtualizingPanel.VirtualizationMode="Recycling">
                 <DataGrid.Columns>

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -50,6 +50,10 @@
                         Visibility="{Binding IsElevated, Converter={StaticResource BoolToVis}}">
                     <TextBlock Text="✓ Administrator" FontSize="11" Foreground="#4ADE80"/>
                 </Border>
+                <Border Background="#2D1F1F" CornerRadius="4" Padding="6,2" Margin="4,0"
+                        Visibility="{Binding IsElevated, Converter={StaticResource BoolToVis}, ConverterParameter=Inverse}">
+                    <TextBlock Text="⚠ Not elevated — toggle disabled" FontSize="11" Foreground="#F59E0B"/>
+                </Border>
             </WrapPanel>
         </Border>
 


### PR DESCRIPTION
## Summary

Migrates the entire solution from .NET 8 to .NET 9. Fixes DI regression and several minor UI issues found during testing.

## Changes
- All 4 projects: net8.0-windows -> net9.0-windows
- CI workflows: .NET 9 SDK
- DI: PowerShellRunner Singleton -> Transient (fixes output cross-talk)
- Microsoft.Extensions.DependencyInjection 8.0.1 -> 9.0.4
- Uninstaller: filter empty rows (name < 2 chars)
- Process Manager: CanUserResizeColumns=True
- Windows Features: not-elevated warning badge
- SpeedTestService: SYSLIB0057 pragma suppress
- README + ARCHITECTURE: .NET 9 references

BREAKING: requires .NET 9 runtime

Closes #257
