### PR TITLE
feat: add 20 WIP placeholders and reorganize navigation into 12 groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.53.0] - 2026-05-13
+
+### Added
+- **Navigation: 4 new groups** — Gaming & Profiles, Privacy & Security,
+  Customization, and Advanced groups added to sidebar navigation.
+- **Gaming & Profiles (5 WIP tabs)** — Gaming Profile, Standby List Cleaner,
+  Timer Resolution, CPU Core Affinity, Display Profiles.
+- **Privacy & Security (6 WIP tabs)** — Privacy & Telemetry, Debloater & Ads,
+  Browser Cleaner, Edge/OneDrive Remover, Defender Tweaks, Notification Blocker.
+- **Customization (4 WIP tabs)** — Context Menu, Dark Mode Scheduler, Volume
+  Control, Environment Variables.
+- **Advanced (4 WIP tabs)** — Restore Points, Profile Export/Import, CLI
+  Interface, System Report.
+- **Monitor (3 new WIP tabs)** — File Lock Detector, Settings Watchdog,
+  Bandwidth Monitor added to existing Monitor group.
+- **System (2 new WIP tabs)** — Task Scheduler, Boot Analyzer added to
+  existing System group.
+- **Cleanup (1 new WIP tab)** — Scheduled Maintenance moved into Cleanup group.
+
+### Changed
+- **Navigation structure** — reorganized from 9 groups to 12 groups for better
+  feature categorization as the app grows.
+- **Placeholder descriptions** — improved all WIP placeholder descriptions with
+  clearer feature explanations and correct issue references.
+
 ## [0.52.0] - 2026-05-13
 
 ### Fixed

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -75,47 +75,91 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
-    public void NavItems_ContainAll36()
+    public void NavItems_ContainAll56()
     {
         var vm = new MainWindowViewModel();
-        Assert.Equal(36, vm.NavItems.Count);
+        Assert.Equal(56, vm.NavItems.Count);
         var ids = vm.NavItems.Select(n => n.Id).ToList();
+
+        // Dashboard
         Assert.Contains("nav-dashboard", ids);
+
+        // System (8)
         Assert.Contains("nav-system-health", ids);
         Assert.Contains("nav-windows-update", ids);
         Assert.Contains("nav-performance", ids);
         Assert.Contains("nav-services", ids);
         Assert.Contains("nav-startup", ids);
         Assert.Contains("nav-windows-features", ids);
+        Assert.Contains("nav-task-scheduler", ids);
+        Assert.Contains("nav-boot-analyzer", ids);
+
+        // Gaming & Profiles (5)
+        Assert.Contains("nav-gaming-profile", ids);
+        Assert.Contains("nav-standby-cleaner", ids);
+        Assert.Contains("nav-timer-resolution", ids);
+        Assert.Contains("nav-cpu-affinity", ids);
+        Assert.Contains("nav-display-profiles", ids);
+
+        // Monitor (7)
         Assert.Contains("nav-processes", ids);
         Assert.Contains("nav-resource-history", ids);
         Assert.Contains("nav-app-alerts", ids);
         Assert.Contains("nav-privacy-monitor", ids);
+        Assert.Contains("nav-file-lock", ids);
+        Assert.Contains("nav-settings-watchdog", ids);
+        Assert.Contains("nav-bandwidth-monitor", ids);
+
+        // Cleanup (5)
         Assert.Contains("nav-cleanup", ids);
         Assert.Contains("nav-deep-cleanup", ids);
         Assert.Contains("nav-shortcut-cleaner", ids);
         Assert.Contains("nav-file-shredder", ids);
+        Assert.Contains("nav-scheduled-maintenance", ids);
+
+        // Storage (2)
         Assert.Contains("nav-disk-analyzer", ids);
         Assert.Contains("nav-duplicates", ids);
+
+        // Network (6)
         Assert.Contains("nav-ping", ids);
         Assert.Contains("nav-traceroute", ids);
         Assert.Contains("nav-speed-test", ids);
         Assert.Contains("nav-network-repair", ids);
         Assert.Contains("nav-dns-changer", ids);
         Assert.Contains("nav-hosts-editor", ids);
+
+        // Apps (4)
         Assert.Contains("nav-app-updates", ids);
         Assert.Contains("nav-bulk-installer", ids);
         Assert.Contains("nav-uninstaller", ids);
         Assert.Contains("nav-app-blocker", ids);
+
+        // Privacy & Security (6)
         Assert.Contains("nav-privacy-settings", ids);
+        Assert.Contains("nav-debloater", ids);
+        Assert.Contains("nav-browser-cleaner", ids);
+        Assert.Contains("nav-edge-onedrive", ids);
+        Assert.Contains("nav-defender-tweaks", ids);
+        Assert.Contains("nav-notification-blocker", ids);
+
+        // Customization (4)
         Assert.Contains("nav-context-menu", ids);
-        Assert.Contains("nav-restore-points", ids);
-        Assert.Contains("nav-scheduled-maintenance", ids);
-        Assert.Contains("nav-system-report", ids);
+        Assert.Contains("nav-dark-mode", ids);
+        Assert.Contains("nav-volume-control", ids);
+        Assert.Contains("nav-env-variables", ids);
+
+        // Info (4)
         Assert.Contains("nav-drivers", ids);
         Assert.Contains("nav-battery", ids);
         Assert.Contains("nav-logs", ids);
         Assert.Contains("nav-about", ids);
+
+        // Advanced (4)
+        Assert.Contains("nav-restore-points", ids);
+        Assert.Contains("nav-profile-export", ids);
+        Assert.Contains("nav-cli-interface", ids);
+        Assert.Contains("nav-system-report", ids);
     }
 
     [Fact]
@@ -159,10 +203,10 @@ public class MainWindowViewModelTests
     // ── NavGroup tests ──────────────────────────────────────────────
 
     [Fact]
-    public void NavGroups_Has9Groups()
+    public void NavGroups_Has12Groups()
     {
         var vm = new MainWindowViewModel();
-        Assert.Equal(9, vm.NavGroups.Count);
+        Assert.Equal(12, vm.NavGroups.Count);
     }
 
     [Fact]
@@ -195,11 +239,11 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
-    public void NavGroups_SystemGroup_Contains6Items()
+    public void NavGroups_SystemGroup_Contains8Items()
     {
         var vm = new MainWindowViewModel();
         var sys = vm.NavGroups.First(g => g.Id == "grp-system");
-        Assert.Equal(6, sys.Children.Count);
+        Assert.Equal(8, sys.Children.Count);
         var ids = sys.Children.Select(c => c.Id).ToList();
         Assert.Contains("nav-system-health", ids);
         Assert.Contains("nav-windows-update", ids);
@@ -207,6 +251,8 @@ public class MainWindowViewModelTests
         Assert.Contains("nav-services", ids);
         Assert.Contains("nav-startup", ids);
         Assert.Contains("nav-windows-features", ids);
+        Assert.Contains("nav-task-scheduler", ids);
+        Assert.Contains("nav-boot-analyzer", ids);
     }
 
     [Fact]
@@ -220,12 +266,12 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
-    public void NavGroups_CleanupGroup_Has4Items()
+    public void NavGroups_CleanupGroup_Has5Items()
     {
-        // Cleanup now has: Quick, Deep, Shortcut Cleaner, File Shredder
+        // Cleanup now has: Quick, Deep, Shortcut Cleaner, File Shredder, Scheduled Maintenance
         var vm = new MainWindowViewModel();
         var cleanup = vm.NavGroups.First(g => g.Id == "grp-cleanup");
-        Assert.Equal(4, cleanup.Children.Count);
+        Assert.Equal(5, cleanup.Children.Count);
     }
 
     [Fact]

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -37,24 +37,63 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     public AboutViewModel About { get; }
     public ServicesViewModel Services { get; }
 
-    // ── Placeholder ViewModels for planned features (WIP) ──────────
+    // ── Implemented ViewModels (non-DI resolved) ─────────────────────
     public WindowsFeaturesViewModel WindowsFeatures { get; }
-    public PlaceholderViewModel WipResourceHistory { get; private set; } = null!;
     public AppAlertsViewModel AppAlerts { get; }
-    public PlaceholderViewModel WipPrivacyMonitor { get; private set; } = null!;
     public ShortcutCleanerViewModel ShortcutCleaner { get; }
+    public AppBlockerViewModel AppBlocker { get; }
+
+    // ── Placeholder ViewModels for planned features (WIP) ──────────
+    // Monitor group
+    public PlaceholderViewModel WipResourceHistory { get; private set; } = null!;
+    public PlaceholderViewModel WipPrivacyMonitor { get; private set; } = null!;
+    public PlaceholderViewModel WipFileLockDetector { get; private set; } = null!;
+    public PlaceholderViewModel WipSettingsWatchdog { get; private set; } = null!;
+    public PlaceholderViewModel WipBandwidthMonitor { get; private set; } = null!;
+
+    // Gaming & Profiles group
+    public PlaceholderViewModel WipGamingProfile { get; private set; } = null!;
+    public PlaceholderViewModel WipStandbyListCleaner { get; private set; } = null!;
+    public PlaceholderViewModel WipTimerResolution { get; private set; } = null!;
+    public PlaceholderViewModel WipCpuAffinity { get; private set; } = null!;
+    public PlaceholderViewModel WipDisplayProfiles { get; private set; } = null!;
+
+    // Cleanup group
     public PlaceholderViewModel WipFileShredder { get; private set; } = null!;
+    public PlaceholderViewModel WipScheduledMaintenance { get; private set; } = null!;
+
+    // Network group
     public PlaceholderViewModel WipDnsChanger { get; private set; } = null!;
     public PlaceholderViewModel WipHostsEditor { get; private set; } = null!;
+
+    // Apps group
     public PlaceholderViewModel WipBulkInstaller { get; private set; } = null!;
-    public AppBlockerViewModel AppBlocker { get; }
+
+    // Privacy & Security group
     public PlaceholderViewModel WipPrivacySettings { get; private set; } = null!;
+    public PlaceholderViewModel WipDebloater { get; private set; } = null!;
+    public PlaceholderViewModel WipBrowserCleaner { get; private set; } = null!;
+    public PlaceholderViewModel WipEdgeOneDriveRemover { get; private set; } = null!;
+    public PlaceholderViewModel WipDefenderTweaks { get; private set; } = null!;
+    public PlaceholderViewModel WipNotificationBlocker { get; private set; } = null!;
+
+    // Customization group
     public PlaceholderViewModel WipContextMenu { get; private set; } = null!;
+    public PlaceholderViewModel WipDarkModeScheduler { get; private set; } = null!;
+    public PlaceholderViewModel WipVolumeControl { get; private set; } = null!;
+    public PlaceholderViewModel WipEnvVariableEditor { get; private set; } = null!;
+
+    // System group (additions)
+    public PlaceholderViewModel WipTaskScheduler { get; private set; } = null!;
+    public PlaceholderViewModel WipBootAnalyzer { get; private set; } = null!;
+
+    // Advanced group
     public PlaceholderViewModel WipRestorePoints { get; private set; } = null!;
-    public PlaceholderViewModel WipScheduledMaintenance { get; private set; } = null!;
+    public PlaceholderViewModel WipProfileExportImport { get; private set; } = null!;
+    public PlaceholderViewModel WipCliInterface { get; private set; } = null!;
     public PlaceholderViewModel WipSystemReport { get; private set; } = null!;
 
-    /// <summary>Grouped sidebar tree (9 categories).</summary>
+    /// <summary>Grouped sidebar tree (12 categories).</summary>
     public ObservableCollection<NavGroup> NavGroups { get; } = new();
 
     /// <summary>Flat list of every leaf NavItem (backward compat + lookup).</summary>
@@ -145,17 +184,55 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private void InitPlaceholders()
     {
         // ── WIP placeholders for planned features ──────────────────────
-        WipResourceHistory = new PlaceholderViewModel("Resource History", "Historical CPU, RAM, GPU and temperature graphs.", "377");
-        WipPrivacyMonitor = new PlaceholderViewModel("Privacy Monitor", "Monitor and alert on webcam, microphone, and location access.", "380");
-        WipFileShredder = new PlaceholderViewModel("File Shredder", "Securely delete files beyond recovery.", "386");
-        WipDnsChanger = new PlaceholderViewModel("DNS Changer", "Quickly switch DNS servers for any network adapter.", "382");
-        WipHostsEditor = new PlaceholderViewModel("Hosts Editor", "Edit the Windows hosts file with a friendly UI.", "382");
-        WipBulkInstaller = new PlaceholderViewModel("Bulk Installer", "Install multiple applications at once via winget.", "387");
-        WipPrivacySettings = new PlaceholderViewModel("Privacy Settings", "Windows debloat and privacy toggles.", "384");
-        WipContextMenu = new PlaceholderViewModel("Context Menu", "Manage right-click context menu entries.", "385");
-        WipRestorePoints = new PlaceholderViewModel("Restore Points", "Create and manage system restore points.", "383");
-        WipScheduledMaintenance = new PlaceholderViewModel("Scheduled Maintenance", "Automate cleanup and maintenance tasks.", "383");
-        WipSystemReport = new PlaceholderViewModel("System Report", "Comprehensive system info export.", "389");
+
+        // Monitor group
+        WipResourceHistory = new PlaceholderViewModel("Resource History", "Historical CPU, RAM, GPU and temperature graphs with timeline.", "#13");
+        WipPrivacyMonitor = new PlaceholderViewModel("Privacy Monitor", "Monitor and alert on webcam, microphone, and location access in real-time.", "#12");
+        WipFileLockDetector = new PlaceholderViewModel("File Lock Detector", "Find which process is locking a file and optionally release the handle.", "#333");
+        WipSettingsWatchdog = new PlaceholderViewModel("Settings Watchdog", "Detect when Windows Update resets your settings and offer one-click restore.", "#335");
+        WipBandwidthMonitor = new PlaceholderViewModel("Bandwidth Monitor", "Real-time per-app network usage with history graphs and alerts.", "#337");
+
+        // Gaming & Profiles group
+        WipGamingProfile = new PlaceholderViewModel("Gaming Profile", "One-click game mode: kill background processes, clear RAM, set timer resolution, auto-revert on game exit.", "#324");
+        WipStandbyListCleaner = new PlaceholderViewModel("Standby List Cleaner", "Automatic standby memory purging when free RAM drops below threshold (ISLC-style).", "#325");
+        WipTimerResolution = new PlaceholderViewModel("Timer Resolution", "Set Windows timer to 0.5ms for reduced input lag in competitive games.", "#326");
+        WipCpuAffinity = new PlaceholderViewModel("CPU Core Affinity", "Set per-game CPU affinity with P-core/E-core awareness for Intel hybrid CPUs.", "#327");
+        WipDisplayProfiles = new PlaceholderViewModel("Display Profiles", "Quick-switch refresh rate, HDR, resolution presets (Gaming/Work/Movie).", "#328");
+
+        // Cleanup group
+        WipFileShredder = new PlaceholderViewModel("File Shredder", "Securely delete files beyond recovery with multi-pass overwrite (DoD/Gutmann).", "#7");
+        WipScheduledMaintenance = new PlaceholderViewModel("Scheduled Maintenance", "Automate cleanup, RAM trim, and health checks on schedule or idle trigger.", "#10");
+
+        // Network group
+        WipDnsChanger = new PlaceholderViewModel("DNS Changer", "Quick-switch DNS with benchmark, DNS-over-HTTPS, and TCP/IP optimization.", "#11");
+        WipHostsEditor = new PlaceholderViewModel("Hosts Editor", "GUI hosts file editor with domain toggle, import block lists, and backup/restore.", "#11");
+
+        // Apps group
+        WipBulkInstaller = new PlaceholderViewModel("Bulk Installer", "Curated checkbox app installer via winget with presets (Gamer/Dev/Creative).", "#6");
+
+        // Privacy & Security group
+        WipPrivacySettings = new PlaceholderViewModel("Privacy & Telemetry", "80-100+ toggles for telemetry, ads, AI/Copilot, location, diagnostics with presets.", "#9");
+        WipDebloater = new PlaceholderViewModel("Debloater & Ads", "Remove UWP bloatware, disable all Windows ads, remove Copilot/Recall/AI features.", "#9");
+        WipBrowserCleaner = new PlaceholderViewModel("Browser Cleaner", "Per-browser cache/cookies/history cleanup with keep-list for important cookies.", "#336");
+        WipEdgeOneDriveRemover = new PlaceholderViewModel("Edge/OneDrive Remover", "Safely remove or disable Edge and OneDrive with full restore capability.", "#339");
+        WipDefenderTweaks = new PlaceholderViewModel("Defender Tweaks", "Toggle SmartScreen, manage exclusions, configure PUA and cloud protection.", "#344");
+        WipNotificationBlocker = new PlaceholderViewModel("Notification Blocker", "Suppress annoying app pop-ups (update nags, trial reminders) with allowlist.", "#340");
+
+        // Customization group
+        WipContextMenu = new PlaceholderViewModel("Context Menu", "Manage right-click entries, restore Win10 full menu, add custom items.", "#8");
+        WipDarkModeScheduler = new PlaceholderViewModel("Dark Mode Scheduler", "Auto light/dark theme + color temperature (f.lux-style) on schedule or sunset.", "#329");
+        WipVolumeControl = new PlaceholderViewModel("Volume Control", "Per-app volume mixer with output device routing and profile presets.", "#332");
+        WipEnvVariableEditor = new PlaceholderViewModel("Environment Variables", "GUI PATH editor with drag-reorder, duplicate detection, and path validation.", "#331");
+
+        // System group (additions)
+        WipTaskScheduler = new PlaceholderViewModel("Task Scheduler", "Browse and toggle scheduled tasks with color-coded safety indicators.", "#334");
+        WipBootAnalyzer = new PlaceholderViewModel("Boot Analyzer", "Measure boot time breakdown per service/driver with optimization recommendations.", "#343");
+
+        // Advanced group
+        WipRestorePoints = new PlaceholderViewModel("Restore Points", "Create and manage system restore points with size tracking.", "#10");
+        WipProfileExportImport = new PlaceholderViewModel("Profile Export/Import", "Export SysManager configuration as JSON, import on another PC.", "#341");
+        WipCliInterface = new PlaceholderViewModel("CLI Interface", "Command-line control: sysmanager --cleanup --apply-profile Gaming --silent.", "#342");
+        WipSystemReport = new PlaceholderViewModel("System Report", "Comprehensive system info export (better than DxDiag) in HTML/JSON.", "#4");
     }
 
     private void InitNavigation()
@@ -165,7 +242,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         Title = IsElevated ? "SysManager — Administrator" : "SysManager";
         Log.Information("MainWindow initialized. Elevated: {IsElevated}", IsElevated);
 
-        // ── Sidebar tree: 9 groups, 36 leaf items ──────────────────────
+        // ── Sidebar tree: 12 groups ────────────────────────────────────
         // Views are instantiated lazily on first access — lets unit tests
         // construct the VM on an MTA thread without pulling WPF resources in.
 
@@ -174,42 +251,60 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             new NavItem { Id = "nav-dashboard", Label = "Dashboard", Glyph = "\uE80F", Content = Dashboard, ViewType = typeof(Views.DashboardView) },
         }};
 
-        // 🔧 System (6)
+        // 🔧 System (8)
         var grpSystem = new NavGroup { Id = "grp-system", Label = "System", Glyph = "\uE912",
-            Subtitle = "Health · WinUpdate · Perf · Services · Startup · Features",
-            Tooltip = "System Health\nWindows Update\nPerformance Mode\nServices\nStartup Manager\nWindows Features",
+            Subtitle = "Health · WinUpdate · Perf · Services · Startup · Features · Tasks · Boot",
+            Tooltip = "System Health\nWindows Update\nPerformance Mode\nServices\nStartup Manager\nWindows Features\nTask Scheduler\nBoot Analyzer",
             Children = {
-            new NavItem { Id = "nav-system-health",     Label = "System Health",     Glyph = "\uE9D9", Content = SystemHealth,       ViewType = typeof(Views.SystemHealthView) },
-            new NavItem { Id = "nav-windows-update",    Label = "Windows Update",    Glyph = "\uE895", Content = WindowsUpdate,      ViewType = typeof(Views.WindowsUpdateView) },
-            new NavItem { Id = "nav-performance",       Label = "Performance Mode",  Glyph = "\uE945", Content = Performance,        ViewType = typeof(Views.PerformanceView) },
-            new NavItem { Id = "nav-services",          Label = "Services",          Glyph = "\uE912", Content = Services,           ViewType = typeof(Views.ServicesView) },
-            new NavItem { Id = "nav-startup",           Label = "Startup Manager",   Glyph = "\uE7B5", Content = Startup,            ViewType = typeof(Views.StartupView) },
-            new NavItem { Id = "nav-windows-features",  Label = "Windows Features",  Glyph = "\uE9CE", Content = WindowsFeatures, ViewType = typeof(Views.WindowsFeaturesView) },
+            new NavItem { Id = "nav-system-health",     Label = "System Health",     Glyph = "\uE9D9", Content = SystemHealth,     ViewType = typeof(Views.SystemHealthView) },
+            new NavItem { Id = "nav-windows-update",    Label = "Windows Update",    Glyph = "\uE895", Content = WindowsUpdate,    ViewType = typeof(Views.WindowsUpdateView) },
+            new NavItem { Id = "nav-performance",       Label = "Performance Mode",  Glyph = "\uE945", Content = Performance,      ViewType = typeof(Views.PerformanceView) },
+            new NavItem { Id = "nav-services",          Label = "Services",          Glyph = "\uE912", Content = Services,         ViewType = typeof(Views.ServicesView) },
+            new NavItem { Id = "nav-startup",           Label = "Startup Manager",   Glyph = "\uE7B5", Content = Startup,          ViewType = typeof(Views.StartupView) },
+            new NavItem { Id = "nav-windows-features",  Label = "Windows Features",  Glyph = "\uE9CE", Content = WindowsFeatures,  ViewType = typeof(Views.WindowsFeaturesView) },
+            new NavItem { Id = "nav-task-scheduler",    Label = "Task Scheduler",    Glyph = "\uE916", Content = WipTaskScheduler, ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-boot-analyzer",     Label = "Boot Analyzer",     Glyph = "\uE7F8", Content = WipBootAnalyzer,  ViewType = typeof(Views.PlaceholderView) },
         }};
 
-        // 📊 Monitor (4) — NEW GROUP
+        // 🎮 Gaming & Profiles (5) — NEW GROUP
+        var grpGaming = new NavGroup { Id = "grp-gaming", Label = "Gaming & Profiles", Glyph = "\uE7FC",
+            Subtitle = "Game Mode · Standby · Timer · Affinity · Display",
+            Tooltip = "Gaming Profile\nStandby List Cleaner\nTimer Resolution\nCPU Core Affinity\nDisplay Profiles",
+            Children = {
+            new NavItem { Id = "nav-gaming-profile",   Label = "Gaming Profile",       Glyph = "\uE7FC", Content = WipGamingProfile,      ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-standby-cleaner",  Label = "Standby List Cleaner", Glyph = "\uE945", Content = WipStandbyListCleaner, ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-timer-resolution", Label = "Timer Resolution",     Glyph = "\uE916", Content = WipTimerResolution,    ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-cpu-affinity",     Label = "CPU Core Affinity",    Glyph = "\uE950", Content = WipCpuAffinity,        ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-display-profiles", Label = "Display Profiles",     Glyph = "\uE7F4", Content = WipDisplayProfiles,    ViewType = typeof(Views.PlaceholderView) },
+        }};
+
+        // 📊 Monitor (7)
         var grpMonitor = new NavGroup { Id = "grp-monitor", Label = "Monitor", Glyph = "\uE9D9",
-            Subtitle = "Processes · Resources · Alerts · Privacy",
-            Tooltip = "Process Manager\nResource History\nApp Alerts\nPrivacy Monitor",
+            Subtitle = "Processes · Resources · Alerts · Privacy · Lock · Watchdog · Bandwidth",
+            Tooltip = "Process Manager\nResource History\nApp Alerts\nPrivacy Monitor\nFile Lock Detector\nSettings Watchdog\nBandwidth Monitor",
             Children = {
-            new NavItem { Id = "nav-processes",        Label = "Process Manager",  Glyph = "\uEBC4", Content = ProcessManager,    ViewType = typeof(Views.ProcessManagerView) },
-            new NavItem { Id = "nav-resource-history", Label = "Resource History", Glyph = "\uE9D9", Content = WipResourceHistory, ViewType = typeof(Views.PlaceholderView) },
-            new NavItem { Id = "nav-app-alerts",       Label = "App Alerts",       Glyph = "\uEA8F", Content = AppAlerts,          ViewType = typeof(Views.AppAlertsView) },
-            new NavItem { Id = "nav-privacy-monitor",  Label = "Privacy Monitor",  Glyph = "\uE727", Content = WipPrivacyMonitor,  ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-processes",         Label = "Process Manager",    Glyph = "\uEBC4", Content = ProcessManager,      ViewType = typeof(Views.ProcessManagerView) },
+            new NavItem { Id = "nav-resource-history",  Label = "Resource History",   Glyph = "\uE9D9", Content = WipResourceHistory,  ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-app-alerts",        Label = "App Alerts",         Glyph = "\uEA8F", Content = AppAlerts,           ViewType = typeof(Views.AppAlertsView) },
+            new NavItem { Id = "nav-privacy-monitor",   Label = "Privacy Monitor",    Glyph = "\uE727", Content = WipPrivacyMonitor,   ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-file-lock",         Label = "File Lock Detector", Glyph = "\uE72E", Content = WipFileLockDetector, ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-settings-watchdog", Label = "Settings Watchdog",  Glyph = "\uE7BA", Content = WipSettingsWatchdog, ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-bandwidth-monitor", Label = "Bandwidth Monitor",  Glyph = "\uE839", Content = WipBandwidthMonitor, ViewType = typeof(Views.PlaceholderView) },
         }};
 
-        // 🧹 Cleanup (4)
+        // 🧹 Cleanup (5)
         var grpCleanup = new NavGroup { Id = "grp-cleanup", Label = "Cleanup", Glyph = "\uE74D",
-            Subtitle = "Quick · Deep · Shortcuts · Shredder",
-            Tooltip = "Quick Cleanup\nDeep Cleanup\nShortcut Cleaner\nFile Shredder",
+            Subtitle = "Quick · Deep · Shortcuts · Shredder · Maintenance",
+            Tooltip = "Quick Cleanup\nDeep Cleanup\nShortcut Cleaner\nFile Shredder\nScheduled Maintenance",
             Children = {
-            new NavItem { Id = "nav-cleanup",           Label = "Quick Cleanup",    Glyph = "\uE74D", Content = Cleanup,            ViewType = typeof(Views.CleanupView) },
-            new NavItem { Id = "nav-deep-cleanup",      Label = "Deep Cleanup",     Glyph = "\uE81E", Content = DeepCleanup,        ViewType = typeof(Views.DeepCleanupView) },
-            new NavItem { Id = "nav-shortcut-cleaner",  Label = "Shortcut Cleaner", Glyph = "\uE71B", Content = ShortcutCleaner, ViewType = typeof(Views.ShortcutCleanerView) },
-            new NavItem { Id = "nav-file-shredder",     Label = "File Shredder",    Glyph = "\uE74D", Content = WipFileShredder,    ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-cleanup",               Label = "Quick Cleanup",         Glyph = "\uE74D", Content = Cleanup,                 ViewType = typeof(Views.CleanupView) },
+            new NavItem { Id = "nav-deep-cleanup",          Label = "Deep Cleanup",          Glyph = "\uE81E", Content = DeepCleanup,             ViewType = typeof(Views.DeepCleanupView) },
+            new NavItem { Id = "nav-shortcut-cleaner",      Label = "Shortcut Cleaner",      Glyph = "\uE71B", Content = ShortcutCleaner,         ViewType = typeof(Views.ShortcutCleanerView) },
+            new NavItem { Id = "nav-file-shredder",         Label = "File Shredder",         Glyph = "\uE74D", Content = WipFileShredder,         ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-scheduled-maintenance", Label = "Scheduled Maintenance", Glyph = "\uE823", Content = WipScheduledMaintenance, ViewType = typeof(Views.PlaceholderView) },
         }};
 
-        // 💾 Storage (2) — unchanged
+        // 💾 Storage (2)
         var grpStorage = new NavGroup { Id = "grp-storage", Label = "Storage", Glyph = "\uE958",
             Subtitle = "Disk Analyzer · Duplicate Finder",
             Tooltip = "Disk Analyzer\nDuplicate Finder",
@@ -236,22 +331,34 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             Subtitle = "Updates · Installer · Uninstaller · Blocker",
             Tooltip = "App Updates\nBulk Installer\nUninstaller\nApp Blocker",
             Children = {
-            new NavItem { Id = "nav-app-updates",    Label = "App Updates",     Glyph = "\uE7B8", Content = AppUpdates,      ViewType = typeof(Views.AppUpdatesView) },
-            new NavItem { Id = "nav-bulk-installer", Label = "Bulk Installer",  Glyph = "\uE896", Content = WipBulkInstaller, ViewType = typeof(Views.PlaceholderView) },
-            new NavItem { Id = "nav-uninstaller",    Label = "Uninstaller",     Glyph = "\uE738", Content = Uninstaller,     ViewType = typeof(Views.UninstallerView) },
-            new NavItem { Id = "nav-app-blocker",    Label = "App Blocker",     Glyph = "\uE8F8", Content = AppBlocker,      ViewType = typeof(Views.AppBlockerView) },
+            new NavItem { Id = "nav-app-updates",    Label = "App Updates",    Glyph = "\uE7B8", Content = AppUpdates,       ViewType = typeof(Views.AppUpdatesView) },
+            new NavItem { Id = "nav-bulk-installer", Label = "Bulk Installer", Glyph = "\uE896", Content = WipBulkInstaller, ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-uninstaller",    Label = "Uninstaller",    Glyph = "\uE738", Content = Uninstaller,      ViewType = typeof(Views.UninstallerView) },
+            new NavItem { Id = "nav-app-blocker",    Label = "App Blocker",    Glyph = "\uE8F8", Content = AppBlocker,       ViewType = typeof(Views.AppBlockerView) },
         }};
 
-        // 🛡️ Control (5) — NEW GROUP
-        var grpControl = new NavGroup { Id = "grp-control", Label = "Control", Glyph = "\uE83D",
-            Subtitle = "Privacy · Context Menu · Restore · Maintenance · Report",
-            Tooltip = "Privacy Settings\nContext Menu\nRestore Points\nScheduled Maintenance\nSystem Report",
+        // 🛡️ Privacy & Security (6) — NEW GROUP
+        var grpPrivacy = new NavGroup { Id = "grp-privacy", Label = "Privacy & Security", Glyph = "\uE72E",
+            Subtitle = "Telemetry · Debloat · Browser · Edge/OneDrive · Defender · Notifications",
+            Tooltip = "Privacy & Telemetry\nDebloater & Ads\nBrowser Cleaner\nEdge/OneDrive Remover\nDefender Tweaks\nNotification Blocker",
             Children = {
-            new NavItem { Id = "nav-privacy-settings",      Label = "Privacy Settings",      Glyph = "\uE72E", Content = WipPrivacySettings,      ViewType = typeof(Views.PlaceholderView) },
-            new NavItem { Id = "nav-context-menu",          Label = "Context Menu",          Glyph = "\uE700", Content = WipContextMenu,          ViewType = typeof(Views.PlaceholderView) },
-            new NavItem { Id = "nav-restore-points",        Label = "Restore Points",        Glyph = "\uE7AD", Content = WipRestorePoints,        ViewType = typeof(Views.PlaceholderView) },
-            new NavItem { Id = "nav-scheduled-maintenance", Label = "Scheduled Maintenance", Glyph = "\uE823", Content = WipScheduledMaintenance, ViewType = typeof(Views.PlaceholderView) },
-            new NavItem { Id = "nav-system-report",         Label = "System Report",         Glyph = "\uE9F9", Content = WipSystemReport,         ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-privacy-settings",     Label = "Privacy & Telemetry",   Glyph = "\uE72E", Content = WipPrivacySettings,     ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-debloater",            Label = "Debloater & Ads",       Glyph = "\uE74D", Content = WipDebloater,           ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-browser-cleaner",      Label = "Browser Cleaner",       Glyph = "\uEB41", Content = WipBrowserCleaner,      ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-edge-onedrive",        Label = "Edge/OneDrive Remover", Glyph = "\uE738", Content = WipEdgeOneDriveRemover, ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-defender-tweaks",      Label = "Defender Tweaks",       Glyph = "\uE83D", Content = WipDefenderTweaks,      ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-notification-blocker", Label = "Notification Blocker",  Glyph = "\uE7ED", Content = WipNotificationBlocker, ViewType = typeof(Views.PlaceholderView) },
+        }};
+
+        // 🎨 Customization (4) — NEW GROUP
+        var grpCustomization = new NavGroup { Id = "grp-customization", Label = "Customization", Glyph = "\uE771",
+            Subtitle = "Context Menu · Dark Mode · Volume · Env Variables",
+            Tooltip = "Context Menu\nDark Mode Scheduler\nVolume Control\nEnvironment Variables",
+            Children = {
+            new NavItem { Id = "nav-context-menu",   Label = "Context Menu",          Glyph = "\uE700", Content = WipContextMenu,       ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-dark-mode",      Label = "Dark Mode Scheduler",   Glyph = "\uE793", Content = WipDarkModeScheduler, ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-volume-control", Label = "Volume Control",        Glyph = "\uE767", Content = WipVolumeControl,     ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-env-variables",  Label = "Environment Variables", Glyph = "\uE943", Content = WipEnvVariableEditor, ViewType = typeof(Views.PlaceholderView) },
         }};
 
         // ℹ️ Info (4)
@@ -265,15 +372,29 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             new NavItem { Id = "nav-about",   Label = "About",          Glyph = "\uE946", Content = About,         ViewType = typeof(Views.AboutView) },
         }};
 
+        // ⚙️ Advanced (4) — NEW GROUP
+        var grpAdvanced = new NavGroup { Id = "grp-advanced", Label = "Advanced", Glyph = "\uE713",
+            Subtitle = "Restore · Export/Import · CLI · Report",
+            Tooltip = "Restore Points\nProfile Export/Import\nCLI Interface\nSystem Report",
+            Children = {
+            new NavItem { Id = "nav-restore-points", Label = "Restore Points",       Glyph = "\uE7AD", Content = WipRestorePoints,       ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-profile-export", Label = "Profile Export/Import", Glyph = "\uE8B5", Content = WipProfileExportImport, ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-cli-interface",  Label = "CLI Interface",         Glyph = "\uE756", Content = WipCliInterface,        ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-system-report",  Label = "System Report",         Glyph = "\uE9F9", Content = WipSystemReport,        ViewType = typeof(Views.PlaceholderView) },
+        }};
+
         NavGroups.Add(grpDashboard);
         NavGroups.Add(grpSystem);
+        NavGroups.Add(grpGaming);
         NavGroups.Add(grpMonitor);
         NavGroups.Add(grpCleanup);
         NavGroups.Add(grpStorage);
         NavGroups.Add(grpNetwork);
         NavGroups.Add(grpApps);
-        NavGroups.Add(grpControl);
+        NavGroups.Add(grpPrivacy);
+        NavGroups.Add(grpCustomization);
         NavGroups.Add(grpInfo);
+        NavGroups.Add(grpAdvanced);
 
         // Flat index for backward compat (Open*Tab commands, tests, automation).
         foreach (var g in NavGroups)
@@ -346,20 +467,43 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         Services?.Dispose();
         NetworkShared?.Dispose();
         WindowsFeatures?.Dispose();
-        WipResourceHistory?.Dispose();
         AppAlerts?.Dispose();
-        WipPrivacyMonitor?.Dispose();
         ShortcutCleaner?.Dispose();
+        AppBlocker?.Dispose();
+
+        // WIP placeholders
+        WipResourceHistory?.Dispose();
+        WipPrivacyMonitor?.Dispose();
+        WipFileLockDetector?.Dispose();
+        WipSettingsWatchdog?.Dispose();
+        WipBandwidthMonitor?.Dispose();
+        WipGamingProfile?.Dispose();
+        WipStandbyListCleaner?.Dispose();
+        WipTimerResolution?.Dispose();
+        WipCpuAffinity?.Dispose();
+        WipDisplayProfiles?.Dispose();
         WipFileShredder?.Dispose();
+        WipScheduledMaintenance?.Dispose();
         WipDnsChanger?.Dispose();
         WipHostsEditor?.Dispose();
         WipBulkInstaller?.Dispose();
-        AppBlocker?.Dispose();
         WipPrivacySettings?.Dispose();
+        WipDebloater?.Dispose();
+        WipBrowserCleaner?.Dispose();
+        WipEdgeOneDriveRemover?.Dispose();
+        WipDefenderTweaks?.Dispose();
+        WipNotificationBlocker?.Dispose();
         WipContextMenu?.Dispose();
+        WipDarkModeScheduler?.Dispose();
+        WipVolumeControl?.Dispose();
+        WipEnvVariableEditor?.Dispose();
+        WipTaskScheduler?.Dispose();
+        WipBootAnalyzer?.Dispose();
         WipRestorePoints?.Dispose();
-        WipScheduledMaintenance?.Dispose();
+        WipProfileExportImport?.Dispose();
+        WipCliInterface?.Dispose();
         WipSystemReport?.Dispose();
+
         GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
## Summary
Expand the sidebar navigation from 9 to 12 groups to accommodate the full feature roadmap. Add 20 new WIP placeholder tabs across 4 new navigation groups plus additions to existing groups.

## New Navigation Groups
- **Gaming & Profiles** (5 tabs): Gaming Profile, Standby List Cleaner, Timer Resolution, CPU Core Affinity, Display Profiles
- **Privacy & Security** (6 tabs): Privacy & Telemetry, Debloater & Ads, Browser Cleaner, Edge/OneDrive Remover, Defender Tweaks, Notification Blocker
- **Customization** (4 tabs): Context Menu, Dark Mode Scheduler, Volume Control, Environment Variables
- **Advanced** (4 tabs): Restore Points, Profile Export/Import, CLI Interface, System Report

## Additions to Existing Groups
- **System** (+2): Task Scheduler, Boot Analyzer
- **Monitor** (+3): File Lock Detector, Settings Watchdog, Bandwidth Monitor
- **Cleanup** (+1): Scheduled Maintenance moved here

## Changes
- Navigation reorganized from 9 groups (36 items) to 12 groups (56 items)
- All existing WIP placeholders retained with improved descriptions
- Integration tests updated to reflect new counts
- Build: 0 errors across all 3 projects

## Related Issues
New issues created: #324, #325, #326, #327, #328, #329, #331, #332, #333, #334, #335, #336, #337, #339, #340, #341, #342, #343, #344
