### PR TITLE
fix: dispose resource leaks in NetworkSharedState, TrayIconService, MemoryTestService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.53.1] - 2026-05-14
+
+### Fixed
+- **Resource leak: NetworkSharedState** — dispose SKTypeface on LegendTextPaint
+  in Dispose() to release unmanaged SkiaSharp memory (LEAK-003).
+- **Resource leak: TrayIconService** — dispose icon resource stream after
+  creating System.Drawing.Icon to prevent stream leak (LEAK-006).
+- **Resource leak: MemoryTestService** — dispose Process returned by
+  Process.Start when launching mdsched.exe (LEAK-007).
+
 ## [0.53.0] - 2026-05-13
 
 ### Added

--- a/SysManager/SysManager/Services/MemoryTestService.cs
+++ b/SysManager/SysManager/Services/MemoryTestService.cs
@@ -80,7 +80,7 @@ public sealed class MemoryTestService
             // mdsched.exe prompts interactively. Use the schedule flag to avoid UI.
             // On Win10/11, the easiest way without UI is the "bcdedit" toggle used
             // behind the scenes, but safest portable option is to launch mdsched.
-            Process.Start(new ProcessStartInfo
+            using var proc = Process.Start(new ProcessStartInfo
             {
                 FileName = "mdsched.exe",
                 UseShellExecute = true

--- a/SysManager/SysManager/Services/TrayIconService.cs
+++ b/SysManager/SysManager/Services/TrayIconService.cs
@@ -90,8 +90,10 @@ public sealed class TrayIconService : IDisposable
         try
         {
             var uri = new Uri("pack://application:,,,/Resources/app.ico", UriKind.Absolute);
-            var stream = Application.GetResourceStream(uri)?.Stream;
-            return stream != null ? new System.Drawing.Icon(stream) : null;
+            var streamInfo = Application.GetResourceStream(uri);
+            if (streamInfo?.Stream == null) return null;
+            using var stream = streamInfo.Stream;
+            return new System.Drawing.Icon(stream);
         }
         catch (System.IO.IOException ex)
         {

--- a/SysManager/SysManager/ViewModels/NetworkSharedState.cs
+++ b/SysManager/SysManager/ViewModels/NetworkSharedState.cs
@@ -487,5 +487,8 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
         TraceMonitor.Stop();
         TraceMonitor.Dispose();
         FlushTimer?.Stop();
+
+        // Dispose SKTypeface (unmanaged SkiaSharp memory) — LEAK-003
+        LegendTextPaint.SKTypeface?.Dispose();
     }
 }


### PR DESCRIPTION
## Summary
Fix 3 resource leaks identified in code review (LEAK-003, LEAK-006, LEAK-007).

## Changes
- **NetworkSharedState** — dispose SKTypeface on LegendTextPaint in Dispose() to release unmanaged SkiaSharp memory
- **TrayIconService** — dispose icon resource stream after creating System.Drawing.Icon
- **MemoryTestService** — dispose Process returned by Process.Start when launching mdsched.exe

## Testing
- Build: 0 errors
- No behavioral changes — only resource cleanup on disposal

Closes #305, Closes #321
