### PR TITLE
fix: remove fabricated SHA-256 hashes from SpeedTestService (SEC-001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.2] - 2026-05-14
+
+### Fixed
+- **Security: SpeedTestService** — remove fabricated placeholder SHA-256 hashes
+  that caused perpetual warning logs (alert fatigue). Security now relies on
+  Authenticode signature verification of the extracted binary + zip structural
+  integrity check (SEC-001).
+
 ## [0.53.1] - 2026-05-14
 
 ### Fixed

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -292,23 +292,14 @@ public sealed class SpeedTestService
             await resp.Content.CopyToAsync(fs, ct);
         }
 
-        // SEC-002: Verify download integrity with pinned SHA-256 hashes.
-        // Ookla CLI 1.2.0 hashes from verified downloads (2024-01).
-        const string PinnedHashWin64 = "2B17ADAC8F0B0F7C9B3D1F5E6A8C4D2E9F1B3A5C7D9E1F3A5B7C9D1E3F5A7B9C";
-        const string PinnedHashWin32 = "4D6E8F1A3B5C7D9E2F4A6B8C1D3E5F7A9B2C4D6E8F1A3B5C7D9E2F4A6B8C1D3E";
+        // Log download integrity info for audit (SHA-256 of the zip).
+        // Security relies on Authenticode signature verification of the
+        // extracted binary, not on pinned hashes (which break on Ookla updates).
         await Task.Run(() =>
         {
             var hash = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(zipPath)));
             Log.Information("Ookla CLI downloaded: {Url}, SHA256={Hash}, Size={Size}",
                 zipUrl, hash, new FileInfo(zipPath).Length);
-
-            var expectedHash = arch == "win64" ? PinnedHashWin64 : PinnedHashWin32;
-            if (!string.Equals(hash, expectedHash, StringComparison.OrdinalIgnoreCase))
-            {
-                Log.Warning("Ookla CLI hash mismatch! Expected={Expected}, Got={Got}", expectedHash, hash);
-                // Don't block — hash may change with minor Ookla updates.
-                // Log warning but allow if zip is structurally valid.
-            }
 
             // Structural integrity check: must be a valid zip with speedtest.exe
             try


### PR DESCRIPTION
## Summary
Remove placeholder SHA-256 hash constants that never matched real Ookla CLI downloads, causing perpetual warning logs and alert fatigue.

## Problem
PinnedHashWin64 and PinnedHashWin32 were fabricated values. Every download triggered a hash mismatch warning, making real attacks indistinguishable from normal operation.

## Fix
Removed fake hash comparison. Security now relies on:
1. Authenticode signature verification (checks Ookla subject in cert)
2. Zip structural integrity (must contain speedtest.exe)
3. SHA-256 logged for audit (not compared against fake values)

## Testing
- Build: 0 errors
- No behavioral change for users (speed test still works identically)
- Eliminates false warning logs on every download

Closes #308
