### PR TITLE
fix: address 6 medium bugs (#311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.3] - 2026-05-14
+
+### Fixed
+- **DuplicateFileGroup** — WastedBytes now raises PropertyChanged when Count or
+  FileSize changes (missing NotifyPropertyChangedFor attributes).
+- **UpdateService** — pre-release and draft GitHub releases are now filtered out
+  in GetRecentAsync results.
+- **ServiceManagerService** — StartService no longer throws when the service is
+  already in StartPending state.
+- **DiskAnalyzerService** — empty directories are no longer incorrectly flagged
+  as access-denied; the flag now tracks actual UnauthorizedAccessException.
+- **WindowsUpdateViewModel** — null-conditional on Application.Current before
+  calling Shutdown() prevents NullReferenceException during unit tests or
+  non-standard hosting.
+- **TuneUpService** — SHEmptyRecycleBin HRESULT is now checked; returns false
+  on failure instead of always reporting success.
+
 ## [0.48.2] - 2026-05-14
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DiskAnalyzerServiceTests.cs
+++ b/SysManager/SysManager.Tests/DiskAnalyzerServiceTests.cs
@@ -127,6 +127,19 @@ public class DiskAnalyzerServiceTests : IDisposable
         Assert.True(big.Percentage > small.Percentage);
     }
 
+    [Fact]
+    public async Task Analyze_EmptySubfolder_NotMarkedAsAccessDenied()
+    {
+        // An empty directory should NOT be flagged as access denied
+        CreateDir("emptydir");
+        var result = await _service.AnalyzeAsync(_root);
+        Assert.Single(result);
+        Assert.Equal("emptydir", result[0].Name);
+        Assert.False(result[0].IsAccessDenied);
+        Assert.Equal(0, result[0].SizeBytes);
+        Assert.Equal(0, result[0].FileCount);
+    }
+
     // ── Invalid inputs ──
 
     [Fact]

--- a/SysManager/SysManager.Tests/DuplicateFileGroupTests.cs
+++ b/SysManager/SysManager.Tests/DuplicateFileGroupTests.cs
@@ -1,0 +1,110 @@
+// SysManager · DuplicateFileGroupTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="DuplicateFileGroup"/> model — validates WastedBytes
+/// calculation and property change notifications.
+/// </summary>
+public class DuplicateFileGroupTests
+{
+    [Fact]
+    public void WastedBytes_CalculatesCorrectly()
+    {
+        var group = new DuplicateFileGroup();
+        group.FileSize = 1024;
+        group.Count = 3;
+        // Wasted = (3 - 1) * 1024 = 2048
+        Assert.Equal(2048, group.WastedBytes);
+    }
+
+    [Fact]
+    public void WastedBytes_ZeroWhenCountIsOne()
+    {
+        var group = new DuplicateFileGroup();
+        group.FileSize = 5000;
+        group.Count = 1;
+        Assert.Equal(0, group.WastedBytes);
+    }
+
+    [Fact]
+    public void WastedBytes_ZeroWhenCountIsZero()
+    {
+        var group = new DuplicateFileGroup();
+        group.FileSize = 5000;
+        group.Count = 0;
+        Assert.Equal(0, group.WastedBytes);
+    }
+
+    [Fact]
+    public void WastedBytes_NotifiesWhenFileSizeChanges()
+    {
+        var group = new DuplicateFileGroup();
+        group.Count = 3;
+        var changed = new List<string>();
+        group.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+
+        group.FileSize = 2048;
+
+        Assert.Contains("WastedBytes", changed);
+    }
+
+    [Fact]
+    public void WastedBytes_NotifiesWhenCountChanges()
+    {
+        var group = new DuplicateFileGroup();
+        group.FileSize = 1024;
+        var changed = new List<string>();
+        group.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+
+        group.Count = 5;
+
+        Assert.Contains("WastedBytes", changed);
+    }
+
+    [Fact]
+    public void Hash_PropertyNotifies()
+    {
+        var group = new DuplicateFileGroup();
+        var changed = new List<string>();
+        group.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+
+        group.Hash = "abc123";
+
+        Assert.Contains("Hash", changed);
+    }
+
+    [Fact]
+    public void Files_Collection_IsInitialized()
+    {
+        var group = new DuplicateFileGroup();
+        Assert.NotNull(group.Files);
+        Assert.Empty(group.Files);
+    }
+
+    // ── DuplicateFileEntry tests ──
+
+    [Fact]
+    public void DuplicateFileEntry_Properties_Notify()
+    {
+        var entry = new DuplicateFileEntry();
+        var changed = new List<string>();
+        entry.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+
+        entry.Path = @"C:\test\file.txt";
+        entry.Name = "file.txt";
+        entry.SizeBytes = 4096;
+        entry.LastModified = DateTime.Now;
+        entry.IsSelected = true;
+
+        Assert.Contains("Path", changed);
+        Assert.Contains("Name", changed);
+        Assert.Contains("SizeBytes", changed);
+        Assert.Contains("LastModified", changed);
+        Assert.Contains("IsSelected", changed);
+    }
+}

--- a/SysManager/SysManager/Models/DuplicateFileGroup.cs
+++ b/SysManager/SysManager/Models/DuplicateFileGroup.cs
@@ -14,8 +14,13 @@ namespace SysManager.Models;
 public partial class DuplicateFileGroup : ObservableObject
 {
     [ObservableProperty] private string _hash = "";
-    [ObservableProperty] private long _fileSize;
-    [ObservableProperty] private int _count;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(WastedBytes))]
+    private long _fileSize;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(WastedBytes))]
+    private int _count;
 
     public ObservableCollection<DuplicateFileEntry> Files { get; } = new();
 

--- a/SysManager/SysManager/Services/DiskAnalyzerService.cs
+++ b/SysManager/SysManager/Services/DiskAnalyzerService.cs
@@ -82,7 +82,7 @@ public sealed class DiskAnalyzerService
             scanned++;
             progress?.Report(new AnalysisProgress(scanned, Path.GetFileName(dir)));
 
-            var (size, files, folders) = MeasureFolder(dir, ct);
+            var (size, files, folders, denied) = MeasureFolder(dir, ct);
             var name = Path.GetFileName(dir);
             if (string.IsNullOrEmpty(name)) name = dir;
 
@@ -93,7 +93,7 @@ public sealed class DiskAnalyzerService
                 SizeBytes = size,
                 FileCount = files,
                 FolderCount = folders,
-                IsAccessDenied = size == 0 && files == 0 && folders == 0
+                IsAccessDenied = denied
             });
         }
 
@@ -124,11 +124,12 @@ public sealed class DiskAnalyzerService
         return results;
     }
 
-    private static (long size, int files, int folders) MeasureFolder(string path, CancellationToken ct)
+    private static (long size, int files, int folders, bool accessDenied) MeasureFolder(string path, CancellationToken ct)
     {
         long totalSize = 0;
         int fileCount = 0;
         int folderCount = 0;
+        bool accessDenied = false;
 
         var stack = new Stack<string>();
         stack.Push(path);
@@ -140,10 +141,10 @@ public sealed class DiskAnalyzerService
             string[] files = Array.Empty<string>();
             string[] dirs = Array.Empty<string>();
             try { files = Directory.GetFiles(current); }
-            catch (UnauthorizedAccessException) { /* skip protected folder */ }
+            catch (UnauthorizedAccessException) { accessDenied = true; }
             catch (IOException) { /* skip inaccessible folder */ }
             try { dirs = Directory.GetDirectories(current); }
-            catch (UnauthorizedAccessException) { /* skip protected folder */ }
+            catch (UnauthorizedAccessException) { accessDenied = true; }
             catch (IOException) { /* skip inaccessible folder */ }
 
             foreach (var f in files)
@@ -154,7 +155,7 @@ public sealed class DiskAnalyzerService
                     totalSize += new FileInfo(f).Length;
                     fileCount++;
                 }
-                catch (UnauthorizedAccessException) { /* skip inaccessible file */ }
+                catch (UnauthorizedAccessException) { accessDenied = true; }
                 catch (IOException) { /* skip inaccessible file */ }
             }
 
@@ -167,7 +168,7 @@ public sealed class DiskAnalyzerService
                     var attr = File.GetAttributes(d);
                     if ((attr & FileAttributes.ReparsePoint) != 0) continue;
                 }
-                catch (UnauthorizedAccessException) { continue; }
+                catch (UnauthorizedAccessException) { accessDenied = true; continue; }
                 catch (IOException) { continue; }
 
                 folderCount++;
@@ -175,7 +176,7 @@ public sealed class DiskAnalyzerService
             }
         }
 
-        return (totalSize, fileCount, folderCount);
+        return (totalSize, fileCount, folderCount, accessDenied);
     }
 
     private static bool ShouldSkip(string path)

--- a/SysManager/SysManager/Services/ServiceManagerService.cs
+++ b/SysManager/SysManager/Services/ServiceManagerService.cs
@@ -86,18 +86,19 @@ public class ServiceManagerService
     public static void StartService(string serviceName)
     {
         using var sc = new ServiceController(serviceName);
-        if (sc.Status != ServiceControllerStatus.Running)
+        if (sc.Status == ServiceControllerStatus.Running ||
+            sc.Status == ServiceControllerStatus.StartPending)
+            return;
+
+        sc.Start();
+        try
         {
-            sc.Start();
-            try
-            {
-                sc.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromSeconds(30));
-            }
-            catch (System.ServiceProcess.TimeoutException)
-            {
-                throw new InvalidOperationException(
-                    $"Service '{serviceName}' did not start within 30 seconds. It may still be starting — check Services again in a moment.");
-            }
+            sc.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromSeconds(30));
+        }
+        catch (System.ServiceProcess.TimeoutException)
+        {
+            throw new InvalidOperationException(
+                $"Service '{serviceName}' did not start within 30 seconds. It may still be starting — check Services again in a moment.");
         }
     }
 

--- a/SysManager/SysManager/Services/TuneUpService.cs
+++ b/SysManager/SysManager/Services/TuneUpService.cs
@@ -218,8 +218,9 @@ public sealed class TuneUpService
         try
         {
             // SHEmptyRecycleBin with SHERB_NOCONFIRMATION | SHERB_NOPROGRESSUI | SHERB_NOSOUND
-            NativeMethods.SHEmptyRecycleBin(IntPtr.Zero, null, 0x00000007);
-            return true;
+            int hr = NativeMethods.SHEmptyRecycleBin(IntPtr.Zero, null, 0x00000007);
+            // S_OK (0) = success, 0x80070012 (ERROR_NO_MORE_FILES) = bin already empty
+            return hr >= 0 || unchecked((uint)hr) == 0x80070012;
         }
         catch (System.ComponentModel.Win32Exception ex)
         {

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -260,6 +260,7 @@ public sealed class UpdateService
     private static ReleaseInfo? Map(GhRelease dto)
     {
         if (dto.TagName == null) return null;
+        if (dto.Prerelease || dto.Draft) return null;
         var version = ParseVersion(dto.TagName);
         if (version == null) return null;
 

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -74,7 +74,7 @@ public partial class WindowsUpdateViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current.Shutdown();
+            System.Windows.Application.Current?.Shutdown();
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary
Fixes 6 medium-priority bugs identified in the code review.

## Changes

1. **DuplicateFileGroup** — added [NotifyPropertyChangedFor(nameof(WastedBytes))] on _count and _fileSize so UI updates when these change.
2. **UpdateService** — Map() now returns null for pre-release and draft releases, filtering them from GetRecentAsync results.
3. **ServiceManagerService** — StartService checks for StartPending state before calling Start(), preventing InvalidOperationException.
4. **DiskAnalyzerService** — MeasureFolder now tracks actual UnauthorizedAccessException occurrences instead of using the heuristic (size==0 && files==0 && folders==0) which incorrectly flagged empty directories.
5. **WindowsUpdateViewModel** — null-conditional on Application.Current?.Shutdown() prevents NRE in test/non-standard hosting scenarios.
6. **TuneUpService** — SHEmptyRecycleBin HRESULT is now checked; S_OK or 0x80070012 (bin empty) = success, anything else = false.

## Tests
- New: DuplicateFileGroupTests (8 tests) — WastedBytes calculation, PropertyChanged notifications
- New: DiskAnalyzerServiceTests.Analyze_EmptySubfolder_NotMarkedAsAccessDenied

Closes #311
