### PR TITLE
fix: resolve thread safety issues in 5 services (#310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.49.0] - 2026-05-14
+
+### Fixed
+- **IconExtractorService** — cache eviction race condition resolved with
+  double-checked lock pattern (THR-002).
+- **PingMonitorService** — Start/Stop race on _cts resolved with lock around
+  state transitions (THR-003).
+- **TracerouteMonitorService** — same Start/Stop race fix as PingMonitor
+  (THR-003).
+- **AppAlertService** — List<FileSystemWatcher> access from concurrent threads
+  protected with lock on Start/Stop (THR-004).
+- **NetworkRepairService** — List<string> output replaced with ConcurrentQueue
+  to prevent corruption from background thread callbacks (THR-005).
+- **PerformanceView** — SyncRadioButtons now marshals to UI thread via
+  Dispatcher.BeginInvoke when called from background (THR-006).
+
 ## [0.48.3] - 2026-05-14
 
 ### Fixed

--- a/SysManager/SysManager/Services/AppAlertService.cs
+++ b/SysManager/SysManager/Services/AppAlertService.cs
@@ -17,6 +17,7 @@ namespace SysManager.Services;
 public sealed class AppAlertService : IDisposable
 {
     private readonly List<FileSystemWatcher> _watchers = new();
+    private readonly object _watcherLock = new();
     private readonly ConcurrentDictionary<string, bool> _knownFolders = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, bool> _knownRegistryApps = new(StringComparer.OrdinalIgnoreCase);
     private Timer? _registryTimer;
@@ -53,21 +54,24 @@ public sealed class AppAlertService : IDisposable
     {
         if (_disposed) return;
 
-        foreach (var dir in GetMonitoredDirectories().Where(Directory.Exists))
+        lock (_watcherLock)
         {
-            try
+            foreach (var dir in GetMonitoredDirectories().Where(Directory.Exists))
             {
-                var watcher = new FileSystemWatcher(dir)
+                try
                 {
-                    NotifyFilter = NotifyFilters.DirectoryName,
-                    IncludeSubdirectories = false,
-                    EnableRaisingEvents = true
-                };
-                watcher.Created += OnDirectoryCreated;
-                _watchers.Add(watcher);
+                    var watcher = new FileSystemWatcher(dir)
+                    {
+                        NotifyFilter = NotifyFilters.DirectoryName,
+                        IncludeSubdirectories = false,
+                        EnableRaisingEvents = true
+                    };
+                    watcher.Created += OnDirectoryCreated;
+                    _watchers.Add(watcher);
+                }
+                catch (IOException ex) { Log.Debug(ex, "Failed to watch {Dir}", dir); }
+                catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Access denied watching {Dir}", dir); }
             }
-            catch (IOException ex) { Log.Debug(ex, "Failed to watch {Dir}", dir); }
-            catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Access denied watching {Dir}", dir); }
         }
 
         _registryTimer = new Timer(CheckRegistry, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
@@ -82,12 +86,15 @@ public sealed class AppAlertService : IDisposable
         _registryTimer?.Dispose();
         _registryTimer = null;
 
-        foreach (var w in _watchers)
+        lock (_watcherLock)
         {
-            w.EnableRaisingEvents = false;
-            w.Dispose();
+            foreach (var w in _watchers)
+            {
+                w.EnableRaisingEvents = false;
+                w.Dispose();
+            }
+            _watchers.Clear();
         }
-        _watchers.Clear();
         Log.Information("App alert monitoring stopped");
     }
 

--- a/SysManager/SysManager/Services/IconExtractorService.cs
+++ b/SysManager/SysManager/Services/IconExtractorService.cs
@@ -23,6 +23,7 @@ namespace SysManager.Services;
 public sealed class IconExtractorService
 {
     private static readonly ConcurrentDictionary<string, ImageSource?> _cache = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly object _evictionLock = new();
 
     /// <summary>Maximum number of cached icons before eviction kicks in.</summary>
     public static int MaxCacheSize { get; set; } = 500;
@@ -50,8 +51,15 @@ public sealed class IconExtractorService
         // the cache to amortize the cost of eviction.
         if (_cache.Count >= MaxCacheSize)
         {
-            var keys = _cache.Keys.Take(_cache.Count / 2).ToList();
-            foreach (var k in keys) _cache.TryRemove(k, out _);
+            lock (_evictionLock)
+            {
+                // Double-check inside lock to avoid redundant eviction.
+                if (_cache.Count >= MaxCacheSize)
+                {
+                    var keys = _cache.Keys.Take(_cache.Count / 2).ToList();
+                    foreach (var k in keys) _cache.TryRemove(k, out _);
+                }
+            }
         }
 
         return _cache.GetOrAdd(normalized, static path => ExtractIcon(path));

--- a/SysManager/SysManager/Services/NetworkRepairService.cs
+++ b/SysManager/SysManager/Services/NetworkRepairService.cs
@@ -21,8 +21,8 @@ public class NetworkRepairService
     /// </summary>
     public async Task<NetworkRepairResult> FlushDnsAsync(CancellationToken ct = default)
     {
-        var output = new List<string>();
-        void OnLine(PowerShellLine line) => output.Add(line.Text);
+        var output = new System.Collections.Concurrent.ConcurrentQueue<string>();
+        void OnLine(PowerShellLine line) => output.Enqueue(line.Text);
         _ps.LineReceived += OnLine;
         try
         {
@@ -42,8 +42,8 @@ public class NetworkRepairService
     /// </summary>
     public async Task<NetworkRepairResult> ResetWinsockAsync(CancellationToken ct = default)
     {
-        var output = new List<string>();
-        void OnLine(PowerShellLine line) => output.Add(line.Text);
+        var output = new System.Collections.Concurrent.ConcurrentQueue<string>();
+        void OnLine(PowerShellLine line) => output.Enqueue(line.Text);
         _ps.LineReceived += OnLine;
         try
         {
@@ -63,8 +63,8 @@ public class NetworkRepairService
     /// </summary>
     public async Task<NetworkRepairResult> ResetTcpIpAsync(CancellationToken ct = default)
     {
-        var output = new List<string>();
-        void OnLine(PowerShellLine line) => output.Add(line.Text);
+        var output = new System.Collections.Concurrent.ConcurrentQueue<string>();
+        void OnLine(PowerShellLine line) => output.Enqueue(line.Text);
         _ps.LineReceived += OnLine;
         try
         {

--- a/SysManager/SysManager/Services/PingMonitorService.cs
+++ b/SysManager/SysManager/Services/PingMonitorService.cs
@@ -31,6 +31,7 @@ public sealed class PingMonitorService : IDisposable
 
     private CancellationTokenSource? _cts;
     private Task? _loop;
+    private readonly object _stateLock = new();
 
     public bool IsRunning => _loop is { IsCompleted: false };
 
@@ -39,18 +40,24 @@ public sealed class PingMonitorService : IDisposable
 
     public void Start()
     {
-        if (IsRunning) return;
-        _cts = new CancellationTokenSource();
-        _loop = Task.Run(() => PumpAsync(_cts.Token));
+        lock (_stateLock)
+        {
+            if (IsRunning) return;
+            _cts = new CancellationTokenSource();
+            _loop = Task.Run(() => PumpAsync(_cts.Token));
+        }
     }
 
     public void Stop()
     {
-        _cts?.Cancel();
-        try { _loop?.Wait(1500); } catch { /* ignore */ }
-        _cts?.Dispose();
-        _cts = null;
-        _loop = null;
+        lock (_stateLock)
+        {
+            _cts?.Cancel();
+            try { _loop?.Wait(1500); } catch { /* ignore */ }
+            _cts?.Dispose();
+            _cts = null;
+            _loop = null;
+        }
     }
 
     private async Task PumpAsync(CancellationToken ct)

--- a/SysManager/SysManager/Services/TracerouteMonitorService.cs
+++ b/SysManager/SysManager/Services/TracerouteMonitorService.cs
@@ -32,6 +32,7 @@ public sealed class TracerouteMonitorService : IDisposable
 
     private CancellationTokenSource? _cts;
     private Task? _loop;
+    private readonly object _stateLock = new();
 
     public bool IsRunning => _loop is { IsCompleted: false };
 
@@ -51,18 +52,24 @@ public sealed class TracerouteMonitorService : IDisposable
 
     public void Start()
     {
-        if (IsRunning) return;
-        _cts = new CancellationTokenSource();
-        _loop = Task.Run(() => PumpAsync(_cts.Token));
+        lock (_stateLock)
+        {
+            if (IsRunning) return;
+            _cts = new CancellationTokenSource();
+            _loop = Task.Run(() => PumpAsync(_cts.Token));
+        }
     }
 
     public void Stop()
     {
-        _cts?.Cancel();
-        try { _loop?.Wait(3000); } catch { /* ignore */ }
-        _cts?.Dispose();
-        _cts = null;
-        _loop = null;
+        lock (_stateLock)
+        {
+            _cts?.Cancel();
+            try { _loop?.Wait(3000); } catch { /* ignore */ }
+            _cts?.Dispose();
+            _cts = null;
+            _loop = null;
+        }
     }
 
     private async Task PumpAsync(CancellationToken ct)

--- a/SysManager/SysManager/Views/PerformanceView.xaml.cs
+++ b/SysManager/SysManager/Views/PerformanceView.xaml.cs
@@ -38,6 +38,11 @@ public partial class PerformanceView : UserControl
 
     private void SyncRadioButtons(string plan)
     {
+        if (!Dispatcher.CheckAccess())
+        {
+            Dispatcher.BeginInvoke(() => SyncRadioButtons(plan));
+            return;
+        }
         RbBalanced.IsChecked = plan == "balanced";
         RbHigh.IsChecked = plan == "high";
         RbUltimate.IsChecked = plan == "ultimate";


### PR DESCRIPTION
## Summary
Fixes 5 thread safety issues (race conditions, unsafe collections) across services.

## Changes

1. **IconExtractorService (THR-002)** — cache eviction race resolved with double-checked lock pattern. Multiple threads could enter eviction simultaneously; now only one thread evicts at a time.
2. **PingMonitorService (THR-003)** — Start/Stop race on _cts resolved with lock around state transitions. Concurrent Start+Stop could dispose _cts while PumpAsync still holds a reference.
3. **TracerouteMonitorService (THR-003)** — same Start/Stop lock pattern as PingMonitor.
4. **AppAlertService (THR-004)** — List<FileSystemWatcher> protected with lock on Start/Stop to prevent concurrent modification.
5. **NetworkRepairService (THR-005)** — List<string> output replaced with ConcurrentQueue<string> to prevent corruption when LineReceived fires from background threads.
6. **PerformanceView (THR-006)** — SyncRadioButtons now checks Dispatcher.CheckAccess() and marshals to UI thread via BeginInvoke when PropertyChanged fires from background.

Closes #310
