### PR TITLE
docs: correct CHANGELOG version 0.49.0 -> 0.48.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [0.49.0] - 2026-05-14
+## [0.48.4] - 2026-05-14
 
 ### Fixed
 - **IconExtractorService** — cache eviction race condition resolved with


### PR DESCRIPTION
Auto-release created v0.48.4 (fix: = patch bump), but CHANGELOG incorrectly listed [0.49.0]. This corrects the version header to match the actual release tag.
