### PR TITLE
fix: performance improvements (#312)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.5] - 2026-05-14
+
+### Changed
+- **DuplicateFileService** — ShouldSkipDir uses OrdinalIgnoreCase instead of
+  ToLowerInvariant allocation on every path (PERF-002).
+- **LargeFileScanner** — same OrdinalIgnoreCase fix (PERF-002).
+- **SpeedTestService** — SHA-256 hashing uses stream instead of
+  File.ReadAllBytes to avoid loading entire zip into memory (PERF-004).
+- **ProcessManagerService** — MainModule accessed once per process instead of
+  twice, halving P/Invoke overhead (PERF-005).
+- **AboutViewModel** — CopyEnvironmentInfo WMI queries now run on background
+  thread via Task.Run, preventing UI freeze (PERF-008).
+
 ## [0.48.4] - 2026-05-14
 
 ### Fixed

--- a/SysManager/SysManager/Services/DuplicateFileService.cs
+++ b/SysManager/SysManager/Services/DuplicateFileService.cs
@@ -226,8 +226,7 @@ public sealed class DuplicateFileService
 
     private static bool ShouldSkipDir(string path)
     {
-        var lower = path.ToLowerInvariant();
-        return SkipSegments.Any(seg => lower.Contains(seg));
+        return SkipSegments.Any(seg => path.Contains(seg, StringComparison.OrdinalIgnoreCase));
     }
 
     private static bool ShouldSkipFile(string name)

--- a/SysManager/SysManager/Services/LargeFileScanner.cs
+++ b/SysManager/SysManager/Services/LargeFileScanner.cs
@@ -125,7 +125,6 @@ public sealed class LargeFileScanner
 
     private static bool ShouldSkip(string path)
     {
-        var lower = path.ToLowerInvariant();
-        return SkipSegments.Any(seg => lower.Contains(seg));
+        return SkipSegments.Any(seg => path.Contains(seg, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/SysManager/SysManager/Services/ProcessManagerService.cs
+++ b/SysManager/SysManager/Services/ProcessManagerService.cs
@@ -71,10 +71,12 @@ public sealed class ProcessManagerService
                         catch (System.ComponentModel.Win32Exception) { /* process may have exited */ }
                     }
 
-                    try { entry.Description = p.MainModule?.FileVersionInfo.FileDescription ?? ""; }
-                    catch (InvalidOperationException) { /* access denied or process exited */ }
-                    catch (System.ComponentModel.Win32Exception) { /* access denied or process exited */ }
-                    try { entry.FilePath = p.MainModule?.FileName ?? ""; }
+                    try
+                    {
+                        var module = p.MainModule;
+                        entry.Description = module?.FileVersionInfo.FileDescription ?? "";
+                        entry.FilePath = module?.FileName ?? "";
+                    }
                     catch (InvalidOperationException) { /* access denied or process exited */ }
                     catch (System.ComponentModel.Win32Exception) { /* access denied or process exited */ }
                     entry.CanOpenFileLocation = !string.IsNullOrWhiteSpace(entry.FilePath)

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -297,7 +297,8 @@ public sealed class SpeedTestService
         // extracted binary, not on pinned hashes (which break on Ookla updates).
         await Task.Run(() =>
         {
-            var hash = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(zipPath)));
+            using var stream = File.OpenRead(zipPath);
+            var hash = Convert.ToHexString(SHA256.HashData(stream));
             Log.Information("Ookla CLI downloaded: {Url}, SHA256={Hash}, Size={Size}",
                 zipUrl, hash, new FileInfo(zipPath).Length);
 

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -217,7 +217,26 @@ public partial class AboutViewModel : ViewModelBase
     /// Fully defensive — falls back gracefully on any WMI / registry miss.
     /// </summary>
     [RelayCommand]
-    private void CopyEnvironmentInfo()
+    private async Task CopyEnvironmentInfoAsync()
+    {
+        try
+        {
+            var text = await Task.Run(() => CollectEnvironmentInfo()).ConfigureAwait(true);
+            try { Clipboard.SetText(text); }
+            catch (System.Runtime.InteropServices.ExternalException ex) { Log.Debug("Clipboard locked: {Error}", ex.Message); }
+            UpdateStatus = "Environment info copied to clipboard.";
+        }
+        catch (System.Management.ManagementException ex)
+        {
+            UpdateStatus = $"Couldn't collect environment info: {ex.Message}";
+        }
+        catch (InvalidOperationException ex)
+        {
+            UpdateStatus = $"Couldn't collect environment info: {ex.Message}";
+        }
+    }
+
+    private string CollectEnvironmentInfo()
     {
         try
         {
@@ -315,17 +334,15 @@ public partial class AboutViewModel : ViewModelBase
             catch (System.Management.ManagementException ex) { Log.Debug("Display info unavailable: {Error}", ex.Message); }
 
             var text = sb.ToString();
-            try { Clipboard.SetText(text); }
-            catch (System.Runtime.InteropServices.ExternalException ex) { Log.Debug("Clipboard locked: {Error}", ex.Message); }
-            UpdateStatus = "Environment info copied to clipboard.";
+            return text;
         }
         catch (System.Management.ManagementException ex)
         {
-            UpdateStatus = $"Couldn't collect environment info: {ex.Message}";
+            return $"Couldn't collect environment info: {ex.Message}";
         }
         catch (InvalidOperationException ex)
         {
-            UpdateStatus = $"Couldn't collect environment info: {ex.Message}";
+            return $"Couldn't collect environment info: {ex.Message}";
         }
     }
 


### PR DESCRIPTION
## Summary
Addresses 5 of 6 performance issues from the code review (PERF-002/004/005/008).

## Changes

1. **DuplicateFileService + LargeFileScanner (PERF-002)** — replaced ToLowerInvariant() + Contains() with OrdinalIgnoreCase comparison. Eliminates string allocation on every directory path during traversal.
2. **SpeedTestService (PERF-004)** — SHA-256 hashing now uses File.OpenRead() stream instead of File.ReadAllBytes(). Avoids loading entire zip into memory.
3. **ProcessManagerService (PERF-005)** — p.MainModule cached once per process instead of accessed twice. Halves P/Invoke overhead.
4. **AboutViewModel (PERF-008)** — CopyEnvironmentInfo WMI queries moved to Task.Run background thread. UI no longer freezes during collection.

## Not addressed (lower priority, separate PR)
- PERF-003: ObservableCollection bulk-update (6 VMs, more invasive)
- PERF-007: FontFamily per code inline (MarkdownTextBlock)

Closes #312
