### PR TITLE
fix: resolve 4 CodeQL alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.6] - 2026-05-14
+
+### Fixed
+- **PingMonitorService** — bare catch replaced with specific AggregateException
+  and ObjectDisposedException (CodeQL cs/catch-of-all-exceptions).
+- **TracerouteMonitorService** — same bare catch fix.
+- **OutputKindToBrushConverter** — simplifiable boolean expression refactored
+  to pattern matching (CodeQL cs/simplifiable-boolean-expression).
+- **LogsViewModel** — unsafe cast from ICollectionView to CollectionView
+  replaced with safe as-cast with fallback (CodeQL cs/cast-from-abstract).
+
 ## [0.48.5] - 2026-05-14
 
 ### Changed

--- a/SysManager/SysManager/Helpers/OutputKindToBrushConverter.cs
+++ b/SysManager/SysManager/Helpers/OutputKindToBrushConverter.cs
@@ -65,10 +65,10 @@ public class FlexibleBoolToVisibilityConverter : IValueConverter
 public sealed class BoolInverterConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        => value is bool b ? !b : true;
+        => value is not true;
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        => value is bool b ? !b : true;
+        => value is not true;
 }
 
 public class BoolToElevationBadgeBrushConverter : IValueConverter

--- a/SysManager/SysManager/Services/PingMonitorService.cs
+++ b/SysManager/SysManager/Services/PingMonitorService.cs
@@ -53,7 +53,9 @@ public sealed class PingMonitorService : IDisposable
         lock (_stateLock)
         {
             _cts?.Cancel();
-            try { _loop?.Wait(1500); } catch { /* ignore */ }
+            try { _loop?.Wait(1500); }
+            catch (AggregateException) { /* task cancellation or faulted — expected during stop */ }
+            catch (ObjectDisposedException) { /* task already cleaned up */ }
             _cts?.Dispose();
             _cts = null;
             _loop = null;

--- a/SysManager/SysManager/Services/TracerouteMonitorService.cs
+++ b/SysManager/SysManager/Services/TracerouteMonitorService.cs
@@ -65,7 +65,9 @@ public sealed class TracerouteMonitorService : IDisposable
         lock (_stateLock)
         {
             _cts?.Cancel();
-            try { _loop?.Wait(3000); } catch { /* ignore */ }
+            try { _loop?.Wait(3000); }
+            catch (AggregateException) { /* task cancellation or faulted — expected during stop */ }
+            catch (ObjectDisposedException) { /* task already cleaned up */ }
             _cts?.Dispose();
             _cts = null;
             _loop = null;

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -69,7 +69,7 @@ public partial class LogsViewModel : ViewModelBase
     {
         // PERF-002: Use CollectionView.Count directly instead of iterating
         // the entire filtered collection via Cast<object>().Count().
-        VisibleCount = ((CollectionView)EntriesView).Count;
+        VisibleCount = (EntriesView as CollectionView)?.Count ?? EntriesView.Cast<object>().Count();
         HasNoResults = Entries.Count > 0 && VisibleCount == 0;
     }
 


### PR DESCRIPTION
## Summary
Fixes 4 actionable CodeQL alerts in source code. Remaining 26 alerts are in generated code (obj/Release/*.g.cs) and 1 P/Invoke call (acceptable).

## Alerts fixed
- #236 cs/catch-of-all-exceptions — PingMonitorService.Stop() bare catch → AggregateException + ObjectDisposedException
- #237 cs/catch-of-all-exceptions — TracerouteMonitorService.Stop() same fix
- #232, #234 cs/simplifiable-boolean-expression — BoolInverterConverter simplified to pattern matching
- #231 cs/cast-from-abstract-to-concrete-collection — LogsViewModel safe as-cast with fallback

## Remaining alerts (26)
All in generated code (RegexGenerator.g.cs, *.g.cs view files) — cannot be fixed in source.
