### PR TITLE
chore: modernize C# — collection expressions (#313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.7] - 2026-05-14
+
+### Changed
+- **Modern C#** — replaced Array.Empty<T>() with collection expressions []
+  across 7 files: DiskAnalyzerService, DuplicateFileService, LargeFileScanner,
+  UpdateService, CleanupCategory, TuneUpResult, HealthScoreResult (MODERN-003).
+
 ## [0.48.6] - 2026-05-14
 
 ### Fixed

--- a/SysManager/SysManager/Models/CleanupCategory.cs
+++ b/SysManager/SysManager/Models/CleanupCategory.cs
@@ -39,7 +39,7 @@ public sealed class CleanupResult
 {
     public long BytesFreed { get; init; }
     public int FilesDeleted { get; init; }
-    public IReadOnlyList<string> Errors { get; init; } = Array.Empty<string>();
+    public IReadOnlyList<string> Errors { get; init; } = [];
     public string Summary =>
         $"Freed {CleanupCategory.HumanSize(BytesFreed)} across {FilesDeleted:N0} files" +
         (Errors.Count > 0 ? $" · {Errors.Count} skipped" : string.Empty);

--- a/SysManager/SysManager/Models/HealthScoreResult.cs
+++ b/SysManager/SysManager/Models/HealthScoreResult.cs
@@ -33,7 +33,7 @@ public sealed class HealthScoreResult
 
     /// <summary>Top recommendations (max 3).</summary>
     public IReadOnlyList<HealthRecommendation> Recommendations { get; init; }
-        = Array.Empty<HealthRecommendation>();
+        = [];
 
     /// <summary>Individual component scores for breakdown display.</summary>
     public int DiskScore { get; init; } = 100;

--- a/SysManager/SysManager/Models/TuneUpResult.cs
+++ b/SysManager/SysManager/Models/TuneUpResult.cs
@@ -23,7 +23,7 @@ public sealed class TuneUpResult
     public int BrokenShortcutsFound { get; init; }
 
     // ── Disk health ────────────────────────────────────────────────────
-    public IReadOnlyList<DiskHealthSummary> DiskResults { get; init; } = Array.Empty<DiskHealthSummary>();
+    public IReadOnlyList<DiskHealthSummary> DiskResults { get; init; } = [];
 
     // ── Uptime ─────────────────────────────────────────────────────────
     public TimeSpan Uptime { get; init; }

--- a/SysManager/SysManager/Services/DiskAnalyzerService.cs
+++ b/SysManager/SysManager/Services/DiskAnalyzerService.cs
@@ -35,12 +35,12 @@ public sealed class DiskAnalyzerService
         CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(rootPath) || !Directory.Exists(rootPath))
-            return Array.Empty<DiskUsageEntry>();
+            return [];
 
         string[] topDirs;
         try { topDirs = Directory.GetDirectories(rootPath); }
-        catch (UnauthorizedAccessException ex) { Log.Warning(ex, "Access denied listing directories in {Root}", rootPath); return Array.Empty<DiskUsageEntry>(); }
-        catch (IOException ex) { Log.Warning(ex, "I/O error listing directories in {Root}", rootPath); return Array.Empty<DiskUsageEntry>(); }
+        catch (UnauthorizedAccessException ex) { Log.Warning(ex, "Access denied listing directories in {Root}", rootPath); return []; }
+        catch (IOException ex) { Log.Warning(ex, "I/O error listing directories in {Root}", rootPath); return []; }
 
         var results = new List<DiskUsageEntry>();
         int scanned = 0;

--- a/SysManager/SysManager/Services/DuplicateFileService.cs
+++ b/SysManager/SysManager/Services/DuplicateFileService.cs
@@ -56,7 +56,7 @@ public sealed class DuplicateFileService
         CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(rootPath) || !Directory.Exists(rootPath))
-            return Array.Empty<DuplicateFileGroup>();
+            return [];
 
         // ── Pass 1: discover files and group by size ──
         var sizeGroups = new Dictionary<long, List<FileInfo>>();

--- a/SysManager/SysManager/Services/LargeFileScanner.cs
+++ b/SysManager/SysManager/Services/LargeFileScanner.cs
@@ -41,7 +41,7 @@ public sealed class LargeFileScanner
         CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(rootPath) || !Directory.Exists(rootPath))
-            return Array.Empty<LargeFileEntry>();
+            return [];
 
         var heap = new SortedSet<(long Size, string Path)>(Comparer<(long, string)>.Create(
             (a, b) =>

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -101,22 +101,22 @@ public sealed class UpdateService
         {
             var url = $"https://api.github.com/repos/{Owner}/{Repo}/releases?per_page={count}";
             var dto = await Http.GetFromJsonAsync<GhRelease[]>(url, ct).ConfigureAwait(false);
-            if (dto == null) return Array.Empty<ReleaseInfo>();
+            if (dto == null) return [];
             return dto.Select(Map).OfType<ReleaseInfo>().ToList();
         }
         catch (OperationCanceledException)
         {
-            return Array.Empty<ReleaseInfo>();
+            return [];
         }
         catch (HttpRequestException ex)
         {
             Serilog.Log.Warning(ex, "Failed to fetch recent releases (network)");
-            return Array.Empty<ReleaseInfo>();
+            return [];
         }
         catch (System.Text.Json.JsonException ex)
         {
             Serilog.Log.Warning(ex, "Failed to parse recent releases JSON");
-            return Array.Empty<ReleaseInfo>();
+            return [];
         }
     }
 


### PR DESCRIPTION
## Summary
Replaces Array.Empty<T>() with C# 12 collection expressions [] across 7 files.

## Changes
- DiskAnalyzerService — 3 return statements
- DuplicateFileService — 1 return statement
- LargeFileScanner — 1 return statement
- UpdateService — 4 return statements
- CleanupCategory model — 1 property initializer
- TuneUpResult model — 1 property initializer
- HealthScoreResult model — 1 property initializer

## Not addressed (separate PRs)
- MODERN-001: GeneratedRegex (requires partial method refactoring)
- MODERN-002: LibraryImport (marshalling risk)
- MODERN-004/005/006: sealed records, sealed classes, mutable lists

Partially addresses #313
