### PR TITLE
fix: security hardening (#319)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.8] - 2026-05-14
+
+### Fixed
+- **UninstallerService (SEC-002)** — UninstallLocalAsync now validates that the
+  executable exists and has a .exe extension before running. Prevents execution
+  of arbitrary commands from HKCU registry keys (modifiable without admin).
+- **EventLogService (SEC-003)** — XPath sanitization now strips quotes, brackets,
+  slashes in addition to single quotes to prevent XPath injection.
+- **LogService (SEC-004)** — path sanitization regex now covers all drive letters
+  (A-Z:\Users\) instead of only C: drive.
+
 ## [0.48.7] - 2026-05-14
 
 ### Changed

--- a/SysManager/SysManager/Services/EventLogService.cs
+++ b/SysManager/SysManager/Services/EventLogService.cs
@@ -146,7 +146,14 @@ public sealed class EventLogService
 
         if (!string.IsNullOrWhiteSpace(opt.ProviderName))
         {
-            var safe = opt.ProviderName.Replace("'", "");
+            // SEC-003: Strip XPath metacharacters to prevent injection.
+            var safe = opt.ProviderName
+                .Replace("'", "")
+                .Replace("\"", "")
+                .Replace("[", "")
+                .Replace("]", "")
+                .Replace("/", "")
+                .Replace("\\", "");
             clauses.Add($"Provider[@Name='{safe}']");
         }
 

--- a/SysManager/SysManager/Services/LogService.cs
+++ b/SysManager/SysManager/Services/LogService.cs
@@ -16,9 +16,9 @@ public static class LogService
     public static string LogDir { get; } =
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager", "logs");
 
-    // Matches C:\Users\<username>\ and replaces the username with [user].
+    // Matches <DriveLetter>:\Users\<username>\ and replaces the username with [user].
     private static readonly Regex UserPathRegex = new(
-        @"(?i)(C:\\Users\\)[^\\]+",
+        @"(?i)([A-Z]:\\Users\\)[^\\]+",
         RegexOptions.Compiled);
 
     public static void Init()

--- a/SysManager/SysManager/Services/UninstallerService.cs
+++ b/SysManager/SysManager/Services/UninstallerService.cs
@@ -250,6 +250,22 @@ public sealed partial class UninstallerService
         // Handles both quoted paths ("C:\path\uninstall.exe" /S) and unquoted.
         var (exe, args) = ParseUninstallCommand(command);
 
+        // SEC-002: Validate the executable exists and is a real file (not a
+        // script or arbitrary command). HKCU uninstall keys can be modified
+        // without admin, so we must not blindly execute whatever is there.
+        if (!exe.StartsWith("MsiExec", StringComparison.OrdinalIgnoreCase) &&
+            !exe.StartsWith("rundll32", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!System.IO.File.Exists(exe))
+                throw new InvalidOperationException(
+                    $"Uninstall executable not found: '{exe}'. The app may have been removed already.");
+
+            var ext = System.IO.Path.GetExtension(exe);
+            if (!ext.Equals(".exe", StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException(
+                    $"Uninstall target is not an executable (.exe): '{exe}'. Refusing to run for security.");
+        }
+
         Log.Information("Uninstalling local app '{Name}' via: {Exe} {Args}", app.Name, exe, args);
         return await _runner.RunProcessAsync(exe, args, ct).ConfigureAwait(false);
     }


### PR DESCRIPTION
## Summary
Addresses 3 security findings from the code review.

## Changes

1. **UninstallerService (SEC-002)** — UninstallLocalAsync now validates the parsed executable: must exist on disk and have .exe extension. MsiExec and rundll32 are exempted (system binaries). Prevents execution of arbitrary commands planted in HKCU uninstall registry keys (writable without admin).
2. **EventLogService (SEC-003)** — XPath BuildXPath sanitization now strips quotes, brackets, and slashes in addition to single quotes. Prevents XPath injection via crafted provider names.
3. **LogService (SEC-004)** — UserPathRegex now matches any drive letter (A-Z) instead of only C:. Ensures usernames are redacted regardless of Windows installation drive.

Closes #319
