### PR TITLE
docs: correct CHANGELOG — merge phantom v0.48.8 into v0.48.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [0.48.8] - 2026-05-14
+## [0.48.7] - 2026-05-14
 
 ### Fixed
 - **UninstallerService (SEC-002)** — UninstallLocalAsync now validates that the
@@ -16,8 +16,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   slashes in addition to single quotes to prevent XPath injection.
 - **LogService (SEC-004)** — path sanitization regex now covers all drive letters
   (A-Z:\Users\) instead of only C: drive.
-
-## [0.48.7] - 2026-05-14
 
 ### Changed
 - **Modern C#** — replaced Array.Empty<T>() with collection expressions []


### PR DESCRIPTION
## Summary
The previous session incorrectly split v0.48.7 into two entries:
- [0.48.8] for security hardening (fix: commit)
- [0.48.7] for collection expressions (chore: commit)

In reality, auto-release created only v0.48.7 (triggered by the fix: commit).
The chore: commit does not trigger a release but is included in v0.48.7.

## Changes
- Merged phantom [0.48.8] section into [0.48.7]
- v0.48.7 now correctly shows both Fixed (security) and Changed (collection expressions)

## No release triggered
docs: prefix — no version bump.
