### PR TITLE
fix: resolve 12 review findings — security, resource leaks, null guards, UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.8] - 2026-05-14
+
+### Fixed
+- **UninstallerService (SEC-005)** — `StartsWith` allowlist replaced with exact
+  filename match to prevent bypass via similarly-named executables (e.g.
+  "MsiExecEvil.exe"). `/I` → `/X` replacement now uses regex word-boundary
+  match to avoid corrupting GUIDs.
+- **SpeedTestService (SEC-006)** — Authenticode verification now fail-closed:
+  if the Ookla binary is unsigned or subject mismatches, it is deleted and an
+  exception is thrown instead of just logging a warning.
+- **DialogService** — singleton setter now rejects null to prevent global
+  null-swap hazards.
+- **Application.Current.Shutdown()** — added null-conditional `?.` operator on
+  all 5 shutdown call sites (WindowsUpdateVM ×2, DashboardVM, AppUpdatesVM,
+  TrayIconService) to prevent NullReferenceException in tests or non-standard
+  hosting.
+- **AboutViewModel** — clipboard copy no longer reports success when
+  `Clipboard.SetText` throws `ExternalException` (clipboard locked).
+- **NetworkSharedState** — TOCTOU race in FlushPending replaced
+  `ContainsKey` + indexer with `TryGetValue`; all paint SKTypeface instances
+  now disposed on cleanup (LEAK-003 complete).
+- **AppAlertService** — replaced `ContainsKey` + set with atomic `TryAdd` to
+  prevent duplicate new-app notifications in race conditions.
+- **PerformanceService** — `CreateRestorePointAsync` no longer uses always-true
+  `results != null` check; relies on exception propagation for failure.
+- **ServiceManagerService** — service name regex narrowed from `\s` (any
+  whitespace including newlines) to literal space only.
+- **WindowsFeaturesViewModel** — CancellationTokenSource now cancelled before
+  disposal in all code paths to prevent orphaned in-flight operations.
+- **App.xaml.cs** — DI ServiceProvider now disposed on application exit,
+  ensuring all DI-owned singletons implementing IDisposable are cleaned up.
+- **DashboardView.xaml** — disk verdict and overall tune-up verdict colors now
+  bound to model `ColorHex`/`OverallColorHex` instead of hardcoded green.
+
 ## [0.48.7] - 2026-05-14
 
 ### Fixed

--- a/SysManager/SysManager/App.xaml.cs
+++ b/SysManager/SysManager/App.xaml.cs
@@ -74,6 +74,7 @@ public partial class App : Application
     protected override void OnExit(ExitEventArgs e)
     {
         _trayService?.Dispose();
+        (Services as IDisposable)?.Dispose();
         LogService.Shutdown();
         _instanceMutex?.ReleaseMutex();
         _instanceMutex?.Dispose();

--- a/SysManager/SysManager/Services/AppAlertService.cs
+++ b/SysManager/SysManager/Services/AppAlertService.cs
@@ -150,8 +150,7 @@ public sealed class AppAlertService : IDisposable
 
     private void OnDirectoryCreated(object sender, FileSystemEventArgs e)
     {
-        if (_knownFolders.ContainsKey(e.FullPath)) return;
-        _knownFolders[e.FullPath] = true;
+        if (!_knownFolders.TryAdd(e.FullPath, true)) return;
 
         var entry = new AppInstallEntry
         {
@@ -172,7 +171,7 @@ public sealed class AppAlertService : IDisposable
             var current = GetRegistryApps();
             foreach (var app in current.Where(a => !_knownRegistryApps.ContainsKey(a.Name)))
             {
-                _knownRegistryApps[app.Name] = true;
+                if (!_knownRegistryApps.TryAdd(app.Name, true)) continue;
 
                 app.DetectedAt = DateTime.Now;
                 Log.Information("New app detected in registry: {Name}", app.Name);

--- a/SysManager/SysManager/Services/DialogService.cs
+++ b/SysManager/SysManager/Services/DialogService.cs
@@ -13,7 +13,12 @@ namespace SysManager.Services;
 public sealed class DialogService : IDialogService
 {
     /// <summary>Shared singleton instance for ViewModels without DI.</summary>
-    public static IDialogService Instance { get; set; } = new DialogService();
+    private static volatile IDialogService _instance = new DialogService();
+    public static IDialogService Instance
+    {
+        get => _instance;
+        set => _instance = value ?? throw new ArgumentNullException(nameof(value));
+    }
 
     /// <inheritdoc/>
     public bool Confirm(string message, string title)

--- a/SysManager/SysManager/Services/PerformanceService.cs
+++ b/SysManager/SysManager/Services/PerformanceService.cs
@@ -515,8 +515,10 @@ public class PerformanceService
         // escaping. AddParameter doesn't create script-scope variables.
         var safeDesc = (description ?? "SysManager Restore Point").Replace("'", "''");
         var script = $"Checkpoint-Computer -Description '{safeDesc}' -RestorePointType 'MODIFY_SETTINGS'";
-        var results = await _ps.RunAsync(script, null, ct).ConfigureAwait(false);
-        return results != null;
+        await _ps.RunAsync(script, null, ct).ConfigureAwait(false);
+        // If RunAsync completes without throwing, the command succeeded.
+        // Checkpoint-Computer produces no output on success but throws on failure.
+        return true;
     }
 
     // ═══════════════════════════════════════════════════════════════

--- a/SysManager/SysManager/Services/ServiceManagerService.cs
+++ b/SysManager/SysManager/Services/ServiceManagerService.cs
@@ -128,7 +128,7 @@ public class ServiceManagerService
         // hyphens, underscores, dots, and dollar signs only (covers all valid
         // Windows service names including instance names like MSSQL$INSTANCE).
         if (string.IsNullOrWhiteSpace(serviceName) ||
-            !System.Text.RegularExpressions.Regex.IsMatch(serviceName, @"^[\w\s\-.$]+$"))
+            !System.Text.RegularExpressions.Regex.IsMatch(serviceName, @"^[\w \-.$]+$"))
             throw new ArgumentException("Invalid service name.", nameof(serviceName));
 
         var allowedTypes = new[] { "auto", "delayed-auto", "demand", "disabled" };

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -326,7 +326,8 @@ public sealed class SpeedTestService
         if (!File.Exists(exe))
             throw new FileNotFoundException("speedtest.exe not found after extraction");
 
-        // Verify Authenticode signature on extracted binary
+        // Verify Authenticode signature on extracted binary — fail-closed.
+        // If the binary is not signed by Ookla, delete it and throw.
         await Task.Run(() =>
         {
             try
@@ -335,13 +336,20 @@ public sealed class SpeedTestService
                 var cert = System.Security.Cryptography.X509Certificates.X509Certificate.CreateFromSignedFile(exe);
 #pragma warning restore SYSLIB0057
                 if (cert == null || !cert.Subject.Contains("Ookla", StringComparison.OrdinalIgnoreCase))
+                {
                     Log.Warning("Ookla speedtest.exe Authenticode subject mismatch: {Subject}", cert?.Subject ?? "none");
-                else
-                    Log.Information("Ookla speedtest.exe Authenticode verified: {Subject}", cert.Subject);
+                    try { File.Delete(exe); } catch (IOException) { } catch (UnauthorizedAccessException) { }
+                    throw new InvalidOperationException(
+                        $"Ookla speedtest.exe failed Authenticode verification (subject: {cert?.Subject ?? "none"}). Binary deleted for security.");
+                }
+                Log.Information("Ookla speedtest.exe Authenticode verified: {Subject}", cert.Subject);
             }
             catch (System.Security.Cryptography.CryptographicException ex)
             {
                 Log.Warning(ex, "Ookla speedtest.exe has no valid Authenticode signature");
+                try { File.Delete(exe); } catch (IOException) { } catch (UnauthorizedAccessException) { }
+                throw new InvalidOperationException(
+                    "Ookla speedtest.exe has no valid Authenticode signature. Binary deleted for security.", ex);
             }
         }, ct).ConfigureAwait(false);
 

--- a/SysManager/SysManager/Services/TrayIconService.cs
+++ b/SysManager/SysManager/Services/TrayIconService.cs
@@ -115,7 +115,7 @@ public sealed class TrayIconService : IDisposable
         var exitItem = new System.Windows.Controls.MenuItem { Header = "Exit" };
         exitItem.Click += (_, _) =>
         {
-            Application.Current.Shutdown();
+            Application.Current?.Shutdown();
         };
         menu.Items.Add(exitItem);
 

--- a/SysManager/SysManager/Services/UninstallerService.cs
+++ b/SysManager/SysManager/Services/UninstallerService.cs
@@ -253,8 +253,16 @@ public sealed partial class UninstallerService
         // SEC-002: Validate the executable exists and is a real file (not a
         // script or arbitrary command). HKCU uninstall keys can be modified
         // without admin, so we must not blindly execute whatever is there.
-        if (!exe.StartsWith("MsiExec", StringComparison.OrdinalIgnoreCase) &&
-            !exe.StartsWith("rundll32", StringComparison.OrdinalIgnoreCase))
+        // Use exact filename match for system binaries to prevent bypass via
+        // similarly-named executables (e.g. "MsiExecEvil.exe").
+        var exeFileName = System.IO.Path.GetFileName(exe);
+        var isTrustedSystemBinary =
+            exeFileName.Equals("MsiExec.exe", StringComparison.OrdinalIgnoreCase) ||
+            exeFileName.Equals("MsiExec", StringComparison.OrdinalIgnoreCase) ||
+            exeFileName.Equals("rundll32.exe", StringComparison.OrdinalIgnoreCase) ||
+            exeFileName.Equals("rundll32", StringComparison.OrdinalIgnoreCase);
+
+        if (!isTrustedSystemBinary)
         {
             if (!System.IO.File.Exists(exe))
                 throw new InvalidOperationException(
@@ -301,8 +309,11 @@ public sealed partial class UninstallerService
             {
                 var exe = command[..spaceIdx];
                 var args = command[(spaceIdx + 1)..].TrimStart();
-                // Convert /I (modify) to /X (uninstall) if needed, add /quiet
-                args = args.Replace("/I", "/X", StringComparison.OrdinalIgnoreCase);
+                // Convert /I (modify) to /X (uninstall) if needed, add /quiet.
+                // Use regex to match /I only as a standalone switch (not inside GUIDs).
+                args = System.Text.RegularExpressions.Regex.Replace(
+                    args, @"(?<![A-Za-z0-9])/I(?![A-Za-z0-9])", "/X",
+                    System.Text.RegularExpressions.RegexOptions.IgnoreCase);
                 if (!args.Contains("/quiet", StringComparison.OrdinalIgnoreCase)
                     && !args.Contains("/qn", StringComparison.OrdinalIgnoreCase))
                     args += " /quiet /norestart";

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -222,9 +222,16 @@ public partial class AboutViewModel : ViewModelBase
         try
         {
             var text = await Task.Run(() => CollectEnvironmentInfo()).ConfigureAwait(true);
-            try { Clipboard.SetText(text); }
-            catch (System.Runtime.InteropServices.ExternalException ex) { Log.Debug("Clipboard locked: {Error}", ex.Message); }
-            UpdateStatus = "Environment info copied to clipboard.";
+            try
+            {
+                Clipboard.SetText(text);
+                UpdateStatus = "Environment info copied to clipboard.";
+            }
+            catch (System.Runtime.InteropServices.ExternalException ex)
+            {
+                Log.Debug("Clipboard locked: {Error}", ex.Message);
+                UpdateStatus = "Couldn't copy to clipboard: it's currently in use by another application.";
+            }
         }
         catch (System.Management.ManagementException ex)
         {

--- a/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
@@ -36,7 +36,7 @@ public partial class AppUpdatesViewModel : ViewModelBase
     {
         Log.Information("Admin elevation requested from App Updates tab");
         if (SysManager.Helpers.AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current.Shutdown();
+            System.Windows.Application.Current?.Shutdown();
     }
 
     partial void OnSelectAllChanged(bool value)

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -123,7 +123,7 @@ public partial class DashboardViewModel : ViewModelBase
     {
         Log.Information("Admin elevation requested from Dashboard");
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current.Shutdown();
+            System.Windows.Application.Current?.Shutdown();
     }
 
     // ── Tune-Up commands ───────────────────────────────────────────────

--- a/SysManager/SysManager/ViewModels/NetworkSharedState.cs
+++ b/SysManager/SysManager/ViewModels/NetworkSharedState.cs
@@ -321,9 +321,9 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
             touched.Add(sample.Host);
         }
 
-        foreach (var host in touched.Where(h => Buffers.ContainsKey(h)))
+        foreach (var host in touched)
         {
-            var buffer = Buffers[host];
+            if (!Buffers.TryGetValue(host, out var buffer)) continue;
             TrimBuffer(buffer);
             var target = Targets.FirstOrDefault(t => t.Host == host);
             if (target == null) continue;
@@ -490,5 +490,8 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
 
         // Dispose SKTypeface (unmanaged SkiaSharp memory) — LEAK-003
         LegendTextPaint.SKTypeface?.Dispose();
+        LegendBackgroundPaint.SKTypeface?.Dispose();
+        TooltipTextPaint.SKTypeface?.Dispose();
+        TooltipBackgroundPaint.SKTypeface?.Dispose();
     }
 }

--- a/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
@@ -47,6 +47,7 @@ public partial class WindowsFeaturesViewModel : ViewModelBase
         StatusMessage = "Querying Windows optional features…";
         AllFeatures.Clear();
         FilteredFeatures.Clear();
+        _cts?.Cancel();
         _cts?.Dispose();
         _cts = new CancellationTokenSource();
 
@@ -97,6 +98,7 @@ public partial class WindowsFeaturesViewModel : ViewModelBase
         ToggleFeatureCommand.NotifyCanExecuteChanged();
         feature.Status = feature.IsEnabled ? "Disabling…" : "Enabling…";
         StatusMessage = $"{(feature.IsEnabled ? "Disabling" : "Enabling")} {feature.DisplayName}…";
+        _cts?.Cancel();
         _cts?.Dispose();
         _cts = new CancellationTokenSource();
 
@@ -158,7 +160,7 @@ public partial class WindowsFeaturesViewModel : ViewModelBase
 
     protected override void Dispose(bool disposing)
     {
-        if (disposing) _cts?.Dispose();
+        if (disposing) { _cts?.Cancel(); _cts?.Dispose(); }
         base.Dispose(disposing);
     }
 

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -111,7 +111,7 @@ public partial class WindowsUpdateViewModel : ViewModelBase
         if (!AdminHelper.IsElevated())
         {
             StatusMessage = "Requesting admin rights...";
-            if (AdminHelper.RelaunchAsAdmin()) System.Windows.Application.Current.Shutdown();
+            if (AdminHelper.RelaunchAsAdmin()) System.Windows.Application.Current?.Shutdown();
             return;
         }
         IsBusy = true;
@@ -347,7 +347,7 @@ public partial class WindowsUpdateViewModel : ViewModelBase
         if (!AdminHelper.IsElevated())
         {
             StatusMessage = "Admin required. Relaunching elevated...";
-            if (AdminHelper.RelaunchAsAdmin()) System.Windows.Application.Current.Shutdown();
+            if (AdminHelper.RelaunchAsAdmin()) System.Windows.Application.Current?.Shutdown();
             return;
         }
         IsBusy = true;

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -250,7 +250,7 @@
                                         <TextBlock Text="{Binding Name}" Foreground="#C9D1D9" Margin="0,0,6,0"
                                                    VerticalAlignment="Center"/>
                                         <TextBlock Text="{Binding Verdict}" FontWeight="SemiBold"
-                                                   VerticalAlignment="Center" Foreground="#22C55E"/>
+                                                   VerticalAlignment="Center" Foreground="{Binding ColorHex}"/>
                                     </StackPanel>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
@@ -295,7 +295,7 @@
                         <!-- Overall verdict -->
                         <Separator Margin="0,8" Background="#21262D"/>
                         <TextBlock Text="{Binding TuneUpResult.OverallVerdict}" FontWeight="SemiBold" FontSize="13"
-                                   Foreground="#22C55E"/>
+                                   Foreground="{Binding TuneUpResult.OverallColorHex}"/>
                     </StackPanel>
                 </Border>
 


### PR DESCRIPTION
## Summary
Resolves 12 actionable findings raised in review across PRs #347, #351, #356, #361, #249, #264, #284, #286, #294, #296.

## Changes

### Security (Critical)
- **UninstallerService** — StartsWith allowlist replaced with exact filename match (prevents MsiExecEvil.exe bypass); /I replacement uses regex word-boundary
- **SpeedTestService** — Authenticode verification now fail-closed (deletes binary + throws on mismatch)

### Resource Leaks (Major)
- **NetworkSharedState** — all 4 paint SKTypeface instances disposed; TOCTOU ContainsKey+indexer replaced with TryGetValue
- **App.xaml.cs** — DI ServiceProvider disposed on exit

### Null Safety (Major)
- **Application.Current?.Shutdown()** — null-guard on all 5 call sites
- **DialogService** — singleton setter rejects null

### Logic Fixes
- **AboutViewModel** — clipboard false-success fixed
- **AppAlertService** — atomic TryAdd prevents duplicate notifications
- **PerformanceService** — removed always-true null check
- **ServiceManagerService** — regex \s narrowed to space only
- **WindowsFeaturesViewModel** — CTS cancelled before disposal

### UX
- **DashboardView** — verdict colors bound to model instead of hardcoded green

## Build
- 0 errors, 0 new warnings
- Tests compile clean
