### PR TITLE
fix: resolve 6 CodeQL alerts — empty-catch-block, missed-ternary-operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.9] - 2026-05-14
+
+### Fixed
+- **SpeedTestService** — empty catch blocks replaced with `Log.Debug` calls for
+  best-effort file cleanup (resolves 4 CodeQL `cs/empty-catch-block` alerts).
+- **WindowsFeaturesViewModel** — if/else replaced with ternary for enable/disable
+  dispatch (CodeQL `cs/missed-ternary-operator`).
+- **UninstallerViewModel** — if/else replaced with ternary for local vs winget
+  uninstall dispatch (CodeQL `cs/missed-ternary-operator`).
+
 ## [0.48.8] - 2026-05-14
 
 ### Fixed

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -210,8 +210,8 @@ public sealed class SpeedTestService
             if (proc.ExitCode == -1073741515) // STATUS_DLL_NOT_FOUND
             {
                 try { File.Delete(exe); }
-                catch (IOException) { /* cleanup failed — will retry next run */ }
-                catch (UnauthorizedAccessException) { /* cleanup failed — will retry next run */ }
+                catch (IOException ex) { Log.Debug("Cleanup failed (locked): {Error}", ex.Message); }
+                catch (UnauthorizedAccessException ex) { Log.Debug("Cleanup failed (access): {Error}", ex.Message); }
             }
             throw new InvalidOperationException($"Ookla failed ({proc.ExitCode}): {stderr}");
         }
@@ -271,8 +271,8 @@ public sealed class SpeedTestService
             if (File.Exists(path) && new FileInfo(path).Length < 1024)
             {
                 try { File.Delete(path); }
-                catch (IOException) { /* cleanup failed — will retry next run */ }
-                catch (UnauthorizedAccessException) { /* cleanup failed — will retry next run */ }
+                catch (IOException ex) { Log.Debug("Cleanup failed (locked): {Error}", ex.Message); }
+                catch (UnauthorizedAccessException ex) { Log.Debug("Cleanup failed (access): {Error}", ex.Message); }
             }
             return !File.Exists(path);
         }, ct).ConfigureAwait(false);
@@ -338,7 +338,9 @@ public sealed class SpeedTestService
                 if (cert == null || !cert.Subject.Contains("Ookla", StringComparison.OrdinalIgnoreCase))
                 {
                     Log.Warning("Ookla speedtest.exe Authenticode subject mismatch: {Subject}", cert?.Subject ?? "none");
-                    try { File.Delete(exe); } catch (IOException) { } catch (UnauthorizedAccessException) { }
+                    try { File.Delete(exe); }
+                    catch (IOException ex2) { Log.Debug("Cleanup failed (locked): {Error}", ex2.Message); }
+                    catch (UnauthorizedAccessException ex2) { Log.Debug("Cleanup failed (access): {Error}", ex2.Message); }
                     throw new InvalidOperationException(
                         $"Ookla speedtest.exe failed Authenticode verification (subject: {cert?.Subject ?? "none"}). Binary deleted for security.");
                 }
@@ -347,7 +349,9 @@ public sealed class SpeedTestService
             catch (System.Security.Cryptography.CryptographicException ex)
             {
                 Log.Warning(ex, "Ookla speedtest.exe has no valid Authenticode signature");
-                try { File.Delete(exe); } catch (IOException) { } catch (UnauthorizedAccessException) { }
+                try { File.Delete(exe); }
+                catch (IOException ex2) { Log.Debug("Cleanup failed (locked): {Error}", ex2.Message); }
+                catch (UnauthorizedAccessException ex2) { Log.Debug("Cleanup failed (access): {Error}", ex2.Message); }
                 throw new InvalidOperationException(
                     "Ookla speedtest.exe has no valid Authenticode signature. Binary deleted for security.", ex);
             }

--- a/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
@@ -109,18 +109,10 @@ public partial class UninstallerViewModel : ViewModelBase
 
                 try
                 {
-                    int code;
-                    if (string.IsNullOrWhiteSpace(app.Source)
+                    var code = (string.IsNullOrWhiteSpace(app.Source)
                         && !string.IsNullOrWhiteSpace(app.UninstallString))
-                    {
-                        // Local app — use registry UninstallString directly
-                        code = await _service.UninstallLocalAsync(app, _cts.Token);
-                    }
-                    else
-                    {
-                        // Winget-managed app — use winget uninstall
-                        code = await _service.UninstallAsync(app.Id, _cts.Token);
-                    }
+                        ? await _service.UninstallLocalAsync(app, _cts.Token)
+                        : await _service.UninstallAsync(app.Id, _cts.Token);
 
                     if (code == 0)
                     {

--- a/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
@@ -104,17 +104,9 @@ public partial class WindowsFeaturesViewModel : ViewModelBase
 
         try
         {
-            bool success;
-            bool reboot;
-
-            if (feature.IsEnabled)
-            {
-                (success, reboot) = await _service.DisableFeatureAsync(feature.Name, _cts.Token);
-            }
-            else
-            {
-                (success, reboot) = await _service.EnableFeatureAsync(feature.Name, _cts.Token);
-            }
+            var (success, reboot) = feature.IsEnabled
+                ? await _service.DisableFeatureAsync(feature.Name, _cts.Token)
+                : await _service.EnableFeatureAsync(feature.Name, _cts.Token);
 
             if (success)
             {


### PR DESCRIPTION
## Summary
Resolves 6 CodeQL alerts in source code.

## Changes

### cs/empty-catch-block (4 alerts)
- **SpeedTestService** — 4 empty catch blocks for best-effort File.Delete now log via Log.Debug instead of swallowing silently.

### cs/missed-ternary-operator (2 alerts)
- **WindowsFeaturesViewModel** — if/else enable/disable dispatch → ternary
- **UninstallerViewModel** — if/else local/winget dispatch → ternary

## Not addressed (acceptable/false-positive)
- cs/call-to-unmanaged-code (TuneUpService P/Invoke) — by design
- cs/call-to-obsolete-method (SpeedTestService) — already suppressed with pragma
- cs/path-combine — already using Path.Combine correctly
- cs/linq/missed-where — complex loop logic, LINQ wouldn't improve readability

## Build
- 0 errors, 0 new warnings
