### PR TITLE
test: improve test quality — [Collection] isolation, locale-safe assertions, stronger sanitize check

### DIFF
--- a/SysManager/SysManager.Tests/CleanupCategoryHumanSizeExtendedTests.cs
+++ b/SysManager/SysManager.Tests/CleanupCategoryHumanSizeExtendedTests.cs
@@ -123,7 +123,9 @@ public class CleanupCategoryHumanSizeExtendedTests
             LastModified = new DateTime(2024, 3, 1)
         };
         Assert.Contains("2024", entry.LastModifiedDisplay);
-        Assert.Contains("Mar", entry.LastModifiedDisplay);
+        // Use the expected month name from the current culture to avoid locale failures
+        var expectedMonth = new DateTime(2024, 3, 1).ToString("MMM", System.Globalization.CultureInfo.CurrentCulture);
+        Assert.Contains(expectedMonth, entry.LastModifiedDisplay);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/LogServiceSanitizeEdgeCaseTests.cs
+++ b/SysManager/SysManager.Tests/LogServiceSanitizeEdgeCaseTests.cs
@@ -39,10 +39,12 @@ public class LogServiceSanitizeEdgeCaseTests
     }
 
     [Fact]
-    public void SanitizePath_MultipleUsersInPath_ReplacesFirst()
+    public void SanitizePath_MultipleUsersInPath_ReplacesAll()
     {
         var result = LogService.SanitizePath(@"C:\Users\alice\backup\C:\Users\bob\file.txt");
         Assert.Contains("[user]", result);
+        Assert.DoesNotContain("alice", result);
+        Assert.DoesNotContain("bob", result);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/OperationLockServiceEdgeCaseTests.cs
+++ b/SysManager/SysManager.Tests/OperationLockServiceEdgeCaseTests.cs
@@ -3,6 +3,7 @@ using SysManager.Services;
 
 namespace SysManager.Tests;
 
+[Collection("OperationLock")]
 public class OperationLockServiceEdgeCaseTests
 {
     private static OperationLockService Service => OperationLockService.Instance;
@@ -117,14 +118,22 @@ public class OperationLockServiceEdgeCaseTests
     public void PropertyChanged_FiredOnAcquire()
     {
         var changed = new List<string>();
-        Service.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        void handler(object? _, System.ComponentModel.PropertyChangedEventArgs e) => changed.Add(e.PropertyName!);
+        Service.PropertyChanged += handler;
 
-        var handle = Service.TryAcquire(OperationCategory.Disk, "PropChanged");
-        Assert.NotNull(handle);
-        handle.Dispose();
+        try
+        {
+            var handle = Service.TryAcquire(OperationCategory.Disk, "PropChanged");
+            Assert.NotNull(handle);
+            handle.Dispose();
 
-        Assert.Contains("ActiveOperations", changed);
-        Assert.Contains("HasActiveOperations", changed);
+            Assert.Contains("ActiveOperations", changed);
+            Assert.Contains("HasActiveOperations", changed);
+        }
+        finally
+        {
+            Service.PropertyChanged -= handler;
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Addresses 3 test quality issues raised in review.

## Changes

### OperationLockServiceEdgeCaseTests
- Added [Collection(OperationLock)] to prevent parallel execution against shared singleton
- PropertyChanged handler now unsubscribed in finally block to prevent callback leaks

### CleanupCategoryHumanSizeExtendedTests
- Replaced hardcoded Mar assertion with culture-aware month format to prevent failures on non-English locales

### LogServiceSanitizeEdgeCaseTests
- Renamed test to ReplacesAll and added DoesNotContain assertions for both usernames to verify complete sanitization

## No release triggered
test: prefix — no version bump.
