### PR TITLE
fix: WQL escaping, atomic lock operations, safe CTS disposal (CQ-007, CQ-008, CQ-015)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.12] - 2026-05-15
+
+### Fixed
+- **DiskHealthService (CQ-007)** — WQL ASSOCIATORS OF query now escapes single
+  quotes in objectId, preventing potential WQL injection.
+- **OperationLockService (CQ-008)** — removed redundant lock object; TryAcquire
+  and Release now use ConcurrentDictionary atomic TryAdd/TryRemove directly.
+- **PingMonitorService (CQ-015)** — CancellationTokenSource only disposed if the
+  background loop actually completed, preventing ObjectDisposedException in
+  still-running pump tasks.
+
 ## [0.48.11] - 2026-05-15
 
 ### Fixed

--- a/SysManager/SysManager/Services/DiskHealthService.cs
+++ b/SysManager/SysManager/Services/DiskHealthService.cs
@@ -69,7 +69,7 @@ public sealed class DiskHealthService
         try
         {
             // Escape quotes & backslashes for the WQL literal.
-            var safeId = objectId.Replace("\\", "\\\\").Replace("\"", "\\\"");
+            var safeId = objectId.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("'", "\\'");
             var query = new ObjectQuery(
                 $"ASSOCIATORS OF {{MSFT_PhysicalDisk.ObjectId=\"{safeId}\"}} WHERE AssocClass=MSFT_PhysicalDiskToStorageReliabilityCounter");
             using var searcher = new ManagementObjectSearcher(scope, query);

--- a/SysManager/SysManager/Services/OperationLockService.cs
+++ b/SysManager/SysManager/Services/OperationLockService.cs
@@ -34,7 +34,6 @@ public sealed partial class OperationLockService : ObservableObject
     public static OperationLockService Instance => _instance.Value;
 
     private readonly ConcurrentDictionary<OperationCategory, OperationInfo> _active = new();
-    private readonly object _lock = new();
 
     private OperationLockService() { }
 
@@ -47,17 +46,13 @@ public sealed partial class OperationLockService : ObservableObject
     /// <returns>A disposable lock handle, or null if the category is busy.</returns>
     public OperationHandle? TryAcquire(OperationCategory category, string operationName)
     {
-        lock (_lock)
-        {
-            if (_active.ContainsKey(category))
-                return null;
+        var info = new OperationInfo(operationName, DateTime.UtcNow);
+        if (!_active.TryAdd(category, info))
+            return null;
 
-            var info = new OperationInfo(operationName, DateTime.UtcNow);
-            _active[category] = info;
-            OnPropertyChanged(nameof(ActiveOperations));
-            OnPropertyChanged(nameof(HasActiveOperations));
-            return new OperationHandle(this, category);
-        }
+        OnPropertyChanged(nameof(ActiveOperations));
+        OnPropertyChanged(nameof(HasActiveOperations));
+        return new OperationHandle(this, category);
     }
 
     /// <summary>
@@ -84,12 +79,9 @@ public sealed partial class OperationLockService : ObservableObject
 
     private void Release(OperationCategory category)
     {
-        lock (_lock)
-        {
-            _active.TryRemove(category, out _);
-            OnPropertyChanged(nameof(ActiveOperations));
-            OnPropertyChanged(nameof(HasActiveOperations));
-        }
+        _active.TryRemove(category, out _);
+        OnPropertyChanged(nameof(ActiveOperations));
+        OnPropertyChanged(nameof(HasActiveOperations));
     }
 
     /// <summary>

--- a/SysManager/SysManager/Services/PingMonitorService.cs
+++ b/SysManager/SysManager/Services/PingMonitorService.cs
@@ -56,7 +56,11 @@ public sealed class PingMonitorService : IDisposable
             try { _loop?.Wait(1500); }
             catch (AggregateException) { /* task cancellation or faulted — expected during stop */ }
             catch (ObjectDisposedException) { /* task already cleaned up */ }
-            _cts?.Dispose();
+            // Only dispose CTS if the loop actually completed; otherwise the
+            // background task still holds a reference to the token and would
+            // throw ObjectDisposedException on next cancellation check.
+            if (_loop is { IsCompleted: true })
+                _cts?.Dispose();
             _cts = null;
             _loop = null;
         }


### PR DESCRIPTION
## Summary
Addresses 3 MEDIUM findings from QA audit.

## Changes

### CQ-007: DiskHealthService WQL injection (MEDIUM)
- Added single-quote escaping to WQL ASSOCIATORS OF query objectId
- Prevents potential WQL injection if disk ObjectId contains quotes

### CQ-008: OperationLockService redundant lock (MEDIUM)
- Removed lock object; TryAcquire uses atomic ConcurrentDictionary.TryAdd
- Release uses atomic TryRemove
- Eliminates unnecessary contention while maintaining thread safety

### CQ-015: PingMonitorService CTS race (MEDIUM)
- CTS now only disposed if background loop task IsCompleted
- Prevents ObjectDisposedException when pump doesn't exit within 1.5s timeout

## Build
- 0 errors (main + tests)
