### PR TITLE
fix: PATH hijacking, orphan process kill, log privacy sanitization (SEC-007, SEC-008, PRIV-001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.13] - 2026-05-15
+
+### Fixed
+- **UninstallerService (SEC-007)** — trusted system binaries (MsiExec, rundll32)
+  now resolved to absolute System32 path before execution, preventing PATH
+  hijacking attacks.
+- **SpeedTestService (SEC-008)** — Ookla CLI process now killed on timeout or
+  cancellation, preventing orphan processes consuming resources indefinitely.
+- **SpeedTestService (PRIV-001)** — all exception messages in Log.Debug calls
+  now sanitized via LogService.SanitizePath to prevent username leakage in logs.
+
 ## [0.48.12] - 2026-05-15
 
 ### Fixed

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -207,7 +207,17 @@ public sealed class SpeedTestService
         await Task.Run(() => proc.Start(), linked).ConfigureAwait(false);
         var stdout = await proc.StandardOutput.ReadToEndAsync(linked);
         var stderr = await proc.StandardError.ReadToEndAsync(linked);
-        await proc.WaitForExitAsync(linked);
+        try
+        {
+            await proc.WaitForExitAsync(linked);
+        }
+        catch (OperationCanceledException)
+        {
+            // Timeout or user cancellation — kill the orphan process
+            try { if (!proc.HasExited) proc.Kill(entireProcessTree: true); }
+            catch (InvalidOperationException) { /* already exited */ }
+            throw;
+        }
 
         if (proc.ExitCode != 0)
         {
@@ -215,8 +225,8 @@ public sealed class SpeedTestService
             if (proc.ExitCode == -1073741515) // STATUS_DLL_NOT_FOUND
             {
                 try { File.Delete(exe); }
-                catch (IOException ex) { Log.Debug("Cleanup failed (locked): {Error}", ex.Message); }
-                catch (UnauthorizedAccessException ex) { Log.Debug("Cleanup failed (access): {Error}", ex.Message); }
+                catch (IOException ex2) { Log.Debug("Cleanup failed (locked): {Error}", LogService.SanitizePath(ex2.Message)); }
+                catch (UnauthorizedAccessException ex2) { Log.Debug("Cleanup failed (access): {Error}", LogService.SanitizePath(ex2.Message)); }
             }
             throw new InvalidOperationException($"Ookla failed ({proc.ExitCode}): {stderr}");
         }
@@ -276,8 +286,8 @@ public sealed class SpeedTestService
             if (File.Exists(path) && new FileInfo(path).Length < 1024)
             {
                 try { File.Delete(path); }
-                catch (IOException ex) { Log.Debug("Cleanup failed (locked): {Error}", ex.Message); }
-                catch (UnauthorizedAccessException ex) { Log.Debug("Cleanup failed (access): {Error}", ex.Message); }
+                catch (IOException ex) { Log.Debug("Cleanup failed (locked): {Error}", LogService.SanitizePath(ex.Message)); }
+                catch (UnauthorizedAccessException ex) { Log.Debug("Cleanup failed (access): {Error}", LogService.SanitizePath(ex.Message)); }
             }
             return !File.Exists(path);
         }, ct).ConfigureAwait(false);
@@ -344,8 +354,8 @@ public sealed class SpeedTestService
                 {
                     Log.Warning("Ookla speedtest.exe Authenticode subject mismatch: {Subject}", cert?.Subject ?? "none");
                     try { File.Delete(exe); }
-                    catch (IOException ex2) { Log.Debug("Cleanup failed (locked): {Error}", ex2.Message); }
-                    catch (UnauthorizedAccessException ex2) { Log.Debug("Cleanup failed (access): {Error}", ex2.Message); }
+                    catch (IOException ex2) { Log.Debug("Cleanup failed (locked): {Error}", LogService.SanitizePath(ex2.Message)); }
+                    catch (UnauthorizedAccessException ex2) { Log.Debug("Cleanup failed (access): {Error}", LogService.SanitizePath(ex2.Message)); }
                     throw new InvalidOperationException(
                         $"Ookla speedtest.exe failed Authenticode verification (subject: {cert?.Subject ?? "none"}). Binary deleted for security.");
                 }
@@ -355,8 +365,8 @@ public sealed class SpeedTestService
             {
                 Log.Warning(ex, "Ookla speedtest.exe has no valid Authenticode signature");
                 try { File.Delete(exe); }
-                catch (IOException ex2) { Log.Debug("Cleanup failed (locked): {Error}", ex2.Message); }
-                catch (UnauthorizedAccessException ex2) { Log.Debug("Cleanup failed (access): {Error}", ex2.Message); }
+                catch (IOException ex2) { Log.Debug("Cleanup failed (locked): {Error}", LogService.SanitizePath(ex2.Message)); }
+                catch (UnauthorizedAccessException ex2) { Log.Debug("Cleanup failed (access): {Error}", LogService.SanitizePath(ex2.Message)); }
                 throw new InvalidOperationException(
                     "Ookla speedtest.exe has no valid Authenticode signature. Binary deleted for security.", ex);
             }

--- a/SysManager/SysManager/Services/UninstallerService.cs
+++ b/SysManager/SysManager/Services/UninstallerService.cs
@@ -255,6 +255,7 @@ public sealed partial class UninstallerService
         // without admin, so we must not blindly execute whatever is there.
         // Use exact filename match for system binaries to prevent bypass via
         // similarly-named executables (e.g. "MsiExecEvil.exe").
+        // Resolve trusted binaries to absolute System32 path to prevent PATH hijacking.
         var exeFileName = System.IO.Path.GetFileName(exe);
         var isTrustedSystemBinary =
             exeFileName.Equals("MsiExec.exe", StringComparison.OrdinalIgnoreCase) ||
@@ -262,7 +263,15 @@ public sealed partial class UninstallerService
             exeFileName.Equals("rundll32.exe", StringComparison.OrdinalIgnoreCase) ||
             exeFileName.Equals("rundll32", StringComparison.OrdinalIgnoreCase);
 
-        if (!isTrustedSystemBinary)
+        if (isTrustedSystemBinary)
+        {
+            // Resolve to absolute path in System32 to prevent PATH hijacking
+            var systemDir = Environment.GetFolderPath(Environment.SpecialFolder.System);
+            var resolvedName = exeFileName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+                ? exeFileName : exeFileName + ".exe";
+            exe = System.IO.Path.Combine(systemDir, resolvedName);
+        }
+        else
         {
             if (!System.IO.File.Exists(exe))
                 throw new InvalidOperationException(


### PR DESCRIPTION
## Summary
PRIORITY 1 security/reliability fixes from QA audit.

## Changes

### SEC-007: PATH hijacking prevention (CRITICAL)
- MsiExec.exe and rundll32.exe now resolved to absolute System32 path
- Prevents attacker from placing malicious binary in PATH ahead of System32
- Uses Environment.GetFolderPath(SpecialFolder.System) for reliable resolution

### SEC-008: Orphan process kill (CRITICAL)
- WaitForExitAsync now wrapped in try/catch(OperationCanceledException)
- On timeout/cancellation, proc.Kill(entireProcessTree: true) is called
- Prevents Ookla CLI from running indefinitely after user cancels or timeout fires

### PRIV-001: Log privacy sanitization (MEDIUM)
- All ex.Message values in SpeedTestService Log.Debug calls now pass through LogService.SanitizePath
- Prevents username leakage via %LOCALAPPDATA% paths in exception messages

## Build
- 0 errors, 0 new warnings
