### PR TITLE
fix: CTS disposal before re-creation, NavItem IDisposable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.17] - 2026-05-15
+
+### Fixed
+- **DeepCleanupViewModel** — dispose previous CancellationTokenSource before
+  creating a new one in Scan/Clean/LargeScan (3 locations). Prevents kernel
+  handle leak on repeated operations.
+- **SpeedTestViewModel** — same CTS disposal fix (2 locations: HTTP + Ookla).
+- **TracerouteViewModel** — same CTS disposal fix.
+- **ShortcutCleanerViewModel** — same CTS disposal fix.
+- **NavItem** — implement `IDisposable` to unsubscribe `PropertyChanged`
+  handler from ViewModel on teardown. Previously 51 subscriptions leaked
+  permanently. `MainWindowViewModel.Dispose()` now disposes all NavItems.
+
 ## [0.48.14] - 2026-05-15
 
 ### Fixed

--- a/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
@@ -152,6 +152,7 @@ public partial class DeepCleanupViewModel : ViewModelBase
         ScanEtaText = "";
         _scanEta.Reset();
         ScanSummary = "Scanning safe cleanup locations...";
+        _scanCts?.Dispose();
         _scanCts = new CancellationTokenSource();
         try
         {
@@ -204,6 +205,7 @@ public partial class DeepCleanupViewModel : ViewModelBase
         CleanEtaText = "";
         _cleanEta.Reset();
         CleanSummary = "Cleaning selected categories — you can keep using the app.";
+        _cleanCts?.Dispose();
         _cleanCts = new CancellationTokenSource();
         try
         {
@@ -264,6 +266,7 @@ public partial class DeepCleanupViewModel : ViewModelBase
         LargeBytesScanned = 0;
         LargeCurrentFolder = string.Empty;
         LargeScanStatus = $"Scanning {SelectedLocation.Label.Trim()}...";
+        _largeCts?.Dispose();
         _largeCts = new CancellationTokenSource();
         try
         {

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -444,6 +444,10 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
     public void Dispose()
     {
+        // Dispose NavItems to unsubscribe PropertyChanged handlers
+        foreach (var item in NavItems)
+            item.Dispose();
+
         Dashboard?.Dispose();
         AppUpdates?.Dispose();
         WindowsUpdate?.Dispose();

--- a/SysManager/SysManager/ViewModels/NavItem.cs
+++ b/SysManager/SysManager/ViewModels/NavItem.cs
@@ -13,8 +13,10 @@ namespace SysManager.ViewModels;
 /// access — keeps unit tests STA-free and makes the VM cheap to construct.
 /// Exposes <see cref="IsBusy"/> from the underlying ViewModel so the sidebar
 /// can show a progress indicator when the tab is working.
+/// Implements <see cref="IDisposable"/> to unsubscribe from ViewModel
+/// PropertyChanged events on teardown.
 /// </summary>
-public sealed partial class NavItem : ObservableObject
+public sealed partial class NavItem : ObservableObject, IDisposable
 {
     private UserControl? _view;
 
@@ -34,6 +36,13 @@ public sealed partial class NavItem : ObservableObject
         if (Content is ViewModelBase vm)
             vm.PropertyChanged += OnViewModelPropertyChanged;
         return this;
+    }
+
+    /// <summary>Unsubscribe from ViewModel events to prevent memory leaks.</summary>
+    public void Dispose()
+    {
+        if (Content is ViewModelBase vm)
+            vm.PropertyChanged -= OnViewModelPropertyChanged;
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
@@ -54,6 +54,7 @@ public partial class ShortcutCleanerViewModel : ViewModelBase
         BrokenCount = 0;
         SelectedCount = 0;
         ScanStatus = "Scanning...";
+        _cts?.Dispose();
         _cts = new CancellationTokenSource();
 
         try

--- a/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
@@ -79,6 +79,7 @@ public partial class SpeedTestViewModel : ViewModelBase
         EstimatedTime = "";
         _eta.Reset();
         HttpStatus = "Starting HTTP speed test…";
+        _speedCts?.Dispose();
         _speedCts = new CancellationTokenSource();
         var progress = new Progress<(int p, string m)>(t =>
         { SpeedProgress = t.p; HttpStatus = t.m; EstimatedTime = _eta.Update(t.p); });
@@ -119,6 +120,7 @@ public partial class SpeedTestViewModel : ViewModelBase
         EstimatedTime = "";
         _eta.Reset();
         OoklaStatus = "Starting Ookla speed test…";
+        _speedCts?.Dispose();
         _speedCts = new CancellationTokenSource();
         var progress = new Progress<(int p, string m)>(t =>
         { SpeedProgress = t.p; OoklaStatus = t.m; EstimatedTime = _eta.Update(t.p); });

--- a/SysManager/SysManager/ViewModels/TracerouteViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TracerouteViewModel.cs
@@ -69,6 +69,7 @@ public partial class TracerouteViewModel : ViewModelBase
         IsTracing = true;
         TraceStatus = $"Tracing {TraceHost}…";
 
+        _traceCts?.Dispose();
         _traceCts = new CancellationTokenSource();
         var collected = new List<TracerouteHop>();
         void OnHop(TracerouteHop hop)


### PR DESCRIPTION
## Summary

Fixes kernel handle leaks and memory leaks from CancellationTokenSource re-creation and permanent event subscriptions.

### CTS Disposal (VM-01, VM-02, VM-03, VM-04)
- **DeepCleanupViewModel** — 3 locations where a new CTS was created without disposing the previous one (Scan, Clean, LargeScan).
- **SpeedTestViewModel** — 2 locations (HTTP test, Ookla test).
- **TracerouteViewModel** — 1 location.
- **ShortcutCleanerViewModel** — 1 location.
- **Fix:** Added _cts?.Dispose() before each new CancellationTokenSource().

Each undisposed CTS leaks a kernel WaitHandle. On repeated operations (user clicks Scan multiple times), handles accumulate until app restart.

### NavItem Memory Leak (H-09)
- **NavItem** subscribed to ViewModel.PropertyChanged via WireBusy() but never unsubscribed. With 51 NavItems, this created 51 permanent subscriptions that prevented GC of ViewModels even after MainWindowViewModel.Dispose().
- **Fix:** NavItem now implements IDisposable. MainWindowViewModel.Dispose() iterates all NavItems and calls Dispose() to unsubscribe.

## Build
- 0 errors, 16 warnings (all pre-existing)
- Tests project: 0 errors
