### PR TITLE
fix: WMI disposal, operation lock deadlock, separate CTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.18] - 2026-05-15
+
+### Fixed
+- **SystemInfoService** — `QueryMemory()` and `QueryDisks()` now properly
+  dispose `ManagementObject` and `ManagementObjectCollection` instances via
+  `using` statements (4 foreach loops fixed, prevents COM handle leaks).
+- **FixedDriveService** — same WMI disposal fix for MSFT_PhysicalDisk query.
+- **DeepCleanupViewModel** — post-clean rescan no longer deadlocks on the
+  operation lock. Extracted `ScanCoreAsync()` (lock-free) called from
+  `CleanAsync` which already holds the disk lock.
+- **WindowsFeaturesViewModel** — separated shared `_cts` into `_scanCts` and
+  `_toggleCts` so toggling a feature no longer cancels a running scan.
+
 ## [0.48.17] - 2026-05-15
 
 ### Fixed

--- a/SysManager/SysManager/Services/FixedDriveService.cs
+++ b/SysManager/SysManager/Services/FixedDriveService.cs
@@ -57,12 +57,16 @@ public sealed class FixedDriveService
 
             using var search = new ManagementObjectSearcher(scope,
                 new ObjectQuery("SELECT DeviceId, MediaType, BusType FROM MSFT_PhysicalDisk"));
-            foreach (ManagementObject mo in search.Get())
+            using var physCollection = search.Get();
+            foreach (ManagementObject mo in physCollection)
             {
-                var id = mo["DeviceId"]?.ToString() ?? "";
-                media[id] = (
-                    MapMedia(Convert.ToUInt32(mo["MediaType"] ?? 0u)),
-                    MapBus(Convert.ToUInt32(mo["BusType"] ?? 0u)));
+                using (mo)
+                {
+                    var id = mo["DeviceId"]?.ToString() ?? "";
+                    media[id] = (
+                        MapMedia(Convert.ToUInt32(mo["MediaType"] ?? 0u)),
+                        MapBus(Convert.ToUInt32(mo["BusType"] ?? 0u)));
+                }
             }
 
             // We can't easily map DeviceId -> drive letter without another join,

--- a/SysManager/SysManager/Services/SystemInfoService.cs
+++ b/SysManager/SysManager/Services/SystemInfoService.cs
@@ -72,10 +72,14 @@ public sealed class SystemInfoService
         double totalKb = 0, freeKb = 0;
         using (var s = new ManagementObjectSearcher("SELECT TotalVisibleMemorySize,FreePhysicalMemory FROM Win32_OperatingSystem"))
         {
-            foreach (ManagementObject mo in s.Get())
+            using var memCollection = s.Get();
+            foreach (ManagementObject mo in memCollection)
             {
-                totalKb = Convert.ToDouble(mo["TotalVisibleMemorySize"] ?? 0);
-                freeKb = Convert.ToDouble(mo["FreePhysicalMemory"] ?? 0);
+                using (mo)
+                {
+                    totalKb = Convert.ToDouble(mo["TotalVisibleMemorySize"] ?? 0);
+                    freeKb = Convert.ToDouble(mo["FreePhysicalMemory"] ?? 0);
+                }
             }
         }
         double totalGB = totalKb / 1024d / 1024d;
@@ -86,15 +90,19 @@ public sealed class SystemInfoService
         var modules = new List<MemoryModule>();
         using (var s = new ManagementObjectSearcher("SELECT BankLabel,Manufacturer,Capacity,Speed,PartNumber FROM Win32_PhysicalMemory"))
         {
-            foreach (ManagementObject mo in s.Get())
+            using var modCollection = s.Get();
+            foreach (ManagementObject mo in modCollection)
             {
-                double capBytes = Convert.ToDouble(mo["Capacity"] ?? 0);
-                modules.Add(new MemoryModule(
-                    mo["BankLabel"]?.ToString() ?? "",
-                    mo["Manufacturer"]?.ToString()?.Trim() ?? "",
-                    capBytes / 1024d / 1024d / 1024d,
-                    Convert.ToUInt32(mo["Speed"] ?? 0u),
-                    mo["PartNumber"]?.ToString()?.Trim() ?? ""));
+                using (mo)
+                {
+                    double capBytes = Convert.ToDouble(mo["Capacity"] ?? 0);
+                    modules.Add(new MemoryModule(
+                        mo["BankLabel"]?.ToString() ?? "",
+                        mo["Manufacturer"]?.ToString()?.Trim() ?? "",
+                        capBytes / 1024d / 1024d / 1024d,
+                        Convert.ToUInt32(mo["Speed"] ?? 0u),
+                        mo["PartNumber"]?.ToString()?.Trim() ?? ""));
+                }
             }
         }
         return new MemoryInfo(totalGB, freeGB, usedGB, pct, modules);
@@ -110,47 +118,55 @@ public sealed class SystemInfoService
             scope.Connect();
             var query = new ObjectQuery("SELECT FriendlyName,MediaType,BusType,Size,HealthStatus,OperationalStatus FROM MSFT_PhysicalDisk");
             using var searcher = new ManagementObjectSearcher(scope, query);
-            foreach (ManagementObject mo in searcher.Get())
+            using var diskCollection = searcher.Get();
+            foreach (ManagementObject mo in diskCollection)
             {
-                var size = Convert.ToDouble(mo["Size"] ?? 0) / 1024d / 1024d / 1024d;
-                var mediaType = (ushort)Convert.ToUInt32(mo["MediaType"] ?? 0u) switch
+                using (mo)
                 {
-                    3 => "HDD",
-                    4 => "SSD",
-                    5 => "SCM",
-                    _ => "Unspecified"
-                };
-                var busType = (ushort)Convert.ToUInt32(mo["BusType"] ?? 0u) switch
-                {
-                    1 => "SCSI", 2 => "ATAPI", 3 => "ATA", 4 => "1394", 5 => "SSA",
-                    6 => "Fibre", 7 => "USB", 8 => "RAID", 9 => "iSCSI", 10 => "SAS",
-                    11 => "SATA", 12 => "SD", 13 => "MMC", 17 => "NVMe",
-                    _ => "Other"
-                };
-                var health = (ushort)Convert.ToUInt32(mo["HealthStatus"] ?? 0u) switch
-                {
-                    0 => "Healthy", 1 => "Warning", 2 => "Unhealthy", _ => "Unknown"
-                };
-                var opStatus = mo["OperationalStatus"] is ushort[] arr && arr.Length > 0
-                    ? string.Join(",", arr.Select(OpStatusName))
-                    : "Unknown";
-                list.Add(new DiskInfo(
-                    mo["FriendlyName"]?.ToString() ?? "Disk",
-                    mediaType, busType, size, health, opStatus, null, null));
+                    var size = Convert.ToDouble(mo["Size"] ?? 0) / 1024d / 1024d / 1024d;
+                    var mediaType = (ushort)Convert.ToUInt32(mo["MediaType"] ?? 0u) switch
+                    {
+                        3 => "HDD",
+                        4 => "SSD",
+                        5 => "SCM",
+                        _ => "Unspecified"
+                    };
+                    var busType = (ushort)Convert.ToUInt32(mo["BusType"] ?? 0u) switch
+                    {
+                        1 => "SCSI", 2 => "ATAPI", 3 => "ATA", 4 => "1394", 5 => "SSA",
+                        6 => "Fibre", 7 => "USB", 8 => "RAID", 9 => "iSCSI", 10 => "SAS",
+                        11 => "SATA", 12 => "SD", 13 => "MMC", 17 => "NVMe",
+                        _ => "Other"
+                    };
+                    var health = (ushort)Convert.ToUInt32(mo["HealthStatus"] ?? 0u) switch
+                    {
+                        0 => "Healthy", 1 => "Warning", 2 => "Unhealthy", _ => "Unknown"
+                    };
+                    var opStatus = mo["OperationalStatus"] is ushort[] arr && arr.Length > 0
+                        ? string.Join(",", arr.Select(OpStatusName))
+                        : "Unknown";
+                    list.Add(new DiskInfo(
+                        mo["FriendlyName"]?.ToString() ?? "Disk",
+                        mediaType, busType, size, health, opStatus, null, null));
+                }
             }
         }
         catch (ManagementException)
         {
             // Fallback to Win32_DiskDrive if MSFT_PhysicalDisk isn't available
             using var s = new ManagementObjectSearcher("SELECT Model,Size,Status FROM Win32_DiskDrive");
-            foreach (ManagementObject mo in s.Get())
+            using var fallbackCollection = s.Get();
+            foreach (ManagementObject mo in fallbackCollection)
             {
-                var size = Convert.ToDouble(mo["Size"] ?? 0) / 1024d / 1024d / 1024d;
-                list.Add(new DiskInfo(
-                    mo["Model"]?.ToString() ?? "Disk",
-                    "Unknown", "Unknown", size,
-                    mo["Status"]?.ToString() ?? "Unknown",
-                    "Unknown", null, null));
+                using (mo)
+                {
+                    var size = Convert.ToDouble(mo["Size"] ?? 0) / 1024d / 1024d / 1024d;
+                    list.Add(new DiskInfo(
+                        mo["Model"]?.ToString() ?? "Disk",
+                        "Unknown", "Unknown", size,
+                        mo["Status"]?.ToString() ?? "Unknown",
+                        "Unknown", null, null));
+                }
             }
         }
         return list;

--- a/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
@@ -146,6 +146,15 @@ public partial class DeepCleanupViewModel : ViewModelBase
             ScanSummary = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.Disk)} is already running.";
             return;
         }
+        await ScanCoreAsync();
+    }
+
+    /// <summary>
+    /// Inner scan logic without lock acquisition. Called directly from CleanAsync
+    /// (which already holds the disk operation lock) to avoid deadlock.
+    /// </summary>
+    private async Task ScanCoreAsync()
+    {
         IsScanning = true;
         ScanProgress = 0;
         ScanStatusLine = "Starting...";
@@ -219,7 +228,7 @@ public partial class DeepCleanupViewModel : ViewModelBase
             CleanSummary = result.Summary;
             CleanStatusLine = "Clean complete.";
             Log.Information("Deep cleanup completed");
-            await ScanAsync();
+            await ScanCoreAsync();
         }
         catch (OperationCanceledException) { CleanSummary = "Clean cancelled."; CleanStatusLine = "Cancelled."; }
         catch (IOException ex) { CleanSummary = $"Clean failed: {ex.Message}"; }

--- a/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
@@ -19,7 +19,8 @@ namespace SysManager.ViewModels;
 public partial class WindowsFeaturesViewModel : ViewModelBase
 {
     private readonly WindowsFeaturesService _service;
-    private CancellationTokenSource? _cts;
+    private CancellationTokenSource? _scanCts;
+    private CancellationTokenSource? _toggleCts;
 
     public ObservableCollection<WindowsFeature> AllFeatures { get; } = new();
     public ObservableCollection<WindowsFeature> FilteredFeatures { get; } = new();
@@ -47,13 +48,13 @@ public partial class WindowsFeaturesViewModel : ViewModelBase
         StatusMessage = "Querying Windows optional features…";
         AllFeatures.Clear();
         FilteredFeatures.Clear();
-        _cts?.Cancel();
-        _cts?.Dispose();
-        _cts = new CancellationTokenSource();
+        _scanCts?.Cancel();
+        _scanCts?.Dispose();
+        _scanCts = new CancellationTokenSource();
 
         try
         {
-            var list = await _service.ListFeaturesAsync(_cts.Token);
+            var list = await _service.ListFeaturesAsync(_scanCts.Token);
             foreach (var feature in list)
                 AllFeatures.Add(feature);
 
@@ -98,15 +99,15 @@ public partial class WindowsFeaturesViewModel : ViewModelBase
         ToggleFeatureCommand.NotifyCanExecuteChanged();
         feature.Status = feature.IsEnabled ? "Disabling…" : "Enabling…";
         StatusMessage = $"{(feature.IsEnabled ? "Disabling" : "Enabling")} {feature.DisplayName}…";
-        _cts?.Cancel();
-        _cts?.Dispose();
-        _cts = new CancellationTokenSource();
+        _toggleCts?.Cancel();
+        _toggleCts?.Dispose();
+        _toggleCts = new CancellationTokenSource();
 
         try
         {
             var (success, reboot) = feature.IsEnabled
-                ? await _service.DisableFeatureAsync(feature.Name, _cts.Token)
-                : await _service.EnableFeatureAsync(feature.Name, _cts.Token);
+                ? await _service.DisableFeatureAsync(feature.Name, _toggleCts.Token)
+                : await _service.EnableFeatureAsync(feature.Name, _toggleCts.Token);
 
             if (success)
             {
@@ -146,13 +147,21 @@ public partial class WindowsFeaturesViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void Cancel() => _cts?.Cancel();
+    private void Cancel()
+    {
+        _scanCts?.Cancel();
+        _toggleCts?.Cancel();
+    }
 
     private bool CanToggle(WindowsFeature? _) => !IsBusy;
 
     protected override void Dispose(bool disposing)
     {
-        if (disposing) { _cts?.Cancel(); _cts?.Dispose(); }
+        if (disposing)
+        {
+            _scanCts?.Cancel(); _scanCts?.Dispose();
+            _toggleCts?.Cancel(); _toggleCts?.Dispose();
+        }
         base.Dispose(disposing);
     }
 


### PR DESCRIPTION
## Summary

Fixes WMI COM handle leaks, operation lock deadlock, and shared CTS interference.

### WMI Disposal (SVC-43-45, SVC-15)
- **SystemInfoService** — QueryMemory() and QueryDisks() iterated ManagementObject without using(mo). 4 foreach loops now properly dispose both the collection and each ManagementObject, preventing COM handle accumulation.
- **FixedDriveService** — same fix for MSFT_PhysicalDisk enumeration.

### Operation Lock Deadlock (VM-16)
- **DeepCleanupViewModel** — CleanAsync() held the disk operation lock while calling ScanAsync() for post-clean rescan. ScanAsync() tried to acquire the same lock and always failed silently, leaving the user with stale data.
- **Fix:** Extracted ScanCoreAsync() (lock-free inner logic). CleanAsync now calls ScanCoreAsync directly since it already holds the disk lock.

### Shared CTS Interference (VM-17)
- **WindowsFeaturesViewModel** — single _cts was shared between scan and toggle operations. Starting a toggle cancelled any running scan.
- **Fix:** Separated into _scanCts and _toggleCts with independent lifecycle.

## Build
- 0 errors, 16 warnings (all pre-existing)
- Tests project: 0 errors
