### PR TITLE
fix: reparse point checks, safe enumeration, async void guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.19] - 2026-05-15
+
+### Fixed
+- **DuplicateFileService** — skip reparse points (symlinks, junctions) during
+  directory traversal to prevent infinite loops on circular symlinks.
+- **LargeFileScanner** — same reparse point check added.
+- **DeepCleanupService** — `EnumerateFiles()` now catches `IOException` and
+  `UnauthorizedAccessException` during `MoveNext()` iteration, not just at
+  enumerator creation. Prevents crashes on files that become inaccessible
+  mid-scan.
+- **TrayIconService** — `OnTimerTick` (async void) now wraps the entire call
+  in try-catch to prevent unhandled exceptions from crashing the application.
+
 ## [0.48.18] - 2026-05-15
 
 ### Fixed

--- a/SysManager/SysManager/Services/DeepCleanupService.cs
+++ b/SysManager/SysManager/Services/DeepCleanupService.cs
@@ -380,7 +380,19 @@ public sealed class DeepCleanupService
             IEnumerable<string> dirs;
             try { files = Directory.EnumerateFiles(cur); } catch (IOException) { continue; } catch (UnauthorizedAccessException) { continue; }
             try { dirs = Directory.EnumerateDirectories(cur); } catch (IOException) { dirs = []; } catch (UnauthorizedAccessException) { dirs = []; }
-            foreach (var f in files) yield return f;
+
+            // Wrap iteration to handle exceptions thrown during MoveNext()
+            // (e.g., file becomes inaccessible mid-enumeration).
+            using var enumerator = files.GetEnumerator();
+            while (true)
+            {
+                string? item;
+                try { if (!enumerator.MoveNext()) break; item = enumerator.Current; }
+                catch (IOException) { continue; }
+                catch (UnauthorizedAccessException) { continue; }
+                yield return item;
+            }
+
             foreach (var d in dirs) stack.Push(d);
         }
     }

--- a/SysManager/SysManager/Services/DuplicateFileService.cs
+++ b/SysManager/SysManager/Services/DuplicateFileService.cs
@@ -107,7 +107,16 @@ public sealed class DuplicateFileService
                 catch (IOException) { /* skip inaccessible file */ }
             }
 
-            foreach (var d in dirs) stack.Push(d);
+            foreach (var d in dirs)
+            {
+                try
+                {
+                    if ((File.GetAttributes(d) & FileAttributes.ReparsePoint) != 0) continue;
+                }
+                catch (IOException) { continue; }
+                catch (UnauthorizedAccessException) { continue; }
+                stack.Push(d);
+            }
         }
 
         // ── Pass 2: partial hash pre-filter, then full hash ──

--- a/SysManager/SysManager/Services/LargeFileScanner.cs
+++ b/SysManager/SysManager/Services/LargeFileScanner.cs
@@ -116,7 +116,16 @@ public sealed class LargeFileScanner
                 lastReport = now;
             }
 
-            foreach (var d in dirs) stack.Push(d);
+            foreach (var d in dirs)
+            {
+                try
+                {
+                    if ((File.GetAttributes(d) & FileAttributes.ReparsePoint) != 0) continue;
+                }
+                catch (IOException) { continue; }
+                catch (UnauthorizedAccessException) { continue; }
+                stack.Push(d);
+            }
         }
 
         progress?.Report(new LargeFileProgress(scanned, bytesScanned, "Done"));

--- a/SysManager/SysManager/Services/TrayIconService.cs
+++ b/SysManager/SysManager/Services/TrayIconService.cs
@@ -124,7 +124,15 @@ public sealed class TrayIconService : IDisposable
 
     private async void OnTimerTick(object? sender, EventArgs e)
     {
-        await UpdateTooltipAsync();
+        try
+        {
+            await UpdateTooltipAsync();
+        }
+        catch (Exception ex)
+        {
+            // async void must never throw — unhandled exceptions crash the app.
+            Log.Warning("TrayIcon timer tick failed: {Error}", ex.Message);
+        }
     }
 
     private async Task UpdateTooltipAsync()


### PR DESCRIPTION
## Summary

Fixes infinite loop risk on symlinks, crash on mid-enumeration file access errors, and async void crash risk.

### Reparse Point Check (SVC-11, SVC-19)
- **DuplicateFileService** and **LargeFileScanner** traversed directories without checking for reparse points (symlinks, junctions). Circular symlinks could cause infinite loops.
- **Fix:** Added FileAttributes.ReparsePoint check before pushing directories onto the traversal stack, matching the existing pattern in DiskAnalyzerService.

### Safe Enumeration (CR-02)
- **DeepCleanupService** — EnumerateFiles() only caught exceptions at enumerator creation, not during MoveNext() iteration. Files becoming inaccessible mid-scan caused unhandled exceptions.
- **Fix:** Wrapped iteration with explicit MoveNext() call inside try-catch for IOException and UnauthorizedAccessException.

### Async Void Guard (SVC-47)
- **TrayIconService** — OnTimerTick is async void (required by event handler signature). If UpdateTooltipAsync threw an unexpected exception type, it would crash the entire application.
- **Fix:** Wrapped the entire call in try-catch(Exception) with logging.

## Build
- 0 errors, 16 warnings (all pre-existing)
- Tests project: 0 errors
