### PR TITLE
fix: eliminate CS0618 and IL3000 build warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.20] - 2026-05-15
+
+### Fixed
+- **NetworkSharedState** — replaced obsolete `SkiaPaint.FontFamily` with
+  `SKTypeface = SKTypeface.FromFamilyName()` on 4 axis paint objects,
+  eliminating all CS0618 build warnings.
+- **AboutViewModel** — replaced `Assembly.Location` (returns empty in
+  single-file publish) with `AppContext.BaseDirectory` lookup, eliminating
+  IL3000 warning.
+
 ## [0.48.19] - 2026-05-15
 
 ### Fixed

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -509,9 +509,16 @@ public partial class AboutViewModel : ViewModelBase
     {
         try
         {
-            var path = typeof(AboutViewModel).Assembly.Location;
-            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
-                return File.GetLastWriteTime(path).ToString("dd MMM yyyy");
+            // Use AppContext.BaseDirectory instead of Assembly.Location which
+            // returns empty string in single-file publish (IL3000).
+            var dir = AppContext.BaseDirectory;
+            var exe = Path.Combine(dir, "SysManager.exe");
+            if (File.Exists(exe))
+                return File.GetLastWriteTime(exe).ToString("dd MMM yyyy");
+            // Fallback: try the DLL
+            var dll = Path.Combine(dir, "SysManager.dll");
+            if (File.Exists(dll))
+                return File.GetLastWriteTime(dll).ToString("dd MMM yyyy");
         }
         catch (IOException) { }
         catch (UnauthorizedAccessException) { }

--- a/SysManager/SysManager/ViewModels/NetworkSharedState.cs
+++ b/SysManager/SysManager/ViewModels/NetworkSharedState.cs
@@ -450,7 +450,7 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
         Labeler = v => new DateTime((long)v).ToString("HH:mm:ss"),
         TextSize = 12,
         NamePaint = new SolidColorPaint(SKColor.Parse("A3ADBF")),
-        LabelsPaint = new SolidColorPaint(SKColor.Parse("E6E9EE")) { FontFamily = "Segoe UI" },
+        LabelsPaint = new SolidColorPaint(SKColor.Parse("E6E9EE")) { SKTypeface = SKTypeface.FromFamilyName("Segoe UI") },
         SeparatorsPaint = new SolidColorPaint(SKColor.Parse("2A3244").WithAlpha(80))
     };
 
@@ -459,8 +459,8 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
         Name = name,
         MinLimit = 0,
         TextSize = 13,
-        NamePaint = new SolidColorPaint(SKColor.Parse("E6E9EE")) { FontFamily = "Segoe UI" },
-        LabelsPaint = new SolidColorPaint(SKColor.Parse("E6E9EE")) { FontFamily = "Segoe UI" },
+        NamePaint = new SolidColorPaint(SKColor.Parse("E6E9EE")) { SKTypeface = SKTypeface.FromFamilyName("Segoe UI") },
+        LabelsPaint = new SolidColorPaint(SKColor.Parse("E6E9EE")) { SKTypeface = SKTypeface.FromFamilyName("Segoe UI") },
         SeparatorsPaint = new SolidColorPaint(SKColor.Parse("2A3244").WithAlpha(80)) { StrokeThickness = 1 },
         Labeler = v => $"{v:F0} ms",
         NameTextSize = 14,
@@ -474,7 +474,7 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
         MinStep = 1,
         TextSize = 12,
         NamePaint = new SolidColorPaint(SKColor.Parse("A3ADBF")),
-        LabelsPaint = new SolidColorPaint(SKColor.Parse("E6E9EE")) { FontFamily = "Segoe UI" },
+        LabelsPaint = new SolidColorPaint(SKColor.Parse("E6E9EE")) { SKTypeface = SKTypeface.FromFamilyName("Segoe UI") },
         SeparatorsPaint = new SolidColorPaint(SKColor.Parse("2A3244").WithAlpha(80))
     };
 


### PR DESCRIPTION
## Summary

Eliminates persistent CS0618 and IL3000 build warnings.

### CS0618 — SkiaPaint.FontFamily obsolete (4 locations)
- **NetworkSharedState** — axis paint objects used the obsolete FontFamily string property. Replaced with SKTypeface = SKTypeface.FromFamilyName("Segoe UI") which is the recommended API.

### IL3000 — Assembly.Location empty in single-file publish
- **AboutViewModel** — BuildStamp() used Assembly.Location which returns empty string when published as single-file. Replaced with AppContext.BaseDirectory + exe/dll file lookup.

### Result
- Build warnings reduced from 16 to 8 (remaining are NU1603/NU1701 NuGet compat warnings — not fixable without package upgrades).

## Build
- 0 errors, 8 warnings (all NuGet compat — pre-existing, unfixable)
- Tests project: 0 errors
