### PR TITLE
fix: process handle leak, brush cache, mutex safety, docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.21] - 2026-05-15
+
+### Fixed
+- **AdminHelper** — `Process.GetCurrentProcess()` now properly disposed via
+  `using` in `RelaunchAsAdmin()` (prevents brief handle leak).
+- **HexToBrushConverter** — frozen brushes now cached by hex value in a
+  `ConcurrentDictionary` to eliminate repeated allocations and GC pressure
+  on frequently-updating bindings (dashboard, health score, tune-up).
+- **App.xaml.cs** — `ReleaseMutex()` wrapped in try-catch for
+  `ApplicationException` (thrown if called from wrong thread on shutdown).
+- **EtaCalculator** — added thread-safety documentation (single-thread
+  requirement via UI dispatcher).
+
 ## [0.48.20] - 2026-05-15
 
 ### Fixed

--- a/SysManager/SysManager/App.xaml.cs
+++ b/SysManager/SysManager/App.xaml.cs
@@ -76,7 +76,8 @@ public partial class App : Application
         _trayService?.Dispose();
         (Services as IDisposable)?.Dispose();
         LogService.Shutdown();
-        _instanceMutex?.ReleaseMutex();
+        try { _instanceMutex?.ReleaseMutex(); }
+        catch (ApplicationException) { /* mutex not owned by this thread */ }
         _instanceMutex?.Dispose();
         base.OnExit(e);
     }

--- a/SysManager/SysManager/Helpers/AdminHelper.cs
+++ b/SysManager/SysManager/Helpers/AdminHelper.cs
@@ -27,7 +27,8 @@ public static class AdminHelper
     {
         try
         {
-            var exePath = Environment.ProcessPath ?? Process.GetCurrentProcess().MainModule?.FileName;
+            using var currentProc = Process.GetCurrentProcess();
+            var exePath = Environment.ProcessPath ?? currentProc.MainModule?.FileName;
             if (string.IsNullOrWhiteSpace(exePath)) return false;
 
             var psi = new ProcessStartInfo

--- a/SysManager/SysManager/Helpers/EtaCalculator.cs
+++ b/SysManager/SysManager/Helpers/EtaCalculator.cs
@@ -15,6 +15,10 @@ namespace SysManager.Helpers;
 /// <see cref="Update"/> each time progress changes. Read <see cref="Remaining"/>
 /// or <see cref="RemainingText"/> for the current estimate.
 /// </para>
+/// <para>
+/// Thread safety: this class is NOT thread-safe. All calls must be made from
+/// the same thread (typically the UI thread via Progress&lt;T&gt; callbacks).
+/// </para>
 /// </summary>
 public sealed class EtaCalculator
 {

--- a/SysManager/SysManager/Helpers/OutputKindToBrushConverter.cs
+++ b/SysManager/SysManager/Helpers/OutputKindToBrushConverter.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
@@ -86,17 +87,26 @@ public class BoolToElevationBadgeBrushConverter : IValueConverter
 /// <summary>Converts a hex string like "#4CC9F0" to a SolidColorBrush.</summary>
 public class HexToBrushConverter : IValueConverter
 {
+    // Cache frozen brushes by hex value to reduce GC pressure on frequently-updating bindings.
+    private static readonly ConcurrentDictionary<string, SolidColorBrush> _cache = new(StringComparer.OrdinalIgnoreCase);
+
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
         if (value is string s && !string.IsNullOrWhiteSpace(s))
         {
-            try
+            return _cache.GetOrAdd(s, static hex =>
             {
-                var brush = new SolidColorBrush((Color)ColorConverter.ConvertFromString(s));
-                brush.Freeze();
-                return brush;
-            }
-            catch (FormatException) { /* fall through */ }
+                try
+                {
+                    var brush = new SolidColorBrush((Color)ColorConverter.ConvertFromString(hex));
+                    brush.Freeze();
+                    return brush;
+                }
+                catch (FormatException)
+                {
+                    return (SolidColorBrush)Brushes.Gray;
+                }
+            });
         }
         return Brushes.Gray;
     }


### PR DESCRIPTION
## Summary

Fixes handle leak, adds brush caching, guards mutex release, and documents thread-safety.

### Process Handle Leak (Helper-02)
- **AdminHelper** — Process.GetCurrentProcess() was not disposed in RelaunchAsAdmin(). Added using statement.

### Brush Cache (Helper-01)
- **HexToBrushConverter** — every Convert() call created a new SolidColorBrush even for the same hex value. Added ConcurrentDictionary cache keyed by hex string. Frozen brushes are reused across calls, eliminating GC pressure on frequently-updating bindings.

### Mutex Safety (ENTRY-02)
- **App.xaml.cs** — ReleaseMutex() can throw ApplicationException if called from a thread that does not own the mutex. Wrapped in try-catch.

### Thread-Safety Documentation (Helper-03)
- **EtaCalculator** — added XML doc paragraph documenting that the class is NOT thread-safe and must be called from the UI thread only.

## Build
- 0 errors, 8 warnings (all NuGet compat)
- Tests project: 0 errors
