### PR TITLE
docs: fix ARCHITECTURE accuracy, update README/SECURITY

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,7 +30,7 @@ SysManager/
 
 ## Tabs (view models)
 
-The sidebar organises tabs into 9 collapsible groups via `NavGroup` →
+The sidebar organises tabs into 12 collapsible groups via `NavGroup` →
 `NavItem` hierarchy. Dashboard renders as a flat top-level entry.
 Collapsed groups show a child count badge, subtitle, and tooltip.
 Planned features use `PlaceholderViewModel` with a WIP view.
@@ -38,14 +38,17 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Group | View Models |
 |-------|-------------|
 | Dashboard | `DashboardViewModel` |
-| System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` |
-| Monitor | `ProcessManagerViewModel` · `AppAlertsViewModel` · `PlaceholderViewModel` (Resource History · Privacy Monitor) |
-| Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `PlaceholderViewModel` (File Shredder) |
+| System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `PlaceholderViewModel` (Task Scheduler · Boot Analyzer) |
+| Gaming & Profiles | `PlaceholderViewModel` (Gaming Profile · Standby List Cleaner · Timer Resolution · CPU Core Affinity · Display Profiles) |
+| Monitor | `ProcessManagerViewModel` · `AppAlertsViewModel` · `PlaceholderViewModel` (Resource History · Privacy Monitor · File Lock Detector · Settings Watchdog · Bandwidth Monitor) |
+| Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `PlaceholderViewModel` (File Shredder · Scheduled Maintenance) |
 | Storage | `DiskAnalyzerViewModel` · `DuplicateFileViewModel` |
 | Network | `PingViewModel` · `TracerouteViewModel` · `SpeedTestViewModel` · `NetworkRepairViewModel` (shared: `NetworkSharedState`) · `PlaceholderViewModel` (DNS Changer · Hosts Editor) |
 | Apps | `AppUpdatesViewModel` · `UninstallerViewModel` · `AppBlockerViewModel` · `PlaceholderViewModel` (Bulk Installer) |
-| Control | `PlaceholderViewModel` (Privacy Settings · Context Menu · Restore Points · Scheduled Maintenance · System Report) |
+| Privacy & Security | `PlaceholderViewModel` (Privacy & Telemetry · Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover · Defender Tweaks · Notification Blocker) |
+| Customization | `PlaceholderViewModel` (Context Menu · Dark Mode Scheduler · Volume Control · Environment Variables) |
 | Info | `DriversViewModel` · `BatteryHealthViewModel` · `LogsViewModel` · `AboutViewModel` |
+| Advanced | `PlaceholderViewModel` (Restore Points · Profile Export/Import · CLI Interface · System Report) |
 
 - `DashboardViewModel` — OS / CPU / RAM / disk snapshot + live uptime.
 - `AppUpdatesViewModel` — winget scan and bulk upgrade.
@@ -72,7 +75,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `WindowsFeaturesViewModel` — list, enable, disable Windows optional features.
 - `AppAlertsViewModel` — monitors new app installations via FileSystemWatcher + registry.
 - `ShortcutCleanerViewModel` — scans and removes broken desktop/Start Menu shortcuts.
-- `AppBlockerViewModel` — block/unblock apps via Windows Firewall rules.
+- `AppBlockerViewModel` — block/unblock apps via IFEO (Image File Execution Options) registry mechanism.
 
 ## Services
 

--- a/README.md
+++ b/README.md
@@ -36,21 +36,24 @@ an honest "is it my PC, my ISP, or the server?" verdict.
 ## Features
 
 ### Sidebar navigation
-The sidebar organises 36 feature tabs into 9 collapsible groups so you can
-find what you need without scrolling through a flat list. 25 tabs are fully
-implemented; 11 are work-in-progress placeholders marked with ⚙️:
+The sidebar organises 51 feature tabs into 12 collapsible groups so you can
+find what you need without scrolling through a flat list. 20 tabs are fully
+implemented; 31 are work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |
 |-------|------|
 | 🏠 Dashboard | Dashboard |
-| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features |
-| 📊 Monitor | Process Manager · Resource History ⚙️ · App Alerts · Privacy Monitor ⚙️ |
-| 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · File Shredder ⚙️ |
+| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Task Scheduler ⚙️ · Boot Analyzer ⚙️ |
+| 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner ⚙️ · Timer Resolution ⚙️ · CPU Core Affinity ⚙️ · Display Profiles ⚙️ |
+| 📊 Monitor | Process Manager · Resource History ⚙️ · App Alerts · Privacy Monitor ⚙️ · File Lock Detector ⚙️ · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
+| 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · File Shredder ⚙️ · Scheduled Maintenance ⚙️ |
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS Changer ⚙️ · Hosts Editor ⚙️ |
 | 📦 Apps | App Updates · Bulk Installer ⚙️ · Uninstaller · App Blocker |
-| 🛡️ Control | Privacy Settings ⚙️ · Context Menu ⚙️ · Restore Points ⚙️ · Scheduled Maintenance ⚙️ · System Report ⚙️ |
+| 🛡️ Privacy & Security | Privacy & Telemetry ⚙️ · Debloater & Ads ⚙️ · Browser Cleaner ⚙️ · Edge/OneDrive Remover ⚙️ · Defender Tweaks ⚙️ · Notification Blocker ⚙️ |
+| 🎨 Customization | Context Menu ⚙️ · Dark Mode Scheduler ⚙️ · Volume Control ⚙️ · Environment Variables ⚙️ |
 | ℹ️ Info | Drivers · Battery Health · System Logs · About |
+| ⚙️ Advanced | Restore Points ⚙️ · Profile Export/Import ⚙️ · CLI Interface ⚙️ · System Report ⚙️ |
 
 > ⚙️ = Work in Progress — placeholder tab visible in the sidebar, implementation coming in future updates.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,9 +13,8 @@ older build, the first step is usually to update.
 | Version | Supported          |
 | ------- | ------------------ |
 | 0.48.x  | :white_check_mark: |
-| 0.47.x  | :white_check_mark: |
-| 0.46.x  | :x:                |
-| < 0.46  | :x:                |
+| 0.47.x  | :x:                |
+| < 0.47  | :x:                |
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
Fixes documentation drift identified in the full codebase audit (H-11, DOC-03, DOC-04, DOC-05).

- **ARCHITECTURE.md**: Correct AppBlocker mechanism description from 'Windows Firewall rules' to 'IFEO registry mechanism'
- **ARCHITECTURE.md**: Update group table from 9 to 12 groups with all current ViewModels
- **README.md**: Update sidebar navigation counts from 36 tabs / 9 groups to 51 tabs / 12 groups. Add Gaming and Profiles, Privacy and Security, Customization, Advanced groups.
- **SECURITY.md**: Update supported versions table (only 0.48.x supported)
