### PR TITLE
fix: thread safety, event marshaling, entry-point robustness, config alignment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,18 @@ updates:
     commit-message:
       prefix: "deps(uitests)"
 
+  - package-ecosystem: "nuget"
+    directory: "/SysManager/SysManager.IntegrationTests"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "tests"
+    commit-message:
+      prefix: "deps(integration)"
+
   # Keep GitHub Actions current.
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.22] - 2026-05-15
+
+### Fixed
+- **AppAlertService** — `NewAppDetected` event now marshaled to the UI thread
+  via captured `SynchronizationContext`, preventing crashes when
+  `FileSystemWatcher`/`Timer` callbacks invoke subscribers directly.
+- **NetworkRepairService** — added `SemaphoreSlim` gate to serialize
+  subscribe/unsubscribe on the shared `PowerShellRunner`, preventing
+  concurrent calls from interleaving output.
+- **PerformanceService** — same `SemaphoreSlim` serialization for all methods
+  that subscribe to `PowerShellRunner.LineReceived`.
+- **PowerShellRunner** — documented that `LineReceived` fires on thread-pool
+  threads; subscribers must marshal to the dispatcher for UI updates.
+- **StartupService** — added `RuntimeBinderException` catch for dynamic COM
+  shortcut resolution (`.lnk` files with broken targets).
+- **StartupService** — `GetAwaiter().GetResult()` on stderr task now guarded
+  with a 5-second timeout to prevent hangs if the pipe isn't fully drained.
+- **AppAlertsViewModel** — use `Application.Current.Dispatcher` instead of
+  `Dispatcher.CurrentDispatcher` to avoid capturing the wrong dispatcher.
+- **NetworkSharedState** — documented that `FlushPending` direct-call path
+  (when `Dispatcher == null`) is intentional for unit tests / headless mode.
+- **AboutViewModel** — removed auto-download of updates without user consent;
+  user must now explicitly click Download.
+- **App.xaml.cs** — single-instance activation now uses a named pipe listener,
+  fixing activation when the window is minimized to tray (no `MainWindowHandle`).
+- **MainWindow.xaml.cs** — ViewModel disposal now also hooks
+  `Application.Current.Exit` as a safety net for when `OnClosed` is not called.
+
+### Changed
+- **SysManager.csproj** — version updated from 0.12.1 to 0.48.21 (cosmetic;
+  auto-release overrides at build time).
+- **SysManager.Tests.csproj** — xunit bumped from 2.5.3 to 2.9.3 (matches
+  UITests project).
+- **SysManager.IntegrationTests.csproj** — xunit bumped from 2.5.3 to 2.9.3.
+- **dependabot.yml** — added `IntegrationTests` directory entry for NuGet
+  dependency monitoring.
+
 ## [0.48.21] - 2026-05-15
 
 ### Fixed

--- a/SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj
+++ b/SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 

--- a/SysManager/SysManager.Tests/SysManager.Tests.csproj
+++ b/SysManager/SysManager.Tests/SysManager.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="Xunit.StaFact" Version="1.1.11" />
   </ItemGroup>

--- a/SysManager/SysManager/App.xaml.cs
+++ b/SysManager/SysManager/App.xaml.cs
@@ -3,6 +3,8 @@
 // License: MIT
 
 using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Threading;
@@ -14,8 +16,10 @@ namespace SysManager;
 public partial class App : Application
 {
     private const string MutexName = "Global\\SysManager_SingleInstance_laurentiu021";
+    private const string PipeName = "SysManager_SingleInstance_Pipe_laurentiu021";
     private Mutex? _instanceMutex;
     private TrayIconService? _trayService;
+    private CancellationTokenSource? _pipeCts;
 
     // Guard against cascading error dialogs — show at most one at a time.
     private static int _errorDialogActive;
@@ -69,10 +73,15 @@ public partial class App : Application
         AppDomain.CurrentDomain.UnhandledException += OnDomain;
         TaskScheduler.UnobservedTaskException += OnTask;
         base.OnStartup(e);
+
+        // Start listening for activation requests from subsequent instances
+        StartPipeListener();
     }
 
     protected override void OnExit(ExitEventArgs e)
     {
+        _pipeCts?.Cancel();
+        _pipeCts?.Dispose();
         _trayService?.Dispose();
         (Services as IDisposable)?.Dispose();
         LogService.Shutdown();
@@ -84,6 +93,17 @@ public partial class App : Application
 
     private static void ActivateExistingInstance()
     {
+        // Try named pipe first — works even when the window is hidden (tray mode)
+        try
+        {
+            using var client = new NamedPipeClientStream(".", PipeName, PipeDirection.Out);
+            client.Connect(timeout: 2000);
+            // Connection alone signals the running instance to activate
+        }
+        catch (TimeoutException) { /* pipe not available, fall back to window activation */ }
+        catch (IOException) { /* pipe not available */ }
+
+        // Fallback: find the window handle (works when window is visible)
         using var current = Process.GetCurrentProcess();
         foreach (var proc in Process.GetProcessesByName(current.ProcessName))
         {
@@ -98,6 +118,38 @@ public partial class App : Application
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Listens for named pipe connections from subsequent instances and
+    /// activates the main window when one connects.
+    /// </summary>
+    private async void StartPipeListener()
+    {
+        _pipeCts = new CancellationTokenSource();
+        var ct = _pipeCts.Token;
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await using var server = new NamedPipeServerStream(
+                    PipeName, PipeDirection.In, 1, PipeTransmissionMode.Byte,
+                    PipeOptions.Asynchronous);
+                await server.WaitForConnectionAsync(ct).ConfigureAwait(false);
+
+                // A second instance connected — activate our window on the UI thread
+                _ = Dispatcher.BeginInvoke(() =>
+                {
+                    var win = MainWindow;
+                    if (win != null)
+                    {
+                        TrayIconService.ShowWindow(win);
+                    }
+                });
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+        catch (IOException) { /* pipe broken during shutdown */ }
     }
 
     private static void OnUi(object s, DispatcherUnhandledExceptionEventArgs e)

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -17,6 +17,15 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+
+        // Ensure ViewModel disposal even if OnClosed is not called (e.g. app shutdown)
+        if (Application.Current != null)
+            Application.Current.Exit += OnApplicationExit;
+    }
+
+    private void OnApplicationExit(object sender, ExitEventArgs e)
+    {
+        (DataContext as MainWindowViewModel)?.Dispose();
     }
 
     /// <summary>

--- a/SysManager/SysManager/Services/AppAlertService.cs
+++ b/SysManager/SysManager/Services/AppAlertService.cs
@@ -20,11 +20,23 @@ public sealed class AppAlertService : IDisposable
     private readonly object _watcherLock = new();
     private readonly ConcurrentDictionary<string, bool> _knownFolders = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, bool> _knownRegistryApps = new(StringComparer.OrdinalIgnoreCase);
+    private readonly SynchronizationContext? _syncContext;
     private Timer? _registryTimer;
     private bool _disposed;
 
-    /// <summary>Raised when a new application installation is detected.</summary>
+    /// <summary>Raised when a new application installation is detected.
+    /// Marshaled to the <see cref="SynchronizationContext"/> captured at construction
+    /// (typically the UI thread) so subscribers can safely update UI elements.</summary>
     public event Action<AppInstallEntry>? NewAppDetected;
+
+    /// <summary>
+    /// Creates a new instance, capturing the current <see cref="SynchronizationContext"/>
+    /// so that events are raised on the UI thread.
+    /// </summary>
+    public AppAlertService()
+    {
+        _syncContext = SynchronizationContext.Current;
+    }
 
     /// <summary>
     /// Takes a snapshot of currently installed apps (baseline).
@@ -161,7 +173,7 @@ public sealed class AppAlertService : IDisposable
         };
 
         Log.Information("New app folder detected: {Path}", e.FullPath);
-        NewAppDetected?.Invoke(entry);
+        RaiseNewAppDetected(entry);
     }
 
     private void CheckRegistry(object? state)
@@ -175,12 +187,24 @@ public sealed class AppAlertService : IDisposable
 
                 app.DetectedAt = DateTime.Now;
                 Log.Information("New app detected in registry: {Name}", app.Name);
-                NewAppDetected?.Invoke(app);
+                RaiseNewAppDetected(app);
             }
         }
         catch (IOException) { /* registry read failed — retry next cycle */ }
         catch (UnauthorizedAccessException) { /* registry read failed — retry next cycle */ }
         catch (System.Security.SecurityException) { /* registry read failed — retry next cycle */ }
+    }
+
+    /// <summary>
+    /// Raises <see cref="NewAppDetected"/> on the captured synchronization context
+    /// (UI thread) if available, otherwise invokes directly on the current thread.
+    /// </summary>
+    private void RaiseNewAppDetected(AppInstallEntry entry)
+    {
+        if (_syncContext != null)
+            _syncContext.Post(_ => NewAppDetected?.Invoke(entry), null);
+        else
+            NewAppDetected?.Invoke(entry);
     }
 
     private static List<string> GetMonitoredDirectories()

--- a/SysManager/SysManager/Services/NetworkRepairService.cs
+++ b/SysManager/SysManager/Services/NetworkRepairService.cs
@@ -13,6 +13,7 @@ namespace SysManager.Services;
 public sealed class NetworkRepairService
 {
     private readonly PowerShellRunner _ps;
+    private readonly SemaphoreSlim _gate = new(1, 1);
 
     public NetworkRepairService(PowerShellRunner ps) => _ps = ps;
 
@@ -21,6 +22,7 @@ public sealed class NetworkRepairService
     /// </summary>
     public async Task<NetworkRepairResult> FlushDnsAsync(CancellationToken ct = default)
     {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
         var output = new System.Collections.Concurrent.ConcurrentQueue<string>();
         void OnLine(PowerShellLine line) => output.Enqueue(line.Text);
         _ps.LineReceived += OnLine;
@@ -34,7 +36,7 @@ public sealed class NetworkRepairService
                 string.Join(Environment.NewLine, output),
                 NeedsReboot: false);
         }
-        finally { _ps.LineReceived -= OnLine; }
+        finally { _ps.LineReceived -= OnLine; _gate.Release(); }
     }
 
     /// <summary>
@@ -42,6 +44,7 @@ public sealed class NetworkRepairService
     /// </summary>
     public async Task<NetworkRepairResult> ResetWinsockAsync(CancellationToken ct = default)
     {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
         var output = new System.Collections.Concurrent.ConcurrentQueue<string>();
         void OnLine(PowerShellLine line) => output.Enqueue(line.Text);
         _ps.LineReceived += OnLine;
@@ -55,7 +58,7 @@ public sealed class NetworkRepairService
                 string.Join(Environment.NewLine, output),
                 NeedsReboot: true);
         }
-        finally { _ps.LineReceived -= OnLine; }
+        finally { _ps.LineReceived -= OnLine; _gate.Release(); }
     }
 
     /// <summary>
@@ -63,6 +66,7 @@ public sealed class NetworkRepairService
     /// </summary>
     public async Task<NetworkRepairResult> ResetTcpIpAsync(CancellationToken ct = default)
     {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
         var output = new System.Collections.Concurrent.ConcurrentQueue<string>();
         void OnLine(PowerShellLine line) => output.Enqueue(line.Text);
         _ps.LineReceived += OnLine;
@@ -76,6 +80,6 @@ public sealed class NetworkRepairService
                 string.Join(Environment.NewLine, output),
                 NeedsReboot: true);
         }
-        finally { _ps.LineReceived -= OnLine; }
+        finally { _ps.LineReceived -= OnLine; _gate.Release(); }
     }
 }

--- a/SysManager/SysManager/Services/PerformanceService.cs
+++ b/SysManager/SysManager/Services/PerformanceService.cs
@@ -27,6 +27,7 @@ namespace SysManager.Services;
 public sealed class PerformanceService
 {
     private readonly PowerShellRunner _ps;
+    private readonly SemaphoreSlim _psGate = new(1, 1);
 
     // ── Well-known power plan GUIDs ──
     internal const string BalancedGuid = "381b4222-f694-41f0-9685-ff5bb260df2e";
@@ -163,11 +164,12 @@ public sealed class PerformanceService
     /// <summary>Parse active plan from powercfg /getactivescheme output.</summary>
     public async Task<(string Name, string Guid)> GetActivePlanAsync(CancellationToken ct = default)
     {
+        await _psGate.WaitAsync(ct).ConfigureAwait(false);
         var lines = new List<string>();
         void OnLine(PowerShellLine l) => lines.Add(l.Text);
         _ps.LineReceived += OnLine;
         try { await _ps.RunProcessAsync("powercfg.exe", "/getactivescheme", ct, PowerShellRunner.OemEncoding); }
-        finally { _ps.LineReceived -= OnLine; }
+        finally { _ps.LineReceived -= OnLine; _psGate.Release(); }
 
         return ParseActivePlan(lines);
     }
@@ -212,9 +214,10 @@ public sealed class PerformanceService
 
         var lines = new List<string>();
         void OnLine(PowerShellLine l) => lines.Add(l.Text);
+        await _psGate.WaitAsync(ct).ConfigureAwait(false);
         _ps.LineReceived += OnLine;
         try { await _ps.RunProcessAsync("powercfg.exe", $"-duplicatescheme {UltimatePerfScheme}", ct, PowerShellRunner.OemEncoding); }
-        finally { _ps.LineReceived -= OnLine; }
+        finally { _ps.LineReceived -= OnLine; _psGate.Release(); }
 
         // Parse GUID from output: "Power Scheme GUID: <guid>  (Ultimate Performance)"
         foreach (var line in lines)
@@ -232,11 +235,12 @@ public sealed class PerformanceService
     /// <summary>Find a plan GUID by name substring.</summary>
     public async Task<string?> FindPlanGuidByNameAsync(string nameSubstring, CancellationToken ct = default)
     {
+        await _psGate.WaitAsync(ct).ConfigureAwait(false);
         var lines = new List<string>();
         void OnLine(PowerShellLine l) => lines.Add(l.Text);
         _ps.LineReceived += OnLine;
         try { await _ps.RunProcessAsync("powercfg.exe", "/list", ct, PowerShellRunner.OemEncoding); }
-        finally { _ps.LineReceived -= OnLine; }
+        finally { _ps.LineReceived -= OnLine; _psGate.Release(); }
 
         return ParsePlanGuidByName(lines, nameSubstring);
     }
@@ -461,6 +465,7 @@ public sealed class PerformanceService
     /// <summary>Read the current processor minimum state percentage (AC).</summary>
     internal async Task<int> ReadProcessorMinPercentAsync(CancellationToken ct = default)
     {
+        await _psGate.WaitAsync(ct).ConfigureAwait(false);
         var lines = new List<string>();
         void OnLine(PowerShellLine l) => lines.Add(l.Text);
         _ps.LineReceived += OnLine;
@@ -469,7 +474,7 @@ public sealed class PerformanceService
             await _ps.RunProcessAsync("powercfg.exe",
                 "/query SCHEME_CURRENT SUB_PROCESSOR PROCTHROTTLEMIN", ct, PowerShellRunner.OemEncoding).ConfigureAwait(false);
         }
-        finally { _ps.LineReceived -= OnLine; }
+        finally { _ps.LineReceived -= OnLine; _psGate.Release(); }
 
         return ParseProcessorMinPercent(lines);
     }

--- a/SysManager/SysManager/Services/PowerShellRunner.cs
+++ b/SysManager/SysManager/Services/PowerShellRunner.cs
@@ -21,6 +21,11 @@ namespace SysManager.Services;
 /// </summary>
 public sealed class PowerShellRunner
 {
+    /// <summary>
+    /// Raised for each line of output from any stream (stdout, stderr, information,
+    /// warning, error, verbose, debug, progress). Fires on a thread-pool thread —
+    /// subscribers that update UI elements must marshal to the dispatcher.
+    /// </summary>
     public event Action<PowerShellLine>? LineReceived;
     public event Action<int>? ProgressChanged; // 0-100
 

--- a/SysManager/SysManager/Services/StartupService.cs
+++ b/SysManager/SysManager/Services/StartupService.cs
@@ -111,6 +111,10 @@ public sealed class StartupService
                     {
                         Log.Debug("Failed to resolve shortcut {File}: {Error}", file, ex.Message);
                     }
+                    catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException ex)
+                    {
+                        Log.Debug("Failed to resolve shortcut {File}: {Error}", file, ex.Message);
+                    }
                     finally
                     {
                         if (shortcut != null) Marshal.ReleaseComObject(shortcut);
@@ -425,7 +429,9 @@ public sealed class StartupService
                 return false;
             }
 
-            var stderr = stderrTask.GetAwaiter().GetResult().Trim();
+            var stderr = stderrTask.Wait(TimeSpan.FromSeconds(5))
+                ? stderrTask.GetAwaiter().GetResult().Trim()
+                : string.Empty;
 
             if (proc.ExitCode == 0)
             {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -11,9 +11,9 @@
     <AssemblyName>SysManager</AssemblyName>
     <RootNamespace>SysManager</RootNamespace>
     <LangVersion>latest</LangVersion>
-    <Version>0.12.1</Version>
-    <FileVersion>0.12.1.0</FileVersion>
-    <AssemblyVersion>0.12.1.0</AssemblyVersion>
+    <Version>0.48.21</Version>
+    <FileVersion>0.48.21.0</FileVersion>
+    <AssemblyVersion>0.48.21.0</AssemblyVersion>
     <Authors>laurentiu021</Authors>
     <Company>laurentiu021</Company>
     <Product>SysManager</Product>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -100,12 +100,7 @@ public partial class AboutViewModel : ViewModelBase
             if (UpdateService.IsNewer(latest.Version, UpdateService.CurrentVersion))
             {
                 UpdateAvailable = true;
-                UpdateStatus = $"Update available: {LatestVersionLabel} ({LatestPublishedLabel}).";
-
-                // Auto-download when a new version is found — falls back
-                // gracefully if blocked.
-                if (!IsDownloading && DownloadedPath == null)
-                    _ = DownloadAsync();
+                UpdateStatus = $"Update available: {LatestVersionLabel} ({LatestPublishedLabel}). Click Download to get it.";
             }
             else
             {

--- a/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Collections.ObjectModel;
+using System.Windows;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -30,7 +31,7 @@ public partial class AppAlertsViewModel : ViewModelBase
 
     public AppAlertsViewModel()
     {
-        _dispatcher = Dispatcher.CurrentDispatcher;
+        _dispatcher = Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
         _service.NewAppDetected += OnNewAppDetected;
     }
 

--- a/SysManager/SysManager/ViewModels/NetworkSharedState.cs
+++ b/SysManager/SysManager/ViewModels/NetworkSharedState.cs
@@ -294,6 +294,9 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
     private void OnSample(PingSample sample)
     {
         Pending.Enqueue(sample);
+        // When Dispatcher is null (unit tests / headless), flush immediately on the
+        // calling thread. ObservableCollections are not bound to UI in that scenario,
+        // so direct modification is safe.
         if (Dispatcher == null) FlushPending();
     }
 


### PR DESCRIPTION
## Summary

Fixes all 13 remaining findings from the FINAL_COMPLETE_AUDIT.

### Service Thread-Safety (SVC-01/02, SVC-21/23, SVC-27, SVC-40, SVC-42)
- **AppAlertService** — events marshaled to UI via captured SynchronizationContext
- **NetworkRepairService** — SemaphoreSlim serializes PowerShellRunner access
- **PerformanceService** — same SemaphoreSlim serialization for all subscribe/unsubscribe
- **PowerShellRunner** — LineReceived documented as thread-pool event
- **StartupService** — catches RuntimeBinderException on dynamic COM invocation
- **StartupService** — stderr task guarded with 5s timeout (prevents GetAwaiter race)

### ViewModel & Entry-Point (VM-19, VM-21, VM-28, ENTRY-01, ENTRY-03)
- **AppAlertsViewModel** — uses Application.Current.Dispatcher (not CurrentDispatcher)
- **NetworkSharedState** — FlushPending bg-thread path documented as intentional
- **AboutViewModel** — no longer auto-downloads updates without user consent
- **App.xaml.cs** — named pipe listener for single-instance activation when minimized to tray
- **MainWindow.xaml.cs** — hooks Application.Exit as safety net for ViewModel disposal

### Config (CFG-01, CFG-02, CFG-03)
- **SysManager.csproj** — version updated from 0.12.1 to 0.48.21
- **SysManager.Tests + IntegrationTests** — xunit bumped 2.5.3 -> 2.9.3
- **dependabot.yml** — added IntegrationTests directory entry

## Build
0 errors, 0 new warnings.

## Files changed (14)
Services: AppAlertService.cs, NetworkRepairService.cs, PerformanceService.cs, PowerShellRunner.cs, StartupService.cs
ViewModels: AboutViewModel.cs, AppAlertsViewModel.cs, NetworkSharedState.cs
Entry: App.xaml.cs, MainWindow.xaml.cs
Config: SysManager.csproj, SysManager.Tests.csproj, IntegrationTests.csproj, dependabot.yml
Docs: CHANGELOG.md
