### PR TITLE
docs: fix CHANGELOG version note, ARCHITECTURE DI claim, SECURITY CI claim

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -137,10 +137,12 @@ Key services:
 
 `ServiceRegistration.cs` configures `Microsoft.Extensions.DependencyInjection`.
 `App.OnStartup` builds the `IServiceProvider` and exposes it as `App.Services`.
-All services and ViewModels are registered as singletons — one shared instance
-per app lifetime. `MainWindowViewModel` resolves child VMs from the container
-at runtime; falls back to manual creation in tests (no DI dependency in the
-test project).
+Core services and ViewModels are registered as singletons — one shared instance
+per app lifetime. Some lightweight services (e.g. `TuneUpService`,
+`ShortcutCleanerService`) are instantiated directly by their consumers rather
+than registered in the container. `MainWindowViewModel` resolves child VMs from
+the container at runtime; falls back to manual creation in tests (no DI
+dependency in the test project).
 
 ## Admin elevation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -422,6 +422,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.48.2] - 2026-05-14
 
+> **Note:** Versions 0.49.0–0.53.1 below were released under the previous
+> repository (`SysManager`). When the project migrated to `SystemManager`
+> (2026-05-14), the auto-release workflow reset to the last tag on the new
+> repo (v0.48.1). Subsequent releases continue from 0.48.2 onward.
+> The entries below are preserved for historical completeness.
+
 ### Fixed
 - **Security: SpeedTestService** — remove fabricated placeholder SHA-256 hashes
   that caused perpetual warning logs (alert fatigue). Security now relies on

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -113,7 +113,8 @@ the meantime.
 
 - Dependencies are tracked via NuGet and kept current by
   [Dependabot](.github/dependabot.yml).
-- CI builds and runs the full test suite on every pull request.
+- CI builds and runs the unit test suite on every pull request.
+  Integration tests (which access real OS APIs) run locally only.
 - The release workflow builds the binary from source on a clean GitHub
   Actions runner and publishes both the `.exe` and its SHA256 sum together.
 


### PR DESCRIPTION
## Summary

Fixes documentation accuracy findings from the comprehensive code review.

### Fixes

- **DOC-C2** — CHANGELOG: Added note explaining the non-monotonic version sequence (0.48.2 follows 0.53.1) due to the repository migration from SysManager to SystemManager.
- **DOC-M1** — ARCHITECTURE.md: Corrected claim that all services are DI-registered. Clarified that core services are registered while lightweight services are instantiated directly by consumers.
- **DOC-M2** — SECURITY.md: Corrected claim that CI runs the full test suite. Clarified that CI runs unit tests only; integration tests (which access real OS APIs) run locally.

### Files changed (3)

CHANGELOG.md, ARCHITECTURE.md, SECURITY.md

## Build

docs: commit — no code changes, no build impact.
