### PR TITLE
docs: fix TESTING.md accuracy — unit tests do touch some OS APIs

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -6,9 +6,9 @@ SysManager has three test projects, each with a distinct scope and runner.
 
 | Project | What it tests | Runs on CI |
 |---|---|---|
-| `SysManager.Tests` | Pure unit tests — no WPF, no WMI, no network, no process spawning | ✅ Every push / PR |
+| `SysManager.Tests` | Unit tests — mostly pure logic, but some tests touch lightweight OS APIs (registry reads, process enumeration, Task Scheduler queries). No WPF dispatcher, no WMI, no network I/O, no admin required. | ✅ Every push / PR |
 | `SysManager.IntegrationTests` | Integration tests — real Windows APIs (Event Log, WMI, PowerShell, ICMP, WPF dispatcher) | ❌ Local only |
-| `SysManager.UITests` | End-to-end UI automation via FlaUI | ❌ Local only (needs a desktop session) |
+| `SysManager.UITests` | End-to-end UI automation via FlaUI | ✅ CI (headless, limited) |
 
 ## Running unit tests (CI-equivalent)
 


### PR DESCRIPTION
## Summary

Fixes TEST-M3 finding: TESTING.md incorrectly claimed unit tests are pure (no OS access). Some tests in SysManager.Tests do access registry, process enumeration, and Task Scheduler.

### Changes

- Corrected SysManager.Tests description from 'Pure unit tests — no WPF, no WMI, no network, no process spawning' to accurately reflect that some tests touch lightweight OS APIs.
- Updated UITests row to reflect that they now run on CI (headless runner).

### Files changed (1)

TESTING.md

## Build

docs: commit — no code changes.
