### PR TITLE
fix: replace fire-and-forget async with safe InitializeAsync helper (CQ-M3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.30] - 2026-05-18
+
+### Fixed
+- **ViewModelBase** — added `InitializeAsync` helper method that wraps
+  fire-and-forget async calls with structured error handling. Exceptions
+  from async initialization are now caught and logged via Serilog instead
+  of becoming unobserved task exceptions (CQ-M3).
+- **12 ViewModels** — replaced `_ = InitAsync()` fire-and-forget pattern
+  with `InitializeAsync(InitAsync)` in: AboutViewModel, BatteryHealthViewModel,
+  CleanupViewModel, DashboardViewModel, DeepCleanupViewModel,
+  PerformanceViewModel, ProcessManagerViewModel, ServicesViewModel,
+  SpeedTestViewModel, StartupViewModel, SystemHealthViewModel,
+  WindowsUpdateViewModel.
+
 ## [0.48.29] - 2026-05-18
 
 ### Changed

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -47,7 +47,7 @@ public partial class AboutViewModel : ViewModelBase
     public AboutViewModel(UpdateService updates)
     {
         _updates = updates;
-        _ = InitAsync();
+        InitializeAsync(InitAsync);
     }
 
     private async Task InitAsync()

--- a/SysManager/SysManager/ViewModels/BatteryHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BatteryHealthViewModel.cs
@@ -23,7 +23,7 @@ public partial class BatteryHealthViewModel : ViewModelBase
 
     public BatteryHealthViewModel()
     {
-        _ = InitAsync();
+        InitializeAsync(InitAsync);
     }
 
     private async Task InitAsync()

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -53,7 +53,7 @@ public partial class CleanupViewModel : ViewModelBase
         _runner.ProgressChanged += OnRunnerProgressChanged;
         IsElevated = AdminHelper.IsElevated();
 
-        _ = InitAsync();
+        InitializeAsync(InitAsync);
     }
 
     private void OnRunnerLineReceived(PowerShellLine l) => Console.Append(l);

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -55,7 +55,7 @@ public partial class DashboardViewModel : ViewModelBase
         _tuneUp = tuneUp;
         _healthScore = healthScore;
         IsElevated = AdminHelper.IsElevated();
-        _ = LoadHealthScoreAsync();
+        InitializeAsync(LoadHealthScoreAsync);
     }
 
     // ── Health Score ───────────────────────────────────────────────────

--- a/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
@@ -60,7 +60,7 @@ public partial class DeepCleanupViewModel : ViewModelBase
 
     public DeepCleanupViewModel()
     {
-        _ = InitAsync();
+        InitializeAsync(InitAsync);
     }
 
     private async Task InitAsync()

--- a/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
@@ -54,7 +54,7 @@ public partial class PerformanceViewModel : ViewModelBase
     public PerformanceViewModel(PowerShellRunner ps)
     {
         _service = new PerformanceService(ps);
-        _ = InitAsync();
+        InitializeAsync(InitAsync);
     }
 
     private async Task InitAsync()

--- a/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
@@ -33,7 +33,7 @@ public partial class ProcessManagerViewModel : ViewModelBase
 
     public ProcessManagerViewModel()
     {
-        _ = InitAsync();
+        InitializeAsync(InitAsync);
     }
 
     private async Task InitAsync()

--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -36,7 +36,7 @@ public partial class ServicesViewModel : ViewModelBase
 
     public ServicesViewModel()
     {
-        _ = InitAsync();
+        InitializeAsync(InitAsync);
     }
 
     private async Task InitAsync()

--- a/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
@@ -40,7 +40,7 @@ public partial class SpeedTestViewModel : ViewModelBase
     public SpeedTestViewModel(NetworkSharedState shared)
     {
         Shared = shared;
-        _ = LoadHistoryAsync();
+        InitializeAsync(LoadHistoryAsync);
     }
 
     private async Task LoadHistoryAsync()

--- a/SysManager/SysManager/ViewModels/StartupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StartupViewModel.cs
@@ -30,7 +30,7 @@ public partial class StartupViewModel : ViewModelBase
 
     public StartupViewModel()
     {
-        _ = InitAsync();
+        InitializeAsync(InitAsync);
     }
 
     partial void OnHideWindowsEntriesChanged(bool value) => ApplyFilter();

--- a/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
@@ -50,7 +50,7 @@ public partial class SystemHealthViewModel : ViewModelBase
         IsElevated = AdminHelper.IsElevated();
         _runner.LineReceived += OnRunnerLineReceived;
 
-        _ = InitAsync();
+        InitializeAsync(InitAsync);
     }
 
     private void OnRunnerLineReceived(PowerShellLine l) => Console.Append(l);

--- a/SysManager/SysManager/ViewModels/ViewModelBase.cs
+++ b/SysManager/SysManager/ViewModels/ViewModelBase.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;
+using Serilog;
 
 namespace SysManager.ViewModels;
 
@@ -14,6 +15,27 @@ public abstract partial class ViewModelBase : ObservableObject, IDisposable
     [ObservableProperty] private bool _isProgressIndeterminate;
 
     private bool _disposed;
+
+    /// <summary>
+    /// Safely launches an async task from a constructor or non-async context.
+    /// Exceptions are caught and logged instead of becoming unobserved task
+    /// exceptions that could crash the application (CQ-M3).
+    /// </summary>
+    protected static async void InitializeAsync(Func<Task> asyncAction, [System.Runtime.CompilerServices.CallerMemberName] string callerName = "")
+    {
+        try
+        {
+            await asyncAction().ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during shutdown — no action needed.
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Unhandled exception in async initialization of {Caller}", callerName);
+        }
+    }
 
     /// <summary>
     /// Override in derived classes to release managed resources

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -35,7 +35,7 @@ public partial class WindowsUpdateViewModel : ViewModelBase
         _runner.LineReceived += OnRunnerLineReceived;
         _runner.ProgressChanged += OnRunnerProgressChanged;
         IsElevated = AdminHelper.IsElevated();
-        _ = InitAsync();
+        InitializeAsync(InitAsync);
     }
 
     private void OnRunnerLineReceived(PowerShellLine l) => Console.Append(l);


### PR DESCRIPTION
## Summary
Resolves CQ-M3: fire-and-forget async in 12 ViewModel constructors that could produce unobserved task exceptions.

## Changes

### ViewModelBase — new InitializeAsync helper
Added a protected static method that wraps async initialization with structured error handling:
- Catches OperationCanceledException silently (expected during shutdown)
- Catches all other exceptions and logs them via Serilog
- Uses CallerMemberName for automatic context in log messages

### 12 ViewModels updated
Replaced bare discard pattern with the safe helper:
- AboutViewModel, BatteryHealthViewModel, CleanupViewModel
- DashboardViewModel, DeepCleanupViewModel, PerformanceViewModel
- ProcessManagerViewModel, ServicesViewModel, SpeedTestViewModel
- StartupViewModel, SystemHealthViewModel, WindowsUpdateViewModel

## Why this matters
The previous pattern discarded the Task, meaning any exception thrown during async initialization would become an unobserved task exception. On .NET 6+ this doesn't crash the app by default, but the errors are silently lost — making debugging difficult. Now all initialization failures are logged with full context.

## Testing
- Build: 0 errors (main + tests)
- No behavioral changes — same initialization, better error visibility
