### PR TITLE
test: enable parallelism, add NSubstitute, document test infrastructure (TEST-M4, H1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.31] - 2026-05-18
+
+### Changed
+- **Test parallelism** — enabled `parallelizeTestCollections` in xunit.runner.json
+  so pure-logic unit tests run concurrently, reducing CI test time. Tests that
+  touch shared OS resources remain serialized via `[Collection("Network")]`
+  (TEST-M4).
+- **Mocking framework** — added NSubstitute 5.3 to the test project, enabling
+  interface-based mocking for future tests that need to isolate OS dependencies
+  (TEST-H1).
+- **TESTING.md** — documented test infrastructure (frameworks, parallelism
+  strategy, conventions for mocking and time-dependent tests).
+
 ## [0.48.30] - 2026-05-18
 
 ### Fixed

--- a/SysManager/SysManager.Tests/SysManager.Tests.csproj
+++ b/SysManager/SysManager.Tests/SysManager.Tests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="Xunit.StaFact" Version="1.1.11" />

--- a/SysManager/SysManager.Tests/xunit.runner.json
+++ b/SysManager/SysManager.Tests/xunit.runner.json
@@ -1,6 +1,6 @@
 {
   "parallelizeAssembly": false,
-  "parallelizeTestCollections": false,
-  "maxParallelThreads": 1,
-  "longRunningTestSeconds": 120
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": 0,
+  "longRunningTestSeconds": 30
 }

--- a/TESTING.md
+++ b/TESTING.md
@@ -49,6 +49,33 @@ Coverage is collected automatically on CI via `coverlet` and uploaded to
 [Codecov](https://codecov.io/gh/laurentiu021/SystemManager). The badge in
 `README.md` reflects the latest `main` branch result.
 
+## Test infrastructure
+
+### Frameworks
+
+| Package | Purpose |
+|---|---|
+| xUnit 2.9 | Test framework |
+| NSubstitute 5.3 | Mocking/substitution for interface-based testing |
+| coverlet | Code coverage collection |
+| Xunit.StaFact | STA thread support for WPF-dependent tests |
+
+### Parallelism
+
+Unit tests run in parallel by default (`parallelizeTestCollections: true`).
+Tests that share state or touch OS resources are isolated via xUnit
+collection definitions:
+
+- `[Collection("Network")]` — tests using ICMP sockets run sequentially.
+
+### Conventions
+
+- Pure logic tests (parsers, analyzers, converters) need no mocking.
+- Tests that depend on OS services should use NSubstitute to mock the
+  service interface, keeping the test fast and deterministic.
+- Time-dependent tests should use injectable time sources or generous
+  tolerances to avoid flakiness on slow CI runners.
+
 To generate a local coverage report:
 
 ```powershell


### PR DESCRIPTION
## Summary
Addresses test quality findings TEST-M4 and TEST-H1 from the full review.

## Changes

### TEST-M4: Enable test parallelism
- Changed xunit.runner.json: parallelizeTestCollections true, maxParallelThreads 0 (auto)
- Tests using shared OS resources remain serialized via [Collection] attributes
- Reduced longRunningTestSeconds from 120 to 30 for faster flaky detection

### TEST-H1: Add mocking framework
- Added NSubstitute 5.3.0 to the test project
- Enables interface-based mocking for future tests that need to isolate OS dependencies
- No existing tests modified — this is infrastructure for new tests going forward

### Documentation
- Updated TESTING.md with test infrastructure section (frameworks table, parallelism strategy, conventions)

## Note
This is a test: commit — no release triggered. TEST-H2 (coverage gaps), TEST-M1 (flaky tests), and TEST-M2 (thread-safety assertions) are tracked in issue #320 for incremental improvement.

## Testing
- Build: 0 errors (tests project compiles with NSubstitute)
