### PR TITLE
fix: eliminate FormatSize and OEM encoding duplication (CQ LOWs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.32] - 2026-05-18
+
+### Fixed
+- **FormatSize duplication** — extracted shared `FormatHelper.FormatSize` method;
+  `ProcessManagerViewModel`, `DiskAnalyzerViewModel`, and `DuplicateFileViewModel`
+  now delegate to the shared helper instead of duplicating the switch expression.
+- **OEM encoding duplication** — `CleanupViewModel` (SFC + DISM) and
+  `SystemHealthViewModel` (chkdsk) now use `PowerShellRunner.OemEncoding`
+  instead of duplicating the encoding resolution logic inline.
+
 ## [0.48.31] - 2026-05-18
 
 ### Changed

--- a/SysManager/SysManager/Helpers/FormatHelper.cs
+++ b/SysManager/SysManager/Helpers/FormatHelper.cs
@@ -1,0 +1,23 @@
+// SysManager · FormatHelper — shared formatting utilities
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Helpers;
+
+/// <summary>
+/// Shared formatting methods used across multiple ViewModels.
+/// Eliminates duplication of common formatting logic.
+/// </summary>
+public static class FormatHelper
+{
+    /// <summary>
+    /// Formats a byte count into a human-readable string (B, KB, MB, GB).
+    /// </summary>
+    public static string FormatSize(long bytes) => bytes switch
+    {
+        >= 1L << 30 => $"{bytes / (double)(1L << 30):F1} GB",
+        >= 1L << 20 => $"{bytes / (double)(1L << 20):F1} MB",
+        >= 1L << 10 => $"{bytes / (double)(1L << 10):F1} KB",
+        _ => $"{bytes} B"
+    };
+}

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -242,18 +242,7 @@ public partial class CleanupViewModel : ViewModelBase
         _runner.LineReceived += Collect;
         try
         {
-            System.Text.Encoding oemEncoding;
-            try
-            {
-                oemEncoding = System.Text.Encoding.GetEncoding(
-                    System.Globalization.CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
-            }
-            catch (NotSupportedException)
-            {
-                oemEncoding = System.Text.Encoding.UTF8;
-            }
-
-            var exit = await _runner.RunProcessAsync("sfc.exe", "/scannow", _sfcCts.Token, oemEncoding);
+            var exit = await _runner.RunProcessAsync("sfc.exe", "/scannow", _sfcCts.Token, PowerShellRunner.OemEncoding);
             var (verdict, color) = ParseSfcResult(captured, exit);
             SfcVerdict = verdict;
             SfcVerdictColorHex = color;
@@ -326,18 +315,7 @@ public partial class CleanupViewModel : ViewModelBase
         _runner.LineReceived += Collect;
         try
         {
-            System.Text.Encoding oemEncoding;
-            try
-            {
-                oemEncoding = System.Text.Encoding.GetEncoding(
-                    System.Globalization.CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
-            }
-            catch (NotSupportedException)
-            {
-                oemEncoding = System.Text.Encoding.UTF8;
-            }
-
-            var exit = await _runner.RunProcessAsync("DISM.exe", "/Online /Cleanup-Image /RestoreHealth", _dismCts.Token, oemEncoding);
+            var exit = await _runner.RunProcessAsync("DISM.exe", "/Online /Cleanup-Image /RestoreHealth", _dismCts.Token, PowerShellRunner.OemEncoding);
             var (verdict, color) = ParseDismResult(captured, exit);
             DismVerdict = verdict;
             DismVerdictColorHex = color;

--- a/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
@@ -227,11 +227,5 @@ public partial class DiskAnalyzerViewModel : ViewModelBase
         HasDriveInfo = false;
     }
 
-    private static string FormatSize(long bytes) => bytes switch
-    {
-        >= 1L << 30 => $"{bytes / (double)(1L << 30):F1} GB",
-        >= 1L << 20 => $"{bytes / (double)(1L << 20):F1} MB",
-        >= 1L << 10 => $"{bytes / (double)(1L << 10):F1} KB",
-        _ => $"{bytes} B"
-    };
+    private static string FormatSize(long bytes) => Helpers.FormatHelper.FormatSize(bytes);
 }

--- a/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
@@ -187,11 +187,5 @@ public partial class DuplicateFileViewModel : ViewModelBase
         }
     }
 
-    private static string FormatSize(long bytes) => bytes switch
-    {
-        >= 1L << 30 => $"{bytes / (double)(1L << 30):F1} GB",
-        >= 1L << 20 => $"{bytes / (double)(1L << 20):F1} MB",
-        >= 1L << 10 => $"{bytes / (double)(1L << 10):F1} KB",
-        _ => $"{bytes} B"
-    };
+    private static string FormatSize(long bytes) => Helpers.FormatHelper.FormatSize(bytes);
 }

--- a/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
@@ -157,13 +157,7 @@ public partial class ProcessManagerViewModel : ViewModelBase
         Summary = $"{ProcessCount} processes · {FormatSize(TotalMemory)} total memory";
     }
 
-    private static string FormatSize(long bytes) => bytes switch
-    {
-        >= 1L << 30 => $"{bytes / (double)(1L << 30):F1} GB",
-        >= 1L << 20 => $"{bytes / (double)(1L << 20):F1} MB",
-        >= 1L << 10 => $"{bytes / (double)(1L << 10):F1} KB",
-        _ => $"{bytes} B"
-    };
+    private static string FormatSize(long bytes) => Helpers.FormatHelper.FormatSize(bytes);
 
     private static bool MatchesFilter(ProcessEntry p, string filter) =>
         p.Name.Contains(filter, StringComparison.OrdinalIgnoreCase) ||

--- a/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
@@ -274,23 +274,10 @@ public partial class SystemHealthViewModel : ViewModelBase
             void OnLine(PowerShellLine l) => captured.Add(l.Text);
             _runner.LineReceived += OnLine;
 
-            System.Text.Encoding oemEncoding;
-            try
-            {
-                oemEncoding = System.Text.Encoding.GetEncoding(
-                    System.Globalization.CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
-            }
-            catch (NotSupportedException)
-            {
-                // Code page (e.g. 437) may not be registered on some systems;
-                // fall back to UTF-8 which handles chkdsk output safely.
-                oemEncoding = System.Text.Encoding.UTF8;
-            }
-
             int exit;
             try
             {
-                exit = await _runner.RunProcessAsync("chkdsk.exe", $"{driveLetter} /scan", ct, oemEncoding);
+                exit = await _runner.RunProcessAsync("chkdsk.exe", $"{driveLetter} /scan", ct, PowerShellRunner.OemEncoding);
             }
             finally { _runner.LineReceived -= OnLine; }
 


### PR DESCRIPTION
## Summary
Resolves two code quality LOW findings: duplicated FormatSize method and duplicated OEM encoding resolution.

## Changes

### FormatSize DRY violation
- Created Helpers/FormatHelper.cs with a shared FormatSize(long bytes) method
- ProcessManagerViewModel, DiskAnalyzerViewModel, DuplicateFileViewModel now delegate to the shared helper
- Identical switch expression removed from 3 files

### OEM encoding duplication
- CleanupViewModel (SFC + DISM commands) and SystemHealthViewModel (chkdsk) were duplicating the OEM encoding resolution logic (try GetEncoding, catch NotSupportedException, fallback to UTF-8)
- Replaced with PowerShellRunner.OemEncoding which already centralizes this logic
- Removed ~30 lines of duplicated code

## Testing
- Build: 0 errors
- No behavioral changes — same formatting, same encoding, less duplication
