### PR TITLE
fix: optimize ConsoleViewModel trimming and LogsViewModel batch dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.33] - 2026-05-18
+
+### Changed
+- **ConsoleViewModel** — buffer trimming now uses clear-and-rebuild when
+  removing more than 25% of lines, reducing worst-case from O(n×excess)
+  to O(n) (CQ-LOW: ConsoleViewModel O(n²)).
+- **LogsViewModel** — event log entries are now dispatched to the UI thread
+  in batches of 50 instead of one-at-a-time, reducing dispatcher overhead
+  by ~98% when loading large event logs (CQ-LOW: LogsViewModel batch dispatch).
+
 ## [0.48.32] - 2026-05-18
 
 ### Fixed

--- a/SysManager/SysManager/ViewModels/ConsoleViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ConsoleViewModel.cs
@@ -38,11 +38,23 @@ public partial class ConsoleViewModel : ObservableObject
             Lines.Add(line);
             if (Lines.Count > MaxLines)
             {
-                // PERF-005: Remove excess items from front (index 0). Each removal
-                // is O(n) but unavoidable with ObservableCollection.
+                // PERF: When excess is large relative to buffer, clear-and-rebuild
+                // is O(n) vs O(n*excess) for repeated RemoveAt(0).
                 var excess = Lines.Count - MaxLines;
-                for (int i = 0; i < excess; i++)
-                    Lines.RemoveAt(0);
+                if (excess > Lines.Count / 4)
+                {
+                    var keep = new PowerShellLine[MaxLines];
+                    for (int i = 0; i < MaxLines; i++)
+                        keep[i] = Lines[excess + i];
+                    Lines.Clear();
+                    foreach (var item in keep)
+                        Lines.Add(item);
+                }
+                else
+                {
+                    for (int i = 0; i < excess; i++)
+                        Lines.RemoveAt(0);
+                }
             }
         }
     }

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -132,14 +132,41 @@ public partial class LogsViewModel : ViewModelBase
 
         try
         {
+            const int batchSize = 50;
+            var batch = new List<FriendlyEventEntry>(batchSize);
+
             await foreach (var entry in _eventLogs.ReadAsync(opt, _cts.Token))
             {
+                batch.Add(entry);
+                if (batch.Count >= batchSize)
+                {
+                    var items = batch.ToArray();
+                    batch.Clear();
+                    Post(() =>
+                    {
+                        foreach (var item in items)
+                        {
+                            Entries.Add(item);
+                            UpdateCounts(item, 1);
+                        }
+                    });
+                }
+            }
+
+            // Flush remaining items
+            if (batch.Count > 0)
+            {
+                var remaining = batch.ToArray();
                 Post(() =>
                 {
-                    Entries.Add(entry);
-                    UpdateCounts(entry, 1);
+                    foreach (var item in remaining)
+                    {
+                        Entries.Add(item);
+                        UpdateCounts(item, 1);
+                    }
                 });
             }
+
             StatusMessage = $"Loaded {Entries.Count} events from {SelectedLog}";
             UpdateVisibleCount();
         }


### PR DESCRIPTION
## Summary
Resolves two performance LOWs from the full code review.

## Changes

### ConsoleViewModel O(n^2) trimming
- Same clear-and-rebuild optimization as PERF-M3 (NetworkSharedState)
- When excess lines exceed 25%% of buffer, snapshot kept items, clear, re-add
- Reduces worst-case from O(n*excess) to O(n)

### LogsViewModel batch dispatch
- Previously dispatched each event entry individually to the UI thread (500 entries = 500 dispatcher calls)
- Now batches entries in groups of 50 before dispatching
- Reduces dispatcher overhead by ~98%% for large event log loads
- UI remains responsive — batches are small enough to not block rendering

## Testing
- Build: 0 errors
- No behavioral changes — same data displayed, faster rendering
