### PR TITLE
fix: audit findings — IDisposable, README counts, ARCHITECTURE accuracy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -132,15 +132,31 @@ Key services:
   system commands with live output capture.
 - `ServiceManagerService` — enumerate Windows services, gaming
   recommendations, start/stop/disable with admin checks.
+- `AppAlertService` — monitors installed apps for available updates and
+  surfaces alerts on the dashboard.
+- `AppBlockerService` — blocks/unblocks app execution via Image File
+  Execution Options (IFEO) debugger redirect.
+- `BatteryService` — battery health, charge cycles, wear level, and
+  power report generation via WMI and `powercfg /batteryreport`.
+- `DialogService` — centralized confirmation/message dialogs (replaces
+  direct MessageBox calls for testability).
+- `IconExtractorService` — extracts application icons from executables
+  for display in process/app lists; caches results.
+- `OperationLockService` — prevents concurrent destructive operations
+  via named semaphore acquisition with timeout.
+- `ProcessDescriptionService` — enriches process entries with friendly
+  descriptions from file version info and known-process database.
+- `SpeedTestHistoryService` — persists speed test results to JSON for
+  historical charting and trend analysis.
+- `ShortcutCleanerService` — scans Start Menu and Desktop for broken
+  shortcuts (dead targets) and offers safe removal.
 
 ## Dependency Injection
 
 `ServiceRegistration.cs` configures `Microsoft.Extensions.DependencyInjection`.
 `App.OnStartup` builds the `IServiceProvider` and exposes it as `App.Services`.
 Core services and ViewModels are registered as singletons — one shared instance
-per app lifetime. Some lightweight services (e.g. `TuneUpService`,
-`ShortcutCleanerService`) are instantiated directly by their consumers rather
-than registered in the container. `MainWindowViewModel` resolves child VMs from
+per app lifetime. `MainWindowViewModel` resolves child VMs from
 the container at runtime; falls back to manual creation in tests (no DI
 dependency in the test project).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **PerformanceService** — implemented `IDisposable` to properly dispose the
+  internal `SemaphoreSlim` gate, preventing resource leaks on app shutdown.
+
+### Changed
+- **README.md** — corrected sidebar tab counts (56 total, 25 implemented).
+- **ARCHITECTURE.md** — removed false claim that TuneUpService and
+  ShortcutCleanerService are instantiated directly (both are registered in DI).
+- **ARCHITECTURE.md** — added 9 missing services to the Key services section
+  (AppAlertService, AppBlockerService, BatteryService, DialogService,
+  IconExtractorService, OperationLockService, ProcessDescriptionService,
+  SpeedTestHistoryService, ShortcutCleanerService).
+
 ## [0.48.33] - 2026-05-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ an honest "is it my PC, my ISP, or the server?" verdict.
 ## Features
 
 ### Sidebar navigation
-The sidebar organises 51 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 20 tabs are fully
+The sidebar organises 56 feature tabs into 12 collapsible groups so you can
+find what you need without scrolling through a flat list. 25 tabs are fully
 implemented; 31 are work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |

--- a/SysManager/SysManager/Services/PerformanceService.cs
+++ b/SysManager/SysManager/Services/PerformanceService.cs
@@ -24,10 +24,11 @@ namespace SysManager.Services;
 /// • NVIDIA GPU subkey is auto-detected (not hardcoded to 0000).
 /// • Visual effects use SystemParametersInfo (instant), not registry-only.
 /// </summary>
-public sealed class PerformanceService
+public sealed class PerformanceService : IDisposable
 {
     private readonly PowerShellRunner _ps;
     private readonly SemaphoreSlim _psGate = new(1, 1);
+    private bool _disposed;
 
     // ── Well-known power plan GUIDs ──
     internal const string BalancedGuid = "381b4222-f694-41f0-9685-ff5bb260df2e";
@@ -617,5 +618,13 @@ public sealed class PerformanceService
 
         // Processor state
         await SetProcessorMinStateAsync(snapshot.ProcessorMinPercentAc, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _psGate.Dispose();
     }
 }


### PR DESCRIPTION
## Summary
Addresses critical and high-priority findings from exhaustive code audit.

## Changes

### Code
- **PerformanceService.cs** — implemented `IDisposable` to dispose `SemaphoreSlim _psGate` on shutdown

### Documentation
- **README.md** — corrected sidebar tab counts: 56 total (was 51), 25 implemented (was 20)
- **ARCHITECTURE.md** — removed false claim that TuneUpService/ShortcutCleanerService are instantiated directly (both registered in DI since ServiceRegistration.cs)
- **ARCHITECTURE.md** — added 9 missing services to Key services section

### GitHub Settings (applied separately)
- Closed duplicate issues #338 (dup of #339) and #330 (dup of #332)
- Added missing `enhancement` label to issue #1
- Enabled branch protection on main (requires CI pass)
