### PR TITLE
ci: add winget-releaser workflow for automatic package updates

### DIFF
--- a/.github/workflows/winget-releaser.yml
+++ b/.github/workflows/winget-releaser.yml
@@ -1,0 +1,19 @@
+# Automatically submit new releases to winget-pkgs
+# Triggers on every published GitHub Release and creates a PR on microsoft/winget-pkgs
+
+name: Winget Releaser
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  winget-update:
+    name: Update winget package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: laurentiu021.SysManager
+          installers-regex: '\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Every published GitHub Release will now auto-submit a PR to microsoft/winget-pkgs with the updated version, URL, and SHA256. Uses vedantmgoyal9/winget-releaser@v2.
