### PR TITLE
test: fix ServicesViewModel tests missing ApplyFilter call after data injection

### DIFF
--- a/SysManager/SysManager.Tests/ServicesViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ServicesViewModelTests.cs
@@ -29,6 +29,10 @@ public class ServicesViewModelTests
         var vm = new ServicesViewModel();
         var field = typeof(ServicesViewModel).GetField("_allServices", BindingFlags.NonPublic | BindingFlags.Instance)!;
         field.SetValue(vm, services ?? TestServices);
+
+        // Trigger ApplyFilter so the Services collection reflects the injected data.
+        var applyFilter = typeof(ServicesViewModel).GetMethod("ApplyFilter", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        applyFilter.Invoke(vm, null);
         return vm;
     }
 


### PR DESCRIPTION
## Problem

The `CreateWithData` helper injected test services via reflection but did not call `ApplyFilter()` afterwards. Since the default `SelectedFilter` is already `"All"`, setting it to `"All"` in tests did not trigger `OnSelectedFilterChanged`, leaving `Services` empty (0 items).

## Fix

Call `ApplyFilter()` via reflection immediately after injecting `_allServices` in `CreateWithData`. This ensures the `Services` collection is populated before assertions run.

## Tests fixed

- `ApplyFilter_All_ShowsAllServices`
- `SelectedFilter_Change_TriggersRefilter`
- `Filter_Change_TriggersRefilter`
