### PR TITLE
fix: dispose ManagementObject in MemoryTestService and SkiaSharp paints in NetworkSharedState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **MemoryTestService** — `ManagementObject` instances in `GetModulesAsync` WMI
+  query are now properly disposed via `using (mo)` block, preventing native handle
+  leaks when enumerating physical memory modules.
+- **NetworkSharedState** — `Dispose()` now fully releases all SkiaSharp paint
+  resources: series paints (stroke, geometry, fill), axis paints (name, labels,
+  separators), and class-level legend/tooltip paints. Previously only typefaces
+  were disposed, leaking unmanaged `SKPaint` handles.
+
 ### Added
 - **ServicesViewModelTests** — 20 unit tests covering ApplyFilter logic: category
   filters (All, Running, Stopped, Safe to disable, Advanced), text search by name/

--- a/SysManager/SysManager/Services/MemoryTestService.cs
+++ b/SysManager/SysManager/Services/MemoryTestService.cs
@@ -103,16 +103,19 @@ public sealed class MemoryTestService
                     "SELECT BankLabel, DeviceLocator, Manufacturer, Capacity, Speed, ConfiguredClockSpeed, PartNumber FROM Win32_PhysicalMemory");
                 foreach (ManagementObject mo in s.Get())
                 {
-                    double cap = Convert.ToDouble(mo["Capacity"] ?? 0) / 1024d / 1024d / 1024d;
-                    list.Add(new MemoryModuleHealth
+                    using (mo)
                     {
-                        Slot = mo["DeviceLocator"]?.ToString() ?? mo["BankLabel"]?.ToString() ?? "",
-                        Manufacturer = (mo["Manufacturer"]?.ToString() ?? "").Trim(),
-                        CapacityGB = Math.Round(cap, 0),
-                        SpeedMHz = Convert.ToUInt32(mo["Speed"] ?? 0u),
-                        ConfiguredSpeedMHz = Convert.ToUInt32(mo["ConfiguredClockSpeed"] ?? 0u),
-                        PartNumber = (mo["PartNumber"]?.ToString() ?? "").Trim()
-                    });
+                        double cap = Convert.ToDouble(mo["Capacity"] ?? 0) / 1024d / 1024d / 1024d;
+                        list.Add(new MemoryModuleHealth
+                        {
+                            Slot = mo["DeviceLocator"]?.ToString() ?? mo["BankLabel"]?.ToString() ?? "",
+                            Manufacturer = (mo["Manufacturer"]?.ToString() ?? "").Trim(),
+                            CapacityGB = Math.Round(cap, 0),
+                            SpeedMHz = Convert.ToUInt32(mo["Speed"] ?? 0u),
+                            ConfiguredSpeedMHz = Convert.ToUInt32(mo["ConfiguredClockSpeed"] ?? 0u),
+                            PartNumber = (mo["PartNumber"]?.ToString() ?? "").Trim()
+                        });
+                    }
                 }
             }
             catch (ManagementException) { /* WMI class not available */ }

--- a/SysManager/SysManager/ViewModels/NetworkSharedState.cs
+++ b/SysManager/SysManager/ViewModels/NetworkSharedState.cs
@@ -260,6 +260,13 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
             (line.GeometryFill as IDisposable)?.Dispose();
             (line.Fill as IDisposable)?.Dispose();
         }
+        else if (series is LineSeries<ObservablePoint> traceLine)
+        {
+            (traceLine.Stroke as IDisposable)?.Dispose();
+            (traceLine.GeometryStroke as IDisposable)?.Dispose();
+            (traceLine.GeometryFill as IDisposable)?.Dispose();
+            (traceLine.Fill as IDisposable)?.Dispose();
+        }
     }
 
     public void ClearHistory()
@@ -551,10 +558,31 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
         TraceMonitor.Dispose();
         FlushTimer?.Stop();
 
-        // Dispose SKTypeface (unmanaged SkiaSharp memory) — LEAK-003
+        // Dispose series paint objects (unmanaged SkiaSharp handles)
+        foreach (var series in LatencySeries) DisposeSeries(series);
+        foreach (var series in TraceSeries) DisposeSeries(series);
+
+        // Dispose axis paint objects
+        DisposeAxisPaints(LatencyXAxes);
+        DisposeAxisPaints(LatencyYAxes);
+        DisposeAxisPaints(TraceXAxes);
+        DisposeAxisPaints(TraceYAxes);
+
+        // Dispose class-level paint objects and their typefaces
         LegendTextPaint.SKTypeface?.Dispose();
-        LegendBackgroundPaint.SKTypeface?.Dispose();
-        TooltipTextPaint.SKTypeface?.Dispose();
-        TooltipBackgroundPaint.SKTypeface?.Dispose();
+        (LegendTextPaint as IDisposable)?.Dispose();
+        (LegendBackgroundPaint as IDisposable)?.Dispose();
+        (TooltipTextPaint as IDisposable)?.Dispose();
+        (TooltipBackgroundPaint as IDisposable)?.Dispose();
+    }
+
+    private static void DisposeAxisPaints(Axis[] axes)
+    {
+        foreach (var axis in axes)
+        {
+            (axis.NamePaint as IDisposable)?.Dispose();
+            (axis.LabelsPaint as IDisposable)?.Dispose();
+            (axis.SeparatorsPaint as IDisposable)?.Dispose();
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fix two resource leaks identified in the full code review (LEAK-003, LEAK-007 subset).

## Changes

### MemoryTestService.cs
- Wrap `ManagementObject mo` in `using (mo)` inside the `GetModulesAsync` foreach loop.
  Without this, each WMI object's native COM handle leaks until GC finalizer runs.

### NetworkSharedState.cs
- `Dispose()` now disposes **all** SkiaSharp paint resources:
  - Series paints (Stroke, GeometryStroke, GeometryFill, Fill) for both latency and trace series
  - Axis paints (NamePaint, LabelsPaint, SeparatorsPaint) for all 4 axis arrays
  - Class-level paints (LegendTextPaint, LegendBackgroundPaint, TooltipTextPaint, TooltipBackgroundPaint)
- `DisposeSeries` now handles both `LineSeries<DateTimePoint>` and `LineSeries<ObservablePoint>`
- Added `DisposeAxisPaints` helper method

### Previously fixed (verified, no action needed)
- LEAK-001 (BatteryService, DiskHealthService, FixedDriveService, SystemInfoService) — already use `using (mo)`
- LEAK-002 (ShortcutCleanerService double ReleaseComObject) — already fixed with comment
- LEAK-004 (UninstallerViewModel lambda) — already unsubscribes in Dispose
- LEAK-005 (PowerShellRunner) — class has no persistent resources (creates Runspace per-call with `using`)
- LEAK-006 (TrayIconService stream) — already uses `using var stream`
- LEAK-007 (MemoryTestService Process.Start) — already uses `using var proc`

## Testing
- Build: 0 errors (main project + test project)
- Existing tests unaffected (no behavior change, only resource cleanup)
