### PR TITLE
fix: prevent integer overflow in DiskHealthReport and document pinned Ookla CLI version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   resources: series paints (stroke, geometry, fill), axis paints (name, labels,
   separators), and class-level legend/tooltip paints. Previously only typefaces
   were disposed, leaking unmanaged `SKPaint` handles.
+- **DiskHealthReport** — fixed potential integer overflow in `HealthPercent`
+  calculation when `ReadErrors` or `WriteErrors` exceed `int.MaxValue`; arithmetic
+  now uses `long` before clamping to the 0–20 deduction cap.
+- **SpeedTestService** — documented pinned Ookla CLI version (`1.2.0`) with
+  maintenance comment explaining update procedure and Authenticode verification.
 
 ### Added
 - **ServicesViewModelTests** — 20 unit tests covering ApplyFilter logic: category

--- a/SysManager/SysManager/Models/DiskHealthReport.cs
+++ b/SysManager/SysManager/Models/DiskHealthReport.cs
@@ -74,8 +74,8 @@ public partial class DiskHealthReport : ObservableObject
                 else if (TemperatureC.Value > 50) score -= 5;
             }
 
-            if (ReadErrors is > 0) score -= Math.Min((int)ReadErrors.Value * 5, 20);
-            if (WriteErrors is > 0) score -= Math.Min((int)WriteErrors.Value * 5, 20);
+            if (ReadErrors is > 0) score -= (int)Math.Min(ReadErrors.Value * 5L, 20L);
+            if (WriteErrors is > 0) score -= (int)Math.Min(WriteErrors.Value * 5L, 20L);
 
             if (!WearPercent.HasValue && !TemperatureC.HasValue && ReadErrors is null && WriteErrors is null)
             {

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -310,6 +310,10 @@ public sealed class SpeedTestService
 
         progress?.Report((5, "Downloading Ookla CLI…"));
         var arch = Environment.Is64BitOperatingSystem ? "win64" : "win32";
+        // MAINTENANCE: Ookla CLI version is pinned. When a new version is released,
+        // update the version string below. Check https://www.speedtest.net/apps/cli
+        // for the latest version. Authenticode signature verification (below) ensures
+        // binary integrity regardless of version.
         var zipUrl = $"https://install.speedtest.net/app/cli/ookla-speedtest-1.2.0-{arch}.zip";
 
         var zipPath = Path.Join(toolsDir, "ookla.zip");


### PR DESCRIPTION
## Summary

Fix two remaining bugs from the full code review (BUG-008, BUG-009).

## Changes

### DiskHealthReport.cs (BUG-009)
- Fixed potential integer overflow in `HealthPercent` when `ReadErrors` or `WriteErrors`
  exceed `int.MaxValue`. The cast `(int)ReadErrors.Value * 5` could wrap to a negative
  number, causing the score to increase instead of decrease.
- Fix: use `long` arithmetic (`ReadErrors.Value * 5L`) before clamping with `Math.Min(..., 20L)`.

### SpeedTestService.cs (BUG-008)
- Added maintenance comment documenting the pinned Ookla CLI version (`1.2.0`) and
  explaining the update procedure. Authenticode signature verification ensures binary
  integrity regardless of version.

## Previously fixed (verified, no action needed)
- BUG-001 (WindowsFeaturesVM CanExecute) — already calls `NotifyCanExecuteChanged`
- BUG-002 (DuplicateFileGroup WastedBytes) — already has `[NotifyPropertyChangedFor]`
- BUG-003 (TuneUpService HRESULT) — already checks return value
- BUG-004 (UpdateService pre-release) — already filters in `Map()`
- BUG-005 (ServiceManagerService StartPending) — already checks status
- BUG-006 (DiskAnalyzerService empty dirs) — correctly tracks exceptions
- BUG-007 (WindowsUpdateVM Shutdown) — already uses `?.Shutdown()`
- SEC-001 (SpeedTestService fake hashes) — no fake hashes exist; uses Authenticode

## Testing
- Build: 0 errors
- No behavior change for normal values (deduction capped at 20 regardless)
