### PR TITLE
chore: seal non-inheritable model and converter classes (MODERN-005)

### DIFF
--- a/SysManager/SysManager/Helpers/OutputKindToBrushConverter.cs
+++ b/SysManager/SysManager/Helpers/OutputKindToBrushConverter.cs
@@ -11,7 +11,7 @@ using SysManager.Models;
 
 namespace SysManager.Helpers;
 
-public class OutputKindToBrushConverter : IValueConverter
+public sealed class OutputKindToBrushConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
@@ -38,7 +38,7 @@ public class OutputKindToBrushConverter : IValueConverter
 /// Also treats any non-null object reference as "true" so it can be used to
 /// toggle visibility based on a nullable result being populated.
 /// </summary>
-public class FlexibleBoolToVisibilityConverter : IValueConverter
+public sealed class FlexibleBoolToVisibilityConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
@@ -72,7 +72,7 @@ public sealed class BoolInverterConverter : IValueConverter
         => value is not true;
 }
 
-public class BoolToElevationBadgeBrushConverter : IValueConverter
+public sealed class BoolToElevationBadgeBrushConverter : IValueConverter
 {
     private static readonly Brush ElevatedBrush = Freeze(new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50)));
     private static readonly Brush NotElevatedBrush = Freeze(new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E)));
@@ -85,7 +85,7 @@ public class BoolToElevationBadgeBrushConverter : IValueConverter
 }
 
 /// <summary>Converts a hex string like "#4CC9F0" to a SolidColorBrush.</summary>
-public class HexToBrushConverter : IValueConverter
+public sealed class HexToBrushConverter : IValueConverter
 {
     // Cache frozen brushes by hex value to reduce GC pressure on frequently-updating bindings.
     private static readonly ConcurrentDictionary<string, SolidColorBrush> _cache = new(StringComparer.OrdinalIgnoreCase);
@@ -119,7 +119,7 @@ public class HexToBrushConverter : IValueConverter
 /// Maps process status text ("Running" / "Not responding") to a coloured brush.
 /// Green for running, red for not responding, grey for anything else.
 /// </summary>
-public class ProcessStatusToBrushConverter : IValueConverter
+public sealed class ProcessStatusToBrushConverter : IValueConverter
 {
     private static readonly Brush RunningBrush = CreateFrozen(Color.FromRgb(0x22, 0xC5, 0x5E));
     private static readonly Brush NotRespondingBrush = CreateFrozen(Color.FromRgb(0xEF, 0x44, 0x44));

--- a/SysManager/SysManager/Models/AppInstallEntry.cs
+++ b/SysManager/SysManager/Models/AppInstallEntry.cs
@@ -9,7 +9,7 @@ namespace SysManager.Models;
 /// <summary>
 /// Represents a newly detected application installation.
 /// </summary>
-public partial class AppInstallEntry : ObservableObject
+public sealed partial class AppInstallEntry : ObservableObject
 {
     /// <summary>Application display name.</summary>
     [ObservableProperty] private string _name = "";

--- a/SysManager/SysManager/Models/AppPackage.cs
+++ b/SysManager/SysManager/Models/AppPackage.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace SysManager.Models;
 
-public partial class AppPackage : ObservableObject
+public sealed partial class AppPackage : ObservableObject
 {
     [ObservableProperty] private bool _isSelected = true;
     [ObservableProperty] private string _name = string.Empty;

--- a/SysManager/SysManager/Models/BatteryInfo.cs
+++ b/SysManager/SysManager/Models/BatteryInfo.cs
@@ -9,7 +9,7 @@ namespace SysManager.Models;
 /// <summary>
 /// Battery health snapshot from WMI / Win32_Battery.
 /// </summary>
-public partial class BatteryInfo : ObservableObject
+public sealed partial class BatteryInfo : ObservableObject
 {
     [ObservableProperty] private bool _hasBattery;
     [ObservableProperty] private string _name = "";

--- a/SysManager/SysManager/Models/BlockedApp.cs
+++ b/SysManager/SysManager/Models/BlockedApp.cs
@@ -9,7 +9,7 @@ namespace SysManager.Models;
 /// <summary>
 /// Represents an application that has been blocked from executing via IFEO.
 /// </summary>
-public partial class BlockedApp : ObservableObject
+public sealed partial class BlockedApp : ObservableObject
 {
     /// <summary>Executable file name (e.g., "notepad.exe").</summary>
     [ObservableProperty] private string _executableName = "";

--- a/SysManager/SysManager/Models/BrokenShortcut.cs
+++ b/SysManager/SysManager/Models/BrokenShortcut.cs
@@ -9,7 +9,7 @@ namespace SysManager.Models;
 /// <summary>
 /// Represents a .lnk shortcut whose target no longer exists.
 /// </summary>
-public partial class BrokenShortcut : ObservableObject
+public sealed partial class BrokenShortcut : ObservableObject
 {
     /// <summary>Display name of the shortcut (without .lnk extension).</summary>
     [ObservableProperty] private string _name = "";

--- a/SysManager/SysManager/Models/CleanupCategory.cs
+++ b/SysManager/SysManager/Models/CleanupCategory.cs
@@ -10,7 +10,7 @@ namespace SysManager.Models;
 /// One bucket of safe-to-delete files, shown as a selectable row in the
 /// Deep Cleanup view. Mutable so checkbox state can two-way bind.
 /// </summary>
-public partial class CleanupCategory : ObservableObject
+public sealed partial class CleanupCategory : ObservableObject
 {
     [ObservableProperty] private bool _isSelected;
 

--- a/SysManager/SysManager/Models/DiskHealthReport.cs
+++ b/SysManager/SysManager/Models/DiskHealthReport.cs
@@ -11,7 +11,7 @@ namespace SysManager.Models;
 /// counters (SMART-sourced). All fields nullable because not every driver
 /// exposes every counter.
 /// </summary>
-public partial class DiskHealthReport : ObservableObject
+public sealed partial class DiskHealthReport : ObservableObject
 {
     [ObservableProperty] private string _friendlyName = "";
     [ObservableProperty] private string _mediaType = "";       // HDD / SSD / NVMe

--- a/SysManager/SysManager/Models/DiskUsageEntry.cs
+++ b/SysManager/SysManager/Models/DiskUsageEntry.cs
@@ -10,7 +10,7 @@ namespace SysManager.Models;
 /// A folder or drive with its total size and percentage of parent.
 /// Used by the Disk Analyzer tab to show space breakdown.
 /// </summary>
-public partial class DiskUsageEntry : ObservableObject
+public sealed partial class DiskUsageEntry : ObservableObject
 {
     [ObservableProperty] private string _name = "";
     [ObservableProperty] private string _fullPath = "";

--- a/SysManager/SysManager/Models/DuplicateFileGroup.cs
+++ b/SysManager/SysManager/Models/DuplicateFileGroup.cs
@@ -11,7 +11,7 @@ namespace SysManager.Models;
 /// A group of files that share the same content (identical SHA-256 hash).
 /// Read-only by design — the UI only offers "Show in Explorer" and "Copy path".
 /// </summary>
-public partial class DuplicateFileGroup : ObservableObject
+public sealed partial class DuplicateFileGroup : ObservableObject
 {
     [ObservableProperty] private string _hash = "";
     [ObservableProperty]
@@ -29,7 +29,7 @@ public partial class DuplicateFileGroup : ObservableObject
 }
 
 /// <summary>A single file within a duplicate group.</summary>
-public partial class DuplicateFileEntry : ObservableObject
+public sealed partial class DuplicateFileEntry : ObservableObject
 {
     [ObservableProperty] private string _path = "";
     [ObservableProperty] private string _name = "";

--- a/SysManager/SysManager/Models/FriendlyEventEntry.cs
+++ b/SysManager/SysManager/Models/FriendlyEventEntry.cs
@@ -11,7 +11,7 @@ namespace SysManager.Models;
 /// Wraps the essentials plus an optional plain-English explanation
 /// attached by <see cref="Services.EventExplainer"/>.
 /// </summary>
-public partial class FriendlyEventEntry : ObservableObject
+public sealed partial class FriendlyEventEntry : ObservableObject
 {
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(RelativeTime))]

--- a/SysManager/SysManager/Models/HealthDiagnostic.cs
+++ b/SysManager/SysManager/Models/HealthDiagnostic.cs
@@ -21,7 +21,7 @@ public enum HealthVerdict
 /// Aggregated health view over the last few seconds of ping data.
 /// Updated in place by the analyzer so a single binding covers the UI.
 /// </summary>
-public partial class HealthDiagnostic : ObservableObject
+public sealed partial class HealthDiagnostic : ObservableObject
 {
     [ObservableProperty] private HealthVerdict _verdict = HealthVerdict.Unknown;
     [ObservableProperty] private string _headline = "Waiting for data…";

--- a/SysManager/SysManager/Models/InstalledApp.cs
+++ b/SysManager/SysManager/Models/InstalledApp.cs
@@ -10,7 +10,7 @@ namespace SysManager.Models;
 /// <summary>
 /// An installed Windows application as reported by winget list.
 /// </summary>
-public partial class InstalledApp : ObservableObject
+public sealed partial class InstalledApp : ObservableObject
 {
     [ObservableProperty] private bool _isSelected;
     [ObservableProperty] private string _name = "";

--- a/SysManager/SysManager/Models/PerformanceProfile.cs
+++ b/SysManager/SysManager/Models/PerformanceProfile.cs
@@ -11,7 +11,7 @@ namespace SysManager.Models;
 /// Every property is read-only from the system — the ViewModel holds the
 /// "desired" state separately so we can diff before applying.
 /// </summary>
-public partial class PerformanceProfile : ObservableObject
+public sealed partial class PerformanceProfile : ObservableObject
 {
     // ── Power plan ──
     [ObservableProperty]

--- a/SysManager/SysManager/Models/PingTarget.cs
+++ b/SysManager/SysManager/Models/PingTarget.cs
@@ -11,7 +11,7 @@ namespace SysManager.Models;
 /// (assigned when added) and a live latency series. Enabled can be toggled
 /// at runtime to temporarily hide a series without losing its history.
 /// </summary>
-public partial class PingTarget : ObservableObject
+public sealed partial class PingTarget : ObservableObject
 {
     [ObservableProperty] private string _name = "";
     [ObservableProperty] private string _host = "";

--- a/SysManager/SysManager/Models/ProcessEntry.cs
+++ b/SysManager/SysManager/Models/ProcessEntry.cs
@@ -10,7 +10,7 @@ namespace SysManager.Models;
 /// <summary>
 /// A running Windows process with its resource usage.
 /// </summary>
-public partial class ProcessEntry : ObservableObject
+public sealed partial class ProcessEntry : ObservableObject
 {
     [ObservableProperty] private int _pid;
     [ObservableProperty] private string _name = "";

--- a/SysManager/SysManager/Models/ServiceEntry.cs
+++ b/SysManager/SysManager/Models/ServiceEntry.cs
@@ -9,7 +9,7 @@ namespace SysManager.Models;
 /// <summary>
 /// Represents a Windows service with its current state and gaming recommendation.
 /// </summary>
-public partial class ServiceEntry : ObservableObject
+public sealed partial class ServiceEntry : ObservableObject
 {
     public string Name { get; init; } = "";
     public string DisplayName { get; init; } = "";

--- a/SysManager/SysManager/Models/StartupEntry.cs
+++ b/SysManager/SysManager/Models/StartupEntry.cs
@@ -12,7 +12,7 @@ namespace SysManager.Models;
 /// renames the registry value (adds/removes a "Disabled_" prefix) —
 /// completely non-destructive and reversible.
 /// </summary>
-public partial class StartupEntry : ObservableObject
+public sealed partial class StartupEntry : ObservableObject
 {
     [ObservableProperty] private string _name = "";
     [ObservableProperty] private string _command = "";

--- a/SysManager/SysManager/Models/TracerouteHop.cs
+++ b/SysManager/SysManager/Models/TracerouteHop.cs
@@ -10,7 +10,7 @@ namespace SysManager.Models;
 /// A single hop in a traceroute result. LatencyMs is an average across the
 /// attempted probes (null if all probes timed out at this hop).
 /// </summary>
-public partial class TracerouteHop : ObservableObject
+public sealed partial class TracerouteHop : ObservableObject
 {
     [ObservableProperty] private int _hopNumber;
     [ObservableProperty] private string _address = "*";

--- a/SysManager/SysManager/Models/WindowsFeature.cs
+++ b/SysManager/SysManager/Models/WindowsFeature.cs
@@ -9,7 +9,7 @@ namespace SysManager.Models;
 /// <summary>
 /// Represents a Windows optional feature with its current state.
 /// </summary>
-public partial class WindowsFeature : ObservableObject
+public sealed partial class WindowsFeature : ObservableObject
 {
     [ObservableProperty] private string _name = "";
     [ObservableProperty] private string _displayName = "";


### PR DESCRIPTION
Add sealed modifier to 24 classes that are not designed for inheritance:

**Converters (5):** OutputKindToBrushConverter, FlexibleBoolToVisibilityConverter, BoolToElevationBadgeBrushConverter, HexToBrushConverter, ProcessStatusToBrushConverter

**Models (19):** AppInstallEntry, AppPackage, BatteryInfo, BlockedApp, BrokenShortcut, CleanupCategory, DiskHealthReport, DiskUsageEntry, DuplicateFileGroup, DuplicateFileEntry, FriendlyEventEntry, HealthDiagnostic, InstalledApp, PerformanceProfile, PingTarget, ProcessEntry, ServiceEntry, StartupEntry, TracerouteHop, WindowsFeature

Sealing prevents unintended inheritance and enables JIT devirtualization optimizations.

Build: 0 errors (main + tests).
