### PR TITLE
chore: replace Array.Empty<T>() with collection expressions (MODERN-003)

### DIFF
--- a/SysManager/SysManager.Tests/CleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/CleanupViewModelTests.cs
@@ -437,7 +437,7 @@ public class SfcResultParsingTests
     [Fact]
     public void ParseSfcResult_EmptyLines_FallsBackToExitCode()
     {
-        var (verdict, color) = CleanupViewModel.ParseSfcResult(Array.Empty<string>(), 0);
+        var (verdict, color) = CleanupViewModel.ParseSfcResult([], 0);
         Assert.Contains("successfully", verdict);
         Assert.Equal("#22C55E", color);
     }

--- a/SysManager/SysManager.Tests/DeepCleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupViewModelTests.cs
@@ -195,12 +195,12 @@ public class DeepCleanupViewModelTests
         var vm = NewVm();
         var c1 = new CleanupCategory
         {
-            Name = "A", Description = "a", Paths = Array.Empty<string>(),
+            Name = "A", Description = "a", Paths = [],
             TotalSizeBytes = 1000, FileCount = 1, IsSelected = true
         };
         var c2 = new CleanupCategory
         {
-            Name = "B", Description = "b", Paths = Array.Empty<string>(),
+            Name = "B", Description = "b", Paths = [],
             TotalSizeBytes = 2000, FileCount = 2, IsSelected = false
         };
         vm.Categories.Add(c1);
@@ -272,12 +272,12 @@ public class DeepCleanupViewModelTests
         var vm = NewVm();
         vm.Categories.Add(new CleanupCategory
         {
-            Name = "Safe", Description = "d", Paths = Array.Empty<string>(),
+            Name = "Safe", Description = "d", Paths = [],
             TotalSizeBytes = 100, FileCount = 1, IsDestructiveHint = false
         });
         vm.Categories.Add(new CleanupCategory
         {
-            Name = "Dangerous", Description = "d", Paths = Array.Empty<string>(),
+            Name = "Dangerous", Description = "d", Paths = [],
             TotalSizeBytes = 200, FileCount = 1, IsDestructiveHint = true
         });
 
@@ -293,7 +293,7 @@ public class DeepCleanupViewModelTests
         var vm = NewVm();
         var c = new CleanupCategory
         {
-            Name = "X", Description = "d", Paths = Array.Empty<string>(),
+            Name = "X", Description = "d", Paths = [],
             TotalSizeBytes = 100, FileCount = 1, IsSelected = true
         };
         vm.Categories.Add(c);
@@ -309,7 +309,7 @@ public class DeepCleanupViewModelTests
         var vm = NewVm();
         vm.Categories.Add(new CleanupCategory
         {
-            Name = "X", Description = "d", Paths = Array.Empty<string>(),
+            Name = "X", Description = "d", Paths = [],
             TotalSizeBytes = 100, FileCount = 1, IsDestructiveHint = false
         });
 

--- a/SysManager/SysManager.Tests/HealthAnalyzerTests.cs
+++ b/SysManager/SysManager.Tests/HealthAnalyzerTests.cs
@@ -23,7 +23,7 @@ public class HealthAnalyzerTests
     [Fact]
     public void NoMetrics_ReturnsUnknown()
     {
-        var d = Analyze(Array.Empty<TargetMetric>());
+        var d = Analyze([]);
         Assert.Equal(HealthVerdict.Unknown, d.Verdict);
         Assert.False(string.IsNullOrWhiteSpace(d.Headline));
         Assert.Equal("#9AA0A6", d.ColorHex);

--- a/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
+++ b/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
@@ -34,7 +34,7 @@ public class HealthScoreServiceTests
     [Fact]
     public void ComputeDiskScore_EmptyList_Returns100()
     {
-        Assert.Equal(100, HealthScoreService.ComputeDiskScore(Array.Empty<DiskHealthReport>()));
+        Assert.Equal(100, HealthScoreService.ComputeDiskScore([]));
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/SystemHealthViewModelTests.cs
+++ b/SysManager/SysManager.Tests/SystemHealthViewModelTests.cs
@@ -262,14 +262,14 @@ public class SystemHealthViewModelTests
     [Fact]
     public void ParseChkdskVerdict_EmptyOutput_ExitZero_ReturnsHealthy()
     {
-        var lines = Array.Empty<string>();
+        string[] lines = [];
         Assert.Equal("Healthy", SystemHealthViewModel.ParseChkdskVerdict(lines, 0));
     }
 
     [Fact]
     public void ParseChkdskVerdict_EmptyOutput_NonZeroExit_ReturnsExitCode()
     {
-        var lines = Array.Empty<string>();
+        string[] lines = [];
         Assert.Equal("Exit 3", SystemHealthViewModel.ParseChkdskVerdict(lines, 3));
     }
 }

--- a/SysManager/SysManager.Tests/TuneUpServiceTests.cs
+++ b/SysManager/SysManager.Tests/TuneUpServiceTests.cs
@@ -108,7 +108,7 @@ public class TuneUpServiceTests
             BrokenShortcutsFound = 5,
             Uptime = TimeSpan.FromDays(1),
             RamUsedPercent = 50,
-            DiskResults = Array.Empty<DiskHealthSummary>()
+            DiskResults = []
         };
         Assert.Equal(1, result.WarningCount);
     }
@@ -121,7 +121,7 @@ public class TuneUpServiceTests
             BrokenShortcutsFound = 0,
             Uptime = TimeSpan.FromDays(20),
             RamUsedPercent = 50,
-            DiskResults = Array.Empty<DiskHealthSummary>()
+            DiskResults = []
         };
         Assert.Equal(1, result.WarningCount);
     }
@@ -134,7 +134,7 @@ public class TuneUpServiceTests
             BrokenShortcutsFound = 0,
             Uptime = TimeSpan.FromDays(1),
             RamUsedPercent = 90,
-            DiskResults = Array.Empty<DiskHealthSummary>()
+            DiskResults = []
         };
         Assert.Equal(1, result.WarningCount);
     }
@@ -181,7 +181,7 @@ public class TuneUpServiceTests
             BrokenShortcutsFound = 0,
             Uptime = TimeSpan.FromDays(1),
             RamUsedPercent = 50,
-            DiskResults = Array.Empty<DiskHealthSummary>()
+            DiskResults = []
         };
         Assert.Equal("All good", result.OverallVerdict);
     }
@@ -194,7 +194,7 @@ public class TuneUpServiceTests
             BrokenShortcutsFound = 2,
             Uptime = TimeSpan.FromDays(1),
             RamUsedPercent = 50,
-            DiskResults = Array.Empty<DiskHealthSummary>()
+            DiskResults = []
         };
         Assert.Equal("1 recommendation", result.OverallVerdict);
     }
@@ -207,7 +207,7 @@ public class TuneUpServiceTests
             BrokenShortcutsFound = 2,
             Uptime = TimeSpan.FromDays(20),
             RamUsedPercent = 50,
-            DiskResults = Array.Empty<DiskHealthSummary>()
+            DiskResults = []
         };
         Assert.Equal("2 recommendations", result.OverallVerdict);
     }
@@ -220,7 +220,7 @@ public class TuneUpServiceTests
             BrokenShortcutsFound = 0,
             Uptime = TimeSpan.FromDays(1),
             RamUsedPercent = 50,
-            DiskResults = Array.Empty<DiskHealthSummary>()
+            DiskResults = []
         };
         Assert.Equal("#22C55E", result.OverallColorHex);
     }
@@ -233,7 +233,7 @@ public class TuneUpServiceTests
             BrokenShortcutsFound = 2,
             Uptime = TimeSpan.FromDays(1),
             RamUsedPercent = 50,
-            DiskResults = Array.Empty<DiskHealthSummary>()
+            DiskResults = []
         };
         Assert.Equal("#F59E0B", result.OverallColorHex);
     }
@@ -246,7 +246,7 @@ public class TuneUpServiceTests
             BrokenShortcutsFound = 2,
             Uptime = TimeSpan.FromDays(20),
             RamUsedPercent = 92,
-            DiskResults = Array.Empty<DiskHealthSummary>()
+            DiskResults = []
         };
         Assert.Equal("#EF4444", result.OverallColorHex);
     }


### PR DESCRIPTION
Replace Array.Empty<T>() with C# 12 collection expressions ([]) in 6 test files (20 occurrences). The main project had zero instances — already modernized. Two cases required explicit string[] type annotation where the compiler could not infer the target type (ar lines = [] → string[] lines = []).