### PR TITLE
chore: seal record types, use IReadOnlyList in SystemSnapshot, fix ServicesVM error messages

### DIFF
--- a/SysManager/SysManager/Models/PingSample.cs
+++ b/SysManager/SysManager/Models/PingSample.cs
@@ -8,4 +8,4 @@ namespace SysManager.Models;
 /// A single ping result for one target at one point in time.
 /// LatencyMs is null on timeout/error so the chart can render a gap.
 /// </summary>
-public record PingSample(DateTime Timestamp, string Host, double? LatencyMs, string Status);
+public sealed record PingSample(DateTime Timestamp, string Host, double? LatencyMs, string Status);

--- a/SysManager/SysManager/Models/PowerShellOutput.cs
+++ b/SysManager/SysManager/Models/PowerShellOutput.cs
@@ -6,7 +6,7 @@ namespace SysManager.Models;
 
 public enum OutputKind { Info, Output, Warning, Error, Verbose, Debug, Progress }
 
-public record PowerShellLine(OutputKind Kind, string Text, DateTime Timestamp)
+public sealed record PowerShellLine(OutputKind Kind, string Text, DateTime Timestamp)
 {
     public static PowerShellLine Info(string text) => new(OutputKind.Info, text, DateTime.Now);
     public static PowerShellLine Output(string text) => new(OutputKind.Output, text, DateTime.Now);

--- a/SysManager/SysManager/Models/SpeedTestResult.cs
+++ b/SysManager/SysManager/Models/SpeedTestResult.cs
@@ -8,7 +8,7 @@ namespace SysManager.Models;
 /// Result of a speed test run. Values are in Mbps. PingMs is the RTT measured
 /// against the test endpoint.
 /// </summary>
-public record SpeedTestResult(
+public sealed record SpeedTestResult(
     string Engine,            // "HTTP" or "Ookla"
     double DownloadMbps,
     double UploadMbps,

--- a/SysManager/SysManager/Models/SystemSnapshot.cs
+++ b/SysManager/SysManager/Models/SystemSnapshot.cs
@@ -4,21 +4,21 @@
 
 namespace SysManager.Models;
 
-public record MemoryInfo(
+public sealed record MemoryInfo(
     double TotalGB,
     double AvailableGB,
     double UsedGB,
     double UsedPercent,
-    List<MemoryModule> Modules);
+    IReadOnlyList<MemoryModule> Modules);
 
-public record MemoryModule(
+public sealed record MemoryModule(
     string BankLabel,
     string Manufacturer,
     double CapacityGB,
     uint SpeedMHz,
     string PartNumber);
 
-public record DiskInfo(
+public sealed record DiskInfo(
     string FriendlyName,
     string MediaType,
     string BusType,
@@ -28,23 +28,23 @@ public record DiskInfo(
     double? TemperatureC,
     int? WearPercent);
 
-public record CpuInfo(
+public sealed record CpuInfo(
     string Name,
     uint Cores,
     uint LogicalProcessors,
     uint MaxClockMHz,
     double LoadPercent);
 
-public record OsInfo(
+public sealed record OsInfo(
     string Caption,
     string Version,
     string BuildNumber,
     TimeSpan Uptime,
     string Architecture);
 
-public record SystemSnapshot(
+public sealed record SystemSnapshot(
     OsInfo Os,
     CpuInfo Cpu,
     MemoryInfo Memory,
-    List<DiskInfo> Disks,
+    IReadOnlyList<DiskInfo> Disks,
     DateTime CapturedAt);

--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -95,7 +95,7 @@ public partial class ServicesViewModel : ViewModelBase
             StatusMessage = $"✓ {entry.DisplayName} started.";
             Log.Information("Service started: {ServiceName}", entry.Name);
         }
-        catch (InvalidOperationException ex) { StatusMessage = $"Service scan failed: {ex.Message}"; }
+        catch (InvalidOperationException ex) { StatusMessage = $"Start service failed: {ex.Message}"; }
         catch (System.ServiceProcess.TimeoutException) { StatusMessage = $"Timeout starting {entry.DisplayName}."; }
     }
 
@@ -116,7 +116,7 @@ public partial class ServicesViewModel : ViewModelBase
             StatusMessage = $"✓ {entry.DisplayName} stopped.";
             Log.Information("Service stopped: {ServiceName}", entry.Name);
         }
-        catch (InvalidOperationException ex) { StatusMessage = $"Service scan failed: {ex.Message}"; }
+        catch (InvalidOperationException ex) { StatusMessage = $"Stop service failed: {ex.Message}"; }
         catch (System.ServiceProcess.TimeoutException) { StatusMessage = $"Timeout stopping {entry.DisplayName}."; }
     }
 


### PR DESCRIPTION
Combines three small modernization/quality fixes:

**MODERN-004:** Add sealed to positional record types (PingSample, SpeedTestResult, MemoryInfo, MemoryModule, DiskInfo, CpuInfo, OsInfo, SystemSnapshot, PowerShellLine) — prevents unintended inheritance and enables JIT devirtualization.

**MODERN-006:** Replace mutable List<T> with IReadOnlyList<T> in SystemSnapshot records (MemoryInfo.Modules, SystemSnapshot.Disks) — enforces immutability at the type level.

**QUAL-004:** Fix copy-paste error messages in ServicesViewModel — StartService catch said 'Service scan failed' instead of 'Start service failed', same for StopService.

Build: 0 errors (main + tests).
