### PR TITLE
chore: rename OutputKindToBrushConverter.cs to ValueConverters.cs (QUAL-005)

### DIFF
--- a/SysManager/SysManager/Helpers/ValueConverters.cs
+++ b/SysManager/SysManager/Helpers/ValueConverters.cs
@@ -1,4 +1,4 @@
-// SysManager · OutputKindToBrushConverter
+// SysManager · ValueConverters
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 


### PR DESCRIPTION
The file contained 5 unrelated converters (OutputKindToBrush, FlexibleBoolToVisibility, BoolToElevationBadgeBrush, HexToBrush, ProcessStatusToBrush) but was named after only the first one. Renamed to ValueConverters.cs to accurately reflect its contents.
