### PR TITLE
ci: add dotnet format check to CI and fix existing formatting violations (INFRA-002)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
           dotnet restore SysManager/SysManager.Tests/SysManager.Tests.csproj
           dotnet restore SysManager/SysManager.UITests/SysManager.UITests.csproj
 
+      - name: Check formatting
+        run: dotnet format SysManager/SysManager/SysManager.csproj --verify-no-changes --verbosity diagnostic
+
       - name: Build (Release)
         run: dotnet build SysManager/SysManager/SysManager.csproj -c Release --no-restore
 

--- a/SysManager/SysManager/AssemblyInfo.cs
+++ b/SysManager/SysManager/AssemblyInfo.cs
@@ -14,7 +14,7 @@ using System.Windows;
 [assembly: AssemblyTrademark("SysManager by laurentiu021")]
 [assembly: InternalsVisibleTo("SysManager.Tests")]
 
-[assembly:ThemeInfo(
+[assembly: ThemeInfo(
     ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
                                                 //(used if a resource is not found in the page,
                                                 // or application resource dictionaries)

--- a/SysManager/SysManager/Models/FriendlyEventEntry.cs
+++ b/SysManager/SysManager/Models/FriendlyEventEntry.cs
@@ -38,20 +38,20 @@ public sealed partial class FriendlyEventEntry : ObservableObject
     public string SeverityIcon => Severity switch
     {
         EventSeverity.Critical => "⛔",
-        EventSeverity.Error    => "🔴",
-        EventSeverity.Warning  => "🟡",
-        EventSeverity.Info     => "🔵",
-        EventSeverity.Verbose  => "⚪",
+        EventSeverity.Error => "🔴",
+        EventSeverity.Warning => "🟡",
+        EventSeverity.Info => "🔵",
+        EventSeverity.Verbose => "⚪",
         _ => "•"
     };
 
     public string SeverityColor => Severity switch
     {
         EventSeverity.Critical => "#FF3B30",
-        EventSeverity.Error    => "#FF6B6B",
-        EventSeverity.Warning  => "#FFD166",
-        EventSeverity.Info     => "#4CC9F0",
-        EventSeverity.Verbose  => "#9AA0A6",
+        EventSeverity.Error => "#FF6B6B",
+        EventSeverity.Warning => "#FFD166",
+        EventSeverity.Info => "#4CC9F0",
+        EventSeverity.Verbose => "#9AA0A6",
         _ => "#9AA0A6"
     };
 

--- a/SysManager/SysManager/Services/DeepCleanupService.cs
+++ b/SysManager/SysManager/Services/DeepCleanupService.cs
@@ -42,12 +42,12 @@ public sealed class DeepCleanupService
     private static List<Def> BuildDefinitions()
     {
         var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        var programData  = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-        var systemDrive  = Path.GetPathRoot(Environment.SystemDirectory) ?? @"C:\";
-        var windowsDir   = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
-        var tempUser     = Path.GetTempPath();
+        var programData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+        var systemDrive = Path.GetPathRoot(Environment.SystemDirectory) ?? @"C:\";
+        var windowsDir = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+        var tempUser = Path.GetTempPath();
         var pfx86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
-        var pf    = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        var pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
 
         var defs = new List<Def>
         {

--- a/SysManager/SysManager/Services/DiskHealthService.cs
+++ b/SysManager/SysManager/Services/DiskHealthService.cs
@@ -186,17 +186,31 @@ public sealed class DiskHealthService
 
     private static string MapMedia(uint v) => v switch
     {
-        3 => "HDD", 4 => "SSD", 5 => "SCM", _ => "Unspecified"
+        3 => "HDD",
+        4 => "SSD",
+        5 => "SCM",
+        _ => "Unspecified"
     };
 
     private static string MapBus(uint v) => v switch
     {
-        1 => "SCSI", 3 => "ATA", 6 => "Fibre", 7 => "USB", 8 => "RAID",
-        9 => "iSCSI", 10 => "SAS", 11 => "SATA", 17 => "NVMe", _ => "Other"
+        1 => "SCSI",
+        3 => "ATA",
+        6 => "Fibre",
+        7 => "USB",
+        8 => "RAID",
+        9 => "iSCSI",
+        10 => "SAS",
+        11 => "SATA",
+        17 => "NVMe",
+        _ => "Other"
     };
 
     private static string MapHealth(uint v) => v switch
     {
-        0 => "Healthy", 1 => "Warning", 2 => "Unhealthy", _ => "Unknown"
+        0 => "Healthy",
+        1 => "Warning",
+        2 => "Unhealthy",
+        _ => "Unknown"
     };
 }

--- a/SysManager/SysManager/Services/EventExplainer.cs
+++ b/SysManager/SysManager/Services/EventExplainer.cs
@@ -168,17 +168,17 @@ public static class EventExplainer
     private static string BuildGenericExplanation(FriendlyEventEntry e) => e.Severity switch
     {
         EventSeverity.Critical => $"Critical condition reported by '{e.ProviderName}'. The system or a core component is in trouble.",
-        EventSeverity.Error    => $"An error was logged by '{e.ProviderName}'.",
-        EventSeverity.Warning  => $"A warning from '{e.ProviderName}' — not necessarily broken, but worth a look if it repeats.",
-        EventSeverity.Info     => $"Informational event from '{e.ProviderName}'.",
+        EventSeverity.Error => $"An error was logged by '{e.ProviderName}'.",
+        EventSeverity.Warning => $"A warning from '{e.ProviderName}' — not necessarily broken, but worth a look if it repeats.",
+        EventSeverity.Info => $"Informational event from '{e.ProviderName}'.",
         _ => "Low-level diagnostic event."
     };
 
     private static string BuildGenericRecommendation(FriendlyEventEntry e) => e.Severity switch
     {
         EventSeverity.Critical => "Read the full message below. If it repeats, search the web for 'Event ID " + e.EventId + " " + e.ProviderName + "'.",
-        EventSeverity.Error    => "If this keeps repeating, search for 'Event ID " + e.EventId + " " + e.ProviderName + "'.",
-        EventSeverity.Warning  => "Usually safe to ignore one-offs. Check if it's a pattern.",
+        EventSeverity.Error => "If this keeps repeating, search for 'Event ID " + e.EventId + " " + e.ProviderName + "'.",
+        EventSeverity.Warning => "Usually safe to ignore one-offs. Check if it's a pattern.",
         _ => "No action needed."
     };
 }

--- a/SysManager/SysManager/Services/FixedDriveService.cs
+++ b/SysManager/SysManager/Services/FixedDriveService.cs
@@ -116,11 +116,20 @@ public sealed class FixedDriveService
 
     private static string MapMedia(uint v) => v switch
     {
-        3 => "HDD", 4 => "SSD", 5 => "SCM", _ => ""
+        3 => "HDD",
+        4 => "SSD",
+        5 => "SCM",
+        _ => ""
     };
 
     private static string MapBus(uint v) => v switch
     {
-        1 => "SCSI", 3 => "ATA", 7 => "USB", 10 => "SAS", 11 => "SATA", 17 => "NVMe", _ => ""
+        1 => "SCSI",
+        3 => "ATA",
+        7 => "USB",
+        10 => "SAS",
+        11 => "SATA",
+        17 => "NVMe",
+        _ => ""
     };
 }

--- a/SysManager/SysManager/Services/IconExtractorService.cs
+++ b/SysManager/SysManager/Services/IconExtractorService.cs
@@ -31,7 +31,7 @@ public sealed class IconExtractorService
     // Lazy-initialized contextual fallback icons (shell32.dll icon indices)
     private static readonly Lazy<ImageSource?> _appFallback = new(() => ExtractShell32Icon(2));
     private static readonly Lazy<ImageSource?> _windowsIcon = new(() => ExtractShell32Icon(44));
-    private static readonly Lazy<ImageSource?> _gearIcon    = new(() => ExtractShell32Icon(15));
+    private static readonly Lazy<ImageSource?> _gearIcon = new(() => ExtractShell32Icon(15));
 
     /// <summary>
     /// Gets the icon for the given file path or command string.

--- a/SysManager/SysManager/Services/LargeFileScanner.cs
+++ b/SysManager/SysManager/Services/LargeFileScanner.cs
@@ -65,7 +65,7 @@ public sealed class LargeFileScanner
             string[] files = [];
             string[] dirs = [];
             try { files = Directory.GetFiles(cur); } catch (IOException) { } catch (UnauthorizedAccessException) { }
-            try { dirs  = Directory.GetDirectories(cur); } catch (IOException) { } catch (UnauthorizedAccessException) { }
+            try { dirs = Directory.GetDirectories(cur); } catch (IOException) { } catch (UnauthorizedAccessException) { }
 
             foreach (var f in files)
             {
@@ -84,7 +84,9 @@ public sealed class LargeFileScanner
                         heap.Add((fi.Length, f));
                         meta[f] = new LargeFileEntry
                         {
-                            Path = f, Name = fi.Name, SizeBytes = fi.Length,
+                            Path = f,
+                            Name = fi.Name,
+                            SizeBytes = fi.Length,
                             LastModified = fi.LastWriteTime
                         };
                     }
@@ -98,7 +100,9 @@ public sealed class LargeFileScanner
                             heap.Add((fi.Length, f));
                             meta[f] = new LargeFileEntry
                             {
-                                Path = f, Name = fi.Name, SizeBytes = fi.Length,
+                                Path = f,
+                                Name = fi.Name,
+                                SizeBytes = fi.Length,
                                 LastModified = fi.LastWriteTime
                             };
                         }

--- a/SysManager/SysManager/Services/SystemInfoService.cs
+++ b/SysManager/SysManager/Services/SystemInfoService.cs
@@ -194,14 +194,28 @@ public sealed class SystemInfoService
                     };
                     var busType = (ushort)Convert.ToUInt32(mo["BusType"] ?? 0u) switch
                     {
-                        1 => "SCSI", 2 => "ATAPI", 3 => "ATA", 4 => "1394", 5 => "SSA",
-                        6 => "Fibre", 7 => "USB", 8 => "RAID", 9 => "iSCSI", 10 => "SAS",
-                        11 => "SATA", 12 => "SD", 13 => "MMC", 17 => "NVMe",
+                        1 => "SCSI",
+                        2 => "ATAPI",
+                        3 => "ATA",
+                        4 => "1394",
+                        5 => "SSA",
+                        6 => "Fibre",
+                        7 => "USB",
+                        8 => "RAID",
+                        9 => "iSCSI",
+                        10 => "SAS",
+                        11 => "SATA",
+                        12 => "SD",
+                        13 => "MMC",
+                        17 => "NVMe",
                         _ => "Other"
                     };
                     var health = (ushort)Convert.ToUInt32(mo["HealthStatus"] ?? 0u) switch
                     {
-                        0 => "Healthy", 1 => "Warning", 2 => "Unhealthy", _ => "Unknown"
+                        0 => "Healthy",
+                        1 => "Warning",
+                        2 => "Unhealthy",
+                        _ => "Unknown"
                     };
                     var opStatus = mo["OperationalStatus"] is ushort[] arr && arr.Length > 0
                         ? string.Join(",", arr.Select(OpStatusName))
@@ -235,8 +249,17 @@ public sealed class SystemInfoService
 
     private static string OpStatusName(ushort v) => v switch
     {
-        1 => "Other", 2 => "Unknown", 3 => "OK", 4 => "Degraded",
-        5 => "Stressed", 6 => "Predictive Failure", 7 => "Error", 8 => "Non-Recoverable Error",
-        9 => "Starting", 10 => "Stopping", 11 => "Stopped", _ => $"Code {v}"
+        1 => "Other",
+        2 => "Unknown",
+        3 => "OK",
+        4 => "Degraded",
+        5 => "Stressed",
+        6 => "Predictive Failure",
+        7 => "Error",
+        8 => "Non-Recoverable Error",
+        9 => "Starting",
+        10 => "Stopping",
+        11 => "Stopped",
+        _ => $"Code {v}"
     };
 }

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -21,7 +21,7 @@ namespace SysManager.Services;
 public sealed class UpdateService
 {
     public const string Owner = "laurentiu021";
-    public const string Repo  = "SystemManager";
+    public const string Repo = "SystemManager";
     public const string AssetName = "SysManager.exe";
 
     private static readonly HttpClient Http = CreateClient();
@@ -367,20 +367,20 @@ public sealed class UpdateService
 
     private sealed class GhRelease
     {
-        [JsonPropertyName("tag_name")]     public string? TagName { get; set; }
-        [JsonPropertyName("name")]         public string? Name { get; set; }
-        [JsonPropertyName("body")]         public string? Body { get; set; }
-        [JsonPropertyName("html_url")]     public string? HtmlUrl { get; set; }
+        [JsonPropertyName("tag_name")] public string? TagName { get; set; }
+        [JsonPropertyName("name")] public string? Name { get; set; }
+        [JsonPropertyName("body")] public string? Body { get; set; }
+        [JsonPropertyName("html_url")] public string? HtmlUrl { get; set; }
         [JsonPropertyName("published_at")] public DateTimeOffset? PublishedAt { get; set; }
-        [JsonPropertyName("prerelease")]   public bool Prerelease { get; set; }
-        [JsonPropertyName("draft")]        public bool Draft { get; set; }
-        [JsonPropertyName("assets")]       public GhAsset[]? Assets { get; set; }
+        [JsonPropertyName("prerelease")] public bool Prerelease { get; set; }
+        [JsonPropertyName("draft")] public bool Draft { get; set; }
+        [JsonPropertyName("assets")] public GhAsset[]? Assets { get; set; }
     }
 
     private sealed class GhAsset
     {
-        [JsonPropertyName("name")]                 public string? Name { get; set; }
-        [JsonPropertyName("size")]                 public long Size { get; set; }
+        [JsonPropertyName("name")] public string? Name { get; set; }
+        [JsonPropertyName("size")] public long Size { get; set; }
         [JsonPropertyName("browser_download_url")] public string? BrowserDownloadUrl { get; set; }
     }
 }

--- a/SysManager/SysManager/ViewModels/BatteryHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BatteryHealthViewModel.cs
@@ -2,10 +2,10 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Management;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
-using System.Management;
 using SysManager.Models;
 using SysManager.Services;
 

--- a/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
@@ -79,14 +79,14 @@ public partial class DeepCleanupViewModel : ViewModelBase
 
             AddLocation("📥  Downloads", Helpers.KnownFolders.GetDownloadsPath());
             AddLocation("📄  Documents", Helpers.KnownFolders.GetDocumentsPath());
-            AddLocation("🖥️  Desktop",   Helpers.KnownFolders.GetDesktopPath());
-            AddLocation("🎬  Videos",    Helpers.KnownFolders.GetVideosPath());
-            AddLocation("🖼️  Pictures",  Helpers.KnownFolders.GetPicturesPath());
-            AddLocation("🎵  Music",     Helpers.KnownFolders.GetMusicPath());
+            AddLocation("🖥️  Desktop", Helpers.KnownFolders.GetDesktopPath());
+            AddLocation("🎬  Videos", Helpers.KnownFolders.GetVideosPath());
+            AddLocation("🖼️  Pictures", Helpers.KnownFolders.GetPicturesPath());
+            AddLocation("🎵  Music", Helpers.KnownFolders.GetMusicPath());
 
-            var pf    = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+            var pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
             var pfx86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
-            AddLocation("💼  Program Files",      pf);
+            AddLocation("💼  Program Files", pf);
             AddLocation("💼  Program Files (x86)", pfx86);
 
             var drives = await _drives.EnumerateAsync();

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -89,10 +89,10 @@ public partial class LogsViewModel : ViewModelBase
         var sevOk = e.Severity switch
         {
             EventSeverity.Critical => ShowCritical,
-            EventSeverity.Error    => ShowError,
-            EventSeverity.Warning  => ShowWarning,
-            EventSeverity.Info     => ShowInfo,
-            EventSeverity.Verbose  => ShowVerbose,
+            EventSeverity.Error => ShowError,
+            EventSeverity.Warning => ShowWarning,
+            EventSeverity.Info => ShowInfo,
+            EventSeverity.Verbose => ShowVerbose,
             _ => true
         };
         if (!sevOk) return false;
@@ -321,9 +321,9 @@ public partial class LogsViewModel : ViewModelBase
         switch (e.Severity)
         {
             case EventSeverity.Critical: CriticalCount += delta; break;
-            case EventSeverity.Error:    ErrorCount += delta; break;
-            case EventSeverity.Warning:  WarningCount += delta; break;
-            case EventSeverity.Info:     InfoCount += delta; break;
+            case EventSeverity.Error: ErrorCount += delta; break;
+            case EventSeverity.Warning: WarningCount += delta; break;
+            case EventSeverity.Info: InfoCount += delta; break;
         }
     }
 

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -247,12 +247,22 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         // construct the VM on an MTA thread without pulling WPF resources in.
 
         // 🏠 Dashboard (single-item group — renders flat)
-        var grpDashboard = new NavGroup { Id = "grp-dashboard", Label = "Dashboard", Glyph = "\uE80F", Children = {
+        var grpDashboard = new NavGroup
+        {
+            Id = "grp-dashboard",
+            Label = "Dashboard",
+            Glyph = "\uE80F",
+            Children = {
             new NavItem { Id = "nav-dashboard", Label = "Dashboard", Glyph = "\uE80F", Content = Dashboard, ViewType = typeof(Views.DashboardView) },
-        }};
+        }
+        };
 
         // 🔧 System (8)
-        var grpSystem = new NavGroup { Id = "grp-system", Label = "System", Glyph = "\uE912",
+        var grpSystem = new NavGroup
+        {
+            Id = "grp-system",
+            Label = "System",
+            Glyph = "\uE912",
             Subtitle = "Health · WinUpdate · Perf · Services · Startup · Features · Tasks · Boot",
             Tooltip = "System Health\nWindows Update\nPerformance Mode\nServices\nStartup Manager\nWindows Features\nTask Scheduler\nBoot Analyzer",
             Children = {
@@ -264,10 +274,15 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             new NavItem { Id = "nav-windows-features",  Label = "Windows Features",  Glyph = "\uE9CE", Content = WindowsFeatures,  ViewType = typeof(Views.WindowsFeaturesView) },
             new NavItem { Id = "nav-task-scheduler",    Label = "Task Scheduler",    Glyph = "\uE916", Content = WipTaskScheduler, ViewType = typeof(Views.PlaceholderView) },
             new NavItem { Id = "nav-boot-analyzer",     Label = "Boot Analyzer",     Glyph = "\uE7F8", Content = WipBootAnalyzer,  ViewType = typeof(Views.PlaceholderView) },
-        }};
+        }
+        };
 
         // 🎮 Gaming & Profiles (5) — NEW GROUP
-        var grpGaming = new NavGroup { Id = "grp-gaming", Label = "Gaming & Profiles", Glyph = "\uE7FC",
+        var grpGaming = new NavGroup
+        {
+            Id = "grp-gaming",
+            Label = "Gaming & Profiles",
+            Glyph = "\uE7FC",
             Subtitle = "Game Mode · Standby · Timer · Affinity · Display",
             Tooltip = "Gaming Profile\nStandby List Cleaner\nTimer Resolution\nCPU Core Affinity\nDisplay Profiles",
             Children = {
@@ -276,10 +291,15 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             new NavItem { Id = "nav-timer-resolution", Label = "Timer Resolution",     Glyph = "\uE916", Content = WipTimerResolution,    ViewType = typeof(Views.PlaceholderView) },
             new NavItem { Id = "nav-cpu-affinity",     Label = "CPU Core Affinity",    Glyph = "\uE950", Content = WipCpuAffinity,        ViewType = typeof(Views.PlaceholderView) },
             new NavItem { Id = "nav-display-profiles", Label = "Display Profiles",     Glyph = "\uE7F4", Content = WipDisplayProfiles,    ViewType = typeof(Views.PlaceholderView) },
-        }};
+        }
+        };
 
         // 📊 Monitor (7)
-        var grpMonitor = new NavGroup { Id = "grp-monitor", Label = "Monitor", Glyph = "\uE9D9",
+        var grpMonitor = new NavGroup
+        {
+            Id = "grp-monitor",
+            Label = "Monitor",
+            Glyph = "\uE9D9",
             Subtitle = "Processes · Resources · Alerts · Privacy · Lock · Watchdog · Bandwidth",
             Tooltip = "Process Manager\nResource History\nApp Alerts\nPrivacy Monitor\nFile Lock Detector\nSettings Watchdog\nBandwidth Monitor",
             Children = {
@@ -290,10 +310,15 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             new NavItem { Id = "nav-file-lock",         Label = "File Lock Detector", Glyph = "\uE72E", Content = WipFileLockDetector, ViewType = typeof(Views.PlaceholderView) },
             new NavItem { Id = "nav-settings-watchdog", Label = "Settings Watchdog",  Glyph = "\uE7BA", Content = WipSettingsWatchdog, ViewType = typeof(Views.PlaceholderView) },
             new NavItem { Id = "nav-bandwidth-monitor", Label = "Bandwidth Monitor",  Glyph = "\uE839", Content = WipBandwidthMonitor, ViewType = typeof(Views.PlaceholderView) },
-        }};
+        }
+        };
 
         // 🧹 Cleanup (5)
-        var grpCleanup = new NavGroup { Id = "grp-cleanup", Label = "Cleanup", Glyph = "\uE74D",
+        var grpCleanup = new NavGroup
+        {
+            Id = "grp-cleanup",
+            Label = "Cleanup",
+            Glyph = "\uE74D",
             Subtitle = "Quick · Deep · Shortcuts · Shredder · Maintenance",
             Tooltip = "Quick Cleanup\nDeep Cleanup\nShortcut Cleaner\nFile Shredder\nScheduled Maintenance",
             Children = {
@@ -302,19 +327,29 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             new NavItem { Id = "nav-shortcut-cleaner",      Label = "Shortcut Cleaner",      Glyph = "\uE71B", Content = ShortcutCleaner,         ViewType = typeof(Views.ShortcutCleanerView) },
             new NavItem { Id = "nav-file-shredder",         Label = "File Shredder",         Glyph = "\uE74D", Content = WipFileShredder,         ViewType = typeof(Views.PlaceholderView) },
             new NavItem { Id = "nav-scheduled-maintenance", Label = "Scheduled Maintenance", Glyph = "\uE823", Content = WipScheduledMaintenance, ViewType = typeof(Views.PlaceholderView) },
-        }};
+        }
+        };
 
         // 💾 Storage (2)
-        var grpStorage = new NavGroup { Id = "grp-storage", Label = "Storage", Glyph = "\uE958",
+        var grpStorage = new NavGroup
+        {
+            Id = "grp-storage",
+            Label = "Storage",
+            Glyph = "\uE958",
             Subtitle = "Disk Analyzer · Duplicate Finder",
             Tooltip = "Disk Analyzer\nDuplicate Finder",
             Children = {
             new NavItem { Id = "nav-disk-analyzer", Label = "Disk Analyzer",    Glyph = "\uE958", Content = DiskAnalyzer,  ViewType = typeof(Views.DiskAnalyzerView) },
             new NavItem { Id = "nav-duplicates",    Label = "Duplicate Finder", Glyph = "\uE8C8", Content = DuplicateFile, ViewType = typeof(Views.DuplicateFileView) },
-        }};
+        }
+        };
 
         // 🌐 Network (6)
-        var grpNetwork = new NavGroup { Id = "grp-network", Label = "Network", Glyph = "\uE839",
+        var grpNetwork = new NavGroup
+        {
+            Id = "grp-network",
+            Label = "Network",
+            Glyph = "\uE839",
             Subtitle = "Ping · Traceroute · Speed · Repair · DNS · Hosts",
             Tooltip = "Ping\nTraceroute\nSpeed Test\nNetwork Repair\nDNS Changer\nHosts Editor",
             Children = {
@@ -324,10 +359,15 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             new NavItem { Id = "nav-network-repair", Label = "Network Repair", Glyph = "\uE90F", Content = NetworkRepair,  ViewType = typeof(Views.NetworkRepairView) },
             new NavItem { Id = "nav-dns-changer",    Label = "DNS Changer",    Glyph = "\uE968", Content = WipDnsChanger,  ViewType = typeof(Views.PlaceholderView) },
             new NavItem { Id = "nav-hosts-editor",   Label = "Hosts Editor",   Glyph = "\uE8A5", Content = WipHostsEditor, ViewType = typeof(Views.PlaceholderView) },
-        }};
+        }
+        };
 
         // 📦 Apps (4)
-        var grpApps = new NavGroup { Id = "grp-apps", Label = "Apps", Glyph = "\uE7B8",
+        var grpApps = new NavGroup
+        {
+            Id = "grp-apps",
+            Label = "Apps",
+            Glyph = "\uE7B8",
             Subtitle = "Updates · Installer · Uninstaller · Blocker",
             Tooltip = "App Updates\nBulk Installer\nUninstaller\nApp Blocker",
             Children = {
@@ -335,10 +375,15 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             new NavItem { Id = "nav-bulk-installer", Label = "Bulk Installer", Glyph = "\uE896", Content = WipBulkInstaller, ViewType = typeof(Views.PlaceholderView) },
             new NavItem { Id = "nav-uninstaller",    Label = "Uninstaller",    Glyph = "\uE738", Content = Uninstaller,      ViewType = typeof(Views.UninstallerView) },
             new NavItem { Id = "nav-app-blocker",    Label = "App Blocker",    Glyph = "\uE8F8", Content = AppBlocker,       ViewType = typeof(Views.AppBlockerView) },
-        }};
+        }
+        };
 
         // 🛡️ Privacy & Security (6) — NEW GROUP
-        var grpPrivacy = new NavGroup { Id = "grp-privacy", Label = "Privacy & Security", Glyph = "\uE72E",
+        var grpPrivacy = new NavGroup
+        {
+            Id = "grp-privacy",
+            Label = "Privacy & Security",
+            Glyph = "\uE72E",
             Subtitle = "Telemetry · Debloat · Browser · Edge/OneDrive · Defender · Notifications",
             Tooltip = "Privacy & Telemetry\nDebloater & Ads\nBrowser Cleaner\nEdge/OneDrive Remover\nDefender Tweaks\nNotification Blocker",
             Children = {
@@ -348,10 +393,15 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             new NavItem { Id = "nav-edge-onedrive",        Label = "Edge/OneDrive Remover", Glyph = "\uE738", Content = WipEdgeOneDriveRemover, ViewType = typeof(Views.PlaceholderView) },
             new NavItem { Id = "nav-defender-tweaks",      Label = "Defender Tweaks",       Glyph = "\uE83D", Content = WipDefenderTweaks,      ViewType = typeof(Views.PlaceholderView) },
             new NavItem { Id = "nav-notification-blocker", Label = "Notification Blocker",  Glyph = "\uE7ED", Content = WipNotificationBlocker, ViewType = typeof(Views.PlaceholderView) },
-        }};
+        }
+        };
 
         // 🎨 Customization (4) — NEW GROUP
-        var grpCustomization = new NavGroup { Id = "grp-customization", Label = "Customization", Glyph = "\uE771",
+        var grpCustomization = new NavGroup
+        {
+            Id = "grp-customization",
+            Label = "Customization",
+            Glyph = "\uE771",
             Subtitle = "Context Menu · Dark Mode · Volume · Env Variables",
             Tooltip = "Context Menu\nDark Mode Scheduler\nVolume Control\nEnvironment Variables",
             Children = {
@@ -359,10 +409,15 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             new NavItem { Id = "nav-dark-mode",      Label = "Dark Mode Scheduler",   Glyph = "\uE793", Content = WipDarkModeScheduler, ViewType = typeof(Views.PlaceholderView) },
             new NavItem { Id = "nav-volume-control", Label = "Volume Control",        Glyph = "\uE767", Content = WipVolumeControl,     ViewType = typeof(Views.PlaceholderView) },
             new NavItem { Id = "nav-env-variables",  Label = "Environment Variables", Glyph = "\uE943", Content = WipEnvVariableEditor, ViewType = typeof(Views.PlaceholderView) },
-        }};
+        }
+        };
 
         // ℹ️ Info (4)
-        var grpInfo = new NavGroup { Id = "grp-info", Label = "Info", Glyph = "\uE946",
+        var grpInfo = new NavGroup
+        {
+            Id = "grp-info",
+            Label = "Info",
+            Glyph = "\uE946",
             Subtitle = "Drivers · Battery · Logs · About",
             Tooltip = "Drivers\nBattery Health\nSystem Logs\nAbout",
             Children = {
@@ -370,10 +425,15 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             new NavItem { Id = "nav-battery", Label = "Battery Health", Glyph = "\uEBA6", Content = BatteryHealth, ViewType = typeof(Views.BatteryHealthView) },
             new NavItem { Id = "nav-logs",    Label = "System Logs",    Glyph = "\uE9F9", Content = Logs,          ViewType = typeof(Views.LogsView) },
             new NavItem { Id = "nav-about",   Label = "About",          Glyph = "\uE946", Content = About,         ViewType = typeof(Views.AboutView) },
-        }};
+        }
+        };
 
         // ⚙️ Advanced (4) — NEW GROUP
-        var grpAdvanced = new NavGroup { Id = "grp-advanced", Label = "Advanced", Glyph = "\uE713",
+        var grpAdvanced = new NavGroup
+        {
+            Id = "grp-advanced",
+            Label = "Advanced",
+            Glyph = "\uE713",
             Subtitle = "Restore · Export/Import · CLI · Report",
             Tooltip = "Restore Points\nProfile Export/Import\nCLI Interface\nSystem Report",
             Children = {
@@ -381,7 +441,8 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             new NavItem { Id = "nav-profile-export", Label = "Profile Export/Import", Glyph = "\uE8B5", Content = WipProfileExportImport, ViewType = typeof(Views.PlaceholderView) },
             new NavItem { Id = "nav-cli-interface",  Label = "CLI Interface",         Glyph = "\uE756", Content = WipCliInterface,        ViewType = typeof(Views.PlaceholderView) },
             new NavItem { Id = "nav-system-report",  Label = "System Report",         Glyph = "\uE9F9", Content = WipSystemReport,        ViewType = typeof(Views.PlaceholderView) },
-        }};
+        }
+        };
 
         NavGroups.Add(grpDashboard);
         NavGroups.Add(grpSystem);

--- a/SysManager/SysManager/ViewModels/NetworkSharedState.cs
+++ b/SysManager/SysManager/ViewModels/NetworkSharedState.cs
@@ -94,8 +94,8 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
 
         LatencyXAxes = new[] { BuildTimeAxis() };
         LatencyYAxes = new[] { BuildValueAxis("Latency (ms)") };
-        TraceXAxes  = new[] { BuildHopAxis() };
-        TraceYAxes  = new[] { BuildValueAxis("Latency (ms)") };
+        TraceXAxes = new[] { BuildHopAxis() };
+        TraceYAxes = new[] { BuildValueAxis("Latency (ms)") };
 
         Pinger.SampleReceived += OnSample;
         TraceMonitor.RouteCompleted += OnRouteCompleted;

--- a/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
@@ -46,11 +46,11 @@ public partial class ShortcutCleanerViewModel : ViewModelBase
         IsScanning = true;
         IsBusy = true;
         IsProgressIndeterminate = true;
-            // MEM-007: Unsubscribe from old items before clearing to prevent
-            // PropertyChanged lambda leaks across rescans.
-            foreach (var old in BrokenShortcuts)
-                old.PropertyChanged -= OnShortcutPropertyChanged;
-            BrokenShortcuts.Clear();
+        // MEM-007: Unsubscribe from old items before clearing to prevent
+        // PropertyChanged lambda leaks across rescans.
+        foreach (var old in BrokenShortcuts)
+            old.PropertyChanged -= OnShortcutPropertyChanged;
+        BrokenShortcuts.Clear();
         BrokenCount = 0;
         SelectedCount = 0;
         ScanStatus = "Scanning...";

--- a/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
@@ -2,9 +2,9 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.IO;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;

--- a/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
@@ -206,16 +206,16 @@ public partial class UninstallerViewModel : ViewModelBase
     {
         var reason = exitCode switch
         {
-            1  => "The app's uninstaller reported a generic error.",
-            2  => "The uninstall was cancelled by the user or a UAC prompt was declined.",
-            5  => "Access denied — try running SysManager as Administrator.",
+            1 => "The app's uninstaller reported a generic error.",
+            2 => "The uninstall was cancelled by the user or a UAC prompt was declined.",
+            5 => "Access denied — try running SysManager as Administrator.",
             87 => "Invalid parameter — the app may require a manual uninstall.",
             1602 => "The uninstall was cancelled by the user.",
             1603 => "The app's installer encountered a fatal error during removal.",
             1605 => "The app is not currently installed (already removed?).",
             1618 => "Another installation is in progress — wait and try again.",
             3010 => "Uninstall succeeded but a reboot is required to complete removal.",
-            _  => $"The app's uninstaller returned exit code {exitCode}."
+            _ => $"The app's uninstaller returned exit code {exitCode}."
         };
 
         return $"Failed — {reason}";

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml.cs
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml.cs
@@ -4,4 +4,5 @@
 
 using System.Windows.Controls;
 namespace SysManager.Views;
+
 public partial class AppUpdatesView : UserControl { public AppUpdatesView() { InitializeComponent(); } }

--- a/SysManager/SysManager/Views/CleanupView.xaml.cs
+++ b/SysManager/SysManager/Views/CleanupView.xaml.cs
@@ -4,4 +4,5 @@
 
 using System.Windows.Controls;
 namespace SysManager.Views;
+
 public partial class CleanupView : UserControl { public CleanupView() { InitializeComponent(); } }

--- a/SysManager/SysManager/Views/DashboardView.xaml.cs
+++ b/SysManager/SysManager/Views/DashboardView.xaml.cs
@@ -4,4 +4,5 @@
 
 using System.Windows.Controls;
 namespace SysManager.Views;
+
 public partial class DashboardView : UserControl { public DashboardView() { InitializeComponent(); } }

--- a/SysManager/SysManager/Views/DriversView.xaml.cs
+++ b/SysManager/SysManager/Views/DriversView.xaml.cs
@@ -4,4 +4,5 @@
 
 using System.Windows.Controls;
 namespace SysManager.Views;
+
 public partial class DriversView : UserControl { public DriversView() { InitializeComponent(); } }

--- a/SysManager/SysManager/Views/LogsView.xaml.cs
+++ b/SysManager/SysManager/Views/LogsView.xaml.cs
@@ -4,4 +4,5 @@
 
 using System.Windows.Controls;
 namespace SysManager.Views;
+
 public partial class LogsView : UserControl { public LogsView() { InitializeComponent(); } }

--- a/SysManager/SysManager/Views/NetworkRepairView.xaml.cs
+++ b/SysManager/SysManager/Views/NetworkRepairView.xaml.cs
@@ -4,4 +4,5 @@
 
 using System.Windows.Controls;
 namespace SysManager.Views;
+
 public partial class NetworkRepairView : UserControl { public NetworkRepairView() { InitializeComponent(); } }

--- a/SysManager/SysManager/Views/PingView.xaml.cs
+++ b/SysManager/SysManager/Views/PingView.xaml.cs
@@ -4,4 +4,5 @@
 
 using System.Windows.Controls;
 namespace SysManager.Views;
+
 public partial class PingView : UserControl { public PingView() { InitializeComponent(); } }

--- a/SysManager/SysManager/Views/SpeedTestView.xaml.cs
+++ b/SysManager/SysManager/Views/SpeedTestView.xaml.cs
@@ -4,4 +4,5 @@
 
 using System.Windows.Controls;
 namespace SysManager.Views;
+
 public partial class SpeedTestView : UserControl { public SpeedTestView() { InitializeComponent(); } }

--- a/SysManager/SysManager/Views/SystemHealthView.xaml.cs
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml.cs
@@ -4,4 +4,5 @@
 
 using System.Windows.Controls;
 namespace SysManager.Views;
+
 public partial class SystemHealthView : UserControl { public SystemHealthView() { InitializeComponent(); } }

--- a/SysManager/SysManager/Views/TracerouteView.xaml.cs
+++ b/SysManager/SysManager/Views/TracerouteView.xaml.cs
@@ -4,4 +4,5 @@
 
 using System.Windows.Controls;
 namespace SysManager.Views;
+
 public partial class TracerouteView : UserControl { public TracerouteView() { InitializeComponent(); } }

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml.cs
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml.cs
@@ -4,4 +4,5 @@
 
 using System.Windows.Controls;
 namespace SysManager.Views;
+
 public partial class WindowsUpdateView : UserControl { public WindowsUpdateView() { InitializeComponent(); } }


### PR DESCRIPTION
Adds a dotnet format --verify-no-changes step to the CI pipeline (after Restore, before Build). This ensures all future PRs conform to the .editorconfig formatting rules.

Also fixes 18 existing files that had minor formatting violations (whitespace, import ordering) so the new check passes on the current codebase.

No logic changes — purely whitespace and using-statement reordering.
