### PR TITLE
chore: use [GeneratedRegex] source generator (MODERN-001)

### DIFF
--- a/SysManager/SysManager/Helpers/MarkdownTextBlock.cs
+++ b/SysManager/SysManager/Helpers/MarkdownTextBlock.cs
@@ -19,7 +19,7 @@ namespace SysManager.Helpers;
 /// Supported syntax: ## headings, **bold**, - / * bullets, `code`,
 /// blank-line paragraph breaks. Anything else is rendered as plain text.
 /// </summary>
-public static class MarkdownTextBlock
+public static partial class MarkdownTextBlock
 {
     public static readonly DependencyProperty MarkdownProperty =
         DependencyProperty.RegisterAttached(
@@ -81,9 +81,8 @@ public static class MarkdownTextBlock
         }
     }
 
-    // PERF-004: Pre-compiled regex avoids creating a new state machine on every call.
-    private static readonly Regex InlineFormattingRegex = new(
-        @"\*\*(.+?)\*\*|`([^`]+)`", RegexOptions.Compiled);
+    [GeneratedRegex(@"\*\*(.+?)\*\*|`([^`]+)`")]
+    private static partial Regex InlineFormattingRegex();
 
     // PERF-007: Cache FontFamily to avoid allocating a new instance per code span render.
     private static readonly FontFamily CodeFontFamily = new("Consolas");
@@ -95,7 +94,7 @@ public static class MarkdownTextBlock
     private static void AddFormattedText(TextBlock tb, string text)
     {
         // Merge bold and code patterns, process left-to-right
-        var combined = InlineFormattingRegex.Matches(text);
+        var combined = InlineFormattingRegex().Matches(text);
         var pos = 0;
 
         foreach (Match m in combined)

--- a/SysManager/SysManager/Services/DiskHealthService.cs
+++ b/SysManager/SysManager/Services/DiskHealthService.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Management;
+using System.Text.RegularExpressions;
 using Serilog;
 using SysManager.Models;
 
@@ -14,7 +15,7 @@ namespace SysManager.Services;
 /// user-friendly verdict ("Healthy / Watch out / Replace soon").
 /// No admin required for read-only queries.
 /// </summary>
-public sealed class DiskHealthService
+public sealed partial class DiskHealthService
 {
     public Task<IReadOnlyList<DiskHealthReport>> CollectAsync(CancellationToken ct = default)
         => Task.Run(() => Collect(), ct);
@@ -72,7 +73,7 @@ public sealed class DiskHealthService
             // Defense-in-depth: validate objectId format before WQL interpolation.
             // ObjectId from MSFT_PhysicalDisk is typically like {guid}\\PhysicalDisk0.
             // Reject anything that doesn't match expected characters.
-            if (!System.Text.RegularExpressions.Regex.IsMatch(objectId, @"^[\w{}\-\\.:/]+$"))
+            if (!ObjectIdFormatPattern().IsMatch(objectId))
             {
                 Log.Warning("DiskHealth: unexpected objectId format, skipping reliability query");
                 return;
@@ -213,4 +214,7 @@ public sealed class DiskHealthService
         2 => "Unhealthy",
         _ => "Unknown"
     };
+
+    [GeneratedRegex(@"^[\w{}\-\\.:/]+$")]
+    private static partial Regex ObjectIdFormatPattern();
 }

--- a/SysManager/SysManager/Services/UninstallerService.cs
+++ b/SysManager/SysManager/Services/UninstallerService.cs
@@ -65,8 +65,17 @@ public sealed partial class UninstallerService
     /// Matches valid winget package IDs: alphanumeric, dots, hyphens,
     /// underscores, forward slashes, plus signs, and spaces. Max 256 chars.
     /// </summary>
-    [System.Text.RegularExpressions.GeneratedRegex(@"^[\w.\-/+ ]{1,256}$")]
-    private static partial System.Text.RegularExpressions.Regex PackageIdPattern();
+    [GeneratedRegex(@"^[\w.\-/+ ]{1,256}$")]
+    private static partial Regex PackageIdPattern();
+
+    [GeneratedRegex(@"^\s*Name\s+Id\s+Version", RegexOptions.IgnoreCase)]
+    private static partial Regex ListHeaderPattern();
+
+    [GeneratedRegex(@"^\d+\s+packages?\s+", RegexOptions.IgnoreCase)]
+    private static partial Regex PackageSummaryPattern();
+
+    [GeneratedRegex(@"(?<![A-Za-z0-9])/I(?![A-Za-z0-9])", RegexOptions.IgnoreCase)]
+    private static partial Regex MsiInstallSwitchPattern();
 
     internal static List<InstalledApp> ParseListTable(List<string> lines)
     {
@@ -74,7 +83,7 @@ public sealed partial class UninstallerService
 
         // Find header line: "Name   Id   Version  [Available]  Source"
         int headerIdx = lines.FindIndex(l =>
-            Regex.IsMatch(l, @"^\s*Name\s+Id\s+Version", RegexOptions.IgnoreCase));
+            ListHeaderPattern().IsMatch(l));
         if (headerIdx < 0) return apps;
 
         var header = lines[headerIdx];
@@ -95,7 +104,7 @@ public sealed partial class UninstallerService
             if (string.IsNullOrWhiteSpace(line)) continue;
             if (line.StartsWith("--")) continue;
             // Stop at summary lines like "123 packages installed"
-            if (Regex.IsMatch(line, @"^\d+\s+packages?\s+", RegexOptions.IgnoreCase)) break;
+            if (PackageSummaryPattern().IsMatch(line)) break;
             if (line.Length < idxVersion) continue;
 
             string Slice(int start, int end) =>
@@ -337,9 +346,7 @@ public sealed partial class UninstallerService
                 var args = command[(spaceIdx + 1)..].TrimStart();
                 // Convert /I (modify) to /X (uninstall) if needed, add /quiet.
                 // Use regex to match /I only as a standalone switch (not inside GUIDs).
-                args = System.Text.RegularExpressions.Regex.Replace(
-                    args, @"(?<![A-Za-z0-9])/I(?![A-Za-z0-9])", "/X",
-                    System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+                args = MsiInstallSwitchPattern().Replace(args, "/X");
                 if (!args.Contains("/quiet", StringComparison.OrdinalIgnoreCase)
                     && !args.Contains("/qn", StringComparison.OrdinalIgnoreCase))
                     args += " /quiet /norestart";

--- a/SysManager/SysManager/Services/WingetService.cs
+++ b/SysManager/SysManager/Services/WingetService.cs
@@ -50,7 +50,7 @@ public partial class WingetService
         var packages = new List<AppPackage>();
         // Find the header line containing "Name" and "Id" and "Version" and "Available"
         int headerIdx = lines.FindIndex(l =>
-            Regex.IsMatch(l, @"^\s*Name\s+Id\s+Version\s+Available", RegexOptions.IgnoreCase));
+            UpgradeHeaderPattern().IsMatch(l));
         if (headerIdx < 0) return packages;
 
         var header = lines[headerIdx];
@@ -66,7 +66,7 @@ public partial class WingetService
             if (string.IsNullOrWhiteSpace(line)) continue;
             if (line.StartsWith("--")) continue;
             // Stop at "X upgrades available." summary or similar
-            if (Regex.IsMatch(line, @"^\d+\s+(upgrades|packages|package)\s+", RegexOptions.IgnoreCase)) break;
+            if (UpgradeSummaryPattern().IsMatch(line)) break;
             if (line.Length < idxAvailable) continue;
 
             string Slice(int start, int end) =>
@@ -111,6 +111,12 @@ public partial class WingetService
     /// </summary>
     [GeneratedRegex(@"^[\w.\-/+\s]{1,256}$")]
     private static partial Regex PackageIdPattern();
+
+    [GeneratedRegex(@"^\s*Name\s+Id\s+Version\s+Available", RegexOptions.IgnoreCase)]
+    private static partial Regex UpgradeHeaderPattern();
+
+    [GeneratedRegex(@"^\d+\s+(upgrades|packages|package)\s+", RegexOptions.IgnoreCase)]
+    private static partial Regex UpgradeSummaryPattern();
 
     public async Task<int> UpgradeAllAsync(CancellationToken ct = default)
     {

--- a/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
@@ -5,6 +5,7 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
+using System.Text.RegularExpressions;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
@@ -198,7 +199,7 @@ public partial class SystemHealthViewModel : ViewModelBase
         }
 
         // SEC-003: validate drive letter format to prevent argument injection
-        if (!System.Text.RegularExpressions.Regex.IsMatch(driveLetter, @"^[A-Z]:$", System.Text.RegularExpressions.RegexOptions.IgnoreCase))
+        if (!DriveLetterPattern().IsMatch(driveLetter))
         {
             StatusMessage = "Invalid drive letter format.";
             return;
@@ -346,6 +347,9 @@ public partial class SystemHealthViewModel : ViewModelBase
         if (AdminHelper.RelaunchAsAdmin())
             System.Windows.Application.Current?.Shutdown();
     }
+
+    [GeneratedRegex(@"^[A-Z]:$", RegexOptions.IgnoreCase)]
+    private static partial Regex DriveLetterPattern();
 
     [RelayCommand]
     private void CancelScan() => _cts?.Cancel();


### PR DESCRIPTION
## Summary
- Replaced runtime `Regex` instantiation and static `Regex.IsMatch`/`Regex.Replace` calls with `[GeneratedRegex]` source-generated methods
- Made `MarkdownTextBlock` and `DiskHealthService` classes `partial` to support source generation
- **Files changed:**
  - `Helpers/MarkdownTextBlock.cs` — 1 regex (inline bold/code formatting)
  - `Services/UninstallerService.cs` — 3 regex (header detection, summary line, MSI switch replacement)
  - `Services/WingetService.cs` — 2 regex (upgrade header, summary line)
  - `Services/DiskHealthService.cs` — 1 regex (objectId format validation)
  - `ViewModels/SystemHealthViewModel.cs` — 1 regex (drive letter validation)
- **Skipped:** `Services/LogService.cs` — uses dynamic runtime-interpolated pattern, cannot be source-generated

## Test plan
- [ ] CI build passes (source generator emits code at compile time)
- [ ] Unit tests pass (parsing logic unchanged)
- [ ] Verify regex behavior unchanged via existing tests
