### PR TITLE
chore: migrate P/Invoke declarations to [LibraryImport] (MODERN-002)

### DIFF
--- a/SysManager/SysManager/App.xaml.cs
+++ b/SysManager/SysManager/App.xaml.cs
@@ -30,15 +30,17 @@ public partial class App : Application
     /// <summary>The shared tray icon service instance.</summary>
     public TrayIconService? TrayService => _trayService;
 
-    [DllImport("user32.dll")]
-    private static extern bool SetForegroundWindow(IntPtr hWnd);
-
-    [DllImport("user32.dll")]
-    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
-
-    [DllImport("user32.dll")]
+    [LibraryImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool IsIconic(IntPtr hWnd);
+    private static partial bool SetForegroundWindow(IntPtr hWnd);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool IsIconic(IntPtr hWnd);
 
     private const int SW_RESTORE = 9;
 

--- a/SysManager/SysManager/Helpers/KnownFolders.cs
+++ b/SysManager/SysManager/Helpers/KnownFolders.cs
@@ -12,7 +12,7 @@ namespace SysManager.Helpers;
 /// Handles cases where the user has moved default folders (Downloads,
 /// Documents, Desktop, etc.) to a non-standard location.
 /// </summary>
-internal static class KnownFolders
+internal static partial class KnownFolders
 {
     // Known Folder GUIDs — https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid
     private static readonly Guid Downloads = new("374DE290-123F-4565-9164-39C4925E467B");
@@ -22,9 +22,9 @@ internal static class KnownFolders
     private static readonly Guid Music = new("4BD8D571-6D19-48D3-BE97-422220080E43");
     private static readonly Guid Videos = new("18989B1D-99B5-455B-841C-AB7C74E4DDFC");
 
-    [DllImport("shell32.dll", CharSet = CharSet.Unicode, ExactSpelling = true, PreserveSig = false)]
-    private static extern void SHGetKnownFolderPath(
-        [MarshalAs(UnmanagedType.LPStruct)] Guid rfid,
+    [LibraryImport("shell32.dll", StringMarshalling = StringMarshalling.Utf16)]
+    private static partial void SHGetKnownFolderPath(
+        in Guid rfid,
         uint dwFlags,
         nint hToken,
         out string pszPath);

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -58,8 +58,8 @@ public partial class MainWindow : Window
         return IntPtr.Zero;
     }
 
-    [System.Runtime.InteropServices.DllImport("user32.dll")]
-    private static extern IntPtr DefWindowProc(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
+    [System.Runtime.InteropServices.LibraryImport("user32.dll")]
+    private static partial IntPtr DefWindowProc(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
 
     /// <summary>Click on a single-item group (Dashboard, Network).</summary>
     private void SingleGroup_Click(object sender, MouseButtonEventArgs e)

--- a/SysManager/SysManager/Services/IconExtractorService.cs
+++ b/SysManager/SysManager/Services/IconExtractorService.cs
@@ -20,7 +20,7 @@ namespace SysManager.Services;
 /// icons (Windows logo for system processes, gear for services, generic app icon).
 /// Results are cached per-path to avoid repeated extraction.
 /// </summary>
-public sealed class IconExtractorService
+public sealed partial class IconExtractorService
 {
     private static readonly ConcurrentDictionary<string, ImageSource?> _cache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly object _evictionLock = new();
@@ -203,7 +203,7 @@ public sealed class IconExtractorService
             var shell32 = Path.Join(
                 Environment.GetFolderPath(Environment.SpecialFolder.System), "shell32.dll");
 
-            var hIcon = ExtractIconW(IntPtr.Zero, shell32, index);
+            var hIcon = ExtractIcon(IntPtr.Zero, shell32, index);
             if (hIcon == IntPtr.Zero || hIcon == (IntPtr)1)
                 return null;
 
@@ -470,15 +470,15 @@ public sealed class IconExtractorService
         public string szTypeName;
     }
 
-    [DllImport("shell32.dll", CharSet = CharSet.Auto)]
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
     private static extern IntPtr SHGetFileInfo(
         string pszPath, uint dwFileAttributes,
         ref SHFILEINFO psfi, uint cbSizeFileInfo, uint uFlags);
 
-    [DllImport("shell32.dll", CharSet = CharSet.Auto)]
-    private static extern IntPtr ExtractIconW(IntPtr hInst, string lpszExeFileName, int nIconIndex);
+    [LibraryImport("shell32.dll", StringMarshalling = StringMarshalling.Utf16, EntryPoint = "ExtractIconW")]
+    private static partial IntPtr ExtractIcon(IntPtr hInst, string lpszExeFileName, int nIconIndex);
 
-    [DllImport("user32.dll", SetLastError = true)]
+    [LibraryImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool DestroyIcon(IntPtr hIcon);
+    private static partial bool DestroyIcon(IntPtr hIcon);
 }

--- a/SysManager/SysManager/Services/PerformanceService.cs
+++ b/SysManager/SysManager/Services/PerformanceService.cs
@@ -24,7 +24,7 @@ namespace SysManager.Services;
 /// • NVIDIA GPU subkey is auto-detected (not hardcoded to 0000).
 /// • Visual effects use SystemParametersInfo (instant), not registry-only.
 /// </summary>
-public sealed class PerformanceService : IDisposable
+public sealed partial class PerformanceService : IDisposable
 {
     private readonly PowerShellRunner _ps;
     private readonly SemaphoreSlim _psGate = new(1, 1);
@@ -46,15 +46,15 @@ public sealed class PerformanceService : IDisposable
     private const uint SPI_SETUIEFFECTS = 0x103F;
     private const uint SPIF_SENDCHANGE = 0x02;
 
-    [DllImport("user32.dll", SetLastError = true)]
+    [LibraryImport("user32.dll", EntryPoint = "SystemParametersInfoW", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool SystemParametersInfo(
-        uint uiAction, uint uiParam, ref bool pvParam, uint fWinIni);
+    private static partial bool SystemParametersInfoGet(
+        uint uiAction, uint uiParam, ref int pvParam, uint fWinIni);
 
-    [DllImport("user32.dll", SetLastError = true)]
+    [LibraryImport("user32.dll", EntryPoint = "SystemParametersInfoW", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool SystemParametersInfo(
-        uint uiAction, uint uiParam, bool pvParam, uint fWinIni);
+    private static partial bool SystemParametersInfoSet(
+        uint uiAction, uint uiParam, int pvParam, uint fWinIni);
 
     public PerformanceService(PowerShellRunner ps) => _ps = ps;
 
@@ -266,9 +266,9 @@ public sealed class PerformanceService : IDisposable
     /// <summary>Read whether UI effects are currently enabled.</summary>
     internal static bool GetUiEffectsEnabled()
     {
-        bool enabled = true;
-        SystemParametersInfo(SPI_GETUIEFFECTS, 0, ref enabled, 0);
-        return enabled;
+        int enabled = 1;
+        SystemParametersInfoGet(SPI_GETUIEFFECTS, 0, ref enabled, 0);
+        return enabled != 0;
     }
 
     /// <summary>
@@ -279,7 +279,7 @@ public sealed class PerformanceService : IDisposable
     /// </summary>
     public static void SetUiEffects(bool enabled)
     {
-        SystemParametersInfo(SPI_SETUIEFFECTS, 0, enabled, SPIF_SENDCHANGE);
+        SystemParametersInfoSet(SPI_SETUIEFFECTS, 0, enabled ? 1 : 0, SPIF_SENDCHANGE);
         Log.Information("System: Visual effects {Action}", enabled ? "enabled" : "reduced");
     }
 
@@ -531,9 +531,9 @@ public sealed class PerformanceService : IDisposable
     //  RAM WORKING SET TRIM — via EmptyWorkingSet (instant)
     // ═══════════════════════════════════════════════════════════════
 
-    [DllImport("psapi.dll", SetLastError = true)]
+    [LibraryImport("psapi.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool EmptyWorkingSet(IntPtr hProcess);
+    private static partial bool EmptyWorkingSet(IntPtr hProcess);
 
     /// <summary>
     /// Trim the working set of all accessible processes, freeing physical

--- a/SysManager/SysManager/Services/ShortcutCleanerService.cs
+++ b/SysManager/SysManager/Services/ShortcutCleanerService.cs
@@ -14,7 +14,7 @@ namespace SysManager.Services;
 /// Scans common locations for .lnk shortcuts whose targets no longer exist.
 /// Supports deletion to Recycle Bin or permanent delete.
 /// </summary>
-public sealed class ShortcutCleanerService
+public sealed partial class ShortcutCleanerService
 {
     /// <summary>
     /// Scans all common shortcut locations and returns broken shortcuts.

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>SysManager</AssemblyName>
     <RootNamespace>SysManager</RootNamespace>
     <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Version>0.48.21</Version>
     <FileVersion>0.48.21.0</FileVersion>
     <AssemblyVersion>0.48.21.0</AssemblyVersion>


### PR DESCRIPTION
## Summary
- Migrated 10 of 12 `[DllImport]` declarations to `[LibraryImport]` source generator across 6 files
- Added `<AllowUnsafeBlocks>true</AllowUnsafeBlocks>` to .csproj (required by LibraryImport source gen)
- Made classes partial where needed: `IconExtractorService`, `PerformanceService`, `ShortcutCleanerService`, `KnownFolders`
- Renamed `SystemParametersInfo` overloads to `SystemParametersInfoGet`/`SystemParametersInfoSet` with `EntryPoint`
- Renamed `ExtractIconW` to `ExtractIcon` with `EntryPoint = "ExtractIconW"`
- **Kept as DllImport:** `SHGetFileInfo` and `SHFileOperation` (structs with `ByValTStr` fields not supported by source generator)

## Test plan
- [ ] CI build passes
- [ ] Unit tests pass
- [ ] P/Invoke calls work at runtime (icon extraction, performance tuning, recycle bin)
