### PR TITLE
chore: move DTO classes from service files to Models/ (QUAL-006)

### DIFF
--- a/SysManager/SysManager/Models/EventLogQueryOptions.cs
+++ b/SysManager/SysManager/Models/EventLogQueryOptions.cs
@@ -1,0 +1,16 @@
+// SysManager · EventLogQueryOptions
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>Filter parameters for one query against one log.</summary>
+public sealed class EventLogQueryOptions
+{
+    public string LogName { get; set; } = "System";
+    public List<EventSeverity>? Severities { get; set; }
+    public DateTime? Since { get; set; }
+    public string? ProviderName { get; set; }
+    public int? EventId { get; set; }
+    public int MaxResults { get; set; } = 500;
+}

--- a/SysManager/SysManager/Models/MemoryModuleHealth.cs
+++ b/SysManager/SysManager/Models/MemoryModuleHealth.cs
@@ -1,0 +1,15 @@
+// SysManager · MemoryModuleHealth
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+public sealed class MemoryModuleHealth
+{
+    public string Slot { get; set; } = "";
+    public string Manufacturer { get; set; } = "";
+    public double CapacityGB { get; set; }
+    public uint SpeedMHz { get; set; }
+    public uint ConfiguredSpeedMHz { get; set; }
+    public string PartNumber { get; set; } = "";
+}

--- a/SysManager/SysManager/Models/OperationInfo.cs
+++ b/SysManager/SysManager/Models/OperationInfo.cs
@@ -1,0 +1,10 @@
+// SysManager · OperationInfo
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// Information about a currently running operation.
+/// </summary>
+public sealed record OperationInfo(string Name, DateTime StartedUtc);

--- a/SysManager/SysManager/Services/EventLogService.cs
+++ b/SysManager/SysManager/Services/EventLogService.cs
@@ -184,14 +184,3 @@ public sealed class EventLogService
         _ => 4
     };
 }
-
-/// <summary>Filter parameters for one query against one log.</summary>
-public sealed class EventLogQueryOptions
-{
-    public string LogName { get; set; } = "System";
-    public List<EventSeverity>? Severities { get; set; }
-    public DateTime? Since { get; set; }
-    public string? ProviderName { get; set; }
-    public int? EventId { get; set; }
-    public int MaxResults { get; set; } = 500;
-}

--- a/SysManager/SysManager/Services/MemoryTestService.cs
+++ b/SysManager/SysManager/Services/MemoryTestService.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Management;
+using SysManager.Models;
 
 namespace SysManager.Services;
 
@@ -123,14 +124,4 @@ public sealed class MemoryTestService
             return list;
         });
     }
-}
-
-public sealed class MemoryModuleHealth
-{
-    public string Slot { get; set; } = "";
-    public string Manufacturer { get; set; } = "";
-    public double CapacityGB { get; set; }
-    public uint SpeedMHz { get; set; }
-    public uint ConfiguredSpeedMHz { get; set; }
-    public string PartNumber { get; set; } = "";
 }

--- a/SysManager/SysManager/Services/OperationLockService.cs
+++ b/SysManager/SysManager/Services/OperationLockService.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Concurrent;
 using CommunityToolkit.Mvvm.ComponentModel;
+using SysManager.Models;
 
 namespace SysManager.Services;
 
@@ -107,8 +108,3 @@ public sealed partial class OperationLockService : ObservableObject
         }
     }
 }
-
-/// <summary>
-/// Information about a currently running operation.
-/// </summary>
-public sealed record OperationInfo(string Name, DateTime StartedUtc);


### PR DESCRIPTION
## Summary
- Moved 3 data-container classes from service files to dedicated files in Models/:
  - `EventLogQueryOptions` from EventLogService.cs
  - `MemoryModuleHealth` from MemoryTestService.cs
  - `OperationInfo` from OperationLockService.cs
- Added appropriate `using SysManager.Models;` to service files

## Test plan
- [ ] CI build passes
- [ ] Unit tests pass (no logic changes, only file relocation)
