### PR TITLE
chore: extract WingetTableParser from duplicated parsing logic (QUAL-001)

### DIFF
--- a/SysManager/SysManager/Helpers/WingetTableParser.cs
+++ b/SysManager/SysManager/Helpers/WingetTableParser.cs
@@ -1,0 +1,102 @@
+// SysManager · WingetTableParser — shared column-based table parser for winget CLI output
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Text.RegularExpressions;
+
+namespace SysManager.Helpers;
+
+/// <summary>
+/// Parses fixed-width table output from winget.exe (list and upgrade commands).
+/// Both commands produce the same column-based format with a header line followed
+/// by a dashes separator and data rows.
+/// </summary>
+internal static partial class WingetTableParser
+{
+    /// <summary>
+    /// Parsed column positions from a winget table header.
+    /// </summary>
+    internal readonly struct ColumnLayout
+    {
+        public int Name { get; init; }
+        public int Id { get; init; }
+        public int Version { get; init; }
+        public int Available { get; init; }
+        public int Source { get; init; }
+    }
+
+    /// <summary>
+    /// A raw row parsed from the table. Callers map this to their specific model.
+    /// </summary>
+    internal readonly struct RawRow
+    {
+        public string Name { get; init; }
+        public string Id { get; init; }
+        public string Version { get; init; }
+        public string Available { get; init; }
+        public string Source { get; init; }
+    }
+
+    /// <summary>
+    /// Parses a winget table output into raw rows. The headerPattern identifies the
+    /// header line, and summaryPattern identifies the termination line.
+    /// </summary>
+    internal static List<RawRow> Parse(
+        List<string> lines,
+        Regex headerPattern,
+        Regex summaryPattern)
+    {
+        var rows = new List<RawRow>();
+
+        int headerIdx = lines.FindIndex(l => headerPattern.IsMatch(l));
+        if (headerIdx < 0) return rows;
+
+        var header = lines[headerIdx];
+        var layout = DetectColumns(header);
+        if (layout.Id < 0 || layout.Version < 0) return rows;
+
+        for (int i = headerIdx + 2; i < lines.Count; i++)
+        {
+            var line = lines[i];
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            if (line.StartsWith("--")) continue;
+            if (summaryPattern.IsMatch(line)) break;
+            if (line.Length < layout.Version) continue;
+
+            var name = Slice(line, layout.Name, layout.Id);
+            var id = Slice(line, layout.Id, layout.Version);
+            var version = Slice(line, layout.Version, layout.Available >= 0 ? layout.Available : (layout.Source >= 0 ? layout.Source : -1));
+            var available = layout.Available >= 0 ? Slice(line, layout.Available, layout.Source >= 0 ? layout.Source : -1) : "";
+            var source = layout.Source >= 0 ? Slice(line, layout.Source, -1) : "";
+
+            if (string.IsNullOrWhiteSpace(id)) continue;
+
+            rows.Add(new RawRow
+            {
+                Name = name,
+                Id = id,
+                Version = version,
+                Available = available,
+                Source = source
+            });
+        }
+
+        return rows;
+    }
+
+    private static ColumnLayout DetectColumns(string header) => new()
+    {
+        Name = 0,
+        Id = header.IndexOf("Id", StringComparison.OrdinalIgnoreCase),
+        Version = header.IndexOf("Version", StringComparison.OrdinalIgnoreCase),
+        Available = header.IndexOf("Available", StringComparison.OrdinalIgnoreCase),
+        Source = header.IndexOf("Source", StringComparison.OrdinalIgnoreCase)
+    };
+
+    private static string Slice(string line, int start, int end)
+    {
+        if (start < 0 || start >= line.Length) return string.Empty;
+        int actualEnd = end < 0 ? line.Length : Math.Min(end, line.Length);
+        return line[start..actualEnd].Trim();
+    }
+}

--- a/SysManager/SysManager/Services/UninstallerService.cs
+++ b/SysManager/SysManager/Services/UninstallerService.cs
@@ -79,53 +79,19 @@ public sealed partial class UninstallerService
 
     internal static List<InstalledApp> ParseListTable(List<string> lines)
     {
-        var apps = new List<InstalledApp>();
+        var rows = Helpers.WingetTableParser.Parse(lines, ListHeaderPattern(), PackageSummaryPattern());
+        var apps = new List<InstalledApp>(rows.Count);
 
-        // Find header line: "Name   Id   Version  [Available]  Source"
-        int headerIdx = lines.FindIndex(l =>
-            ListHeaderPattern().IsMatch(l));
-        if (headerIdx < 0) return apps;
-
-        var header = lines[headerIdx];
-        int idxId = header.IndexOf("Id", StringComparison.OrdinalIgnoreCase);
-        int idxVersion = header.IndexOf("Version", StringComparison.OrdinalIgnoreCase);
-        int idxAvailable = header.IndexOf("Available", StringComparison.OrdinalIgnoreCase);
-        int idxSource = header.IndexOf("Source", StringComparison.OrdinalIgnoreCase);
-        if (idxId < 0 || idxVersion < 0) return apps;
-
-        // Version end boundary: Available if present, else Source, else line end
-        int versionEnd = idxAvailable > 0 ? idxAvailable
-                       : idxSource > 0 ? idxSource
-                       : -1;
-
-        for (int i = headerIdx + 2; i < lines.Count; i++)
+        foreach (var row in rows)
         {
-            var line = lines[i];
-            if (string.IsNullOrWhiteSpace(line)) continue;
-            if (line.StartsWith("--")) continue;
-            // Stop at summary lines like "123 packages installed"
-            if (PackageSummaryPattern().IsMatch(line)) break;
-            if (line.Length < idxVersion) continue;
-
-            string Slice(int start, int end) =>
-                start < line.Length
-                    ? line[start..Math.Min(end < 0 ? line.Length : end, line.Length)].Trim()
-                    : string.Empty;
-
-            var name = Slice(0, idxId);
-            var id = Slice(idxId, idxVersion);
-            var version = Slice(idxVersion, versionEnd);
-            var source = idxSource > 0 ? Slice(idxSource, -1) : "";
-
-            if (string.IsNullOrWhiteSpace(id)) continue;
-            if (string.IsNullOrWhiteSpace(name) || name.Length < 2) continue;
+            if (string.IsNullOrWhiteSpace(row.Name) || row.Name.Length < 2) continue;
 
             apps.Add(new InstalledApp
             {
-                Name = name,
-                Id = id,
-                Version = version,
-                Source = string.IsNullOrWhiteSpace(source) ? "" : source,
+                Name = row.Name,
+                Id = row.Id,
+                Version = row.Version,
+                Source = string.IsNullOrWhiteSpace(row.Source) ? "" : row.Source,
                 Status = ""
             });
         }

--- a/SysManager/SysManager/Services/WingetService.cs
+++ b/SysManager/SysManager/Services/WingetService.cs
@@ -47,46 +47,20 @@ public partial class WingetService
 
     private static List<AppPackage> ParseUpgradeTable(List<string> lines)
     {
-        var packages = new List<AppPackage>();
-        // Find the header line containing "Name" and "Id" and "Version" and "Available"
-        int headerIdx = lines.FindIndex(l =>
-            UpgradeHeaderPattern().IsMatch(l));
-        if (headerIdx < 0) return packages;
+        var rows = Helpers.WingetTableParser.Parse(lines, UpgradeHeaderPattern(), UpgradeSummaryPattern());
+        var packages = new List<AppPackage>(rows.Count);
 
-        var header = lines[headerIdx];
-        int idxId = header.IndexOf("Id", StringComparison.OrdinalIgnoreCase);
-        int idxVersion = header.IndexOf("Version", StringComparison.OrdinalIgnoreCase);
-        int idxAvailable = header.IndexOf("Available", StringComparison.OrdinalIgnoreCase);
-        int idxSource = header.IndexOf("Source", StringComparison.OrdinalIgnoreCase);
-        if (idxId < 0 || idxVersion < 0 || idxAvailable < 0) return packages;
-
-        for (int i = headerIdx + 2; i < lines.Count; i++)
+        foreach (var row in rows)
         {
-            var line = lines[i];
-            if (string.IsNullOrWhiteSpace(line)) continue;
-            if (line.StartsWith("--")) continue;
-            // Stop at "X upgrades available." summary or similar
-            if (UpgradeSummaryPattern().IsMatch(line)) break;
-            if (line.Length < idxAvailable) continue;
-
-            string Slice(int start, int end) =>
-                start < line.Length ? line[start..Math.Min(end, line.Length)].Trim() : string.Empty;
-
-            var name = Slice(0, idxId);
-            var id = Slice(idxId, idxVersion);
-            var version = Slice(idxVersion, idxAvailable);
-            var available = idxSource > 0 ? Slice(idxAvailable, idxSource) : Slice(idxAvailable, line.Length);
-            var source = idxSource > 0 ? Slice(idxSource, line.Length) : "winget";
-
-            if (string.IsNullOrWhiteSpace(id)) continue;
+            if (string.IsNullOrWhiteSpace(row.Available)) continue;
 
             packages.Add(new AppPackage
             {
-                Name = name,
-                Id = id,
-                CurrentVersion = version,
-                AvailableVersion = available,
-                Source = string.IsNullOrWhiteSpace(source) ? "winget" : source,
+                Name = row.Name,
+                Id = row.Id,
+                CurrentVersion = row.Version,
+                AvailableVersion = row.Available,
+                Source = string.IsNullOrWhiteSpace(row.Source) ? "winget" : row.Source,
                 Status = "Pending"
             });
         }


### PR DESCRIPTION
## Summary
- Created `Helpers/WingetTableParser.cs` with shared column-based table parsing logic
- Refactored `UninstallerService.ParseListTable` and `WingetService.ParseUpgradeTable` to use the shared parser
- Eliminated ~60 lines of duplicated column detection + slicing logic

## Test plan
- [ ] CI build passes
- [ ] Unit tests pass (existing parser tests exercise the same code paths)
- [ ] winget list and winget upgrade produce same results
