### PR TITLE
ci: add Directory.Build.props with shared build configuration (INFRA-001)

### DIFF
--- a/SysManager/Directory.Build.props
+++ b/SysManager/Directory.Build.props
@@ -1,0 +1,19 @@
+<Project>
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Authors>laurentiu021</Authors>
+    <Company>laurentiu021</Company>
+    <Copyright>Copyright (c) 2026 laurentiu021</Copyright>
+    <RepositoryUrl>https://github.com/laurentiu021/SystemManager</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/SysManager/SysManager.IntegrationTests/FixedDriveServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/FixedDriveServiceTests.cs
@@ -95,12 +95,12 @@ public class FixedDriveServiceTests
     }
 
     [Fact]
-    public void EnumerateSync_ReturnsSameAsAsync()
+    public async Task EnumerateSync_ReturnsSameAsAsync()
     {
         var s = new FixedDriveService();
         var sync = FixedDriveService.Enumerate();
-        var async = s.EnumerateAsync().Result;
-        Assert.Equal(sync.Count, async.Count);
+        var asyncResult = await s.EnumerateAsync();
+        Assert.Equal(sync.Count, asyncResult.Count);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/SysManager.Tests.csproj
+++ b/SysManager/SysManager.Tests/SysManager.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0-windows</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
 
     <IsPackable>false</IsPackable>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -3,26 +3,19 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net9.0-windows</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Resources\app.ico</ApplicationIcon>
     <AssemblyName>SysManager</AssemblyName>
     <RootNamespace>SysManager</RootNamespace>
-    <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>NU1603;NU1701</NoWarn>
     <Version>0.48.21</Version>
     <FileVersion>0.48.21.0</FileVersion>
     <AssemblyVersion>0.48.21.0</AssemblyVersion>
-    <Authors>laurentiu021</Authors>
-    <Company>laurentiu021</Company>
     <Product>SysManager</Product>
-    <Copyright>Copyright (c) 2026 laurentiu021</Copyright>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/laurentiu021/SystemManager</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Created `SysManager/Directory.Build.props` with shared properties: Nullable, ImplicitUsings, LangVersion, TreatWarningsAsErrors, metadata, SourceLink
- Removed duplicated properties from individual .csproj files
- Added `<NoWarn>NU1603;NU1701</NoWarn>` to main project (known NuGet compatibility warnings from transitive deps)
- Fixed xUnit1031 warning in FixedDriveServiceTests (blocking `.Result` → `await`)

## Test plan
- [ ] CI build passes (all 4 projects compile with TreatWarningsAsErrors)
- [ ] Unit tests pass
- [ ] No new warnings introduced
