### PR TITLE
ci: promote nullable diagnostics to warning severity (INFRA-003)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -118,8 +118,8 @@ csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 csharp_indent_labels = flush_left
 
-# Nullability analysis produces warnings, not errors, by default.
-dotnet_diagnostic.CS8600.severity = suggestion
-dotnet_diagnostic.CS8602.severity = suggestion
-dotnet_diagnostic.CS8603.severity = suggestion
-dotnet_diagnostic.CS8625.severity = suggestion
+# Nullability analysis at warning severity (TreatWarningsAsErrors promotes to error).
+dotnet_diagnostic.CS8600.severity = warning
+dotnet_diagnostic.CS8602.severity = warning
+dotnet_diagnostic.CS8603.severity = warning
+dotnet_diagnostic.CS8625.severity = warning

--- a/SysManager/SysManager.IntegrationTests/AboutViewUiTests.cs
+++ b/SysManager/SysManager.IntegrationTests/AboutViewUiTests.cs
@@ -90,7 +90,7 @@ public class AboutViewUiTests
                 // Merge App resources so styles defined at app scope are available.
                 var uri = new Uri("pack://application:,,,/SysManager;component/App.xaml", UriKind.Absolute);
                 var dict = (ResourceDictionary)Application.LoadComponent(uri);
-                System.Windows.Application.Current.Resources.MergedDictionaries.Add(dict);
+                System.Windows.Application.Current?.Resources.MergedDictionaries.Add(dict);
             }
             catch
             {

--- a/SysManager/SysManager.IntegrationTests/DeepCleanupViewUiTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DeepCleanupViewUiTests.cs
@@ -83,7 +83,7 @@ public class DeepCleanupViewUiTests
                 };
                 var uri = new Uri("pack://application:,,,/SysManager;component/App.xaml", UriKind.Absolute);
                 var dict = (ResourceDictionary)Application.LoadComponent(uri);
-                System.Windows.Application.Current.Resources.MergedDictionaries.Add(dict);
+                System.Windows.Application.Current?.Resources.MergedDictionaries.Add(dict);
             }
             catch { }
         }


### PR DESCRIPTION
## Summary
- Promoted CS8600/CS8602/CS8603/CS8625 from `suggestion` to `warning` in .editorconfig
- Combined with TreatWarningsAsErrors from INFRA-001, these are now compile errors
- Fixed 2 nullable dereferences in integration tests (Application.Current?.Resources)

## Test plan
- [ ] CI build passes (all projects compile cleanly)
- [ ] Unit tests pass
- [ ] No nullable warnings remain
