### PR TITLE
fix: batch ObservableCollection updates to reduce UI notification overhead (PERF-003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **ObservableCollection batch updates** — replaced Clear() + foreach Add() pattern
+  (N+1 CollectionChanged events) with BulkObservableCollection.ReplaceWith() (single
+  Reset notification) across 10 ViewModels, reducing UI notification overhead during
+  data refreshes.
+
 ## [0.48.38] - 2026-05-20
 
 ### Fixed

--- a/SysManager/SysManager/Helpers/ObservableCollectionExtensions.cs
+++ b/SysManager/SysManager/Helpers/ObservableCollectionExtensions.cs
@@ -1,0 +1,55 @@
+// SysManager · ObservableCollectionExtensions
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+namespace SysManager.Helpers;
+
+/// <summary>
+/// An <see cref="ObservableCollection{T}"/> that supports bulk replacement
+/// with a single <see cref="NotifyCollectionChangedAction.Reset"/> notification.
+/// </summary>
+public class BulkObservableCollection<T> : ObservableCollection<T>
+{
+    private bool _suppressNotifications;
+
+    /// <summary>
+    /// Replaces all items with a single Reset notification instead of
+    /// N+1 individual change events.
+    /// </summary>
+    public void ReplaceWith(IEnumerable<T> items)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+
+        _suppressNotifications = true;
+        try
+        {
+            Items.Clear();
+            foreach (var item in items)
+                Items.Add(item);
+        }
+        finally
+        {
+            _suppressNotifications = false;
+        }
+
+        OnPropertyChanged(new PropertyChangedEventArgs("Count"));
+        OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
+        OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+    }
+
+    protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+    {
+        if (!_suppressNotifications)
+            base.OnCollectionChanged(e);
+    }
+
+    protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+    {
+        if (!_suppressNotifications)
+            base.OnPropertyChanged(e);
+    }
+}

--- a/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -17,7 +18,7 @@ public partial class AppUpdatesViewModel : ViewModelBase
     private CancellationTokenSource? _cts;
     private readonly Action<PowerShellLine> _lineHandler;
 
-    public ObservableCollection<AppPackage> Packages { get; } = new();
+    public BulkObservableCollection<AppPackage> Packages { get; } = new();
     public ConsoleViewModel Console { get; } = new();
 
     [ObservableProperty] private bool _selectAll = true;
@@ -56,7 +57,7 @@ public partial class AppUpdatesViewModel : ViewModelBase
         try
         {
             var list = await _winget.ListUpgradableAsync(_cts.Token);
-            foreach (var p in list) Packages.Add(p);
+            Packages.ReplaceWith(list);
             StatusMessage = $"{Packages.Count} upgradable package(s) found";
         }
         catch (OperationCanceledException) { StatusMessage = "Scan cancelled."; }

--- a/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
@@ -25,8 +25,8 @@ public partial class DeepCleanupViewModel : ViewModelBase
     private readonly EtaCalculator _scanEta = new();
     private readonly EtaCalculator _cleanEta = new();
 
-    public ObservableCollection<CleanupCategory> Categories { get; } = new();
-    public ObservableCollection<LargeFileEntry> LargeFiles { get; } = new();
+    public BulkObservableCollection<CleanupCategory> Categories { get; } = new();
+    public BulkObservableCollection<LargeFileEntry> LargeFiles { get; } = new();
     public ObservableCollection<ScanLocation> ScanLocations { get; } = new();
 
     [ObservableProperty] private bool _isScanning;
@@ -173,17 +173,14 @@ public partial class DeepCleanupViewModel : ViewModelBase
             });
             var cats = await _cleanup.ScanAsync(progress, _scanCts.Token);
 
-            // Batch-update the observable collection to avoid per-item UI
-            // re-renders that can stall the dispatcher on large lists.
             // MEM-006: Unsubscribe from old categories before clearing to prevent
             // PropertyChanged lambda leaks across rescans.
             foreach (var old in Categories)
                 old.PropertyChanged -= OnCategoryPropertyChanged;
-            Categories.Clear();
             var catList = cats.ToList();
             foreach (var c in catList)
                 c.PropertyChanged += OnCategoryPropertyChanged;
-            foreach (var c in catList) Categories.Add(c);
+            Categories.ReplaceWith(catList);
             var total = cats.Sum(c => c.TotalSizeBytes);
             ScanSummary = $"Found {FormatHelper.FormatSize(total)} across {cats.Count} categories. Untick anything you want to keep.";
             ScanStatusLine = "Scan complete.";
@@ -291,7 +288,7 @@ public partial class DeepCleanupViewModel : ViewModelBase
                 top: TopCount,
                 progress: progress,
                 ct: _largeCts.Token);
-            foreach (var f in list) LargeFiles.Add(f);
+            LargeFiles.ReplaceWith(list);
             LargeScanStatus = $"Found {list.Count} files ≥ {MinSizeMB} MB in {SelectedLocation.Label.Trim()}.";
             Log.Information("Large file scan completed: {Count} files ≥ {MinSize} MB",
                 list.Count, MinSizeMB);

--- a/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
@@ -7,6 +7,7 @@ using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -21,7 +22,7 @@ public partial class DiskAnalyzerViewModel : ViewModelBase
     private readonly DiskAnalyzerService _service = new();
     private CancellationTokenSource? _cts;
 
-    public ObservableCollection<DiskUsageEntry> Entries { get; } = new();
+    public BulkObservableCollection<DiskUsageEntry> Entries { get; } = new();
     public ObservableCollection<string> PresetPaths { get; } = new();
 
     [ObservableProperty] private string _selectedPath = "";
@@ -100,8 +101,7 @@ public partial class DiskAnalyzerViewModel : ViewModelBase
 
             var results = await _service.AnalyzeAsync(SelectedPath, progress, ct);
 
-            foreach (var e in results)
-                Entries.Add(e);
+            Entries.ReplaceWith(results);
 
             EntryCount = Entries.Count;
             TotalSize = Entries.Sum(e => e.SizeBytes);

--- a/SysManager/SysManager/ViewModels/DriversViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DriversViewModel.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -19,7 +20,7 @@ public partial class DriversViewModel : ViewModelBase
     private CancellationTokenSource? _cts;
     private readonly List<DriverEntry> _allDrivers = new();
 
-    public ObservableCollection<DriverEntry> Drivers { get; } = new();
+    public BulkObservableCollection<DriverEntry> Drivers { get; } = new();
 
     [ObservableProperty] private int _driverCount;
     [ObservableProperty] private string _summary = "Click List drivers to scan installed drivers.";
@@ -122,13 +123,11 @@ public partial class DriversViewModel : ViewModelBase
 
     private void ApplyFilter()
     {
-        Drivers.Clear();
         var filtered = HideSystemDrivers
             ? _allDrivers.Where(d => !IsSystemDriver(d))
             : _allDrivers;
 
-        foreach (var d in filtered)
-            Drivers.Add(d);
+        Drivers.ReplaceWith(filtered);
 
         DriverCount = Drivers.Count;
         if (_allDrivers.Count > 0)

--- a/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
@@ -7,6 +7,7 @@ using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -22,7 +23,7 @@ public partial class DuplicateFileViewModel : ViewModelBase
     private readonly DuplicateFileService _service = new();
     private CancellationTokenSource? _cts;
 
-    public ObservableCollection<DuplicateFileGroup> Groups { get; } = new();
+    public BulkObservableCollection<DuplicateFileGroup> Groups { get; } = new();
     public ObservableCollection<string> PresetFolders { get; } = new();
 
     [ObservableProperty] private string _selectedFolder = "";
@@ -98,8 +99,7 @@ public partial class DuplicateFileViewModel : ViewModelBase
 
             var results = await _service.ScanAsync(SelectedFolder, minBytes, progress, ct);
 
-            foreach (var g in results)
-                Groups.Add(g);
+            Groups.ReplaceWith(results);
 
             GroupCount = Groups.Count;
             DuplicateFileCount = Groups.Sum(g => g.Files.Count);

--- a/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -19,8 +20,8 @@ public partial class ProcessManagerViewModel : ViewModelBase
 {
     private readonly ProcessManagerService _service = new();
 
-    public ObservableCollection<ProcessEntry> Processes { get; } = new();
-    public ObservableCollection<ProcessEntry> FilteredProcesses { get; } = new();
+    public BulkObservableCollection<ProcessEntry> Processes { get; } = new();
+    public BulkObservableCollection<ProcessEntry> FilteredProcesses { get; } = new();
 
     [ObservableProperty] private string _filterText = "";
     [ObservableProperty] private bool _showOnlyApps;
@@ -77,9 +78,7 @@ public partial class ProcessManagerViewModel : ViewModelBase
                 return snapshot;
             });
 
-            Processes.Clear();
-            foreach (var p in enriched)
-                Processes.Add(p);
+            Processes.ReplaceWith(enriched);
 
             ApplyFilter();
             StatusMessage = $"Loaded {ProcessCount} processes.";
@@ -133,8 +132,6 @@ public partial class ProcessManagerViewModel : ViewModelBase
 
     private void ApplyFilter()
     {
-        FilteredProcesses.Clear();
-
         IEnumerable<ProcessEntry> source = Processes;
 
         if (ShowOnlyApps)
@@ -147,10 +144,7 @@ public partial class ProcessManagerViewModel : ViewModelBase
         }
 
         // Default order by memory descending; DataGrid column headers handle user sorting.
-        source = source.OrderByDescending(p => p.MemoryBytes);
-
-        foreach (var p in source)
-            FilteredProcesses.Add(p);
+        FilteredProcesses.ReplaceWith(source.OrderByDescending(p => p.MemoryBytes));
 
         ProcessCount = FilteredProcesses.Count;
         TotalMemory = FilteredProcesses.Sum(p => p.MemoryBytes);

--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -23,7 +23,7 @@ public partial class ServicesViewModel : ViewModelBase
     private readonly PowerShellRunner _ps = new();
     private List<ServiceEntry> _allServices = new();
 
-    public ObservableCollection<ServiceEntry> Services { get; } = new();
+    public BulkObservableCollection<ServiceEntry> Services { get; } = new();
 
     [ObservableProperty] private string _filter = "";
     [ObservableProperty] private string _selectedFilter = "All";
@@ -158,7 +158,6 @@ public partial class ServicesViewModel : ViewModelBase
 
     private void ApplyFilter()
     {
-        Services.Clear();
         var filtered = _allServices.AsEnumerable();
 
         if (!string.IsNullOrWhiteSpace(Filter))
@@ -177,9 +176,7 @@ public partial class ServicesViewModel : ViewModelBase
         };
 
         // Default order by name; DataGrid column headers handle user sorting.
-        filtered = filtered.OrderBy(s => s.DisplayName, StringComparer.OrdinalIgnoreCase);
-
-        foreach (var s in filtered) Services.Add(s);
+        Services.ReplaceWith(filtered.OrderBy(s => s.DisplayName, StringComparer.OrdinalIgnoreCase));
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
@@ -32,10 +32,10 @@ public partial class SpeedTestViewModel : ViewModelBase
     [ObservableProperty] private string _estimatedTime = "";
 
     /// <summary>Persisted history of HTTP speed test results (newest first).</summary>
-    public ObservableCollection<SpeedTestResult> HttpHistory { get; } = new();
+    public BulkObservableCollection<SpeedTestResult> HttpHistory { get; } = new();
 
     /// <summary>Persisted history of Ookla speed test results (newest first).</summary>
-    public ObservableCollection<SpeedTestResult> OoklaHistory { get; } = new();
+    public BulkObservableCollection<SpeedTestResult> OoklaHistory { get; } = new();
 
     public SpeedTestViewModel(NetworkSharedState shared)
     {
@@ -48,14 +48,10 @@ public partial class SpeedTestViewModel : ViewModelBase
         try
         {
             var all = await _history.LoadAsync();
-            HttpHistory.Clear();
-            OoklaHistory.Clear();
-            foreach (var r in all.Where(r => string.Equals(r.Engine, "HTTP", StringComparison.OrdinalIgnoreCase))
-                                 .OrderByDescending(r => r.CompletedAt))
-                HttpHistory.Add(r);
-            foreach (var r in all.Where(r => string.Equals(r.Engine, "Ookla", StringComparison.OrdinalIgnoreCase))
-                                 .OrderByDescending(r => r.CompletedAt))
-                OoklaHistory.Add(r);
+            HttpHistory.ReplaceWith(all.Where(r => string.Equals(r.Engine, "HTTP", StringComparison.OrdinalIgnoreCase))
+                                       .OrderByDescending(r => r.CompletedAt));
+            OoklaHistory.ReplaceWith(all.Where(r => string.Equals(r.Engine, "Ookla", StringComparison.OrdinalIgnoreCase))
+                                        .OrderByDescending(r => r.CompletedAt));
         }
         catch (InvalidOperationException ex)
         {

--- a/SysManager/SysManager/ViewModels/StartupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StartupViewModel.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -20,7 +21,7 @@ public partial class StartupViewModel : ViewModelBase
     private readonly StartupService _service = new();
     private readonly List<StartupEntry> _allEntries = new();
 
-    public ObservableCollection<StartupEntry> Entries { get; } = new();
+    public BulkObservableCollection<StartupEntry> Entries { get; } = new();
 
     [ObservableProperty] private int _enabledCount;
     [ObservableProperty] private int _disabledCount;
@@ -140,13 +141,11 @@ public partial class StartupViewModel : ViewModelBase
 
     private void ApplyFilter()
     {
-        Entries.Clear();
         var filtered = HideWindowsEntries
             ? _allEntries.Where(e => !IsWindowsEntry(e))
             : _allEntries;
 
-        foreach (var item in filtered)
-            Entries.Add(item);
+        Entries.ReplaceWith(filtered);
 
         UpdateCounts();
     }

--- a/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
@@ -24,10 +24,10 @@ public partial class SystemHealthViewModel : ViewModelBase
     private readonly PowerShellRunner _runner = new();
     private CancellationTokenSource? _cts;
 
-    public ObservableCollection<MemoryModule> Modules { get; } = new();
-    public ObservableCollection<DiskInfo> Disks { get; } = new();
-    public ObservableCollection<DiskHealthReport> DiskHealth { get; } = new();
-    public ObservableCollection<DriveTarget> ChkdskDrives { get; } = new();
+    public BulkObservableCollection<MemoryModule> Modules { get; } = new();
+    public BulkObservableCollection<DiskInfo> Disks { get; } = new();
+    public BulkObservableCollection<DiskHealthReport> DiskHealth { get; } = new();
+    public BulkObservableCollection<DriveTarget> ChkdskDrives { get; } = new();
 
     public ConsoleViewModel Console { get; } = new();
 
@@ -86,10 +86,8 @@ public partial class SystemHealthViewModel : ViewModelBase
             Os = snap.Os;
             Cpu = snap.Cpu;
             Memory = snap.Memory;
-            Modules.Clear();
-            foreach (var m in snap.Memory.Modules) Modules.Add(m);
-            Disks.Clear();
-            foreach (var d in snap.Disks) Disks.Add(d);
+            Modules.ReplaceWith(snap.Memory.Modules);
+            Disks.ReplaceWith(snap.Disks);
             Summary = $"OS {snap.Os.Caption}  —  CPU {snap.Cpu.Name} ({snap.Cpu.Cores}c/{snap.Cpu.LogicalProcessors}t)  —  RAM {snap.Memory.UsedGB:0.0}/{snap.Memory.TotalGB:0.0} GB  —  Disks {snap.Disks.Count}";
             StatusMessage = $"Scan at {snap.CapturedAt:HH:mm:ss}";
             Log.Information("System health scan completed");
@@ -106,22 +104,18 @@ public partial class SystemHealthViewModel : ViewModelBase
         try
         {
             var list = await _drives.EnumerateAsync();
-            ChkdskDrives.Clear();
-            foreach (var d in list)
+            ChkdskDrives.ReplaceWith(list.Select(d => new DriveTarget
             {
-                ChkdskDrives.Add(new DriveTarget
-                {
-                    Letter = d.Letter,
-                    Label = d.Label,
-                    FileSystem = d.FileSystem,
-                    SizeGB = d.SizeGB,
-                    FreeGB = d.FreeGB,
-                    MediaType = d.MediaType,
-                    BusType = d.BusType,
-                    IsSelected = string.Equals(d.Letter, "C:", StringComparison.OrdinalIgnoreCase),
-                    Status = "Idle"
-                });
-            }
+                Letter = d.Letter,
+                Label = d.Label,
+                FileSystem = d.FileSystem,
+                SizeGB = d.SizeGB,
+                FreeGB = d.FreeGB,
+                MediaType = d.MediaType,
+                BusType = d.BusType,
+                IsSelected = string.Equals(d.Letter, "C:", StringComparison.OrdinalIgnoreCase),
+                Status = "Idle"
+            }));
         }
         catch (IOException ex) { StatusMessage = $"Drive enumeration failed: {ex.Message}"; }
         catch (UnauthorizedAccessException ex) { StatusMessage = $"Drive enumeration failed: {ex.Message}"; }
@@ -134,11 +128,10 @@ public partial class SystemHealthViewModel : ViewModelBase
         IsBusy = true;
         IsProgressIndeterminate = true;
         StatusMessage = "Reading SMART data...";
-        DiskHealth.Clear();
         try
         {
             var reports = await _diskHealth.CollectAsync();
-            foreach (var r in reports) DiskHealth.Add(r);
+            DiskHealth.ReplaceWith(reports);
             StatusMessage = $"Collected {reports.Count} disk report(s).";
         }
         catch (System.Management.ManagementException ex) { StatusMessage = $"CheckDiskHealth failed: {ex.Message}"; }


### PR DESCRIPTION
## Summary
- Created `BulkObservableCollection<T>` helper that suppresses per-item notifications during bulk updates and fires a single Reset event
- Replaced Clear() + foreach Add() pattern (N+1 CollectionChanged events) with `ReplaceWith()` (1 event) across 10 ViewModels:
  - ProcessManagerViewModel, DriversViewModel, ServicesViewModel, StartupViewModel
  - SystemHealthViewModel, AppUpdatesViewModel, DuplicateFileViewModel
  - DiskAnalyzerViewModel, DeepCleanupViewModel, SpeedTestViewModel
- Skipped LogsViewModel (uses async streaming batch pattern, not applicable)

## Test plan
- [ ] CI build passes
- [ ] Unit tests pass
- [ ] UI responsiveness improved during large data refreshes (process list, drivers, services)
- [ ] No visual regressions (collections still display correctly after refresh)
