### PR TITLE
docs: assign version header for v0.48.39 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.48.39] - 2026-05-20
+
 ### Fixed
 - **ObservableCollection batch updates** — replaced Clear() + foreach Add() pattern
   (N+1 CollectionChanged events) with BulkObservableCollection.ReplaceWith() (single


### PR DESCRIPTION
Assigns [0.48.39] header to the released entry.
