### PR TITLE
feat!: migrate to .NET 10 (CRIT-001)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup .NET 9 SDK
+      - name: Setup .NET 10 SDK
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Cache NuGet packages
         uses: actions/cache@v5
@@ -95,10 +95,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup .NET 9 SDK
+      - name: Setup .NET 10 SDK
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Restore
         run: dotnet restore SysManager/SysManager.UITests/SysManager.UITests.csproj

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup .NET 9 SDK
+      - name: Setup .NET 10 SDK
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref }}
 
-      - name: Setup .NET 9 SDK
+      - name: Setup .NET 10 SDK
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Extract tag version
         id: version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING:** migrated from .NET 9 to .NET 10 — requires .NET 10 Desktop Runtime
+  to run. All projects (main, tests, integration tests, UI tests) now target
+  `net10.0-windows`. CI workflows updated to use .NET 10 SDK.
+
 ## [0.48.39] - 2026-05-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ recommended mitigation — see [SECURITY.md](SECURITY.md) for details.
 
 ## Build from source
 
-Prerequisites: Windows 10 or newer and the [.NET 9 SDK](https://dotnet.microsoft.com/download/dotnet/9.0).
+Prerequisites: Windows 10 or newer and the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0).
 
 ```powershell
 git clone https://github.com/laurentiu021/SystemManager.git
@@ -450,7 +450,7 @@ and elevation state in a format ready to paste into a bug report.
 
 ## Tech stack
 
-- .NET 9 (WPF, C# 13)
+- .NET 10 (WPF, C# 14)
 - CommunityToolkit.Mvvm for MVVM plumbing
 - Microsoft.Extensions.DependencyInjection for IoC
 - ModernWpfUI for the modern title bar

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ older build, the first step is usually to update.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.48.x  | :white_check_mark: |
-| 0.47.x  | :x:                |
-| < 0.47  | :x:                |
+| 0.49.x  | :white_check_mark: |
+| 0.48.x  | :x:                |
+| < 0.48  | :x:                |
 
 ## Reporting a vulnerability
 

--- a/SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj
+++ b/SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>

--- a/SysManager/SysManager.Tests/SysManager.Tests.csproj
+++ b/SysManager/SysManager.Tests/SysManager.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
 
     <IsPackable>false</IsPackable>

--- a/SysManager/SysManager.UITests/SysManager.UITests.csproj
+++ b/SysManager/SysManager.UITests/SysManager.UITests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Resources\app.ico</ApplicationIcon>


### PR DESCRIPTION
## Summary
- **BREAKING CHANGE:** requires .NET 10 Desktop Runtime
- Migrated all 4 projects from `net9.0-windows` to `net10.0-windows`
- Updated all CI workflows (`ci.yml`, `codeql.yml`, `release.yml`) to use .NET 10 SDK
- Updated README (prerequisites, tech stack)
- Updated SECURITY.md (supported versions)
- Updated CHANGELOG with breaking change entry

## Package Compatibility
All packages verified compatible:
- System.Management, Microsoft.Extensions.DI, coverlet — explicitly target net10.0
- CommunityToolkit.Mvvm, Serilog, xunit, NSubstitute — via netstandard2.0/2.1
- LiveChartsCore, SkiaSharp, H.NotifyIcon — via net6.0+/net8.0+ targets
- ModernWpfUI — via net5.0-windows7.0 (unmaintained but functional)
- OpenTK (transitive) — .NET Framework only, suppressed via NU1701

## Test plan
- [ ] CI build passes (all projects compile on .NET 10)
- [ ] Unit tests pass
- [ ] CodeQL analysis passes
- [ ] Application launches and functions correctly on .NET 10 runtime
