### PR TITLE
chore: upgrade Xunit.StaFact from 1.1.11 to 1.2.69

### DIFF
--- a/SysManager/SysManager.Tests/SysManager.Tests.csproj
+++ b/SysManager/SysManager.Tests/SysManager.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageReference Include="Xunit.StaFact" Version="1.1.11" />
+    <PackageReference Include="Xunit.StaFact" Version="1.2.69" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Upgraded Xunit.StaFact from 1.1.11 to 1.2.69 (latest compatible with xUnit v2)
- No API changes — `[StaFact]` attribute is identical across all 1.x versions
- StaFact 3.x requires xUnit v3 (full test framework migration) — not feasible now

## Context (issue #283)
The original Dependabot PR (#248) tried to bump to 3.x which requires xUnit v3. The correct path is to stay on 1.x line (latest 1.2.69) while on xUnit 2.9.3. Full xUnit v3 migration is a separate future effort.

## Test plan
- [ ] CI build passes
- [ ] All 12 `[StaFact]` tests pass unchanged
