### PR TITLE
chore: replace ModernWpfUI with WPF-UI (lepoco/wpfui)

### DIFF
--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -2,14 +2,14 @@
 <Application x:Class="SysManager.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:ui="http://schemas.modernwpf.com/2019"
+             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
              xmlns:h="clr-namespace:SysManager.Helpers"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ui:ThemeResources RequestedTheme="Dark" />
-                <ui:XamlControlsResources />
+                <ui:ThemesDictionary Theme="Dark" />
+                <ui:ControlsDictionary />
             </ResourceDictionary.MergedDictionaries>
 
             <!-- ============================================================ -->

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -2,12 +2,10 @@
 <Window x:Class="SysManager.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:ui="http://schemas.modernwpf.com/2019"
         xmlns:vm="clr-namespace:SysManager.ViewModels"
         Title="{Binding Title}"
         Width="1280" Height="820"
         MinWidth="960" MinHeight="640"
-        ui:WindowHelper.UseModernWindowStyle="True"
         Background="{StaticResource Surface0}"
         Icon="Resources/app.ico"
         AutomationProperties.AutomationId="MainWindow">

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="H.NotifyIcon.Wpf" Version="2.2.1" />
     <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageReference Include="ModernWpfUI" Version="0.9.6" />
+    <PackageReference Include="WPF-UI" Version="4.3.0" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="System.Management" Version="10.0.8" />

--- a/SysManager/SysManager/Views/ConsoleView.xaml
+++ b/SysManager/SysManager/Views/ConsoleView.xaml
@@ -1,8 +1,7 @@
 <!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.ConsoleView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:ui="http://schemas.modernwpf.com/2019">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Border BorderThickness="1" BorderBrush="#333" CornerRadius="6" Background="#0E1116" Padding="0">
         <Grid>
             <Grid.RowDefinitions>

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -1,8 +1,7 @@
 <!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.DashboardView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:ui="http://schemas.modernwpf.com/2019">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Grid Margin="16">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>


### PR DESCRIPTION
## Summary
- Replaced unmaintained ModernWpfUI 0.9.6 with actively maintained WPF-UI 4.3.0 (lepoco/wpfui)
- Updated App.xaml: `ThemeResources` → `ThemesDictionary`, `XamlControlsResources` → `ControlsDictionary`
- Removed unused `ui:` namespace declarations from ConsoleView.xaml and DashboardView.xaml
- Removed `WindowHelper.UseModernWindowStyle` from MainWindow (WPF-UI applies theme globally via ControlsDictionary)

Closes #462

## Impact
- Dark theme preserved via `ThemesDictionary Theme="Dark"`
- WPF-UI provides .NET 10 support, Fluent Design controls, active maintenance
- No functional changes — only library swap

## Test plan
- [ ] CI build passes
- [ ] Application launches with correct dark theme
- [ ] All views render correctly (no style regressions)
- [ ] Unit tests pass
