### PR TITLE
feat: add individual update selection to Windows Update tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Windows Update** — individual update selection via checkboxes. Users can now
+  select/deselect specific updates before installing. Added "Select all" and
+  "Deselect all" buttons. KB article IDs validated before passing to PowerShell.
+
 ## [1.0.0] - 2026-05-20
 
 ### Changed

--- a/SysManager/SysManager/Models/UpdateEntry.cs
+++ b/SysManager/SysManager/Models/UpdateEntry.cs
@@ -2,13 +2,17 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using CommunityToolkit.Mvvm.ComponentModel;
+
 namespace SysManager.Models;
 
 /// <summary>
 /// Represents a Windows Update entry (available, hidden, or from history).
 /// </summary>
-public sealed class UpdateEntry
+public sealed partial class UpdateEntry : ObservableObject
 {
+    [ObservableProperty] private bool _isSelected = true;
+
     public string Title { get; init; } = "";
     public string KB { get; init; } = "";
     public string Size { get; init; } = "";

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -344,6 +344,15 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
     [RelayCommand]
     private async Task InstallUpdatesAsync()
     {
+        var selected = Updates
+            .Where(u => u.IsSelected && !string.IsNullOrWhiteSpace(u.KB) && u.KB.All(c => char.IsLetterOrDigit(c)))
+            .ToList();
+        if (selected.Count == 0)
+        {
+            StatusMessage = "No updates selected.";
+            return;
+        }
+
         if (!AdminHelper.IsElevated())
         {
             StatusMessage = "Admin required. Relaunching elevated...";
@@ -352,22 +361,35 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
         }
         IsBusy = true;
         IsProgressIndeterminate = true;
-        StatusMessage = "Installing updates (do not reboot)…";
+        StatusMessage = $"Installing {selected.Count} update(s) (do not reboot)…";
         ShowConsole = true;
         Console.ClearCommand.Execute(null);
         _cts?.Dispose();
         _cts = new CancellationTokenSource();
         try
         {
-            await _runner.RunScriptViaPwshAsync(@"
+            var kbFilter = string.Join("','", selected.Select(u => u.KB));
+            await _runner.RunScriptViaPwshAsync($@"
                 Import-Module PSWindowsUpdate -ErrorAction Stop
-                Install-WindowsUpdate -MicrosoftUpdate -AcceptAll -IgnoreReboot -Verbose
+                Install-WindowsUpdate -MicrosoftUpdate -KBArticleID '{kbFilter}' -AcceptAll -IgnoreReboot -Verbose
             ", cancellationToken: _cts.Token);
-            StatusMessage = "Installation finished";
+            StatusMessage = $"Installed {selected.Count} update(s).";
         }
         catch (OperationCanceledException) { StatusMessage = "Cancelled."; }
         catch (InvalidOperationException ex) { StatusMessage = $"Error: {ex.Message}"; }
         finally { IsBusy = false; IsProgressIndeterminate = false; }
+    }
+
+    [RelayCommand]
+    private void SelectAll()
+    {
+        foreach (var u in Updates) u.IsSelected = true;
+    }
+
+    [RelayCommand]
+    private void DeselectAll()
+    {
+        foreach (var u in Updates) u.IsSelected = false;
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -104,7 +104,9 @@
                     <Button Content="Feature upgrades" Command="{Binding ListFeatureUpdatesCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"/>
                     <Button Content="History" Command="{Binding ShowHistoryCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"/>
                     <Button Content="Pending reboot?" Command="{Binding CheckPendingRebootCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"/>
-                    <Button Content="Install updates" Command="{Binding InstallUpdatesCommand}" Style="{StaticResource PrimaryButton}" Margin="0,0,8,8"/>
+                    <Button Content="Install selected" Command="{Binding InstallUpdatesCommand}" Style="{StaticResource PrimaryButton}" Margin="0,0,8,8"/>
+                    <Button Content="Select all" Command="{Binding SelectAllCommand}" Style="{StaticResource GhostButton}" Margin="0,0,8,8"/>
+                    <Button Content="Deselect all" Command="{Binding DeselectAllCommand}" Style="{StaticResource GhostButton}" Margin="0,0,8,8"/>
                     <Button Content="Cancel" Command="{Binding CancelCommand}" Style="{StaticResource GhostButton}" Margin="0,0,8,8"/>
                 </WrapPanel>
             </StackPanel>
@@ -121,13 +123,15 @@
             <DataGrid AutomationProperties.Name="Data table" ItemsSource="{Binding Updates}"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
                       Background="Transparent" BorderThickness="0"
-                      GridLinesVisibility="None" IsReadOnly="True"
+                      GridLinesVisibility="None"
                       RowBackground="Transparent" AlternatingRowBackground="#0F141C"
                       SelectionMode="Single" CanUserSortColumns="True"
                       VirtualizingPanel.IsVirtualizing="True"
                       VirtualizingPanel.VirtualizationMode="Recycling">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="*"
+                    <DataGridCheckBoxColumn Header="✓" Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" Width="36"/>
+
+                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="*" IsReadOnly="True"
                                         SortMemberPath="Title">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">


### PR DESCRIPTION
## Summary
- Added checkbox column to Windows Update DataGrid for individual update selection
- "Install selected" replaces "Install updates" — only installs checked items
- Added "Select all" / "Deselect all" buttons
- KB article IDs validated (alphanumeric only) before PowerShell interpolation
- `UpdateEntry` model now extends `ObservableObject` with `IsSelected` property

Closes #14

## Security
KB values are validated with `u.KB.All(c => char.IsLetterOrDigit(c))` before being interpolated into the PowerShell `-KBArticleID` parameter. This prevents injection via crafted KB strings.

## Test plan
- [ ] CI build passes
- [ ] List updates → checkboxes appear, all selected by default
- [ ] Deselect some → "Install selected" installs only checked ones
- [ ] Select all / Deselect all buttons work
- [ ] Empty selection shows "No updates selected" message
