### PR TITLE
feat: add bulk application installer via winget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-05-21
+
 ### Added
 - **Windows Update** — individual update selection via checkboxes. Users can now
   select/deselect specific updates before installing. Added "Select all" and

--- a/SysManager/SysManager/Models/InstallableApp.cs
+++ b/SysManager/SysManager/Models/InstallableApp.cs
@@ -1,0 +1,20 @@
+// SysManager · InstallableApp — model for bulk-installable applications
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SysManager.Models;
+
+/// <summary>
+/// A curated application available for bulk installation via winget.
+/// </summary>
+public sealed partial class InstallableApp : ObservableObject
+{
+    [ObservableProperty] private bool _isSelected;
+    [ObservableProperty] private string _status = "";
+
+    public required string Name { get; init; }
+    public required string WingetId { get; init; }
+    public required string Category { get; init; }
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -50,6 +50,7 @@ public static class ServiceRegistration
         services.AddSingleton<TracerouteMonitorService>();
         services.AddSingleton<TracerouteService>();
         services.AddSingleton<UninstallerService>();
+        services.AddSingleton<BulkInstallerService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
         services.AddSingleton<DashboardViewModel>();
@@ -79,6 +80,7 @@ public static class ServiceRegistration
         services.AddSingleton<WindowsFeaturesService>();
         services.AddSingleton<WindowsFeaturesViewModel>();
         services.AddSingleton<AppBlockerViewModel>();
+        services.AddSingleton<BulkInstallerViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/BulkInstallerService.cs
+++ b/SysManager/SysManager/Services/BulkInstallerService.cs
@@ -1,0 +1,44 @@
+// SysManager · BulkInstallerService — install apps via winget
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Text.RegularExpressions;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Wraps winget.exe to install packages by their winget ID.
+/// </summary>
+public sealed partial class BulkInstallerService
+{
+    private readonly PowerShellRunner _runner;
+
+    public BulkInstallerService(PowerShellRunner runner) => _runner = runner;
+
+    public event Action<PowerShellLine>? LineReceived
+    {
+        add => _runner.LineReceived += value;
+        remove => _runner.LineReceived -= value;
+    }
+
+    /// <summary>
+    /// Installs a package by its winget ID. Returns the process exit code.
+    /// </summary>
+    public async Task<int> InstallAsync(string wingetId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(wingetId)
+            || !PackageIdPattern().IsMatch(wingetId))
+            throw new ArgumentException("Invalid package ID.", nameof(wingetId));
+
+        var args = $"install --id \"{wingetId}\" -e --silent --accept-source-agreements --accept-package-agreements --disable-interactivity";
+        return await _runner.RunProcessAsync("winget", args, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Matches valid winget package IDs: alphanumeric, dots, hyphens,
+    /// underscores, forward slashes, plus signs, and spaces. Max 256 chars.
+    /// </summary>
+    [GeneratedRegex(@"^[\w.\-/+ ]{1,256}$")]
+    private static partial Regex PackageIdPattern();
+}

--- a/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
@@ -1,0 +1,209 @@
+// SysManager · BulkInstallerViewModel — bulk install curated apps via winget
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// Bulk Installer tab — select curated apps and install them via winget.
+/// </summary>
+public sealed partial class BulkInstallerViewModel : ViewModelBase
+{
+    private readonly BulkInstallerService _service;
+    private CancellationTokenSource? _cts;
+
+    public BulkObservableCollection<InstallableApp> Apps { get; } = new();
+    public ObservableCollection<InstallableApp> FilteredApps { get; } = new();
+
+    [ObservableProperty] private string _filterText = "";
+    [ObservableProperty] private string _selectedCategory = "All";
+
+    public List<string> Categories { get; } =
+    [
+        "All",
+        "Browsers",
+        "Communication",
+        "Media",
+        "Development",
+        "Utilities",
+        "Gaming",
+        "Security"
+    ];
+
+    partial void OnFilterTextChanged(string value) => ApplyFilter();
+    partial void OnSelectedCategoryChanged(string value) => ApplyFilter();
+
+    public BulkInstallerViewModel(BulkInstallerService service)
+    {
+        _service = service;
+        Apps.ReplaceWith(BuildCuratedApps());
+        ApplyFilter();
+    }
+
+    [RelayCommand]
+    private async Task InstallSelectedAsync()
+    {
+        var selected = Apps.Where(a => a.IsSelected).ToList();
+        if (selected.Count == 0)
+        {
+            StatusMessage = "No apps selected.";
+            return;
+        }
+
+        IsBusy = true;
+        IsProgressIndeterminate = false;
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+
+        var installed = 0;
+        var failed = 0;
+
+        try
+        {
+            for (var i = 0; i < selected.Count; i++)
+            {
+                _cts.Token.ThrowIfCancellationRequested();
+
+                var app = selected[i];
+                app.Status = "Installing...";
+                Progress = (int)((double)i / selected.Count * 100);
+                StatusMessage = $"Installing {app.Name} ({i + 1}/{selected.Count})…";
+
+                try
+                {
+                    var exitCode = await _service.InstallAsync(app.WingetId, _cts.Token);
+                    if (exitCode == 0)
+                    {
+                        app.Status = "Installed";
+                        installed++;
+                    }
+                    else
+                    {
+                        app.Status = $"Failed (exit {exitCode})";
+                        failed++;
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    app.Status = "Cancelled";
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    app.Status = $"Error: {ex.Message}";
+                    failed++;
+                    Log.Warning(ex, "Failed to install {WingetId}", app.WingetId);
+                }
+            }
+
+            Progress = 100;
+            StatusMessage = $"Done. Installed: {installed}, Failed: {failed}.";
+        }
+        catch (OperationCanceledException)
+        {
+            StatusMessage = "Installation cancelled.";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private void Cancel() => _cts?.Cancel();
+
+    [RelayCommand]
+    private void SelectAll()
+    {
+        foreach (var app in FilteredApps)
+            app.IsSelected = true;
+    }
+
+    [RelayCommand]
+    private void DeselectAll()
+    {
+        foreach (var app in Apps)
+            app.IsSelected = false;
+    }
+
+    [RelayCommand]
+    private void SelectCategory(string category)
+    {
+        foreach (var app in Apps.Where(a => a.Category == category))
+            app.IsSelected = true;
+    }
+
+    private void ApplyFilter()
+    {
+        var filtered = Apps.AsEnumerable();
+
+        if (SelectedCategory != "All")
+            filtered = filtered.Where(a => a.Category == SelectedCategory);
+
+        if (!string.IsNullOrWhiteSpace(FilterText))
+            filtered = filtered.Where(a =>
+                a.Name.Contains(FilterText, StringComparison.OrdinalIgnoreCase));
+
+        FilteredApps.Clear();
+        foreach (var app in filtered)
+            FilteredApps.Add(app);
+    }
+
+    private static List<InstallableApp> BuildCuratedApps() =>
+    [
+        // Browsers
+        new() { Name = "Google Chrome",  WingetId = "Google.Chrome",   Category = "Browsers" },
+        new() { Name = "Firefox",        WingetId = "Mozilla.Firefox", Category = "Browsers" },
+        new() { Name = "Brave",          WingetId = "Brave.Brave",     Category = "Browsers" },
+        new() { Name = "Vivaldi",        WingetId = "Vivaldi.Vivaldi", Category = "Browsers" },
+
+        // Communication
+        new() { Name = "Discord",  WingetId = "Discord.Discord",              Category = "Communication" },
+        new() { Name = "Slack",    WingetId = "SlackTechnologies.Slack",       Category = "Communication" },
+        new() { Name = "Zoom",     WingetId = "Zoom.Zoom",                    Category = "Communication" },
+        new() { Name = "Telegram", WingetId = "Telegram.TelegramDesktop",     Category = "Communication" },
+
+        // Media
+        new() { Name = "VLC",       WingetId = "VideoLAN.VLC",              Category = "Media" },
+        new() { Name = "Spotify",   WingetId = "Spotify.Spotify",           Category = "Media" },
+        new() { Name = "foobar2000", WingetId = "PeterPawlowski.foobar2000", Category = "Media" },
+
+        // Development
+        new() { Name = "VS Code",  WingetId = "Microsoft.VisualStudioCode", Category = "Development" },
+        new() { Name = "Git",      WingetId = "Git.Git",                    Category = "Development" },
+        new() { Name = "Node.js",  WingetId = "OpenJS.NodeJS.LTS",          Category = "Development" },
+        new() { Name = "Python",   WingetId = "Python.Python.3.12",         Category = "Development" },
+
+        // Utilities
+        new() { Name = "7-Zip",      WingetId = "7zip.7zip",              Category = "Utilities" },
+        new() { Name = "Notepad++",  WingetId = "Notepad++.Notepad++",    Category = "Utilities" },
+        new() { Name = "Everything", WingetId = "voidtools.Everything",   Category = "Utilities" },
+        new() { Name = "PowerToys",  WingetId = "Microsoft.PowerToys",    Category = "Utilities" },
+
+        // Gaming
+        new() { Name = "Steam",        WingetId = "Valve.Steam",                    Category = "Gaming" },
+        new() { Name = "Epic Games",   WingetId = "EpicGames.EpicGamesLauncher",    Category = "Gaming" },
+        new() { Name = "GOG Galaxy",   WingetId = "GOG.Galaxy",                     Category = "Gaming" },
+
+        // Security
+        new() { Name = "Bitwarden",    WingetId = "Bitwarden.Bitwarden",       Category = "Security" },
+        new() { Name = "Malwarebytes", WingetId = "Malwarebytes.Malwarebytes", Category = "Security" },
+    ];
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _cts?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -42,6 +42,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public AppAlertsViewModel AppAlerts { get; }
     public ShortcutCleanerViewModel ShortcutCleaner { get; }
     public AppBlockerViewModel AppBlocker { get; }
+    public BulkInstallerViewModel BulkInstaller { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -66,8 +67,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public PlaceholderViewModel WipDnsChanger { get; private set; } = null!;
     public PlaceholderViewModel WipHostsEditor { get; private set; } = null!;
 
-    // Apps group
-    public PlaceholderViewModel WipBulkInstaller { get; private set; } = null!;
+    // Apps group (Bulk Installer is now fully implemented)
 
     // Privacy & Security group
     public PlaceholderViewModel WipPrivacySettings { get; private set; } = null!;
@@ -140,6 +140,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             AppAlerts = sp.GetRequiredService<AppAlertsViewModel>();
             ShortcutCleaner = sp.GetRequiredService<ShortcutCleanerViewModel>();
             AppBlocker = sp.GetRequiredService<AppBlockerViewModel>();
+            BulkInstaller = sp.GetRequiredService<BulkInstallerViewModel>();
             WindowsFeatures = sp.GetRequiredService<WindowsFeaturesViewModel>();
         }
         else
@@ -185,6 +186,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             AppAlerts = new AppAlertsViewModel(new AppAlertService());
             ShortcutCleaner = new ShortcutCleanerViewModel(shortcuts);
             AppBlocker = new AppBlockerViewModel();
+            BulkInstaller = new BulkInstallerViewModel(new BulkInstallerService(new PowerShellRunner()));
             WindowsFeatures = new WindowsFeaturesViewModel(new WindowsFeaturesService(runner));
         }
 
@@ -218,8 +220,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         WipDnsChanger = new PlaceholderViewModel("DNS Changer", "Quick-switch DNS with benchmark, DNS-over-HTTPS, and TCP/IP optimization.", "#11");
         WipHostsEditor = new PlaceholderViewModel("Hosts Editor", "GUI hosts file editor with domain toggle, import block lists, and backup/restore.", "#11");
 
-        // Apps group
-        WipBulkInstaller = new PlaceholderViewModel("Bulk Installer", "Curated checkbox app installer via winget with presets (Gamer/Dev/Creative).", "#6");
+        // Apps group — Bulk Installer is now fully implemented (no placeholder needed)
 
         // Privacy & Security group
         WipPrivacySettings = new PlaceholderViewModel("Privacy & Telemetry", "80-100+ toggles for telemetry, ads, AI/Copilot, location, diagnostics with presets.", "#9");
@@ -383,7 +384,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Tooltip = "App Updates\nBulk Installer\nUninstaller\nApp Blocker",
             Children = {
             new NavItem { Id = "nav-app-updates",    Label = "App Updates",    Glyph = "\uE7B8", Content = AppUpdates,       ViewType = typeof(Views.AppUpdatesView) },
-            new NavItem { Id = "nav-bulk-installer", Label = "Bulk Installer", Glyph = "\uE896", Content = WipBulkInstaller, ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-bulk-installer", Label = "Bulk Installer", Glyph = "\uE896", Content = BulkInstaller, ViewType = typeof(Views.BulkInstallerView) },
             new NavItem { Id = "nav-uninstaller",    Label = "Uninstaller",    Glyph = "\uE738", Content = Uninstaller,      ViewType = typeof(Views.UninstallerView) },
             new NavItem { Id = "nav-app-blocker",    Label = "App Blocker",    Glyph = "\uE8F8", Content = AppBlocker,       ViewType = typeof(Views.AppBlockerView) },
         }
@@ -546,6 +547,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         AppAlerts?.Dispose();
         ShortcutCleaner?.Dispose();
         AppBlocker?.Dispose();
+        BulkInstaller?.Dispose();
 
         // WIP placeholders
         WipResourceHistory?.Dispose();
@@ -562,7 +564,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         WipScheduledMaintenance?.Dispose();
         WipDnsChanger?.Dispose();
         WipHostsEditor?.Dispose();
-        WipBulkInstaller?.Dispose();
         WipPrivacySettings?.Dispose();
         WipDebloater?.Dispose();
         WipBrowserCleaner?.Dispose();

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -1,0 +1,139 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.BulkInstallerView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             d:DataContext="{d:DesignInstance vm:BulkInstallerViewModel}"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             Background="{StaticResource Surface0}">
+
+    <Grid Margin="32,24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,16">
+            <TextBlock Text="Bulk Installer" Style="{StaticResource Display}"/>
+            <TextBlock Text="Select applications to install in bulk via winget."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+        </StackPanel>
+
+        <!-- Toolbar -->
+        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+            <WrapPanel>
+                <TextBlock Text="Category:" VerticalAlignment="Center" Margin="0,0,8,0"
+                           Style="{StaticResource Subtle}"/>
+                <ComboBox ItemsSource="{Binding Categories}"
+                          SelectedItem="{Binding SelectedCategory}"
+                          Width="140" Margin="0,0,12,0"/>
+                <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0"
+                           Style="{StaticResource Subtle}"/>
+                <Grid Width="200" Margin="0,0,12,0">
+                    <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"/>
+                    <TextBlock Text="Search apps…" IsHitTestVisible="False"
+                               Foreground="{StaticResource TextMuted}" Margin="6,0,0,0"
+                               VerticalAlignment="Center" FontSize="12"
+                               Visibility="{Binding FilterText, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                </Grid>
+                <Button Content="Install Selected" Command="{Binding InstallSelectedCommand}"
+                        Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"/>
+                <Button Content="Select All" Command="{Binding SelectAllCommand}"
+                        Style="{StaticResource GhostButton}" Margin="0,0,4,0"/>
+                <Button Content="Deselect All" Command="{Binding DeselectAllCommand}"
+                        Style="{StaticResource GhostButton}" Margin="0,0,8,0"/>
+                <Button Content="Cancel" Command="{Binding CancelCommand}"
+                        Style="{StaticResource GhostButton}"
+                        Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+            </WrapPanel>
+        </Border>
+
+        <!-- App list -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
+            <DataGrid AutomationProperties.Name="Data table" ItemsSource="{Binding FilteredApps}"
+                      AutoGenerateColumns="False" HeadersVisibility="Column"
+                      Background="Transparent" BorderThickness="0"
+                      GridLinesVisibility="None" IsReadOnly="False"
+                      RowBackground="Transparent" AlternatingRowBackground="#0F141C"
+                      SelectionMode="Single" CanUserSortColumns="True"
+                      VirtualizingPanel.IsVirtualizing="True"
+                      VirtualizingPanel.VirtualizationMode="Recycling">
+                <DataGrid.Columns>
+                    <DataGridCheckBoxColumn Header="" Width="32"
+                                            Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}"
+                                            CanUserSort="False">
+                        <DataGridCheckBoxColumn.ElementStyle>
+                            <Style TargetType="CheckBox">
+                                <Setter Property="HorizontalAlignment" Value="Center"/>
+                            </Style>
+                        </DataGridCheckBoxColumn.ElementStyle>
+                        <DataGridCheckBoxColumn.EditingElementStyle>
+                            <Style TargetType="CheckBox">
+                                <Setter Property="HorizontalAlignment" Value="Center"/>
+                            </Style>
+                        </DataGridCheckBoxColumn.EditingElementStyle>
+                    </DataGridCheckBoxColumn>
+
+                    <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"
+                                        SortMemberPath="Name" IsReadOnly="True">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                <Setter Property="FontSize" Value="13"/>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+
+                    <DataGridTextColumn Header="Category" Binding="{Binding Category}" Width="120"
+                                        SortMemberPath="Category" IsReadOnly="True">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
+                                <Setter Property="FontSize" Value="12"/>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+
+                    <DataGridTextColumn Header="Winget ID" Binding="{Binding WingetId}" Width="220"
+                                        SortMemberPath="WingetId" IsReadOnly="True">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="FontFamily" Value="Consolas"/>
+                                <Setter Property="FontSize" Value="12"/>
+                                <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+
+                    <DataGridTemplateColumn Header="Status" Width="160" SortMemberPath="Status">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Border Style="{StaticResource Badge}"
+                                        VerticalAlignment="Center" Margin="4,0"
+                                        Visibility="{Binding Status, Converter={StaticResource FlexVis}}"
+                                        ToolTip="{Binding Status}">
+                                    <TextBlock Text="{Binding Status}" FontSize="11"
+                                               TextTrimming="CharacterEllipsis" MaxWidth="140"/>
+                                </Border>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                </DataGrid.Columns>
+            </DataGrid>
+        </Border>
+
+        <!-- Status bar -->
+        <DockPanel Grid.Row="3" Margin="0,8,0,0">
+            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+                         IsIndeterminate="{Binding IsProgressIndeterminate}"
+                         Value="{Binding Progress}"
+                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml.cs
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · BulkInstallerView — bulk installer UI
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class BulkInstallerView : UserControl
+{
+    public BulkInstallerView() => InitializeComponent();
+}


### PR DESCRIPTION
## Summary
New tab in the Apps group: Bulk Installer — install multiple applications in one click via winget.

- **25 curated apps** across 7 categories: Browsers, Communication, Media, Development, Utilities, Gaming, Security
- **Category filter** — ComboBox to show all or specific category
- **Text search** — filter by app name
- **Checkbox selection** — select/deselect individual apps, Select All, Deselect All
- **Sequential install** — installs selected apps one by one with per-app status updates
- **Cancel** — stop installation mid-way
- **Security** — winget IDs validated with regex before shell execution

### Files Created
- `Models/InstallableApp.cs` — ObservableObject with IsSelected + Status
- `Services/BulkInstallerService.cs` — winget install wrapper with ID validation
- `ViewModels/BulkInstallerViewModel.cs` — curated list, filtering, install logic
- `Views/BulkInstallerView.xaml` + `.xaml.cs` — DataGrid UI with filter controls

Closes #6

## Test plan
- [ ] CI build passes
- [ ] Tab appears in Apps nav group
- [ ] Category filter works
- [ ] Search filter works
- [ ] Select/Deselect all works
- [ ] Install selected installs apps via winget with status feedback
- [ ] Cancel stops installation
