### PR TITLE
feat: add secure file shredder with multi-pass overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **File Shredder** — secure file deletion with multiple overwrite methods (Quick 1-pass,
+  Standard 3-pass, Thorough 7-pass). Protects system paths, uses confirmation dialog,
+  supports files and folders.
+
 ## [1.1.0] - 2026-05-21
 
 ### Added

--- a/SysManager/SysManager/Models/ShredItem.cs
+++ b/SysManager/SysManager/Models/ShredItem.cs
@@ -1,0 +1,23 @@
+// SysManager · ShredItem — model for a file/folder queued for secure deletion
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using SysManager.Helpers;
+
+namespace SysManager.Models;
+
+/// <summary>
+/// Represents a file or folder queued for secure shredding.
+/// </summary>
+public sealed partial class ShredItem : ObservableObject
+{
+    [ObservableProperty] private string _status = "Pending";
+
+    public required string Path { get; init; }
+    public required string Name { get; init; }
+    public required long SizeBytes { get; init; }
+    public bool IsFolder { get; init; }
+
+    public string SizeDisplay => FormatHelper.FormatSize(SizeBytes);
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -52,6 +52,7 @@ public static class ServiceRegistration
         services.AddSingleton<TracerouteService>();
         services.AddSingleton<UninstallerService>();
         services.AddSingleton<BulkInstallerService>();
+        services.AddSingleton<FileShredderService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
         services.AddSingleton<DashboardViewModel>();
@@ -82,6 +83,7 @@ public static class ServiceRegistration
         services.AddSingleton<WindowsFeaturesViewModel>();
         services.AddSingleton<AppBlockerViewModel>();
         services.AddSingleton<BulkInstallerViewModel>();
+        services.AddSingleton<FileShredderViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/FileShredderService.cs
+++ b/SysManager/SysManager/Services/FileShredderService.cs
@@ -1,0 +1,195 @@
+// SysManager · FileShredderService — secure file deletion with multi-pass overwrite
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Security;
+using Serilog;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Specifies the number of overwrite passes for secure file deletion.
+/// </summary>
+public enum ShredMethod
+{
+    /// <summary>1 pass — zero fill.</summary>
+    Quick = 1,
+
+    /// <summary>3 passes — 0x00, 0xFF, random.</summary>
+    Standard = 3,
+
+    /// <summary>7 passes — alternating patterns + random.</summary>
+    Thorough = 7
+}
+
+/// <summary>
+/// Securely deletes files by overwriting their contents with specified patterns
+/// before removing them from the file system.
+/// </summary>
+public sealed class FileShredderService
+{
+    private const int BufferSize = 65_536; // 64 KB
+
+    private static readonly string[] ProtectedPrefixes = GetProtectedPrefixes();
+
+    private static string[] GetProtectedPrefixes()
+    {
+        var winDir = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+        var sys32 = Path.Combine(winDir, "System32");
+        var progFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        var progFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+
+        return [winDir, sys32, progFiles, progFilesX86];
+    }
+
+    /// <summary>
+    /// Securely shreds a single file using the specified method.
+    /// </summary>
+    public async Task ShredFileAsync(string filePath, ShredMethod method, IProgress<int>? progress, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        ValidatePath(filePath);
+
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException("File not found.", filePath);
+
+        var fileLength = new FileInfo(filePath).Length;
+        var totalPasses = (int)method;
+        var patterns = GetPatterns(method);
+
+        for (var pass = 0; pass < totalPasses; pass++)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            await using var stream = new FileStream(
+                filePath,
+                FileMode.Open,
+                FileAccess.Write,
+                FileShare.None,
+                BufferSize,
+                FileOptions.WriteThrough | FileOptions.SequentialScan);
+
+            var buffer = new byte[BufferSize];
+            var pattern = patterns[pass];
+
+            if (pattern == null)
+            {
+                // Random pass
+                Random.Shared.NextBytes(buffer);
+            }
+            else
+            {
+                Array.Fill(buffer, pattern.Value);
+            }
+
+            var bytesRemaining = fileLength;
+            while (bytesRemaining > 0)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var writeSize = (int)Math.Min(BufferSize, bytesRemaining);
+
+                // Re-randomize buffer each chunk for random passes
+                if (pattern == null)
+                    Random.Shared.NextBytes(buffer.AsSpan(0, writeSize));
+
+                await stream.WriteAsync(buffer.AsMemory(0, writeSize), ct).ConfigureAwait(false);
+                bytesRemaining -= writeSize;
+            }
+
+            await stream.FlushAsync(ct).ConfigureAwait(false);
+
+            var overallProgress = (int)((pass + 1) * 100.0 / totalPasses);
+            progress?.Report(overallProgress);
+        }
+
+        // Final cleanup: truncate, flush, close, then delete
+        await using (var finalStream = new FileStream(filePath, FileMode.Open, FileAccess.Write, FileShare.None))
+        {
+            finalStream.SetLength(0);
+            await finalStream.FlushAsync(ct).ConfigureAwait(false);
+        }
+
+        File.Delete(filePath);
+        Log.Information("File shredded successfully: {Path} ({Method})", filePath, method);
+    }
+
+    /// <summary>
+    /// Securely shreds all files in a folder recursively, then removes the folder.
+    /// </summary>
+    public async Task ShredFolderAsync(string folderPath, ShredMethod method, IProgress<int>? progress, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(folderPath);
+        ValidatePath(folderPath);
+
+        if (!Directory.Exists(folderPath))
+            throw new DirectoryNotFoundException($"Folder not found: {folderPath}");
+
+        var files = Directory.GetFiles(folderPath, "*", SearchOption.AllDirectories);
+        var totalFiles = files.Length;
+
+        for (var i = 0; i < totalFiles; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            try
+            {
+                // Remove read-only attribute if present
+                var attrs = File.GetAttributes(files[i]);
+                if (attrs.HasFlag(FileAttributes.ReadOnly))
+                    File.SetAttributes(files[i], attrs & ~FileAttributes.ReadOnly);
+
+                await ShredFileAsync(files[i], method, null, ct).ConfigureAwait(false);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                Log.Warning(ex, "Access denied while shredding file: {Path}", files[i]);
+            }
+            catch (IOException ex)
+            {
+                Log.Warning(ex, "I/O error while shredding file: {Path}", files[i]);
+            }
+
+            var overallProgress = (int)((i + 1) * 100.0 / totalFiles);
+            progress?.Report(overallProgress);
+        }
+
+        // Remove empty directories bottom-up
+        try
+        {
+            Directory.Delete(folderPath, recursive: true);
+        }
+        catch (IOException ex)
+        {
+            Log.Warning(ex, "Could not fully remove folder structure: {Path}", folderPath);
+        }
+
+        Log.Information("Folder shredded successfully: {Path} ({Method})", folderPath, method);
+    }
+
+    private static void ValidatePath(string path)
+    {
+        var fullPath = Path.GetFullPath(path);
+
+        foreach (var prefix in ProtectedPrefixes)
+        {
+            if (fullPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new SecurityException(
+                    $"Shredding system-protected paths is not allowed: {fullPath}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the byte pattern for each pass. A null entry means random fill.
+    /// </summary>
+    private static byte?[] GetPatterns(ShredMethod method) => method switch
+    {
+        ShredMethod.Quick => [0x00],
+        ShredMethod.Standard => [0x00, 0xFF, null],
+        ShredMethod.Thorough => [0x00, 0xFF, 0x00, 0xFF, 0xAA, 0x55, null],
+        _ => [0x00]
+    };
+}

--- a/SysManager/SysManager/ViewModels/FileShredderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/FileShredderViewModel.cs
@@ -1,0 +1,225 @@
+// SysManager · FileShredderViewModel — secure file deletion UI logic
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the File Shredder tab — allows users to securely delete
+/// files and folders with multi-pass overwrite patterns.
+/// </summary>
+public sealed partial class FileShredderViewModel : ViewModelBase
+{
+    private readonly FileShredderService _service;
+    private CancellationTokenSource? _cts;
+
+    public BulkObservableCollection<ShredItem> Items { get; } = new();
+
+    [ObservableProperty] private ShredMethod _selectedMethod = ShredMethod.Standard;
+    [ObservableProperty] private bool _isShredding;
+
+    public FileShredderViewModel(FileShredderService service)
+    {
+        _service = service;
+    }
+
+    [RelayCommand]
+    private void AddFiles()
+    {
+        var dialog = new Microsoft.Win32.OpenFileDialog
+        {
+            Title = "Select files to shred",
+            Multiselect = true,
+            Filter = "All files (*.*)|*.*"
+        };
+
+        if (dialog.ShowDialog() != true) return;
+
+        foreach (var filePath in dialog.FileNames)
+        {
+            if (Items.Any(i => i.Path.Equals(filePath, StringComparison.OrdinalIgnoreCase)))
+                continue;
+
+            try
+            {
+                var info = new FileInfo(filePath);
+                Items.Add(new ShredItem
+                {
+                    Path = filePath,
+                    Name = info.Name,
+                    SizeBytes = info.Length,
+                    IsFolder = false
+                });
+            }
+            catch (IOException ex)
+            {
+                Log.Warning(ex, "Could not read file info: {Path}", filePath);
+            }
+        }
+    }
+
+    [RelayCommand]
+    private void AddFolder()
+    {
+        var dialog = new Microsoft.Win32.OpenFolderDialog
+        {
+            Title = "Select folder to shred"
+        };
+
+        if (dialog.ShowDialog() != true) return;
+
+        var folderPath = dialog.FolderName;
+        if (Items.Any(i => i.Path.Equals(folderPath, StringComparison.OrdinalIgnoreCase)))
+            return;
+
+        try
+        {
+            var dirInfo = new DirectoryInfo(folderPath);
+            var size = dirInfo.EnumerateFiles("*", SearchOption.AllDirectories)
+                .Sum(f => f.Length);
+
+            Items.Add(new ShredItem
+            {
+                Path = folderPath,
+                Name = dirInfo.Name,
+                SizeBytes = size,
+                IsFolder = true
+            });
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Log.Warning(ex, "Access denied while reading folder: {Path}", folderPath);
+        }
+        catch (IOException ex)
+        {
+            Log.Warning(ex, "Could not read folder info: {Path}", folderPath);
+        }
+    }
+
+    [RelayCommand]
+    private void RemoveItem(ShredItem? item)
+    {
+        if (item != null)
+            Items.Remove(item);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanShredAll))]
+    private async Task ShredAllAsync()
+    {
+        if (Items.Count == 0) return;
+
+        var confirmed = DialogService.Instance.Confirm(
+            $"You are about to permanently shred {Items.Count} item(s) using the {SelectedMethod} method.\n\n" +
+            "This action is IRREVERSIBLE. The data cannot be recovered.\n\nContinue?",
+            "Confirm Secure Shred");
+
+        if (!confirmed) return;
+
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        var ct = _cts.Token;
+
+        IsShredding = true;
+        IsBusy = true;
+        StatusMessage = "Shredding...";
+
+        var completed = 0;
+        var failed = 0;
+
+        try
+        {
+            // Process items sequentially
+            for (var i = Items.Count - 1; i >= 0; i--)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var item = Items[i];
+                var totalPasses = (int)SelectedMethod;
+
+                var itemProgress = new Progress<int>(p =>
+                {
+                    var currentPass = (int)Math.Ceiling(p / 100.0 * totalPasses);
+                    item.Status = $"Shredding pass {currentPass}/{totalPasses}...";
+                });
+
+                try
+                {
+                    if (item.IsFolder)
+                    {
+                        item.Status = $"Shredding pass 1/{totalPasses}...";
+                        await _service.ShredFolderAsync(item.Path, SelectedMethod, itemProgress, ct).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        item.Status = $"Shredding pass 1/{totalPasses}...";
+                        await _service.ShredFileAsync(item.Path, SelectedMethod, itemProgress, ct).ConfigureAwait(false);
+                    }
+
+                    item.Status = "Done";
+                    completed++;
+                }
+                catch (OperationCanceledException)
+                {
+                    item.Status = "Cancelled";
+                    throw;
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+                {
+                    item.Status = "Failed";
+                    failed++;
+                    Log.Warning(ex, "Failed to shred: {Path}", item.Path);
+                }
+            }
+
+            StatusMessage = $"Complete — {completed} shredded, {failed} failed.";
+        }
+        catch (OperationCanceledException)
+        {
+            StatusMessage = "Shredding cancelled.";
+        }
+        finally
+        {
+            IsShredding = false;
+            IsBusy = false;
+
+            // Remove successfully shredded items
+            for (var i = Items.Count - 1; i >= 0; i--)
+            {
+                if (Items[i].Status == "Done")
+                    Items.RemoveAt(i);
+            }
+
+            ShredAllCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    private bool CanShredAll() => Items.Count > 0 && !IsShredding;
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        _cts?.Cancel();
+    }
+
+    partial void OnIsShreddingChanged(bool value)
+    {
+        ShredAllCommand.NotifyCanExecuteChanged();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _cts?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -43,6 +43,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public ShortcutCleanerViewModel ShortcutCleaner { get; }
     public AppBlockerViewModel AppBlocker { get; }
     public BulkInstallerViewModel BulkInstaller { get; }
+    public FileShredderViewModel FileShredder { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -59,8 +60,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public PlaceholderViewModel WipCpuAffinity { get; private set; } = null!;
     public PlaceholderViewModel WipDisplayProfiles { get; private set; } = null!;
 
-    // Cleanup group
-    public PlaceholderViewModel WipFileShredder { get; private set; } = null!;
+    // Cleanup group (File Shredder is now fully implemented)
     public PlaceholderViewModel WipScheduledMaintenance { get; private set; } = null!;
 
     // Network group
@@ -141,6 +141,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             ShortcutCleaner = sp.GetRequiredService<ShortcutCleanerViewModel>();
             AppBlocker = sp.GetRequiredService<AppBlockerViewModel>();
             BulkInstaller = sp.GetRequiredService<BulkInstallerViewModel>();
+            FileShredder = sp.GetRequiredService<FileShredderViewModel>();
             WindowsFeatures = sp.GetRequiredService<WindowsFeaturesViewModel>();
         }
         else
@@ -187,6 +188,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             ShortcutCleaner = new ShortcutCleanerViewModel(shortcuts);
             AppBlocker = new AppBlockerViewModel();
             BulkInstaller = new BulkInstallerViewModel(new BulkInstallerService(new PowerShellRunner()));
+            FileShredder = new FileShredderViewModel(new FileShredderService());
             WindowsFeatures = new WindowsFeaturesViewModel(new WindowsFeaturesService(runner));
         }
 
@@ -212,8 +214,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         WipCpuAffinity = new PlaceholderViewModel("CPU Core Affinity", "Set per-game CPU affinity with P-core/E-core awareness for Intel hybrid CPUs.", "#327");
         WipDisplayProfiles = new PlaceholderViewModel("Display Profiles", "Quick-switch refresh rate, HDR, resolution presets (Gaming/Work/Movie).", "#328");
 
-        // Cleanup group
-        WipFileShredder = new PlaceholderViewModel("File Shredder", "Securely delete files beyond recovery with multi-pass overwrite (DoD/Gutmann).", "#7");
+        // Cleanup group (File Shredder is now fully implemented)
         WipScheduledMaintenance = new PlaceholderViewModel("Scheduled Maintenance", "Automate cleanup, RAM trim, and health checks on schedule or idle trigger.", "#10");
 
         // Network group
@@ -337,7 +338,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             new NavItem { Id = "nav-cleanup",               Label = "Quick Cleanup",         Glyph = "\uE74D", Content = Cleanup,                 ViewType = typeof(Views.CleanupView) },
             new NavItem { Id = "nav-deep-cleanup",          Label = "Deep Cleanup",          Glyph = "\uE81E", Content = DeepCleanup,             ViewType = typeof(Views.DeepCleanupView) },
             new NavItem { Id = "nav-shortcut-cleaner",      Label = "Shortcut Cleaner",      Glyph = "\uE71B", Content = ShortcutCleaner,         ViewType = typeof(Views.ShortcutCleanerView) },
-            new NavItem { Id = "nav-file-shredder",         Label = "File Shredder",         Glyph = "\uE74D", Content = WipFileShredder,         ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-file-shredder",         Label = "File Shredder",         Glyph = "\uE74D", Content = FileShredder,            ViewType = typeof(Views.FileShredderView) },
             new NavItem { Id = "nav-scheduled-maintenance", Label = "Scheduled Maintenance", Glyph = "\uE823", Content = WipScheduledMaintenance, ViewType = typeof(Views.PlaceholderView) },
         }
         };
@@ -548,6 +549,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         ShortcutCleaner?.Dispose();
         AppBlocker?.Dispose();
         BulkInstaller?.Dispose();
+        FileShredder?.Dispose();
 
         // WIP placeholders
         WipResourceHistory?.Dispose();
@@ -560,7 +562,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         WipTimerResolution?.Dispose();
         WipCpuAffinity?.Dispose();
         WipDisplayProfiles?.Dispose();
-        WipFileShredder?.Dispose();
         WipScheduledMaintenance?.Dispose();
         WipDnsChanger?.Dispose();
         WipHostsEditor?.Dispose();

--- a/SysManager/SysManager/Views/FileShredderView.xaml
+++ b/SysManager/SysManager/Views/FileShredderView.xaml
@@ -1,0 +1,98 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.FileShredderView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:svc="clr-namespace:SysManager.Services"
+             d:DataContext="{d:DesignInstance vm:FileShredderViewModel}"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <LinearGradientBrush x:Key="PageBg" StartPoint="0,0" EndPoint="1,1">
+            <GradientStop Color="#070A0F" Offset="0"/>
+            <GradientStop Color="#0B1220" Offset="0.5"/>
+            <GradientStop Color="#090D16" Offset="1"/>
+        </LinearGradientBrush>
+        <ObjectDataProvider x:Key="ShredMethods" MethodName="GetValues" ObjectType="{x:Type svc:ShredMethod}">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="svc:ShredMethod"/>
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
+    </UserControl.Resources>
+
+    <Grid Background="{StaticResource PageBg}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="28,24,28,0">
+            <TextBlock Text="File Shredder" Style="{StaticResource Display}"/>
+            <TextBlock Text="Securely delete files beyond recovery with multi-pass overwrite."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+        </StackPanel>
+
+        <!-- Toolbar -->
+        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="28,16,28,0" Padding="12">
+            <WrapPanel>
+                <TextBlock Text="Method:" VerticalAlignment="Center" Margin="0,0,8,0"
+                           Foreground="{StaticResource TextSecondary}"/>
+                <ComboBox ItemsSource="{Binding Source={StaticResource ShredMethods}}"
+                          SelectedItem="{Binding SelectedMethod}"
+                          Width="120" Margin="0,0,16,0" VerticalAlignment="Center"/>
+                <Button Content="Add Files" Command="{Binding AddFilesCommand}"
+                        Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"/>
+                <Button Content="Add Folder" Command="{Binding AddFolderCommand}"
+                        Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
+                <Button Content="Shred All" Command="{Binding ShredAllCommand}"
+                        Style="{StaticResource PrimaryButton}" Foreground="#EF4444" Margin="0,0,8,0"/>
+                <Button Content="Cancel" Command="{Binding CancelCommand}"
+                        Style="{StaticResource GhostButton}"
+                        Visibility="{Binding IsShredding, Converter={StaticResource BoolToVis}}"/>
+            </WrapPanel>
+        </Border>
+
+        <!-- Items DataGrid -->
+        <DataGrid Grid.Row="2" ItemsSource="{Binding Items}"
+                  AutoGenerateColumns="False" IsReadOnly="True"
+                  CanUserAddRows="False" CanUserDeleteRows="False"
+                  CanUserSortColumns="True"
+                  HeadersVisibility="Column" GridLinesVisibility="None"
+                  Margin="28,12,28,0">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="200"/>
+                <DataGridTextColumn Header="Path" Binding="{Binding Path}" Width="*"/>
+                <DataGridTextColumn Header="Size" Binding="{Binding SizeDisplay}" Width="90"/>
+                <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="160"/>
+                <DataGridTemplateColumn Header="" Width="70">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <Button Content="Remove"
+                                    Command="{Binding DataContext.RemoveItemCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                    CommandParameter="{Binding}"
+                                    Style="{StaticResource GhostButton}"
+                                    Padding="4,2" FontSize="11"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <!-- Footer -->
+        <Border Grid.Row="3" Margin="28,8,28,16" Padding="8">
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Style="{StaticResource Subtle}">
+                    <Run Text="{Binding Items.Count, Mode=OneWay}"/>
+                    <Run Text=" item(s) queued"/>
+                </TextBlock>
+                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Subtle}"
+                           Margin="16,0,0,0" Opacity="0.8"/>
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/FileShredderView.xaml.cs
+++ b/SysManager/SysManager/Views/FileShredderView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · FileShredderView — secure file deletion UI
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class FileShredderView : UserControl
+{
+    public FileShredderView() => InitializeComponent();
+}


### PR DESCRIPTION
## Summary
New Security feature: File Shredder — permanently destroy files by overwriting content before deletion.

### ShredMethod options:
- **Quick** (1 pass) — zero-fill
- **Standard** (3 passes) — 0x00, 0xFF, random
- **Thorough** (7 passes) — alternating patterns + random

### Features:
- Add files or folders via picker dialogs
- Per-item status tracking (pass progress)
- Cancel mid-operation
- Confirmation dialog before shredding (irreversible!)
- System path protection (rejects Windows/, System32/, Program Files/)
- 64KB buffer for efficient large file processing

Closes #7

## Test plan
- [ ] CI build passes
- [ ] Add files → appear in list with size
- [ ] Shred all → confirmation dialog → files permanently deleted
- [ ] System paths rejected with error
