### PR TITLE
feat: add privacy toggles for telemetry, ads, and tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Privacy Toggles** — 12 one-click privacy switches (telemetry, advertising ID, Copilot,
+  Cortana, web search, widgets, Start suggestions, lock screen tips) with instant apply
+  and registry state detection.
+
 ## [1.3.0] - 2026-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,24 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-05-21
+
 ### Added
 - **File Shredder** — secure file deletion with multiple overwrite methods (Quick 1-pass,
   Standard 3-pass, Thorough 7-pass). Protects system paths, uses confirmation dialog,
   supports files and folders.
 
-## [1.1.0] - 2026-05-21
+## [1.2.0] - 2026-05-21
 
 ### Added
 - **System Info Export** — comprehensive system report (OS, CPU, GPU, RAM, storage,
   network, SMART data) exportable to file or clipboard from the About tab.
+- **Bulk App Installer** — install multiple applications via winget with curated list
+  of 25 apps across 7 categories, category/text filtering, and per-app progress.
+
+## [1.1.0] - 2026-05-21
+
+### Added
 - **Windows Update** — individual update selection via checkboxes. Users can now
   select/deselect specific updates before installing. Added "Select all" and
   "Deselect all" buttons. KB article IDs validated before passing to PowerShell.

--- a/SysManager/SysManager/Models/PrivacyToggle.cs
+++ b/SysManager/SysManager/Models/PrivacyToggle.cs
@@ -1,0 +1,38 @@
+// SysManager · PrivacyToggle — model for privacy/telemetry registry toggles
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SysManager.Models;
+
+/// <summary>
+/// Represents a single privacy toggle backed by a Windows registry value.
+/// When <see cref="IsEnabled"/> is true, privacy protection is active
+/// (i.e., the associated tracking/feature is DISABLED).
+/// </summary>
+public sealed partial class PrivacyToggle : ObservableObject
+{
+    [ObservableProperty] private bool _isEnabled;
+
+    /// <summary>Short human-readable name shown in the toggle list.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Explanatory description displayed under the name.</summary>
+    public required string Description { get; init; }
+
+    /// <summary>Grouping category (e.g. Telemetry, UI Declutter, Features).</summary>
+    public required string Category { get; init; }
+
+    /// <summary>Full registry path (e.g. HKLM\SOFTWARE\...).</summary>
+    public required string RegistryPath { get; init; }
+
+    /// <summary>Registry value name to read/write.</summary>
+    public required string ValueName { get; init; }
+
+    /// <summary>Value written when privacy protection is ON.</summary>
+    public required int EnabledValue { get; init; }
+
+    /// <summary>Value written when privacy protection is OFF (default Windows state).</summary>
+    public required int DisabledValue { get; init; }
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -53,6 +53,7 @@ public static class ServiceRegistration
         services.AddSingleton<UninstallerService>();
         services.AddSingleton<BulkInstallerService>();
         services.AddSingleton<FileShredderService>();
+        services.AddSingleton<PrivacyService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
         services.AddSingleton<DashboardViewModel>();
@@ -84,6 +85,7 @@ public static class ServiceRegistration
         services.AddSingleton<AppBlockerViewModel>();
         services.AddSingleton<BulkInstallerViewModel>();
         services.AddSingleton<FileShredderViewModel>();
+        services.AddSingleton<PrivacyViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/PrivacyService.cs
+++ b/SysManager/SysManager/Services/PrivacyService.cs
@@ -1,0 +1,281 @@
+// SysManager · PrivacyService — reads/writes privacy-related registry toggles
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Security;
+using Microsoft.Win32;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Provides a curated list of Windows privacy toggles and persists their
+/// state to the registry. HKCU writes always succeed; HKLM writes require
+/// elevation and failures are handled gracefully.
+/// </summary>
+public sealed class PrivacyService
+{
+    /// <summary>
+    /// Creates the full toggle list with current state read from the registry.
+    /// </summary>
+    public List<PrivacyToggle> LoadToggles()
+    {
+        var toggles = CreateToggleDefinitions();
+
+        foreach (var toggle in toggles)
+        {
+            toggle.IsEnabled = ReadCurrentState(toggle);
+        }
+
+        return toggles;
+    }
+
+    /// <summary>
+    /// Writes a single toggle's current <see cref="PrivacyToggle.IsEnabled"/> state
+    /// to the registry.
+    /// </summary>
+    public void ApplyToggle(PrivacyToggle toggle)
+    {
+        ArgumentNullException.ThrowIfNull(toggle);
+
+        var valueToWrite = toggle.IsEnabled ? toggle.EnabledValue : toggle.DisabledValue;
+
+        try
+        {
+            using var key = OpenOrCreateKey(toggle.RegistryPath, writable: true);
+            if (key != null)
+            {
+                key.SetValue(toggle.ValueName, valueToWrite, RegistryValueKind.DWord);
+                Log.Information("Privacy toggle applied: {Name} = {Value} at {Path}\\{ValueName}",
+                    toggle.Name, valueToWrite, toggle.RegistryPath, toggle.ValueName);
+            }
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Log.Warning(ex, "Access denied writing privacy toggle {Name} at {Path} — elevation required",
+                toggle.Name, toggle.RegistryPath);
+        }
+        catch (SecurityException ex)
+        {
+            Log.Warning(ex, "Security exception writing privacy toggle {Name} at {Path} — elevation required",
+                toggle.Name, toggle.RegistryPath);
+        }
+    }
+
+    /// <summary>
+    /// Applies all toggles in sequence. Errors on individual toggles are
+    /// logged but do not stop the batch.
+    /// </summary>
+    public void ApplyAll(IEnumerable<PrivacyToggle> toggles)
+    {
+        ArgumentNullException.ThrowIfNull(toggles);
+
+        foreach (var toggle in toggles)
+        {
+            ApplyToggle(toggle);
+        }
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Reads the current registry state for a toggle.
+    /// Returns true (privacy ON) if the current value matches <see cref="PrivacyToggle.EnabledValue"/>.
+    /// If the key/value does not exist, returns false (default Windows state = privacy off).
+    /// </summary>
+    private static bool ReadCurrentState(PrivacyToggle toggle)
+    {
+        try
+        {
+            using var key = OpenOrCreateKey(toggle.RegistryPath, writable: false);
+            if (key == null) return false;
+
+            var value = key.GetValue(toggle.ValueName);
+            if (value == null) return false;
+
+            if (value is int intVal)
+                return intVal == toggle.EnabledValue;
+
+            if (int.TryParse(value.ToString(), out var parsed))
+                return parsed == toggle.EnabledValue;
+
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            Log.Debug("Cannot read {Path}\\{Value} — access denied", toggle.RegistryPath, toggle.ValueName);
+            return false;
+        }
+        catch (SecurityException)
+        {
+            Log.Debug("Cannot read {Path}\\{Value} — security exception", toggle.RegistryPath, toggle.ValueName);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Opens or creates a registry key from a full path string (e.g. "HKLM\SOFTWARE\...").
+    /// Returns null if the root hive is unrecognized or access is denied.
+    /// </summary>
+    private static RegistryKey? OpenOrCreateKey(string fullPath, bool writable)
+    {
+        var separatorIndex = fullPath.IndexOf('\\');
+        if (separatorIndex < 0) return null;
+
+        var hiveName = fullPath[..separatorIndex].ToUpperInvariant();
+        var subPath = fullPath[(separatorIndex + 1)..];
+
+        var hive = hiveName switch
+        {
+            "HKCU" or "HKEY_CURRENT_USER" => Registry.CurrentUser,
+            "HKLM" or "HKEY_LOCAL_MACHINE" => Registry.LocalMachine,
+            _ => null
+        };
+
+        if (hive == null) return null;
+
+        if (writable)
+        {
+            // CreateSubKey creates intermediate keys if missing
+            return hive.CreateSubKey(subPath, writable: true);
+        }
+
+        return hive.OpenSubKey(subPath, writable: false);
+    }
+
+    /// <summary>
+    /// Builds the full set of toggle definitions with their registry mappings.
+    /// </summary>
+    private static List<PrivacyToggle> CreateToggleDefinitions()
+    {
+        return
+        [
+            // ── Telemetry ─────────────────────────────────────────────────
+            new PrivacyToggle
+            {
+                Name = "Disable diagnostic data",
+                Description = "Prevents Windows from sending diagnostic and usage data to Microsoft.",
+                Category = "Telemetry",
+                RegistryPath = @"HKLM\SOFTWARE\Policies\Microsoft\Windows\DataCollection",
+                ValueName = "AllowTelemetry",
+                EnabledValue = 0,
+                DisabledValue = 3
+            },
+            new PrivacyToggle
+            {
+                Name = "Disable activity history",
+                Description = "Stops Windows from collecting activity history and sending it to Microsoft.",
+                Category = "Telemetry",
+                RegistryPath = @"HKLM\SOFTWARE\Policies\Microsoft\Windows\System",
+                ValueName = "EnableActivityFeed",
+                EnabledValue = 0,
+                DisabledValue = 1
+            },
+            new PrivacyToggle
+            {
+                Name = "Disable advertising ID",
+                Description = "Prevents apps from using your advertising ID for targeted ads.",
+                Category = "Telemetry",
+                RegistryPath = @"HKCU\Software\Microsoft\Windows\CurrentVersion\AdvertisingInfo",
+                ValueName = "Enabled",
+                EnabledValue = 0,
+                DisabledValue = 1
+            },
+            new PrivacyToggle
+            {
+                Name = "Disable feedback",
+                Description = "Stops Windows from prompting for feedback surveys.",
+                Category = "Telemetry",
+                RegistryPath = @"HKCU\Software\Microsoft\Siuf\Rules",
+                ValueName = "NumberOfSIUFInPeriod",
+                EnabledValue = 0,
+                DisabledValue = 1
+            },
+
+            // ── UI Declutter ──────────────────────────────────────────────
+            new PrivacyToggle
+            {
+                Name = "Disable Start suggestions",
+                Description = "Removes suggested apps and content from the Start menu.",
+                Category = "UI Declutter",
+                RegistryPath = @"HKCU\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager",
+                ValueName = "SubscribedContent-338388Enabled",
+                EnabledValue = 0,
+                DisabledValue = 1
+            },
+            new PrivacyToggle
+            {
+                Name = "Disable tips",
+                Description = "Turns off Windows tips and suggestions notifications.",
+                Category = "UI Declutter",
+                RegistryPath = @"HKCU\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager",
+                ValueName = "SoftLandingEnabled",
+                EnabledValue = 0,
+                DisabledValue = 1
+            },
+            new PrivacyToggle
+            {
+                Name = "Disable lock screen tips",
+                Description = "Removes tips and tricks from the lock screen.",
+                Category = "UI Declutter",
+                RegistryPath = @"HKCU\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager",
+                ValueName = "RotatingLockScreenOverlayEnabled",
+                EnabledValue = 0,
+                DisabledValue = 1
+            },
+            new PrivacyToggle
+            {
+                Name = "Disable Spotlight ads",
+                Description = "Removes promotional content from Windows Spotlight on the lock screen.",
+                Category = "UI Declutter",
+                RegistryPath = @"HKCU\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager",
+                ValueName = "SubscribedContent-353696Enabled",
+                EnabledValue = 0,
+                DisabledValue = 1
+            },
+
+            // ── Features ──────────────────────────────────────────────────
+            new PrivacyToggle
+            {
+                Name = "Disable Copilot",
+                Description = "Turns off Windows Copilot AI assistant integration.",
+                Category = "Features",
+                RegistryPath = @"HKCU\Software\Policies\Microsoft\Windows\WindowsCopilot",
+                ValueName = "TurnOffWindowsCopilot",
+                EnabledValue = 1,
+                DisabledValue = 0
+            },
+            new PrivacyToggle
+            {
+                Name = "Disable Cortana",
+                Description = "Prevents Cortana from running and collecting voice/search data.",
+                Category = "Features",
+                RegistryPath = @"HKLM\SOFTWARE\Policies\Microsoft\Windows\Windows Search",
+                ValueName = "AllowCortana",
+                EnabledValue = 0,
+                DisabledValue = 1
+            },
+            new PrivacyToggle
+            {
+                Name = "Disable web search",
+                Description = "Removes Bing web results from Start menu and taskbar search.",
+                Category = "Features",
+                RegistryPath = @"HKCU\Software\Policies\Microsoft\Windows\Explorer",
+                ValueName = "DisableSearchBoxSuggestions",
+                EnabledValue = 1,
+                DisabledValue = 0
+            },
+            new PrivacyToggle
+            {
+                Name = "Disable widgets",
+                Description = "Turns off the Widgets board (news and interests) on the taskbar.",
+                Category = "Features",
+                RegistryPath = @"HKLM\SOFTWARE\Policies\Microsoft\Dsh",
+                ValueName = "AllowNewsAndInterests",
+                EnabledValue = 0,
+                DisabledValue = 1
+            },
+        ];
+    }
+}

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -44,6 +44,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public AppBlockerViewModel AppBlocker { get; }
     public BulkInstallerViewModel BulkInstaller { get; }
     public FileShredderViewModel FileShredder { get; }
+    public PrivacyViewModel Privacy { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -69,8 +70,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
     // Apps group (Bulk Installer is now fully implemented)
 
-    // Privacy & Security group
-    public PlaceholderViewModel WipPrivacySettings { get; private set; } = null!;
+    // Privacy & Security group (Privacy & Telemetry is now fully implemented)
     public PlaceholderViewModel WipDebloater { get; private set; } = null!;
     public PlaceholderViewModel WipBrowserCleaner { get; private set; } = null!;
     public PlaceholderViewModel WipEdgeOneDriveRemover { get; private set; } = null!;
@@ -143,6 +143,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             BulkInstaller = sp.GetRequiredService<BulkInstallerViewModel>();
             FileShredder = sp.GetRequiredService<FileShredderViewModel>();
             WindowsFeatures = sp.GetRequiredService<WindowsFeaturesViewModel>();
+            Privacy = sp.GetRequiredService<PrivacyViewModel>();
         }
         else
         {
@@ -190,6 +191,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             BulkInstaller = new BulkInstallerViewModel(new BulkInstallerService(new PowerShellRunner()));
             FileShredder = new FileShredderViewModel(new FileShredderService());
             WindowsFeatures = new WindowsFeaturesViewModel(new WindowsFeaturesService(runner));
+            Privacy = new PrivacyViewModel(new PrivacyService());
         }
 
         InitPlaceholders();
@@ -223,8 +225,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
         // Apps group — Bulk Installer is now fully implemented (no placeholder needed)
 
-        // Privacy & Security group
-        WipPrivacySettings = new PlaceholderViewModel("Privacy & Telemetry", "80-100+ toggles for telemetry, ads, AI/Copilot, location, diagnostics with presets.", "#9");
+        // Privacy & Security group (Privacy & Telemetry is now fully implemented)
         WipDebloater = new PlaceholderViewModel("Debloater & Ads", "Remove UWP bloatware, disable all Windows ads, remove Copilot/Recall/AI features.", "#9");
         WipBrowserCleaner = new PlaceholderViewModel("Browser Cleaner", "Per-browser cache/cookies/history cleanup with keep-list for important cookies.", "#336");
         WipEdgeOneDriveRemover = new PlaceholderViewModel("Edge/OneDrive Remover", "Safely remove or disable Edge and OneDrive with full restore capability.", "#339");
@@ -400,7 +401,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Subtitle = "Telemetry · Debloat · Browser · Edge/OneDrive · Defender · Notifications",
             Tooltip = "Privacy & Telemetry\nDebloater & Ads\nBrowser Cleaner\nEdge/OneDrive Remover\nDefender Tweaks\nNotification Blocker",
             Children = {
-            new NavItem { Id = "nav-privacy-settings",     Label = "Privacy & Telemetry",   Glyph = "\uE72E", Content = WipPrivacySettings,     ViewType = typeof(Views.PlaceholderView) },
+            new NavItem { Id = "nav-privacy-settings",     Label = "Privacy & Telemetry",   Glyph = "\uE72E", Content = Privacy,                ViewType = typeof(Views.PrivacyView) },
             new NavItem { Id = "nav-debloater",            Label = "Debloater & Ads",       Glyph = "\uE74D", Content = WipDebloater,           ViewType = typeof(Views.PlaceholderView) },
             new NavItem { Id = "nav-browser-cleaner",      Label = "Browser Cleaner",       Glyph = "\uEB41", Content = WipBrowserCleaner,      ViewType = typeof(Views.PlaceholderView) },
             new NavItem { Id = "nav-edge-onedrive",        Label = "Edge/OneDrive Remover", Glyph = "\uE738", Content = WipEdgeOneDriveRemover, ViewType = typeof(Views.PlaceholderView) },
@@ -565,7 +566,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         WipScheduledMaintenance?.Dispose();
         WipDnsChanger?.Dispose();
         WipHostsEditor?.Dispose();
-        WipPrivacySettings?.Dispose();
+        Privacy?.Dispose();
         WipDebloater?.Dispose();
         WipBrowserCleaner?.Dispose();
         WipEdgeOneDriveRemover?.Dispose();

--- a/SysManager/SysManager/ViewModels/PrivacyViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PrivacyViewModel.cs
@@ -1,0 +1,143 @@
+// SysManager · PrivacyViewModel — privacy toggles management
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the Privacy Toggles tab. Loads registry-backed toggles,
+/// groups them by category, and applies changes immediately on toggle flip.
+/// </summary>
+public sealed partial class PrivacyViewModel : ViewModelBase
+{
+    private readonly PrivacyService _service;
+    private bool _suppressApply;
+
+    public BulkObservableCollection<PrivacyToggle> Toggles { get; } = new();
+
+    [ObservableProperty] private List<string> _categories = new();
+    [ObservableProperty] private string _selectedCategory = "All";
+    [ObservableProperty] private bool _isElevated;
+
+    public BulkObservableCollection<PrivacyToggle> FilteredToggles { get; } = new();
+
+    public PrivacyViewModel(PrivacyService service)
+    {
+        _service = service;
+        IsElevated = AdminHelper.IsElevated();
+        LoadToggles();
+    }
+
+    private void LoadToggles()
+    {
+        _suppressApply = true;
+        try
+        {
+            // Unsubscribe from old toggles
+            foreach (var t in Toggles)
+                t.PropertyChanged -= OnTogglePropertyChanged;
+
+            var loaded = _service.LoadToggles();
+            Toggles.ReplaceWith(loaded);
+
+            // Subscribe to property changes for immediate apply
+            foreach (var t in Toggles)
+                t.PropertyChanged += OnTogglePropertyChanged;
+
+            // Build category list
+            var cats = new List<string> { "All" };
+            cats.AddRange(Toggles.Select(t => t.Category).Distinct().OrderBy(c => c));
+            Categories = cats;
+            SelectedCategory = "All";
+
+            ApplyFilter();
+            UpdateStatus();
+        }
+        finally
+        {
+            _suppressApply = false;
+        }
+    }
+
+    partial void OnSelectedCategoryChanged(string value) => ApplyFilter();
+
+    private void ApplyFilter()
+    {
+        IEnumerable<PrivacyToggle> source = Toggles;
+
+        if (!string.IsNullOrEmpty(SelectedCategory) && SelectedCategory != "All")
+            source = source.Where(t => t.Category == SelectedCategory);
+
+        FilteredToggles.ReplaceWith(source);
+    }
+
+    private void OnTogglePropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (_suppressApply) return;
+        if (e.PropertyName != nameof(PrivacyToggle.IsEnabled)) return;
+        if (sender is not PrivacyToggle toggle) return;
+
+        _service.ApplyToggle(toggle);
+        UpdateStatus();
+    }
+
+    [RelayCommand]
+    private void ApplyAll()
+    {
+        _service.ApplyAll(Toggles);
+        StatusMessage = $"All {Toggles.Count} toggles applied.";
+        Log.Information("Privacy: applied all {Count} toggles", Toggles.Count);
+    }
+
+    [RelayCommand]
+    private void ResetAll()
+    {
+        _suppressApply = true;
+        try
+        {
+            foreach (var toggle in Toggles)
+                toggle.IsEnabled = false;
+        }
+        finally
+        {
+            _suppressApply = false;
+        }
+
+        // Write defaults to registry in batch
+        _service.ApplyAll(Toggles);
+        UpdateStatus();
+        StatusMessage = "All toggles reset to Windows defaults.";
+        Log.Information("Privacy: reset all toggles to defaults");
+    }
+
+    [RelayCommand]
+    private void Refresh()
+    {
+        LoadToggles();
+        StatusMessage = "Toggles refreshed from registry.";
+        Log.Information("Privacy: refreshed toggle states from registry");
+    }
+
+    private void UpdateStatus()
+    {
+        var enabledCount = Toggles.Count(t => t.IsEnabled);
+        StatusMessage = $"{enabledCount} of {Toggles.Count} privacy protections active.";
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            foreach (var t in Toggles)
+                t.PropertyChanged -= OnTogglePropertyChanged;
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -1,0 +1,110 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.PrivacyView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             d:DataContext="{d:DesignInstance vm:PrivacyViewModel}"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             Background="{StaticResource Surface0}">
+
+    <Grid Margin="32,24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,16">
+            <TextBlock Text="Privacy Toggles" Style="{StaticResource Display}"/>
+            <TextBlock Text="Control telemetry, ads, and unwanted features. Toggle ON = privacy protection active."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+        </StackPanel>
+
+        <!-- Toolbar -->
+        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+            <WrapPanel>
+                <Button Content="Apply All" Command="{Binding ApplyAllCommand}"
+                        Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
+                <Button Content="Reset to defaults" Command="{Binding ResetAllCommand}"
+                        Style="{StaticResource GhostButton}" Margin="0,0,8,0"/>
+                <Button Content="Refresh" Command="{Binding RefreshCommand}"
+                        Style="{StaticResource GhostButton}" Margin="0,0,16,0"/>
+
+                <TextBlock Text="Category:" VerticalAlignment="Center" Margin="8,0,8,0"
+                           Style="{StaticResource Subtle}"/>
+                <ComboBox ItemsSource="{Binding Categories}"
+                          SelectedItem="{Binding SelectedCategory}"
+                          Width="140" Margin="0,0,12,0"/>
+
+                <Border Background="#1F2D1F" CornerRadius="4" Padding="6,2" Margin="4,0"
+                        Visibility="{Binding IsElevated, Converter={StaticResource BoolToVis}}">
+                    <TextBlock Text="Administrator" FontSize="11" Foreground="#4ADE80"/>
+                </Border>
+                <Border Background="#2D1F1F" CornerRadius="4" Padding="6,2" Margin="4,0"
+                        Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+                    <TextBlock Text="Some toggles need elevation" FontSize="11" Foreground="#F59E0B"/>
+                </Border>
+            </WrapPanel>
+        </Border>
+
+        <!-- Toggle list grouped by category -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
+            <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="16,12">
+                <ItemsControl ItemsSource="{Binding FilteredToggles}">
+                    <ItemsControl.GroupStyle>
+                        <GroupStyle>
+                            <GroupStyle.HeaderTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Name}" FontWeight="Bold" FontSize="14"
+                                               Foreground="{StaticResource TextPrimary}"
+                                               Margin="0,16,0,8"/>
+                                </DataTemplate>
+                            </GroupStyle.HeaderTemplate>
+                        </GroupStyle>
+                    </ItemsControl.GroupStyle>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Margin="0,2" Padding="12,10" CornerRadius="6"
+                                    Background="#0A0E14"
+                                    BorderBrush="#1A1F2E" BorderThickness="1">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+
+                                    <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13"/>
+                                        <TextBlock Text="{Binding Description}" FontSize="11"
+                                                   Foreground="{StaticResource TextMuted}"
+                                                   TextWrapping="Wrap" Margin="0,2,16,0"/>
+                                        <TextBlock Text="{Binding Category}" FontSize="10"
+                                                   Foreground="{StaticResource TextMuted}"
+                                                   Margin="0,2,0,0" Opacity="0.6"/>
+                                    </StackPanel>
+
+                                    <CheckBox Grid.Column="1" IsChecked="{Binding IsEnabled}"
+                                              VerticalAlignment="Center" Margin="8,0,0,0"
+                                              ToolTip="Toggle privacy protection on/off">
+                                        <CheckBox.LayoutTransform>
+                                            <ScaleTransform ScaleX="1.3" ScaleY="1.3"/>
+                                        </CheckBox.LayoutTransform>
+                                    </CheckBox>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </Border>
+
+        <!-- Status bar -->
+        <DockPanel Grid.Row="3" Margin="0,8,0,0">
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/PrivacyView.xaml.cs
+++ b/SysManager/SysManager/Views/PrivacyView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · PrivacyView
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class PrivacyView : UserControl
+{
+    public PrivacyView() => InitializeComponent();
+}


### PR DESCRIPTION
## Summary
New Privacy tab with 12 one-click toggles for Windows privacy settings.

### Categories:
- **Telemetry** — diagnostic data, activity history, advertising ID, feedback
- **UI Declutter** — Start suggestions, tips, lock screen tips, Spotlight ads
- **Features** — Copilot, Cortana, web search in Start, widgets

### Behavior:
- Reads current state from registry on load
- Instant apply on toggle change (no "Save" button needed)
- "Apply All" enables all privacy protections at once
- "Reset to defaults" turns all off (restores Windows defaults)
- Category filter for quick access
- Graceful handling of HKLM paths requiring admin (shows elevation badge)

Closes #9

## Test plan
- [ ] CI build passes
- [ ] Tab appears in navigation
- [ ] Toggles reflect current registry state
- [ ] Toggling a switch immediately writes to registry
- [ ] HKLM toggles show warning if not elevated
- [ ] Apply All / Reset work correctly
