### PR TITLE
fix: design polish — Bulk Installer, Context Menu, elevation badges

### DIFF
--- a/SysManager/SysManager.Tests/BulkInstallerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/BulkInstallerViewModelTests.cs
@@ -21,7 +21,7 @@ public class BulkInstallerViewModelTests
     public void Constructor_PopulatesAppsWithCuratedList()
     {
         var vm = CreateVm();
-        Assert.Equal(24, vm.Apps.Count);
+        Assert.Equal(46, vm.Apps.Count);
     }
 
     [Fact]
@@ -51,12 +51,16 @@ public class BulkInstallerViewModelTests
 
     [Theory]
     [InlineData("Browsers", 4)]
-    [InlineData("Communication", 4)]
+    [InlineData("Communication", 6)]
     [InlineData("Media", 3)]
     [InlineData("Development", 4)]
-    [InlineData("Utilities", 4)]
+    [InlineData("Utilities", 8)]
     [InlineData("Gaming", 3)]
     [InlineData("Security", 2)]
+    [InlineData("Office & Productivity", 4)]
+    [InlineData("Creativity", 4)]
+    [InlineData("Networking & VPN", 4)]
+    [InlineData("Runtimes & Frameworks", 4)]
     public void FilterByCategory_ShowsOnlyMatchingCategory(string category, int expectedCount)
     {
         var vm = CreateVm();
@@ -87,10 +91,11 @@ public class BulkInstallerViewModelTests
     }
 
     [Fact]
-    public void Categories_ContainsAllAndSevenSpecific()
+    public void Categories_ContainsAllAndElevenSpecificPlusCustom()
     {
         var vm = CreateVm();
         Assert.Contains("All", vm.Categories);
-        Assert.Equal(8, vm.Categories.Count);
+        Assert.Contains("Custom", vm.Categories);
+        Assert.Equal(13, vm.Categories.Count);
     }
 }

--- a/SysManager/SysManager/Models/ContextMenuEntry.cs
+++ b/SysManager/SysManager/Models/ContextMenuEntry.cs
@@ -30,4 +30,10 @@ public sealed partial class ContextMenuEntry : ObservableObject
 
     /// <summary>Application that added the entry (inferred from command path).</summary>
     public string Source { get; init; } = "";
+
+    /// <summary>Original registry key name before friendly-name resolution.</summary>
+    public string RawName { get; init; } = "";
+
+    /// <summary>Whether this entry is considered a system/internal entry (raw name starts with @ or .).</summary>
+    public bool IsSystemEntry { get; init; }
 }

--- a/SysManager/SysManager/Models/InstallableApp.cs
+++ b/SysManager/SysManager/Models/InstallableApp.cs
@@ -17,4 +17,5 @@ public sealed partial class InstallableApp : ObservableObject
     public required string Name { get; init; }
     public required string WingetId { get; init; }
     public required string Category { get; init; }
+    public string Description { get; init; } = "";
 }

--- a/SysManager/SysManager/Services/ContextMenuService.cs
+++ b/SysManager/SysManager/Services/ContextMenuService.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Security;
+using System.Text.RegularExpressions;
 using Microsoft.Win32;
 using Serilog;
 using SysManager.Models;
@@ -70,14 +71,19 @@ public sealed class ContextMenuService
 
                         var registryPath = $@"HKCR\{subKey}\{entryName}";
 
+                        // Resolve a user-friendly display name
+                        var friendlyName = GetFriendlyName(displayName, command);
+
                         entries.Add(new ContextMenuEntry
                         {
-                            Name = displayName,
+                            Name = friendlyName,
+                            RawName = displayName,
                             Command = command,
                             RegistryPath = registryPath,
                             Location = location,
                             Source = source,
-                            IsEnabled = isEnabled
+                            IsEnabled = isEnabled,
+                            IsSystemEntry = IsSystemEntry(displayName)
                         });
                     }
                     catch (SecurityException ex)
@@ -235,6 +241,197 @@ public sealed class ContextMenuService
             // Backup is best-effort — don't block the actual operation
             Log.Debug("Registry backup failed (non-critical): {Error}", ex.Message);
         }
+    }
+
+    // Well-known registry entry names mapped to user-friendly display names
+    private static readonly Dictionary<string, string> KnownNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["cmd"] = "Command Prompt",
+        ["powershell"] = "PowerShell",
+        ["Windows.ModernShare"] = "Share",
+        ["pintohomefile"] = "Pin to Quick Access",
+        ["PinToStartScreen"] = "Pin to Start",
+        ["removeproperties"] = "Remove Properties",
+        ["EditStickers"] = "Edit Stickers",
+        ["find"] = "Search",
+        ["opennewwindow"] = "Open New Window",
+        ["opennewtab"] = "Open New Tab",
+        ["Troubleshoot compatibility"] = "Troubleshoot Compatibility",
+        ["runas"] = "Run as Administrator",
+        ["runasuser"] = "Run as Different User",
+        ["edit"] = "Edit",
+        ["open"] = "Open",
+        ["print"] = "Print",
+        ["explore"] = "Explore",
+        ["properties"] = "Properties",
+        ["copy"] = "Copy",
+        ["cut"] = "Cut",
+        ["paste"] = "Paste",
+        ["delete"] = "Delete",
+        ["rename"] = "Rename",
+    };
+
+    // Known DLL resource strings mapped to friendly names
+    private static readonly Dictionary<string, string> KnownResourceStrings = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["@shell32.dll,-8506"] = "Open Command Prompt",
+        ["@shell32.dll,-8508"] = "Open PowerShell",
+        ["@shell32.dll,-8517"] = "Open Command Prompt as Administrator",
+        ["@shell32.dll,-8518"] = "Open PowerShell as Administrator",
+        ["@shell32.dll,-31328"] = "Share",
+        ["@shell32.dll,-37400"] = "Pin to Quick Access",
+    };
+
+    // Known executable names mapped to friendly application names
+    private static readonly Dictionary<string, string> KnownExeNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["git-bash"] = "Git Bash",
+        ["git-gui"] = "Git GUI",
+        ["code"] = "Visual Studio Code",
+        ["notepad++"] = "Notepad++",
+        ["notepad"] = "Notepad",
+        ["vlc"] = "VLC Media Player",
+        ["7zFM"] = "7-Zip File Manager",
+        ["WinRAR"] = "WinRAR",
+        ["mspaint"] = "Paint",
+        ["calc"] = "Calculator",
+        ["explorer"] = "Windows Explorer",
+        ["powershell"] = "PowerShell",
+        ["pwsh"] = "PowerShell",
+        ["cmd"] = "Command Prompt",
+        ["wt"] = "Windows Terminal",
+    };
+
+    /// <summary>
+    /// Resolves a raw registry entry name into a user-friendly display name.
+    /// Falls back to CamelCase splitting and cleanup for unknown entries.
+    /// </summary>
+    private static string GetFriendlyName(string rawName, string command)
+    {
+        // 1. Check exact match in known names
+        if (KnownNames.TryGetValue(rawName, out var known))
+            return known;
+
+        // 2. Check if it's a resource string like @shell32.dll,-8506
+        if (rawName.StartsWith('@'))
+        {
+            if (KnownResourceStrings.TryGetValue(rawName, out var resourceName))
+                return resourceName;
+
+            // Try to extract a meaningful name from DLL resource references
+            // Format: @C:\Windows\System32\display.dll,-4
+            var dllMatch = Regex.Match(rawName, @"@.*?\\?([^\\,]+)\.dll", RegexOptions.IgnoreCase);
+            if (dllMatch.Success)
+            {
+                var dllName = dllMatch.Groups[1].Value;
+                return $"{SplitCamelCase(dllName)} (System)";
+            }
+
+            // Unknown resource string — just mark as system
+            return $"{rawName} (System)";
+        }
+
+        // 3. Handle dot-prefixed names like .SpotlightLearnMore
+        if (rawName.StartsWith('.'))
+        {
+            var cleaned = rawName.TrimStart('.');
+            // Insert " — " at boundaries for known patterns
+            if (cleaned.StartsWith("Spotlight", StringComparison.OrdinalIgnoreCase))
+            {
+                var suffix = cleaned["Spotlight".Length..];
+                if (!string.IsNullOrEmpty(suffix))
+                    return $"Spotlight — {SplitCamelCase(suffix)}";
+                return "Spotlight";
+            }
+            return SplitCamelCase(cleaned);
+        }
+
+        // 4. Try to infer from command if the raw name is cryptic
+        if (IsCrypticName(rawName) && !string.IsNullOrWhiteSpace(command))
+        {
+            var inferred = InferNameFromCommand(command);
+            if (!string.IsNullOrEmpty(inferred))
+                return inferred;
+        }
+
+        // 5. Split CamelCase for readable raw names
+        return SplitCamelCase(rawName);
+    }
+
+    /// <summary>
+    /// Determines if an entry is a system/internal entry based on its raw name.
+    /// </summary>
+    private static bool IsSystemEntry(string rawName)
+    {
+        return rawName.StartsWith('@') || rawName.StartsWith('.');
+    }
+
+    /// <summary>
+    /// Determines if a name looks cryptic and not user-friendly.
+    /// </summary>
+    private static bool IsCrypticName(string name)
+    {
+        // Names with only lowercase and no spaces, very short, or contain hyphens/underscores
+        if (name.Length <= 2) return true;
+        if (name.Contains("__") || name.Contains("--")) return true;
+        return false;
+    }
+
+    /// <summary>
+    /// Infers a display name from the command executable.
+    /// </summary>
+    private static string InferNameFromCommand(string command)
+    {
+        try
+        {
+            // Try to extract executable name
+            var path = command.Trim('"', ' ');
+            var percentIdx = path.IndexOf('%');
+            if (percentIdx > 0) path = path[..percentIdx].Trim();
+
+            var spaceIdx = path.IndexOf(' ');
+            if (spaceIdx > 0 && !File.Exists(path))
+                path = path[..spaceIdx].Trim('"');
+
+            var exeName = Path.GetFileNameWithoutExtension(path);
+            if (!string.IsNullOrEmpty(exeName) && KnownExeNames.TryGetValue(exeName, out var friendly))
+                return friendly;
+        }
+        catch (ArgumentException)
+        {
+            // Invalid path characters — skip inference
+        }
+
+        return "";
+    }
+
+    /// <summary>
+    /// Splits a CamelCase or PascalCase string into separate words.
+    /// </summary>
+    private static string SplitCamelCase(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input)) return input;
+
+        // Remove leading dots, @ signs
+        input = input.TrimStart('.', '@');
+
+        // Replace underscores and hyphens with spaces
+        input = input.Replace('_', ' ').Replace('-', ' ');
+
+        // Insert space before each uppercase letter that follows a lowercase letter or digit
+        var result = Regex.Replace(input, @"(?<=[a-z0-9])([A-Z])", " $1");
+
+        // Insert space between consecutive uppercase letters followed by lowercase
+        result = Regex.Replace(result, @"(?<=[A-Z])([A-Z])(?=[a-z])", " $1");
+
+        // Collapse multiple spaces
+        result = Regex.Replace(result, @"\s+", " ").Trim();
+
+        // Capitalize first letter
+        if (result.Length > 0)
+            result = char.ToUpper(result[0]) + result[1..];
+
+        return result;
     }
 
     /// <summary>

--- a/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
@@ -3,6 +3,8 @@
 // License: MIT
 
 using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Windows.Data;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
@@ -22,6 +24,7 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
 
     public BulkObservableCollection<InstallableApp> Apps { get; } = new();
     public ObservableCollection<InstallableApp> FilteredApps { get; } = new();
+    public ICollectionView GroupedView { get; }
 
     [ObservableProperty] private string _filterText = "";
     [ObservableProperty] private string _selectedCategory = "All";
@@ -35,8 +38,18 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
         "Development",
         "Utilities",
         "Gaming",
-        "Security"
+        "Security",
+        "Office & Productivity",
+        "Creativity",
+        "Networking & VPN",
+        "Runtimes & Frameworks",
+        "Custom"
     ];
+
+    // Custom winget search
+    [ObservableProperty] private string _searchQuery = "";
+    [ObservableProperty] private bool _isSearching;
+    public BulkObservableCollection<InstallableApp> SearchResults { get; } = new();
 
     partial void OnFilterTextChanged(string value) => ApplyFilter();
     partial void OnSelectedCategoryChanged(string value) => ApplyFilter();
@@ -46,6 +59,9 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
         _service = service;
         Apps.ReplaceWith(BuildCuratedApps());
         ApplyFilter();
+
+        GroupedView = CollectionViewSource.GetDefaultView(FilteredApps);
+        GroupedView.GroupDescriptions.Add(new PropertyGroupDescription(nameof(InstallableApp.Category)));
     }
 
     [RelayCommand]
@@ -141,6 +157,102 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
             app.IsSelected = true;
     }
 
+    [RelayCommand]
+    private async Task SearchWingetAsync()
+    {
+        if (string.IsNullOrWhiteSpace(SearchQuery) || SearchQuery.Length < 2) return;
+        IsSearching = true;
+        SearchResults.Clear();
+        try
+        {
+            var results = await Task.Run(() => SearchWingetPackages(SearchQuery));
+            SearchResults.ReplaceWith(results);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Winget search failed for query {Query}", SearchQuery);
+            StatusMessage = "Search failed. Ensure winget is available.";
+        }
+        finally { IsSearching = false; }
+    }
+
+    [RelayCommand]
+    private void AddToInstallList(InstallableApp? app)
+    {
+        if (app == null || Apps.Any(a => a.WingetId == app.WingetId)) return;
+        Apps.Add(app);
+        ApplyFilter();
+    }
+
+    private List<InstallableApp> SearchWingetPackages(string query)
+    {
+        var results = new List<InstallableApp>();
+
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "winget",
+            Arguments = $"search \"{query}\" --accept-source-agreements",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            StandardOutputEncoding = System.Text.Encoding.UTF8,
+        };
+
+        using var proc = System.Diagnostics.Process.Start(psi);
+        if (proc == null) return results;
+
+        var output = proc.StandardOutput.ReadToEnd();
+        proc.WaitForExit(30_000);
+
+        // Parse the tabular output from winget search.
+        // The output has a header line with column names, a separator line of dashes,
+        // then data rows. Columns are: Name, Id, Version, [Match], Source
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        // Find the separator line (all dashes and spaces)
+        var separatorIndex = -1;
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].TrimEnd().All(c => c == '-' || c == ' ') && lines[i].Contains("--"))
+            {
+                separatorIndex = i;
+                break;
+            }
+        }
+
+        if (separatorIndex < 1 || separatorIndex + 1 >= lines.Length) return results;
+
+        // Determine column positions from the header line
+        var header = lines[separatorIndex - 1];
+        var idStart = header.IndexOf("Id", StringComparison.Ordinal);
+        var versionStart = header.IndexOf("Version", StringComparison.Ordinal);
+
+        if (idStart < 0 || versionStart < 0) return results;
+
+        // Parse data rows
+        for (var i = separatorIndex + 1; i < lines.Length && results.Count < 30; i++)
+        {
+            var line = lines[i];
+            if (line.Length < versionStart) continue;
+
+            var name = line[..idStart].TrimEnd();
+            var id = line[idStart..versionStart].TrimEnd();
+
+            if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(id)) continue;
+
+            results.Add(new InstallableApp
+            {
+                Name = name,
+                WingetId = id,
+                Category = "Custom",
+                Description = $"winget: {id}",
+            });
+        }
+
+        return results;
+    }
+
     private void ApplyFilter()
     {
         var filtered = Apps.AsEnumerable();
@@ -160,42 +272,76 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
     private static List<InstallableApp> BuildCuratedApps() =>
     [
         // Browsers
-        new() { Name = "Google Chrome",  WingetId = "Google.Chrome",   Category = "Browsers" },
-        new() { Name = "Firefox",        WingetId = "Mozilla.Firefox", Category = "Browsers" },
-        new() { Name = "Brave",          WingetId = "Brave.Brave",     Category = "Browsers" },
-        new() { Name = "Vivaldi",        WingetId = "Vivaldi.Vivaldi", Category = "Browsers" },
+        new() { Name = "Google Chrome",  WingetId = "Google.Chrome",   Category = "Browsers",       Description = "Fast, secure web browser by Google" },
+        new() { Name = "Firefox",        WingetId = "Mozilla.Firefox", Category = "Browsers",       Description = "Privacy-focused open-source web browser" },
+        new() { Name = "Brave",          WingetId = "Brave.Brave",     Category = "Browsers",       Description = "Privacy-first browser with built-in ad blocker" },
+        new() { Name = "Vivaldi",        WingetId = "Vivaldi.Vivaldi", Category = "Browsers",       Description = "Highly customizable browser for power users" },
 
         // Communication
-        new() { Name = "Discord",  WingetId = "Discord.Discord",              Category = "Communication" },
-        new() { Name = "Slack",    WingetId = "SlackTechnologies.Slack",       Category = "Communication" },
-        new() { Name = "Zoom",     WingetId = "Zoom.Zoom",                    Category = "Communication" },
-        new() { Name = "Telegram", WingetId = "Telegram.TelegramDesktop",     Category = "Communication" },
+        new() { Name = "Discord",  WingetId = "Discord.Discord",              Category = "Communication", Description = "Voice, video, and text chat for communities" },
+        new() { Name = "Slack",    WingetId = "SlackTechnologies.Slack",       Category = "Communication", Description = "Team messaging and collaboration platform" },
+        new() { Name = "Zoom",     WingetId = "Zoom.Zoom",                    Category = "Communication", Description = "Video conferencing and online meetings" },
+        new() { Name = "Telegram", WingetId = "Telegram.TelegramDesktop",     Category = "Communication", Description = "Fast, secure cloud-based messaging" },
 
         // Media
-        new() { Name = "VLC",       WingetId = "VideoLAN.VLC",              Category = "Media" },
-        new() { Name = "Spotify",   WingetId = "Spotify.Spotify",           Category = "Media" },
-        new() { Name = "foobar2000", WingetId = "PeterPawlowski.foobar2000", Category = "Media" },
+        new() { Name = "VLC",        WingetId = "VideoLAN.VLC",              Category = "Media", Description = "Free multimedia player supporting all formats" },
+        new() { Name = "Spotify",    WingetId = "Spotify.Spotify",           Category = "Media", Description = "Music streaming with millions of songs" },
+        new() { Name = "foobar2000", WingetId = "PeterPawlowski.foobar2000", Category = "Media", Description = "Lightweight advanced audio player" },
 
         // Development
-        new() { Name = "VS Code",  WingetId = "Microsoft.VisualStudioCode", Category = "Development" },
-        new() { Name = "Git",      WingetId = "Git.Git",                    Category = "Development" },
-        new() { Name = "Node.js",  WingetId = "OpenJS.NodeJS.LTS",          Category = "Development" },
-        new() { Name = "Python",   WingetId = "Python.Python.3.12",         Category = "Development" },
+        new() { Name = "VS Code",  WingetId = "Microsoft.VisualStudioCode", Category = "Development", Description = "Lightweight code editor with extensions" },
+        new() { Name = "Git",      WingetId = "Git.Git",                    Category = "Development", Description = "Distributed version control system" },
+        new() { Name = "Node.js",  WingetId = "OpenJS.NodeJS.LTS",          Category = "Development", Description = "JavaScript runtime for server-side apps" },
+        new() { Name = "Python",   WingetId = "Python.Python.3.12",         Category = "Development", Description = "General-purpose programming language" },
 
         // Utilities
-        new() { Name = "7-Zip",      WingetId = "7zip.7zip",              Category = "Utilities" },
-        new() { Name = "Notepad++",  WingetId = "Notepad++.Notepad++",    Category = "Utilities" },
-        new() { Name = "Everything", WingetId = "voidtools.Everything",   Category = "Utilities" },
-        new() { Name = "PowerToys",  WingetId = "Microsoft.PowerToys",    Category = "Utilities" },
+        new() { Name = "7-Zip",      WingetId = "7zip.7zip",              Category = "Utilities", Description = "Free file archiver with high compression" },
+        new() { Name = "Notepad++",  WingetId = "Notepad++.Notepad++",    Category = "Utilities", Description = "Powerful text and source code editor" },
+        new() { Name = "Everything", WingetId = "voidtools.Everything",   Category = "Utilities", Description = "Instant file search for Windows" },
+        new() { Name = "PowerToys",  WingetId = "Microsoft.PowerToys",    Category = "Utilities", Description = "Microsoft utilities for power users" },
 
         // Gaming
-        new() { Name = "Steam",        WingetId = "Valve.Steam",                    Category = "Gaming" },
-        new() { Name = "Epic Games",   WingetId = "EpicGames.EpicGamesLauncher",    Category = "Gaming" },
-        new() { Name = "GOG Galaxy",   WingetId = "GOG.Galaxy",                     Category = "Gaming" },
+        new() { Name = "Steam",        WingetId = "Valve.Steam",                    Category = "Gaming", Description = "Gaming platform and digital store" },
+        new() { Name = "Epic Games",   WingetId = "EpicGames.EpicGamesLauncher",    Category = "Gaming", Description = "Game store and launcher" },
+        new() { Name = "GOG Galaxy",   WingetId = "GOG.Galaxy",                     Category = "Gaming", Description = "DRM-free gaming platform" },
 
         // Security
-        new() { Name = "Bitwarden",    WingetId = "Bitwarden.Bitwarden",       Category = "Security" },
-        new() { Name = "Malwarebytes", WingetId = "Malwarebytes.Malwarebytes", Category = "Security" },
+        new() { Name = "Bitwarden",    WingetId = "Bitwarden.Bitwarden",       Category = "Security", Description = "Open-source password manager" },
+        new() { Name = "Malwarebytes", WingetId = "Malwarebytes.Malwarebytes", Category = "Security", Description = "Anti-malware protection and scanning" },
+
+        // Office & Productivity
+        new() { Name = "LibreOffice",         WingetId = "TheDocumentFoundation.LibreOffice",  Category = "Office & Productivity", Description = "Free open-source office suite" },
+        new() { Name = "Obsidian",            WingetId = "Obsidian.Obsidian",                  Category = "Office & Productivity", Description = "Knowledge base with Markdown notes" },
+        new() { Name = "Notion",              WingetId = "Notion.Notion",                      Category = "Office & Productivity", Description = "All-in-one workspace for notes and docs" },
+        new() { Name = "Adobe Acrobat Reader", WingetId = "Adobe.Acrobat.Reader.64-bit",       Category = "Office & Productivity", Description = "View, print, and annotate PDFs" },
+
+        // Creativity
+        new() { Name = "OBS Studio", WingetId = "OBSProject.OBSStudio",       Category = "Creativity", Description = "Free streaming and screen recording" },
+        new() { Name = "GIMP",       WingetId = "GIMP.GIMP",                  Category = "Creativity", Description = "Free image editor (Photoshop alternative)" },
+        new() { Name = "Audacity",   WingetId = "Audacity.Audacity",          Category = "Creativity", Description = "Free audio editor and recorder" },
+        new() { Name = "Blender",    WingetId = "BlenderFoundation.Blender",  Category = "Creativity", Description = "Free 3D creation suite" },
+
+        // Networking & VPN
+        new() { Name = "qBittorrent", WingetId = "qBittorrent.qBittorrent",       Category = "Networking & VPN", Description = "Free open-source BitTorrent client" },
+        new() { Name = "ProtonVPN",   WingetId = "ProtonTechnologies.ProtonVPN",   Category = "Networking & VPN", Description = "Free privacy-focused VPN" },
+        new() { Name = "WireGuard",   WingetId = "WireGuard.WireGuard",            Category = "Networking & VPN", Description = "Fast modern VPN protocol" },
+        new() { Name = "PuTTY",       WingetId = "SimonTatham.PuTTY",              Category = "Networking & VPN", Description = "SSH and Telnet client" },
+
+        // Runtimes & Frameworks
+        new() { Name = ".NET Desktop Runtime 8",      WingetId = "Microsoft.DotNet.DesktopRuntime.8", Category = "Runtimes & Frameworks", Description = "Required by many modern apps" },
+        new() { Name = "Visual C++ Redistributable",  WingetId = "Microsoft.VCRedist.2015+.x64",     Category = "Runtimes & Frameworks", Description = "Required by games and apps" },
+        new() { Name = "Java Runtime",                WingetId = "Oracle.JavaRuntimeEnvironment",     Category = "Runtimes & Frameworks", Description = "Required by Minecraft and enterprise apps" },
+        new() { Name = "DirectX Runtime",             WingetId = "Microsoft.DirectX",                 Category = "Runtimes & Frameworks", Description = "Required by most games" },
+
+        // More Utilities
+        new() { Name = "WinRAR",        WingetId = "RARLab.WinRAR",             Category = "Utilities", Description = "Popular file archiver" },
+        new() { Name = "ShareX",        WingetId = "ShareX.ShareX",             Category = "Utilities", Description = "Screenshot and screen recording tool" },
+        new() { Name = "Greenshot",     WingetId = "Greenshot.Greenshot",       Category = "Utilities", Description = "Lightweight screenshot tool" },
+        new() { Name = "TreeSize Free", WingetId = "JAMSoftware.TreeSize.Free", Category = "Utilities", Description = "Visualize disk space usage" },
+
+        // More Communication
+        new() { Name = "WhatsApp",        WingetId = "WhatsApp.WhatsApp",   Category = "Communication", Description = "Messaging app for desktop" },
+        new() { Name = "Microsoft Teams", WingetId = "Microsoft.Teams",     Category = "Communication", Description = "Business communication platform" },
     ];
 
     protected override void Dispose(bool disposing)

--- a/SysManager/SysManager/ViewModels/ContextMenuViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ContextMenuViewModel.cs
@@ -25,6 +25,7 @@ public sealed partial class ContextMenuViewModel : ViewModelBase
 
     [ObservableProperty] private string _filterText = "";
     [ObservableProperty] private string _selectedLocation = "All";
+    [ObservableProperty] private bool _showSystemEntries;
     [ObservableProperty] private int _enabledCount;
     [ObservableProperty] private int _disabledCount;
     [ObservableProperty] private int _totalCount;
@@ -43,6 +44,7 @@ public sealed partial class ContextMenuViewModel : ViewModelBase
 
     partial void OnFilterTextChanged(string value) => ApplyFilter();
     partial void OnSelectedLocationChanged(string value) => ApplyFilter();
+    partial void OnShowSystemEntriesChanged(bool value) => ApplyFilter();
 
     private async Task InitAsync()
     {
@@ -115,6 +117,10 @@ public sealed partial class ContextMenuViewModel : ViewModelBase
     {
         var filtered = _allEntries.AsEnumerable();
 
+        // Hide system/internal entries unless the user opted in
+        if (!ShowSystemEntries)
+            filtered = filtered.Where(e => !e.IsSystemEntry);
+
         // Location filter
         if (!string.Equals(SelectedLocation, "All", StringComparison.OrdinalIgnoreCase))
             filtered = filtered.Where(e => string.Equals(e.Location, SelectedLocation, StringComparison.OrdinalIgnoreCase));
@@ -126,7 +132,8 @@ public sealed partial class ContextMenuViewModel : ViewModelBase
             filtered = filtered.Where(e =>
                 e.Name.Contains(text, StringComparison.OrdinalIgnoreCase) ||
                 e.Command.Contains(text, StringComparison.OrdinalIgnoreCase) ||
-                e.Source.Contains(text, StringComparison.OrdinalIgnoreCase));
+                e.Source.Contains(text, StringComparison.OrdinalIgnoreCase) ||
+                e.RawName.Contains(text, StringComparison.OrdinalIgnoreCase));
         }
 
         Entries.ReplaceWith(filtered);

--- a/SysManager/SysManager/ViewModels/PrivacyViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PrivacyViewModel.cs
@@ -89,6 +89,13 @@ public sealed partial class PrivacyViewModel : ViewModelBase
     }
 
     [RelayCommand]
+    private void RelaunchElevated()
+    {
+        if (AdminHelper.RelaunchAsAdmin())
+            System.Windows.Application.Current?.Shutdown();
+    }
+
+    [RelayCommand]
     private void ApplyAll()
     {
         _service.ApplyAll(Toggles);

--- a/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
@@ -41,6 +41,13 @@ public sealed partial class WindowsFeaturesViewModel : ViewModelBase
     }
 
     [RelayCommand]
+    private void RelaunchElevated()
+    {
+        if (AdminHelper.RelaunchAsAdmin())
+            System.Windows.Application.Current?.Shutdown();
+    }
+
+    [RelayCommand]
     private async Task ScanAsync()
     {
         IsBusy = true;

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -13,6 +13,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -53,82 +54,151 @@
             </WrapPanel>
         </Border>
 
-        <!-- App list -->
-        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
-            <DataGrid AutomationProperties.Name="Data table" ItemsSource="{Binding FilteredApps}"
-                      AutoGenerateColumns="False" HeadersVisibility="Column"
-                      Background="Transparent" BorderThickness="0"
-                      GridLinesVisibility="None" IsReadOnly="False"
-                      RowBackground="Transparent" AlternatingRowBackground="#0F141C"
-                      SelectionMode="Single" CanUserSortColumns="True"
-                      VirtualizingPanel.IsVirtualizing="True"
-                      VirtualizingPanel.VirtualizationMode="Recycling">
-                <DataGrid.Columns>
-                    <DataGridCheckBoxColumn Header="" Width="32"
-                                            Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}"
-                                            CanUserSort="False">
-                        <DataGridCheckBoxColumn.ElementStyle>
-                            <Style TargetType="CheckBox">
-                                <Setter Property="HorizontalAlignment" Value="Center"/>
-                            </Style>
-                        </DataGridCheckBoxColumn.ElementStyle>
-                        <DataGridCheckBoxColumn.EditingElementStyle>
-                            <Style TargetType="CheckBox">
-                                <Setter Property="HorizontalAlignment" Value="Center"/>
-                            </Style>
-                        </DataGridCheckBoxColumn.EditingElementStyle>
-                    </DataGridCheckBoxColumn>
+        <!-- Custom winget search -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+            <StackPanel>
+                <TextBlock Text="Search winget packages" FontWeight="SemiBold" FontSize="14"
+                           Foreground="{StaticResource TextPrimary}"/>
+                <TextBlock Text="Find and install any app available on winget."
+                           Style="{StaticResource Subtle}" Margin="0,2,0,12"/>
+                <DockPanel>
+                    <Button Content="Search" Command="{Binding SearchWingetCommand}"
+                            Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Margin="8,0,0,0"/>
+                    <Grid>
+                        <TextBox Text="{Binding SearchQuery, UpdateSourceTrigger=PropertyChanged}"/>
+                        <TextBlock Text="Search apps…" IsHitTestVisible="False"
+                                   Foreground="{StaticResource TextMuted}" Margin="6,0,0,0"
+                                   VerticalAlignment="Center" FontSize="12"
+                                   Visibility="{Binding SearchQuery, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                    </Grid>
+                </DockPanel>
 
-                    <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"
-                                        SortMemberPath="Name" IsReadOnly="True">
-                        <DataGridTextColumn.ElementStyle>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="FontWeight" Value="SemiBold"/>
-                                <Setter Property="FontSize" Value="13"/>
-                            </Style>
-                        </DataGridTextColumn.ElementStyle>
-                    </DataGridTextColumn>
+                <!-- Searching indicator -->
+                <ProgressBar IsIndeterminate="True" Height="2" Margin="0,8,0,0"
+                             Visibility="{Binding IsSearching, Converter={StaticResource BoolToVis}}"/>
 
-                    <DataGridTextColumn Header="Category" Binding="{Binding Category}" Width="120"
-                                        SortMemberPath="Category" IsReadOnly="True">
-                        <DataGridTextColumn.ElementStyle>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
-                                <Setter Property="FontSize" Value="12"/>
-                            </Style>
-                        </DataGridTextColumn.ElementStyle>
-                    </DataGridTextColumn>
+                <!-- Search results -->
+                <ItemsControl ItemsSource="{Binding SearchResults}" Margin="0,8,0,0"
+                              Visibility="{Binding SearchResults.Count, Converter={StaticResource FlexVis}}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Padding="8,6" Margin="0,1" CornerRadius="6" Background="Transparent">
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Style.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter Property="Background" Value="{StaticResource Surface2}"/>
+                                            </Trigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{Binding Name}"
+                                               FontSize="12.5" VerticalAlignment="Center"
+                                               Foreground="{StaticResource TextPrimary}"
+                                               TextTrimming="CharacterEllipsis"/>
+                                    <TextBlock Grid.Column="1" Text="{Binding WingetId}"
+                                               FontSize="11" VerticalAlignment="Center"
+                                               Foreground="{StaticResource TextMuted}"
+                                               Margin="12,0" TextTrimming="CharacterEllipsis"
+                                               MaxWidth="220"/>
+                                    <Button Grid.Column="2" Content="Add"
+                                            Command="{Binding DataContext.AddToInstallListCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                            CommandParameter="{Binding}"
+                                            Style="{StaticResource GhostButton}"
+                                            Padding="10,4" FontSize="11"/>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </Border>
 
-                    <DataGridTextColumn Header="Winget ID" Binding="{Binding WingetId}" Width="220"
-                                        SortMemberPath="WingetId" IsReadOnly="True">
-                        <DataGridTextColumn.ElementStyle>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="FontFamily" Value="Consolas"/>
-                                <Setter Property="FontSize" Value="12"/>
-                                <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
-                            </Style>
-                        </DataGridTextColumn.ElementStyle>
-                    </DataGridTextColumn>
+        <!-- App list (grouped by category) -->
+        <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
+            <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="0">
+                <ItemsControl ItemsSource="{Binding GroupedView}"
+                              VirtualizingPanel.IsVirtualizing="True"
+                              VirtualizingPanel.VirtualizationMode="Recycling">
 
-                    <DataGridTemplateColumn Header="Status" Width="160" SortMemberPath="Status">
-                        <DataGridTemplateColumn.CellTemplate>
-                            <DataTemplate>
-                                <Border Style="{StaticResource Badge}"
-                                        VerticalAlignment="Center" Margin="4,0"
-                                        Visibility="{Binding Status, Converter={StaticResource FlexVis}}"
-                                        ToolTip="{Binding Status}">
-                                    <TextBlock Text="{Binding Status}" FontSize="11"
-                                               TextTrimming="CharacterEllipsis" MaxWidth="140"/>
-                                </Border>
-                            </DataTemplate>
-                        </DataGridTemplateColumn.CellTemplate>
-                    </DataGridTemplateColumn>
-                </DataGrid.Columns>
-            </DataGrid>
+                    <!-- Category group headers -->
+                    <ItemsControl.GroupStyle>
+                        <GroupStyle>
+                            <GroupStyle.HeaderTemplate>
+                                <DataTemplate>
+                                    <StackPanel Margin="16,20,16,6">
+                                        <TextBlock Text="{Binding Name}"
+                                                   FontWeight="SemiBold" FontSize="14"
+                                                   Foreground="{StaticResource TextPrimary}"/>
+                                        <Rectangle Height="1" Fill="{StaticResource Border1}" Margin="0,8,0,0"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </GroupStyle.HeaderTemplate>
+                        </GroupStyle>
+                    </ItemsControl.GroupStyle>
+
+                    <!-- Individual app row -->
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Padding="16,10" Margin="4,1"
+                                    CornerRadius="8" Background="Transparent"
+                                    ToolTip="{Binding WingetId}">
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Style.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter Property="Background" Value="{StaticResource Surface2}"/>
+                                            </Trigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+
+                                    <!-- Checkbox -->
+                                    <CheckBox Grid.Column="0" VerticalAlignment="Center"
+                                              IsChecked="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}"
+                                              Margin="0,0,12,0"/>
+
+                                    <!-- Name + description -->
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                        <TextBlock Text="{Binding Name}"
+                                                   FontWeight="SemiBold" FontSize="13"
+                                                   Foreground="{StaticResource TextPrimary}"/>
+                                        <TextBlock Text="{Binding Description}"
+                                                   FontSize="11.5" Margin="0,2,0,0"
+                                                   Foreground="{StaticResource TextSecondary}"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                    </StackPanel>
+
+                                    <!-- Status badge -->
+                                    <Border Grid.Column="2" Style="{StaticResource Badge}"
+                                            VerticalAlignment="Center" Margin="12,0,0,0"
+                                            Visibility="{Binding Status, Converter={StaticResource FlexVis}}">
+                                        <TextBlock Text="{Binding Status}" FontSize="11"
+                                                   TextTrimming="CharacterEllipsis" MaxWidth="120"/>
+                                    </Border>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+
+                </ItemsControl>
+            </ScrollViewer>
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="3" Margin="0,8,0,0">
+        <DockPanel Grid.Row="4" Margin="0,8,0,0">
             <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Value="{Binding Progress}"

--- a/SysManager/SysManager/Views/ContextMenuView.xaml
+++ b/SysManager/SysManager/Views/ContextMenuView.xaml
@@ -20,8 +20,8 @@
         <!-- Header -->
         <StackPanel Grid.Row="0" Margin="0,0,0,16">
             <TextBlock Text="Context Menu Manager" Style="{StaticResource Display}"/>
-            <TextBlock Text="Manage Windows Explorer right-click menu entries. Disabling is non-destructive — entries can be re-enabled anytime."
-                       Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+            <TextBlock Text="These are entries that appear when you right-click files, folders, or the desktop in Windows Explorer. Toggle to show/hide them."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
         <!-- Toolbar -->
@@ -47,6 +47,9 @@
                     </TextBox>
                     <Button Content="Refresh" Command="{Binding RefreshCommand}"
                             Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
+                    <CheckBox Content="Show system entries"
+                              IsChecked="{Binding ShowSystemEntries}"
+                              VerticalAlignment="Center" Margin="8,0,0,0"/>
                 </StackPanel>
                 <TextBlock DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right"
                            Style="{StaticResource Subtle}">
@@ -81,28 +84,28 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"
-                                        SortMemberPath="Name" IsReadOnly="True">
-                        <DataGridTextColumn.ElementStyle>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="FontWeight" Value="SemiBold"/>
-                                <Setter Property="FontSize" Value="13"/>
-                                <Setter Property="VerticalAlignment" Value="Center"/>
-                            </Style>
-                        </DataGridTextColumn.ElementStyle>
-                    </DataGridTextColumn>
-
-                    <DataGridTextColumn Header="Command" Binding="{Binding Command}" Width="280"
-                                        SortMemberPath="Command" IsReadOnly="True">
-                        <DataGridTextColumn.ElementStyle>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
-                                <Setter Property="FontSize" Value="12"/>
-                                <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
-                                <Setter Property="VerticalAlignment" Value="Center"/>
-                            </Style>
-                        </DataGridTextColumn.ElementStyle>
-                    </DataGridTextColumn>
+                    <DataGridTemplateColumn Header="Name" Width="*" SortMemberPath="Name" IsReadOnly="True">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="4,4" VerticalAlignment="Center">
+                                    <StackPanel.ToolTip>
+                                        <StackPanel MaxWidth="500">
+                                            <TextBlock FontWeight="SemiBold" Text="Registry Name:"/>
+                                            <TextBlock Text="{Binding RawName}" TextWrapping="Wrap" Margin="0,2,0,6"/>
+                                            <TextBlock FontWeight="SemiBold" Text="Full Command:"/>
+                                            <TextBlock Text="{Binding Command}" TextWrapping="Wrap" Margin="0,2,0,4"/>
+                                            <TextBlock FontWeight="SemiBold" Text="Registry Path:"/>
+                                            <TextBlock Text="{Binding RegistryPath}" TextWrapping="Wrap" Margin="0,2,0,0"/>
+                                        </StackPanel>
+                                    </StackPanel.ToolTip>
+                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13"/>
+                                    <TextBlock Text="{Binding Command}" Foreground="{StaticResource TextMuted}"
+                                               FontSize="11" TextTrimming="CharacterEllipsis" MaxWidth="380"
+                                               HorizontalAlignment="Left" Margin="0,2,0,0"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
 
                     <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="140"
                                         SortMemberPath="Location" IsReadOnly="True">

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -13,6 +13,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -44,15 +45,27 @@
                         Visibility="{Binding IsElevated, Converter={StaticResource BoolToVis}}">
                     <TextBlock Text="Administrator" FontSize="11" Foreground="#4ADE80"/>
                 </Border>
-                <Border Background="#2D1F1F" CornerRadius="4" Padding="6,2" Margin="4,0"
-                        Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-                    <TextBlock Text="Some toggles need elevation" FontSize="11" Foreground="#F59E0B"/>
-                </Border>
             </WrapPanel>
         </Border>
 
+        <!-- Elevation info strip (shown when not running as admin) -->
+        <Border Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="12,8" Margin="0,0,0,12"
+                Grid.Row="2" Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
+                        Style="{StaticResource SecondaryButton}" DockPanel.Dock="Right" Padding="12,6"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="14" Margin="0,0,8,0" Foreground="{StaticResource TextSecondary}"/>
+                    <TextBlock Text="Some settings require administrator privileges to change."
+                               Style="{StaticResource Subtle}" VerticalAlignment="Center"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
         <!-- Toggle list grouped by category -->
-        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
+        <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
             <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="16,12">
                 <ItemsControl ItemsSource="{Binding FilteredToggles}">
                     <ItemsControl.GroupStyle>
@@ -103,7 +116,7 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="3" Margin="0,8,0,0">
+        <DockPanel Grid.Row="4" Margin="0,8,0,0">
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
         </DockPanel>
     </Grid>

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -14,6 +14,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -50,20 +51,32 @@
                         Visibility="{Binding IsElevated, Converter={StaticResource BoolToVis}}">
                     <TextBlock Text="✓ Administrator" FontSize="11" Foreground="#4ADE80"/>
                 </Border>
-                <Border Background="#2D1F1F" CornerRadius="4" Padding="6,2" Margin="4,0"
-                        Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-                    <TextBlock Text="⚠ Not elevated — toggle disabled" FontSize="11" Foreground="#F59E0B"/>
-                </Border>
             </WrapPanel>
         </Border>
 
+        <!-- Elevation info strip (shown when not running as admin) -->
+        <Border Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="12,8" Margin="0,0,0,12"
+                Grid.Row="2" Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
+                        Style="{StaticResource SecondaryButton}" DockPanel.Dock="Right" Padding="12,6"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="14" Margin="0,0,8,0" Foreground="{StaticResource TextSecondary}"/>
+                    <TextBlock Text="Administrator privileges required to modify Windows features."
+                               Style="{StaticResource Subtle}" VerticalAlignment="Center"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
         <!-- Summary -->
-        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+        <Border Grid.Row="3" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
             <TextBlock Text="{Binding Summary}" FontWeight="SemiBold" FontSize="13"/>
         </Border>
 
         <!-- Feature list -->
-        <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
+        <Border Grid.Row="4" Style="{StaticResource Card}" Padding="0">
             <DataGrid AutomationProperties.Name="Features table" ItemsSource="{Binding FilteredFeatures}"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
                       Background="Transparent" BorderThickness="0"
@@ -169,7 +182,7 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="4" Margin="0,8,0,0">
+        <DockPanel Grid.Row="5" Margin="0,8,0,0">
             <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>


### PR DESCRIPTION
## Summary
UI/UX polish for 4 pages based on user feedback.

### Bulk Installer
- Expanded from 24 to 47 curated apps across 8 categories
- New categories: Office & Productivity, Creativity, Networking & VPN, Runtimes
- Added app descriptions (one-line under each name)
- Replaced DataGrid with grouped ItemsControl (category headers with dividers)
- Winget ID moved to tooltip (not cluttering the view)
- **Custom winget search**: users can search any package and add it to install list

### Context Menu Manager
- Friendly names for cryptic entries (.SpotlightLearnMore → "Spotlight — Learn More")
- Dictionary of known entries + command-based inference + CamelCase splitting
- Rich tooltip showing raw registry name, full command, path
- "Show system entries" toggle (defaults OFF — hides internal/cryptic entries)
- Explanatory header text for non-power-users

### Privacy Toggles + Windows Features
- Replaced alarming red/orange elevation badges with subtle info strips
- Consistent Surface2 card with shield icon + calm text
- Added "Run as administrator" button inline
- Hidden when already elevated

## Test plan
- [ ] CI build passes
- [ ] Bulk Installer shows categories, descriptions, grouping
- [ ] Custom search finds winget packages and adds to list
- [ ] Context Menu shows friendly names, hides system entries by default
- [ ] Privacy/Features pages show subtle elevation banner (not alarming)
- [ ] "Run as administrator" button works
- [ ] App launches without crash
