### PR TITLE
fix: ghost checkboxes, DNS elevation banner, startup column width, shredder empty state

### DIFF
--- a/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
@@ -236,6 +236,13 @@ public sealed partial class DnsHostsViewModel : ViewModelBase
     [RelayCommand]
     private void RefreshHosts() => LoadHosts();
 
+    [RelayCommand]
+    private void RelaunchElevated()
+    {
+        if (AdminHelper.RelaunchAsAdmin())
+            System.Windows.Application.Current?.Shutdown();
+    }
+
     // ── Cleanup ──────────────────────────────────────────────────────────
 
     protected override void Dispose(bool disposing)

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml
@@ -67,6 +67,7 @@
                       AutoGenerateColumns="False" HeadersVisibility="Column"
                       GridLinesVisibility="None" CanUserAddRows="False"
                       CanUserSortColumns="True"
+                      CanUserResizeColumns="True"
                       Background="Transparent" RowBackground="Transparent"
                       AlternatingRowBackground="#0F141C" BorderThickness="0"
                       VirtualizingPanel.IsVirtualizing="True"

--- a/SysManager/SysManager/Views/ContextMenuView.xaml
+++ b/SysManager/SysManager/Views/ContextMenuView.xaml
@@ -70,6 +70,7 @@
                       GridLinesVisibility="None" IsReadOnly="False"
                       RowBackground="Transparent" AlternatingRowBackground="#0F141C"
                       SelectionMode="Single" CanUserSortColumns="True"
+                      CanUserResizeColumns="True"
                       VirtualizingPanel.IsVirtualizing="True"
                       VirtualizingPanel.VirtualizationMode="Recycling">
                 <DataGrid.Columns>

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -13,6 +13,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
@@ -21,13 +22,26 @@
             <TextBlock Text="DNS &amp; Hosts Editor" Style="{StaticResource Display}"/>
             <TextBlock Text="Change DNS servers and manage the hosts file."
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
-            <TextBlock Text="Requires administrator." Foreground="#EF4444" FontSize="11"
-                       Margin="0,2,0,0"
-                       Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
         </StackPanel>
 
+        <!-- Elevation banner -->
+        <Border Grid.Row="1" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="12,8" Margin="28,12,28,0"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
+                        Style="{StaticResource SecondaryButton}" DockPanel.Dock="Right" Padding="12,6"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="14" Margin="0,0,8,0" Foreground="{StaticResource TextSecondary}"/>
+                    <TextBlock Text="Administrator privileges required to change DNS and edit the hosts file."
+                               Style="{StaticResource Subtle}" VerticalAlignment="Center"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
         <!-- DNS Section -->
-        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="28,16,28,0">
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,0">
             <StackPanel>
                 <TextBlock Text="DNS Server" FontWeight="SemiBold" FontSize="16" Margin="0,0,0,12"/>
 
@@ -62,7 +76,7 @@
         </Border>
 
         <!-- Hosts File Section -->
-        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,28">
+        <Border Grid.Row="3" Style="{StaticResource Card}" Margin="28,16,28,28">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>

--- a/SysManager/SysManager/Views/DriversView.xaml
+++ b/SysManager/SysManager/Views/DriversView.xaml
@@ -49,6 +49,7 @@
                           GridLinesVisibility="None" IsReadOnly="True"
                           RowBackground="Transparent" AlternatingRowBackground="#0F141C"
                           SelectionMode="Single" CanUserSortColumns="True"
+                      CanUserResizeColumns="True"
                           VerticalScrollBarVisibility="Auto"
                           VirtualizingPanel.IsVirtualizing="True"
                           VirtualizingPanel.VirtualizationMode="Recycling">

--- a/SysManager/SysManager/Views/FileShredderView.xaml
+++ b/SysManager/SysManager/Views/FileShredderView.xaml
@@ -62,10 +62,21 @@
                   AutoGenerateColumns="False" IsReadOnly="True"
                   CanUserAddRows="False" CanUserDeleteRows="False"
                   CanUserSortColumns="True"
-                  HeadersVisibility="Column" GridLinesVisibility="None"
+                      CanUserResizeColumns="True"
+                  GridLinesVisibility="None"
                   Margin="28,12,28,0"
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling">
+            <DataGrid.Style>
+                <Style TargetType="DataGrid">
+                    <Setter Property="HeadersVisibility" Value="Column"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding Items.Count}" Value="0">
+                            <Setter Property="HeadersVisibility" Value="None"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </DataGrid.Style>
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="200"/>
                 <DataGridTextColumn Header="Path" Binding="{Binding Path}" Width="*"/>

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -54,6 +54,7 @@
                   GridLinesVisibility="None" IsReadOnly="True"
                   RowBackground="Transparent" AlternatingRowBackground="#0F141C"
                   SelectionMode="Single" CanUserSortColumns="True"
+                      CanUserResizeColumns="True"
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling">
             <DataGrid.Columns>

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml
@@ -57,6 +57,7 @@
                   AutoGenerateColumns="False" IsReadOnly="False"
                   CanUserAddRows="False" CanUserDeleteRows="False"
                   CanUserSortColumns="True"
+                      CanUserResizeColumns="True"
                   HeadersVisibility="Column" GridLinesVisibility="None"
                   Margin="28,12,28,0"
                   VirtualizingPanel.IsVirtualizing="True"

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -47,6 +47,7 @@
                       GridLinesVisibility="None" IsReadOnly="False"
                       RowBackground="Transparent" AlternatingRowBackground="#0F141C"
                       SelectionMode="Single" CanUserSortColumns="True"
+                      CanUserResizeColumns="True"
                       VirtualizingPanel.IsVirtualizing="True"
                       VirtualizingPanel.VirtualizationMode="Recycling">
                 <DataGrid.Columns>
@@ -99,7 +100,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTemplateColumn Header="" Width="40" CanUserSort="False">
+                    <DataGridTemplateColumn Header="" Width="60" CanUserSort="False">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Button Content="Open" ToolTip="Open file location"

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -62,11 +62,12 @@
                       AutoGenerateColumns="False" HeadersVisibility="Column"
                       Background="Transparent" BorderThickness="0"
                       GridLinesVisibility="None" IsReadOnly="False"
+                      CanUserAddRows="False"
                       RowBackground="Transparent" AlternatingRowBackground="#0F141C"
                       SelectionMode="Single" CanUserSortColumns="True"
+                      CanUserResizeColumns="True"
                       VirtualizingPanel.IsVirtualizing="True"
-                      VirtualizingPanel.VirtualizationMode="Recycling"
-                      Visibility="{Binding FilteredApps.Count, Converter={StaticResource GreaterThanZero}}">
+                      VirtualizingPanel.VirtualizationMode="Recycling">
                 <DataGrid.Columns>
                     <DataGridCheckBoxColumn Header="" Width="32"
                                             Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}"

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -83,6 +83,7 @@
                       GridLinesVisibility="None" IsReadOnly="True"
                       RowBackground="Transparent" AlternatingRowBackground="#0F141C"
                       SelectionMode="Single" CanUserSortColumns="True"
+                      CanUserResizeColumns="True"
                       VirtualizingPanel.IsVirtualizing="True"
                       VirtualizingPanel.VirtualizationMode="Recycling">
                 <DataGrid.Columns>

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -126,6 +126,8 @@
                       GridLinesVisibility="None"
                       RowBackground="Transparent" AlternatingRowBackground="#0F141C"
                       SelectionMode="Single" CanUserSortColumns="True"
+                      CanUserResizeColumns="True"
+                      CanUserAddRows="False"
                       VirtualizingPanel.IsVirtualizing="True"
                       VirtualizingPanel.VirtualizationMode="Recycling"
                       Visibility="{Binding UpdateCount, Converter={StaticResource GreaterThanZero}}">


### PR DESCRIPTION
## Fixes
1. **Ghost checkbox in Uninstaller/Windows Update** — added `CanUserAddRows="False"` to DataGrids (WPF default adds empty "new item" row)
2. **DNS & Hosts missing elevation banner** — added consistent Surface2 banner with "Run as administrator" button (same pattern as Privacy/Features)
3. **File Shredder empty headers** — hide DataGrid headers when Items.Count == 0 via DataTrigger
4. **Startup Manager last column cut** — widened "Open" button column from 40px to 60px

## Test plan
- [ ] CI passes
- [ ] No ghost checkbox rows in any DataGrid
- [ ] DNS & Hosts shows elevation banner with working button
- [ ] File Shredder shows no table when empty
- [ ] Startup "Open" button fully visible
