### PR TITLE
fix: uniform elevation banners across all admin-required pages

### DIFF
--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -25,6 +25,7 @@ public sealed partial class ServicesViewModel : ViewModelBase
 
     public BulkObservableCollection<ServiceEntry> Services { get; } = new();
 
+    [ObservableProperty] private bool _isElevated;
     [ObservableProperty] private string _filter = "";
     [ObservableProperty] private string _selectedFilter = "All";
     [ObservableProperty] private ServiceEntry? _selectedService;
@@ -37,7 +38,15 @@ public sealed partial class ServicesViewModel : ViewModelBase
     public ServicesViewModel(PowerShellRunner ps)
     {
         _ps = ps;
+        IsElevated = AdminHelper.IsElevated();
         InitializeAsync(InitAsync);
+    }
+
+    [RelayCommand]
+    private void RelaunchElevated()
+    {
+        if (AdminHelper.RelaunchAsAdmin())
+            System.Windows.Application.Current?.Shutdown();
     }
 
     private async Task InitAsync()

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -24,20 +24,30 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
         </StackPanel>
 
-        <!-- Elevation banner -->
+        <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="12,8" Margin="28,12,28,0"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
-                        Style="{StaticResource SecondaryButton}" DockPanel.Dock="Right" Padding="12,6"/>
+                        Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="14" Margin="0,0,8,0" Foreground="{StaticResource TextSecondary}"/>
-                    <TextBlock Text="Administrator privileges required to change DNS and edit the hosts file."
-                               Style="{StaticResource Subtle}" VerticalAlignment="Center"/>
+                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                    <TextBlock Text="Changing DNS and editing the hosts file requires administrator privileges."
+                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                 </StackPanel>
             </DockPanel>
+        </Border>
+
+        <!-- Elevation banner: elevated -->
+        <Border Grid.Row="1" Background="#0D1F12" BorderBrush="#22C55E44" BorderThickness="1"
+                CornerRadius="8" Padding="10,8" Margin="28,12,28,0"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <StackPanel Orientation="Horizontal">
+                <Ellipse Width="8" Height="8" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <TextBlock Text="Running as administrator — you can change DNS settings and edit the hosts file." Foreground="#22C55E" FontSize="13" FontWeight="Medium"/>
+            </StackPanel>
         </Border>
 
         <!-- DNS Section -->

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -48,20 +48,30 @@
             </WrapPanel>
         </Border>
 
-        <!-- Elevation info strip (shown when not running as admin) -->
-        <Border Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="12,8" Margin="0,0,0,12"
-                Grid.Row="2" Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+        <!-- Elevation banner: not elevated -->
+        <Border Grid.Row="2" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
-                        Style="{StaticResource SecondaryButton}" DockPanel.Dock="Right" Padding="12,6"/>
+                        Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="14" Margin="0,0,8,0" Foreground="{StaticResource TextSecondary}"/>
-                    <TextBlock Text="Some settings require administrator privileges to change."
-                               Style="{StaticResource Subtle}" VerticalAlignment="Center"/>
+                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                    <TextBlock Text="Some privacy settings write to system-wide registry keys and require administrator privileges."
+                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                 </StackPanel>
             </DockPanel>
+        </Border>
+
+        <!-- Elevation banner: elevated -->
+        <Border Grid.Row="2" Background="#0D1F12" BorderBrush="#22C55E44" BorderThickness="1"
+                CornerRadius="8" Padding="10,8" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <StackPanel Orientation="Horizontal">
+                <Ellipse Width="8" Height="8" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <TextBlock Text="Running as administrator — all privacy toggles are available." Foreground="#22C55E" FontSize="13" FontWeight="Medium"/>
+            </StackPanel>
         </Border>
 
         <!-- Toggle list grouped by category -->

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -13,6 +13,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -46,8 +47,34 @@
             </DockPanel>
         </Border>
 
+        <!-- Elevation banner: not elevated -->
+        <Border Grid.Row="2" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
+                        Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                    <TextBlock Text="Starting and stopping Windows services requires administrator privileges."
+                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- Elevation banner: elevated -->
+        <Border Grid.Row="2" Background="#0D1F12" BorderBrush="#22C55E44" BorderThickness="1"
+                CornerRadius="8" Padding="10,8" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <StackPanel Orientation="Horizontal">
+                <Ellipse Width="8" Height="8" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <TextBlock Text="Running as administrator — you can start, stop, and configure services." Foreground="#22C55E" FontSize="13" FontWeight="Medium"/>
+            </StackPanel>
+        </Border>
+
         <!-- Services list -->
-        <DataGrid AutomationProperties.Name="Data table" Grid.Row="2" ItemsSource="{Binding Services}"
+        <DataGrid AutomationProperties.Name="Data table" Grid.Row="3" ItemsSource="{Binding Services}"
                   SelectedItem="{Binding SelectedService}"
                   AutoGenerateColumns="False" HeadersVisibility="Column"
                   Background="Transparent" BorderThickness="0"
@@ -121,7 +148,7 @@
         </DataGrid>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="3" Margin="0,8,0,0">
+        <DockPanel Grid.Row="4" Margin="0,8,0,0">
             <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -54,20 +54,30 @@
             </WrapPanel>
         </Border>
 
-        <!-- Elevation info strip (shown when not running as admin) -->
-        <Border Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="12,8" Margin="0,0,0,12"
-                Grid.Row="2" Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+        <!-- Elevation banner: not elevated -->
+        <Border Grid.Row="2" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
-                        Style="{StaticResource SecondaryButton}" DockPanel.Dock="Right" Padding="12,6"/>
+                        Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="14" Margin="0,0,8,0" Foreground="{StaticResource TextSecondary}"/>
-                    <TextBlock Text="Administrator privileges required to modify Windows features."
-                               Style="{StaticResource Subtle}" VerticalAlignment="Center"/>
+                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                    <TextBlock Text="Enabling or disabling Windows features requires administrator privileges."
+                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                 </StackPanel>
             </DockPanel>
+        </Border>
+
+        <!-- Elevation banner: elevated -->
+        <Border Grid.Row="2" Background="#0D1F12" BorderBrush="#22C55E44" BorderThickness="1"
+                CornerRadius="8" Padding="10,8" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <StackPanel Orientation="Horizontal">
+                <Ellipse Width="8" Height="8" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <TextBlock Text="Running as administrator — you can enable and disable Windows features." Foreground="#22C55E" FontSize="13" FontWeight="Medium"/>
+            </StackPanel>
         </Border>
 
         <!-- Summary -->

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -35,30 +35,30 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
         </StackPanel>
 
-        <!-- Admin banner -->
-        <Border Grid.Row="1" Margin="28,16,28,0" Padding="16,14" CornerRadius="10"
-                Background="#2A1E14" BorderBrush="#F59E0B" BorderThickness="1"
+        <!-- Elevation banner: not elevated -->
+        <Border Grid.Row="1" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-                <StackPanel Grid.Column="0">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="&#xE7EF;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                                   FontSize="18" Foreground="#F59E0B" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                        <TextBlock Text="These actions need administrator rights"
-                                   FontSize="15" FontWeight="SemiBold" Foreground="#F59E0B" VerticalAlignment="Center"/>
-                    </StackPanel>
-                    <TextBlock Text="Windows Update COM APIs can't list or install updates without elevation. Click the button to restart the app as admin."
-                               Foreground="{StaticResource TextSecondary}" Margin="28,6,0,0" TextWrapping="Wrap"/>
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                    <TextBlock Text="Listing and installing Windows updates requires administrator privileges."
+                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                 </StackPanel>
-                <Button Grid.Column="1" Content="Run as Administrator"
-                        Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource PrimaryButton}"
-                        Padding="18,10" FontSize="14" VerticalAlignment="Center" Margin="16,0,0,0"/>
-            </Grid>
+            </DockPanel>
+        </Border>
+
+        <!-- Elevation banner: elevated -->
+        <Border Grid.Row="1" Background="#0D1F12" BorderBrush="#22C55E44" BorderThickness="1"
+                CornerRadius="8" Padding="10,8" Margin="28,12,28,0"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <StackPanel Orientation="Horizontal">
+                <Ellipse Width="8" Height="8" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <TextBlock Text="Running as administrator — you can list and install updates." Foreground="#22C55E" FontSize="13" FontWeight="Medium"/>
+            </StackPanel>
         </Border>
 
         <!-- Module status: missing -->


### PR DESCRIPTION
## Summary
Replaces all inconsistent elevation UI with a single uniform design across 5 pages.

### Design:
- **Not elevated**: Grey Surface2 banner + shield icon + page-specific reason + blue "Run as administrator" button
- **Elevated**: Green compact banner with dot + page-specific confirmation text

### Pages updated:
- Windows Update: "Listing and installing Windows updates requires administrator privileges."
- Windows Features: "Enabling or disabling Windows features requires administrator privileges."
- Privacy Toggles: "Some privacy settings write to system-wide registry keys and require administrator privileges."
- DNS & Hosts: "Changing DNS and editing the hosts file requires administrator privileges."
- Services: "Starting and stopping Windows services requires administrator privileges." (NEW — didn't have elevation UI before)

### Elevated state messages:
- "Running as administrator — you can list and install updates."
- "Running as administrator — you can enable and disable Windows features."
- "Running as administrator — all privacy toggles are available."
- "Running as administrator — you can change DNS settings and edit the hosts file."
- "Running as administrator — you can start, stop, and configure services."

## Test plan
- [ ] CI passes
- [ ] All 5 pages show grey banner when not elevated
- [ ] All 5 pages show green banner when elevated
- [ ] "Run as administrator" button works (relaunches app)
- [ ] No visual inconsistencies between pages
