### PR TITLE
fix: force tray icon creation + upgrade H.NotifyIcon to 2.3.0

### DIFF
--- a/SysManager/SysManager/Services/TrayIconService.cs
+++ b/SysManager/SysManager/Services/TrayIconService.cs
@@ -54,11 +54,12 @@ public sealed class TrayIconService : IDisposable
         var icon = LoadAppIcon() ?? System.Drawing.SystemIcons.Application;
         _trayIcon = new TaskbarIcon
         {
-            ToolTipText = "SysManager — loading…",
+            ToolTipText = "SysManager",
             Icon = icon,
             ContextMenu = BuildContextMenu(mainWindow),
             Visibility = System.Windows.Visibility.Visible
         };
+        _trayIcon.ForceCreate();
 
         _trayIcon.TrayLeftMouseDown += (_, _) => ShowWindow(mainWindow);
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="H.NotifyIcon.Wpf" Version="2.2.1" />
+    <PackageReference Include="H.NotifyIcon.Wpf" Version="2.3.0" />
     <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageReference Include="WPF-UI" Version="4.3.0" />


### PR DESCRIPTION
Fixes invisible system tray icon. Added ForceCreate() call + upgraded H.NotifyIcon from 2.2.1 to 2.3.0.
