### PR TITLE
feat: UI redesign + community bug fixes

### DIFF
--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -91,6 +91,28 @@
                 <Setter Property="TextOptions.TextRenderingMode" Value="ClearType"/>
             </Style>
 
+            <Style TargetType="ProgressBar">
+                <Setter Property="Foreground" Value="{StaticResource Accent}"/>
+                <Setter Property="Background" Value="{StaticResource Surface2}"/>
+                <Setter Property="BorderThickness" Value="0"/>
+            </Style>
+
+            <Style TargetType="RadioButton">
+                <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
+                <Style.Resources>
+                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="{StaticResource AccentColor}"/>
+                </Style.Resources>
+            </Style>
+
+            <Style TargetType="CheckBox">
+                <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
+                <Style.Resources>
+                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="{StaticResource AccentColor}"/>
+                </Style.Resources>
+            </Style>
+
             <!-- ============================================================ -->
             <!-- Card — reusable container                                      -->
             <!-- ============================================================ -->

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -55,12 +55,13 @@
             <SolidColorBrush x:Key="TextDisabled" Color="#4A5266"/>
 
             <!-- Accent (primary action) -->
-            <Color x:Key="AccentColor">#5B8DEF</Color>
-            <Color x:Key="AccentHoverColor">#6E9CF6</Color>
-            <Color x:Key="AccentPressedColor">#4979D6</Color>
+            <Color x:Key="AccentColor">#6366F1</Color>
+            <Color x:Key="AccentHoverColor">#818CF8</Color>
+            <Color x:Key="AccentPressedColor">#4F46E5</Color>
             <SolidColorBrush x:Key="Accent" Color="{StaticResource AccentColor}"/>
             <SolidColorBrush x:Key="AccentHover" Color="{StaticResource AccentHoverColor}"/>
             <SolidColorBrush x:Key="AccentPressed" Color="{StaticResource AccentPressedColor}"/>
+            <SolidColorBrush x:Key="AccentSoft" Color="#0F6366F1"/>
 
             <!-- Status colors -->
             <SolidColorBrush x:Key="Success" Color="#22C55E"/>
@@ -141,6 +142,7 @@
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter TargetName="Bd" Property="Opacity" Value="0.88"/>
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource BorderAccent}"/>
                                 </Trigger>
                                 <Trigger Property="IsPressed" Value="True">
                                     <Setter TargetName="Bd" Property="Opacity" Value="0.75"/>
@@ -172,21 +174,24 @@
                 <Setter Property="BorderThickness" Value="1"/>
             </Style>
 
-            <!-- Ghost: transparent with hover bg -->
+            <!-- Ghost: subtle border, highlighted on hover -->
             <Style x:Key="GhostButton" TargetType="Button" BasedOn="{StaticResource ButtonBase}">
                 <Setter Property="Background" Value="Transparent"/>
-                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="BorderThickness" Value="1"/>
                 <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="Button">
-                            <Border x:Name="Bd" Background="Transparent" CornerRadius="8" Padding="{TemplateBinding Padding}">
+                            <Border x:Name="Bd" Background="Transparent" CornerRadius="8"
+                                    Padding="{TemplateBinding Padding}"
+                                    BorderThickness="1" BorderBrush="#1AFFFFFF">
                                 <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
                                                   TextBlock.Foreground="{TemplateBinding Foreground}"/>
                             </Border>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter TargetName="Bd" Property="Background" Value="{StaticResource Surface3}"/>
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="#33FFFFFF"/>
                                     <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
                                 </Trigger>
                                 <Trigger Property="IsPressed" Value="True">
@@ -194,7 +199,44 @@
                                 </Trigger>
                                 <Trigger Property="IsKeyboardFocused" Value="True">
                                     <Setter TargetName="Bd" Property="Background" Value="{StaticResource Surface3}"/>
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="#33FFFFFF"/>
                                     <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                                </Trigger>
+                                <Trigger Property="IsEnabled" Value="False">
+                                    <Setter Property="Opacity" Value="0.4"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <!-- Admin: golden glass button for elevation requests -->
+            <Style x:Key="AdminButton" TargetType="Button" BasedOn="{StaticResource ButtonBase}">
+                <Setter Property="Foreground" Value="#FCD34D"/>
+                <Setter Property="Cursor" Value="Hand"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border x:Name="Bd" CornerRadius="10" Padding="{TemplateBinding Padding}"
+                                    Background="#14FBBF24" BorderBrush="#30FBBF24" BorderThickness="1">
+                                <Grid>
+                                    <Border Background="#FBBF24" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                                            Margin="-14,-8,0,-8" x:Name="Bar"/>
+                                    <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
+                                        <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                                        <ContentPresenter Margin="8,0,0,0" VerticalAlignment="Center"
+                                                          TextBlock.Foreground="#FCD34D" TextBlock.FontWeight="SemiBold"/>
+                                    </StackPanel>
+                                </Grid>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="#60FBBF24"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="#20FBBF24"/>
+                                </Trigger>
+                                <Trigger Property="IsPressed" Value="True">
+                                    <Setter TargetName="Bd" Property="Background" Value="#28FBBF24"/>
                                 </Trigger>
                                 <Trigger Property="IsEnabled" Value="False">
                                     <Setter Property="Opacity" Value="0.4"/>
@@ -335,7 +377,7 @@
                                     <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
                                 </Trigger>
                                 <Trigger Property="IsSelected" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource Surface3}"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource AccentSoft}"/>
                                     <Setter TargetName="ActiveMark" Property="Visibility" Value="Visible"/>
                                     <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
                                     <Setter Property="FontWeight" Value="SemiBold"/>
@@ -462,38 +504,49 @@
 
             <Style TargetType="DataGridColumnHeader">
                 <Setter Property="Background" Value="{StaticResource Surface2}"/>
-                <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
+                <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
                 <Setter Property="FontWeight" Value="SemiBold"/>
-                <Setter Property="FontSize" Value="12"/>
-                <Setter Property="Padding" Value="10,8"/>
+                <Setter Property="FontSize" Value="11"/>
+                <Setter Property="Padding" Value="12,10"/>
                 <Setter Property="BorderBrush" Value="{StaticResource Border1}"/>
                 <Setter Property="BorderThickness" Value="0,0,0,1"/>
+                <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="DataGridColumnHeader">
-                            <Border x:Name="HeaderBorder"
-                                    Background="{TemplateBinding Background}"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    Padding="{TemplateBinding Padding}">
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="Auto"/>
-                                    </Grid.ColumnDefinitions>
-                                    <ContentPresenter Grid.Column="0"
-                                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                      VerticalAlignment="Center"
-                                                      Content="{TemplateBinding Content}"
-                                                      ContentTemplate="{TemplateBinding ContentTemplate}"/>
-                                    <Path x:Name="SortArrow" Grid.Column="1"
-                                          Visibility="Collapsed"
-                                          Fill="{StaticResource TextSecondary}"
-                                          Margin="6,0,0,0"
-                                          VerticalAlignment="Center"
-                                          RenderTransformOrigin="0.5,0.5"/>
-                                </Grid>
-                            </Border>
+                            <Grid>
+                                <Border x:Name="HeaderBorder"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        Padding="{TemplateBinding Padding}">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <ContentPresenter Grid.Column="0"
+                                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                          VerticalAlignment="Center"
+                                                          Content="{TemplateBinding Content}"
+                                                          ContentTemplate="{TemplateBinding ContentTemplate}"/>
+                                        <Path x:Name="SortArrow" Grid.Column="1"
+                                              Visibility="Collapsed"
+                                              Fill="{StaticResource TextSecondary}"
+                                              Margin="6,0,0,0"
+                                              VerticalAlignment="Center"
+                                              RenderTransformOrigin="0.5,0.5"/>
+                                    </Grid>
+                                </Border>
+                                <Thumb x:Name="PART_RightHeaderGripper" HorizontalAlignment="Right"
+                                       Width="6" Cursor="SizeWE" BorderThickness="0">
+                                    <Thumb.Template>
+                                        <ControlTemplate TargetType="Thumb">
+                                            <Border Background="Transparent" Width="6"/>
+                                        </ControlTemplate>
+                                    </Thumb.Template>
+                                </Thumb>
+                            </Grid>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter TargetName="HeaderBorder" Property="Background" Value="{StaticResource Surface3}"/>
@@ -520,10 +573,10 @@
                 <Setter Property="BorderThickness" Value="0"/>
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
-                        <Setter Property="Background" Value="{StaticResource Surface2}"/>
+                        <Setter Property="Background" Value="#186366F1"/>
                     </Trigger>
                     <Trigger Property="IsSelected" Value="True">
-                        <Setter Property="Background" Value="{StaticResource Surface3}"/>
+                        <Setter Property="Background" Value="#146366F1"/>
                         <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
                     </Trigger>
                 </Style.Triggers>

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -53,15 +53,15 @@
                                 <Border x:Name="SingleBd"
                                         Visibility="{Binding IsSingleItem, Converter={StaticResource FlexVis}}"
                                         CornerRadius="8" Padding="14,10" Cursor="Hand"
-                                        Background="Transparent"
                                         MouseLeftButtonUp="SingleGroup_Click"
                                         Tag="{Binding Children[0]}"
                                         AutomationProperties.AutomationId="{Binding Children[0].Id}">
                                     <Border.Style>
                                         <Style TargetType="Border">
+                                            <Setter Property="Background" Value="Transparent"/>
                                             <Style.Triggers>
                                                 <Trigger Property="IsMouseOver" Value="True">
-                                                    <Setter Property="Background" Value="{StaticResource Surface2}"/>
+                                                    <Setter Property="Background" Value="#186366F1"/>
                                                 </Trigger>
                                             </Style.Triggers>
                                         </Style>
@@ -88,8 +88,19 @@
                                           BorderThickness="0"
                                           Foreground="{StaticResource TextSecondary}">
                                     <Expander.Header>
-                                        <StackPanel Margin="4,4,0,4"
-                                                    ToolTip="{Binding Tooltip}">
+                                        <Border CornerRadius="8" Padding="4,4,8,4" Margin="-4,-4,-8,-4"
+                                                ToolTip="{Binding Tooltip}">
+                                            <Border.Style>
+                                                <Style TargetType="Border">
+                                                    <Setter Property="Background" Value="Transparent"/>
+                                                    <Style.Triggers>
+                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                            <Setter Property="Background" Value="#126366F1"/>
+                                                        </Trigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Border.Style>
+                                        <StackPanel>
                                             <StackPanel Orientation="Horizontal">
                                                 <TextBlock Text="{Binding Glyph}"
                                                            FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
@@ -125,21 +136,23 @@
                                                 </TextBlock.Style>
                                             </TextBlock>
                                         </StackPanel>
+                                        </Border>
                                     </Expander.Header>
                                     <ItemsControl ItemsSource="{Binding Children}" Focusable="False">
                                         <ItemsControl.ItemTemplate>
                                             <DataTemplate>
                                                 <Border x:Name="ChildBd"
                                                         CornerRadius="8" Padding="28,9,14,9"
-                                                        Cursor="Hand" Background="Transparent"
+                                                        Cursor="Hand"
                                                         MouseLeftButtonUp="NavChild_Click"
                                                         Tag="{Binding}"
                                                         AutomationProperties.AutomationId="{Binding Id}">
                                                     <Border.Style>
                                                         <Style TargetType="Border">
+                                                            <Setter Property="Background" Value="Transparent"/>
                                                             <Style.Triggers>
                                                                 <Trigger Property="IsMouseOver" Value="True">
-                                                                    <Setter Property="Background" Value="{StaticResource Surface2}"/>
+                                                                    <Setter Property="Background" Value="#186366F1"/>
                                                                 </Trigger>
                                                             </Style.Triggers>
                                                         </Style>

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -38,12 +38,25 @@ public partial class MainWindow : Window
     {
         base.OnSourceInitialized(e);
         if (PresentationSource.FromVisual(this) is HwndSource source)
+        {
             source.AddHook(WndProc);
+            ApplyDarkTitleBar(source.Handle);
+        }
 
         // Initialize tray icon after window handle is available
         if (Application.Current is App app && app.TrayService != null)
             app.TrayService.Initialize(this);
     }
+
+    private static void ApplyDarkTitleBar(IntPtr hwnd)
+    {
+        const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
+        int value = 1;
+        DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, ref value, sizeof(int));
+    }
+
+    [System.Runtime.InteropServices.LibraryImport("dwmapi.dll")]
+    private static partial int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int value, int size);
 
     private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
     {

--- a/SysManager/SysManager/Services/DnsService.cs
+++ b/SysManager/SysManager/Services/DnsService.cs
@@ -42,17 +42,16 @@ public sealed class DnsService : IDisposable
         try
         {
             const string script = """
-                $adapter = Get-NetAdapter | Where-Object { $_.Status -eq 'Up' } | Select-Object -First 1
-                if ($adapter) {
+                $adapters = Get-NetAdapter | Where-Object { $_.Status -eq 'Up' -and $_.Virtual -eq $false } | Sort-Object -Property ifIndex
+                if (-not $adapters) { $adapters = Get-NetAdapter | Where-Object { $_.Status -eq 'Up' } | Sort-Object -Property ifIndex }
+                foreach ($adapter in $adapters) {
                     $dns = Get-DnsClientServerAddress -InterfaceIndex $adapter.ifIndex -AddressFamily IPv4
                     if ($dns.ServerAddresses.Count -gt 0) {
                         $dns.ServerAddresses -join ', '
-                    } else {
-                        'Automatic (DHCP)'
+                        return
                     }
-                } else {
-                    'No active adapter'
                 }
+                if ($adapters) { 'Automatic (DHCP)' } else { 'No active adapter' }
                 """;
 
             Collection<PSObject> results = await _ps.RunAsync(script, cancellationToken: ct)

--- a/SysManager/SysManager/Services/WindowsFeaturesService.cs
+++ b/SysManager/SysManager/Services/WindowsFeaturesService.cs
@@ -133,6 +133,7 @@ public sealed partial class WindowsFeaturesService
                     Name = name,
                     DisplayName = HumanizeName(name),
                     IsEnabled = isEnabled,
+                    Status = isEnabled ? "Enabled" : "Disabled",
                     Category = WindowsFeature.CategorizeFeature(name)
                 };
             })

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -2,7 +2,6 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
@@ -23,7 +22,7 @@ public sealed partial class AboutViewModel : ViewModelBase
     private readonly SystemReportService _reportService;
     private UpdateService.ReleaseInfo? _latest;
 
-    public ObservableCollection<ReleaseNote> ReleaseHistory { get; } = new();
+    [ObservableProperty] private IReadOnlyList<ReleaseNote> _releaseHistory = [];
 
     [ObservableProperty] private string _currentVersion = UpdateService.CurrentVersion.ToString(3);
     [ObservableProperty] private string _buildDate = BuildStamp();
@@ -37,11 +36,20 @@ public sealed partial class AboutViewModel : ViewModelBase
     [ObservableProperty] private string _latestNotes = string.Empty;
 
     // Download state
-    [ObservableProperty] private bool _isDownloading;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowDownloadButton))]
+    private bool _isDownloading;
+
     [ObservableProperty] private int _downloadPercent;
     [ObservableProperty] private string _downloadStatus = string.Empty;
-    [ObservableProperty] private string? _downloadedPath;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowDownloadButton))]
+    private string? _downloadedPath;
+
     [ObservableProperty] private bool _autoDownloadFailed;
+
+    public bool ShowDownloadButton => !IsDownloading && string.IsNullOrEmpty(DownloadedPath);
 
     // Report export state
     [ObservableProperty] private bool _isGeneratingReport;
@@ -132,9 +140,7 @@ public sealed partial class AboutViewModel : ViewModelBase
                 IsCurrent = r.Version == UpdateService.CurrentVersion
             }).ToList();
 
-            ReleaseHistory.Clear();
-            foreach (var note in notes)
-                ReleaseHistory.Add(note);
+            ReleaseHistory = notes;
         }
         catch (HttpRequestException ex) { Log.Debug("Release history load skipped (network): {Error}", ex.Message); }
         catch (TaskCanceledException ex) { Log.Debug("Release history load timed out: {Error}", ex.Message); }

--- a/SysManager/SysManager/ViewModels/StartupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StartupViewModel.cs
@@ -51,16 +51,27 @@ public sealed partial class StartupViewModel : ViewModelBase
         StatusMessage = "Scanning startup items…";
         try
         {
-            var items = await _service.ScanAsync();
-            _allEntries.Clear();
-            Entries.Clear();
-            foreach (var item in items.OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase))
-            {
+            var items = await _service.ScanAsync().ConfigureAwait(false);
+            var sorted = items.OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase).ToList();
+            foreach (var item in sorted)
                 item.Icon = IconExtractorService.GetIcon(item.Command);
-                _allEntries.Add(item);
+
+            if (System.Windows.Application.Current?.Dispatcher is { } dispatcher)
+            {
+                dispatcher.Invoke(() =>
+                {
+                    _allEntries.Clear();
+                    _allEntries.AddRange(sorted);
+                    ApplyFilter();
+                });
+            }
+            else
+            {
+                _allEntries.Clear();
+                _allEntries.AddRange(sorted);
+                ApplyFilter();
             }
 
-            ApplyFilter();
             StatusMessage = $"Found {_allEntries.Count} startup items.";
         }
         catch (InvalidOperationException ex)
@@ -113,12 +124,8 @@ public sealed partial class StartupViewModel : ViewModelBase
         if (parameter is not StartupEntry entry) return;
         try
         {
-            var path = entry.Command.Trim('"', ' ');
-            var spaceIdx = path.IndexOf(' ');
-            if (spaceIdx > 0 && !System.IO.File.Exists(path))
-                path = path[..spaceIdx].Trim('"');
-
-            if (System.IO.File.Exists(path))
+            var path = ExtractExecutablePath(entry.Command);
+            if (path is not null && System.IO.File.Exists(path))
             {
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
                 {
@@ -127,9 +134,45 @@ public sealed partial class StartupViewModel : ViewModelBase
                     UseShellExecute = true
                 });
             }
+            else
+            {
+                StatusMessage = "File not found — the application may have been moved or uninstalled.";
+            }
         }
         catch (InvalidOperationException) { StatusMessage = "Could not open file location."; }
         catch (System.ComponentModel.Win32Exception) { StatusMessage = "Could not open file location."; }
+    }
+
+    private static string? ExtractExecutablePath(string command)
+    {
+        if (string.IsNullOrWhiteSpace(command)) return null;
+        var cmd = command.Trim();
+
+        if (cmd.StartsWith('"'))
+        {
+            var endQuote = cmd.IndexOf('"', 1);
+            if (endQuote > 1)
+                return cmd[1..endQuote];
+        }
+
+        if (System.IO.File.Exists(cmd)) return cmd;
+
+        var extensions = new[] { ".exe", ".bat", ".cmd", ".com" };
+        for (var i = 0; i < cmd.Length; i++)
+        {
+            if (cmd[i] != ' ') continue;
+            var candidate = cmd[..i];
+            if (System.IO.File.Exists(candidate)) return candidate;
+            foreach (var ext in extensions)
+            {
+                if (candidate.EndsWith(ext, StringComparison.OrdinalIgnoreCase))
+                    break;
+                if (System.IO.File.Exists(candidate + ext))
+                    return candidate + ext;
+            }
+        }
+
+        return null;
     }
 
     private void UpdateCounts()

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -28,6 +28,7 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
     [ObservableProperty] private int _updateCount;
     [ObservableProperty] private string _tableSummary = "";
     [ObservableProperty] private bool _showConsole;
+    [ObservableProperty] private bool _isShowingHistory;
 
     public WindowsUpdateViewModel(PowerShellRunner runner)
     {
@@ -141,6 +142,7 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
     {
         IsBusy = true;
         IsProgressIndeterminate = true;
+        IsShowingHistory = false;
         StatusMessage = "Listing available Windows Updates…";
         Updates.Clear();
         ShowConsole = false;
@@ -207,6 +209,7 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
     {
         IsBusy = true;
         IsProgressIndeterminate = true;
+        IsShowingHistory = true;
         StatusMessage = "Loading update history…";
         Updates.Clear();
         ShowConsole = false;
@@ -258,6 +261,7 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
     {
         IsBusy = true;
         IsProgressIndeterminate = true;
+        IsShowingHistory = false;
         StatusMessage = "Checking for feature upgrades…";
         Updates.Clear();
         ShowConsole = false;

--- a/SysManager/SysManager/Views/AboutView.xaml
+++ b/SysManager/SysManager/Views/AboutView.xaml
@@ -96,6 +96,9 @@
                                 <TextBlock Text="{Binding UpdateStatus}" Style="{StaticResource Subtle}" Margin="0,6,0,0" TextWrapping="Wrap"/>
                             </StackPanel>
                             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                <Button Content="Download" Command="{Binding DownloadCommand}"
+                                        Style="{StaticResource PrimaryButton}" Padding="18,10" FontSize="14"
+                                        Visibility="{Binding ShowDownloadButton, Converter={StaticResource BoolToVis}}"/>
                                 <Button Content="Install" Command="{Binding InstallUpdateCommand}"
                                         Style="{StaticResource PrimaryButton}" Padding="18,10" FontSize="14"
                                         Visibility="{Binding DownloadedPath, Converter={StaticResource FlexVis}}"/>

--- a/SysManager/SysManager/Views/AppBlockerView.xaml
+++ b/SysManager/SysManager/Views/AppBlockerView.xaml
@@ -32,7 +32,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
@@ -43,13 +43,18 @@
         </Border>
 
         <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="#0D1F12" BorderBrush="#22C55E44" BorderThickness="1"
-                CornerRadius="8" Padding="10,8" Margin="0,0,0,12"
+        <Border Grid.Row="1" Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <StackPanel Orientation="Horizontal">
-                <Ellipse Width="8" Height="8" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <TextBlock Text="Running as administrator — you can block and unblock applications." Foreground="#22C55E" FontSize="13" FontWeight="Medium"/>
-            </StackPanel>
+            <Grid>
+                <Border Background="#FBBF24" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — you can block and unblock applications."
+                               Foreground="#FCD34D" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
         </Border>
 
         <!-- Block input -->

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml
@@ -33,7 +33,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
@@ -44,13 +44,18 @@
         </Border>
 
         <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="#0D1F12" BorderBrush="#22C55E44" BorderThickness="1"
-                CornerRadius="8" Padding="10,8" Margin="28,12,28,0"
+        <Border Grid.Row="1" Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <StackPanel Orientation="Horizontal">
-                <Ellipse Width="8" Height="8" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <TextBlock Text="Running as administrator — all packages can be upgraded." Foreground="#22C55E" FontSize="13" FontWeight="Medium"/>
-            </StackPanel>
+            <Grid>
+                <Border Background="#FBBF24" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — all packages can be upgraded."
+                               Foreground="#FCD34D" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
         </Border>
 
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,0">
@@ -68,8 +73,7 @@
                       GridLinesVisibility="None" CanUserAddRows="False"
                       CanUserSortColumns="True"
                       CanUserResizeColumns="True"
-                      Background="Transparent" RowBackground="Transparent"
-                      AlternatingRowBackground="#0F141C" BorderThickness="0"
+                      Background="Transparent" BorderThickness="0"
                       VirtualizingPanel.IsVirtualizing="True"
                       VirtualizingPanel.VirtualizationMode="Recycling">
                 <DataGrid.Columns>

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -32,7 +32,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
-                        Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
@@ -43,13 +43,18 @@
         </Border>
 
         <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="#0D1F12" BorderBrush="#22C55E44" BorderThickness="1"
-                CornerRadius="8" Padding="10,8" Margin="0,0,0,12"
+        <Border Grid.Row="1" Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <StackPanel Orientation="Horizontal">
-                <Ellipse Width="8" Height="8" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <TextBlock Text="Running as administrator — all applications can be installed." Foreground="#22C55E" FontSize="13" FontWeight="Medium"/>
-            </StackPanel>
+            <Grid>
+                <Border Background="#FBBF24" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — all applications can be installed."
+                               Foreground="#FCD34D" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
         </Border>
 
         <!-- Toolbar -->
@@ -223,11 +228,17 @@
                                     </StackPanel>
 
                                     <!-- Status badge -->
-                                    <Border Grid.Column="3" Style="{StaticResource Badge}"
+                                    <Border Grid.Column="3" CornerRadius="8" Padding="8,4"
+                                            Background="#14475569" BorderBrush="#0AFFFFFF" BorderThickness="1"
                                             VerticalAlignment="Center" Margin="12,0,0,0"
                                             Visibility="{Binding Status, Converter={StaticResource FlexVis}}">
-                                        <TextBlock Text="{Binding Status}" FontSize="11"
-                                                   TextTrimming="CharacterEllipsis" MaxWidth="120"/>
+                                        <Grid>
+                                            <Border Background="#475569" Width="3" HorizontalAlignment="Left"
+                                                    CornerRadius="2" Margin="-8,-4,0,-4"/>
+                                            <TextBlock Text="{Binding Status}" FontSize="11" Foreground="#94A3B8"
+                                                       FontWeight="SemiBold" Margin="4,0,0,0"
+                                                       TextTrimming="CharacterEllipsis" MaxWidth="120"/>
+                                        </Grid>
                                     </Border>
                                 </Grid>
                             </Border>

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -185,7 +185,7 @@
                                     <Style TargetType="Border">
                                         <Style.Triggers>
                                             <Trigger Property="IsMouseOver" Value="True">
-                                                <Setter Property="Background" Value="{StaticResource Surface2}"/>
+                                                <Setter Property="Background" Value="#186366F1"/>
                                             </Trigger>
                                         </Style.Triggers>
                                     </Style>

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -32,7 +32,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
@@ -43,13 +43,18 @@
         </Border>
 
         <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="#0D1F12" BorderBrush="#22C55E44" BorderThickness="1"
-                CornerRadius="8" Padding="10,8" Margin="28,12,28,0"
+        <Border Grid.Row="1" Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <StackPanel Orientation="Horizontal">
-                <Ellipse Width="8" Height="8" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <TextBlock Text="Running as administrator — you can run system file checks and repairs." Foreground="#22C55E" FontSize="13" FontWeight="Medium"/>
-            </StackPanel>
+            <Grid>
+                <Border Background="#FBBF24" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — you can run system file checks and repairs."
+                               Foreground="#FCD34D" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
         </Border>
 
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,0">

--- a/SysManager/SysManager/Views/ContextMenuView.xaml
+++ b/SysManager/SysManager/Views/ContextMenuView.xaml
@@ -68,7 +68,6 @@
                       CanUserAddRows="False"
                       Background="Transparent" BorderThickness="0"
                       GridLinesVisibility="None" IsReadOnly="False"
-                      RowBackground="Transparent" AlternatingRowBackground="#0F141C"
                       SelectionMode="Single" CanUserSortColumns="True"
                       CanUserResizeColumns="True"
                       VirtualizingPanel.IsVirtualizing="True"

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -12,14 +12,45 @@
 
         <StackPanel Orientation="Horizontal" Grid.Row="0">
             <TextBlock Text="System overview" FontSize="22" FontWeight="SemiBold"/>
-            <Border CornerRadius="10" Padding="10,2" Margin="16,4,0,0"
-                    Background="#1F6FEB" Visibility="{Binding IsElevated, Converter={StaticResource BoolToVis}}">
-                <TextBlock Text="Administrator" Foreground="White" FontSize="12"/>
+            <Border CornerRadius="10" Padding="10,5" Margin="16,2,0,0"
+                    Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
+                    Visibility="{Binding IsElevated, Converter={StaticResource BoolToVis}}">
+                <Grid>
+                    <Border Background="#FBBF24" Width="3" HorizontalAlignment="Left" CornerRadius="2"
+                            Margin="-10,-5,0,-5"/>
+                    <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
+                        <TextBlock Text="&#x1F6E1;" FontSize="12" VerticalAlignment="Center"/>
+                        <TextBlock Text="Administrator" Foreground="#FCD34D" FontSize="12"
+                                   FontWeight="SemiBold" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Grid>
             </Border>
-            <Button Margin="16,0,0,0" Content="Request admin"
-                    Command="{Binding RequestElevationCommand}">
+            <Button Margin="16,0,0,0"
+                    Command="{Binding RequestElevationCommand}" Cursor="Hand">
+                <Button.Template>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bd" CornerRadius="10" Padding="10,5"
+                                Background="#14FBBF24" BorderBrush="#30FBBF24" BorderThickness="1">
+                            <Grid>
+                                <Border Background="#FBBF24" Width="3" HorizontalAlignment="Left" CornerRadius="2"
+                                        Margin="-10,-5,0,-5" Opacity="0.7"/>
+                                <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
+                                    <TextBlock Text="&#x1F6E1;" FontSize="12" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Request admin" Foreground="#FCD34D" FontSize="12"
+                                               FontWeight="SemiBold" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </Grid>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="BorderBrush" Value="#60FBBF24"/>
+                                <Setter TargetName="Bd" Property="Background" Value="#20FBBF24"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Button.Template>
                 <Button.Style>
-                    <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                    <Style TargetType="Button">
                         <Setter Property="Visibility" Value="Visible"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding IsElevated}" Value="True">

--- a/SysManager/SysManager/Views/DeepCleanupView.xaml
+++ b/SysManager/SysManager/Views/DeepCleanupView.xaml
@@ -194,8 +194,7 @@
                                   AutoGenerateColumns="False" HeadersVisibility="Column"
                                   GridLinesVisibility="None" IsReadOnly="True"
                                   CanUserResizeColumns="True"
-                                  Background="Transparent" RowBackground="Transparent"
-                                  AlternatingRowBackground="#0F141C" BorderThickness="0"
+                                  Background="Transparent" BorderThickness="0"
                                   MaxHeight="380"
                                   VirtualizingPanel.IsVirtualizing="True"
                                   VirtualizingPanel.VirtualizationMode="Recycling">

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -30,7 +30,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
-                        Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
@@ -41,13 +41,18 @@
         </Border>
 
         <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="#0D1F12" BorderBrush="#22C55E44" BorderThickness="1"
-                CornerRadius="8" Padding="10,8" Margin="28,12,28,0"
+        <Border Grid.Row="1" Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <StackPanel Orientation="Horizontal">
-                <Ellipse Width="8" Height="8" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <TextBlock Text="Running as administrator — you can change DNS settings and edit the hosts file." Foreground="#22C55E" FontSize="13" FontWeight="Medium"/>
-            </StackPanel>
+            <Grid>
+                <Border Background="#FBBF24" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — you can change DNS settings and edit the hosts file."
+                               Foreground="#FCD34D" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
         </Border>
 
         <!-- DNS Section -->
@@ -113,8 +118,7 @@
                           CanUserDeleteRows="False" HeadersVisibility="Column"
                           CanUserResizeColumns="True"
                           GridLinesVisibility="Horizontal" BorderThickness="0"
-                          Background="Transparent" RowBackground="#0D1B2A"
-                          AlternatingRowBackground="#111D2E"
+                          Background="Transparent"
                           Foreground="#E2E8F0" FontSize="12"
                           HorizontalGridLinesBrush="#1E293B"
                           SelectionMode="Single" IsReadOnly="False"

--- a/SysManager/SysManager/Views/DriversView.xaml
+++ b/SysManager/SysManager/Views/DriversView.xaml
@@ -47,7 +47,6 @@
                           AutoGenerateColumns="False" HeadersVisibility="Column"
                           Background="Transparent" BorderThickness="0"
                           GridLinesVisibility="None" IsReadOnly="True"
-                          RowBackground="Transparent" AlternatingRowBackground="#0F141C"
                           SelectionMode="Single" CanUserSortColumns="True"
                       CanUserResizeColumns="True"
                           VerticalScrollBarVisibility="Auto"

--- a/SysManager/SysManager/Views/FileShredderView.xaml
+++ b/SysManager/SysManager/Views/FileShredderView.xaml
@@ -35,6 +35,15 @@
             <TextBlock Text="File Shredder" Style="{StaticResource Display}"/>
             <TextBlock Text="Securely delete files beyond recovery with multi-pass overwrite."
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+            <Border Background="#1C1A0F" BorderBrush="#3D3A20" BorderThickness="1" CornerRadius="6"
+                    Margin="0,10,0,0" Padding="10,8">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="&#xE7BA;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="14" Foreground="#EAB308" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                    <TextBlock Foreground="#EAB308" FontSize="12" TextWrapping="Wrap" VerticalAlignment="Center"
+                               Text="SSD users: overwrite-based shredding is unreliable on solid-state drives due to wear-leveling. Use full-disk encryption (BitLocker/VeraCrypt) for secure data disposal on SSDs."/>
+                </StackPanel>
+            </Border>
         </StackPanel>
 
         <!-- Toolbar -->

--- a/SysManager/SysManager/Views/FileShredderView.xaml
+++ b/SysManager/SysManager/Views/FileShredderView.xaml
@@ -64,8 +64,7 @@
                   CanUserSortColumns="True"
                   CanUserResizeColumns="True"
                   GridLinesVisibility="None"
-                  Background="Transparent" RowBackground="Transparent"
-                  AlternatingRowBackground="#0F141C" BorderThickness="0"
+                  Background="Transparent" BorderThickness="0"
                   Margin="28,12,28,0"
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling">

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -9,13 +9,17 @@
             <GradientStop Color="#090D16" Offset="1"/>
         </LinearGradientBrush>
 
-        <!-- Reusable "severity dot" — a glowing colored ring.
-             Usage: <ContentPresenter Content="…" Resources="{StaticResource SevDotStyle}"/> -->
         <Style x:Key="SevDot" TargetType="Ellipse">
-            <Setter Property="Width" Value="10"/>
-            <Setter Property="Height" Value="10"/>
+            <Setter Property="Width" Value="8"/>
+            <Setter Property="Height" Value="8"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
-            <Setter Property="StrokeThickness" Value="2"/>
+        </Style>
+
+        <Style x:Key="GlassCard" TargetType="Border">
+            <Setter Property="CornerRadius" Value="14"/>
+            <Setter Property="Padding" Value="16,12"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="BorderBrush" Value="#0FFFFFFF"/>
         </Style>
     </UserControl.Resources>
 
@@ -42,35 +46,79 @@
             </StackPanel>
         </DockPanel>
 
-        <!-- Severity count pills -->
+        <!-- Severity count glass cards -->
         <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="28,16,28,0">
-            <Border Background="#2A1114" BorderBrush="#FF3B30" BorderThickness="1" CornerRadius="999" Padding="14,8" Margin="0,0,10,0">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <Ellipse Style="{StaticResource SevDot}" Fill="#FF3B30" Margin="0,0,8,0"/>
-                    <TextBlock Text="{Binding CriticalCount}" FontSize="14" FontWeight="SemiBold" Foreground="#FF3B30" VerticalAlignment="Center"/>
-                    <TextBlock Text=" Critical" FontSize="12" Foreground="{StaticResource TextSecondary}" Margin="4,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
+            <!-- Critical -->
+            <Border Style="{StaticResource GlassCard}" Background="#14FF3B30" Margin="0,0,12,0">
+                <Grid>
+                    <Border Background="#FF3B30" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                            Margin="-16,-12,0,-12"/>
+                    <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
+                        <Ellipse Style="{StaticResource SevDot}" Fill="#FF3B30">
+                            <Ellipse.Effect>
+                                <DropShadowEffect Color="#FF3B30" BlurRadius="8" ShadowDepth="0" Opacity="0.6"/>
+                            </Ellipse.Effect>
+                        </Ellipse>
+                        <TextBlock Text="{Binding CriticalCount}" FontSize="20" FontWeight="Bold"
+                                   Foreground="#FF6B6B" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                        <TextBlock Text="Critical" FontSize="12" Foreground="#64748B"
+                                   VerticalAlignment="Center" Margin="10,0,0,0"/>
+                    </StackPanel>
+                </Grid>
             </Border>
-            <Border Background="#2A1E1E" BorderBrush="#F87171" BorderThickness="1" CornerRadius="999" Padding="14,8" Margin="0,0,10,0">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <Ellipse Style="{StaticResource SevDot}" Fill="#F87171" Margin="0,0,8,0"/>
-                    <TextBlock Text="{Binding ErrorCount}" FontSize="14" FontWeight="SemiBold" Foreground="#F87171" VerticalAlignment="Center"/>
-                    <TextBlock Text=" Errors" FontSize="12" Foreground="{StaticResource TextSecondary}" Margin="4,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
+            <!-- Errors -->
+            <Border Style="{StaticResource GlassCard}" Background="#14F87171" Margin="0,0,12,0">
+                <Grid>
+                    <Border Background="#F87171" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                            Margin="-16,-12,0,-12"/>
+                    <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
+                        <Ellipse Style="{StaticResource SevDot}" Fill="#F87171">
+                            <Ellipse.Effect>
+                                <DropShadowEffect Color="#F87171" BlurRadius="8" ShadowDepth="0" Opacity="0.6"/>
+                            </Ellipse.Effect>
+                        </Ellipse>
+                        <TextBlock Text="{Binding ErrorCount}" FontSize="20" FontWeight="Bold"
+                                   Foreground="#FCA5A5" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                        <TextBlock Text="Errors" FontSize="12" Foreground="#64748B"
+                                   VerticalAlignment="Center" Margin="10,0,0,0"/>
+                    </StackPanel>
+                </Grid>
             </Border>
-            <Border Background="#2A2314" BorderBrush="#FBBF24" BorderThickness="1" CornerRadius="999" Padding="14,8" Margin="0,0,10,0">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <Ellipse Style="{StaticResource SevDot}" Fill="#FBBF24" Margin="0,0,8,0"/>
-                    <TextBlock Text="{Binding WarningCount}" FontSize="14" FontWeight="SemiBold" Foreground="#FBBF24" VerticalAlignment="Center"/>
-                    <TextBlock Text=" Warnings" FontSize="12" Foreground="{StaticResource TextSecondary}" Margin="4,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
+            <!-- Warnings -->
+            <Border Style="{StaticResource GlassCard}" Background="#14FBBF24" Margin="0,0,12,0">
+                <Grid>
+                    <Border Background="#FBBF24" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                            Margin="-16,-12,0,-12"/>
+                    <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
+                        <Ellipse Style="{StaticResource SevDot}" Fill="#FBBF24">
+                            <Ellipse.Effect>
+                                <DropShadowEffect Color="#FBBF24" BlurRadius="8" ShadowDepth="0" Opacity="0.6"/>
+                            </Ellipse.Effect>
+                        </Ellipse>
+                        <TextBlock Text="{Binding WarningCount}" FontSize="20" FontWeight="Bold"
+                                   Foreground="#FDE68A" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                        <TextBlock Text="Warnings" FontSize="12" Foreground="#64748B"
+                                   VerticalAlignment="Center" Margin="10,0,0,0"/>
+                    </StackPanel>
+                </Grid>
             </Border>
-            <Border Background="#11212A" BorderBrush="#38BDF8" BorderThickness="1" CornerRadius="999" Padding="14,8">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <Ellipse Style="{StaticResource SevDot}" Fill="#38BDF8" Margin="0,0,8,0"/>
-                    <TextBlock Text="{Binding InfoCount}" FontSize="14" FontWeight="SemiBold" Foreground="#38BDF8" VerticalAlignment="Center"/>
-                    <TextBlock Text=" Info" FontSize="12" Foreground="{StaticResource TextSecondary}" Margin="4,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
+            <!-- Info -->
+            <Border Style="{StaticResource GlassCard}" Background="#1438BDF8">
+                <Grid>
+                    <Border Background="#38BDF8" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                            Margin="-16,-12,0,-12"/>
+                    <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
+                        <Ellipse Style="{StaticResource SevDot}" Fill="#38BDF8">
+                            <Ellipse.Effect>
+                                <DropShadowEffect Color="#38BDF8" BlurRadius="8" ShadowDepth="0" Opacity="0.6"/>
+                            </Ellipse.Effect>
+                        </Ellipse>
+                        <TextBlock Text="{Binding InfoCount}" FontSize="20" FontWeight="Bold"
+                                   Foreground="#7DD3FC" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                        <TextBlock Text="Info" FontSize="12" Foreground="#64748B"
+                                   VerticalAlignment="Center" Margin="10,0,0,0"/>
+                    </StackPanel>
+                </Grid>
             </Border>
         </StackPanel>
 
@@ -175,8 +223,6 @@
                               IsReadOnly="True"
                               CanUserResizeColumns="True"
                               Background="Transparent"
-                              RowBackground="Transparent"
-                              AlternatingRowBackground="#0F141C"
                               BorderThickness="0"
                               SelectionMode="Single"
                               VirtualizingPanel.IsVirtualizing="True"

--- a/SysManager/SysManager/Views/NetworkRepairView.xaml
+++ b/SysManager/SysManager/Views/NetworkRepairView.xaml
@@ -27,7 +27,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
@@ -38,13 +38,18 @@
         </Border>
 
         <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="#0D1F12" BorderBrush="#22C55E44" BorderThickness="1"
-                CornerRadius="8" Padding="10,8" Margin="28,12,28,0"
+        <Border Grid.Row="1" Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <StackPanel Orientation="Horizontal">
-                <Ellipse Width="8" Height="8" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <TextBlock Text="Running as administrator — you can reset network settings." Foreground="#22C55E" FontSize="13" FontWeight="Medium"/>
-            </StackPanel>
+            <Grid>
+                <Border Background="#FBBF24" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — you can reset network settings."
+                               Foreground="#FCD34D" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
         </Border>
 
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,28">
@@ -52,19 +57,43 @@
                 <TextBlock Text="Winsock and TCP/IP resets require admin and a reboot."
                            Style="{StaticResource Subtle}" Margin="0,0,0,16"/>
 
-                <Border Style="{StaticResource Card}" Padding="16" Margin="0,0,0,12">
+                <Border Padding="16" Margin="0,0,0,12" CornerRadius="10" BorderThickness="1">
+                    <Border.Style>
+                        <Style TargetType="Border">
+                            <Setter Property="Background" Value="{StaticResource Surface1}"/>
+                            <Setter Property="BorderBrush" Value="{StaticResource Border1}"/>
+                            <Style.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Background" Value="#10141D"/>
+                                    <Setter Property="BorderBrush" Value="#2A3244"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Border.Style>
                     <DockPanel>
                         <StackPanel>
                             <TextBlock Text="Flush DNS Cache" FontWeight="SemiBold" FontSize="14"/>
                             <TextBlock Text="Clears the local DNS resolver cache. Fixes stale DNS entries. Safe, instant, no reboot."
                                        Style="{StaticResource Subtle}" FontSize="11" Margin="0,4,0,0" TextWrapping="Wrap" MaxWidth="600"/>
                         </StackPanel>
-                        <Button Content="Flush DNS" Command="{Binding FlushDnsCommand}" Style="{StaticResource PrimaryButton}"
+                        <Button Content="Flush DNS" Command="{Binding FlushDnsCommand}" Style="{StaticResource SecondaryButton}"
                                 HorizontalAlignment="Right" DockPanel.Dock="Right" Padding="18,8"
                                 IsEnabled="{Binding IsRepairing, Converter={StaticResource BoolInvert}}"/>
                     </DockPanel>
                 </Border>
-                <Border Style="{StaticResource Card}" Padding="16" Margin="0,0,0,12">
+                <Border Padding="16" Margin="0,0,0,12" CornerRadius="10" BorderThickness="1">
+                    <Border.Style>
+                        <Style TargetType="Border">
+                            <Setter Property="Background" Value="{StaticResource Surface1}"/>
+                            <Setter Property="BorderBrush" Value="{StaticResource Border1}"/>
+                            <Style.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Background" Value="#10141D"/>
+                                    <Setter Property="BorderBrush" Value="#2A3244"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Border.Style>
                     <DockPanel>
                         <StackPanel>
                             <TextBlock Text="Reset Winsock Catalog" FontWeight="SemiBold" FontSize="14"/>
@@ -76,7 +105,19 @@
                                 IsEnabled="{Binding IsRepairing, Converter={StaticResource BoolInvert}}"/>
                     </DockPanel>
                 </Border>
-                <Border Style="{StaticResource Card}" Padding="16" Margin="0,0,0,12">
+                <Border Padding="16" Margin="0,0,0,12" CornerRadius="10" BorderThickness="1">
+                    <Border.Style>
+                        <Style TargetType="Border">
+                            <Setter Property="Background" Value="{StaticResource Surface1}"/>
+                            <Setter Property="BorderBrush" Value="{StaticResource Border1}"/>
+                            <Style.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Background" Value="#10141D"/>
+                                    <Setter Property="BorderBrush" Value="#2A3244"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Border.Style>
                     <DockPanel>
                         <StackPanel>
                             <TextBlock Text="Reset TCP/IP Stack" FontWeight="SemiBold" FontSize="14"/>

--- a/SysManager/SysManager/Views/PerformanceView.xaml
+++ b/SysManager/SysManager/Views/PerformanceView.xaml
@@ -32,7 +32,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
@@ -43,13 +43,18 @@
         </Border>
 
         <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="#0D1F12" BorderBrush="#22C55E44" BorderThickness="1"
-                CornerRadius="8" Padding="10,8" Margin="0,0,0,12"
+        <Border Grid.Row="1" Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <StackPanel Orientation="Horizontal">
-                <Ellipse Width="8" Height="8" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <TextBlock Text="Running as administrator — you can apply performance tweaks and create restore points." Foreground="#22C55E" FontSize="13" FontWeight="Medium"/>
-            </StackPanel>
+            <Grid>
+                <Border Background="#FBBF24" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — you can apply performance tweaks and create restore points."
+                               Foreground="#FCD34D" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
         </Border>
 
         <!-- Toolbar -->

--- a/SysManager/SysManager/Views/PingView.xaml
+++ b/SysManager/SysManager/Views/PingView.xaml
@@ -102,40 +102,55 @@
                            Style="{StaticResource Subtle}" Margin="0,4,0,0" TextTrimming="CharacterEllipsis"/>
                 <ItemsControl ItemsSource="{Binding Shared.Targets}" Margin="0,14,0,0">
                     <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate><WrapPanel Orientation="Horizontal"/></ItemsPanelTemplate>
+                        <ItemsPanelTemplate>
+                            <UniformGrid Columns="2"/>
+                        </ItemsPanelTemplate>
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Border Margin="0,0,10,10" Padding="12,8" CornerRadius="999"
-                                    Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}" BorderThickness="1">
-                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                    <Ellipse Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,8,0"
-                                             Fill="{Binding ColorHex, Converter={StaticResource HexBrush}}"/>
-                                    <CheckBox IsChecked="{Binding IsEnabled}" VerticalAlignment="Center" Margin="0,0,2,0"/>
-                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                                    <TextBlock Text="  " VerticalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Host}" Foreground="{StaticResource TextMuted}" VerticalAlignment="Center" FontSize="11"/>
-                                    <Border Width="1" Height="14" Background="{StaticResource Border2}" Margin="10,0"/>
-                                    <TextBlock Text="{Binding LastLatencyMs, StringFormat={}{0:F0} ms, FallbackValue=—}"
-                                               VerticalAlignment="Center" Foreground="#60A5FA" FontWeight="SemiBold"/>
-                                    <TextBlock Text=" · " Foreground="{StaticResource TextMuted}" VerticalAlignment="Center"/>
-                                    <TextBlock Text="avg " Style="{StaticResource Caption}" VerticalAlignment="Center"/>
-                                    <TextBlock Text="{Binding AverageMs, StringFormat={}{0:F1}, FallbackValue=—}"
-                                               VerticalAlignment="Center" Foreground="{StaticResource TextSecondary}"/>
-                                    <TextBlock Text=" · " Foreground="{StaticResource TextMuted}" VerticalAlignment="Center"/>
-                                    <TextBlock Text="jitter " Style="{StaticResource Caption}" VerticalAlignment="Center"/>
-                                    <TextBlock Text="{Binding JitterMs, StringFormat={}{0:F0}, FallbackValue=—}"
-                                               VerticalAlignment="Center" Foreground="#F472B6"/>
-                                    <TextBlock Text=" · " Foreground="{StaticResource TextMuted}" VerticalAlignment="Center"/>
-                                    <TextBlock Text="loss " Style="{StaticResource Caption}" VerticalAlignment="Center"/>
-                                    <TextBlock Text="{Binding LossPercent, StringFormat={}{0:F0}%}"
-                                               VerticalAlignment="Center" Foreground="#FBBF24"/>
-                                    <Button Content="X" Margin="10,0,0,0" Padding="6,0" FontSize="10"
-                                            Style="{StaticResource GhostButton}"
-                                            Command="{Binding DataContext.RemoveTargetCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                            CommandParameter="{Binding}"
-                                            Visibility="{Binding IsCustom, Converter={StaticResource FlexVis}}"/>
-                                </StackPanel>
+                            <Border Margin="0,0,10,10" Padding="14,12" CornerRadius="12"
+                                    Background="#0D22C55E" BorderBrush="#0AFFFFFF" BorderThickness="1">
+                                <Grid>
+                                    <Border Background="{Binding ColorHex, Converter={StaticResource HexBrush}}"
+                                            Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                                            Margin="-14,-12,0,-12"/>
+                                    <DockPanel Margin="6,0,0,0">
+                                        <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" MinWidth="100">
+                                            <StackPanel Orientation="Horizontal">
+                                                <CheckBox IsChecked="{Binding IsEnabled}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13" VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                            <TextBlock Text="{Binding Host}" Foreground="{StaticResource TextMuted}" FontSize="11" Margin="22,2,0,0"/>
+                                        </StackPanel>
+                                        <Button Content="&#x2715;" DockPanel.Dock="Right" Padding="6,2" FontSize="10"
+                                                VerticalAlignment="Center" Style="{StaticResource GhostButton}"
+                                                Command="{Binding DataContext.RemoveTargetCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                CommandParameter="{Binding}"
+                                                Visibility="{Binding IsCustom, Converter={StaticResource FlexVis}}"/>
+                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                                            <StackPanel Margin="0,0,16,0" HorizontalAlignment="Center">
+                                                <TextBlock Text="{Binding LastLatencyMs, StringFormat={}{0:F0} ms, FallbackValue=—}"
+                                                           Foreground="#60A5FA" FontWeight="Bold" FontSize="13" HorizontalAlignment="Center"/>
+                                                <TextBlock Text="LATENCY" Foreground="#475569" FontSize="9" HorizontalAlignment="Center" Margin="0,2,0,0"/>
+                                            </StackPanel>
+                                            <StackPanel Margin="0,0,16,0" HorizontalAlignment="Center">
+                                                <TextBlock Text="{Binding AverageMs, StringFormat={}{0:F1}, FallbackValue=—}"
+                                                           Foreground="{StaticResource TextSecondary}" FontWeight="Bold" FontSize="13" HorizontalAlignment="Center"/>
+                                                <TextBlock Text="AVG" Foreground="#475569" FontSize="9" HorizontalAlignment="Center" Margin="0,2,0,0"/>
+                                            </StackPanel>
+                                            <StackPanel Margin="0,0,16,0" HorizontalAlignment="Center">
+                                                <TextBlock Text="{Binding JitterMs, StringFormat={}{0:F0}, FallbackValue=—}"
+                                                           Foreground="#F472B6" FontWeight="Bold" FontSize="13" HorizontalAlignment="Center"/>
+                                                <TextBlock Text="JITTER" Foreground="#475569" FontSize="9" HorizontalAlignment="Center" Margin="0,2,0,0"/>
+                                            </StackPanel>
+                                            <StackPanel HorizontalAlignment="Center">
+                                                <TextBlock Text="{Binding LossPercent, StringFormat={}{0:F0}%}"
+                                                           Foreground="#FBBF24" FontWeight="Bold" FontSize="13" HorizontalAlignment="Center"/>
+                                                <TextBlock Text="LOSS" Foreground="#475569" FontSize="9" HorizontalAlignment="Center" Margin="0,2,0,0"/>
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </DockPanel>
+                                </Grid>
                             </Border>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -25,8 +25,39 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
         </StackPanel>
 
+        <!-- Elevation banner: not elevated -->
+        <Border Grid.Row="1" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                    <TextBlock Text="Some privacy settings write to system-wide registry keys and require administrator privileges."
+                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- Elevation banner: elevated -->
+        <Border Grid.Row="1" Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Border Background="#FBBF24" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — all privacy toggles are available."
+                               Foreground="#FCD34D" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
         <!-- Toolbar -->
-        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
             <WrapPanel>
                 <Button Content="Apply All" Command="{Binding ApplyAllCommand}"
                         Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
@@ -41,37 +72,20 @@
                           SelectedItem="{Binding SelectedCategory}"
                           Width="140" Margin="0,0,12,0"/>
 
-                <Border Background="#1F2D1F" CornerRadius="4" Padding="6,2" Margin="4,0"
+                <Border CornerRadius="10" Padding="10,4" Margin="4,0"
+                        Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
                         Visibility="{Binding IsElevated, Converter={StaticResource BoolToVis}}">
-                    <TextBlock Text="Administrator" FontSize="11" Foreground="#4ADE80"/>
+                    <Grid>
+                        <Border Background="#FBBF24" Width="3" HorizontalAlignment="Left" CornerRadius="2"
+                                Margin="-10,-4,0,-4"/>
+                        <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
+                            <TextBlock Text="&#x1F6E1;" FontSize="11" VerticalAlignment="Center"/>
+                            <TextBlock Text="Administrator" FontSize="11" Foreground="#FCD34D"
+                                       FontWeight="SemiBold" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Grid>
                 </Border>
             </WrapPanel>
-        </Border>
-
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="2" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
-                        Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Padding="14,8"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
-                    <TextBlock Text="Some privacy settings write to system-wide registry keys and require administrator privileges."
-                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="2" Background="#0D1F12" BorderBrush="#22C55E44" BorderThickness="1"
-                CornerRadius="8" Padding="10,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <StackPanel Orientation="Horizontal">
-                <Ellipse Width="8" Height="8" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <TextBlock Text="Running as administrator — all privacy toggles are available." Foreground="#22C55E" FontSize="13" FontWeight="Medium"/>
-            </StackPanel>
         </Border>
 
         <!-- Toggle list grouped by category -->
@@ -92,8 +106,19 @@
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Border Margin="0,2" Padding="12,10" CornerRadius="6"
-                                    Background="#0A0E14"
-                                    BorderBrush="#1A1F2E" BorderThickness="1">
+                                    BorderThickness="1">
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Setter Property="Background" Value="#0A0E14"/>
+                                        <Setter Property="BorderBrush" Value="#1A1F2E"/>
+                                        <Style.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter Property="Background" Value="#10141D"/>
+                                                <Setter Property="BorderBrush" Value="#2A3244"/>
+                                            </Trigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*"/>

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -56,7 +56,6 @@
                       AutoGenerateColumns="False" HeadersVisibility="Column"
                       Background="Transparent" BorderThickness="0"
                       GridLinesVisibility="None" IsReadOnly="True"
-                      RowBackground="Transparent" AlternatingRowBackground="#0F141C"
                       SelectionMode="Single" CanUserSortColumns="True"
                       CanUserResizeColumns="True"
                       VirtualizingPanel.IsVirtualizing="True"
@@ -91,8 +90,13 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTextColumn Header="Mem" Binding="{Binding MemoryDisplay}" Width="70"
+                    <DataGridTextColumn Header="Memory" Binding="{Binding MemoryDisplay}" Width="80"
                                         SortMemberPath="MemoryBytes">
+                        <DataGridTextColumn.HeaderStyle>
+                            <Style TargetType="DataGridColumnHeader" BasedOn="{StaticResource {x:Type DataGridColumnHeader}}">
+                                <Setter Property="HorizontalContentAlignment" Value="Right"/>
+                            </Style>
+                        </DataGridTextColumn.HeaderStyle>
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="HorizontalAlignment" Value="Right"/>
@@ -102,8 +106,13 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTextColumn Header="CPU" Binding="{Binding CpuPercent, StringFormat={}{0:F1}%}" Width="50"
+                    <DataGridTextColumn Header="CPU" Binding="{Binding CpuPercent, StringFormat={}{0:F1}%}" Width="60"
                                         SortMemberPath="CpuPercent">
+                        <DataGridTextColumn.HeaderStyle>
+                            <Style TargetType="DataGridColumnHeader" BasedOn="{StaticResource {x:Type DataGridColumnHeader}}">
+                                <Setter Property="HorizontalContentAlignment" Value="Right"/>
+                            </Style>
+                        </DataGridTextColumn.HeaderStyle>
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="HorizontalAlignment" Value="Right"/>
@@ -114,8 +123,13 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTextColumn Header="Thr" Binding="{Binding ThreadCount}" Width="45"
+                    <DataGridTextColumn Header="Threads" Binding="{Binding ThreadCount}" Width="70"
                                         SortMemberPath="ThreadCount">
+                        <DataGridTextColumn.HeaderStyle>
+                            <Style TargetType="DataGridColumnHeader" BasedOn="{StaticResource {x:Type DataGridColumnHeader}}">
+                                <Setter Property="HorizontalContentAlignment" Value="Center"/>
+                            </Style>
+                        </DataGridTextColumn.HeaderStyle>
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="HorizontalAlignment" Value="Center"/>
@@ -125,21 +139,29 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTemplateColumn Header="Status" Width="80" SortMemberPath="Status">
+                    <DataGridTemplateColumn Header="Status" Width="100" SortMemberPath="Status">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                    <Ellipse Width="8" Height="8" VerticalAlignment="Center" Margin="0,0,6,0"
-                                             Fill="{Binding Status, Converter={StaticResource StatusBrush}}"/>
-                                    <TextBlock Text="{Binding Status}" FontSize="11"
-                                               Foreground="{Binding Status, Converter={StaticResource StatusBrush}}"
-                                               VerticalAlignment="Center"/>
-                                </StackPanel>
+                                <Border CornerRadius="8" Padding="8,4" VerticalAlignment="Center"
+                                        Background="#10FFFFFF" BorderThickness="1" BorderBrush="#0AFFFFFF">
+                                    <Grid>
+                                        <Border Width="3" HorizontalAlignment="Left" CornerRadius="2"
+                                                Margin="-8,-4,0,-4"
+                                                Background="{Binding Status, Converter={StaticResource StatusBrush}}"/>
+                                        <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
+                                            <Ellipse Width="6" Height="6" VerticalAlignment="Center"
+                                                     Fill="{Binding Status, Converter={StaticResource StatusBrush}}"/>
+                                            <TextBlock Text="{Binding Status}" FontSize="11" FontWeight="SemiBold"
+                                                       Foreground="{Binding Status, Converter={StaticResource StatusBrush}}"
+                                                       VerticalAlignment="Center" Margin="6,0,0,0"/>
+                                        </StackPanel>
+                                    </Grid>
+                                </Border>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTemplateColumn Header="Actions" Width="70" CanUserSort="False">
+                    <DataGridTemplateColumn Header="Actions" Width="120" CanUserSort="False">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal">

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -31,7 +31,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
-                        Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
@@ -42,13 +42,18 @@
         </Border>
 
         <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="#0D1F12" BorderBrush="#22C55E44" BorderThickness="1"
-                CornerRadius="8" Padding="10,8" Margin="0,0,0,12"
+        <Border Grid.Row="1" Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <StackPanel Orientation="Horizontal">
-                <Ellipse Width="8" Height="8" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <TextBlock Text="Running as administrator — you can start, stop, and configure services." Foreground="#22C55E" FontSize="13" FontWeight="Medium"/>
-            </StackPanel>
+            <Grid>
+                <Border Background="#FBBF24" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — you can start, stop, and configure services."
+                               Foreground="#FCD34D" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
         </Border>
 
         <!-- Toolbar -->
@@ -79,9 +84,9 @@
                   AutoGenerateColumns="False" HeadersVisibility="Column"
                   Background="Transparent" BorderThickness="0"
                   GridLinesVisibility="None" IsReadOnly="True"
-                  RowBackground="Transparent" AlternatingRowBackground="#0F141C"
                   SelectionMode="Single" CanUserSortColumns="True"
-                      CanUserResizeColumns="True"
+                  CanUserResizeColumns="True"
+                  ScrollViewer.HorizontalScrollBarVisibility="Auto"
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling">
             <DataGrid.Columns>
@@ -120,7 +125,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Actions" Width="200">
+                <DataGridTemplateColumn Header="Actions" Width="280">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <StackPanel Orientation="Horizontal">

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -45,7 +45,6 @@
                       CanUserAddRows="False"
                       Background="Transparent" BorderThickness="0"
                       GridLinesVisibility="None" IsReadOnly="False"
-                      RowBackground="Transparent" AlternatingRowBackground="#0F141C"
                       SelectionMode="Single" CanUserSortColumns="True"
                       CanUserResizeColumns="True"
                       VirtualizingPanel.IsVirtualizing="True"
@@ -62,7 +61,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTemplateColumn Header="Name" Width="*" SortMemberPath="Name">
+                    <DataGridTemplateColumn Header="Name" Width="*" MinWidth="200" SortMemberPath="Name">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal">
@@ -80,7 +79,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTextColumn Header="Publisher" Binding="{Binding Publisher}" Width="180"
+                    <DataGridTextColumn Header="Publisher" Binding="{Binding Publisher}" Width="160"
                                         SortMemberPath="Publisher" IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
@@ -90,11 +89,63 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTemplateColumn Header="Status" Width="100" SortMemberPath="StatusText">
+                    <DataGridTemplateColumn Header="Status" Width="120" SortMemberPath="StatusText">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <Border Style="{StaticResource Badge}" VerticalAlignment="Center" Margin="4,0">
-                                    <TextBlock Text="{Binding StatusText}" FontSize="11"/>
+                                <Border CornerRadius="8" Padding="8,5" VerticalAlignment="Center" Margin="4,0"
+                                        BorderThickness="1" BorderBrush="#0AFFFFFF">
+                                    <Border.Style>
+                                        <Style TargetType="Border">
+                                            <Setter Property="Background" Value="#1422C55E"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsEnabled}" Value="False">
+                                                    <Setter Property="Background" Value="#14475569"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Border.Style>
+                                    <Grid>
+                                        <Border Width="3" HorizontalAlignment="Left" CornerRadius="2"
+                                                Margin="-8,-5,0,-5">
+                                            <Border.Style>
+                                                <Style TargetType="Border">
+                                                    <Setter Property="Background" Value="#22C55E"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsEnabled}" Value="False">
+                                                            <Setter Property="Background" Value="#475569"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Border.Style>
+                                        </Border>
+                                        <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
+                                            <Ellipse Width="6" Height="6" VerticalAlignment="Center">
+                                                <Ellipse.Style>
+                                                    <Style TargetType="Ellipse">
+                                                        <Setter Property="Fill" Value="#22C55E"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding IsEnabled}" Value="False">
+                                                                <Setter Property="Fill" Value="#475569"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Ellipse.Style>
+                                            </Ellipse>
+                                            <TextBlock Text="{Binding StatusText}" FontSize="11" FontWeight="SemiBold"
+                                                       VerticalAlignment="Center" Margin="6,0,0,0">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Foreground" Value="#86EFAC"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding IsEnabled}" Value="False">
+                                                                <Setter Property="Foreground" Value="#94A3B8"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </StackPanel>
+                                    </Grid>
                                 </Border>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -32,7 +32,7 @@
                         Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
                     <DockPanel>
                         <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                                Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                                Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                             <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                        FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
@@ -43,13 +43,18 @@
                 </Border>
 
                 <!-- Elevation banner: elevated -->
-                <Border Background="#0D1F12" BorderBrush="#22C55E44" BorderThickness="1"
-                        CornerRadius="8" Padding="10,8" Margin="0,12,0,0"
+                <Border Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
+                        CornerRadius="10" Padding="12,8" Margin="0,12,0,0"
                         Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-                    <StackPanel Orientation="Horizontal">
-                        <Ellipse Width="8" Height="8" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                        <TextBlock Text="Running as administrator — you can run disk integrity checks." Foreground="#22C55E" FontSize="13" FontWeight="Medium"/>
-                    </StackPanel>
+                    <Grid>
+                        <Border Background="#FBBF24" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                                Margin="-12,-8,0,-8"/>
+                        <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                            <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                            <TextBlock Text="Running as administrator — you can run disk integrity checks."
+                                       Foreground="#FCD34D" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Grid>
                 </Border>
 
                 <!-- Summary card -->
@@ -68,8 +73,7 @@
                                   AutoGenerateColumns="False" HeadersVisibility="Column"
                                   GridLinesVisibility="None" IsReadOnly="True"
                                   CanUserResizeColumns="True"
-                                  Background="Transparent" RowBackground="Transparent"
-                                  AlternatingRowBackground="#0F141C" BorderThickness="0"
+                                  Background="Transparent" BorderThickness="0"
                                   Margin="0,10,0,0"
                                   VirtualizingPanel.IsVirtualizing="True"
                                   VirtualizingPanel.VirtualizationMode="Recycling">
@@ -122,8 +126,7 @@
                                   AutoGenerateColumns="False" HeadersVisibility="Column"
                                   GridLinesVisibility="None" IsReadOnly="True"
                                   CanUserResizeColumns="True"
-                                  Background="Transparent" RowBackground="Transparent"
-                                  AlternatingRowBackground="#0F141C" BorderThickness="0"
+                                  Background="Transparent" BorderThickness="0"
                                   Margin="0,10,0,0"
                                   VirtualizingPanel.IsVirtualizing="True"
                                   VirtualizingPanel.VirtualizationMode="Recycling">

--- a/SysManager/SysManager/Views/TracerouteView.xaml
+++ b/SysManager/SysManager/Views/TracerouteView.xaml
@@ -91,7 +91,6 @@
                               CanUserResizeColumns="True"
                               Background="Transparent" BorderThickness="0"
                               GridLinesVisibility="None" IsReadOnly="True"
-                              RowBackground="Transparent" AlternatingRowBackground="#0F141C"
                               VirtualizingPanel.IsVirtualizing="True"
                               VirtualizingPanel.VirtualizationMode="Recycling">
                         <DataGrid.Columns>

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -32,7 +32,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
-                        Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
@@ -43,13 +43,18 @@
         </Border>
 
         <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="#0D1F12" BorderBrush="#22C55E44" BorderThickness="1"
-                CornerRadius="8" Padding="10,8" Margin="0,0,0,12"
+        <Border Grid.Row="1" Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <StackPanel Orientation="Horizontal">
-                <Ellipse Width="8" Height="8" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <TextBlock Text="Running as administrator — you can uninstall any application." Foreground="#22C55E" FontSize="13" FontWeight="Medium"/>
-            </StackPanel>
+            <Grid>
+                <Border Background="#FBBF24" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — you can uninstall any application."
+                               Foreground="#FCD34D" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
         </Border>
 
         <!-- Toolbar -->
@@ -90,7 +95,6 @@
                       Background="Transparent" BorderThickness="0"
                       GridLinesVisibility="None" IsReadOnly="False"
                       CanUserAddRows="False"
-                      RowBackground="Transparent" AlternatingRowBackground="#0F141C"
                       SelectionMode="Single" CanUserSortColumns="True"
                       CanUserResizeColumns="True"
                       VirtualizingPanel.IsVirtualizing="True"
@@ -156,24 +160,68 @@
                     <DataGridTextColumn Header="Publisher" Binding="{Binding Publisher}" Width="180"
                                         SortMemberPath="Publisher" IsReadOnly="True"/>
 
-                    <DataGridTemplateColumn Header="Source" Width="80" SortMemberPath="Source">
+                    <DataGridTemplateColumn Header="Source" Width="90" SortMemberPath="Source">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <TextBlock FontSize="11" VerticalAlignment="Center" HorizontalAlignment="Center">
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Text" Value="{Binding Source}"/>
-                                            <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
+                                <Border CornerRadius="8" Padding="8,4" VerticalAlignment="Center"
+                                        BorderThickness="1" BorderBrush="#0AFFFFFF"
+                                        HorizontalAlignment="Center">
+                                    <Border.Style>
+                                        <Style TargetType="Border">
+                                            <Setter Property="Background" Value="#146366F1"/>
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding Source}" Value="">
-                                                    <Setter Property="Text" Value="Local"/>
-                                                    <Setter Property="Foreground" Value="#F59E0B"/>
-                                                    <Setter Property="ToolTip" Value="Not from winget — uses registry uninstall command"/>
+                                                    <Setter Property="Background" Value="#14FBBF24"/>
                                                 </DataTrigger>
                                             </Style.Triggers>
                                         </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
+                                    </Border.Style>
+                                    <Grid>
+                                        <Border Width="3" HorizontalAlignment="Left" CornerRadius="2"
+                                                Margin="-8,-4,0,-4">
+                                            <Border.Style>
+                                                <Style TargetType="Border">
+                                                    <Setter Property="Background" Value="#6366F1"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding Source}" Value="">
+                                                            <Setter Property="Background" Value="#FBBF24"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Border.Style>
+                                        </Border>
+                                        <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
+                                            <Ellipse Width="5" Height="5" VerticalAlignment="Center">
+                                                <Ellipse.Style>
+                                                    <Style TargetType="Ellipse">
+                                                        <Setter Property="Fill" Value="#6366F1"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Source}" Value="">
+                                                                <Setter Property="Fill" Value="#FBBF24"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Ellipse.Style>
+                                            </Ellipse>
+                                            <TextBlock FontSize="11" FontWeight="SemiBold"
+                                                       VerticalAlignment="Center" Margin="6,0,0,0">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Text" Value="{Binding Source}"/>
+                                                        <Setter Property="Foreground" Value="#A78BFA"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Source}" Value="">
+                                                                <Setter Property="Text" Value="Local"/>
+                                                                <Setter Property="Foreground" Value="#FDE68A"/>
+                                                                <Setter Property="ToolTip" Value="Not from winget — uses registry uninstall command"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </StackPanel>
+                                    </Grid>
+                                </Border>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
@@ -181,12 +229,18 @@
                     <DataGridTemplateColumn Header="Status" Width="180" SortMemberPath="Status">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <Border Style="{StaticResource Badge}"
+                                <Border CornerRadius="8" Padding="8,4"
+                                        Background="#14475569" BorderBrush="#0AFFFFFF" BorderThickness="1"
                                         VerticalAlignment="Center" Margin="4,0"
                                         Visibility="{Binding Status, Converter={StaticResource FlexVis}}"
                                         ToolTip="{Binding Status}">
-                                    <TextBlock Text="{Binding Status}" FontSize="11"
-                                               TextTrimming="CharacterEllipsis" MaxWidth="160"/>
+                                    <Grid>
+                                        <Border Background="#475569" Width="3" HorizontalAlignment="Left"
+                                                CornerRadius="2" Margin="-8,-4,0,-4"/>
+                                        <TextBlock Text="{Binding Status}" FontSize="11" Foreground="#94A3B8"
+                                                   FontWeight="SemiBold" Margin="4,0,0,0"
+                                                   TextTrimming="CharacterEllipsis" MaxWidth="160"/>
+                                    </Grid>
                                 </Border>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -47,9 +47,18 @@
                         Visibility="{Binding PendingReboot, Converter={StaticResource BoolToVis}}">
                     <TextBlock Text="⚠ Reboot pending" FontSize="11" Foreground="#F59E0B"/>
                 </Border>
-                <Border Background="#1F2D1F" CornerRadius="4" Padding="6,2" Margin="4,0"
+                <Border CornerRadius="10" Padding="10,5" Margin="4,0"
+                        Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
                         Visibility="{Binding IsElevated, Converter={StaticResource BoolToVis}}">
-                    <TextBlock Text="✓ Administrator" FontSize="11" Foreground="#4ADE80"/>
+                    <Grid>
+                        <Border Background="#FBBF24" Width="3" HorizontalAlignment="Left" CornerRadius="2"
+                                Margin="-10,-5,0,-5"/>
+                        <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
+                            <TextBlock Text="&#x1F6E1;" FontSize="11" VerticalAlignment="Center"/>
+                            <TextBlock Text="Administrator" Foreground="#FCD34D" FontSize="11"
+                                       FontWeight="SemiBold" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Grid>
                 </Border>
             </WrapPanel>
         </Border>
@@ -60,7 +69,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
-                        Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
@@ -71,13 +80,18 @@
         </Border>
 
         <!-- Elevation banner: elevated -->
-        <Border Grid.Row="2" Background="#0D1F12" BorderBrush="#22C55E44" BorderThickness="1"
-                CornerRadius="8" Padding="10,8" Margin="0,0,0,12"
+        <Border Grid.Row="2" Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <StackPanel Orientation="Horizontal">
-                <Ellipse Width="8" Height="8" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <TextBlock Text="Running as administrator — you can enable and disable Windows features." Foreground="#22C55E" FontSize="13" FontWeight="Medium"/>
-            </StackPanel>
+            <Grid>
+                <Border Background="#FBBF24" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — you can enable and disable Windows features."
+                               Foreground="#FCD34D" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
         </Border>
 
         <!-- Summary -->
@@ -91,7 +105,6 @@
                       AutoGenerateColumns="False" HeadersVisibility="Column"
                       Background="Transparent" BorderThickness="0"
                       GridLinesVisibility="None" IsReadOnly="True"
-                      RowBackground="Transparent" AlternatingRowBackground="#0F141C"
                       SelectionMode="Single" CanUserSortColumns="True"
                       CanUserResizeColumns="True"
                       VirtualizingPanel.IsVirtualizing="True"
@@ -161,30 +174,91 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTemplateColumn Header="Status" Width="120" SortMemberPath="Status">
+                    <DataGridTemplateColumn Header="Status" Width="130" SortMemberPath="Status">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding Status}" FontSize="11"
-                                           VerticalAlignment="Center"
-                                           TextTrimming="CharacterEllipsis"
-                                           ToolTip="{Binding Status}">
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
+                                <Border CornerRadius="8" Padding="8,4" VerticalAlignment="Center"
+                                        BorderThickness="1" BorderBrush="#0AFFFFFF"
+                                        Visibility="{Binding Status, Converter={StaticResource FlexVis}}"
+                                        ToolTip="{Binding Status}">
+                                    <Border.Style>
+                                        <Style TargetType="Border">
+                                            <Setter Property="Background" Value="#14475569"/>
                                             <Style.Triggers>
-                                                <DataTrigger Binding="{Binding Status}" Value="Reboot required">
-                                                    <Setter Property="Foreground" Value="#F59E0B"/>
-                                                </DataTrigger>
                                                 <DataTrigger Binding="{Binding Status}" Value="Done">
-                                                    <Setter Property="Foreground" Value="#4ADE80"/>
+                                                    <Setter Property="Background" Value="#1422C55E"/>
                                                 </DataTrigger>
                                                 <DataTrigger Binding="{Binding Status}" Value="Failed">
-                                                    <Setter Property="Foreground" Value="#EF4444"/>
+                                                    <Setter Property="Background" Value="#14EF4444"/>
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding Status}" Value="Reboot required">
+                                                    <Setter Property="Background" Value="#14F59E0B"/>
                                                 </DataTrigger>
                                             </Style.Triggers>
                                         </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
+                                    </Border.Style>
+                                    <Grid>
+                                        <Border Width="3" HorizontalAlignment="Left" CornerRadius="2"
+                                                Margin="-8,-4,0,-4">
+                                            <Border.Style>
+                                                <Style TargetType="Border">
+                                                    <Setter Property="Background" Value="#475569"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding Status}" Value="Done">
+                                                            <Setter Property="Background" Value="#22C55E"/>
+                                                        </DataTrigger>
+                                                        <DataTrigger Binding="{Binding Status}" Value="Failed">
+                                                            <Setter Property="Background" Value="#EF4444"/>
+                                                        </DataTrigger>
+                                                        <DataTrigger Binding="{Binding Status}" Value="Reboot required">
+                                                            <Setter Property="Background" Value="#F59E0B"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Border.Style>
+                                        </Border>
+                                        <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
+                                            <Ellipse Width="6" Height="6" VerticalAlignment="Center">
+                                                <Ellipse.Style>
+                                                    <Style TargetType="Ellipse">
+                                                        <Setter Property="Fill" Value="#475569"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Status}" Value="Done">
+                                                                <Setter Property="Fill" Value="#22C55E"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Status}" Value="Failed">
+                                                                <Setter Property="Fill" Value="#EF4444"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Status}" Value="Reboot required">
+                                                                <Setter Property="Fill" Value="#F59E0B"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Ellipse.Style>
+                                            </Ellipse>
+                                            <TextBlock Text="{Binding Status}" FontSize="11" FontWeight="SemiBold"
+                                                       VerticalAlignment="Center" Margin="6,0,0,0"
+                                                       TextTrimming="CharacterEllipsis">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Foreground" Value="#94A3B8"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Status}" Value="Done">
+                                                                <Setter Property="Foreground" Value="#86EFAC"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Status}" Value="Failed">
+                                                                <Setter Property="Foreground" Value="#FCA5A5"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Status}" Value="Reboot required">
+                                                                <Setter Property="Foreground" Value="#FDE68A"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </StackPanel>
+                                    </Grid>
+                                </Border>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -109,9 +109,12 @@
                     <Button Content="Feature upgrades" Command="{Binding ListFeatureUpdatesCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"/>
                     <Button Content="History" Command="{Binding ShowHistoryCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"/>
                     <Button Content="Pending reboot?" Command="{Binding CheckPendingRebootCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"/>
-                    <Button Content="Install selected" Command="{Binding InstallUpdatesCommand}" Style="{StaticResource PrimaryButton}" Margin="0,0,8,8"/>
-                    <Button Content="Select all" Command="{Binding SelectAllCommand}" Style="{StaticResource GhostButton}" Margin="0,0,8,8"/>
-                    <Button Content="Deselect all" Command="{Binding DeselectAllCommand}" Style="{StaticResource GhostButton}" Margin="0,0,8,8"/>
+                    <Button Content="Install selected" Command="{Binding InstallUpdatesCommand}" Style="{StaticResource PrimaryButton}" Margin="0,0,8,8"
+                            Visibility="{Binding IsShowingHistory, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                    <Button Content="Select all" Command="{Binding SelectAllCommand}" Style="{StaticResource GhostButton}" Margin="0,0,8,8"
+                            Visibility="{Binding IsShowingHistory, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                    <Button Content="Deselect all" Command="{Binding DeselectAllCommand}" Style="{StaticResource GhostButton}" Margin="0,0,8,8"
+                            Visibility="{Binding IsShowingHistory, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                     <Button Content="Cancel" Command="{Binding CancelCommand}" Style="{StaticResource GhostButton}" Margin="0,0,8,8"/>
                 </WrapPanel>
             </StackPanel>

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -41,7 +41,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
@@ -52,13 +52,18 @@
         </Border>
 
         <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="#0D1F12" BorderBrush="#22C55E44" BorderThickness="1"
-                CornerRadius="8" Padding="10,8" Margin="28,12,28,0"
+        <Border Grid.Row="1" Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <StackPanel Orientation="Horizontal">
-                <Ellipse Width="8" Height="8" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <TextBlock Text="Running as administrator — you can list and install updates." Foreground="#22C55E" FontSize="13" FontWeight="Medium"/>
-            </StackPanel>
+            <Grid>
+                <Border Background="#FBBF24" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — you can list and install updates."
+                               Foreground="#FCD34D" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
         </Border>
 
         <!-- Module status: missing -->
@@ -124,7 +129,6 @@
                       AutoGenerateColumns="False" HeadersVisibility="Column"
                       Background="Transparent" BorderThickness="0"
                       GridLinesVisibility="None"
-                      RowBackground="Transparent" AlternatingRowBackground="#0F141C"
                       SelectionMode="Single" CanUserSortColumns="True"
                       CanUserResizeColumns="True"
                       CanUserAddRows="False"


### PR DESCRIPTION
## Summary
- Complete UI redesign: glass cards, golden admin system, modern components, purple accent throughout
- Dark title bar via DWM API
- Global ProgressBar/RadioButton/CheckBox accent color styles
- Missing Download button in updater card
- SSD warning banner on File Shredder
- Windows Features status column populated on load
- Robust startup app path extraction (fixes Open folder for lghub etc.)
- DNS detection skips virtual adapters
- Startup Manager refresh threading fix
- Hide Install/Select buttons in Windows Update history view
- Bulk installer hover highlight improved
- ReleaseHistory single notification (ObservableCollection → IReadOnlyList)

## Test plan
- [ ] Verify dark title bar on Windows 11
- [ ] Verify ProgressBars are purple across all tabs
- [ ] Verify RadioButtons (Performance power plan) are purple
- [ ] Click Download button when update is available
- [ ] Open File Shredder — SSD warning visible
- [ ] Windows Features — status column shows Enabled/Disabled
- [ ] Startup Manager — Refresh works, Open folder works for various apps
- [ ] DNS tab — current DNS detected correctly
- [ ] Windows Update — History tab hides Install/Select buttons
- [ ] Bulk Installer — hover highlight visible on app rows
