### PR TITLE
fix: startup column overflow, icon resolution, live output sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Startup Manager columns** — reduced fixed widths to prevent last column overflow.
+- **Startup Manager icons** — use extracted executable path for more accurate icon resolution.
+- **Windows Update live output** — increased MinHeight/MaxHeight for better visibility.
+
 ## [1.9.0] - 2026-05-26
 
 ### Added

--- a/SysManager/SysManager/ViewModels/StartupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StartupViewModel.cs
@@ -54,7 +54,10 @@ public sealed partial class StartupViewModel : ViewModelBase
             var items = await _service.ScanAsync().ConfigureAwait(false);
             var sorted = items.OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase).ToList();
             foreach (var item in sorted)
-                item.Icon = IconExtractorService.GetIcon(item.Command);
+            {
+                var exePath = ExtractExecutablePath(item.Command);
+                item.Icon = IconExtractorService.GetIcon(exePath ?? item.Command);
+            }
 
             if (System.Windows.Application.Current?.Dispatcher is { } dispatcher)
             {

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -62,7 +62,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTemplateColumn Header="Name" Width="*" MinWidth="200" SortMemberPath="Name">
+                    <DataGridTemplateColumn Header="Name" Width="*" MinWidth="150" SortMemberPath="Name">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal">
@@ -80,7 +80,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTextColumn Header="Publisher" Binding="{Binding Publisher}" Width="160"
+                    <DataGridTextColumn Header="Publisher" Binding="{Binding Publisher}" Width="140"
                                         SortMemberPath="Publisher" IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
@@ -90,7 +90,7 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTemplateColumn Header="Status" Width="120" SortMemberPath="StatusText">
+                    <DataGridTemplateColumn Header="Status" Width="100" SortMemberPath="StatusText">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Border CornerRadius="8" Padding="8,5" VerticalAlignment="Center" Margin="4,0"

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -211,7 +211,7 @@
         <!-- Console output (collapsible — shown only during install/reboot check) -->
         <Border Grid.Row="6" Style="{StaticResource Card}" Margin="28,16,28,0" Padding="0"
                 Visibility="{Binding ShowConsole, Converter={StaticResource BoolToVis}}"
-                MaxHeight="200">
+                MinHeight="180" MaxHeight="350">
             <Expander Header="Live output" IsExpanded="True" Padding="8">
                 <v:ConsoleView DataContext="{Binding Console}"/>
             </Expander>


### PR DESCRIPTION
## Summary
- Startup Manager: reduced Publisher (160→140) and Status (120→100) column widths, Name MinWidth 200→150 to prevent last column going off-screen
- Startup Manager: icon extraction uses parsed executable path instead of raw command string
- Windows Update: live output area MinHeight 180px, MaxHeight 350px (was 200 max only)

## Test plan
- [ ] Startup Manager — all columns visible without horizontal scroll at default window size
- [ ] Startup Manager — icons load correctly for apps like lghub, OneDrive, etc.
- [ ] Windows Update — live output panel is taller and more readable during install