### PR TITLE
feat: safety ratings, filter chips, hide system toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Fixed
-- **Startup Manager columns** — reduced fixed widths to prevent last column overflow.
-- **Startup Manager icons** — use extracted executable path for more accurate icon resolution.
-- **Windows Update live output** — increased MinHeight/MaxHeight for better visibility.
+## [1.10.0] - 2026-05-26
+
+### Added
+- **Safety ratings on Services** — each service shows Safe/Caution/Critical badge with
+  description tooltip. Filter chips in toolbar to show only safe-to-disable services.
+- **Safety ratings on Windows Features** — same badge system as Services.
+- **Curated safety database** — 50+ services and 20+ features with researched safety
+  levels and human-readable explanations.
+- **Startup Manager hide system** — toggle to filter out Windows/Microsoft system entries.
+- **Filter chip styles** — reusable green/amber/red radio pill components.
 
 ## [1.9.0] - 2026-05-26
 

--- a/SysManager/SysManager.Tests/ServicesViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ServicesViewModelTests.cs
@@ -17,11 +17,11 @@ public class ServicesViewModelTests
 {
     private static readonly List<ServiceEntry> TestServices = new()
     {
-        new() { Name = "wuauserv", DisplayName = "Windows Update", Description = "Manages Windows updates", Status = "Running", StartType = "Automatic", Recommendation = "keep-enabled" },
-        new() { Name = "Spooler", DisplayName = "Print Spooler", Description = "Manages print jobs", Status = "Running", StartType = "Automatic", Recommendation = "safe-to-disable" },
-        new() { Name = "XboxGipSvc", DisplayName = "Xbox Accessory Management", Description = "Manages Xbox accessories", Status = "Stopped", StartType = "Manual", Recommendation = "safe-to-disable" },
-        new() { Name = "WSearch", DisplayName = "Windows Search", Description = "Provides content indexing", Status = "Running", StartType = "Automatic", Recommendation = "advanced" },
-        new() { Name = "BITS", DisplayName = "Background Intelligent Transfer", Description = "Transfers files in background", Status = "Stopped", StartType = "Manual", Recommendation = "keep-enabled" },
+        new() { Name = "wuauserv", DisplayName = "Windows Update", Description = "Manages Windows updates", Status = "Running", StartType = "Automatic", Recommendation = "keep-enabled", SafetyLevel = Models.SafetyLevel.Caution },
+        new() { Name = "Spooler", DisplayName = "Print Spooler", Description = "Manages print jobs", Status = "Running", StartType = "Automatic", Recommendation = "safe-to-disable", SafetyLevel = Models.SafetyLevel.Caution },
+        new() { Name = "XboxGipSvc", DisplayName = "Xbox Accessory Management", Description = "Manages Xbox accessories", Status = "Stopped", StartType = "Manual", Recommendation = "safe-to-disable", SafetyLevel = Models.SafetyLevel.Safe },
+        new() { Name = "WSearch", DisplayName = "Windows Search", Description = "Provides content indexing", Status = "Running", StartType = "Automatic", Recommendation = "advanced", SafetyLevel = Models.SafetyLevel.Caution },
+        new() { Name = "BITS", DisplayName = "Background Intelligent Transfer", Description = "Transfers files in background", Status = "Stopped", StartType = "Manual", Recommendation = "keep-enabled", SafetyLevel = Models.SafetyLevel.Critical },
     };
 
     private static ServicesViewModel CreateWithData(List<ServiceEntry>? services = null)
@@ -52,8 +52,9 @@ public class ServicesViewModelTests
         Assert.Contains("All", vm.FilterOptions);
         Assert.Contains("Running", vm.FilterOptions);
         Assert.Contains("Stopped", vm.FilterOptions);
-        Assert.Contains("Safe to disable", vm.FilterOptions);
-        Assert.Contains("Advanced", vm.FilterOptions);
+        Assert.Contains("Safe", vm.FilterOptions);
+        Assert.Contains("Caution", vm.FilterOptions);
+        Assert.Contains("Critical", vm.FilterOptions);
     }
 
     [Fact]
@@ -111,21 +112,20 @@ public class ServicesViewModelTests
     }
 
     [Fact]
-    public void ApplyFilter_SafeToDisable_ShowsOnlySafe()
+    public void ApplyFilter_SafeLevel_ShowsOnlySafe()
     {
         var vm = CreateWithData();
-        vm.SelectedFilter = "Safe to disable";
-        Assert.All(vm.Services, s => Assert.Equal("safe-to-disable", s.Recommendation));
-        Assert.Equal(2, vm.Services.Count);
+        vm.SelectedFilter = "Safe";
+        Assert.All(vm.Services, s => Assert.Equal(Models.SafetyLevel.Safe, s.SafetyLevel));
+        Assert.Single(vm.Services);
     }
 
     [Fact]
-    public void ApplyFilter_Advanced_ShowsOnlyAdvanced()
+    public void ApplyFilter_Safe_ShowsOnlySafe()
     {
         var vm = CreateWithData();
-        vm.SelectedFilter = "Advanced";
-        Assert.All(vm.Services, s => Assert.Equal("advanced", s.Recommendation));
-        Assert.Single(vm.Services);
+        vm.SelectedFilter = "Safe";
+        Assert.All(vm.Services, s => Assert.Equal(Models.SafetyLevel.Safe, s.SafetyLevel));
     }
 
     // ── ApplyFilter: text filter ──

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -21,6 +21,9 @@
             <h:HexToBrushConverter x:Key="HexBrush"/>
             <h:OutputKindToBrushConverter x:Key="KindBrush"/>
             <h:ProcessStatusToBrushConverter x:Key="StatusBrush"/>
+            <h:SafetyLevelToBrushConverter x:Key="SafetyBrush"/>
+            <h:SafetyLevelToBackgroundConverter x:Key="SafetyBg"/>
+            <h:SafetyLevelToTextConverter x:Key="SafetyText"/>
             <h:IntGreaterThanZeroConverter x:Key="GreaterThanZero"/>
             <h:EqualityConverter x:Key="IsEqual"/>
 
@@ -266,6 +269,92 @@
                                 </Trigger>
                                 <Trigger Property="IsEnabled" Value="False">
                                     <Setter Property="Opacity" Value="0.4"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <!-- ============================================================ -->
+            <!-- Filter Chips — safety level radio buttons                    -->
+            <!-- ============================================================ -->
+            <Style x:Key="FilterChip" TargetType="RadioButton">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="RadioButton">
+                            <Border x:Name="Bd" CornerRadius="999" Padding="8,4"
+                                    Background="#1522C55E" BorderBrush="#3022C55E" BorderThickness="1"
+                                    Cursor="Hand">
+                                <StackPanel Orientation="Horizontal">
+                                    <Ellipse x:Name="Dot" Width="6" Height="6" Fill="#22C55E" Margin="0,0,5,0"/>
+                                    <ContentPresenter VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsChecked" Value="True">
+                                    <Setter TargetName="Bd" Property="Background" Value="#3022C55E"/>
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="#6022C55E"/>
+                                </Trigger>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="Bd" Property="Background" Value="#186366F1"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="Foreground" Value="#4ADE80"/>
+                <Setter Property="FontSize" Value="11"/>
+                <Setter Property="FontWeight" Value="Medium"/>
+            </Style>
+
+            <Style x:Key="FilterChipCaution" TargetType="RadioButton" BasedOn="{StaticResource FilterChip}">
+                <Setter Property="Foreground" Value="#FBBF24"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="RadioButton">
+                            <Border x:Name="Bd" CornerRadius="999" Padding="8,4"
+                                    Background="#15F59E0B" BorderBrush="#30F59E0B" BorderThickness="1"
+                                    Cursor="Hand">
+                                <StackPanel Orientation="Horizontal">
+                                    <Ellipse x:Name="Dot" Width="6" Height="6" Fill="#F59E0B" Margin="0,0,5,0"/>
+                                    <ContentPresenter VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsChecked" Value="True">
+                                    <Setter TargetName="Bd" Property="Background" Value="#30F59E0B"/>
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="#60F59E0B"/>
+                                </Trigger>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="Bd" Property="Background" Value="#186366F1"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <Style x:Key="FilterChipCritical" TargetType="RadioButton" BasedOn="{StaticResource FilterChip}">
+                <Setter Property="Foreground" Value="#F87171"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="RadioButton">
+                            <Border x:Name="Bd" CornerRadius="999" Padding="8,4"
+                                    Background="#15EF4444" BorderBrush="#30EF4444" BorderThickness="1"
+                                    Cursor="Hand">
+                                <StackPanel Orientation="Horizontal">
+                                    <Ellipse x:Name="Dot" Width="6" Height="6" Fill="#EF4444" Margin="0,0,5,0"/>
+                                    <ContentPresenter VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsChecked" Value="True">
+                                    <Setter TargetName="Bd" Property="Background" Value="#30EF4444"/>
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="#60EF4444"/>
+                                </Trigger>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="Bd" Property="Background" Value="#186366F1"/>
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>

--- a/SysManager/SysManager/Helpers/ValueConverters.cs
+++ b/SysManager/SysManager/Helpers/ValueConverters.cs
@@ -146,3 +146,76 @@ public sealed class ProcessStatusToBrushConverter : IValueConverter
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         => throw new NotSupportedException();
 }
+
+public sealed class SafetyLevelToBrushConverter : IValueConverter
+{
+    private static readonly SolidColorBrush SafeBrush = new(Color.FromRgb(0x4A, 0xDE, 0x80));
+    private static readonly SolidColorBrush CautionBrush = new(Color.FromRgb(0xFB, 0xBF, 0x24));
+    private static readonly SolidColorBrush CriticalBrush = new(Color.FromRgb(0xF8, 0x71, 0x71));
+
+    static SafetyLevelToBrushConverter()
+    {
+        SafeBrush.Freeze();
+        CautionBrush.Freeze();
+        CriticalBrush.Freeze();
+    }
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value is SafetyLevel level ? level switch
+        {
+            SafetyLevel.Safe => SafeBrush,
+            SafetyLevel.Caution => CautionBrush,
+            SafetyLevel.Critical => CriticalBrush,
+            _ => CriticalBrush
+        } : CriticalBrush;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+public sealed class SafetyLevelToBackgroundConverter : IValueConverter
+{
+    private static readonly SolidColorBrush SafeBg = new(Color.FromArgb(0x20, 0x22, 0xC5, 0x5E));
+    private static readonly SolidColorBrush CautionBg = new(Color.FromArgb(0x20, 0xF5, 0x9E, 0x0B));
+    private static readonly SolidColorBrush CriticalBg = new(Color.FromArgb(0x20, 0xEF, 0x44, 0x44));
+
+    static SafetyLevelToBackgroundConverter()
+    {
+        SafeBg.Freeze();
+        CautionBg.Freeze();
+        CriticalBg.Freeze();
+    }
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value is SafetyLevel level ? level switch
+        {
+            SafetyLevel.Safe => SafeBg,
+            SafetyLevel.Caution => CautionBg,
+            SafetyLevel.Critical => CriticalBg,
+            _ => CriticalBg
+        } : CriticalBg;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+public sealed class SafetyLevelToTextConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value is SafetyLevel level ? level switch
+        {
+            SafetyLevel.Safe => "Safe",
+            SafetyLevel.Caution => "Caution",
+            SafetyLevel.Critical => "Critical",
+            _ => "Critical"
+        } : "Critical";
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/SysManager/SysManager/Models/SafetyLevel.cs
+++ b/SysManager/SysManager/Models/SafetyLevel.cs
@@ -1,0 +1,12 @@
+// SysManager · SafetyLevel
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+public enum SafetyLevel
+{
+    Safe,
+    Caution,
+    Critical
+}

--- a/SysManager/SysManager/Models/ServiceEntry.cs
+++ b/SysManager/SysManager/Models/ServiceEntry.cs
@@ -24,4 +24,7 @@ public sealed partial class ServiceEntry : ObservableObject
 
     /// <summary>Short explanation of what this service does and why the recommendation.</summary>
     public string RecommendationReason { get; init; } = "";
+
+    public SafetyLevel SafetyLevel { get; init; } = SafetyLevel.Critical;
+    public string SafetyDescription { get; init; } = "";
 }

--- a/SysManager/SysManager/Models/WindowsFeature.cs
+++ b/SysManager/SysManager/Models/WindowsFeature.cs
@@ -18,6 +18,9 @@ public sealed partial class WindowsFeature : ObservableObject
     [ObservableProperty] private string _category = "Other";
     [ObservableProperty] private string _status = "";
 
+    public SafetyLevel SafetyLevel { get; init; } = SafetyLevel.Caution;
+    public string SafetyDescription { get; init; } = "";
+
     /// <summary>Category assignment based on feature name patterns.</summary>
     public static string CategorizeFeature(string featureName)
     {

--- a/SysManager/SysManager/Services/SafetyDatabase.cs
+++ b/SysManager/SysManager/Services/SafetyDatabase.cs
@@ -1,0 +1,130 @@
+// SysManager · SafetyDatabase — curated safety ratings for services and features
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+public static class SafetyDatabase
+{
+    public static (SafetyLevel Level, string Description) GetServiceSafety(string serviceName)
+    {
+        if (SafeServices.TryGetValue(serviceName, out var safe))
+            return (SafetyLevel.Safe, safe);
+        if (CautionServices.TryGetValue(serviceName, out var caution))
+            return (SafetyLevel.Caution, caution);
+        if (CriticalServices.TryGetValue(serviceName, out var critical))
+            return (SafetyLevel.Critical, critical);
+        return (SafetyLevel.Critical, "Unknown service — treat as critical until verified.");
+    }
+
+    public static (SafetyLevel Level, string Description) GetFeatureSafety(string featureName)
+    {
+        if (SafeFeatures.TryGetValue(featureName, out var safe))
+            return (SafetyLevel.Safe, safe);
+        if (CautionFeatures.TryGetValue(featureName, out var caution))
+            return (SafetyLevel.Caution, caution);
+        if (CriticalFeatures.TryGetValue(featureName, out var critical))
+            return (SafetyLevel.Critical, critical);
+        return (SafetyLevel.Caution, "Check documentation before modifying.");
+    }
+
+    private static readonly Dictionary<string, string> SafeServices = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["DiagTrack"] = "Connected User Experiences and Telemetry — sends diagnostic data to Microsoft. Disabling stops all telemetry.",
+        ["dmwappushservice"] = "WAP Push Message Routing — used for telemetry delivery. Safe to disable.",
+        ["SysMain"] = "Superfetch — prefetches apps into memory. Unnecessary on SSD, wastes write cycles.",
+        ["WSearch"] = "Windows Search Indexer — indexes files for fast search. Disable if you use Everything or don't search in Explorer.",
+        ["MapsBroker"] = "Downloaded Maps Manager — background map updates. Safe unless you use Windows Maps.",
+        ["lfsvc"] = "Geolocation Service — tracks device location. Disable for privacy unless apps need it.",
+        ["RetailDemo"] = "Retail Demo Service — only for store display PCs. Always safe to disable.",
+        ["wisvc"] = "Windows Insider Service — only needed if in Insider Program.",
+        ["TabletInputService"] = "Touch Keyboard and Handwriting — only needed on touchscreen devices.",
+        ["Fax"] = "Windows Fax — only needed if you send faxes through a modem.",
+        ["XblAuthManager"] = "Xbox Live Auth Manager — only needed for Xbox/Game Pass features.",
+        ["XblGameSave"] = "Xbox Live Game Save — only needed for Xbox cloud saves.",
+        ["XboxGipSvc"] = "Xbox Accessory Management — only needed for Xbox controllers via Xbox app.",
+        ["XboxNetApiSvc"] = "Xbox Live Networking — only needed for Xbox multiplayer.",
+        ["WMPNetworkSvc"] = "Windows Media Player Network Sharing — legacy media sharing. Rarely needed.",
+        ["AxInstSV"] = "ActiveX Installer — legacy IE component. Not needed on modern browsers.",
+        ["RemoteRegistry"] = "Remote Registry — allows remote registry editing. Security risk if enabled.",
+        ["TrkWks"] = "Distributed Link Tracking Client — tracks NTFS links across network. Rarely needed.",
+        ["WerSvc"] = "Windows Error Reporting — sends crash reports to Microsoft.",
+        ["PhoneSvc"] = "Phone Service — manages telephony state. Not needed on desktops.",
+    };
+
+    private static readonly Dictionary<string, string> CautionServices = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["wuauserv"] = "Windows Update — handles updates. Disabling prevents security patches. Only disable temporarily.",
+        ["Spooler"] = "Print Spooler — required for printing. Disable only if you never print.",
+        ["BITS"] = "Background Intelligent Transfer — used by Windows Update and Store. Disabling may break updates.",
+        ["Themes"] = "Themes — provides visual themes. Disabling gives classic look but saves minimal resources.",
+        ["AudioSrv"] = "Windows Audio — disabling removes all sound. Only disable on headless servers.",
+        ["Audiosrv"] = "Windows Audio — disabling removes all sound.",
+        ["Dhcp"] = "DHCP Client — auto-assigns IP. Disable only with static IP configured.",
+        ["Dnscache"] = "DNS Client — caches DNS lookups. Disabling slows browsing.",
+        ["EventLog"] = "Windows Event Log — disabling prevents all logging. Bad for troubleshooting.",
+        ["LanmanServer"] = "Server — SMB file sharing. Disable if you don't share files on network.",
+        ["LanmanWorkstation"] = "Workstation — SMB client. Disable if you don't access network shares.",
+        ["Schedule"] = "Task Scheduler — many system tasks depend on this. Disabling can break maintenance.",
+    };
+
+    private static readonly Dictionary<string, string> CriticalServices = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["RpcSs"] = "Remote Procedure Call — core Windows IPC. System will not function without it.",
+        ["RpcEptMapper"] = "RPC Endpoint Mapper — required by RPC. Do not disable.",
+        ["DcomLaunch"] = "DCOM Server Process Launcher — core component. Breaking this crashes Windows.",
+        ["LSM"] = "Local Session Manager — manages user sessions. Disabling prevents login.",
+        ["SamSs"] = "Security Accounts Manager — stores security credentials. Critical for authentication.",
+        ["WinDefend"] = "Windows Defender Antivirus — primary security layer. Do not disable without replacement.",
+        ["mpssvc"] = "Windows Defender Firewall — network protection. Disabling exposes all ports.",
+        ["BFE"] = "Base Filtering Engine — core firewall engine. Required by Windows Firewall.",
+        ["CryptSvc"] = "Cryptographic Services — handles certificates, Windows Update signatures. Breaking halts updates.",
+        ["lsass"] = "Local Security Authority — authentication core. Cannot be disabled.",
+        ["Winmgmt"] = "Windows Management Instrumentation — WMI is used by most management tools.",
+        ["PlugPlay"] = "Plug and Play — device detection. Disabling breaks hardware recognition.",
+        ["Power"] = "Power — manages power policy. Disabling causes unpredictable behavior.",
+        ["ProfSvc"] = "User Profile Service — loads user profiles. Disabling prevents login.",
+        ["nsi"] = "Network Store Interface — network connectivity core.",
+    };
+
+    private static readonly Dictionary<string, string> SafeFeatures = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Internet-Explorer-Optional-amd64"] = "Legacy IE compatibility in Edge. Not needed unless you use old enterprise sites.",
+        ["MediaPlayback"] = "Windows Media Player legacy — replaced by modern Media Player app.",
+        ["WindowsMediaPlayer"] = "Windows Media Player legacy codec pack. Modern apps don't need it.",
+        ["Printing-XPSServices-Features"] = "XPS Document Writer — rarely used virtual printer.",
+        ["Printing-PrintToPDFServices-Features"] = "Microsoft Print to PDF — useful but can reinstall if needed.",
+        ["WorkFolders-Client"] = "Work Folders — enterprise file sync. Not needed for personal use.",
+        ["MicrosoftWindowsPowerShellV2Root"] = "PowerShell 2.0 — legacy version, security risk. Use PowerShell 7+.",
+        ["MicrosoftWindowsPowerShellV2"] = "PowerShell 2.0 Engine — legacy, unnecessary with modern PS.",
+        ["MSRDC-Infrastructure"] = "Remote Desktop Client — only needed if you RDP into other machines.",
+        ["TelnetClient"] = "Telnet Client — insecure protocol. Use SSH instead.",
+        ["TFTP"] = "TFTP Client — trivial file transfer. Rarely needed.",
+        ["DirectPlay"] = "DirectPlay — legacy gaming API. Only needed for very old games.",
+        ["SimpleTCP"] = "Simple TCP/IP Services — echo, daytime servers. Never needed on workstations.",
+        ["SMB1Protocol"] = "SMB 1.0 — insecure file sharing protocol. Disable unless connecting to ancient NAS.",
+    };
+
+    private static readonly Dictionary<string, string> CautionFeatures = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["NetFx4-AdvSrvs"] = ".NET Framework 4.x Advanced Services — some apps depend on this.",
+        ["NetFx3"] = ".NET Framework 3.5 — needed by some older applications.",
+        ["SearchEngine-Client-Package"] = "Windows Search — disabling removes Start menu and Explorer search.",
+        ["Printing-Foundation-Features"] = "Print and Document Services — needed for any printing.",
+        ["SmbDirect"] = "SMB Direct (RDMA) — high-speed file transfer. Only needed with RDMA NICs.",
+        ["WCF-Services45"] = "WCF Services — .NET communication framework. Some enterprise apps need it.",
+        ["Microsoft-Windows-Subsystem-Linux"] = "WSL — Windows Subsystem for Linux. Needed by developers using Linux tools.",
+    };
+
+    private static readonly Dictionary<string, string> CriticalFeatures = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Microsoft-Hyper-V-All"] = "Hyper-V — virtualization platform. Required by Docker, WSL2, Android Emulator.",
+        ["Microsoft-Hyper-V"] = "Hyper-V core. Disabling breaks all VM-based tools.",
+        ["VirtualMachinePlatform"] = "Virtual Machine Platform — required by WSL2 and Hyper-V.",
+        ["HypervisorPlatform"] = "Windows Hypervisor Platform — needed by third-party VMs (VirtualBox, etc).",
+        ["Containers"] = "Windows Containers — used by Docker. Disabling breaks container workloads.",
+        ["Microsoft-Windows-Client-EmbeddedExp-Package"] = "Windows Sandbox — isolated test environment. Useful for security.",
+    };
+}

--- a/SysManager/SysManager/Services/ServiceManagerService.cs
+++ b/SysManager/SysManager/Services/ServiceManagerService.cs
@@ -64,6 +64,8 @@ public sealed partial class ServiceManagerService
                         ? guide
                         : ("", "");
 
+                    var (safety, safetyDesc) = SafetyDatabase.GetServiceSafety(sc.ServiceName);
+
                     result.Add(new ServiceEntry
                     {
                         Name = sc.ServiceName,
@@ -73,6 +75,8 @@ public sealed partial class ServiceManagerService
                         StartType = sc.StartType.ToString(),
                         Recommendation = rec,
                         RecommendationReason = reason,
+                        SafetyLevel = safety,
+                        SafetyDescription = safetyDesc,
                     });
                 }
                 catch (InvalidOperationException) { /* service disappeared — skip */ }

--- a/SysManager/SysManager/Services/WindowsFeaturesService.cs
+++ b/SysManager/SysManager/Services/WindowsFeaturesService.cs
@@ -128,13 +128,17 @@ public sealed partial class WindowsFeaturesService
 
                 var isEnabled = state.Equals("Enabled", StringComparison.OrdinalIgnoreCase);
 
+                var (safety, safetyDesc) = SafetyDatabase.GetFeatureSafety(name);
+
                 return new WindowsFeature
                 {
                     Name = name,
                     DisplayName = HumanizeName(name),
                     IsEnabled = isEnabled,
                     Status = isEnabled ? "Enabled" : "Disabled",
-                    Category = WindowsFeature.CategorizeFeature(name)
+                    Category = WindowsFeature.CategorizeFeature(name),
+                    SafetyLevel = safety,
+                    SafetyDescription = safetyDesc,
                 };
             })
             .Where(f => f is not null)

--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -31,9 +31,12 @@ public sealed partial class ServicesViewModel : ViewModelBase
     [ObservableProperty] private ServiceEntry? _selectedService;
     [ObservableProperty] private int _totalCount;
     [ObservableProperty] private int _runningCount;
+    [ObservableProperty] private int _safeCount;
+    [ObservableProperty] private int _cautionCount;
+    [ObservableProperty] private int _criticalCount;
 
     public string[] FilterOptions { get; } =
-        { "All", "Running", "Stopped", "Safe to disable", "Advanced" };
+        { "All", "Running", "Stopped", "Safe", "Caution", "Critical" };
 
     public ServicesViewModel(PowerShellRunner ps)
     {
@@ -180,13 +183,17 @@ public sealed partial class ServicesViewModel : ViewModelBase
         {
             "Running" => filtered.Where(s => s.Status == "Running"),
             "Stopped" => filtered.Where(s => s.Status == "Stopped"),
-            "Safe to disable" => filtered.Where(s => s.Recommendation == "safe-to-disable"),
-            "Advanced" => filtered.Where(s => s.Recommendation == "advanced"),
+            "Safe" => filtered.Where(s => s.SafetyLevel == SafetyLevel.Safe),
+            "Caution" => filtered.Where(s => s.SafetyLevel == SafetyLevel.Caution),
+            "Critical" => filtered.Where(s => s.SafetyLevel == SafetyLevel.Critical),
             _ => filtered
         };
 
-        // Default order by name; DataGrid column headers handle user sorting.
         Services.ReplaceWith(filtered.OrderBy(s => s.DisplayName, StringComparer.OrdinalIgnoreCase));
+
+        SafeCount = _allServices.Count(s => s.SafetyLevel == SafetyLevel.Safe);
+        CautionCount = _allServices.Count(s => s.SafetyLevel == SafetyLevel.Caution);
+        CriticalCount = _allServices.Count(s => s.SafetyLevel == SafetyLevel.Critical);
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -58,24 +58,43 @@
 
         <!-- Toolbar -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
-            <DockPanel>
-                <StackPanel Orientation="Horizontal">
-                    <Button Content="Refresh" Command="{Binding RefreshCommand}"
-                            Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
-                    <ComboBox ItemsSource="{Binding FilterOptions}"
-                              SelectedItem="{Binding SelectedFilter}" Width="150" Margin="0,0,8,0"/>
-                    <TextBox Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged}"
-                             Width="240" VerticalContentAlignment="Center"/>
+            <StackPanel>
+                <DockPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <Button Content="Refresh" Command="{Binding RefreshCommand}"
+                                Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
+                        <TextBox Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged}"
+                                 Width="240" VerticalContentAlignment="Center"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Right">
+                        <TextBlock Style="{StaticResource Subtle}" VerticalAlignment="Center">
+                            <Run Text="{Binding RunningCount, Mode=OneWay}"/>
+                            <Run Text=" running / "/>
+                            <Run Text="{Binding TotalCount, Mode=OneWay}"/>
+                            <Run Text=" total"/>
+                        </TextBlock>
+                    </StackPanel>
+                </DockPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                    <TextBlock Text="Filter:" Foreground="{StaticResource TextMuted}" FontSize="11"
+                               VerticalAlignment="Center" Margin="0,0,8,0"/>
+                    <RadioButton Content="{Binding SafeCount, StringFormat='Safe ({0})'}"
+                                 GroupName="SafetyFilter" Margin="0,0,6,0"
+                                 IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=Safe}"
+                                 Style="{StaticResource FilterChip}"/>
+                    <RadioButton Content="{Binding CautionCount, StringFormat='Caution ({0})'}"
+                                 GroupName="SafetyFilter" Margin="0,0,6,0"
+                                 IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=Caution}"
+                                 Style="{StaticResource FilterChipCaution}"/>
+                    <RadioButton Content="{Binding CriticalCount, StringFormat='Critical ({0})'}"
+                                 GroupName="SafetyFilter" Margin="0,0,6,0"
+                                 IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=Critical}"
+                                 Style="{StaticResource FilterChipCritical}"/>
+                    <RadioButton Content="All" GroupName="SafetyFilter" Margin="0,0,6,0"
+                                 IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=All}"
+                                 Style="{StaticResource FilterChip}"/>
                 </StackPanel>
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Right">
-                    <TextBlock Style="{StaticResource Subtle}" VerticalAlignment="Center">
-                        <Run Text="{Binding RunningCount, Mode=OneWay}"/>
-                        <Run Text=" running / "/>
-                        <Run Text="{Binding TotalCount, Mode=OneWay}"/>
-                        <Run Text=" total"/>
-                    </TextBlock>
-                </StackPanel>
-            </DockPanel>
+            </StackPanel>
         </Border>
 
         <!-- Services list -->
@@ -101,27 +120,22 @@
                         </Style>
                     </DataGridTextColumn.ElementStyle>
                 </DataGridTextColumn>
-                <DataGridTemplateColumn Header="Rec." Width="100" SortMemberPath="Recommendation">
+                <DataGridTemplateColumn Header="Safety" Width="90" SortMemberPath="SafetyLevel">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <TextBlock Text="{Binding Recommendation}" FontSize="11" VerticalAlignment="Center"
-                                       ToolTip="{Binding RecommendationReason}">
-                                <TextBlock.Style>
-                                    <Style TargetType="TextBlock">
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding Recommendation}" Value="safe-to-disable">
-                                                <Setter Property="Foreground" Value="#22C55E"/>
-                                            </DataTrigger>
-                                            <DataTrigger Binding="{Binding Recommendation}" Value="advanced">
-                                                <Setter Property="Foreground" Value="#F59E0B"/>
-                                            </DataTrigger>
-                                            <DataTrigger Binding="{Binding Recommendation}" Value="keep-enabled">
-                                                <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </TextBlock.Style>
-                            </TextBlock>
+                            <Border CornerRadius="6" Padding="6,3"
+                                    Background="{Binding SafetyLevel, Converter={StaticResource SafetyBg}}"
+                                    BorderBrush="{Binding SafetyLevel, Converter={StaticResource SafetyBg}}"
+                                    BorderThickness="1" HorizontalAlignment="Left"
+                                    ToolTip="{Binding SafetyDescription}">
+                                <StackPanel Orientation="Horizontal">
+                                    <Ellipse Width="6" Height="6" VerticalAlignment="Center" Margin="0,0,4,0"
+                                             Fill="{Binding SafetyLevel, Converter={StaticResource SafetyBrush}}"/>
+                                    <TextBlock Text="{Binding SafetyLevel, Converter={StaticResource SafetyText}}"
+                                               FontSize="10" FontWeight="SemiBold"
+                                               Foreground="{Binding SafetyLevel, Converter={StaticResource SafetyBrush}}"/>
+                                </StackPanel>
+                            </Border>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -32,6 +32,11 @@
                             Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
                     <Button Content="Enable All" Command="{Binding EnableAllCommand}"
                             Style="{StaticResource GhostButton}" Margin="0,0,8,0"/>
+                    <ToggleButton Style="{StaticResource ToggleSwitch}"
+                                  IsChecked="{Binding HideWindowsEntries}" Margin="12,0,6,0"
+                                  VerticalAlignment="Center" ToolTip="Hide Windows/Microsoft system entries"/>
+                    <TextBlock Text="Hide system" FontSize="11" Foreground="{StaticResource TextMuted}"
+                               VerticalAlignment="Center"/>
                 </StackPanel>
                 <TextBlock Text="{Binding ScanSummary}" Style="{StaticResource Subtle}"
                            VerticalAlignment="Center" HorizontalAlignment="Right" DockPanel.Dock="Right"/>

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -121,6 +121,25 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
+                    <DataGridTemplateColumn Header="Safety" Width="80" SortMemberPath="SafetyLevel">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Border CornerRadius="6" Padding="6,3"
+                                        Background="{Binding SafetyLevel, Converter={StaticResource SafetyBg}}"
+                                        HorizontalAlignment="Left"
+                                        ToolTip="{Binding SafetyDescription}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <Ellipse Width="6" Height="6" VerticalAlignment="Center" Margin="0,0,4,0"
+                                                 Fill="{Binding SafetyLevel, Converter={StaticResource SafetyBrush}}"/>
+                                        <TextBlock Text="{Binding SafetyLevel, Converter={StaticResource SafetyText}}"
+                                                   FontSize="10" FontWeight="SemiBold"
+                                                   Foreground="{Binding SafetyLevel, Converter={StaticResource SafetyBrush}}"/>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+
                     <DataGridTextColumn Header="Feature" Binding="{Binding DisplayName}" Width="*"
                                         SortMemberPath="DisplayName" IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>


### PR DESCRIPTION
## Summary
- Safety ratings (Safe/Caution/Critical) on Services and Windows Features
- Curated SafetyDatabase with 50+ services and 20+ features researched
- Filter chips on Services toolbar (replaces ComboBox)
- Safety badge column with colored dot + text + tooltip description
- "Hide system" toggle on Startup Manager toolbar
- 3 new ValueConverters for SafetyLevel rendering
- 3 new FilterChip styles (green/amber/red pills)

## Test plan
- [ ] Services tab: safety badges visible on each row
- [ ] Services tab: filter chips work (Safe/Caution/Critical/All)
- [ ] Services tab: tooltip shows description on badge hover
- [ ] Windows Features: safety badge column visible
- [ ] Startup Manager: "Hide system" toggle filters Microsoft entries
- [ ] Build + tests pass
