### PR TITLE
feat: bulk installer installed detection, speedtest/network explanations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Bulk Installer "Installed" badge** — apps already on the system show a green "Installed"
+  badge. Detection via `winget list` at startup.
+- **SpeedTest explanation** — info banner explaining Ookla vs HTTP test differences.
+- **Network Repair explanations** — detailed descriptions for each repair action
+  (Flush DNS, Reset Winsock, Reset TCP/IP).
+
+### Fixed
+- **App update failure messages** — more helpful explanations when downloads fail
+  (mentions network issues, firewall, retry suggestions).
+
 ## [1.10.3] - 2026-05-26
 
 ### Fixed

--- a/SysManager/SysManager/Models/InstallableApp.cs
+++ b/SysManager/SysManager/Models/InstallableApp.cs
@@ -14,6 +14,7 @@ public sealed partial class InstallableApp : ObservableObject
 {
     [ObservableProperty] private bool _isSelected;
     [ObservableProperty] private string _status = "";
+    [ObservableProperty] private bool _isInstalled;
     [ObservableProperty] private ImageSource? _icon;
 
     public required string Name { get; init; }

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -179,18 +179,18 @@ public sealed partial class AboutViewModel : ViewModelBase
             else
             {
                 AutoDownloadFailed = true;
-                DownloadStatus = "Automatic download failed — use Manual download to get it from GitHub.";
+                DownloadStatus = "Automatic download failed — the server may be temporarily unavailable. Click 'Manual download' to get it directly from GitHub, or try again later.";
             }
         }
         catch (HttpRequestException ex)
         {
             AutoDownloadFailed = true;
-            DownloadStatus = $"Automatic download failed: {ex.Message}";
+            DownloadStatus = $"Download failed: {ex.Message}. This usually means a network issue or firewall blocking the connection. Try 'Manual download' as fallback.";
         }
         catch (IOException ex)
         {
             AutoDownloadFailed = true;
-            DownloadStatus = $"Automatic download failed: {ex.Message}";
+            DownloadStatus = $"Download failed: {ex.Message}. This usually means a network issue or firewall blocking the connection. Try 'Manual download' as fallback.";
         }
         catch (TaskCanceledException ex)
         {

--- a/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
@@ -67,7 +67,10 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
         GroupedView = CollectionViewSource.GetDefaultView(FilteredApps);
         GroupedView.GroupDescriptions.Add(new PropertyGroupDescription(nameof(InstallableApp.Category)));
 
-        InitializeAsync(LoadIconsAsync);
+        InitializeAsync(async () =>
+        {
+            await Task.WhenAll(LoadIconsAsync(), MarkInstalledAppsAsync()).ConfigureAwait(false);
+        });
     }
 
     private async Task LoadIconsAsync()
@@ -77,6 +80,50 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
             var icon = await _iconService.GetIconAsync(app.WingetId).ConfigureAwait(false);
             if (icon != null)
                 App.Current?.Dispatcher.Invoke(() => app.Icon = icon);
+        }
+    }
+
+    private async Task MarkInstalledAppsAsync()
+    {
+        try
+        {
+            var output = await Task.Run(() =>
+            {
+                var psi = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "winget",
+                    Arguments = "list --disable-interactivity",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    StandardOutputEncoding = System.Text.Encoding.UTF8,
+                };
+
+                using var proc = System.Diagnostics.Process.Start(psi);
+                if (proc == null) return string.Empty;
+
+                var result = proc.StandardOutput.ReadToEnd();
+                proc.WaitForExit(30_000);
+                return result;
+            }).ConfigureAwait(false);
+
+            if (string.IsNullOrWhiteSpace(output)) return;
+
+            var lines = output.Split('\n');
+
+            App.Current?.Dispatcher.Invoke(() =>
+            {
+                foreach (var app in Apps)
+                {
+                    if (lines.Any(line => line.Contains(app.WingetId, StringComparison.OrdinalIgnoreCase)))
+                        app.IsInstalled = true;
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "Could not determine installed apps via winget list");
         }
     }
 

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -218,9 +218,15 @@
 
                                     <!-- Name + description -->
                                     <StackPanel Grid.Column="2" VerticalAlignment="Center">
-                                        <TextBlock Text="{Binding Name}"
-                                                   FontWeight="SemiBold" FontSize="13"
-                                                   Foreground="{StaticResource TextPrimary}"/>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="{Binding Name}"
+                                                       FontWeight="SemiBold" FontSize="13"
+                                                       Foreground="{StaticResource TextPrimary}"/>
+                                            <Border CornerRadius="4" Padding="4,2" Margin="8,0,0,0" Background="#1422C55E" BorderBrush="#3022C55E" BorderThickness="1"
+                                                    Visibility="{Binding IsInstalled, Converter={StaticResource BoolToVis}}">
+                                                <TextBlock Text="Installed" FontSize="9" Foreground="#4ADE80" FontWeight="SemiBold"/>
+                                            </Border>
+                                        </StackPanel>
                                         <TextBlock Text="{Binding Description}"
                                                    FontSize="11.5" Margin="0,2,0,0"
                                                    Foreground="{StaticResource TextSecondary}"

--- a/SysManager/SysManager/Views/NetworkRepairView.xaml
+++ b/SysManager/SysManager/Views/NetworkRepairView.xaml
@@ -75,6 +75,8 @@
                             <TextBlock Text="Flush DNS Cache" FontWeight="SemiBold" FontSize="14"/>
                             <TextBlock Text="Clears the local DNS resolver cache. Fixes stale DNS entries. Safe, instant, no reboot."
                                        Style="{StaticResource Subtle}" FontSize="11" Margin="0,4,0,0" TextWrapping="Wrap" MaxWidth="600"/>
+                            <TextBlock Style="{StaticResource Subtle}" FontSize="11" Margin="0,4,0,0" TextWrapping="Wrap"
+                                       Text="When you visit a website, Windows caches its IP address. If the site moves or your DNS provider updates, the stale cache causes failures. This clears all cached lookups so fresh queries occur."/>
                         </StackPanel>
                         <Button Content="Flush DNS" Command="{Binding FlushDnsCommand}" Style="{StaticResource SecondaryButton}"
                                 HorizontalAlignment="Right" DockPanel.Dock="Right" Padding="18,8"
@@ -99,6 +101,8 @@
                             <TextBlock Text="Reset Winsock Catalog" FontWeight="SemiBold" FontSize="14"/>
                             <TextBlock Text="Resets the Windows socket API. Fixes corrupted network drivers. Requires admin + reboot."
                                        Style="{StaticResource Subtle}" FontSize="11" Margin="0,4,0,0" TextWrapping="Wrap" MaxWidth="600"/>
+                            <TextBlock Style="{StaticResource Subtle}" FontSize="11" Margin="0,4,0,0" TextWrapping="Wrap"
+                                       Text="Winsock is the low-level API all network applications use. Broken VPN drivers, malware, or corrupted LSP providers can break it. This resets the network catalog to factory defaults."/>
                         </StackPanel>
                         <Button Content="Reset Winsock" Command="{Binding ResetWinsockCommand}" Style="{StaticResource SecondaryButton}"
                                 HorizontalAlignment="Right" DockPanel.Dock="Right" Padding="18,8"
@@ -123,6 +127,8 @@
                             <TextBlock Text="Reset TCP/IP Stack" FontWeight="SemiBold" FontSize="14"/>
                             <TextBlock Text="Restores all TCP/IP settings to defaults. Nuclear option. Requires admin + reboot."
                                        Style="{StaticResource Subtle}" FontSize="11" Margin="0,4,0,0" TextWrapping="Wrap" MaxWidth="600"/>
+                            <TextBlock Style="{StaticResource Subtle}" FontSize="11" Margin="0,4,0,0" TextWrapping="Wrap"
+                                       Text="Completely rebuilds TCP/IP stack registry keys. Use only when other fixes fail — this resets all custom IP configurations, routes, and adapter settings to Windows defaults."/>
                         </StackPanel>
                         <Button Content="Reset TCP/IP" Command="{Binding ResetTcpIpCommand}" Style="{StaticResource SecondaryButton}"
                                 HorizontalAlignment="Right" DockPanel.Dock="Right" Padding="18,8"

--- a/SysManager/SysManager/Views/SpeedTestView.xaml
+++ b/SysManager/SysManager/Views/SpeedTestView.xaml
@@ -27,6 +27,7 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
@@ -82,8 +83,21 @@
                     </StackPanel>
                 </Border>
 
+                <!-- Info: Ookla vs HTTP explanation -->
+                <Border Grid.Row="1" Grid.ColumnSpan="2" Background="#0F1A2E" BorderBrush="#1E3A5F" BorderThickness="1"
+                        CornerRadius="8" Padding="12,10" Margin="0,12,0,0">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="&#xE946;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                                   FontSize="14" Foreground="{StaticResource Info}" VerticalAlignment="Top" Margin="0,0,10,0"/>
+                        <TextBlock TextWrapping="Wrap" Foreground="{StaticResource TextSecondary}" FontSize="12">
+                            <Run FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}">Ookla</Run><Run> measures raw TCP throughput to a nearby server — most accurate for ISP bandwidth. </Run>
+                            <Run FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}">HTTP</Run><Run> tests download/upload via Cloudflare CDN — reflects real web browsing speed but may show lower results due to HTTP overhead and CDN routing.</Run>
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
+
                 <!-- Ookla History -->
-                <Border Grid.Row="1" Grid.Column="0" Style="{StaticResource Card}" Margin="0,16,0,0">
+                <Border Grid.Row="2" Grid.Column="0" Style="{StaticResource Card}" Margin="0,16,0,0">
                     <StackPanel>
                         <DockPanel>
                             <TextBlock Text="Ookla History" Style="{StaticResource SectionTitle}"/>
@@ -113,7 +127,7 @@
                 </Border>
 
                 <!-- HTTP History -->
-                <Border Grid.Row="1" Grid.Column="1" Style="{StaticResource Card}" Margin="16,16,0,0">
+                <Border Grid.Row="2" Grid.Column="1" Style="{StaticResource Card}" Margin="16,16,0,0">
                     <StackPanel>
                         <DockPanel>
                             <TextBlock Text="HTTP History" Style="{StaticResource SectionTitle}"/>


### PR DESCRIPTION
## Summary
- Bulk Installer shows "Installed" badge for apps already on system (winget list check)
- SpeedTest has explanation banner for Ookla vs HTTP differences
- Network Repair has detailed descriptions for each action
- App update failures show better troubleshooting messages

## Test plan
- [ ] Bulk Installer: apps already installed show green "Installed" badge
- [ ] SpeedTest: info banner visible between cards and history
- [ ] Network Repair: each card has detailed explanation text
- [ ] About/Update: failure messages are more descriptive