### PR TITLE
feat: SpeedTest Ookla server selection dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **SpeedTest server selection** — dropdown to choose Ookla test server (Auto/Bucharest/
+  London/Frankfurt/Amsterdam/Paris/New York) instead of always using nearest.
+
+## [1.11.0] - 2026-05-26
+
+### Added
 - **Bulk Installer "Installed" badge** — apps already on the system show a green "Installed"
   badge. Detection via `winget list` at startup.
 - **SpeedTest explanation** — info banner explaining Ookla vs HTTP test differences.

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -172,7 +172,7 @@ public sealed class SpeedTestService
     // ---------------- Ookla ----------------
 
     public async Task<SpeedTestResult> RunOoklaAsync(
-        IProgress<(int Percent, string Message)>? progress, CancellationToken ct)
+        IProgress<(int Percent, string Message)>? progress, CancellationToken ct, int? serverId = null)
     {
         string exe;
         try
@@ -185,8 +185,10 @@ public sealed class SpeedTestService
         }
 
         progress?.Report((20, "Running Ookla speedtest…"));
-        var psi = new ProcessStartInfo(exe,
-            "--accept-license --accept-gdpr --format=json --progress=no")
+        var args = "--accept-license --accept-gdpr --format=json --progress=no";
+        if (serverId is not null)
+            args += $" --server-id={serverId}";
+        var psi = new ProcessStartInfo(exe, args)
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,

--- a/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
@@ -22,6 +22,17 @@ public sealed partial class SpeedTestViewModel : ViewModelBase
 
     [ObservableProperty] private SpeedTestResult? _httpResult;
     [ObservableProperty] private SpeedTestResult? _ooklaResult;
+    [ObservableProperty] private string _selectedOoklaServer = "Auto (nearest)";
+
+    public string[] OoklaServerOptions { get; } = {
+        "Auto (nearest)",
+        "Bucharest, RO (ID: 2616)",
+        "London, UK (ID: 12884)",
+        "Frankfurt, DE (ID: 31120)",
+        "Amsterdam, NL (ID: 28922)",
+        "Paris, FR (ID: 5765)",
+        "New York, US (ID: 10390)",
+    };
     [ObservableProperty] private int _speedProgress;
     [ObservableProperty] private string _speedStatus = "";
     [ObservableProperty] private string _httpStatus = "";
@@ -123,7 +134,7 @@ public sealed partial class SpeedTestViewModel : ViewModelBase
         { SpeedProgress = t.p; OoklaStatus = t.m; EstimatedTime = _eta.Update(t.p); });
         try
         {
-            OoklaResult = await Shared.Speed.RunOoklaAsync(progress, _speedCts.Token);
+            OoklaResult = await Shared.Speed.RunOoklaAsync(progress, _speedCts.Token, ParseServerId(SelectedOoklaServer));
             OoklaStatus = "Ookla done";
             Log.Information("Ookla speed test: {Down:F1} Mbps down, {Up:F1} Mbps up",
                 OoklaResult.DownloadMbps, OoklaResult.UploadMbps);
@@ -158,6 +169,13 @@ public sealed partial class SpeedTestViewModel : ViewModelBase
 
     [RelayCommand]
     private void CancelSpeed() => _speedCts?.Cancel();
+
+    private static int? ParseServerId(string option)
+    {
+        if (option.StartsWith("Auto")) return null;
+        var match = System.Text.RegularExpressions.Regex.Match(option, @"ID:\s*(\d+)");
+        return match.Success ? int.Parse(match.Groups[1].Value) : null;
+    }
 
     protected override void Dispose(bool disposing)
     {

--- a/SysManager/SysManager/Views/SpeedTestView.xaml
+++ b/SysManager/SysManager/Views/SpeedTestView.xaml
@@ -45,6 +45,10 @@
                             <Button Content="Run" Command="{Binding RunOoklaSpeedCommand}" Style="{StaticResource PrimaryButton}"
                                     HorizontalAlignment="Right" DockPanel.Dock="Right" Padding="18,8"
                                     IsEnabled="{Binding IsSpeedTesting, Converter={StaticResource BoolInvert}}"/>
+                            <ComboBox ItemsSource="{Binding OoklaServerOptions}"
+                                      SelectedItem="{Binding SelectedOoklaServer}"
+                                      Width="180" Margin="0,0,8,0" VerticalAlignment="Center"
+                                      DockPanel.Dock="Right"/>
                         </DockPanel>
                         <Grid Margin="0,16,0,0" Visibility="{Binding OoklaResult, Converter={StaticResource FlexVis}}">
                             <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="*"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>


### PR DESCRIPTION
## Summary
- Ookla speed test now has a server dropdown (Auto + 6 popular servers)
- Passes --server-id to CLI when specific server chosen
- Also fixes missing v1.11.0 header in CHANGELOG

## Test plan
- [ ] ComboBox visible in Ookla card
- [ ] "Auto (nearest)" works as before
- [ ] Selecting a specific server passes correct --server-id