### PR TITLE
docs: add v1.12.0 header in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-05-26
+
 ### Added
 - **SpeedTest server selection** — dropdown to choose Ookla test server (Auto/Bucharest/
   London/Frankfurt/Amsterdam/Paris/New York) instead of always using nearest.


### PR DESCRIPTION
Move SpeedTest entry from Unreleased to v1.12.0 header.