### PR TITLE
ci: enable winget-releaser with manual dispatch fallback

### DIFF
--- a/.github/workflows/winget-releaser.yml
+++ b/.github/workflows/winget-releaser.yml
@@ -6,6 +6,11 @@ name: Winget Releaser
 on:
   release:
     types: [released]
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        description: "Release tag to submit (e.g. v1.12.0)"
+        required: true
 
 jobs:
   winget-update:
@@ -16,4 +21,5 @@ jobs:
         with:
           identifier: laurentiu021.SysManager
           installers-regex: '\.exe$'
+          release-tag: ${{ inputs.release-tag || github.event.release.tag_name }}
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
## Summary
- Re-enables the Winget Releaser workflow (was disabled while awaiting initial approval on microsoft/winget-pkgs)
- Adds `workflow_dispatch` trigger with `release-tag` input for manual retriggers
- Uses `release-tag` parameter so both automatic (on release) and manual dispatch work correctly

## Context
PR microsoft/winget-pkgs#376382 was merged — `laurentiu021.SysManager` is now in the winget registry. Future releases will automatically submit update PRs.
