### PR TITLE
fix: remove duplicate CheckBox style causing startup crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.12.1] - 2026-05-27
+
+### Fixed
+- **Startup crash** — duplicate implicit CheckBox style in App.xaml caused
+  `XamlParseException` ("Item has already been added") preventing the app from launching.
+
 ## [1.12.0] - 2026-05-26
 
 ### Added

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -108,14 +108,6 @@
                 </Style.Resources>
             </Style>
 
-            <Style TargetType="CheckBox">
-                <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
-                <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
-                <Style.Resources>
-                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="{StaticResource AccentColor}"/>
-                </Style.Resources>
-            </Style>
-
             <!-- ============================================================ -->
             <!-- Card — reusable container                                      -->
             <!-- ============================================================ -->


### PR DESCRIPTION
## Summary
- Removes a duplicate implicit `Style TargetType="CheckBox"` in App.xaml that caused `XamlParseException` at startup
- The app was completely unable to launch since v1.10.1 (when the full CheckBox template was added without removing the older minimal style)

## Root cause
Two implicit styles for `CheckBox` existed in the same ResourceDictionary:
1. Line 111: minimal style (Foreground + HighlightBrush) — added early in development
2. Line 558: full custom template (dark-friendly with purple accent) — added in v1.10.1

WPF's ResourceDictionary uses a Hashtable internally and throws `ArgumentException: Item has already been added` when two implicit styles share the same key (`typeof(CheckBox)`).

## Test plan
- [x] Build: 0 errors, 0 warnings
- [x] Published self-contained EXE launches and stays alive 20+ seconds
- [x] Verified via Event Log: no crash entries after fix