### PR TITLE
feat: theme customization with Dark/Light/Custom presets and persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-05-27
+
+### Added
+- **Theme customization** — persistent appearance settings with Dark/Light/Custom modes.
+  Choose from 12 curated presets (6 dark, 6 light) or fully customize accent, background,
+  surface, and text colors. Settings saved between sessions.
+- **Theme button** — palette icon in top-right corner, accessible from every page.
+- **Background shade slider** — fine-tune lightness/darkness within any preset.
+- **Auto companion preset** — switching Dark↔Light automatically selects the matching
+  color family (e.g. Midnight Indigo ↔ Clean Indigo).
+
+### Changed
+- All color resources converted from `StaticResource` to `DynamicResource` for live
+  theme switching without restart.
+
 ## [1.12.1] - 2026-05-27
 
 ### Fixed

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -40,11 +40,11 @@
             <Color x:Key="Surface3Color">#1C2230</Color>
             <Color x:Key="Surface4Color">#252C3C</Color>
 
-            <SolidColorBrush x:Key="Surface0" Color="{StaticResource Surface0Color}"/>
-            <SolidColorBrush x:Key="Surface1" Color="{StaticResource Surface1Color}"/>
-            <SolidColorBrush x:Key="Surface2" Color="{StaticResource Surface2Color}"/>
-            <SolidColorBrush x:Key="Surface3" Color="{StaticResource Surface3Color}"/>
-            <SolidColorBrush x:Key="Surface4" Color="{StaticResource Surface4Color}"/>
+            <SolidColorBrush x:Key="Surface0" Color="{DynamicResource Surface0Color}"/>
+            <SolidColorBrush x:Key="Surface1" Color="{DynamicResource Surface1Color}"/>
+            <SolidColorBrush x:Key="Surface2" Color="{DynamicResource Surface2Color}"/>
+            <SolidColorBrush x:Key="Surface3" Color="{DynamicResource Surface3Color}"/>
+            <SolidColorBrush x:Key="Surface4" Color="{DynamicResource Surface4Color}"/>
 
             <!-- Borders -->
             <SolidColorBrush x:Key="Border1" Color="#1F2633"/>
@@ -61,9 +61,9 @@
             <Color x:Key="AccentColor">#6366F1</Color>
             <Color x:Key="AccentHoverColor">#818CF8</Color>
             <Color x:Key="AccentPressedColor">#4F46E5</Color>
-            <SolidColorBrush x:Key="Accent" Color="{StaticResource AccentColor}"/>
-            <SolidColorBrush x:Key="AccentHover" Color="{StaticResource AccentHoverColor}"/>
-            <SolidColorBrush x:Key="AccentPressed" Color="{StaticResource AccentPressedColor}"/>
+            <SolidColorBrush x:Key="Accent" Color="{DynamicResource AccentColor}"/>
+            <SolidColorBrush x:Key="AccentHover" Color="{DynamicResource AccentHoverColor}"/>
+            <SolidColorBrush x:Key="AccentPressed" Color="{DynamicResource AccentPressedColor}"/>
             <SolidColorBrush x:Key="AccentSoft" Color="#0F6366F1"/>
 
             <!-- Status colors -->
@@ -85,26 +85,56 @@
             <FontFamily x:Key="UiFont">Segoe UI Variable Text, Segoe UI, Inter, Arial</FontFamily>
 
             <!-- ============================================================ -->
+            <!-- Theme popup styles                                             -->
+            <!-- ============================================================ -->
+            <Style x:Key="ModePill" TargetType="RadioButton">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="RadioButton">
+                            <Border x:Name="Bd" Padding="7,6" CornerRadius="10" Background="Transparent"
+                                    Cursor="Hand" HorizontalAlignment="Stretch">
+                                <TextBlock x:Name="Txt" Text="{TemplateBinding Content}" FontSize="12" FontWeight="SemiBold"
+                                           HorizontalAlignment="Center" Foreground="{DynamicResource TextPrimary}"/>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsChecked" Value="True">
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Accent}"/>
+                                    <Setter TargetName="Txt" Property="Foreground" Value="White"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <Style x:Key="SectionLabel" TargetType="TextBlock">
+                <Setter Property="FontSize" Value="11"/>
+                <Setter Property="FontWeight" Value="SemiBold"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextMuted}"/>
+                <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
+            </Style>
+
+            <!-- ============================================================ -->
             <!-- Global defaults — every Control gets a modern base look       -->
             <!-- ============================================================ -->
             <Style TargetType="TextBlock">
-                <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                 <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
                 <Setter Property="TextOptions.TextFormattingMode" Value="Ideal"/>
                 <Setter Property="TextOptions.TextRenderingMode" Value="ClearType"/>
             </Style>
 
             <Style TargetType="ProgressBar">
-                <Setter Property="Foreground" Value="{StaticResource Accent}"/>
-                <Setter Property="Background" Value="{StaticResource Surface2}"/>
+                <Setter Property="Foreground" Value="{DynamicResource Accent}"/>
+                <Setter Property="Background" Value="{DynamicResource Surface2}"/>
                 <Setter Property="BorderThickness" Value="0"/>
             </Style>
 
             <Style TargetType="RadioButton">
-                <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                 <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
                 <Style.Resources>
-                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="{StaticResource AccentColor}"/>
+                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="{DynamicResource AccentColor}"/>
                 </Style.Resources>
             </Style>
 
@@ -112,8 +142,8 @@
             <!-- Card — reusable container                                      -->
             <!-- ============================================================ -->
             <Style x:Key="Card" TargetType="Border">
-                <Setter Property="Background" Value="{StaticResource Surface1}"/>
-                <Setter Property="BorderBrush" Value="{StaticResource Border1}"/>
+                <Setter Property="Background" Value="{DynamicResource Surface1}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource Border1}"/>
                 <Setter Property="BorderThickness" Value="1"/>
                 <Setter Property="CornerRadius" Value="10"/>
                 <Setter Property="Padding" Value="16"/>
@@ -123,11 +153,11 @@
             <!-- PERF-008: CardElevated kept without DropShadowEffect to avoid
                  software-rendered shadows when many cards are visible. -->
             <Style x:Key="CardElevated" TargetType="Border" BasedOn="{StaticResource Card}">
-                <Setter Property="Background" Value="{StaticResource Surface2}"/>
+                <Setter Property="Background" Value="{DynamicResource Surface2}"/>
             </Style>
 
             <Style x:Key="CardInner" TargetType="Border" BasedOn="{StaticResource Card}">
-                <Setter Property="Background" Value="{StaticResource Surface2}"/>
+                <Setter Property="Background" Value="{DynamicResource Surface2}"/>
                 <Setter Property="CornerRadius" Value="8"/>
                 <Setter Property="Padding" Value="12"/>
             </Style>
@@ -139,7 +169,7 @@
                 <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
                 <Setter Property="FontSize" Value="13"/>
                 <Setter Property="FontWeight" Value="SemiBold"/>
-                <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                 <Setter Property="Padding" Value="14,8"/>
                 <Setter Property="Cursor" Value="Hand"/>
                 <Setter Property="SnapsToDevicePixels" Value="True"/>
@@ -159,13 +189,13 @@
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter TargetName="Bd" Property="Opacity" Value="0.88"/>
-                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource BorderAccent}"/>
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource BorderAccent}"/>
                                 </Trigger>
                                 <Trigger Property="IsPressed" Value="True">
                                     <Setter TargetName="Bd" Property="Opacity" Value="0.75"/>
                                 </Trigger>
                                 <Trigger Property="IsKeyboardFocused" Value="True">
-                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource Accent}"/>
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Accent}"/>
                                     <Setter TargetName="Bd" Property="BorderThickness" Value="1.5"/>
                                 </Trigger>
                                 <Trigger Property="IsEnabled" Value="False">
@@ -179,15 +209,15 @@
 
             <!-- Primary: accent background -->
             <Style x:Key="PrimaryButton" TargetType="Button" BasedOn="{StaticResource ButtonBase}">
-                <Setter Property="Background" Value="{StaticResource Accent}"/>
+                <Setter Property="Background" Value="{DynamicResource Accent}"/>
                 <Setter Property="BorderThickness" Value="0"/>
                 <Setter Property="Foreground" Value="White"/>
             </Style>
 
             <!-- Secondary: subtle surface with border -->
             <Style x:Key="SecondaryButton" TargetType="Button" BasedOn="{StaticResource ButtonBase}">
-                <Setter Property="Background" Value="{StaticResource Surface3}"/>
-                <Setter Property="BorderBrush" Value="{StaticResource Border2}"/>
+                <Setter Property="Background" Value="{DynamicResource Surface3}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource Border2}"/>
                 <Setter Property="BorderThickness" Value="1"/>
             </Style>
 
@@ -195,7 +225,7 @@
             <Style x:Key="GhostButton" TargetType="Button" BasedOn="{StaticResource ButtonBase}">
                 <Setter Property="Background" Value="Transparent"/>
                 <Setter Property="BorderThickness" Value="1"/>
-                <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="Button">
@@ -207,17 +237,17 @@
                             </Border>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource Surface3}"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Surface3}"/>
                                     <Setter TargetName="Bd" Property="BorderBrush" Value="#33FFFFFF"/>
-                                    <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                                 </Trigger>
                                 <Trigger Property="IsPressed" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource Surface4}"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Surface4}"/>
                                 </Trigger>
                                 <Trigger Property="IsKeyboardFocused" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource Surface3}"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Surface3}"/>
                                     <Setter TargetName="Bd" Property="BorderBrush" Value="#33FFFFFF"/>
-                                    <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                                 </Trigger>
                                 <Trigger Property="IsEnabled" Value="False">
                                     <Setter Property="Opacity" Value="0.4"/>
@@ -252,7 +282,7 @@
                             </Grid>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsChecked" Value="True">
-                                    <Setter TargetName="Track" Property="Background" Value="{StaticResource Accent}"/>
+                                    <Setter TargetName="Track" Property="Background" Value="{DynamicResource Accent}"/>
                                     <Setter TargetName="Thumb" Property="HorizontalAlignment" Value="Right"/>
                                     <Setter TargetName="Thumb" Property="Margin" Value="0,2,2,2"/>
                                 </Trigger>
@@ -392,7 +422,7 @@
 
             <!-- Danger: red background for destructive actions -->
             <Style x:Key="DangerButton" TargetType="Button" BasedOn="{StaticResource ButtonBase}">
-                <Setter Property="Background" Value="{StaticResource Danger}"/>
+                <Setter Property="Background" Value="{DynamicResource Danger}"/>
                 <Setter Property="BorderThickness" Value="0"/>
                 <Setter Property="Foreground" Value="White"/>
             </Style>
@@ -404,15 +434,15 @@
             <!-- TextBox & ComboBox                                            -->
             <!-- ============================================================ -->
             <Style TargetType="TextBox">
-                <Setter Property="Background" Value="{StaticResource Surface2}"/>
-                <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
-                <Setter Property="BorderBrush" Value="{StaticResource Border2}"/>
+                <Setter Property="Background" Value="{DynamicResource Surface2}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource Border2}"/>
                 <Setter Property="BorderThickness" Value="1"/>
                 <Setter Property="Padding" Value="10,7"/>
                 <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
                 <Setter Property="FontSize" Value="13"/>
-                <Setter Property="CaretBrush" Value="{StaticResource Accent}"/>
-                <Setter Property="SelectionBrush" Value="{StaticResource Accent}"/>
+                <Setter Property="CaretBrush" Value="{DynamicResource Accent}"/>
+                <Setter Property="SelectionBrush" Value="{DynamicResource Accent}"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="TextBox">
@@ -427,10 +457,10 @@
                             </Border>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsKeyboardFocused" Value="True">
-                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource Accent}"/>
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Accent}"/>
                                 </Trigger>
                                 <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource BorderAccent}"/>
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource BorderAccent}"/>
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>
@@ -444,32 +474,32 @@
             <Style x:Key="Display" TargetType="TextBlock">
                 <Setter Property="FontSize" Value="28"/>
                 <Setter Property="FontWeight" Value="SemiBold"/>
-                <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                 <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
             </Style>
 
             <Style x:Key="Heading" TargetType="TextBlock">
                 <Setter Property="FontSize" Value="20"/>
                 <Setter Property="FontWeight" Value="SemiBold"/>
-                <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                 <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
             </Style>
 
             <Style x:Key="SectionTitle" TargetType="TextBlock">
                 <Setter Property="FontSize" Value="14"/>
                 <Setter Property="FontWeight" Value="SemiBold"/>
-                <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                 <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
             </Style>
 
             <Style x:Key="Caption" TargetType="TextBlock">
                 <Setter Property="FontSize" Value="11"/>
-                <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextMuted}"/>
                 <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
             </Style>
 
             <Style x:Key="Subtle" TargetType="TextBlock">
-                <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
                 <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
                 <Setter Property="FontSize" Value="12"/>
             </Style>
@@ -484,7 +514,7 @@
             <!-- Side-nav tab style (vertical tabs with icon + label)          -->
             <!-- ============================================================ -->
             <Style x:Key="SideNavTabItem" TargetType="TabItem">
-                <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
                 <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
                 <Setter Property="FontSize" Value="13"/>
                 <Setter Property="FontWeight" Value="Medium"/>
@@ -503,7 +533,7 @@
                                     <Rectangle x:Name="ActiveMark"
                                                HorizontalAlignment="Left"
                                                Width="3" Height="20"
-                                               Fill="{StaticResource Accent}"
+                                               Fill="{DynamicResource Accent}"
                                                RadiusX="2" RadiusY="2"
                                                Margin="-14,0,0,0"
                                                Visibility="Collapsed"/>
@@ -516,13 +546,13 @@
                             </Border>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource Surface2}"/>
-                                    <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Surface2}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                                 </Trigger>
                                 <Trigger Property="IsSelected" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource AccentSoft}"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource AccentSoft}"/>
                                     <Setter TargetName="ActiveMark" Property="Visibility" Value="Visible"/>
-                                    <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                                     <Setter Property="FontWeight" Value="SemiBold"/>
                                 </Trigger>
                             </ControlTemplate.Triggers>
@@ -535,20 +565,20 @@
             <!-- Pill / Badge                                                  -->
             <!-- ============================================================ -->
             <Style x:Key="Badge" TargetType="Border">
-                <Setter Property="Background" Value="{StaticResource Surface3}"/>
+                <Setter Property="Background" Value="{DynamicResource Surface3}"/>
                 <Setter Property="CornerRadius" Value="999"/>
                 <Setter Property="Padding" Value="10,3"/>
             </Style>
 
             <Style x:Key="BadgeAccent" TargetType="Border" BasedOn="{StaticResource Badge}">
-                <Setter Property="Background" Value="{StaticResource Accent}"/>
+                <Setter Property="Background" Value="{DynamicResource Accent}"/>
             </Style>
 
             <!-- ============================================================ -->
             <!-- CheckBox (dark-friendly bifă)                                 -->
             <!-- ============================================================ -->
             <Style TargetType="CheckBox">
-                <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                 <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
                 <Setter Property="FontSize" Value="13"/>
                 <Setter Property="VerticalContentAlignment" Value="Center"/>
@@ -559,8 +589,8 @@
                         <ControlTemplate TargetType="CheckBox">
                             <StackPanel Orientation="Horizontal">
                                 <Border x:Name="Box" Width="18" Height="18" CornerRadius="5"
-                                        Background="{StaticResource Surface2}"
-                                        BorderBrush="{StaticResource Border2}" BorderThickness="1.5"
+                                        Background="{DynamicResource Surface2}"
+                                        BorderBrush="{DynamicResource Border2}" BorderThickness="1.5"
                                         VerticalAlignment="Center">
                                     <Path x:Name="Check"
                                           Data="M 3 9 L 7 13 L 15 5"
@@ -576,12 +606,12 @@
                             </StackPanel>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsChecked" Value="True">
-                                    <Setter TargetName="Box" Property="Background" Value="{StaticResource Accent}"/>
-                                    <Setter TargetName="Box" Property="BorderBrush" Value="{StaticResource Accent}"/>
+                                    <Setter TargetName="Box" Property="Background" Value="{DynamicResource Accent}"/>
+                                    <Setter TargetName="Box" Property="BorderBrush" Value="{DynamicResource Accent}"/>
                                     <Setter TargetName="Check" Property="Visibility" Value="Visible"/>
                                 </Trigger>
                                 <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="Box" Property="BorderBrush" Value="{StaticResource BorderAccent}"/>
+                                    <Setter TargetName="Box" Property="BorderBrush" Value="{DynamicResource BorderAccent}"/>
                                 </Trigger>
                                 <Trigger Property="IsEnabled" Value="False">
                                     <Setter Property="Opacity" Value="0.5"/>
@@ -596,7 +626,7 @@
             <!-- Horizontal pill tabs (used inside Network sub-sections)      -->
             <!-- ============================================================ -->
             <Style x:Key="PillTabItem" TargetType="TabItem">
-                <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
                 <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
                 <Setter Property="FontSize" Value="13"/>
                 <Setter Property="FontWeight" Value="Medium"/>
@@ -615,11 +645,11 @@
                             </Border>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource Surface2}"/>
-                                    <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Surface2}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                                 </Trigger>
                                 <Trigger Property="IsSelected" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource Accent}"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Accent}"/>
                                     <Setter Property="Foreground" Value="White"/>
                                     <Setter Property="FontWeight" Value="SemiBold"/>
                                 </Trigger>
@@ -634,24 +664,24 @@
             <!-- ============================================================ -->
             <Style TargetType="DataGrid">
                 <Setter Property="Background" Value="Transparent"/>
-                <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                 <Setter Property="BorderThickness" Value="0"/>
                 <Setter Property="GridLinesVisibility" Value="None"/>
                 <Setter Property="RowBackground" Value="Transparent"/>
-                <Setter Property="AlternatingRowBackground" Value="{StaticResource Surface1}"/>
-                <Setter Property="HorizontalGridLinesBrush" Value="{StaticResource Border1}"/>
-                <Setter Property="VerticalGridLinesBrush" Value="{StaticResource Border1}"/>
+                <Setter Property="AlternatingRowBackground" Value="{DynamicResource Surface1}"/>
+                <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource Border1}"/>
+                <Setter Property="VerticalGridLinesBrush" Value="{DynamicResource Border1}"/>
                 <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
                 <Setter Property="FontSize" Value="13"/>
             </Style>
 
             <Style TargetType="DataGridColumnHeader">
-                <Setter Property="Background" Value="{StaticResource Surface2}"/>
-                <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
+                <Setter Property="Background" Value="{DynamicResource Surface2}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextMuted}"/>
                 <Setter Property="FontWeight" Value="SemiBold"/>
                 <Setter Property="FontSize" Value="11"/>
                 <Setter Property="Padding" Value="12,10"/>
-                <Setter Property="BorderBrush" Value="{StaticResource Border1}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource Border1}"/>
                 <Setter Property="BorderThickness" Value="0,0,0,1"/>
                 <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
                 <Setter Property="Template">
@@ -675,7 +705,7 @@
                                                           ContentTemplate="{TemplateBinding ContentTemplate}"/>
                                         <Path x:Name="SortArrow" Grid.Column="1"
                                               Visibility="Collapsed"
-                                              Fill="{StaticResource TextSecondary}"
+                                              Fill="{DynamicResource TextSecondary}"
                                               Margin="6,0,0,0"
                                               VerticalAlignment="Center"
                                               RenderTransformOrigin="0.5,0.5"/>
@@ -692,8 +722,8 @@
                             </Grid>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="HeaderBorder" Property="Background" Value="{StaticResource Surface3}"/>
-                                    <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                                    <Setter TargetName="HeaderBorder" Property="Background" Value="{DynamicResource Surface3}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                                     <Setter Property="Cursor" Value="Hand"/>
                                 </Trigger>
                                 <Trigger Property="SortDirection" Value="Ascending">
@@ -712,7 +742,7 @@
 
             <Style TargetType="DataGridRow">
                 <Setter Property="Background" Value="Transparent"/>
-                <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                 <Setter Property="BorderThickness" Value="0"/>
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
@@ -720,14 +750,14 @@
                     </Trigger>
                     <Trigger Property="IsSelected" Value="True">
                         <Setter Property="Background" Value="#146366F1"/>
-                        <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                        <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                     </Trigger>
                 </Style.Triggers>
             </Style>
 
             <Style TargetType="DataGridCell">
                 <Setter Property="Background" Value="Transparent"/>
-                <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                 <Setter Property="BorderThickness" Value="0"/>
                 <Setter Property="Padding" Value="10,6"/>
                 <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
@@ -745,7 +775,7 @@
                 <Style.Triggers>
                     <Trigger Property="IsSelected" Value="True">
                         <Setter Property="Background" Value="Transparent"/>
-                        <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                        <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                     </Trigger>
                 </Style.Triggers>
             </Style>

--- a/SysManager/SysManager/App.xaml.cs
+++ b/SysManager/SysManager/App.xaml.cs
@@ -76,6 +76,8 @@ public partial class App : Application
         TaskScheduler.UnobservedTaskException += OnTask;
         base.OnStartup(e);
 
+        ThemeService.Instance.Initialize();
+
         // Start listening for activation requests from subsequent instances
         StartPipeListener();
     }

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -6,7 +6,7 @@
         Title="{Binding Title}"
         Width="1280" Height="820"
         MinWidth="960" MinHeight="640"
-        Background="{StaticResource Surface0}"
+        Background="{DynamicResource Surface0}"
         Icon="Resources/app.ico"
         AutomationProperties.AutomationId="MainWindow">
     <Window.DataContext>
@@ -21,8 +21,8 @@
 
         <!-- ================= Left nav ================= -->
         <Border Grid.Column="0"
-                Background="{StaticResource Surface1}"
-                BorderBrush="{StaticResource Border1}"
+                Background="{DynamicResource Surface1}"
+                BorderBrush="{DynamicResource Border1}"
                 BorderThickness="0,0,1,0">
             <Grid>
                 <Grid.RowDefinitions>
@@ -34,7 +34,7 @@
                 <!-- Header -->
                 <StackPanel Grid.Row="0" Margin="20,20,20,16">
                     <TextBlock Text="SysManager" FontSize="20" FontWeight="SemiBold"
-                               Foreground="{StaticResource TextPrimary}"
+                               Foreground="{DynamicResource TextPrimary}"
                                FontFamily="{StaticResource UiFont}"/>
                     <TextBlock Text="System toolkit" Style="{StaticResource Caption}" Margin="0,2,0,0"/>
                 </StackPanel>
@@ -71,12 +71,12 @@
                                                    FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                                    FontSize="14" Margin="0,0,12,0"
                                                    VerticalAlignment="Center"
-                                                   Foreground="{StaticResource TextSecondary}"/>
+                                                   Foreground="{DynamicResource TextSecondary}"/>
                                         <TextBlock Text="{Binding Label}"
                                                    VerticalAlignment="Center"
                                                    FontFamily="{StaticResource UiFont}"
                                                    FontSize="13" FontWeight="Medium"
-                                                   Foreground="{StaticResource TextSecondary}"/>
+                                                   Foreground="{DynamicResource TextSecondary}"/>
                                     </StackPanel>
                                 </Border>
 
@@ -86,7 +86,7 @@
                                           Padding="0" Margin="0"
                                           Background="Transparent"
                                           BorderThickness="0"
-                                          Foreground="{StaticResource TextSecondary}">
+                                          Foreground="{DynamicResource TextSecondary}">
                                     <Expander.Header>
                                         <Border CornerRadius="8" Padding="4,4,8,4" Margin="-4,-4,-8,-4"
                                                 ToolTip="{Binding Tooltip}">
@@ -106,22 +106,22 @@
                                                            FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                                            FontSize="13" Margin="0,0,10,0"
                                                            VerticalAlignment="Center"
-                                                           Foreground="{StaticResource TextSecondary}"/>
+                                                           Foreground="{DynamicResource TextSecondary}"/>
                                                 <TextBlock Text="{Binding Label}"
                                                            VerticalAlignment="Center"
                                                            FontFamily="{StaticResource UiFont}"
                                                            FontSize="12" FontWeight="SemiBold"
-                                                           Foreground="{StaticResource TextSecondary}"/>
+                                                           Foreground="{DynamicResource TextSecondary}"/>
                                                 <TextBlock Text="{Binding ChildCount, StringFormat=' ({0})'}"
                                                            VerticalAlignment="Center"
                                                            FontFamily="{StaticResource UiFont}"
-                                                           FontSize="10" Foreground="{StaticResource TextSecondary}"
+                                                           FontSize="10" Foreground="{DynamicResource TextSecondary}"
                                                            Opacity="0.7" Margin="2,0,0,0"/>
                                             </StackPanel>
                                             <!-- Subtitle: visible only when collapsed -->
                                             <TextBlock Text="{Binding Subtitle}"
                                                        FontFamily="{StaticResource UiFont}"
-                                                       FontSize="11" Foreground="{StaticResource TextSecondary}"
+                                                       FontSize="11" Foreground="{DynamicResource TextSecondary}"
                                                        Opacity="0.65" Margin="23,2,0,0"
                                                        TextTrimming="CharacterEllipsis">
                                                 <TextBlock.Style>
@@ -161,7 +161,7 @@
                                                         <Rectangle x:Name="ActiveMark"
                                                                    HorizontalAlignment="Left"
                                                                    Width="3" Height="18"
-                                                                   Fill="{StaticResource Accent}"
+                                                                   Fill="{DynamicResource Accent}"
                                                                    RadiusX="2" RadiusY="2"
                                                                    Margin="-28,0,0,0"
                                                                    Visibility="Collapsed"/>
@@ -170,12 +170,12 @@
                                                                        FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                                                        FontSize="13" Margin="0,0,10,0"
                                                                        VerticalAlignment="Center"
-                                                                       Foreground="{StaticResource TextSecondary}"/>
+                                                                       Foreground="{DynamicResource TextSecondary}"/>
                                                             <StackPanel VerticalAlignment="Center">
                                                                 <TextBlock Text="{Binding Label}"
                                                                            FontFamily="{StaticResource UiFont}"
                                                                            FontSize="13" FontWeight="Medium"
-                                                                           Foreground="{StaticResource TextSecondary}"/>
+                                                                           Foreground="{DynamicResource TextSecondary}"/>
                                                                 <ProgressBar Height="2" Margin="0,3,0,0"
                                                                              IsIndeterminate="True"
                                                                              Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
@@ -195,7 +195,7 @@
 
                 <!-- Footer -->
                 <StackPanel Grid.Row="2" Margin="20,10,20,16">
-                    <Border Background="{StaticResource Surface3}" CornerRadius="999"
+                    <Border Background="{DynamicResource Surface3}" CornerRadius="999"
                             Padding="10,3" HorizontalAlignment="Left"
                             AutomationProperties.AutomationId="ElevationBadge">
                         <StackPanel Orientation="Horizontal">
@@ -204,10 +204,10 @@
                                        FontSize="11" Margin="0,0,6,0" VerticalAlignment="Center">
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock">
-                                        <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
+                                        <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsElevated}" Value="True">
-                                                <Setter Property="Foreground" Value="{StaticResource Accent}"/>
+                                                <Setter Property="Foreground" Value="{DynamicResource Accent}"/>
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
@@ -215,7 +215,7 @@
                             </TextBlock>
                             <TextBlock Text="{Binding ElevationBadge}"
                                        FontSize="11" FontWeight="SemiBold"
-                                       Foreground="{StaticResource TextSecondary}"
+                                       Foreground="{DynamicResource TextSecondary}"
                                        VerticalAlignment="Center"/>
                         </StackPanel>
                     </Border>
@@ -228,7 +228,7 @@
 
         <!-- ================= Content ================= -->
         <Border Grid.Column="1"
-                Background="{StaticResource Surface0}"
+                Background="{DynamicResource Surface0}"
                 AutomationProperties.AutomationId="ContentHost"
                 AutomationProperties.Name="ContentHost">
             <Grid>
@@ -239,7 +239,7 @@
 
                 <!-- Update banner — only when a newer release is available. -->
                 <Border Grid.Row="0" Margin="24,16,24,0" Padding="14,10" CornerRadius="10"
-                        Background="#0F1A2E" BorderBrush="{StaticResource Accent}" BorderThickness="1"
+                        Background="#0F1A2E" BorderBrush="{DynamicResource Accent}" BorderThickness="1"
                         Visibility="{Binding About.UpdateAvailable, Converter={StaticResource FlexVis}}">
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -248,25 +248,49 @@
                         </Grid.ColumnDefinitions>
                         <StackPanel Grid.Column="0" Orientation="Horizontal">
                             <TextBlock Text="&#xE896;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                                       FontSize="16" Foreground="{StaticResource Accent}" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                            <TextBlock Text="Update available" FontWeight="SemiBold" Foreground="{StaticResource Accent}" VerticalAlignment="Center"/>
-                            <TextBlock Text="  ·  " Foreground="{StaticResource TextMuted}" VerticalAlignment="Center"/>
-                            <TextBlock Text="{Binding About.LatestVersionLabel}" Foreground="{StaticResource TextPrimary}" VerticalAlignment="Center"/>
-                            <TextBlock Text="  ·  " Foreground="{StaticResource TextMuted}" VerticalAlignment="Center"/>
-                            <TextBlock Text="{Binding About.LatestPublishedLabel}" Foreground="{StaticResource TextSecondary}" FontSize="12" VerticalAlignment="Center"/>
+                                       FontSize="16" Foreground="{DynamicResource Accent}" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <TextBlock Text="Update available" FontWeight="SemiBold" Foreground="{DynamicResource Accent}" VerticalAlignment="Center"/>
+                            <TextBlock Text="  ·  " Foreground="{DynamicResource TextMuted}" VerticalAlignment="Center"/>
+                            <TextBlock Text="{Binding About.LatestVersionLabel}" Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
+                            <TextBlock Text="  ·  " Foreground="{DynamicResource TextMuted}" VerticalAlignment="Center"/>
+                            <TextBlock Text="{Binding About.LatestPublishedLabel}" Foreground="{DynamicResource TextSecondary}" FontSize="12" VerticalAlignment="Center"/>
                         </StackPanel>
                         <Button Grid.Column="1" Content="View details" Command="{Binding OpenAboutTabCommand}"
                                 Style="{StaticResource PrimaryButton}" Padding="14,6"/>
                     </Grid>
                 </Border>
 
-                <!-- Background task banner — deep cleanup scan / large files scan -->
-                <!-- (moved to sidebar footer — see left nav bottom section) -->
-
-                <!-- (update banner continues below) -->
-
                 <ContentControl Grid.Row="1" x:Name="ContentHost"
                                 Content="{Binding SelectedNav.View}"/>
+
+                <!-- Theme button — top right, persistent -->
+                <Border Grid.Row="1" HorizontalAlignment="Right" VerticalAlignment="Top"
+                        Margin="0,16,28,0">
+                    <Grid>
+                        <Border x:Name="ThemeBtn" Width="36" Height="36" CornerRadius="10"
+                                Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
+                                BorderThickness="1" Cursor="Hand" MouseLeftButtonUp="ThemeBtn_Click"
+                                ToolTip="Appearance">
+                            <Border.Style>
+                                <Style TargetType="Border">
+                                    <Style.Triggers>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter Property="BorderBrush" Value="{DynamicResource Accent}"/>
+                                        </Trigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
+                            <TextBlock Text="&#xE790;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                                       FontSize="16" Foreground="{DynamicResource TextSecondary}"
+                                       HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+
+                        <!-- Theme popup (created on demand in code-behind) -->
+                        <Popup x:Name="ThemePopupHost" Placement="Bottom" PlacementTarget="{Binding ElementName=ThemeBtn}"
+                               StaysOpen="False" AllowsTransparency="True" PopupAnimation="Fade"
+                               HorizontalOffset="-304" VerticalOffset="4"/>
+                    </Grid>
+                </Border>
             </Grid>
         </Border>
 
@@ -294,15 +318,15 @@
                     </Border>
                     <StackPanel Grid.Column="1" VerticalAlignment="Center">
                         <TextBlock x:Name="ToastTitle" FontSize="13" FontWeight="SemiBold"
-                                   Foreground="{StaticResource TextPrimary}"/>
+                                   Foreground="{DynamicResource TextPrimary}"/>
                         <TextBlock x:Name="ToastDetail" FontSize="11"
-                                   Foreground="{StaticResource TextSecondary}" Margin="0,2,0,0"/>
+                                   Foreground="{DynamicResource TextSecondary}" Margin="0,2,0,0"/>
                     </StackPanel>
                     <Border Grid.Column="2" Margin="14,0,0,0" Cursor="Hand"
                             MouseLeftButtonUp="DismissToast_Click"
                             Background="Transparent" Padding="4">
                         <TextBlock Text="&#xE711;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                                   FontSize="12" Foreground="{StaticResource TextMuted}"
+                                   FontSize="12" Foreground="{DynamicResource TextMuted}"
                                    VerticalAlignment="Center"/>
                     </Border>
                 </Grid>

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -133,4 +133,11 @@ public partial class MainWindow : Window
         (DataContext as MainWindowViewModel)?.Dispose();
         base.OnClosed(e);
     }
+
+    private void ThemeBtn_Click(object sender, MouseButtonEventArgs e)
+    {
+        if (ThemePopupHost.Child is null)
+            ThemePopupHost.Child = new Views.ThemePopup();
+        ThemePopupHost.IsOpen = !ThemePopupHost.IsOpen;
+    }
 }

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -1,0 +1,310 @@
+// SysManager · ThemeService — runtime theme switching with persistence
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Text.Json;
+using System.Windows;
+using System.Windows.Media;
+
+namespace SysManager.Services;
+
+public sealed class ThemeService
+{
+    private static ThemeService? _instance;
+    public static ThemeService Instance => _instance ??= new ThemeService();
+
+    private static readonly string SettingsPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "SysManager", "theme.json");
+
+    public event Action? ThemeChanged;
+
+    public ThemePreset CurrentTheme { get; private set; } = ThemePreset.Defaults["midnight-indigo"];
+    public string CurrentPresetId { get; private set; } = "midnight-indigo";
+    public string CurrentMode { get; private set; } = "dark";
+    public double ShadePosition { get; private set; } = 0.5;
+
+    private ThemePreset _baseTheme = ThemePreset.Defaults["midnight-indigo"];
+
+    private static readonly Dictionary<string, string> DarkToLight = new()
+    {
+        ["midnight-indigo"] = "clean-indigo",
+        ["deep-ocean"] = "sky-breeze",
+        ["dark-forest"] = "mint-fresh",
+        ["neon-rose"] = "soft-blossom",
+        ["violet-night"] = "lavender",
+        ["warm-ember"] = "warm-sand",
+    };
+
+    private static readonly Dictionary<string, string> LightToDark =
+        DarkToLight.ToDictionary(kv => kv.Value, kv => kv.Key);
+
+    private ThemeService() { }
+
+    public void Initialize()
+    {
+        Load();
+        Apply(CurrentTheme);
+    }
+
+    public string GetCompanionPreset(string targetMode)
+    {
+        if (targetMode == "dark" && LightToDark.TryGetValue(CurrentPresetId, out var darkId))
+            return darkId;
+        if (targetMode == "light" && DarkToLight.TryGetValue(CurrentPresetId, out var lightId))
+            return lightId;
+        return targetMode == "dark" ? "midnight-indigo" : "clean-indigo";
+    }
+
+    public void SetPreset(string id)
+    {
+        if (!ThemePreset.Defaults.TryGetValue(id, out var preset)) return;
+        CurrentPresetId = id;
+        _baseTheme = preset;
+        CurrentMode = preset.IsDark ? "dark" : "light";
+        ApplyShade();
+        Save();
+    }
+
+    public void SetAccent(Color accent)
+    {
+        _baseTheme = _baseTheme with { Accent = accent };
+        ApplyShade();
+        Save();
+    }
+
+    public void SetShade(double position)
+    {
+        ShadePosition = Math.Clamp(position, 0, 1);
+        ApplyShade();
+        Save();
+    }
+
+    public void SetCustom(Color accent, Color background, Color surface, Color text)
+    {
+        CurrentMode = "custom";
+        CurrentPresetId = "custom";
+        _baseTheme = new ThemePreset(
+            Id: "custom",
+            Name: "Custom",
+            IsDark: background.R + background.G + background.B < 384,
+            Accent: accent,
+            Background: background,
+            Surface: surface,
+            Surface2: Lerp(surface, background, 0.5),
+            Border: Lerp(surface, text, 0.15),
+            TextPrimary: text,
+            TextSecondary: Lerp(text, background, 0.3),
+            TextMuted: Lerp(text, background, 0.55));
+        CurrentTheme = new ThemePreset(
+            Id: "custom",
+            Name: "Custom",
+            IsDark: background.R + background.G + background.B < 384,
+            Accent: accent,
+            Background: background,
+            Surface: surface,
+            Surface2: Lerp(surface, background, 0.5),
+            Border: Lerp(surface, text, 0.15),
+            TextPrimary: text,
+            TextSecondary: Lerp(text, background, 0.3),
+            TextMuted: Lerp(text, background, 0.55));
+        Apply(CurrentTheme);
+        Save();
+    }
+
+    private void ApplyShade()
+    {
+        var t = _baseTheme;
+        var offset = (ShadePosition - 0.5) * 0.12;
+
+        CurrentTheme = t with
+        {
+            Background = ShiftLightness(t.Background, offset),
+            Surface = ShiftLightness(t.Surface, offset),
+            Surface2 = ShiftLightness(t.Surface2, offset),
+            Border = ShiftLightness(t.Border, offset)
+        };
+        Apply(CurrentTheme);
+    }
+
+    public void Apply(ThemePreset theme)
+    {
+        var res = Application.Current.Resources;
+        SetBrush(res, "Surface0", theme.Background);
+        SetBrush(res, "Surface1", theme.Surface);
+        SetBrush(res, "Surface2", theme.Surface2);
+        SetBrush(res, "Surface3", Lerp(theme.Surface2, theme.TextPrimary, 0.05));
+        SetBrush(res, "Surface4", Lerp(theme.Surface2, theme.TextPrimary, 0.1));
+        SetBrush(res, "Border1", theme.Border);
+        SetBrush(res, "Border2", Lerp(theme.Border, theme.TextPrimary, 0.08));
+        SetBrush(res, "BorderAccent", Lerp(theme.Border, theme.Accent, 0.2));
+        SetBrush(res, "TextPrimary", theme.TextPrimary);
+        SetBrush(res, "TextSecondary", theme.TextSecondary);
+        SetBrush(res, "TextMuted", theme.TextMuted);
+        SetBrush(res, "TextDisabled", Lerp(theme.TextMuted, theme.Background, 0.4));
+        SetBrush(res, "Accent", theme.Accent);
+        SetBrush(res, "AccentHover", Lighten(theme.Accent, 0.15));
+        SetBrush(res, "AccentPressed", Darken(theme.Accent, 0.12));
+        SetBrush(res, "AccentSoft", Color.FromArgb(15, theme.Accent.R, theme.Accent.G, theme.Accent.B));
+
+        SetColor(res, "Surface0Color", theme.Background);
+        SetColor(res, "Surface1Color", theme.Surface);
+        SetColor(res, "Surface2Color", theme.Surface2);
+        SetColor(res, "Surface3Color", Lerp(theme.Surface2, theme.TextPrimary, 0.05));
+        SetColor(res, "Surface4Color", Lerp(theme.Surface2, theme.TextPrimary, 0.1));
+        SetColor(res, "AccentColor", theme.Accent);
+        SetColor(res, "AccentHoverColor", Lighten(theme.Accent, 0.15));
+        SetColor(res, "AccentPressedColor", Darken(theme.Accent, 0.12));
+
+        ThemeChanged?.Invoke();
+    }
+
+    private static void SetBrush(ResourceDictionary res, string key, Color color)
+    {
+        res[key] = new SolidColorBrush(color);
+    }
+
+    private static void SetColor(ResourceDictionary res, string key, Color color)
+    {
+        res[key] = color;
+    }
+
+    private static Color Lerp(Color a, Color b, double t)
+    {
+        return Color.FromArgb(
+            (byte)(a.A + (b.A - a.A) * t),
+            (byte)(a.R + (b.R - a.R) * t),
+            (byte)(a.G + (b.G - a.G) * t),
+            (byte)(a.B + (b.B - a.B) * t));
+    }
+
+    private static Color Lighten(Color c, double amount)
+    {
+        return Color.FromArgb(c.A,
+            (byte)Math.Min(255, c.R + (255 - c.R) * amount),
+            (byte)Math.Min(255, c.G + (255 - c.G) * amount),
+            (byte)Math.Min(255, c.B + (255 - c.B) * amount));
+    }
+
+    private static Color Darken(Color c, double amount)
+    {
+        return Color.FromArgb(c.A,
+            (byte)(c.R * (1 - amount)),
+            (byte)(c.G * (1 - amount)),
+            (byte)(c.B * (1 - amount)));
+    }
+
+    private static Color ShiftLightness(Color c, double amount)
+    {
+        if (amount >= 0)
+            return Lighten(c, amount);
+        return Darken(c, -amount);
+    }
+
+    private void Save()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(SettingsPath)!;
+            Directory.CreateDirectory(dir);
+            var data = new ThemeSettings(CurrentPresetId, CurrentMode, ShadePosition,
+                CurrentTheme.Accent.ToString(), CurrentTheme.Background.ToString(),
+                CurrentTheme.Surface.ToString(), CurrentTheme.TextPrimary.ToString());
+            var json = JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(SettingsPath, json);
+        }
+        catch { }
+    }
+
+    private void Load()
+    {
+        try
+        {
+            if (!File.Exists(SettingsPath)) return;
+            var json = File.ReadAllText(SettingsPath);
+            var data = JsonSerializer.Deserialize<ThemeSettings>(json);
+            if (data is null) return;
+
+            CurrentMode = data.Mode;
+            ShadePosition = data.ShadePosition;
+            CurrentPresetId = data.PresetId;
+
+            if (data.PresetId == "custom")
+            {
+                var accent = (Color)ColorConverter.ConvertFromString(data.Accent);
+                var bg = (Color)ColorConverter.ConvertFromString(data.Background);
+                var surface = (Color)ColorConverter.ConvertFromString(data.Surface);
+                var text = (Color)ColorConverter.ConvertFromString(data.Text);
+                SetCustom(accent, bg, surface, text);
+            }
+            else if (ThemePreset.Defaults.TryGetValue(data.PresetId, out var preset))
+            {
+                _baseTheme = preset;
+                CurrentTheme = preset;
+                ApplyShade();
+            }
+        }
+        catch { }
+    }
+
+    private sealed record ThemeSettings(
+        string PresetId, string Mode, double ShadePosition,
+        string Accent, string Background, string Surface, string Text);
+}
+
+public sealed record ThemePreset(
+    string Id,
+    string Name,
+    bool IsDark,
+    Color Accent,
+    Color Background,
+    Color Surface,
+    Color Surface2,
+    Color Border,
+    Color TextPrimary,
+    Color TextSecondary,
+    Color TextMuted)
+{
+    public static readonly Dictionary<string, ThemePreset> Defaults = new()
+    {
+        ["midnight-indigo"] = new("midnight-indigo", "Midnight Indigo", true,
+            C("#6366F1"), C("#070A0F"), C("#0E1218"), C("#151A23"), C("#1F2633"),
+            C("#F1F3F7"), C("#A3ADBF"), C("#6B7489")),
+        ["deep-ocean"] = new("deep-ocean", "Deep Ocean", true,
+            C("#3B82F6"), C("#050D1A"), C("#0A1628"), C("#0F1D33"), C("#1A2D4D"),
+            C("#E2E8F0"), C("#94A3B8"), C("#64748B")),
+        ["dark-forest"] = new("dark-forest", "Dark Forest", true,
+            C("#10B981"), C("#020F0A"), C("#021A12"), C("#03261A"), C("#0A3D2A"),
+            C("#D1FAE5"), C("#6EE7B7"), C("#34D399")),
+        ["neon-rose"] = new("neon-rose", "Neon Rose", true,
+            C("#EC4899"), C("#120508"), C("#1A0A0F"), C("#240E16"), C("#3D1525"),
+            C("#FDF2F8"), C("#F9A8D4"), C("#F472B6")),
+        ["violet-night"] = new("violet-night", "Violet Night", true,
+            C("#A855F7"), C("#0A0515"), C("#0F0A1A"), C("#160F26"), C("#2D1B4E"),
+            C("#F3E8FF"), C("#C4B5FD"), C("#8B5CF6")),
+        ["warm-ember"] = new("warm-ember", "Warm Ember", true,
+            C("#F59E0B"), C("#0F0A04"), C("#1A1008"), C("#24180C"), C("#3D2A12"),
+            C("#FEF3C7"), C("#FCD34D"), C("#FBBF24")),
+        ["clean-indigo"] = new("clean-indigo", "Clean Indigo", false,
+            C("#6366F1"), C("#FFFFFF"), C("#F8FAFC"), C("#F1F5F9"), C("#E2E8F0"),
+            C("#1E1B4B"), C("#4338CA"), C("#6366F1")),
+        ["sky-breeze"] = new("sky-breeze", "Sky Breeze", false,
+            C("#0EA5E9"), C("#F8FAFC"), C("#F0F9FF"), C("#E0F2FE"), C("#BAE6FD"),
+            C("#0C4A6E"), C("#0369A1"), C("#0284C7")),
+        ["warm-sand"] = new("warm-sand", "Warm Sand", false,
+            C("#D97706"), C("#FFFBEB"), C("#FEF3C7"), C("#FDE68A"), C("#FCD34D"),
+            C("#451A03"), C("#78350F"), C("#92400E")),
+        ["mint-fresh"] = new("mint-fresh", "Mint Fresh", false,
+            C("#16A34A"), C("#F0FDF4"), C("#DCFCE7"), C("#BBF7D0"), C("#86EFAC"),
+            C("#14532D"), C("#166534"), C("#15803D")),
+        ["soft-blossom"] = new("soft-blossom", "Soft Blossom", false,
+            C("#DB2777"), C("#FDF2F8"), C("#FCE7F3"), C("#FBCFE8"), C("#F9A8D4"),
+            C("#500724"), C("#831843"), C("#9D174D")),
+        ["lavender"] = new("lavender", "Lavender", false,
+            C("#7C3AED"), C("#FAF5FF"), C("#F3E8FF"), C("#E9D5FF"), C("#D8B4FE"),
+            C("#2E1065"), C("#4C1D95"), C("#5B21B6")),
+    };
+
+    private static Color C(string hex) => (Color)ColorConverter.ConvertFromString(hex);
+}

--- a/SysManager/SysManager/Views/AboutView.xaml
+++ b/SysManager/SysManager/Views/AboutView.xaml
@@ -31,7 +31,7 @@
                         </Grid.ColumnDefinitions>
                         <StackPanel Grid.Column="0">
                             <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="SysManager" FontSize="24" FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}"/>
+                                <TextBlock Text="SysManager" FontSize="24" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}"/>
                                 <Border Style="{StaticResource BadgeAccent}" Margin="12,0,0,0" VerticalAlignment="Center">
                                     <TextBlock Text="{Binding CurrentVersion, StringFormat=v{0}}" Foreground="White" FontWeight="SemiBold" FontSize="12"/>
                                 </Border>
@@ -39,12 +39,12 @@
                             <TextBlock Text="Local Windows system monitoring toolkit." Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
                             <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
                                 <TextBlock Text="BUILD" Style="{StaticResource Caption}"/>
-                                <TextBlock Text="{Binding BuildDate}" Margin="8,0,24,0" Foreground="{StaticResource TextSecondary}" FontSize="12"/>
+                                <TextBlock Text="{Binding BuildDate}" Margin="8,0,24,0" Foreground="{DynamicResource TextSecondary}" FontSize="12"/>
                                 <TextBlock Text="LICENSE" Style="{StaticResource Caption}"/>
-                                <TextBlock Text="MIT" Margin="8,0,24,0" Foreground="{StaticResource TextSecondary}" FontSize="12"/>
+                                <TextBlock Text="MIT" Margin="8,0,24,0" Foreground="{DynamicResource TextSecondary}" FontSize="12"/>
                                 <TextBlock Text="SOURCE" Style="{StaticResource Caption}"/>
                                 <TextBlock Margin="8,0,0,0" FontSize="12">
-                                    <Hyperlink Command="{Binding OpenRepoCommand}" Foreground="{StaticResource Accent}">github.com/laurentiu021/SystemManager</Hyperlink>
+                                    <Hyperlink Command="{Binding OpenRepoCommand}" Foreground="{DynamicResource Accent}">github.com/laurentiu021/SystemManager</Hyperlink>
                                 </TextBlock>
                             </StackPanel>
                         </StackPanel>
@@ -74,7 +74,7 @@
 
                 <!-- Update available card -->
                 <Border Style="{StaticResource Card}" Margin="0,16,0,0"
-                        BorderBrush="{StaticResource Accent}" BorderThickness="1"
+                        BorderBrush="{DynamicResource Accent}" BorderThickness="1"
                         Visibility="{Binding UpdateAvailable, Converter={StaticResource FlexVis}}">
                     <StackPanel>
                         <Grid>
@@ -85,13 +85,13 @@
                             <StackPanel Grid.Column="0">
                                 <StackPanel Orientation="Horizontal">
                                     <TextBlock Text="&#xE896;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                                               FontSize="18" Foreground="{StaticResource Accent}" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                                               FontSize="18" Foreground="{DynamicResource Accent}" VerticalAlignment="Center" Margin="0,0,10,0"/>
                                     <TextBlock Text="Update available" FontSize="16" FontWeight="SemiBold"
-                                               Foreground="{StaticResource Accent}" VerticalAlignment="Center"/>
-                                    <TextBlock Text="  ·  " Foreground="{StaticResource TextMuted}" VerticalAlignment="Center"/>
-                                    <TextBlock Text="{Binding LatestVersionLabel}" FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}" VerticalAlignment="Center"/>
-                                    <TextBlock Text="  ·  " Foreground="{StaticResource TextMuted}" VerticalAlignment="Center"/>
-                                    <TextBlock Text="{Binding LatestPublishedLabel}" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center"/>
+                                               Foreground="{DynamicResource Accent}" VerticalAlignment="Center"/>
+                                    <TextBlock Text="  ·  " Foreground="{DynamicResource TextMuted}" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{Binding LatestVersionLabel}" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
+                                    <TextBlock Text="  ·  " Foreground="{DynamicResource TextMuted}" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{Binding LatestPublishedLabel}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
                                 </StackPanel>
                                 <TextBlock Text="{Binding UpdateStatus}" Style="{StaticResource Subtle}" Margin="0,6,0,0" TextWrapping="Wrap"/>
                             </StackPanel>
@@ -120,9 +120,9 @@
                                     Visibility="{Binding DownloadedPath, Converter={StaticResource FlexVis}}">
                             <Ellipse Width="10" Height="10" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,8,0"/>
                             <TextBlock Text="{Binding DownloadStatus}" Foreground="#22C55E" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                            <TextBlock Text="  ·  " Foreground="{StaticResource TextMuted}" VerticalAlignment="Center"/>
+                            <TextBlock Text="  ·  " Foreground="{DynamicResource TextMuted}" VerticalAlignment="Center"/>
                             <TextBlock VerticalAlignment="Center">
-                                <Hyperlink Command="{Binding OpenDownloadFolderCommand}" Foreground="{StaticResource Accent}">Show file</Hyperlink>
+                                <Hyperlink Command="{Binding OpenDownloadFolderCommand}" Foreground="{DynamicResource Accent}">Show file</Hyperlink>
                             </TextBlock>
                         </StackPanel>
                     </StackPanel>
@@ -138,7 +138,7 @@
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                         <Ellipse Grid.Column="0" Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,10,0" Fill="#22C55E"/>
-                        <TextBlock Grid.Column="1" Text="{Binding UpdateStatus}" Foreground="{StaticResource TextSecondary}"
+                        <TextBlock Grid.Column="1" Text="{Binding UpdateStatus}" Foreground="{DynamicResource TextSecondary}"
                                    VerticalAlignment="Center" TextWrapping="Wrap"/>
                         <Button Grid.Column="2" Content="Retry" Command="{Binding CheckForUpdatesCommand}"
                                 Style="{StaticResource SecondaryButton}" Padding="14,6" Margin="12,0,0,0"
@@ -163,18 +163,18 @@
                                     <Border Style="{StaticResource CardInner}" Margin="0,0,0,10">
                                         <StackPanel>
                                             <StackPanel Orientation="Horizontal">
-                                                <TextBlock Text="{Binding Version}" FontSize="16" FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}"/>
+                                                <TextBlock Text="{Binding Version}" FontSize="16" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}"/>
                                                 <Border Margin="10,0,0,0" VerticalAlignment="Center"
                                                         Visibility="{Binding IsCurrent, Converter={StaticResource BoolToVis}}"
                                                         Style="{StaticResource BadgeAccent}">
                                                     <TextBlock Text="Current" Foreground="White" FontSize="11" FontWeight="SemiBold"/>
                                                 </Border>
-                                                <TextBlock Text="  ·  " Foreground="{StaticResource TextMuted}" VerticalAlignment="Center" Margin="10,0,0,0"/>
-                                                <TextBlock Text="{Binding Title}" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center"/>
-                                                <TextBlock Text="  ·  " Foreground="{StaticResource TextMuted}" VerticalAlignment="Center"/>
-                                                <TextBlock Text="{Binding PublishedAt}" Foreground="{StaticResource TextMuted}" FontSize="12" VerticalAlignment="Center"/>
+                                                <TextBlock Text="  ·  " Foreground="{DynamicResource TextMuted}" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                                                <TextBlock Text="{Binding Title}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
+                                                <TextBlock Text="  ·  " Foreground="{DynamicResource TextMuted}" VerticalAlignment="Center"/>
+                                                <TextBlock Text="{Binding PublishedAt}" Foreground="{DynamicResource TextMuted}" FontSize="12" VerticalAlignment="Center"/>
                                             </StackPanel>
-                                            <TextBlock helpers:MarkdownTextBlock.Markdown="{Binding Body}" Foreground="{StaticResource TextSecondary}"
+                                            <TextBlock helpers:MarkdownTextBlock.Markdown="{Binding Body}" Foreground="{DynamicResource TextSecondary}"
                                                        TextWrapping="Wrap" Margin="0,8,0,0" FontFamily="{StaticResource UiFont}"/>
                                         </StackPanel>
                                     </Border>
@@ -188,7 +188,7 @@
                 <Border Style="{StaticResource Card}" Margin="0,16,0,0">
                     <StackPanel>
                         <TextBlock Text="Legal" Style="{StaticResource SectionTitle}"/>
-                        <TextBlock TextWrapping="Wrap" Margin="0,6,0,0" Foreground="{StaticResource TextSecondary}" FontSize="12">
+                        <TextBlock TextWrapping="Wrap" Margin="0,6,0,0" Foreground="{DynamicResource TextSecondary}" FontSize="12">
                             SysManager is released under the MIT License. The software is provided "AS IS", without warranty of any kind.
                             All operations are local to your machine — no telemetry, no accounts. Updates are fetched from the public
                             GitHub Releases API and downloaded directly from GitHub.

--- a/SysManager/SysManager/Views/AppAlertsView.xaml
+++ b/SysManager/SysManager/Views/AppAlertsView.xaml
@@ -19,9 +19,9 @@
         <!-- Header -->
         <StackPanel Grid.Row="0" Margin="0,0,0,16">
             <TextBlock Text="App Installation Alerts" FontSize="20" FontWeight="SemiBold"
-                       Foreground="{StaticResource TextPrimary}" />
+                       Foreground="{DynamicResource TextPrimary}" />
             <TextBlock Text="{Binding MonitorStatus}" Opacity="0.7" Margin="0,4,0,0"
-                       Foreground="{StaticResource TextSecondary}" />
+                       Foreground="{DynamicResource TextSecondary}" />
         </StackPanel>
 
         <!-- Toolbar -->
@@ -40,7 +40,7 @@
                   CanUserAddRows="False" CanUserDeleteRows="False"
                   CanUserResizeColumns="True"
                   HeadersVisibility="Column" GridLinesVisibility="Horizontal"
-                  BorderThickness="1" BorderBrush="{StaticResource Border1}"
+                  BorderThickness="1" BorderBrush="{DynamicResource Border1}"
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling">
             <DataGrid.Columns>
@@ -55,7 +55,7 @@
         <!-- Footer -->
         <StackPanel Grid.Row="3" Orientation="Horizontal" Margin="0,8,0,0">
             <TextBlock Opacity="0.6" VerticalAlignment="Center"
-                       Foreground="{StaticResource TextSecondary}">
+                       Foreground="{DynamicResource TextSecondary}">
                 <Run Text="{Binding AlertCount, Mode=OneWay}" />
                 <Run Text=" total · " />
                 <Run Text="{Binding UnacknowledgedCount, Mode=OneWay}" />

--- a/SysManager/SysManager/Views/AppBlockerView.xaml
+++ b/SysManager/SysManager/Views/AppBlockerView.xaml
@@ -7,7 +7,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             Background="{StaticResource Surface0}">
+             Background="{DynamicResource Surface0}">
 
     <Grid Margin="28,24,28,0">
         <Grid.RowDefinitions>
@@ -26,7 +26,7 @@
         </StackPanel>
 
         <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
@@ -34,9 +34,9 @@
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
                     <TextBlock Text="Blocking applications modifies system registry keys and requires administrator privileges."
-                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                 </StackPanel>
             </DockPanel>
         </Border>
@@ -79,7 +79,7 @@
                   CanUserAddRows="False" CanUserDeleteRows="False"
                   CanUserResizeColumns="True"
                   HeadersVisibility="Column" GridLinesVisibility="None"
-                  BorderThickness="1" BorderBrush="{StaticResource Border1}"
+                  BorderThickness="1" BorderBrush="{DynamicResource Border1}"
                   Background="Transparent"
                   AutomationProperties.Name="Data table"
                   VirtualizingPanel.IsVirtualizing="True"
@@ -93,7 +93,7 @@
         <!-- Footer -->
         <StackPanel Grid.Row="5" Orientation="Horizontal" Margin="0,8,0,0">
             <TextBlock Opacity="0.6" VerticalAlignment="Center"
-                       Foreground="{StaticResource TextSecondary}">
+                       Foreground="{DynamicResource TextSecondary}">
                 <Run Text="{Binding BlockedCount, Mode=OneWay}" />
                 <Run Text=" blocked" />
             </TextBlock>

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml
@@ -28,7 +28,7 @@
         </StackPanel>
 
         <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
@@ -36,9 +36,9 @@
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
                     <TextBlock Text="Some package upgrades require administrator privileges for system-wide installations."
-                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                 </StackPanel>
             </DockPanel>
         </Border>

--- a/SysManager/SysManager/Views/BatteryHealthView.xaml
+++ b/SysManager/SysManager/Views/BatteryHealthView.xaml
@@ -7,7 +7,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             Background="{StaticResource Surface0}">
+             Background="{DynamicResource Surface0}">
 
     <Grid Margin="32,24">
         <Grid.RowDefinitions>
@@ -44,7 +44,7 @@
                 <StackPanel>
                     <!-- No battery message -->
                     <TextBlock Text="No battery detected on this device."
-                               FontSize="14" Foreground="{StaticResource TextMuted}"
+                               FontSize="14" Foreground="{DynamicResource TextMuted}"
                                Margin="0,0,0,16"
                                Visibility="{Binding Battery.HasBattery, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
 
@@ -97,7 +97,7 @@
                                 <StackPanel Grid.Column="1">
                                     <TextBlock Text="Wear" Style="{StaticResource Subtle}" FontSize="12"/>
                                     <TextBlock FontSize="24" FontWeight="Bold" Margin="0,4,0,0"
-                                               Foreground="{StaticResource Danger}">
+                                               Foreground="{DynamicResource Danger}">
                                         <Run Text="{Binding Battery.WearPercent, Mode=OneWay}"/><Run Text="%"/>
                                     </TextBlock>
                                 </StackPanel>

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -7,7 +7,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             Background="{StaticResource Surface0}">
+             Background="{DynamicResource Surface0}">
 
     <Grid Margin="32,24">
         <Grid.RowDefinitions>
@@ -27,7 +27,7 @@
         </StackPanel>
 
         <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
@@ -35,9 +35,9 @@
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
                     <TextBlock Text="Some applications install system-wide and require administrator privileges."
-                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                 </StackPanel>
             </DockPanel>
         </Border>
@@ -70,7 +70,7 @@
                 <Grid Width="200" Margin="0,0,12,0">
                     <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"/>
                     <TextBlock Text="Search apps…" IsHitTestVisible="False"
-                               Foreground="{StaticResource TextMuted}" Margin="6,0,0,0"
+                               Foreground="{DynamicResource TextMuted}" Margin="6,0,0,0"
                                VerticalAlignment="Center" FontSize="12"
                                Visibility="{Binding FilterText, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                 </Grid>
@@ -90,7 +90,7 @@
         <Border Grid.Row="3" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
             <StackPanel>
                 <TextBlock Text="Search winget packages" FontWeight="SemiBold" FontSize="14"
-                           Foreground="{StaticResource TextPrimary}"/>
+                           Foreground="{DynamicResource TextPrimary}"/>
                 <TextBlock Text="Find and install any app available on winget."
                            Style="{StaticResource Subtle}" Margin="0,2,0,12"/>
                 <DockPanel>
@@ -99,7 +99,7 @@
                     <Grid>
                         <TextBox Text="{Binding SearchQuery, UpdateSourceTrigger=PropertyChanged}"/>
                         <TextBlock Text="Search apps…" IsHitTestVisible="False"
-                                   Foreground="{StaticResource TextMuted}" Margin="6,0,0,0"
+                                   Foreground="{DynamicResource TextMuted}" Margin="6,0,0,0"
                                    VerticalAlignment="Center" FontSize="12"
                                    Visibility="{Binding SearchQuery, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                     </Grid>
@@ -119,7 +119,7 @@
                                     <Style TargetType="Border">
                                         <Style.Triggers>
                                             <Trigger Property="IsMouseOver" Value="True">
-                                                <Setter Property="Background" Value="{StaticResource Surface2}"/>
+                                                <Setter Property="Background" Value="{DynamicResource Surface2}"/>
                                             </Trigger>
                                         </Style.Triggers>
                                     </Style>
@@ -132,11 +132,11 @@
                                     </Grid.ColumnDefinitions>
                                     <TextBlock Grid.Column="0" Text="{Binding Name}"
                                                FontSize="12.5" VerticalAlignment="Center"
-                                               Foreground="{StaticResource TextPrimary}"
+                                               Foreground="{DynamicResource TextPrimary}"
                                                TextTrimming="CharacterEllipsis"/>
                                     <TextBlock Grid.Column="1" Text="{Binding WingetId}"
                                                FontSize="11" VerticalAlignment="Center"
-                                               Foreground="{StaticResource TextMuted}"
+                                               Foreground="{DynamicResource TextMuted}"
                                                Margin="12,0" TextTrimming="CharacterEllipsis"
                                                MaxWidth="220"/>
                                     <Button Grid.Column="2" Content="Add"
@@ -167,8 +167,8 @@
                                     <StackPanel Margin="16,20,16,6">
                                         <TextBlock Text="{Binding Name}"
                                                    FontWeight="SemiBold" FontSize="14"
-                                                   Foreground="{StaticResource TextPrimary}"/>
-                                        <Rectangle Height="1" Fill="{StaticResource Border1}" Margin="0,8,0,0"/>
+                                                   Foreground="{DynamicResource TextPrimary}"/>
+                                        <Rectangle Height="1" Fill="{DynamicResource Border1}" Margin="0,8,0,0"/>
                                     </StackPanel>
                                 </DataTemplate>
                             </GroupStyle.HeaderTemplate>
@@ -212,7 +212,7 @@
                                         <TextBlock Text="{Binding IconGlyph}"
                                                    FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                                    FontSize="18" HorizontalAlignment="Center" VerticalAlignment="Center"
-                                                   Foreground="{StaticResource TextSecondary}"
+                                                   Foreground="{DynamicResource TextSecondary}"
                                                    Visibility="{Binding Icon, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                                     </Grid>
 
@@ -221,7 +221,7 @@
                                         <StackPanel Orientation="Horizontal">
                                             <TextBlock Text="{Binding Name}"
                                                        FontWeight="SemiBold" FontSize="13"
-                                                       Foreground="{StaticResource TextPrimary}"/>
+                                                       Foreground="{DynamicResource TextPrimary}"/>
                                             <Border CornerRadius="4" Padding="4,2" Margin="8,0,0,0" Background="#1422C55E" BorderBrush="#3022C55E" BorderThickness="1"
                                                     Visibility="{Binding IsInstalled, Converter={StaticResource BoolToVis}}">
                                                 <TextBlock Text="Installed" FontSize="9" Foreground="#4ADE80" FontWeight="SemiBold"/>
@@ -229,7 +229,7 @@
                                         </StackPanel>
                                         <TextBlock Text="{Binding Description}"
                                                    FontSize="11.5" Margin="0,2,0,0"
-                                                   Foreground="{StaticResource TextSecondary}"
+                                                   Foreground="{DynamicResource TextSecondary}"
                                                    TextTrimming="CharacterEllipsis"/>
                                     </StackPanel>
 

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -27,7 +27,7 @@
         </StackPanel>
 
         <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
@@ -35,9 +35,9 @@
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
                     <TextBlock Text="Running SFC and DISM system repairs requires administrator privileges."
-                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                 </StackPanel>
             </DockPanel>
         </Border>
@@ -69,7 +69,7 @@
                         <StackPanel>
                             <TextBlock Text="TEMP FOLDERS" Style="{StaticResource Caption}"/>
                             <TextBlock Text="{Binding TempSizeLabel}" FontSize="16" FontWeight="SemiBold"
-                                       Foreground="{StaticResource Info}" Margin="0,4,0,0"/>
+                                       Foreground="{DynamicResource Info}" Margin="0,4,0,0"/>
                         </StackPanel>
                     </Border>
                     <Border Grid.Column="1" Style="{StaticResource CardInner}" Margin="6,0,0,0">
@@ -99,9 +99,9 @@
                      are running so the user can navigate away freely. -->
                 <StackPanel Orientation="Horizontal" Margin="0,10,0,0"
                             Visibility="{Binding IsSfcRunning, Converter={StaticResource FlexVis}}">
-                    <Ellipse Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,8,0" Fill="{StaticResource Success}"/>
-                    <TextBlock Text="SFC /scannow is running in background — " Foreground="{StaticResource Success}" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                    <TextBlock Text="{Binding SfcStatus}" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center"/>
+                    <Ellipse Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,8,0" Fill="{DynamicResource Success}"/>
+                    <TextBlock Text="SFC /scannow is running in background — " Foreground="{DynamicResource Success}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                    <TextBlock Text="{Binding SfcStatus}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
                 </StackPanel>
                 <!-- SFC verdict (shown after completion) -->
                 <Border Margin="0,8,0,0" Padding="12,10" CornerRadius="8"
@@ -110,7 +110,7 @@
                         <SolidColorBrush Color="#0D1117" Opacity="0.8"/>
                     </Border.Background>
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="SFC result:" FontWeight="SemiBold" Foreground="{StaticResource TextSecondary}"
+                        <TextBlock Text="SFC result:" FontWeight="SemiBold" Foreground="{DynamicResource TextSecondary}"
                                    VerticalAlignment="Center" Margin="0,0,8,0"/>
                         <TextBlock Text="{Binding SfcVerdict}" TextWrapping="Wrap" VerticalAlignment="Center"
                                    Foreground="{Binding SfcVerdictColorHex, Converter={StaticResource HexBrush}}"/>
@@ -118,9 +118,9 @@
                 </Border>
                 <StackPanel Orientation="Horizontal" Margin="0,6,0,0"
                             Visibility="{Binding IsDismRunning, Converter={StaticResource FlexVis}}">
-                    <Ellipse Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,8,0" Fill="{StaticResource Info}"/>
-                    <TextBlock Text="DISM is running in background — " Foreground="{StaticResource Info}" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                    <TextBlock Text="{Binding DismStatus}" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center"/>
+                    <Ellipse Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,8,0" Fill="{DynamicResource Info}"/>
+                    <TextBlock Text="DISM is running in background — " Foreground="{DynamicResource Info}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                    <TextBlock Text="{Binding DismStatus}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
                 </StackPanel>
                 <!-- DISM verdict (shown after completion) -->
                 <Border Margin="0,8,0,0" Padding="12,10" CornerRadius="8"
@@ -129,7 +129,7 @@
                         <SolidColorBrush Color="#0D1117" Opacity="0.8"/>
                     </Border.Background>
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="DISM result:" FontWeight="SemiBold" Foreground="{StaticResource TextSecondary}"
+                        <TextBlock Text="DISM result:" FontWeight="SemiBold" Foreground="{DynamicResource TextSecondary}"
                                    VerticalAlignment="Center" Margin="0,0,8,0"/>
                         <TextBlock Text="{Binding DismVerdict}" TextWrapping="Wrap" VerticalAlignment="Center"
                                    Foreground="{Binding DismVerdictColorHex, Converter={StaticResource HexBrush}}"/>

--- a/SysManager/SysManager/Views/ContextMenuView.xaml
+++ b/SysManager/SysManager/Views/ContextMenuView.xaml
@@ -7,7 +7,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             Background="{StaticResource Surface0}">
+             Background="{DynamicResource Surface0}">
 
     <Grid Margin="32,24">
         <Grid.RowDefinitions>
@@ -100,7 +100,7 @@
                                         </StackPanel>
                                     </StackPanel.ToolTip>
                                     <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13"/>
-                                    <TextBlock Text="{Binding Command}" Foreground="{StaticResource TextMuted}"
+                                    <TextBlock Text="{Binding Command}" Foreground="{DynamicResource TextMuted}"
                                                FontSize="11" TextTrimming="CharacterEllipsis" MaxWidth="380"
                                                HorizontalAlignment="Left" Margin="0,2,0,0"/>
                                 </StackPanel>
@@ -112,7 +112,7 @@
                                         SortMemberPath="Location" IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
-                                <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
                                 <Setter Property="FontSize" Value="12"/>
                                 <Setter Property="VerticalAlignment" Value="Center"/>
                             </Style>
@@ -123,7 +123,7 @@
                                         SortMemberPath="Source" IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
-                                <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
                                 <Setter Property="FontSize" Value="12"/>
                                 <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
                                 <Setter Property="VerticalAlignment" Value="Center"/>

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -88,8 +88,8 @@
         <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
             <StackPanel>
                 <!-- Health Score card -->
-                <Border CornerRadius="8" Padding="16" Background="{StaticResource Surface1}" Margin="0,0,0,12"
-                        BorderBrush="{StaticResource Border1}" BorderThickness="1"
+                <Border CornerRadius="8" Padding="16" Background="{DynamicResource Surface1}" Margin="0,0,0,12"
+                        BorderBrush="{DynamicResource Border1}" BorderThickness="1"
                         Visibility="{Binding HasHealthScore, Converter={StaticResource BoolToVis}}">
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -104,9 +104,9 @@
                                 BorderBrush="{Binding HealthResult.ColorHex, Converter={StaticResource HexBrush}}">
                             <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
                                 <TextBlock Text="{Binding HealthResult.Score}" FontSize="32" FontWeight="Bold"
-                                           HorizontalAlignment="Center" Foreground="{StaticResource TextPrimary}"/>
+                                           HorizontalAlignment="Center" Foreground="{DynamicResource TextPrimary}"/>
                                 <TextBlock Text="{Binding HealthResult.Label}" FontSize="11"
-                                           HorizontalAlignment="Center" Foreground="{StaticResource TextSecondary}"/>
+                                           HorizontalAlignment="Center" Foreground="{DynamicResource TextSecondary}"/>
                             </StackPanel>
                         </Border>
 
@@ -116,22 +116,22 @@
 
                             <!-- Component breakdown -->
                             <WrapPanel Margin="0,0,0,8">
-                                <TextBlock Margin="0,0,12,0" Foreground="{StaticResource TextSecondary}" FontSize="12">
+                                <TextBlock Margin="0,0,12,0" Foreground="{DynamicResource TextSecondary}" FontSize="12">
                                     <Run Text="Disk "/>
-                                    <Run Text="{Binding HealthResult.DiskScore, Mode=OneWay}" FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}"/>
+                                    <Run Text="{Binding HealthResult.DiskScore, Mode=OneWay}" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}"/>
                                 </TextBlock>
-                                <TextBlock Margin="0,0,12,0" Foreground="{StaticResource TextSecondary}" FontSize="12">
+                                <TextBlock Margin="0,0,12,0" Foreground="{DynamicResource TextSecondary}" FontSize="12">
                                     <Run Text="RAM "/>
-                                    <Run Text="{Binding HealthResult.RamScore, Mode=OneWay}" FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}"/>
+                                    <Run Text="{Binding HealthResult.RamScore, Mode=OneWay}" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}"/>
                                 </TextBlock>
-                                <TextBlock Margin="0,0,12,0" Foreground="{StaticResource TextSecondary}" FontSize="12">
+                                <TextBlock Margin="0,0,12,0" Foreground="{DynamicResource TextSecondary}" FontSize="12">
                                     <Run Text="Uptime "/>
-                                    <Run Text="{Binding HealthResult.UptimeScore, Mode=OneWay}" FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}"/>
+                                    <Run Text="{Binding HealthResult.UptimeScore, Mode=OneWay}" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}"/>
                                 </TextBlock>
-                                <TextBlock Foreground="{StaticResource TextSecondary}" FontSize="12"
+                                <TextBlock Foreground="{DynamicResource TextSecondary}" FontSize="12"
                                            Visibility="{Binding HealthResult.HasBattery, Converter={StaticResource BoolToVis}}">
                                     <Run Text="Battery "/>
-                                    <Run Text="{Binding HealthResult.BatteryScore, Mode=OneWay}" FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}"/>
+                                    <Run Text="{Binding HealthResult.BatteryScore, Mode=OneWay}" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}"/>
                                 </TextBlock>
                             </WrapPanel>
 
@@ -154,33 +154,33 @@
                 </Border>
 
                 <!-- Health Score loading indicator -->
-                <Border CornerRadius="8" Padding="14" Background="{StaticResource Surface1}" Margin="0,0,0,8"
-                        BorderBrush="{StaticResource Border1}" BorderThickness="1"
+                <Border CornerRadius="8" Padding="14" Background="{DynamicResource Surface1}" Margin="0,0,0,8"
+                        BorderBrush="{DynamicResource Border1}" BorderThickness="1"
                         Visibility="{Binding IsHealthScoreLoading, Converter={StaticResource BoolToVis}}">
                     <StackPanel Orientation="Horizontal">
                         <ProgressBar AutomationProperties.Name="Health score loading" IsIndeterminate="True"
                                      Width="80" Height="4" Margin="0,0,10,0" VerticalAlignment="Center"/>
-                        <TextBlock Text="Computing health score…" Foreground="{StaticResource TextSecondary}" FontSize="12"
+                        <TextBlock Text="Computing health score…" Foreground="{DynamicResource TextSecondary}" FontSize="12"
                                    VerticalAlignment="Center"/>
                     </StackPanel>
                 </Border>
 
                 <!-- Tune-Up progress panel -->
-                <Border CornerRadius="8" Padding="14" Background="{StaticResource Surface1}" Margin="0,0,0,8"
-                        BorderBrush="{StaticResource Accent}" BorderThickness="1"
+                <Border CornerRadius="8" Padding="14" Background="{DynamicResource Surface1}" Margin="0,0,0,8"
+                        BorderBrush="{DynamicResource Accent}" BorderThickness="1"
                         Visibility="{Binding IsTuneUpRunning, Converter={StaticResource BoolToVis}}">
                     <StackPanel>
                         <TextBlock Text="Quick Tune-Up in progress…" FontWeight="SemiBold" FontSize="14"
-                                   Foreground="{StaticResource Info}"/>
-                        <TextBlock Text="{Binding TuneUpStep}" Foreground="{StaticResource TextSecondary}" Margin="0,6,0,6"/>
+                                   Foreground="{DynamicResource Info}"/>
+                        <TextBlock Text="{Binding TuneUpStep}" Foreground="{DynamicResource TextSecondary}" Margin="0,6,0,6"/>
                         <ProgressBar AutomationProperties.Name="Tune-Up progress" Height="6" Minimum="0" Maximum="100"
                                      Value="{Binding TuneUpProgress}"/>
                     </StackPanel>
                 </Border>
 
                 <!-- Tune-Up result summary card -->
-                <Border CornerRadius="8" Padding="14" Background="{StaticResource Surface1}" Margin="0,0,0,12"
-                        BorderBrush="{StaticResource Accent}" BorderThickness="1"
+                <Border CornerRadius="8" Padding="14" Background="{DynamicResource Surface1}" Margin="0,0,0,12"
+                        BorderBrush="{DynamicResource Accent}" BorderThickness="1"
                         Visibility="{Binding HasTuneUpResult, Converter={StaticResource BoolToVis}}">
                     <StackPanel>
                         <Grid>
@@ -190,7 +190,7 @@
                             </Grid.ColumnDefinitions>
                             <StackPanel Grid.Column="0" Orientation="Horizontal">
                                 <TextBlock Text="&#xE930;" FontFamily="Segoe Fluent Icons" FontSize="18"
-                                           VerticalAlignment="Center" Margin="0,0,8,0" Foreground="{StaticResource Info}"/>
+                                           VerticalAlignment="Center" Margin="0,0,8,0" Foreground="{DynamicResource Info}"/>
                                 <TextBlock Text="Tune-Up Summary" FontWeight="SemiBold" FontSize="15"
                                            VerticalAlignment="Center"/>
                             </StackPanel>
@@ -200,15 +200,15 @@
                                     AutomationProperties.Name="Dismiss tune-up results"/>
                         </Grid>
 
-                        <Separator Margin="0,8" Background="{StaticResource Border1}"/>
+                        <Separator Margin="0,8" Background="{DynamicResource Border1}"/>
 
                         <!-- Freed space -->
                         <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                             <TextBlock Text="&#xE74D;" FontFamily="Segoe Fluent Icons" FontSize="14"
-                                       Margin="0,0,8,0" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center"/>
-                            <TextBlock Foreground="{StaticResource TextPrimary}" VerticalAlignment="Center">
+                                       Margin="0,0,8,0" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
+                            <TextBlock Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center">
                                 <Run Text="Freed "/>
-                                <Run Text="{Binding TuneUpResult.FreedDisplay, Mode=OneWay}" FontWeight="SemiBold" Foreground="{StaticResource Info}"/>
+                                <Run Text="{Binding TuneUpResult.FreedDisplay, Mode=OneWay}" FontWeight="SemiBold" Foreground="{DynamicResource Info}"/>
                                 <Run Text=" ("/>
                                 <Run Text="{Binding TuneUpResult.TempFilesDeleted, Mode=OneWay, StringFormat='{}{0:N0}'}"/>
                                 <Run Text=" files)"/>
@@ -218,8 +218,8 @@
                         <!-- Recycle Bin -->
                         <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                             <TextBlock Text="&#xE74D;" FontFamily="Segoe Fluent Icons" FontSize="14"
-                                       Margin="0,0,8,0" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center"/>
-                            <TextBlock Foreground="{StaticResource TextPrimary}" VerticalAlignment="Center">
+                                       Margin="0,0,8,0" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
+                            <TextBlock Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center">
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock">
                                         <Setter Property="Text" Value="Recycle Bin emptied"/>
@@ -236,8 +236,8 @@
                         <!-- Broken shortcuts -->
                         <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                             <TextBlock Text="&#xE71B;" FontFamily="Segoe Fluent Icons" FontSize="14"
-                                       Margin="0,0,8,0" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center"/>
-                            <TextBlock Foreground="{StaticResource TextPrimary}" VerticalAlignment="Center">
+                                       Margin="0,0,8,0" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
+                            <TextBlock Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center">
                                 <Run Text="{Binding TuneUpResult.BrokenShortcutsFound, Mode=OneWay}"/>
                                 <Run Text=" broken shortcuts found"/>
                             </TextBlock>
@@ -262,8 +262,8 @@
                                 <DataTemplate>
                                     <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
                                         <TextBlock Text="&#xEDA2;" FontFamily="Segoe Fluent Icons" FontSize="14"
-                                                   Margin="0,0,8,0" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center"/>
-                                        <TextBlock Text="{Binding Name}" Foreground="{StaticResource TextPrimary}" Margin="0,0,6,0"
+                                                   Margin="0,0,8,0" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{Binding Name}" Foreground="{DynamicResource TextPrimary}" Margin="0,0,6,0"
                                                    VerticalAlignment="Center"/>
                                         <TextBlock Text="{Binding Verdict}" FontWeight="SemiBold"
                                                    VerticalAlignment="Center"
@@ -276,8 +276,8 @@
                         <!-- Uptime -->
                         <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                             <TextBlock Text="&#xE916;" FontFamily="Segoe Fluent Icons" FontSize="14"
-                                       Margin="0,0,8,0" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center"/>
-                            <TextBlock Foreground="{StaticResource TextPrimary}" VerticalAlignment="Center">
+                                       Margin="0,0,8,0" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
+                            <TextBlock Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center">
                                 <Run Text="Uptime: "/>
                                 <Run Text="{Binding TuneUpResult.Uptime.Days, Mode=OneWay}"/>
                                 <Run Text="d "/>
@@ -294,8 +294,8 @@
                         <!-- RAM -->
                         <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                             <TextBlock Text="&#xE950;" FontFamily="Segoe Fluent Icons" FontSize="14"
-                                       Margin="0,0,8,0" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center"/>
-                            <TextBlock Foreground="{StaticResource TextPrimary}" VerticalAlignment="Center">
+                                       Margin="0,0,8,0" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
+                            <TextBlock Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center">
                                 <Run Text="RAM: "/>
                                 <Run Text="{Binding TuneUpResult.RamUsedGB, Mode=OneWay, StringFormat='{}{0:0.0}'}"/>
                                 <Run Text=" / "/>
@@ -310,40 +310,40 @@
                         </StackPanel>
 
                         <!-- Overall verdict -->
-                        <Separator Margin="0,8" Background="{StaticResource Border1}"/>
+                        <Separator Margin="0,8" Background="{DynamicResource Border1}"/>
                         <TextBlock Text="{Binding TuneUpResult.OverallVerdict}" FontWeight="SemiBold" FontSize="13"
                                    Foreground="{Binding TuneUpResult.OverallColorHex, Converter={StaticResource HexBrush}}"/>
                     </StackPanel>
                 </Border>
 
                 <!-- Existing system info cards -->
-                <Border CornerRadius="8" Padding="14" Background="{StaticResource Surface2}" Margin="0,0,0,8">
+                <Border CornerRadius="8" Padding="14" Background="{DynamicResource Surface2}" Margin="0,0,0,8">
                     <StackPanel>
-                        <TextBlock Text="Operating System" Foreground="{StaticResource TextSecondary}" FontSize="12"/>
+                        <TextBlock Text="Operating System" Foreground="{DynamicResource TextSecondary}" FontSize="12"/>
                         <TextBlock Text="{Binding OsLine}" FontSize="15" Margin="0,4,0,0"/>
-                        <TextBlock Text="{Binding UptimeLine}" Foreground="{StaticResource TextSecondary}" Margin="0,6,0,0"/>
+                        <TextBlock Text="{Binding UptimeLine}" Foreground="{DynamicResource TextSecondary}" Margin="0,6,0,0"/>
                     </StackPanel>
                 </Border>
 
-                <Border CornerRadius="8" Padding="14" Background="{StaticResource Surface2}" Margin="0,0,0,8">
+                <Border CornerRadius="8" Padding="14" Background="{DynamicResource Surface2}" Margin="0,0,0,8">
                     <StackPanel>
-                        <TextBlock Text="CPU" Foreground="{StaticResource TextSecondary}" FontSize="12"/>
+                        <TextBlock Text="CPU" Foreground="{DynamicResource TextSecondary}" FontSize="12"/>
                         <TextBlock Text="{Binding CpuLine}" FontSize="15" Margin="0,4,0,0" TextWrapping="Wrap"/>
                     </StackPanel>
                 </Border>
 
-                <Border CornerRadius="8" Padding="14" Background="{StaticResource Surface2}" Margin="0,0,0,8">
+                <Border CornerRadius="8" Padding="14" Background="{DynamicResource Surface2}" Margin="0,0,0,8">
                     <StackPanel>
-                        <TextBlock Text="Memory" Foreground="{StaticResource TextSecondary}" FontSize="12"/>
+                        <TextBlock Text="Memory" Foreground="{DynamicResource TextSecondary}" FontSize="12"/>
                         <TextBlock Text="{Binding MemLine}" FontSize="15" Margin="0,4,0,6"/>
                         <ProgressBar AutomationProperties.Name="Progress" Height="8" Minimum="0" Maximum="100"
                                      Value="{Binding Snapshot.Memory.UsedPercent}"/>
                     </StackPanel>
                 </Border>
 
-                <Border CornerRadius="8" Padding="14" Background="{StaticResource Surface2}" Margin="0,0,0,8">
+                <Border CornerRadius="8" Padding="14" Background="{DynamicResource Surface2}" Margin="0,0,0,8">
                     <StackPanel>
-                        <TextBlock Text="Storage" Foreground="{StaticResource TextSecondary}" FontSize="12"/>
+                        <TextBlock Text="Storage" Foreground="{DynamicResource TextSecondary}" FontSize="12"/>
                         <TextBlock Text="{Binding DiskLine}" FontSize="14" Margin="0,4,0,0" TextWrapping="Wrap"/>
                     </StackPanel>
                 </Border>
@@ -358,7 +358,7 @@
             <ProgressBar AutomationProperties.Name="Progress" Grid.Column="0" Height="4"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Grid.Column="1" Margin="12,0,0,0" Text="{Binding StatusMessage}" Foreground="{StaticResource TextSecondary}"/>
+            <TextBlock Grid.Column="1" Margin="12,0,0,0" Text="{Binding StatusMessage}" Foreground="{DynamicResource TextSecondary}"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/DeepCleanupView.xaml
+++ b/SysManager/SysManager/Views/DeepCleanupView.xaml
@@ -25,13 +25,13 @@
 
                 <!-- Safety note -->
                 <Border Style="{StaticResource Card}" Margin="0,16,0,0"
-                        Background="#122030" BorderBrush="{StaticResource Accent}" BorderThickness="1">
+                        Background="#122030" BorderBrush="{DynamicResource Accent}" BorderThickness="1">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="&#xE946;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                                   FontSize="18" Foreground="{StaticResource Accent}" VerticalAlignment="Top" Margin="0,2,12,0"/>
+                                   FontSize="18" Foreground="{DynamicResource Accent}" VerticalAlignment="Top" Margin="0,2,12,0"/>
                         <StackPanel>
-                            <TextBlock Text="Safe by design" FontWeight="SemiBold" Foreground="{StaticResource Accent}"/>
-                            <TextBlock TextWrapping="Wrap" Foreground="{StaticResource TextSecondary}" MaxWidth="900" Margin="0,4,0,0" FontSize="12">
+                            <TextBlock Text="Safe by design" FontWeight="SemiBold" Foreground="{DynamicResource Accent}"/>
+                            <TextBlock TextWrapping="Wrap" Foreground="{DynamicResource TextSecondary}" MaxWidth="900" Margin="0,4,0,0" FontSize="12">
                                 Only locations documented as safe by vendors (NVIDIA, AMD, Microsoft) are scanned. We never touch browser caches, passwords,
                                 live app settings, the registry, active drivers, or Program Files. A file that's locked or in use is skipped — nothing is forced.
                             </TextBlock>
@@ -62,8 +62,8 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Column="0" Text="{Binding ScanStatusLine}" Foreground="{StaticResource Accent}" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                                <TextBlock Grid.Column="1" Text="{Binding ScanProgress, StringFormat={}{0}%}" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center" Margin="12,0,0,0"/>
+                                <TextBlock Grid.Column="0" Text="{Binding ScanStatusLine}" Foreground="{DynamicResource Accent}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="1" Text="{Binding ScanProgress, StringFormat={}{0}%}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center" Margin="12,0,0,0"/>
                             </Grid>
                             <ProgressBar AutomationProperties.Name="Progress" Height="6" Minimum="0" Maximum="100" Value="{Binding ScanProgress}" Margin="0,6,0,0"/>
                         </StackPanel>
@@ -81,7 +81,7 @@
                                             <CheckBox Grid.Column="0" IsChecked="{Binding IsSelected, Mode=TwoWay}" VerticalAlignment="Center" Margin="0,0,12,0"/>
                                             <StackPanel Grid.Column="1">
                                                 <StackPanel Orientation="Horizontal">
-                                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="14" Foreground="{StaticResource TextPrimary}"/>
+                                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource TextPrimary}"/>
                                                     <Border Margin="10,0,0,0" Padding="8,2" CornerRadius="999"
                                                             Background="#5C1B1B" BorderBrush="#EF4444" BorderThickness="1"
                                                             Visibility="{Binding IsDestructiveHint, Converter={StaticResource BoolToVis}}">
@@ -91,7 +91,7 @@
                                                 <TextBlock Text="{Binding Description}" Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap" MaxWidth="820"/>
                                             </StackPanel>
                                             <StackPanel Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="10,0,0,0">
-                                                <TextBlock Text="{Binding SizeDisplay}" FontWeight="SemiBold" FontSize="14" Foreground="{StaticResource TextPrimary}" HorizontalAlignment="Right"/>
+                                                <TextBlock Text="{Binding SizeDisplay}" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource TextPrimary}" HorizontalAlignment="Right"/>
                                                 <TextBlock Text="{Binding CountDisplay}" Style="{StaticResource Caption}" HorizontalAlignment="Right"/>
                                             </StackPanel>
                                         </Grid>
@@ -108,9 +108,9 @@
                                     <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
                                 <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
-                                    <TextBlock Text="Selected total:" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Selected total:" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
                                     <TextBlock Text="{Binding TotalSelectedDisplay}" FontWeight="SemiBold" FontSize="16"
-                                               Foreground="{StaticResource Accent}" VerticalAlignment="Center" Margin="8,0,0,0"/>
+                                               Foreground="{DynamicResource Accent}" VerticalAlignment="Center" Margin="8,0,0,0"/>
                                 </StackPanel>
                                 <StackPanel Grid.Column="1" Orientation="Horizontal">
                                     <Button Content="Clean selected" Command="{Binding CleanCommand}"
@@ -132,7 +132,7 @@
                                     <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="{Binding CleanStatusLine}" Foreground="#22C55E" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                                <TextBlock Grid.Column="1" Text="{Binding CleanProgress, StringFormat={}{0}%}" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center" Margin="12,0,0,0"/>
+                                <TextBlock Grid.Column="1" Text="{Binding CleanProgress, StringFormat={}{0}%}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center" Margin="12,0,0,0"/>
                             </Grid>
                             <ProgressBar AutomationProperties.Name="Progress" Height="6" Minimum="0" Maximum="100" Value="{Binding CleanProgress}" Margin="0,6,0,0"/>
                         </StackPanel>
@@ -160,12 +160,12 @@
                                 <ColumnDefinition Width="Auto"/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" Text="Location:" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                            <TextBlock Grid.Column="0" Text="Location:" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center" Margin="0,0,8,0"/>
                             <ComboBox Grid.Column="1" ItemsSource="{Binding ScanLocations}" SelectedItem="{Binding SelectedLocation, Mode=TwoWay}"
                                       DisplayMemberPath="Label" MaxWidth="380" HorizontalAlignment="Left"/>
-                            <TextBlock Grid.Column="2" Text="Min size (MB):" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center" Margin="16,0,8,0"/>
+                            <TextBlock Grid.Column="2" Text="Min size (MB):" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center" Margin="16,0,8,0"/>
                             <TextBox Grid.Column="3" Text="{Binding MinSizeMB, Mode=TwoWay}" Width="80"/>
-                            <TextBlock Grid.Column="4" Text="Top:" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center" Margin="16,0,8,0"/>
+                            <TextBlock Grid.Column="4" Text="Top:" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center" Margin="16,0,8,0"/>
                             <TextBox Grid.Column="5" Text="{Binding TopCount, Mode=TwoWay}" Width="60"/>
                         </Grid>
 
@@ -182,12 +182,12 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Column="0" Text="{Binding LargeFilesScanned, StringFormat={}{0:N0} files}" Foreground="{StaticResource TextPrimary}" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                                <TextBlock Grid.Column="1" Text="  ·  " Foreground="{StaticResource TextMuted}" VerticalAlignment="Center"/>
-                                <TextBlock Grid.Column="2" Text="{Binding LargeBytesScannedDisplay, StringFormat=scanned {0}}" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="0" Text="{Binding LargeFilesScanned, StringFormat={}{0:N0} files}" Foreground="{DynamicResource TextPrimary}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="1" Text="  ·  " Foreground="{DynamicResource TextMuted}" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="2" Text="{Binding LargeBytesScannedDisplay, StringFormat=scanned {0}}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
                                 <Button Grid.Column="3" Content="Cancel" Command="{Binding CancelCommand}" Style="{StaticResource GhostButton}" Padding="10,4"/>
                             </Grid>
-                            <TextBlock Text="{Binding LargeCurrentFolder}" Foreground="{StaticResource TextMuted}" FontSize="11" Margin="0,4,0,0" TextTrimming="CharacterEllipsis"/>
+                            <TextBlock Text="{Binding LargeCurrentFolder}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="0,4,0,0" TextTrimming="CharacterEllipsis"/>
                         </StackPanel>
 
                         <DataGrid AutomationProperties.Name="Data table" ItemsSource="{Binding LargeFiles}"

--- a/SysManager/SysManager/Views/DiskAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/DiskAnalyzerView.xaml
@@ -7,7 +7,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             Background="{StaticResource Surface0}">
+             Background="{DynamicResource Surface0}">
 
     <Grid Margin="32,24">
         <Grid.RowDefinitions>
@@ -58,7 +58,7 @@
                     <ProgressBar AutomationProperties.Name="Progress" Grid.Column="0" Height="8" Minimum="0" Maximum="100"
                                  Value="{Binding DriveUsedPercent, Mode=OneWay}"/>
                     <TextBlock Grid.Column="1" Margin="12,0,0,0" FontSize="12"
-                               Foreground="{StaticResource TextMuted}">
+                               Foreground="{DynamicResource TextMuted}">
                         <Run Text="{Binding DriveUsedPercent, Mode=OneWay, StringFormat='{}{0:F1}%'}"/>
                         <Run Text=" used"/>
                     </TextBlock>
@@ -80,7 +80,7 @@
                             <Setter.Value>
                                 <ControlTemplate TargetType="ListViewItem">
                                     <Border x:Name="Bd" Background="Transparent" Padding="{TemplateBinding Padding}"
-                                            BorderBrush="{StaticResource Border1}" BorderThickness="0,0,0,1">
+                                            BorderBrush="{DynamicResource Border1}" BorderThickness="0,0,0,1">
                                         <ContentPresenter/>
                                     </Border>
                                     <ControlTemplate.Triggers>
@@ -114,9 +114,9 @@
                             <!-- Name + file count -->
                             <StackPanel Grid.Column="1" VerticalAlignment="Center">
                                 <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13"/>
-                                <TextBlock FontSize="11" Foreground="{StaticResource TextMuted}">
+                                <TextBlock FontSize="11" Foreground="{DynamicResource TextMuted}">
                                     <Run Text="{Binding FileCount, Mode=OneWay, StringFormat='{}{0:N0} files'}"/>
-                                    <Run Text=" · " Foreground="{StaticResource TextDisabled}"/>
+                                    <Run Text=" · " Foreground="{DynamicResource TextDisabled}"/>
                                     <Run Text="{Binding FolderCount, Mode=OneWay, StringFormat='{}{0:N0} folders'}"/>
                                 </TextBlock>
                             </StackPanel>

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -25,7 +25,7 @@
         </StackPanel>
 
         <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
@@ -33,9 +33,9 @@
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
                     <TextBlock Text="Changing DNS and editing the hosts file requires administrator privileges."
-                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                 </StackPanel>
             </DockPanel>
         </Border>
@@ -64,7 +64,7 @@
                     <TextBlock Text="Current DNS:" VerticalAlignment="Center" Margin="0,0,8,0"
                                Style="{StaticResource Subtle}"/>
                     <TextBlock Text="{Binding CurrentDns}" VerticalAlignment="Center"
-                               FontWeight="SemiBold" Foreground="{StaticResource Accent}"/>
+                               FontWeight="SemiBold" Foreground="{DynamicResource Accent}"/>
                 </DockPanel>
 
                 <DockPanel Margin="0,0,0,12">
@@ -120,7 +120,7 @@
                           GridLinesVisibility="None" BorderThickness="0"
                           Background="Transparent"
                           AutomationProperties.Name="Data table"
-                          Foreground="{StaticResource TextPrimary}" FontSize="12"
+                          Foreground="{DynamicResource TextPrimary}" FontSize="12"
                           HorizontalGridLinesBrush="#1E293B"
                           SelectionMode="Single" IsReadOnly="False"
                           VirtualizingPanel.IsVirtualizing="True"

--- a/SysManager/SysManager/Views/DriversView.xaml
+++ b/SysManager/SysManager/Views/DriversView.xaml
@@ -7,7 +7,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             Background="{StaticResource Surface0}">
+             Background="{DynamicResource Surface0}">
 
     <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
         <Grid Margin="32,24">
@@ -69,7 +69,7 @@
                             <DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock">
                                     <Setter Property="FontSize" Value="12"/>
-                                    <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
                                     <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
                                 </Style>
                             </DataGridTextColumn.ElementStyle>
@@ -81,7 +81,7 @@
                                 <Style TargetType="TextBlock">
                                     <Setter Property="FontFamily" Value="Consolas"/>
                                     <Setter Property="FontSize" Value="12"/>
-                                    <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextMuted}"/>
                                 </Style>
                             </DataGridTextColumn.ElementStyle>
                         </DataGridTextColumn>
@@ -92,7 +92,7 @@
                                 <Style TargetType="TextBlock">
                                     <Setter Property="FontFamily" Value="Consolas"/>
                                     <Setter Property="FontSize" Value="12"/>
-                                    <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextMuted}"/>
                                 </Style>
                             </DataGridTextColumn.ElementStyle>
                         </DataGridTextColumn>

--- a/SysManager/SysManager/Views/DuplicateFileView.xaml
+++ b/SysManager/SysManager/Views/DuplicateFileView.xaml
@@ -7,7 +7,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             Background="{StaticResource Surface0}">
+             Background="{DynamicResource Surface0}">
 
     <Grid Margin="32,24">
         <Grid.RowDefinitions>
@@ -75,18 +75,18 @@
                 </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
                     <DataTemplate>
-                        <Border BorderBrush="{StaticResource Border1}" BorderThickness="0,0,0,1"
+                        <Border BorderBrush="{DynamicResource Border1}" BorderThickness="0,0,0,1"
                                 Padding="12,10" Margin="0">
                             <StackPanel>
                                 <!-- Group header -->
                                 <DockPanel Margin="0,0,0,6">
                                     <TextBlock DockPanel.Dock="Left" FontWeight="SemiBold" FontSize="13">
                                         <Run Text="{Binding Count, Mode=OneWay, StringFormat='{}{0} files'}"/>
-                                        <Run Text=" · " Foreground="{StaticResource TextDisabled}"/>
+                                        <Run Text=" · " Foreground="{DynamicResource TextDisabled}"/>
                                         <Run Text="{Binding FileSize, Mode=OneWay, StringFormat='{}{0:N0} bytes each'}"/>
                                     </TextBlock>
                                     <TextBlock DockPanel.Dock="Right" HorizontalAlignment="Right"
-                                               Foreground="{StaticResource Accent}" FontSize="12">
+                                               Foreground="{DynamicResource Accent}" FontSize="12">
                                         <Run Text="Hash: "/>
                                         <Run Text="{Binding Hash, Mode=OneWay}" FontFamily="Consolas" FontSize="11"/>
                                     </TextBlock>
@@ -113,8 +113,8 @@
                                                            TextTrimming="CharacterEllipsis"
                                                            ToolTip="{Binding Path}">
                                                     <Run Text="{Binding Name, Mode=OneWay}" FontWeight="Medium"/>
-                                                    <Run Text=" — " Foreground="{StaticResource TextDisabled}"/>
-                                                    <Run Text="{Binding Path, Mode=OneWay}" Foreground="{StaticResource TextMuted}"/>
+                                                    <Run Text=" — " Foreground="{DynamicResource TextDisabled}"/>
+                                                    <Run Text="{Binding Path, Mode=OneWay}" Foreground="{DynamicResource TextMuted}"/>
                                                 </TextBlock>
                                             </DockPanel>
                                         </DataTemplate>

--- a/SysManager/SysManager/Views/FileShredderView.xaml
+++ b/SysManager/SysManager/Views/FileShredderView.xaml
@@ -50,7 +50,7 @@
         <Border Grid.Row="1" Style="{StaticResource Card}" Margin="28,16,28,0" Padding="12">
             <WrapPanel>
                 <TextBlock Text="Method:" VerticalAlignment="Center" Margin="0,0,8,0"
-                           Foreground="{StaticResource TextSecondary}"/>
+                           Foreground="{DynamicResource TextSecondary}"/>
                 <ComboBox ItemsSource="{Binding Source={StaticResource ShredMethods}}"
                           SelectedItem="{Binding SelectedMethod}"
                           Width="120" Margin="0,0,16,0" VerticalAlignment="Center"/>

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -157,27 +157,27 @@
                     <StackPanel Orientation="Horizontal" Margin="0,0,14,0">
                         <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding ShowCritical}" VerticalAlignment="Center"/>
                         <Ellipse Style="{StaticResource SevDot}" Fill="#FF3B30" Margin="8,0,6,0"/>
-                        <TextBlock Text="Critical" Foreground="{StaticResource TextPrimary}" VerticalAlignment="Center"/>
+                        <TextBlock Text="Critical" Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,14,0">
                         <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding ShowError}" VerticalAlignment="Center"/>
                         <Ellipse Style="{StaticResource SevDot}" Fill="#F87171" Margin="8,0,6,0"/>
-                        <TextBlock Text="Error" Foreground="{StaticResource TextPrimary}" VerticalAlignment="Center"/>
+                        <TextBlock Text="Error" Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,14,0">
                         <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding ShowWarning}" VerticalAlignment="Center"/>
                         <Ellipse Style="{StaticResource SevDot}" Fill="#FBBF24" Margin="8,0,6,0"/>
-                        <TextBlock Text="Warning" Foreground="{StaticResource TextPrimary}" VerticalAlignment="Center"/>
+                        <TextBlock Text="Warning" Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,14,0">
                         <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding ShowInfo}" VerticalAlignment="Center"/>
                         <Ellipse Style="{StaticResource SevDot}" Fill="#38BDF8" Margin="8,0,6,0"/>
-                        <TextBlock Text="Info" Foreground="{StaticResource TextPrimary}" VerticalAlignment="Center"/>
+                        <TextBlock Text="Info" Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,22,0">
                         <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding ShowVerbose}" VerticalAlignment="Center"/>
                         <Ellipse Style="{StaticResource SevDot}" Fill="#9AA0A6" Margin="8,0,6,0"/>
-                        <TextBlock Text="Verbose" Foreground="{StaticResource TextPrimary}" VerticalAlignment="Center"/>
+                        <TextBlock Text="Verbose" Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
                     </StackPanel>
 
                     <TextBlock Text="Search" Style="{StaticResource Subtle}" VerticalAlignment="Center" Margin="0,0,8,0"/>
@@ -185,7 +185,7 @@
                         <TextBox x:Name="SearchBox" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
                                  ToolTip="Filters by message, provider, or event ID"/>
                         <TextBlock Text="Filter by message, source, or event ID…"
-                                   Foreground="{StaticResource TextMuted}" FontSize="12"
+                                   Foreground="{DynamicResource TextMuted}" FontSize="12"
                                    VerticalAlignment="Center" Margin="8,0,0,0"
                                    IsHitTestVisible="False">
                             <TextBlock.Style>
@@ -230,12 +230,12 @@
                     <DataGrid.RowStyle>
                         <Style TargetType="DataGridRow">
                             <Setter Property="Background" Value="Transparent"/>
-                            <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                             <Setter Property="BorderThickness" Value="0"/>
                             <Style.Triggers>
                                 <Trigger Property="IsSelected" Value="True">
-                                    <Setter Property="Background" Value="{StaticResource Surface3}"/>
-                                    <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                                    <Setter Property="Background" Value="{DynamicResource Surface3}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                                 </Trigger>
                             </Style.Triggers>
                         </Style>
@@ -268,14 +268,14 @@
                                 Visibility="{Binding HasNoResults, Converter={StaticResource FlexVis}}">
                         <TextBlock Text="&#xE721;" FontFamily="Segoe MDL2 Assets" FontSize="32" HorizontalAlignment="Center" Margin="0,0,0,8"/>
                         <TextBlock Text="No events match your filters" FontSize="14" FontWeight="SemiBold"
-                                   Foreground="{StaticResource TextSecondary}" HorizontalAlignment="Center"/>
+                                   Foreground="{DynamicResource TextSecondary}" HorizontalAlignment="Center"/>
                         <TextBlock Text="Try adjusting severity checkboxes or clearing the search"
                                    Style="{StaticResource Subtle}" HorizontalAlignment="Center" Margin="0,4,0,0"/>
                     </StackPanel>
                 </Grid>
             </Border>
 
-            <GridSplitter Grid.Column="1" Width="6" HorizontalAlignment="Center" VerticalAlignment="Stretch" Background="{StaticResource Border1}"/>
+            <GridSplitter Grid.Column="1" Width="6" HorizontalAlignment="Center" VerticalAlignment="Stretch" Background="{DynamicResource Border1}"/>
 
             <!-- Detail -->
             <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
@@ -297,8 +297,8 @@
                                     <StackPanel Orientation="Horizontal">
                                         <TextBlock Text="{Binding SelectedEntry.SeverityLabel}" FontSize="18" FontWeight="SemiBold"
                                                    Foreground="{Binding SelectedEntry.SeverityColor, Converter={StaticResource HexBrush}}"/>
-                                        <TextBlock Text=" — Event " FontSize="18" FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}"/>
-                                        <TextBlock Text="{Binding SelectedEntry.EventId}" FontSize="18" FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}"/>
+                                        <TextBlock Text=" — Event " FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}"/>
+                                        <TextBlock Text="{Binding SelectedEntry.EventId}" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}"/>
                                     </StackPanel>
                                     <TextBlock Text="{Binding SelectedEntry.ProviderName}" Style="{StaticResource Subtle}"/>
                                 </StackPanel>
@@ -320,8 +320,8 @@
                                     <TextBlock Grid.Row="0" Grid.Column="0" Text="When" Style="{StaticResource Subtle}"/>
                                     <TextBlock Grid.Row="0" Grid.Column="1">
                                         <Run Text="{Binding SelectedEntry.RelativeTime, Mode=OneWay}"/>
-                                        <Run Text=" · " Foreground="{StaticResource TextMuted}"/>
-                                        <Run Text="{Binding SelectedEntry.FullTimestamp, Mode=OneWay}" Foreground="{StaticResource TextSecondary}"/>
+                                        <Run Text=" · " Foreground="{DynamicResource TextMuted}"/>
+                                        <Run Text="{Binding SelectedEntry.FullTimestamp, Mode=OneWay}" Foreground="{DynamicResource TextSecondary}"/>
                                     </TextBlock>
                                     <TextBlock Grid.Row="1" Grid.Column="0" Text="Log" Style="{StaticResource Subtle}"/>
                                     <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedEntry.LogName}"/>
@@ -334,12 +334,12 @@
 
                             <TextBlock Text="What this means" Style="{StaticResource SectionTitle}" Margin="0,18,0,6"/>
                             <Border Padding="12" CornerRadius="8" Background="#102028" BorderBrush="#1E3A4A" BorderThickness="1">
-                                <TextBlock Text="{Binding SelectedEntry.Explanation}" TextWrapping="Wrap" Foreground="{StaticResource TextPrimary}"/>
+                                <TextBlock Text="{Binding SelectedEntry.Explanation}" TextWrapping="Wrap" Foreground="{DynamicResource TextPrimary}"/>
                             </Border>
 
                             <TextBlock Text="What to try" Style="{StaticResource SectionTitle}" Margin="0,14,0,6"/>
                             <Border Padding="12" CornerRadius="8" Background="#141B14" BorderBrush="#2D4A2D" BorderThickness="1">
-                                <TextBlock Text="{Binding SelectedEntry.Recommendation}" TextWrapping="Wrap" Foreground="{StaticResource TextPrimary}"/>
+                                <TextBlock Text="{Binding SelectedEntry.Recommendation}" TextWrapping="Wrap" Foreground="{DynamicResource TextPrimary}"/>
                             </Border>
 
                             <StackPanel Orientation="Horizontal" Margin="0,14,0,0">
@@ -347,9 +347,9 @@
                                 <Button Content="Search online" Command="{Binding SearchOnlineCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>
                             </StackPanel>
 
-                            <Expander Header="Full system message" Margin="0,16,0,0" Foreground="{StaticResource TextSecondary}">
-                                <Border Padding="10" CornerRadius="8" Background="{StaticResource Surface0}"
-                                        BorderBrush="{StaticResource Border1}" BorderThickness="1">
+                            <Expander Header="Full system message" Margin="0,16,0,0" Foreground="{DynamicResource TextSecondary}">
+                                <Border Padding="10" CornerRadius="8" Background="{DynamicResource Surface0}"
+                                        BorderBrush="{DynamicResource Border1}" BorderThickness="1">
                                     <TextBox Text="{Binding SelectedEntry.FullMessage, Mode=OneWay}"
                                              IsReadOnly="True" TextWrapping="Wrap"
                                              Background="Transparent" BorderThickness="0"
@@ -360,9 +360,9 @@
                                 </Border>
                             </Expander>
 
-                            <Expander Header="Raw XML (for power users)" Margin="0,8,0,0" Foreground="{StaticResource TextSecondary}">
-                                <Border Padding="10" CornerRadius="8" Background="{StaticResource Surface0}"
-                                        BorderBrush="{StaticResource Border1}" BorderThickness="1">
+                            <Expander Header="Raw XML (for power users)" Margin="0,8,0,0" Foreground="{DynamicResource TextSecondary}">
+                                <Border Padding="10" CornerRadius="8" Background="{DynamicResource Surface0}"
+                                        BorderBrush="{DynamicResource Border1}" BorderThickness="1">
                                     <TextBox Text="{Binding SelectedEntry.Xml, Mode=OneWay}"
                                              IsReadOnly="True" TextWrapping="NoWrap"
                                              Background="Transparent" BorderThickness="0"

--- a/SysManager/SysManager/Views/NetworkRepairView.xaml
+++ b/SysManager/SysManager/Views/NetworkRepairView.xaml
@@ -22,7 +22,7 @@
         </StackPanel>
 
         <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
@@ -30,9 +30,9 @@
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
                     <TextBlock Text="Resetting network configuration (DNS flush, Winsock reset) requires administrator privileges."
-                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                 </StackPanel>
             </DockPanel>
         </Border>
@@ -60,8 +60,8 @@
                 <Border Padding="16" Margin="0,0,0,12" CornerRadius="10" BorderThickness="1">
                     <Border.Style>
                         <Style TargetType="Border">
-                            <Setter Property="Background" Value="{StaticResource Surface1}"/>
-                            <Setter Property="BorderBrush" Value="{StaticResource Border1}"/>
+                            <Setter Property="Background" Value="{DynamicResource Surface1}"/>
+                            <Setter Property="BorderBrush" Value="{DynamicResource Border1}"/>
                             <Style.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter Property="Background" Value="#186366F1"/>
@@ -86,8 +86,8 @@
                 <Border Padding="16" Margin="0,0,0,12" CornerRadius="10" BorderThickness="1">
                     <Border.Style>
                         <Style TargetType="Border">
-                            <Setter Property="Background" Value="{StaticResource Surface1}"/>
-                            <Setter Property="BorderBrush" Value="{StaticResource Border1}"/>
+                            <Setter Property="Background" Value="{DynamicResource Surface1}"/>
+                            <Setter Property="BorderBrush" Value="{DynamicResource Border1}"/>
                             <Style.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter Property="Background" Value="#186366F1"/>
@@ -112,8 +112,8 @@
                 <Border Padding="16" Margin="0,0,0,12" CornerRadius="10" BorderThickness="1">
                     <Border.Style>
                         <Style TargetType="Border">
-                            <Setter Property="Background" Value="{StaticResource Surface1}"/>
-                            <Setter Property="BorderBrush" Value="{StaticResource Border1}"/>
+                            <Setter Property="Background" Value="{DynamicResource Surface1}"/>
+                            <Setter Property="BorderBrush" Value="{DynamicResource Border1}"/>
                             <Style.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter Property="Background" Value="#186366F1"/>
@@ -138,7 +138,7 @@
                 <TextBlock Text="{Binding RepairStatus}" Style="{StaticResource Subtle}" Margin="0,4,0,0"
                            Visibility="{Binding RepairStatus, Converter={StaticResource FlexVis}}"/>
                 <TextBlock Text="⚠ A reboot is required for changes to take effect."
-                           Foreground="{StaticResource Danger}" FontSize="12" Margin="0,8,0,0"
+                           Foreground="{DynamicResource Danger}" FontSize="12" Margin="0,8,0,0"
                            Visibility="{Binding RepairNeedsReboot, Converter={StaticResource BoolToVis}}"/>
             </StackPanel>
         </Border>

--- a/SysManager/SysManager/Views/PerformanceView.xaml
+++ b/SysManager/SysManager/Views/PerformanceView.xaml
@@ -7,7 +7,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             Background="{StaticResource Surface0}">
+             Background="{DynamicResource Surface0}">
 
     <Grid Margin="32,24">
         <Grid.RowDefinitions>
@@ -27,7 +27,7 @@
         </StackPanel>
 
         <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
@@ -35,9 +35,9 @@
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
                     <TextBlock Text="Modifying system performance settings and creating restore points requires administrator privileges."
-                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                 </StackPanel>
             </DockPanel>
         </Border>
@@ -73,10 +73,10 @@
             <StackPanel>
                 <TextBlock Text="{Binding Summary}" FontWeight="SemiBold" FontSize="13"/>
                 <TextBlock Text="⚠ GPU changes require a reboot to take effect."
-                           Foreground="{StaticResource Danger}" FontSize="12" Margin="0,4,0,0"
+                           Foreground="{DynamicResource Danger}" FontSize="12" Margin="0,4,0,0"
                            Visibility="{Binding NeedsReboot, Converter={StaticResource BoolToVis}}"/>
                 <TextBlock Text="✓ Original settings snapshot saved — Restore All is available."
-                           Foreground="{StaticResource Success}" FontSize="12" Margin="0,4,0,0"
+                           Foreground="{DynamicResource Success}" FontSize="12" Margin="0,4,0,0"
                            Visibility="{Binding HasSnapshot, Converter={StaticResource BoolToVis}}"/>
             </StackPanel>
         </Border>
@@ -198,7 +198,7 @@
                             <TextBlock Text="Prevents CPU from downclocking. Increases power consumption."
                                        Style="{StaticResource Subtle}" FontSize="11" Margin="20,0,0,4"/>
                             <TextBlock Text="⚠ Locked to 100 % by the current power plan (High / Ultimate). Switch to Balanced to adjust."
-                                       Foreground="{StaticResource Warning}" FontSize="11" Margin="20,0,0,4"
+                                       Foreground="{DynamicResource Warning}" FontSize="11" Margin="20,0,0,4"
                                        TextWrapping="Wrap"
                                        Visibility="{Binding IsProcessorStateLocked, Converter={StaticResource BoolToVis}}"/>
                             <Button Content="Apply Processor State" Command="{Binding ApplyProcessorStateCommand}"
@@ -229,7 +229,7 @@
                                 Same as "Empty Working Set" in RAMMap. Useful before launching a game.
                             </TextBlock>
                             <TextBlock Text="⚠ Apps may feel briefly slower on next access as pages are faulted back in."
-                                       Foreground="{StaticResource Warning}" FontSize="11" Margin="0,0,0,8"/>
+                                       Foreground="{DynamicResource Warning}" FontSize="11" Margin="0,0,0,8"/>
                             <Button Content="Trim RAM Now" Command="{Binding TrimRamCommand}"
                                     Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"/>
                         </StackPanel>
@@ -247,10 +247,10 @@
                             <StackPanel Orientation="Horizontal" Margin="0,4,0,8">
                                 <TextBlock Text="Currently: " Style="{StaticResource Subtle}" VerticalAlignment="Center"/>
                                 <TextBlock VerticalAlignment="Center" FontWeight="SemiBold"
-                                           Text="Enabled" Foreground="{StaticResource Success}"
+                                           Text="Enabled" Foreground="{DynamicResource Success}"
                                            Visibility="{Binding IsHibernationEnabled, Converter={StaticResource BoolToVis}}"/>
                                 <TextBlock VerticalAlignment="Center" FontWeight="SemiBold"
-                                           Text="Disabled" Foreground="{StaticResource Danger}"
+                                           Text="Disabled" Foreground="{DynamicResource Danger}"
                                            Visibility="{Binding IsHibernationEnabled, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                             </StackPanel>
                             <Button Content="Toggle Hibernation" Command="{Binding ToggleHibernationCommand}"

--- a/SysManager/SysManager/Views/PingView.xaml
+++ b/SysManager/SysManager/Views/PingView.xaml
@@ -60,7 +60,7 @@
                         <TextBlock Text="{Binding Shared.Health.Headline}" FontSize="18" FontWeight="SemiBold"
                                    Foreground="{Binding Shared.Health.ColorHex, Converter={StaticResource HexBrush}}"/>
                     </StackPanel>
-                    <TextBlock Text="{Binding Shared.Health.Detail}" Foreground="{StaticResource TextSecondary}"
+                    <TextBlock Text="{Binding Shared.Health.Detail}" Foreground="{DynamicResource TextSecondary}"
                                Margin="22,6,0,0" TextWrapping="Wrap" MaxWidth="820"/>
                 </StackPanel>
                 <StackPanel Grid.Column="1" Orientation="Horizontal">
@@ -122,7 +122,7 @@
                                                 <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding IsEnabled}" VerticalAlignment="Center" Margin="0,0,6,0"/>
                                                 <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13" VerticalAlignment="Center"/>
                                             </StackPanel>
-                                            <TextBlock Text="{Binding Host}" Foreground="{StaticResource TextMuted}" FontSize="11" Margin="22,2,0,0"/>
+                                            <TextBlock Text="{Binding Host}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="22,2,0,0"/>
                                         </StackPanel>
                                         <Button Content="&#x2715;" DockPanel.Dock="Right" Padding="6,2" FontSize="10"
                                                 VerticalAlignment="Center" Style="{StaticResource GhostButton}"
@@ -137,7 +137,7 @@
                                             </StackPanel>
                                             <StackPanel Margin="0,0,16,0" HorizontalAlignment="Center">
                                                 <TextBlock Text="{Binding AverageMs, StringFormat={}{0:F1}, FallbackValue=—}"
-                                                           Foreground="{StaticResource TextSecondary}" FontWeight="Bold" FontSize="13" HorizontalAlignment="Center"/>
+                                                           Foreground="{DynamicResource TextSecondary}" FontWeight="Bold" FontSize="13" HorizontalAlignment="Center"/>
                                                 <TextBlock Text="AVG" Foreground="#475569" FontSize="9" HorizontalAlignment="Center" Margin="0,2,0,0"/>
                                             </StackPanel>
                                             <StackPanel Margin="0,0,16,0" HorizontalAlignment="Center">

--- a/SysManager/SysManager/Views/PlaceholderView.xaml
+++ b/SysManager/SysManager/Views/PlaceholderView.xaml
@@ -14,28 +14,28 @@
         <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" MaxWidth="500">
             <!-- WIP Icon -->
             <TextBlock Text="&#xE9F5;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                       FontSize="48" Foreground="{StaticResource Accent}"
+                       FontSize="48" Foreground="{DynamicResource Accent}"
                        HorizontalAlignment="Center" Margin="0,0,0,16"/>
 
             <!-- Feature name -->
             <TextBlock Text="{Binding FeatureName}" FontSize="28" FontWeight="SemiBold"
-                       Foreground="{StaticResource TextPrimary}" HorizontalAlignment="Center"
+                       Foreground="{DynamicResource TextPrimary}" HorizontalAlignment="Center"
                        TextWrapping="Wrap" TextAlignment="Center"/>
 
             <!-- WIP badge -->
             <Border Background="#2A1A3A" CornerRadius="4" Padding="12,6"
                     HorizontalAlignment="Center" Margin="0,12,0,0">
                 <TextBlock Text="Work in Progress" FontSize="14" FontWeight="SemiBold"
-                           Foreground="{StaticResource Accent}"/>
+                           Foreground="{DynamicResource Accent}"/>
             </Border>
 
             <!-- Description -->
             <TextBlock Text="{Binding Description}" FontSize="14"
-                       Foreground="{StaticResource TextSecondary}" HorizontalAlignment="Center"
+                       Foreground="{DynamicResource TextSecondary}" HorizontalAlignment="Center"
                        TextWrapping="Wrap" TextAlignment="Center" Margin="0,16,0,0"/>
 
             <!-- Issue reference -->
-            <TextBlock FontSize="12" Foreground="{StaticResource TextMuted}"
+            <TextBlock FontSize="12" Foreground="{DynamicResource TextMuted}"
                        HorizontalAlignment="Center" Margin="0,12,0,0">
                 <Run Text="Tracked in issue #"/><Run Text="{Binding IssueNumber, Mode=OneTime}"/>
             </TextBlock>

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -7,7 +7,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             Background="{StaticResource Surface0}">
+             Background="{DynamicResource Surface0}">
 
     <Grid Margin="32,24">
         <Grid.RowDefinitions>
@@ -26,7 +26,7 @@
         </StackPanel>
 
         <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
@@ -34,9 +34,9 @@
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
                     <TextBlock Text="Some privacy settings write to system-wide registry keys and require administrator privileges."
-                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                 </StackPanel>
             </DockPanel>
         </Border>
@@ -97,7 +97,7 @@
                             <GroupStyle.HeaderTemplate>
                                 <DataTemplate>
                                     <TextBlock Text="{Binding Name}" FontWeight="Bold" FontSize="14"
-                                               Foreground="{StaticResource TextPrimary}"
+                                               Foreground="{DynamicResource TextPrimary}"
                                                Margin="0,16,0,8"/>
                                 </DataTemplate>
                             </GroupStyle.HeaderTemplate>
@@ -128,10 +128,10 @@
                                     <StackPanel Grid.Column="0" VerticalAlignment="Center">
                                         <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13"/>
                                         <TextBlock Text="{Binding Description}" FontSize="11"
-                                                   Foreground="{StaticResource TextMuted}"
+                                                   Foreground="{DynamicResource TextMuted}"
                                                    TextWrapping="Wrap" Margin="0,2,16,0"/>
                                         <TextBlock Text="{Binding Category}" FontSize="10"
-                                                   Foreground="{StaticResource TextMuted}"
+                                                   Foreground="{DynamicResource TextMuted}"
                                                    Margin="0,2,0,0" Opacity="0.6"/>
                                     </StackPanel>
 

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -7,7 +7,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             Background="{StaticResource Surface0}">
+             Background="{DynamicResource Surface0}">
 
     <Grid Margin="32,24">
         <Grid.RowDefinitions>
@@ -35,7 +35,7 @@
                 <Grid Width="200" Margin="0,0,12,0">
                     <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"/>
                     <TextBlock Text="Search processes…" IsHitTestVisible="False"
-                               Foreground="{StaticResource TextMuted}" Margin="6,0,0,0"
+                               Foreground="{DynamicResource TextMuted}" Margin="6,0,0,0"
                                VerticalAlignment="Center" FontSize="12"
                                Visibility="{Binding FilterText, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                 </Grid>
@@ -69,7 +69,7 @@
                             <Style TargetType="TextBlock">
                                 <Setter Property="FontFamily" Value="Consolas"/>
                                 <Setter Property="FontSize" Value="12"/>
-                                <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource TextMuted}"/>
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
@@ -84,7 +84,7 @@
                                     <StackPanel VerticalAlignment="Center">
                                         <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13"/>
                                         <TextBlock Text="{Binding Description}" FontSize="11"
-                                                   Foreground="{StaticResource TextMuted}"
+                                                   Foreground="{DynamicResource TextMuted}"
                                                    TextTrimming="CharacterEllipsis" MaxWidth="400"/>
                                     </StackPanel>
                                 </StackPanel>
@@ -120,7 +120,7 @@
                                 <Setter Property="HorizontalAlignment" Value="Right"/>
                                 <Setter Property="FontFamily" Value="Consolas"/>
                                 <Setter Property="FontSize" Value="12"/>
-                                <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
@@ -136,7 +136,7 @@
                             <Style TargetType="TextBlock">
                                 <Setter Property="HorizontalAlignment" Value="Center"/>
                                 <Setter Property="FontSize" Value="11"/>
-                                <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource TextMuted}"/>
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
@@ -177,7 +177,7 @@
                                             Command="{Binding DataContext.KillProcessCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                             CommandParameter="{Binding}"
                                             Style="{StaticResource GhostButton}" Padding="6,2" FontSize="12"
-                                            Foreground="{StaticResource Danger}"/>
+                                            Foreground="{DynamicResource Danger}"/>
                                 </StackPanel>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -7,7 +7,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             Background="{StaticResource Surface0}">
+             Background="{DynamicResource Surface0}">
 
     <Grid Margin="32,24">
         <Grid.RowDefinitions>
@@ -26,7 +26,7 @@
         </StackPanel>
 
         <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
@@ -34,9 +34,9 @@
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
                     <TextBlock Text="Starting and stopping Windows services requires administrator privileges."
-                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                 </StackPanel>
             </DockPanel>
         </Border>
@@ -76,7 +76,7 @@
                     </StackPanel>
                 </DockPanel>
                 <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-                    <TextBlock Text="Filter:" Foreground="{StaticResource TextMuted}" FontSize="11"
+                    <TextBlock Text="Filter:" Foreground="{DynamicResource TextMuted}" FontSize="11"
                                VerticalAlignment="Center" Margin="0,0,8,0"/>
                     <RadioButton Content="{Binding SafeCount, StringFormat='Safe ({0})'}"
                                  GroupName="SafetyFilter" Margin="0,0,6,0"

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml
@@ -48,7 +48,7 @@
                 <Button Content="Deselect All" Command="{Binding DeselectAllCommand}"
                         Style="{StaticResource GhostButton}" Margin="0,0,16,0"/>
                 <CheckBox Content="Move to Recycle Bin" IsChecked="{Binding MoveToRecycleBin}"
-                          VerticalAlignment="Center" Foreground="{StaticResource TextSecondary}"/>
+                          VerticalAlignment="Center" Foreground="{DynamicResource TextSecondary}"/>
             </WrapPanel>
         </Border>
 

--- a/SysManager/SysManager/Views/SpeedTestView.xaml
+++ b/SysManager/SysManager/Views/SpeedTestView.xaml
@@ -52,9 +52,9 @@
                         </DockPanel>
                         <Grid Margin="0,16,0,0" Visibility="{Binding OoklaResult, Converter={StaticResource FlexVis}}">
                             <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="*"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
-                            <Border Grid.Column="0" Style="{StaticResource CardInner}" Margin="0,0,6,0"><StackPanel><TextBlock Text="DOWNLOAD" Style="{StaticResource Caption}"/><TextBlock Text="{Binding OoklaResult.DownloadMbps, StringFormat={}{0:F1} Mbps}" Style="{StaticResource Metric}" Foreground="{StaticResource Info}"/></StackPanel></Border>
-                            <Border Grid.Column="1" Style="{StaticResource CardInner}" Margin="6,0"><StackPanel><TextBlock Text="UPLOAD" Style="{StaticResource Caption}"/><TextBlock Text="{Binding OoklaResult.UploadMbps, StringFormat={}{0:F1} Mbps}" Style="{StaticResource Metric}" Foreground="{StaticResource Success}"/></StackPanel></Border>
-                            <Border Grid.Column="2" Style="{StaticResource CardInner}" Margin="6,0,0,0"><StackPanel><TextBlock Text="PING" Style="{StaticResource Caption}"/><TextBlock Text="{Binding OoklaResult.PingMs, StringFormat={}{0:F0} ms}" Style="{StaticResource Metric}" Foreground="{StaticResource Warning}"/></StackPanel></Border>
+                            <Border Grid.Column="0" Style="{StaticResource CardInner}" Margin="0,0,6,0"><StackPanel><TextBlock Text="DOWNLOAD" Style="{StaticResource Caption}"/><TextBlock Text="{Binding OoklaResult.DownloadMbps, StringFormat={}{0:F1} Mbps}" Style="{StaticResource Metric}" Foreground="{DynamicResource Info}"/></StackPanel></Border>
+                            <Border Grid.Column="1" Style="{StaticResource CardInner}" Margin="6,0"><StackPanel><TextBlock Text="UPLOAD" Style="{StaticResource Caption}"/><TextBlock Text="{Binding OoklaResult.UploadMbps, StringFormat={}{0:F1} Mbps}" Style="{StaticResource Metric}" Foreground="{DynamicResource Success}"/></StackPanel></Border>
+                            <Border Grid.Column="2" Style="{StaticResource CardInner}" Margin="6,0,0,0"><StackPanel><TextBlock Text="PING" Style="{StaticResource Caption}"/><TextBlock Text="{Binding OoklaResult.PingMs, StringFormat={}{0:F0} ms}" Style="{StaticResource Metric}" Foreground="{DynamicResource Warning}"/></StackPanel></Border>
                         </Grid>
                         <TextBlock Text="{Binding OoklaResult.Server}" Style="{StaticResource Caption}" Margin="0,10,0,0" Visibility="{Binding OoklaResult, Converter={StaticResource FlexVis}}"/>
                         <ProgressBar AutomationProperties.Name="Progress" Value="{Binding SpeedProgress}" Maximum="100" Height="4" Margin="0,14,0,0" Visibility="{Binding IsOoklaTesting, Converter={StaticResource FlexVis}}"/>
@@ -77,9 +77,9 @@
                         </DockPanel>
                         <Grid Margin="0,16,0,0" Visibility="{Binding HttpResult, Converter={StaticResource FlexVis}}">
                             <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="*"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
-                            <Border Grid.Column="0" Style="{StaticResource CardInner}" Margin="0,0,6,0"><StackPanel><TextBlock Text="DOWNLOAD" Style="{StaticResource Caption}"/><TextBlock Text="{Binding HttpResult.DownloadMbps, StringFormat={}{0:F1} Mbps}" Style="{StaticResource Metric}" Foreground="{StaticResource Info}"/></StackPanel></Border>
-                            <Border Grid.Column="1" Style="{StaticResource CardInner}" Margin="6,0"><StackPanel><TextBlock Text="UPLOAD" Style="{StaticResource Caption}"/><TextBlock Text="{Binding HttpResult.UploadMbps, StringFormat={}{0:F1} Mbps}" Style="{StaticResource Metric}" Foreground="{StaticResource Success}"/></StackPanel></Border>
-                            <Border Grid.Column="2" Style="{StaticResource CardInner}" Margin="6,0,0,0"><StackPanel><TextBlock Text="PING" Style="{StaticResource Caption}"/><TextBlock Text="{Binding HttpResult.PingMs, StringFormat={}{0:F0} ms}" Style="{StaticResource Metric}" Foreground="{StaticResource Warning}"/></StackPanel></Border>
+                            <Border Grid.Column="0" Style="{StaticResource CardInner}" Margin="0,0,6,0"><StackPanel><TextBlock Text="DOWNLOAD" Style="{StaticResource Caption}"/><TextBlock Text="{Binding HttpResult.DownloadMbps, StringFormat={}{0:F1} Mbps}" Style="{StaticResource Metric}" Foreground="{DynamicResource Info}"/></StackPanel></Border>
+                            <Border Grid.Column="1" Style="{StaticResource CardInner}" Margin="6,0"><StackPanel><TextBlock Text="UPLOAD" Style="{StaticResource Caption}"/><TextBlock Text="{Binding HttpResult.UploadMbps, StringFormat={}{0:F1} Mbps}" Style="{StaticResource Metric}" Foreground="{DynamicResource Success}"/></StackPanel></Border>
+                            <Border Grid.Column="2" Style="{StaticResource CardInner}" Margin="6,0,0,0"><StackPanel><TextBlock Text="PING" Style="{StaticResource Caption}"/><TextBlock Text="{Binding HttpResult.PingMs, StringFormat={}{0:F0} ms}" Style="{StaticResource Metric}" Foreground="{DynamicResource Warning}"/></StackPanel></Border>
                         </Grid>
                         <ProgressBar AutomationProperties.Name="Progress" Value="{Binding SpeedProgress}" Maximum="100" Height="4" Margin="0,14,0,0" Visibility="{Binding IsHttpTesting, Converter={StaticResource FlexVis}}"/>
                         <TextBlock Text="{Binding HttpStatus}" Style="{StaticResource Subtle}" Margin="0,6,0,0"/>
@@ -92,10 +92,10 @@
                         CornerRadius="8" Padding="12,10" Margin="0,12,0,0">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="&#xE946;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                                   FontSize="14" Foreground="{StaticResource Info}" VerticalAlignment="Top" Margin="0,0,10,0"/>
-                        <TextBlock TextWrapping="Wrap" Foreground="{StaticResource TextSecondary}" FontSize="12">
-                            <Run FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}">Ookla</Run><Run> measures raw TCP throughput to a nearby server — most accurate for ISP bandwidth. </Run>
-                            <Run FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}">HTTP</Run><Run> tests download/upload via Cloudflare CDN — reflects real web browsing speed but may show lower results due to HTTP overhead and CDN routing.</Run>
+                                   FontSize="14" Foreground="{DynamicResource Info}" VerticalAlignment="Top" Margin="0,0,10,0"/>
+                        <TextBlock TextWrapping="Wrap" Foreground="{DynamicResource TextSecondary}" FontSize="12">
+                            <Run FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}">Ookla</Run><Run> measures raw TCP throughput to a nearby server — most accurate for ISP bandwidth. </Run>
+                            <Run FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}">HTTP</Run><Run> tests download/upload via Cloudflare CDN — reflects real web browsing speed but may show lower results due to HTTP overhead and CDN routing.</Run>
                         </TextBlock>
                     </StackPanel>
                 </Border>

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -7,7 +7,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             Background="{StaticResource Surface0}">
+             Background="{DynamicResource Surface0}">
 
     <Grid Margin="32,24">
         <Grid.RowDefinitions>
@@ -35,7 +35,7 @@
                     <ToggleButton Style="{StaticResource ToggleSwitch}"
                                   IsChecked="{Binding HideWindowsEntries}" Margin="12,0,6,0"
                                   VerticalAlignment="Center" ToolTip="Hide Windows/Microsoft system entries"/>
-                    <TextBlock Text="Hide system" FontSize="11" Foreground="{StaticResource TextMuted}"
+                    <TextBlock Text="Hide system" FontSize="11" Foreground="{DynamicResource TextMuted}"
                                VerticalAlignment="Center"/>
                 </StackPanel>
                 <TextBlock Text="{Binding ScanSummary}" Style="{StaticResource Subtle}"
@@ -77,7 +77,7 @@
                                     <StackPanel VerticalAlignment="Center">
                                         <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13"/>
                                         <TextBlock Text="{Binding Command}" FontSize="11"
-                                                   Foreground="{StaticResource TextMuted}"
+                                                   Foreground="{DynamicResource TextMuted}"
                                                    TextTrimming="CharacterEllipsis" MaxWidth="500"/>
                                     </StackPanel>
                                 </StackPanel>
@@ -89,7 +89,7 @@
                                         SortMemberPath="Publisher" IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
-                                <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
                                 <Setter Property="FontSize" Value="12"/>
                             </Style>
                         </DataGridTextColumn.ElementStyle>

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -27,7 +27,7 @@
                 </DockPanel>
 
                 <!-- Elevation banner: not elevated -->
-                <Border Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+                <Border Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
                         BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,12,0,0"
                         Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
                     <DockPanel>
@@ -35,9 +35,9 @@
                                 Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                             <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                                       FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                                       FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
                             <TextBlock Text="Running disk checks (chkdsk) requires administrator privileges."
-                                       Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                                       Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                         </StackPanel>
                     </DockPanel>
                 </Border>
@@ -164,12 +164,12 @@
                                                 <Ellipse Width="12" Height="12" VerticalAlignment="Center" Margin="0,0,10,0"
                                                          Fill="{Binding VerdictColorHex, Converter={StaticResource HexBrush}}"/>
                                                 <TextBlock Text="{Binding FriendlyName}" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center"/>
-                                                <TextBlock Text="  ·  " Foreground="{StaticResource TextMuted}" VerticalAlignment="Center"/>
-                                                <TextBlock Text="{Binding MediaType}" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center"/>
-                                                <TextBlock Text="  ·  " Foreground="{StaticResource TextMuted}" VerticalAlignment="Center"/>
-                                                <TextBlock Text="{Binding BusType}" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center"/>
-                                                <TextBlock Text="  ·  " Foreground="{StaticResource TextMuted}" VerticalAlignment="Center"/>
-                                                <TextBlock Text="{Binding SizeGB, StringFormat={}{0:F0} GB}" Foreground="{StaticResource TextSecondary}" VerticalAlignment="Center"/>
+                                                <TextBlock Text="  ·  " Foreground="{DynamicResource TextMuted}" VerticalAlignment="Center"/>
+                                                <TextBlock Text="{Binding MediaType}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
+                                                <TextBlock Text="  ·  " Foreground="{DynamicResource TextMuted}" VerticalAlignment="Center"/>
+                                                <TextBlock Text="{Binding BusType}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
+                                                <TextBlock Text="  ·  " Foreground="{DynamicResource TextMuted}" VerticalAlignment="Center"/>
+                                                <TextBlock Text="{Binding SizeGB, StringFormat={}{0:F0} GB}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
                                             </StackPanel>
                                             <TextBlock Text="{Binding Verdict}"
                                                        Foreground="{Binding VerdictColorHex, Converter={StaticResource HexBrush}}"
@@ -213,15 +213,15 @@
                                                 </StackPanel>
                                                 <StackPanel Margin="0,0,24,6">
                                                     <TextBlock Text="POWER-ON" Style="{StaticResource Caption}"/>
-                                                    <TextBlock Text="{Binding PowerOnDisplay}" FontSize="14" Foreground="{StaticResource TextPrimary}" Margin="0,4,0,0"/>
+                                                    <TextBlock Text="{Binding PowerOnDisplay}" FontSize="14" Foreground="{DynamicResource TextPrimary}" Margin="0,4,0,0"/>
                                                 </StackPanel>
                                                 <StackPanel Margin="0,0,24,6">
                                                     <TextBlock Text="READ ERRORS" Style="{StaticResource Caption}"/>
-                                                    <TextBlock Text="{Binding ReadErrors, FallbackValue=—}" FontSize="14" Foreground="{StaticResource TextPrimary}" Margin="0,4,0,0"/>
+                                                    <TextBlock Text="{Binding ReadErrors, FallbackValue=—}" FontSize="14" Foreground="{DynamicResource TextPrimary}" Margin="0,4,0,0"/>
                                                 </StackPanel>
                                                 <StackPanel Margin="0,0,0,6">
                                                     <TextBlock Text="WRITE ERRORS" Style="{StaticResource Caption}"/>
-                                                    <TextBlock Text="{Binding WriteErrors, FallbackValue=—}" FontSize="14" Foreground="{StaticResource TextPrimary}" Margin="0,4,0,0"/>
+                                                    <TextBlock Text="{Binding WriteErrors, FallbackValue=—}" FontSize="14" Foreground="{DynamicResource TextPrimary}" Margin="0,4,0,0"/>
                                                 </StackPanel>
                                             </WrapPanel>
                                         </StackPanel>
@@ -255,10 +255,10 @@
                             <Ellipse Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,8,0">
                                 <Ellipse.Style>
                                     <Style TargetType="Ellipse">
-                                        <Setter Property="Fill" Value="{StaticResource TextSecondary}"/>
+                                        <Setter Property="Fill" Value="{DynamicResource TextSecondary}"/>
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsChkdskRunning}" Value="True">
-                                                <Setter Property="Fill" Value="{StaticResource Success}"/>
+                                                <Setter Property="Fill" Value="{DynamicResource Success}"/>
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
@@ -267,10 +267,10 @@
                             <TextBlock Text="{Binding ChkdskStatus}" FontWeight="SemiBold" VerticalAlignment="Center">
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock">
-                                        <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
+                                        <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsChkdskRunning}" Value="True">
-                                                <Setter Property="Foreground" Value="{StaticResource Success}"/>
+                                                <Setter Property="Foreground" Value="{DynamicResource Success}"/>
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
@@ -292,22 +292,22 @@
                                             <CheckBox Grid.Column="0" IsChecked="{Binding IsSelected, Mode=TwoWay}" VerticalAlignment="Center" Margin="0,0,12,0"/>
                                             <StackPanel Grid.Column="1" VerticalAlignment="Center">
                                                 <StackPanel Orientation="Horizontal">
-                                                    <TextBlock Text="{Binding Letter}" FontWeight="Bold" FontSize="15" Foreground="{StaticResource TextPrimary}"/>
-                                                    <TextBlock Text="  ·  " Foreground="{StaticResource TextMuted}"/>
-                                                    <TextBlock Text="{Binding Label}" Foreground="{StaticResource TextSecondary}"/>
+                                                    <TextBlock Text="{Binding Letter}" FontWeight="Bold" FontSize="15" Foreground="{DynamicResource TextPrimary}"/>
+                                                    <TextBlock Text="  ·  " Foreground="{DynamicResource TextMuted}"/>
+                                                    <TextBlock Text="{Binding Label}" Foreground="{DynamicResource TextSecondary}"/>
                                                 </StackPanel>
                                                 <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
-                                                    <TextBlock Text="{Binding SizeGB, StringFormat={}{0:F0} GB}" Foreground="{StaticResource TextMuted}" FontSize="12"/>
-                                                    <TextBlock Text="  ·  " Foreground="{StaticResource TextMuted}" FontSize="12"/>
-                                                    <TextBlock Text="{Binding FileSystem}" Foreground="{StaticResource TextMuted}" FontSize="12"/>
-                                                    <TextBlock Text="  ·  " Foreground="{StaticResource TextMuted}" FontSize="12"
+                                                    <TextBlock Text="{Binding SizeGB, StringFormat={}{0:F0} GB}" Foreground="{DynamicResource TextMuted}" FontSize="12"/>
+                                                    <TextBlock Text="  ·  " Foreground="{DynamicResource TextMuted}" FontSize="12"/>
+                                                    <TextBlock Text="{Binding FileSystem}" Foreground="{DynamicResource TextMuted}" FontSize="12"/>
+                                                    <TextBlock Text="  ·  " Foreground="{DynamicResource TextMuted}" FontSize="12"
                                                                Visibility="{Binding MediaType, Converter={StaticResource FlexVis}}"/>
-                                                    <TextBlock Text="{Binding MediaType}" Foreground="{StaticResource TextMuted}" FontSize="12"/>
+                                                    <TextBlock Text="{Binding MediaType}" Foreground="{DynamicResource TextMuted}" FontSize="12"/>
                                                     <TextBlock Text="  "/>
-                                                    <TextBlock Text="{Binding BusType}" Foreground="{StaticResource TextMuted}" FontSize="12"/>
+                                                    <TextBlock Text="{Binding BusType}" Foreground="{DynamicResource TextMuted}" FontSize="12"/>
                                                 </StackPanel>
                                             </StackPanel>
-                                            <TextBlock Grid.Column="2" Text="{Binding Status}" Foreground="{StaticResource TextSecondary}"
+                                            <TextBlock Grid.Column="2" Text="{Binding Status}" Foreground="{DynamicResource TextSecondary}"
                                                        VerticalAlignment="Center" Margin="10,0,10,0"/>
                                             <Button Grid.Column="3" Content="Scan"
                                                     Command="{Binding DataContext.RunChkdskCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"

--- a/SysManager/SysManager/Views/ThemePopup.xaml
+++ b/SysManager/SysManager/Views/ThemePopup.xaml
@@ -1,0 +1,162 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.ThemePopup"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Width="340">
+    <Border Background="{DynamicResource Surface1}" BorderBrush="{DynamicResource Border1}"
+            BorderThickness="1" CornerRadius="16">
+        <Border.Effect>
+            <DropShadowEffect ShadowDepth="8" BlurRadius="32" Opacity="0.6" Color="Black"/>
+        </Border.Effect>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <!-- Header -->
+            <Border Grid.Row="0" Padding="20,16,20,12" BorderBrush="{DynamicResource Border1}" BorderThickness="0,0,0,1">
+                <StackPanel>
+                    <TextBlock Text="Appearance" FontSize="15" FontWeight="SemiBold"
+                               Foreground="{DynamicResource TextPrimary}" FontFamily="{StaticResource UiFont}"/>
+                    <TextBlock Text="Personalize your workspace" FontSize="11"
+                               Foreground="{DynamicResource TextMuted}" Margin="0,2,0,0"/>
+                </StackPanel>
+            </Border>
+
+            <!-- Body -->
+            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" MaxHeight="480" Padding="20,14,20,18">
+                <StackPanel>
+                    <!-- Mode switcher -->
+                    <Border Background="{DynamicResource Surface0}" CornerRadius="12" Padding="3"
+                            BorderBrush="{DynamicResource Border1}" BorderThickness="1" Margin="0,0,0,16">
+                        <UniformGrid Columns="3">
+                            <RadioButton x:Name="DarkMode" Content="Dark" GroupName="Mode"
+                                         Style="{StaticResource ModePill}" IsChecked="True"/>
+                            <RadioButton x:Name="LightMode" Content="Light" GroupName="Mode"
+                                         Style="{StaticResource ModePill}"/>
+                            <RadioButton x:Name="CustomMode" Content="Custom" GroupName="Mode"
+                                         Style="{StaticResource ModePill}"/>
+                        </UniformGrid>
+                    </Border>
+
+                    <!-- Presets panel (visible for Dark/Light) -->
+                    <StackPanel x:Name="PresetsPanel">
+                        <!-- Presets grid -->
+                        <TextBlock Text="PRESETS" Style="{StaticResource SectionLabel}" Margin="0,0,0,8"/>
+                        <WrapPanel x:Name="PresetPanel"/>
+
+                        <!-- Background shade -->
+                        <TextBlock Text="BACKGROUND" Style="{StaticResource SectionLabel}" Margin="0,16,0,8"/>
+                        <Slider x:Name="ShadeSlider" Minimum="0" Maximum="1" Value="0.5"
+                                LargeChange="0.05" SmallChange="0.01"
+                                IsMoveToPointEnabled="True"
+                                Margin="0,0,0,4"/>
+                    </StackPanel>
+
+
+                    <!-- Custom panel (visible for Custom mode) -->
+                    <StackPanel x:Name="CustomPanel" Visibility="Collapsed">
+                        <TextBlock Text="CUSTOM COLORS" Style="{StaticResource SectionLabel}" Margin="0,0,0,10"/>
+
+                        <!-- Accent picker -->
+                        <Border Background="{DynamicResource Surface0}" CornerRadius="10"
+                                BorderBrush="{DynamicResource Border1}" BorderThickness="1"
+                                Padding="12,8" Margin="0,0,0,8">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="80"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="Accent" Foreground="{DynamicResource TextSecondary}"
+                                           FontSize="12" VerticalAlignment="Center"/>
+                                <Border Grid.Column="1" x:Name="CustomAccentPreview"
+                                        Width="24" Height="24" CornerRadius="6" Background="#6366F1"
+                                        Margin="0,0,10,0" Cursor="Hand"
+                                        MouseLeftButtonUp="CustomAccent_Click"/>
+                                <TextBox Grid.Column="2" x:Name="CustomAccentHex" Text="#6366F1"
+                                         FontFamily="{StaticResource MonoFont}" FontSize="12"
+                                         Background="Transparent" BorderThickness="0"
+                                         Foreground="{DynamicResource TextPrimary}"
+                                         LostFocus="CustomHex_LostFocus" Tag="accent"/>
+                            </Grid>
+                        </Border>
+
+                        <!-- Background picker -->
+                        <Border Background="{DynamicResource Surface0}" CornerRadius="10"
+                                BorderBrush="{DynamicResource Border1}" BorderThickness="1"
+                                Padding="12,8" Margin="0,0,0,8">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="80"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="Background" Foreground="{DynamicResource TextSecondary}"
+                                           FontSize="12" VerticalAlignment="Center"/>
+                                <Border Grid.Column="1" x:Name="CustomBgPreview"
+                                        Width="24" Height="24" CornerRadius="6" Background="#070A0F"
+                                        Margin="0,0,10,0" Cursor="Hand"
+                                        MouseLeftButtonUp="CustomBg_Click"/>
+                                <TextBox Grid.Column="2" x:Name="CustomBgHex" Text="#070A0F"
+                                         FontFamily="{StaticResource MonoFont}" FontSize="12"
+                                         Background="Transparent" BorderThickness="0"
+                                         Foreground="{DynamicResource TextPrimary}"
+                                         LostFocus="CustomHex_LostFocus" Tag="bg"/>
+                            </Grid>
+                        </Border>
+
+                        <!-- Surface picker -->
+                        <Border Background="{DynamicResource Surface0}" CornerRadius="10"
+                                BorderBrush="{DynamicResource Border1}" BorderThickness="1"
+                                Padding="12,8" Margin="0,0,0,8">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="80"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="Surface" Foreground="{DynamicResource TextSecondary}"
+                                           FontSize="12" VerticalAlignment="Center"/>
+                                <Border Grid.Column="1" x:Name="CustomSurfacePreview"
+                                        Width="24" Height="24" CornerRadius="6" Background="#0E1218"
+                                        Margin="0,0,10,0" Cursor="Hand"
+                                        MouseLeftButtonUp="CustomSurface_Click"/>
+                                <TextBox Grid.Column="2" x:Name="CustomSurfaceHex" Text="#0E1218"
+                                         FontFamily="{StaticResource MonoFont}" FontSize="12"
+                                         Background="Transparent" BorderThickness="0"
+                                         Foreground="{DynamicResource TextPrimary}"
+                                         LostFocus="CustomHex_LostFocus" Tag="surface"/>
+                            </Grid>
+                        </Border>
+
+                        <!-- Text picker -->
+                        <Border Background="{DynamicResource Surface0}" CornerRadius="10"
+                                BorderBrush="{DynamicResource Border1}" BorderThickness="1"
+                                Padding="12,8">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="80"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="Text" Foreground="{DynamicResource TextSecondary}"
+                                           FontSize="12" VerticalAlignment="Center"/>
+                                <Border Grid.Column="1" x:Name="CustomTextPreview"
+                                        Width="24" Height="24" CornerRadius="6" Background="#F1F3F7"
+                                        Margin="0,0,10,0" Cursor="Hand"
+                                        MouseLeftButtonUp="CustomText_Click"/>
+                                <TextBox Grid.Column="2" x:Name="CustomTextHex" Text="#F1F3F7"
+                                         FontFamily="{StaticResource MonoFont}" FontSize="12"
+                                         Background="Transparent" BorderThickness="0"
+                                         Foreground="{DynamicResource TextPrimary}"
+                                         LostFocus="CustomHex_LostFocus" Tag="text"/>
+                            </Grid>
+                        </Border>
+                    </StackPanel>
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
+    </Border>
+</UserControl>

--- a/SysManager/SysManager/Views/ThemePopup.xaml.cs
+++ b/SysManager/SysManager/Views/ThemePopup.xaml.cs
@@ -1,0 +1,190 @@
+// SysManager · ThemePopup
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Shapes;
+using SysManager.Services;
+
+namespace SysManager.Views;
+
+public partial class ThemePopup : UserControl
+{
+    private bool _suppressShadeEvent;
+    private bool _isApplyingShade;
+
+    public ThemePopup()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        BuildPresetCards();
+        SyncUiToService();
+
+        DarkMode.Checked += Mode_Changed;
+        LightMode.Checked += Mode_Changed;
+        CustomMode.Checked += Mode_Changed;
+        ShadeSlider.ValueChanged += Shade_Changed;
+    }
+
+
+    private void BuildPresetCards()
+    {
+        PresetPanel.Children.Clear();
+        var mode = DarkMode.IsChecked == true ? "dark" : "light";
+        foreach (var (id, preset) in ThemePreset.Defaults)
+        {
+            if (preset.IsDark != (mode == "dark")) continue;
+            var card = CreatePresetCard(id, preset);
+            PresetPanel.Children.Add(card);
+        }
+    }
+
+    private Border CreatePresetCard(string id, ThemePreset preset)
+    {
+        var mini = new StackPanel { Orientation = Orientation.Horizontal };
+        mini.Children.Add(new Rectangle { Width = 12, Height = 12, RadiusX = 3, RadiusY = 3,
+            Fill = new SolidColorBrush(preset.Background), Margin = new Thickness(0,0,3,0) });
+        mini.Children.Add(new Rectangle { Width = 12, Height = 12, RadiusX = 3, RadiusY = 3,
+            Fill = new SolidColorBrush(preset.Accent), Margin = new Thickness(0,0,3,0) });
+        mini.Children.Add(new Rectangle { Width = 12, Height = 12, RadiusX = 3, RadiusY = 3,
+            Fill = new SolidColorBrush(preset.TextPrimary) });
+
+        var textBrush = TryFindResource("TextPrimary") as Brush ?? new SolidColorBrush(Colors.White);
+        var borderBrush = TryFindResource("Border1") as Brush ?? new SolidColorBrush(Colors.DarkGray);
+        var accentBrush = TryFindResource("Accent") as Brush ?? new SolidColorBrush(Colors.Purple);
+
+        var name = new TextBlock
+        {
+            Text = preset.Name, FontSize = 11, FontWeight = FontWeights.SemiBold,
+            Foreground = textBrush, VerticalAlignment = VerticalAlignment.Center
+        };
+
+        var content = new StackPanel { Orientation = Orientation.Horizontal };
+        content.Children.Add(mini);
+        content.Children.Add(new Border { Width = 10 });
+        content.Children.Add(name);
+
+        var card = new Border
+        {
+            Padding = new Thickness(10),
+            CornerRadius = new CornerRadius(10),
+            BorderThickness = new Thickness(1),
+            BorderBrush = ThemeService.Instance.CurrentPresetId == id ? accentBrush : borderBrush,
+            Cursor = Cursors.Hand,
+            Margin = new Thickness(0, 0, 6, 8),
+            Width = 140,
+            Tag = id,
+            Child = content
+        };
+
+        card.MouseLeftButtonUp += Preset_Click;
+        return card;
+    }
+
+    private void SyncUiToService()
+    {
+        var svc = ThemeService.Instance;
+
+        _suppressShadeEvent = true;
+        ShadeSlider.Value = svc.ShadePosition;
+        _suppressShadeEvent = false;
+
+        switch (svc.CurrentMode)
+        {
+            case "light": LightMode.IsChecked = true; break;
+            case "custom": CustomMode.IsChecked = true; break;
+            default: DarkMode.IsChecked = true; break;
+        }
+    }
+
+
+    private void Preset_Click(object sender, MouseButtonEventArgs e)
+    {
+        var card = (Border)sender;
+        var id = (string)card.Tag;
+        ThemeService.Instance.SetPreset(id);
+
+        var borderBrush = TryFindResource("Border1") as Brush ?? Brushes.DarkGray;
+        var accentBrush = TryFindResource("Accent") as Brush ?? Brushes.Purple;
+
+        foreach (Border c in PresetPanel.Children)
+            c.BorderBrush = borderBrush;
+        card.BorderBrush = accentBrush;
+    }
+
+    private void Shade_Changed(object sender, RoutedPropertyChangedEventArgs<double> e)
+    {
+        if (_suppressShadeEvent || _isApplyingShade) return;
+        _isApplyingShade = true;
+        try
+        {
+            ThemeService.Instance.SetShade(e.NewValue);
+        }
+        finally
+        {
+            _isApplyingShade = false;
+        }
+    }
+
+    private void Mode_Changed(object sender, RoutedEventArgs e)
+    {
+        if (CustomMode.IsChecked == true)
+        {
+            PresetsPanel.Visibility = Visibility.Collapsed;
+            CustomPanel.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            PresetsPanel.Visibility = Visibility.Visible;
+            CustomPanel.Visibility = Visibility.Collapsed;
+
+            var targetMode = LightMode.IsChecked == true ? "light" : "dark";
+            var companion = ThemeService.Instance.GetCompanionPreset(targetMode);
+            ThemeService.Instance.SetPreset(companion);
+
+            BuildPresetCards();
+        }
+    }
+
+    private void CustomHex_LostFocus(object sender, RoutedEventArgs e)
+    {
+        ApplyCustomFromInputs();
+    }
+
+    private void CustomAccent_Click(object sender, MouseButtonEventArgs e) => FocusHex(CustomAccentHex);
+    private void CustomBg_Click(object sender, MouseButtonEventArgs e) => FocusHex(CustomBgHex);
+    private void CustomSurface_Click(object sender, MouseButtonEventArgs e) => FocusHex(CustomSurfaceHex);
+    private void CustomText_Click(object sender, MouseButtonEventArgs e) => FocusHex(CustomTextHex);
+
+    private static void FocusHex(TextBox box)
+    {
+        box.Focus();
+        box.SelectAll();
+    }
+
+    private void ApplyCustomFromInputs()
+    {
+        try
+        {
+            var accent = (Color)ColorConverter.ConvertFromString(CustomAccentHex.Text);
+            var bg = (Color)ColorConverter.ConvertFromString(CustomBgHex.Text);
+            var surface = (Color)ColorConverter.ConvertFromString(CustomSurfaceHex.Text);
+            var text = (Color)ColorConverter.ConvertFromString(CustomTextHex.Text);
+
+            CustomAccentPreview.Background = new SolidColorBrush(accent);
+            CustomBgPreview.Background = new SolidColorBrush(bg);
+            CustomSurfacePreview.Background = new SolidColorBrush(surface);
+            CustomTextPreview.Background = new SolidColorBrush(text);
+
+            ThemeService.Instance.SetCustom(accent, bg, surface, text);
+        }
+        catch { }
+    }
+}

--- a/SysManager/SysManager/Views/ThemePopup.xaml.cs
+++ b/SysManager/SysManager/Views/ThemePopup.xaml.cs
@@ -49,12 +49,32 @@ public partial class ThemePopup : UserControl
     private Border CreatePresetCard(string id, ThemePreset preset)
     {
         var mini = new StackPanel { Orientation = Orientation.Horizontal };
-        mini.Children.Add(new Rectangle { Width = 12, Height = 12, RadiusX = 3, RadiusY = 3,
-            Fill = new SolidColorBrush(preset.Background), Margin = new Thickness(0,0,3,0) });
-        mini.Children.Add(new Rectangle { Width = 12, Height = 12, RadiusX = 3, RadiusY = 3,
-            Fill = new SolidColorBrush(preset.Accent), Margin = new Thickness(0,0,3,0) });
-        mini.Children.Add(new Rectangle { Width = 12, Height = 12, RadiusX = 3, RadiusY = 3,
-            Fill = new SolidColorBrush(preset.TextPrimary) });
+        mini.Children.Add(new Rectangle
+        {
+            Width = 12,
+            Height = 12,
+            RadiusX = 3,
+            RadiusY = 3,
+            Fill = new SolidColorBrush(preset.Background),
+            Margin = new Thickness(0, 0, 3, 0)
+        });
+        mini.Children.Add(new Rectangle
+        {
+            Width = 12,
+            Height = 12,
+            RadiusX = 3,
+            RadiusY = 3,
+            Fill = new SolidColorBrush(preset.Accent),
+            Margin = new Thickness(0, 0, 3, 0)
+        });
+        mini.Children.Add(new Rectangle
+        {
+            Width = 12,
+            Height = 12,
+            RadiusX = 3,
+            RadiusY = 3,
+            Fill = new SolidColorBrush(preset.TextPrimary)
+        });
 
         var textBrush = TryFindResource("TextPrimary") as Brush ?? new SolidColorBrush(Colors.White);
         var borderBrush = TryFindResource("Border1") as Brush ?? new SolidColorBrush(Colors.DarkGray);
@@ -62,8 +82,11 @@ public partial class ThemePopup : UserControl
 
         var name = new TextBlock
         {
-            Text = preset.Name, FontSize = 11, FontWeight = FontWeights.SemiBold,
-            Foreground = textBrush, VerticalAlignment = VerticalAlignment.Center
+            Text = preset.Name,
+            FontSize = 11,
+            FontWeight = FontWeights.SemiBold,
+            Foreground = textBrush,
+            VerticalAlignment = VerticalAlignment.Center
         };
 
         var content = new StackPanel { Orientation = Orientation.Horizontal };

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -7,7 +7,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             Background="{StaticResource Surface0}">
+             Background="{DynamicResource Surface0}">
 
     <Grid Margin="32,24">
         <Grid.RowDefinitions>
@@ -27,7 +27,7 @@
         </StackPanel>
 
         <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
@@ -35,9 +35,9 @@
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
                     <TextBlock Text="Some applications require administrator privileges to uninstall."
-                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                 </StackPanel>
             </DockPanel>
         </Border>
@@ -72,7 +72,7 @@
                 <Grid Width="220" Margin="0,0,12,0">
                     <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"/>
                     <TextBlock Text="Search apps…" IsHitTestVisible="False"
-                               Foreground="{StaticResource TextMuted}" Margin="6,0,0,0"
+                               Foreground="{DynamicResource TextMuted}" Margin="6,0,0,0"
                                VerticalAlignment="Center" FontSize="12"
                                Visibility="{Binding FilterText, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                 </Grid>
@@ -125,7 +125,7 @@
                                     <StackPanel VerticalAlignment="Center">
                                         <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13"/>
                                         <TextBlock Text="{Binding Id}" FontSize="11"
-                                                   Foreground="{StaticResource TextMuted}"
+                                                   Foreground="{DynamicResource TextMuted}"
                                                    TextTrimming="CharacterEllipsis" MaxWidth="400"/>
                                     </StackPanel>
                                 </StackPanel>
@@ -140,7 +140,7 @@
                                 <Setter Property="HorizontalAlignment" Value="Right"/>
                                 <Setter Property="FontFamily" Value="Consolas"/>
                                 <Setter Property="FontSize" Value="12"/>
-                                <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
@@ -152,7 +152,7 @@
                                 <Setter Property="HorizontalAlignment" Value="Right"/>
                                 <Setter Property="FontFamily" Value="Consolas"/>
                                 <Setter Property="FontSize" Value="12"/>
-                                <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource TextMuted}"/>
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
@@ -181,7 +181,7 @@
                                                 Margin="-8,-4,0,-4">
                                             <Border.Style>
                                                 <Style TargetType="Border">
-                                                    <Setter Property="Background" Value="{StaticResource Accent}"/>
+                                                    <Setter Property="Background" Value="{DynamicResource Accent}"/>
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding Source}" Value="">
                                                             <Setter Property="Background" Value="#FBBF24"/>

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -7,7 +7,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             Background="{StaticResource Surface0}">
+             Background="{DynamicResource Surface0}">
 
     <Grid Margin="32,24">
         <Grid.RowDefinitions>
@@ -39,7 +39,7 @@
                 <Grid Width="220" Margin="0,0,12,0">
                     <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"/>
                     <TextBlock Text="Search features…" IsHitTestVisible="False"
-                               Foreground="{StaticResource TextMuted}" Margin="6,0,0,0"
+                               Foreground="{DynamicResource TextMuted}" Margin="6,0,0,0"
                                VerticalAlignment="Center" FontSize="12"
                                Visibility="{Binding FilterText, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                 </Grid>
@@ -64,7 +64,7 @@
         </Border>
 
         <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="2" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+        <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
@@ -72,9 +72,9 @@
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
                     <TextBlock Text="Enabling or disabling Windows features requires administrator privileges."
-                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                 </StackPanel>
             </DockPanel>
         </Border>
@@ -115,7 +115,7 @@
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="FontSize" Value="11"/>
-                                <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource TextMuted}"/>
                                 <Setter Property="VerticalAlignment" Value="Center"/>
                             </Style>
                         </DataGridTextColumn.ElementStyle>
@@ -158,7 +158,7 @@
                                     <TextBlock.Style>
                                         <Style TargetType="TextBlock">
                                             <Setter Property="Text" Value="Disabled"/>
-                                            <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
+                                            <Setter Property="Foreground" Value="{DynamicResource TextMuted}"/>
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding IsEnabled}" Value="True">
                                                     <Setter Property="Text" Value="Enabled"/>

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -36,7 +36,7 @@
         </StackPanel>
 
         <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{StaticResource Surface2}" BorderBrush="{StaticResource Border1}"
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
@@ -44,9 +44,9 @@
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{StaticResource TextSecondary}"/>
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
                     <TextBlock Text="Listing and installing Windows updates requires administrator privileges."
-                               Foreground="{StaticResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                 </StackPanel>
             </DockPanel>
         </Border>
@@ -158,7 +158,7 @@
                             <Style TargetType="TextBlock">
                                 <Setter Property="FontFamily" Value="Consolas"/>
                                 <Setter Property="FontSize" Value="12"/>
-                                <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
@@ -169,7 +169,7 @@
                             <Style TargetType="TextBlock">
                                 <Setter Property="HorizontalAlignment" Value="Right"/>
                                 <Setter Property="FontSize" Value="12"/>
-                                <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource TextMuted}"/>
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
@@ -190,7 +190,7 @@
                             <Style TargetType="TextBlock">
                                 <Setter Property="FontFamily" Value="Consolas"/>
                                 <Setter Property="FontSize" Value="12"/>
-                                <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource TextMuted}"/>
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
@@ -200,7 +200,7 @@
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="FontSize" Value="11"/>
-                                <Setter Property="Foreground" Value="{StaticResource TextMuted}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource TextMuted}"/>
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>


### PR DESCRIPTION
## Summary
- Adds a theme customization system with 12 curated presets (6 dark, 6 light)
- Persistent theme button (palette icon) in top-right corner of every page
- Background shade slider for fine-tuning lightness/darkness
- Custom mode with free hex input for accent, background, surface, and text
- Auto companion preset switching (Dark↔Light maintains color family)
- Settings persisted to `%AppData%/SysManager/theme.json` between sessions
- All 504 color `StaticResource` references converted to `DynamicResource` for live switching

## Dark presets
Midnight Indigo, Deep Ocean, Dark Forest, Neon Rose, Violet Night, Warm Ember

## Light presets
Clean Indigo, Sky Breeze, Warm Sand, Mint Fresh, Soft Blossom, Lavender

## Technical changes
- New `ThemeService` singleton (load/save/apply theme at runtime)
- New `ThemePopup` UserControl (popup UI with mode tabs, presets, slider, custom inputs)
- `ThemePreset` record with full color definitions for each preset
- 38 XAML files updated (StaticResource → DynamicResource on all color tokens)
- ModePill and SectionLabel styles added to App.xaml

## Test plan
- [x] Build: 0 errors, 0 warnings (main + tests + integration tests)
- [x] Published self-contained EXE launches and stays alive 20+ seconds
- [x] No crash entries in Windows Event Log
- [x] Theme popup opens, presets switch colors live
- [x] Dark↔Light auto-companion works
- [x] Background slider adjusts lightness both directions
- [x] Settings persist after restart
- [x] Self-review: no debug code, no AI refs, author headers present
