### PR TITLE
fix: freeze theme brushes and prevent duplicate event subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.13.1] - 2026-05-27
+
+### Fixed
+- **Theme performance** — freeze all runtime-created brushes for reduced GC pressure
+  and improved WPF rendering throughput.
+- **Theme popup duplicate handlers** — prevent event subscriptions from stacking on
+  repeated popup opens, which caused redundant theme re-applies.
+
 ## [1.13.0] - 2026-05-27
 
 ### Added

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -162,7 +162,9 @@ public sealed class ThemeService
 
     private static void SetBrush(ResourceDictionary res, string key, Color color)
     {
-        res[key] = new SolidColorBrush(color);
+        var brush = new SolidColorBrush(color);
+        brush.Freeze();
+        res[key] = brush;
     }
 
     private static void SetColor(ResourceDictionary res, string key, Color color)

--- a/SysManager/SysManager/Views/ThemePopup.xaml.cs
+++ b/SysManager/SysManager/Views/ThemePopup.xaml.cs
@@ -15,6 +15,7 @@ public partial class ThemePopup : UserControl
 {
     private bool _suppressShadeEvent;
     private bool _isApplyingShade;
+    private bool _initialized;
 
     public ThemePopup()
     {
@@ -24,6 +25,9 @@ public partial class ThemePopup : UserControl
 
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
+        if (_initialized) return;
+        _initialized = true;
+
         BuildPresetCards();
         SyncUiToService();
 


### PR DESCRIPTION
## Summary
- Freeze all `SolidColorBrush` instances created by `ThemeService.Apply()` for better WPF rendering performance and reduced GC pressure
- Add `_initialized` guard in `ThemePopup.OnLoaded` to prevent event handler stacking when the popup is reopened multiple times

## Root cause
1. Unfrozen brushes hold dispatcher thread references and cannot be optimized by WPF's rendering pipeline
2. WPF `Loaded` event fires every time a `Popup` opens — without a guard, `Checked`/`ValueChanged` handlers were added on each open, causing N redundant theme re-applies after N open/close cycles

## Test plan
- [x] Build: 0 errors, 0 warnings
- [x] App launches and stays stable 8+ seconds
- [x] Theme popup opens, presets work, no duplicate firings
