### PR TITLE
fix: add MinWidth and lock action columns across all DataGrids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.13.2] - 2026-05-27
+
+### Fixed
+- **DataGrid column resize** — all 19 DataGrids across 16 views now have `MinWidth` on every
+  column preventing content from being compressed to invisible on resize.
+- **Startup Manager "Open" button clipped** — column widened from 60→80px.
+- **Toggle switch clipping** — toggle columns (Startup, Context Menu, Windows Features) widened
+  to 62px to prevent pill shape from being cut off.
+- **Action columns no longer resizable** — buttons/toggles/checkboxes columns locked with
+  `CanUserResize="False"` so users cannot accidentally shrink them.
+
 ## [1.13.1] - 2026-05-27
 
 ### Fixed

--- a/SysManager/SysManager/Views/AppAlertsView.xaml
+++ b/SysManager/SysManager/Views/AppAlertsView.xaml
@@ -44,11 +44,11 @@
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="Detected" Binding="{Binding DetectedAt, StringFormat='{}{0:HH:mm:ss dd-MMM}'}" Width="120" />
-                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="200" />
-                <DataGridTextColumn Header="Publisher" Binding="{Binding Publisher}" Width="150" />
-                <DataGridTextColumn Header="Path" Binding="{Binding InstallPath}" Width="*" />
-                <DataGridTextColumn Header="Source" Binding="{Binding Source}" Width="80" />
+                <DataGridTextColumn Header="Detected" Binding="{Binding DetectedAt, StringFormat='{}{0:HH:mm:ss dd-MMM}'}" Width="120" MinWidth="80" />
+                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="200" MinWidth="100" />
+                <DataGridTextColumn Header="Publisher" Binding="{Binding Publisher}" Width="150" MinWidth="80" />
+                <DataGridTextColumn Header="Path" Binding="{Binding InstallPath}" Width="*" MinWidth="120" />
+                <DataGridTextColumn Header="Source" Binding="{Binding Source}" Width="80" MinWidth="60" />
             </DataGrid.Columns>
         </DataGrid>
 

--- a/SysManager/SysManager/Views/AppBlockerView.xaml
+++ b/SysManager/SysManager/Views/AppBlockerView.xaml
@@ -85,8 +85,8 @@
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling">
             <DataGrid.Columns>
-                <DataGridCheckBoxColumn Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" Width="40" />
-                <DataGridTextColumn Header="Executable" Binding="{Binding ExecutableName}" Width="*" IsReadOnly="True" />
+                <DataGridCheckBoxColumn Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" Width="40" MinWidth="40" CanUserResize="False" />
+                <DataGridTextColumn Header="Executable" Binding="{Binding ExecutableName}" Width="*" MinWidth="120" IsReadOnly="True" />
             </DataGrid.Columns>
         </DataGrid>
 

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml
@@ -77,7 +77,7 @@
                       VirtualizingPanel.IsVirtualizing="True"
                       VirtualizingPanel.VirtualizationMode="Recycling">
                 <DataGrid.Columns>
-                    <DataGridCheckBoxColumn Header="" Width="50" Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" CanUserSort="False">
+                    <DataGridCheckBoxColumn Header="" Width="50" MinWidth="50" CanUserResize="False" Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" CanUserSort="False">
                         <DataGridCheckBoxColumn.ElementStyle>
                             <Style TargetType="CheckBox">
                                 <Setter Property="HorizontalAlignment" Value="Center"/>
@@ -91,12 +91,12 @@
                             </Style>
                         </DataGridCheckBoxColumn.EditingElementStyle>
                     </DataGridCheckBoxColumn>
-                    <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="2*" SortMemberPath="Name"/>
-                    <DataGridTextColumn Header="Id" Binding="{Binding Id}" Width="2*" SortMemberPath="Id"/>
-                    <DataGridTextColumn Header="Current" Binding="{Binding CurrentVersion}" Width="*" SortMemberPath="CurrentVersion"/>
-                    <DataGridTextColumn Header="Available" Binding="{Binding AvailableVersion}" Width="*" SortMemberPath="AvailableVersion"/>
-                    <DataGridTextColumn Header="Source" Binding="{Binding Source}" Width="80" SortMemberPath="Source"/>
-                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="*" SortMemberPath="Status"/>
+                    <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="2*" MinWidth="120" SortMemberPath="Name"/>
+                    <DataGridTextColumn Header="Id" Binding="{Binding Id}" Width="2*" MinWidth="120" SortMemberPath="Id"/>
+                    <DataGridTextColumn Header="Current" Binding="{Binding CurrentVersion}" Width="*" MinWidth="80" SortMemberPath="CurrentVersion"/>
+                    <DataGridTextColumn Header="Available" Binding="{Binding AvailableVersion}" Width="*" MinWidth="80" SortMemberPath="AvailableVersion"/>
+                    <DataGridTextColumn Header="Source" Binding="{Binding Source}" Width="80" MinWidth="60" SortMemberPath="Source"/>
+                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="*" MinWidth="80" SortMemberPath="Status"/>
                 </DataGrid.Columns>
             </DataGrid>
         </Border>

--- a/SysManager/SysManager/Views/ContextMenuView.xaml
+++ b/SysManager/SysManager/Views/ContextMenuView.xaml
@@ -73,7 +73,7 @@
                       VirtualizingPanel.IsVirtualizing="True"
                       VirtualizingPanel.VirtualizationMode="Recycling">
                 <DataGrid.Columns>
-                    <DataGridTemplateColumn Header="" Width="50" CanUserSort="False">
+                    <DataGridTemplateColumn Header="" Width="62" MinWidth="62" CanUserResize="False" CanUserSort="False">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <ToggleButton Style="{StaticResource ToggleSwitch}"
@@ -85,7 +85,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTemplateColumn Header="Name" Width="*" SortMemberPath="Name" IsReadOnly="True">
+                    <DataGridTemplateColumn Header="Name" Width="*" MinWidth="150" SortMemberPath="Name" IsReadOnly="True">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <StackPanel Margin="4,4" VerticalAlignment="Center">
@@ -108,7 +108,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="140"
+                    <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="140" MinWidth="80"
                                         SortMemberPath="Location" IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
@@ -119,7 +119,7 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTextColumn Header="Source" Binding="{Binding Source}" Width="140"
+                    <DataGridTextColumn Header="Source" Binding="{Binding Source}" Width="140" MinWidth="80"
                                         SortMemberPath="Source" IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">

--- a/SysManager/SysManager/Views/DeepCleanupView.xaml
+++ b/SysManager/SysManager/Views/DeepCleanupView.xaml
@@ -199,11 +199,11 @@
                                   VirtualizingPanel.IsVirtualizing="True"
                                   VirtualizingPanel.VirtualizationMode="Recycling">
                             <DataGrid.Columns>
-                                <DataGridTextColumn Header="Size" Binding="{Binding SizeDisplay}" Width="110"/>
-                                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
-                                <DataGridTextColumn Header="Modified" Binding="{Binding LastModifiedDisplay}" Width="110"/>
-                                <DataGridTextColumn Header="Path" Binding="{Binding Path}" Width="2*"/>
-                                <DataGridTemplateColumn Header="Actions" Width="210">
+                                <DataGridTextColumn Header="Size" Binding="{Binding SizeDisplay}" Width="110" MinWidth="70"/>
+                                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*" MinWidth="100"/>
+                                <DataGridTextColumn Header="Modified" Binding="{Binding LastModifiedDisplay}" Width="110" MinWidth="80"/>
+                                <DataGridTextColumn Header="Path" Binding="{Binding Path}" Width="2*" MinWidth="120"/>
+                                <DataGridTemplateColumn Header="Actions" Width="210" MinWidth="210" CanUserResize="False">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
                                             <StackPanel Orientation="Horizontal">

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -126,11 +126,11 @@
                           VirtualizingPanel.IsVirtualizing="True"
                           VirtualizingPanel.VirtualizationMode="Recycling">
                     <DataGrid.Columns>
-                        <DataGridCheckBoxColumn Header="On" Binding="{Binding IsEnabled, UpdateSourceTrigger=PropertyChanged}" Width="40"/>
-                        <DataGridTextColumn Header="IP Address" Binding="{Binding IpAddress}" Width="150" IsReadOnly="True"/>
-                        <DataGridTextColumn Header="Hostname" Binding="{Binding Hostname}" Width="*" IsReadOnly="True"/>
-                        <DataGridTextColumn Header="Comment" Binding="{Binding Comment}" Width="150" IsReadOnly="True"/>
-                        <DataGridTemplateColumn Header="" Width="60">
+                        <DataGridCheckBoxColumn Header="On" Binding="{Binding IsEnabled, UpdateSourceTrigger=PropertyChanged}" Width="40" MinWidth="40" CanUserResize="False"/>
+                        <DataGridTextColumn Header="IP Address" Binding="{Binding IpAddress}" Width="150" MinWidth="80" IsReadOnly="True"/>
+                        <DataGridTextColumn Header="Hostname" Binding="{Binding Hostname}" Width="*" MinWidth="120" IsReadOnly="True"/>
+                        <DataGridTextColumn Header="Comment" Binding="{Binding Comment}" Width="150" MinWidth="80" IsReadOnly="True"/>
+                        <DataGridTemplateColumn Header="" Width="60" MinWidth="60" CanUserResize="False">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
                                     <Button Content="X" Command="{Binding DataContext.RemoveEntryCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"

--- a/SysManager/SysManager/Views/DriversView.xaml
+++ b/SysManager/SysManager/Views/DriversView.xaml
@@ -53,7 +53,7 @@
                           VirtualizingPanel.IsVirtualizing="True"
                           VirtualizingPanel.VirtualizationMode="Recycling">
                     <DataGrid.Columns>
-                        <DataGridTextColumn Header="Device Name" Binding="{Binding DeviceName}" Width="*"
+                        <DataGridTextColumn Header="Device Name" Binding="{Binding DeviceName}" Width="*" MinWidth="120"
                                             SortMemberPath="DeviceName" SortDirection="Ascending">
                             <DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock">
@@ -64,7 +64,7 @@
                             </DataGridTextColumn.ElementStyle>
                         </DataGridTextColumn>
 
-                        <DataGridTextColumn Header="Manufacturer" Binding="{Binding Manufacturer}" Width="180"
+                        <DataGridTextColumn Header="Manufacturer" Binding="{Binding Manufacturer}" Width="180" MinWidth="80"
                                             SortMemberPath="Manufacturer">
                             <DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock">
@@ -75,7 +75,7 @@
                             </DataGridTextColumn.ElementStyle>
                         </DataGridTextColumn>
 
-                        <DataGridTextColumn Header="Version" Binding="{Binding DriverVersion}" Width="140"
+                        <DataGridTextColumn Header="Version" Binding="{Binding DriverVersion}" Width="140" MinWidth="80"
                                             SortMemberPath="DriverVersion">
                             <DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock">
@@ -86,7 +86,7 @@
                             </DataGridTextColumn.ElementStyle>
                         </DataGridTextColumn>
 
-                        <DataGridTextColumn Header="Date" Binding="{Binding DriverDateDisplay}" Width="100"
+                        <DataGridTextColumn Header="Date" Binding="{Binding DriverDateDisplay}" Width="100" MinWidth="80"
                                             SortMemberPath="DriverDate">
                             <DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock">

--- a/SysManager/SysManager/Views/FileShredderView.xaml
+++ b/SysManager/SysManager/Views/FileShredderView.xaml
@@ -88,11 +88,11 @@
                 </Style>
             </DataGrid.Style>
             <DataGrid.Columns>
-                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="200"/>
-                <DataGridTextColumn Header="Path" Binding="{Binding Path}" Width="*"/>
-                <DataGridTextColumn Header="Size" Binding="{Binding SizeDisplay}" Width="90"/>
-                <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="160"/>
-                <DataGridTemplateColumn Header="" Width="70">
+                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="200" MinWidth="100"/>
+                <DataGridTextColumn Header="Path" Binding="{Binding Path}" Width="*" MinWidth="120"/>
+                <DataGridTextColumn Header="Size" Binding="{Binding SizeDisplay}" Width="90" MinWidth="60"/>
+                <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="160" MinWidth="80"/>
+                <DataGridTemplateColumn Header="" Width="70" MinWidth="70" CanUserResize="False">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <Button Content="Remove"

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -242,7 +242,7 @@
                     </DataGrid.RowStyle>
                     <DataGrid.Columns>
                         <!-- Severity column: colored dot instead of emoji -->
-                        <DataGridTemplateColumn Header="" Width="40">
+                        <DataGridTemplateColumn Header="" Width="40" MinWidth="40" CanUserResize="False">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
                                     <Ellipse Width="10" Height="10" VerticalAlignment="Center" HorizontalAlignment="Center"
@@ -250,16 +250,16 @@
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>
                         </DataGridTemplateColumn>
-                        <DataGridTemplateColumn Header="Time" Width="150" SortMemberPath="Timestamp">
+                        <DataGridTemplateColumn Header="Time" Width="150" MinWidth="80" SortMemberPath="Timestamp">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
                                     <TextBlock Text="{Binding RelativeTime}" ToolTip="{Binding FullTimestamp}" VerticalAlignment="Center"/>
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>
                         </DataGridTemplateColumn>
-                        <DataGridTextColumn Header="Source" Binding="{Binding ProviderName}" Width="170"/>
-                        <DataGridTextColumn Header="ID" Binding="{Binding EventId}" Width="60"/>
-                        <DataGridTextColumn Header="Message" Binding="{Binding Message}" Width="*"/>
+                        <DataGridTextColumn Header="Source" Binding="{Binding ProviderName}" Width="170" MinWidth="80"/>
+                        <DataGridTextColumn Header="ID" Binding="{Binding EventId}" Width="60" MinWidth="40"/>
+                        <DataGridTextColumn Header="Message" Binding="{Binding Message}" Width="*" MinWidth="120"/>
                     </DataGrid.Columns>
                 </DataGrid>
 

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -63,8 +63,8 @@
                       VirtualizingPanel.IsVirtualizing="True"
                       VirtualizingPanel.VirtualizationMode="Recycling">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Header="PID" Binding="{Binding Pid}" Width="55"
-                                        SortMemberPath="Pid">
+                    <DataGridTextColumn Header="PID" Binding="{Binding Pid}" Width="55" MinWidth="55"
+                                        SortMemberPath="Pid" CanUserResize="False">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="FontFamily" Value="Consolas"/>
@@ -92,7 +92,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTextColumn Header="Memory" Binding="{Binding MemoryDisplay}" Width="80"
+                    <DataGridTextColumn Header="Memory" Binding="{Binding MemoryDisplay}" Width="80" MinWidth="70"
                                         SortMemberPath="MemoryBytes">
                         <DataGridTextColumn.HeaderStyle>
                             <Style TargetType="DataGridColumnHeader" BasedOn="{StaticResource {x:Type DataGridColumnHeader}}">
@@ -108,7 +108,7 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTextColumn Header="CPU" Binding="{Binding CpuPercent, StringFormat={}{0:F1}%}" Width="60"
+                    <DataGridTextColumn Header="CPU" Binding="{Binding CpuPercent, StringFormat={}{0:F1}%}" Width="60" MinWidth="55"
                                         SortMemberPath="CpuPercent">
                         <DataGridTextColumn.HeaderStyle>
                             <Style TargetType="DataGridColumnHeader" BasedOn="{StaticResource {x:Type DataGridColumnHeader}}">
@@ -125,7 +125,7 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTextColumn Header="Threads" Binding="{Binding ThreadCount}" Width="70"
+                    <DataGridTextColumn Header="Threads" Binding="{Binding ThreadCount}" Width="70" MinWidth="60"
                                         SortMemberPath="ThreadCount">
                         <DataGridTextColumn.HeaderStyle>
                             <Style TargetType="DataGridColumnHeader" BasedOn="{StaticResource {x:Type DataGridColumnHeader}}">
@@ -141,7 +141,7 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTemplateColumn Header="Status" Width="100" SortMemberPath="Status">
+                    <DataGridTemplateColumn Header="Status" Width="100" MinWidth="90" SortMemberPath="Status">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Border CornerRadius="8" Padding="8,4" VerticalAlignment="Center"
@@ -163,7 +163,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTemplateColumn Header="Actions" Width="120" CanUserSort="False">
+                    <DataGridTemplateColumn Header="Actions" Width="120" MinWidth="120" CanUserSort="False" CanUserResize="False">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal">

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -109,18 +109,18 @@
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="Name" Binding="{Binding DisplayName}" Width="200" SortMemberPath="DisplayName"/>
-                <DataGridTextColumn Header="Service" Binding="{Binding Name}" Width="160" SortMemberPath="Name"/>
-                <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="80" SortMemberPath="Status"/>
-                <DataGridTextColumn Header="Startup" Binding="{Binding StartType}" Width="90" SortMemberPath="StartType"/>
-                <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="*" SortMemberPath="Description">
+                <DataGridTextColumn Header="Name" Binding="{Binding DisplayName}" Width="200" MinWidth="120" SortMemberPath="DisplayName"/>
+                <DataGridTextColumn Header="Service" Binding="{Binding Name}" Width="160" MinWidth="100" SortMemberPath="Name"/>
+                <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="80" MinWidth="70" SortMemberPath="Status"/>
+                <DataGridTextColumn Header="Startup" Binding="{Binding StartType}" Width="90" MinWidth="80" SortMemberPath="StartType"/>
+                <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="*" MinWidth="100" SortMemberPath="Description">
                     <DataGridTextColumn.ElementStyle>
                         <Style TargetType="TextBlock">
                             <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
                         </Style>
                     </DataGridTextColumn.ElementStyle>
                 </DataGridTextColumn>
-                <DataGridTemplateColumn Header="Safety" Width="90" SortMemberPath="SafetyLevel">
+                <DataGridTemplateColumn Header="Safety" Width="90" MinWidth="80" SortMemberPath="SafetyLevel">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <Border CornerRadius="6" Padding="6,3"
@@ -139,7 +139,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Actions" Width="280">
+                <DataGridTemplateColumn Header="Actions" Width="280" MinWidth="280" CanUserResize="False">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <StackPanel Orientation="Horizontal">

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml
@@ -63,10 +63,10 @@
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling">
             <DataGrid.Columns>
-                <DataGridCheckBoxColumn Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" Width="40"/>
-                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="200" IsReadOnly="True"/>
-                <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="150" IsReadOnly="True"/>
-                <DataGridTextColumn Header="Target (missing)" Binding="{Binding TargetPath}" Width="*" IsReadOnly="True"/>
+                <DataGridCheckBoxColumn Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" Width="40" MinWidth="40" CanUserResize="False"/>
+                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="200" MinWidth="100" IsReadOnly="True"/>
+                <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="150" MinWidth="80" IsReadOnly="True"/>
+                <DataGridTextColumn Header="Target (missing)" Binding="{Binding TargetPath}" Width="*" MinWidth="120" IsReadOnly="True"/>
             </DataGrid.Columns>
         </DataGrid>
 

--- a/SysManager/SysManager/Views/SpeedTestView.xaml
+++ b/SysManager/SysManager/Views/SpeedTestView.xaml
@@ -117,11 +117,11 @@
                                   VirtualizingPanel.IsVirtualizing="True"
                                   VirtualizingPanel.VirtualizationMode="Recycling">
                             <DataGrid.Columns>
-                                <DataGridTextColumn Header="Date" Binding="{Binding CompletedAt, StringFormat={}{0:dd MMM HH:mm}}" Width="110"/>
-                                <DataGridTextColumn Header="Down (Mbps)" Binding="{Binding DownloadMbps, StringFormat={}{0:F1}}" Width="90"/>
-                                <DataGridTextColumn Header="Up (Mbps)" Binding="{Binding UploadMbps, StringFormat={}{0:F1}}" Width="80"/>
-                                <DataGridTextColumn Header="Ping (ms)" Binding="{Binding PingMs, StringFormat={}{0:F0}}" Width="70"/>
-                                <DataGridTextColumn Header="Server" Binding="{Binding Server}" Width="*"/>
+                                <DataGridTextColumn Header="Date" Binding="{Binding CompletedAt, StringFormat={}{0:dd MMM HH:mm}}" Width="110" MinWidth="80"/>
+                                <DataGridTextColumn Header="Down (Mbps)" Binding="{Binding DownloadMbps, StringFormat={}{0:F1}}" Width="90" MinWidth="70"/>
+                                <DataGridTextColumn Header="Up (Mbps)" Binding="{Binding UploadMbps, StringFormat={}{0:F1}}" Width="80" MinWidth="60"/>
+                                <DataGridTextColumn Header="Ping (ms)" Binding="{Binding PingMs, StringFormat={}{0:F0}}" Width="70" MinWidth="60"/>
+                                <DataGridTextColumn Header="Server" Binding="{Binding Server}" Width="*" MinWidth="80"/>
                             </DataGrid.Columns>
                         </DataGrid>
                         <TextBlock Text="No history yet — run a test to start tracking."
@@ -147,11 +147,11 @@
                                   VirtualizingPanel.IsVirtualizing="True"
                                   VirtualizingPanel.VirtualizationMode="Recycling">
                             <DataGrid.Columns>
-                                <DataGridTextColumn Header="Date" Binding="{Binding CompletedAt, StringFormat={}{0:dd MMM HH:mm}}" Width="110"/>
-                                <DataGridTextColumn Header="Down (Mbps)" Binding="{Binding DownloadMbps, StringFormat={}{0:F1}}" Width="90"/>
-                                <DataGridTextColumn Header="Up (Mbps)" Binding="{Binding UploadMbps, StringFormat={}{0:F1}}" Width="80"/>
-                                <DataGridTextColumn Header="Ping (ms)" Binding="{Binding PingMs, StringFormat={}{0:F0}}" Width="70"/>
-                                <DataGridTextColumn Header="Server" Binding="{Binding Server}" Width="*"/>
+                                <DataGridTextColumn Header="Date" Binding="{Binding CompletedAt, StringFormat={}{0:dd MMM HH:mm}}" Width="110" MinWidth="80"/>
+                                <DataGridTextColumn Header="Down (Mbps)" Binding="{Binding DownloadMbps, StringFormat={}{0:F1}}" Width="90" MinWidth="70"/>
+                                <DataGridTextColumn Header="Up (Mbps)" Binding="{Binding UploadMbps, StringFormat={}{0:F1}}" Width="80" MinWidth="60"/>
+                                <DataGridTextColumn Header="Ping (ms)" Binding="{Binding PingMs, StringFormat={}{0:F0}}" Width="70" MinWidth="60"/>
+                                <DataGridTextColumn Header="Server" Binding="{Binding Server}" Width="*" MinWidth="80"/>
                             </DataGrid.Columns>
                         </DataGrid>
                         <TextBlock Text="No history yet — run a test to start tracking."

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -55,7 +55,7 @@
                       VirtualizingPanel.IsVirtualizing="True"
                       VirtualizingPanel.VirtualizationMode="Recycling">
                 <DataGrid.Columns>
-                    <DataGridTemplateColumn Header="" Width="50" CanUserSort="False">
+                    <DataGridTemplateColumn Header="" Width="62" MinWidth="62" CanUserSort="False" CanUserResize="False">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <ToggleButton Style="{StaticResource ToggleSwitch}"
@@ -85,7 +85,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTextColumn Header="Publisher" Binding="{Binding Publisher}" Width="140"
+                    <DataGridTextColumn Header="Publisher" Binding="{Binding Publisher}" Width="140" MinWidth="100"
                                         SortMemberPath="Publisher" IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
@@ -95,7 +95,7 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTemplateColumn Header="Status" Width="100" SortMemberPath="StatusText">
+                    <DataGridTemplateColumn Header="Status" Width="100" MinWidth="90" SortMemberPath="StatusText">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Border CornerRadius="8" Padding="8,5" VerticalAlignment="Center" Margin="4,0"
@@ -157,7 +157,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTemplateColumn Header="" Width="60" CanUserSort="False">
+                    <DataGridTemplateColumn Header="" Width="80" MinWidth="80" CanUserSort="False" CanUserResize="False">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Button Content="Open" ToolTip="Open file location"

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -78,11 +78,11 @@
                                   VirtualizingPanel.IsVirtualizing="True"
                                   VirtualizingPanel.VirtualizationMode="Recycling">
                             <DataGrid.Columns>
-                                <DataGridTextColumn Header="Slot" Binding="{Binding BankLabel}" Width="*"/>
-                                <DataGridTextColumn Header="Manufacturer" Binding="{Binding Manufacturer}" Width="*"/>
-                                <DataGridTextColumn Header="Capacity (GB)" Binding="{Binding CapacityGB, StringFormat={}{0:F1}}" Width="110"/>
-                                <DataGridTextColumn Header="Speed (MHz)" Binding="{Binding SpeedMHz}" Width="110"/>
-                                <DataGridTextColumn Header="Part #" Binding="{Binding PartNumber}" Width="1.5*"/>
+                                <DataGridTextColumn Header="Slot" Binding="{Binding BankLabel}" Width="*" MinWidth="80"/>
+                                <DataGridTextColumn Header="Manufacturer" Binding="{Binding Manufacturer}" Width="*" MinWidth="80"/>
+                                <DataGridTextColumn Header="Capacity (GB)" Binding="{Binding CapacityGB, StringFormat={}{0:F1}}" Width="110" MinWidth="80"/>
+                                <DataGridTextColumn Header="Speed (MHz)" Binding="{Binding SpeedMHz}" Width="110" MinWidth="80"/>
+                                <DataGridTextColumn Header="Part #" Binding="{Binding PartNumber}" Width="1.5*" MinWidth="100"/>
                             </DataGrid.Columns>
                         </DataGrid>
                     </StackPanel>
@@ -131,11 +131,11 @@
                                   VirtualizingPanel.IsVirtualizing="True"
                                   VirtualizingPanel.VirtualizationMode="Recycling">
                             <DataGrid.Columns>
-                                <DataGridTextColumn Header="Drive" Binding="{Binding FriendlyName}" Width="*"/>
-                                <DataGridTextColumn Header="Media" Binding="{Binding MediaType}" Width="70"/>
-                                <DataGridTextColumn Header="Bus" Binding="{Binding BusType}" Width="70"/>
-                                <DataGridTextColumn Header="Size (GB)" Binding="{Binding SizeGB, StringFormat={}{0:F0}}" Width="90"/>
-                                <DataGridTextColumn Header="Windows Health" Binding="{Binding HealthStatus}" Width="130"/>
+                                <DataGridTextColumn Header="Drive" Binding="{Binding FriendlyName}" Width="*" MinWidth="100"/>
+                                <DataGridTextColumn Header="Media" Binding="{Binding MediaType}" Width="70" MinWidth="60"/>
+                                <DataGridTextColumn Header="Bus" Binding="{Binding BusType}" Width="70" MinWidth="60"/>
+                                <DataGridTextColumn Header="Size (GB)" Binding="{Binding SizeGB, StringFormat={}{0:F0}}" Width="90" MinWidth="70"/>
+                                <DataGridTextColumn Header="Windows Health" Binding="{Binding HealthStatus}" Width="130" MinWidth="80"/>
                             </DataGrid.Columns>
                         </DataGrid>
                     </StackPanel>

--- a/SysManager/SysManager/Views/TracerouteView.xaml
+++ b/SysManager/SysManager/Views/TracerouteView.xaml
@@ -96,9 +96,9 @@
                               VirtualizingPanel.IsVirtualizing="True"
                               VirtualizingPanel.VirtualizationMode="Recycling">
                         <DataGrid.Columns>
-                            <DataGridTextColumn Header="#" Binding="{Binding HopNumber}" Width="36"/>
-                            <DataGridTextColumn Header="Address" Binding="{Binding Address}" Width="*"/>
-                            <DataGridTextColumn Header="ms" Binding="{Binding LatencyMs, StringFormat={}{0:F0}}" Width="60"/>
+                            <DataGridTextColumn Header="#" Binding="{Binding HopNumber}" Width="36" MinWidth="36"/>
+                            <DataGridTextColumn Header="Address" Binding="{Binding Address}" Width="*" MinWidth="80"/>
+                            <DataGridTextColumn Header="ms" Binding="{Binding LatencyMs, StringFormat={}{0:F0}}" Width="60" MinWidth="40"/>
                         </DataGrid.Columns>
                     </DataGrid>
                 </Grid>

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -100,7 +100,7 @@
                       VirtualizingPanel.IsVirtualizing="True"
                       VirtualizingPanel.VirtualizationMode="Recycling">
                 <DataGrid.Columns>
-                    <DataGridCheckBoxColumn Header="" Width="32"
+                    <DataGridCheckBoxColumn Header="" Width="32" MinWidth="32" CanUserResize="False"
                                             Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}"
                                             CanUserSort="False">
                         <DataGridCheckBoxColumn.ElementStyle>
@@ -115,7 +115,7 @@
                         </DataGridCheckBoxColumn.EditingElementStyle>
                     </DataGridCheckBoxColumn>
 
-                    <DataGridTemplateColumn Header="Name" Width="*" SortMemberPath="Name">
+                    <DataGridTemplateColumn Header="Name" Width="*" MinWidth="150" SortMemberPath="Name">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal">
@@ -133,7 +133,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTextColumn Header="Size" Binding="{Binding SizeDisplay}" Width="80"
+                    <DataGridTextColumn Header="Size" Binding="{Binding SizeDisplay}" Width="80" MinWidth="60"
                                         SortMemberPath="SizeBytes" IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
@@ -145,7 +145,7 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTextColumn Header="Version" Binding="{Binding Version}" Width="120"
+                    <DataGridTextColumn Header="Version" Binding="{Binding Version}" Width="120" MinWidth="80"
                                         SortMemberPath="Version" IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
@@ -157,10 +157,10 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTextColumn Header="Publisher" Binding="{Binding Publisher}" Width="180"
+                    <DataGridTextColumn Header="Publisher" Binding="{Binding Publisher}" Width="180" MinWidth="80"
                                         SortMemberPath="Publisher" IsReadOnly="True"/>
 
-                    <DataGridTemplateColumn Header="Source" Width="90" SortMemberPath="Source">
+                    <DataGridTemplateColumn Header="Source" Width="90" MinWidth="70" SortMemberPath="Source">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Border CornerRadius="8" Padding="8,4" VerticalAlignment="Center"
@@ -226,7 +226,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTemplateColumn Header="Status" Width="180" SortMemberPath="Status">
+                    <DataGridTemplateColumn Header="Status" Width="180" MinWidth="80" SortMemberPath="Status">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Border CornerRadius="8" Padding="8,4"

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -110,7 +110,7 @@
                       VirtualizingPanel.IsVirtualizing="True"
                       VirtualizingPanel.VirtualizationMode="Recycling">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Header="Category" Binding="{Binding Category}" Width="120"
+                    <DataGridTextColumn Header="Category" Binding="{Binding Category}" Width="120" MinWidth="80"
                                         SortMemberPath="Category" IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
@@ -121,7 +121,7 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTemplateColumn Header="Safety" Width="80" SortMemberPath="SafetyLevel">
+                    <DataGridTemplateColumn Header="Safety" Width="80" MinWidth="80" SortMemberPath="SafetyLevel">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Border CornerRadius="6" Padding="6,3"
@@ -140,7 +140,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTextColumn Header="Feature" Binding="{Binding DisplayName}" Width="*"
+                    <DataGridTextColumn Header="Feature" Binding="{Binding DisplayName}" Width="*" MinWidth="120"
                                         SortMemberPath="DisplayName" IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
@@ -151,7 +151,7 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTemplateColumn Header="State" Width="90" SortMemberPath="IsEnabled">
+                    <DataGridTemplateColumn Header="State" Width="90" MinWidth="70" SortMemberPath="IsEnabled">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="11">
@@ -172,7 +172,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTemplateColumn Header="Toggle" Width="60">
+                    <DataGridTemplateColumn Header="Toggle" Width="62" MinWidth="62" CanUserResize="False">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <ToggleButton Style="{StaticResource ToggleSwitch}"
@@ -184,7 +184,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTemplateColumn Header="Status" Width="130" SortMemberPath="Status">
+                    <DataGridTemplateColumn Header="Status" Width="130" MinWidth="80" SortMemberPath="Status">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Border CornerRadius="8" Padding="8,4" VerticalAlignment="Center"

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -139,9 +139,9 @@
                       VirtualizingPanel.VirtualizationMode="Recycling"
                       Visibility="{Binding UpdateCount, Converter={StaticResource GreaterThanZero}}">
                 <DataGrid.Columns>
-                    <DataGridCheckBoxColumn Header="✓" Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" Width="36"/>
+                    <DataGridCheckBoxColumn Header="✓" Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" Width="36" MinWidth="36" CanUserResize="False"/>
 
-                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="*" IsReadOnly="True"
+                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="*" MinWidth="150" IsReadOnly="True"
                                         SortMemberPath="Title">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
@@ -152,7 +152,7 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTextColumn Header="KB" Binding="{Binding KB}" Width="100"
+                    <DataGridTextColumn Header="KB" Binding="{Binding KB}" Width="100" MinWidth="70"
                                         SortMemberPath="KB">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
@@ -163,7 +163,7 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTextColumn Header="Size" Binding="{Binding Size}" Width="80"
+                    <DataGridTextColumn Header="Size" Binding="{Binding Size}" Width="80" MinWidth="60"
                                         SortMemberPath="Size">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
@@ -174,7 +174,7 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="90"
+                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="90" MinWidth="70"
                                         SortMemberPath="Status">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
@@ -184,7 +184,7 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTextColumn Header="Date" Binding="{Binding DateDisplay}" Width="100"
+                    <DataGridTextColumn Header="Date" Binding="{Binding DateDisplay}" Width="100" MinWidth="80"
                                         SortMemberPath="Date">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
@@ -195,7 +195,7 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTextColumn Header="Category" Binding="{Binding Category}" Width="110"
+                    <DataGridTextColumn Header="Category" Binding="{Binding Category}" Width="110" MinWidth="70"
                                         SortMemberPath="Category">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">


### PR DESCRIPTION
## Summary
- Adds `MinWidth` to every DataGrid column across 16 views (19 DataGrids total) to prevent columns from being compressed to 0px on user resize
- Adds `CanUserResize="False"` on toggle/checkbox/action button columns that should never be resized
- Fixes "Open" button clipping in Startup Manager (60→80px)
- Fixes ToggleSwitch clipping in Startup/ContextMenu/WindowsFeatures (50→62px)

## Views affected
StartupView, ProcessManagerView, ServicesView, DriversView, DnsHostsView, WindowsFeaturesView, UninstallerView, AppBlockerView, AppAlertsView, LogsView, WindowsUpdateView, SystemHealthView, SpeedTestView, ShortcutCleanerView, FileShredderView, DeepCleanupView, ContextMenuView, AppUpdatesView, TracerouteView

## Test plan
- [x] Build: 0 errors, 0 warnings
- [x] App launches and stays stable
- [x] Startup Manager "Open" text fully visible
- [x] Toggle switches not clipped
- [x] Columns cannot be compressed to invisible