### PR TITLE
fix: replace hardcoded colors with theme tokens for full theme compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.13.3] - 2026-05-27
+
+### Fixed
+- **Theme compliance** — replaced hardcoded hex colors with DynamicResource tokens so all
+  UI elements follow the active theme. ConsoleView, nav hover, DataGrid hover, and semantic
+  status colors (Success, Warning, Danger, Info) now update live on theme switch.
+- **AccentSoft opacity** — unified hover/selected background opacity to 9.4% across all
+  views (was inconsistent between 6%–9.4%).
+
 ## [1.13.2] - 2026-05-27
 
 ### Fixed

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -64,7 +64,7 @@
             <SolidColorBrush x:Key="Accent" Color="{DynamicResource AccentColor}"/>
             <SolidColorBrush x:Key="AccentHover" Color="{DynamicResource AccentHoverColor}"/>
             <SolidColorBrush x:Key="AccentPressed" Color="{DynamicResource AccentPressedColor}"/>
-            <SolidColorBrush x:Key="AccentSoft" Color="#0F6366F1"/>
+            <SolidColorBrush x:Key="AccentSoft" Color="#186366F1"/>
 
             <!-- Status colors -->
             <SolidColorBrush x:Key="Success" Color="#22C55E"/>
@@ -319,7 +319,7 @@
                                     <Setter TargetName="Bd" Property="BorderBrush" Value="#6022C55E"/>
                                 </Trigger>
                                 <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="#186366F1"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource AccentSoft}"/>
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>
@@ -349,7 +349,7 @@
                                     <Setter TargetName="Bd" Property="BorderBrush" Value="#60F59E0B"/>
                                 </Trigger>
                                 <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="#186366F1"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource AccentSoft}"/>
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>
@@ -376,7 +376,7 @@
                                     <Setter TargetName="Bd" Property="BorderBrush" Value="#60EF4444"/>
                                 </Trigger>
                                 <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="#186366F1"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource AccentSoft}"/>
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>
@@ -746,10 +746,10 @@
                 <Setter Property="BorderThickness" Value="0"/>
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
-                        <Setter Property="Background" Value="#186366F1"/>
+                        <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
                     </Trigger>
                     <Trigger Property="IsSelected" Value="True">
-                        <Setter Property="Background" Value="#146366F1"/>
+                        <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
                         <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                     </Trigger>
                 </Style.Triggers>

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -61,7 +61,7 @@
                                             <Setter Property="Background" Value="Transparent"/>
                                             <Style.Triggers>
                                                 <Trigger Property="IsMouseOver" Value="True">
-                                                    <Setter Property="Background" Value="#186366F1"/>
+                                                    <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
                                                 </Trigger>
                                             </Style.Triggers>
                                         </Style>
@@ -95,7 +95,7 @@
                                                     <Setter Property="Background" Value="Transparent"/>
                                                     <Style.Triggers>
                                                         <Trigger Property="IsMouseOver" Value="True">
-                                                            <Setter Property="Background" Value="#126366F1"/>
+                                                            <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
                                                         </Trigger>
                                                     </Style.Triggers>
                                                 </Style>
@@ -152,7 +152,7 @@
                                                             <Setter Property="Background" Value="Transparent"/>
                                                             <Style.Triggers>
                                                                 <Trigger Property="IsMouseOver" Value="True">
-                                                                    <Setter Property="Background" Value="#186366F1"/>
+                                                                    <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
                                                                 </Trigger>
                                                             </Style.Triggers>
                                                         </Style>

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -146,7 +146,7 @@ public sealed class ThemeService
         SetBrush(res, "Accent", theme.Accent);
         SetBrush(res, "AccentHover", Lighten(theme.Accent, 0.15));
         SetBrush(res, "AccentPressed", Darken(theme.Accent, 0.12));
-        SetBrush(res, "AccentSoft", Color.FromArgb(15, theme.Accent.R, theme.Accent.G, theme.Accent.B));
+        SetBrush(res, "AccentSoft", Color.FromArgb(24, theme.Accent.R, theme.Accent.G, theme.Accent.B));
 
         SetColor(res, "Surface0Color", theme.Background);
         SetColor(res, "Surface1Color", theme.Surface);

--- a/SysManager/SysManager/Views/AboutView.xaml
+++ b/SysManager/SysManager/Views/AboutView.xaml
@@ -118,8 +118,8 @@
                         <!-- Download completed -->
                         <StackPanel Margin="0,14,0,0" Orientation="Horizontal"
                                     Visibility="{Binding DownloadedPath, Converter={StaticResource FlexVis}}">
-                            <Ellipse Width="10" Height="10" Fill="#22C55E" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                            <TextBlock Text="{Binding DownloadStatus}" Foreground="#22C55E" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                            <Ellipse Width="10" Height="10" Fill="{DynamicResource Success}" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                            <TextBlock Text="{Binding DownloadStatus}" Foreground="{DynamicResource Success}" FontWeight="SemiBold" VerticalAlignment="Center"/>
                             <TextBlock Text="  ·  " Foreground="{DynamicResource TextMuted}" VerticalAlignment="Center"/>
                             <TextBlock VerticalAlignment="Center">
                                 <Hyperlink Command="{Binding OpenDownloadFolderCommand}" Foreground="{DynamicResource Accent}">Show file</Hyperlink>
@@ -137,7 +137,7 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
-                        <Ellipse Grid.Column="0" Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,10,0" Fill="#22C55E"/>
+                        <Ellipse Grid.Column="0" Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,10,0" Fill="{DynamicResource Success}"/>
                         <TextBlock Grid.Column="1" Text="{Binding UpdateStatus}" Foreground="{DynamicResource TextSecondary}"
                                    VerticalAlignment="Center" TextWrapping="Wrap"/>
                         <Button Grid.Column="2" Content="Retry" Command="{Binding CheckForUpdatesCommand}"

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -185,7 +185,7 @@
                                     <Style TargetType="Border">
                                         <Style.Triggers>
                                             <Trigger Property="IsMouseOver" Value="True">
-                                                <Setter Property="Background" Value="#186366F1"/>
+                                                <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
                                             </Trigger>
                                         </Style.Triggers>
                                     </Style>

--- a/SysManager/SysManager/Views/ConsoleView.xaml
+++ b/SysManager/SysManager/Views/ConsoleView.xaml
@@ -2,7 +2,7 @@
 <UserControl x:Class="SysManager.Views.ConsoleView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Border BorderThickness="1" BorderBrush="#333" CornerRadius="6" Background="#0E1116" Padding="0">
+    <Border BorderThickness="1" BorderBrush="{DynamicResource Border1}" CornerRadius="6" Background="{DynamicResource Surface1}" Padding="0">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
@@ -10,10 +10,10 @@
             </Grid.RowDefinitions>
 
             <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="8,6" >
-                <TextBlock Text="Live output" FontWeight="SemiBold" Foreground="#CFD3DC" VerticalAlignment="Center"/>
+                <TextBlock Text="Live output" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
                 <Button Margin="12,0,0,0" Padding="8,2" Content="Clear" Command="{Binding ClearCommand}"/>
                 <Button Margin="6,0,0,0" Padding="8,2" Content="Copy" Command="{Binding CopyAllCommand}"/>
-                <CheckBox Margin="12,0,0,0" Content="Auto-scroll" IsChecked="{Binding AutoScroll}" Foreground="#CFD3DC"/>
+                <CheckBox Margin="12,0,0,0" Content="Auto-scroll" IsChecked="{Binding AutoScroll}" Foreground="{DynamicResource TextPrimary}"/>
             </StackPanel>
 
             <ListBox x:Name="ListBox_Output"
@@ -38,7 +38,7 @@
                         <StackPanel Orientation="Horizontal">
                             <TextBlock Text="{Binding Timestamp, StringFormat='HH:mm:ss '}"
                                        FontFamily="{StaticResource MonoFont}"
-                                       Foreground="#6B7280"/>
+                                       Foreground="{DynamicResource TextMuted}"/>
                             <TextBlock Text="{Binding Text}"
                                        FontFamily="{StaticResource MonoFont}"
                                        Foreground="{Binding Kind, Converter={StaticResource KindBrush}}"

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -241,7 +241,7 @@
                                 <Run Text="{Binding TuneUpResult.BrokenShortcutsFound, Mode=OneWay}"/>
                                 <Run Text=" broken shortcuts found"/>
                             </TextBlock>
-                            <TextBlock Text=" — open Shortcut Cleaner to review" Foreground="#F59E0B"
+                            <TextBlock Text=" — open Shortcut Cleaner to review" Foreground="{DynamicResource Warning}"
                                        VerticalAlignment="Center">
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock">
@@ -286,7 +286,7 @@
                                 <Run Text="{Binding TuneUpResult.Uptime.Minutes, Mode=OneWay}"/>
                                 <Run Text="m"/>
                             </TextBlock>
-                            <TextBlock Text=" — consider restarting" Foreground="#F59E0B" FontWeight="SemiBold"
+                            <TextBlock Text=" — consider restarting" Foreground="{DynamicResource Warning}" FontWeight="SemiBold"
                                        VerticalAlignment="Center"
                                        Visibility="{Binding TuneUpResult.UptimeWarning, Converter={StaticResource BoolToVis}}"/>
                         </StackPanel>
@@ -304,7 +304,7 @@
                                 <Run Text="{Binding TuneUpResult.RamUsedPercent, Mode=OneWay, StringFormat='{}{0:0}'}"/>
                                 <Run Text="%)"/>
                             </TextBlock>
-                            <TextBlock Text=" — high usage" Foreground="#F59E0B" FontWeight="SemiBold"
+                            <TextBlock Text=" — high usage" Foreground="{DynamicResource Warning}" FontWeight="SemiBold"
                                        VerticalAlignment="Center"
                                        Visibility="{Binding TuneUpResult.RamWarning, Converter={StaticResource BoolToVis}}"/>
                         </StackPanel>

--- a/SysManager/SysManager/Views/DeepCleanupView.xaml
+++ b/SysManager/SysManager/Views/DeepCleanupView.xaml
@@ -83,7 +83,7 @@
                                                 <StackPanel Orientation="Horizontal">
                                                     <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource TextPrimary}"/>
                                                     <Border Margin="10,0,0,0" Padding="8,2" CornerRadius="999"
-                                                            Background="#5C1B1B" BorderBrush="#EF4444" BorderThickness="1"
+                                                            Background="#5C1B1B" BorderBrush="{DynamicResource Danger}" BorderThickness="1"
                                                             Visibility="{Binding IsDestructiveHint, Converter={StaticResource BoolToVis}}">
                                                         <TextBlock Text="Irreversible" Foreground="#FCA5A5" FontSize="11" FontWeight="SemiBold"/>
                                                     </Border>
@@ -131,7 +131,7 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Column="0" Text="{Binding CleanStatusLine}" Foreground="#22C55E" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="0" Text="{Binding CleanStatusLine}" Foreground="{DynamicResource Success}" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                 <TextBlock Grid.Column="1" Text="{Binding CleanProgress, StringFormat={}{0}%}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center" Margin="12,0,0,0"/>
                             </Grid>
                             <ProgressBar AutomationProperties.Name="Progress" Height="6" Minimum="0" Maximum="100" Value="{Binding CleanProgress}" Margin="0,6,0,0"/>

--- a/SysManager/SysManager/Views/DiskAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/DiskAnalyzerView.xaml
@@ -85,7 +85,7 @@
                                     </Border>
                                     <ControlTemplate.Triggers>
                                         <Trigger Property="IsMouseOver" Value="True">
-                                            <Setter TargetName="Bd" Property="Background" Value="#186366F1"/>
+                                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource AccentSoft}"/>
                                         </Trigger>
                                     </ControlTemplate.Triggers>
                                 </ControlTemplate>

--- a/SysManager/SysManager/Views/DuplicateFileView.xaml
+++ b/SysManager/SysManager/Views/DuplicateFileView.xaml
@@ -68,7 +68,7 @@
                         <Setter Property="Margin" Value="0"/>
                         <Style.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">
-                                <Setter Property="Background" Value="#186366F1"/>
+                                <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
                             </Trigger>
                         </Style.Triggers>
                     </Style>

--- a/SysManager/SysManager/Views/FileShredderView.xaml
+++ b/SysManager/SysManager/Views/FileShredderView.xaml
@@ -59,7 +59,7 @@
                 <Button Content="Add Folder" Command="{Binding AddFolderCommand}"
                         Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
                 <Button Content="Shred All" Command="{Binding ShredAllCommand}"
-                        Style="{StaticResource PrimaryButton}" Foreground="#EF4444" Margin="0,0,8,0"/>
+                        Style="{StaticResource PrimaryButton}" Foreground="{DynamicResource Danger}" Margin="0,0,8,0"/>
                 <Button Content="Cancel" Command="{Binding CancelCommand}"
                         Style="{StaticResource GhostButton}"
                         Visibility="{Binding IsShredding, Converter={StaticResource BoolToVis}}"/>

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -105,10 +105,10 @@
             <!-- Info -->
             <Border Style="{StaticResource GlassCard}" Background="#1438BDF8">
                 <Grid>
-                    <Border Background="#38BDF8" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                    <Border Background="{DynamicResource Info}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                             Margin="-16,-12,0,-12"/>
                     <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
-                        <Ellipse Style="{StaticResource SevDot}" Fill="#38BDF8">
+                        <Ellipse Style="{StaticResource SevDot}" Fill="{DynamicResource Info}">
                             <Ellipse.Effect>
                                 <DropShadowEffect Color="#38BDF8" BlurRadius="8" ShadowDepth="0" Opacity="0.6"/>
                             </Ellipse.Effect>
@@ -171,7 +171,7 @@
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,14,0">
                         <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding ShowInfo}" VerticalAlignment="Center"/>
-                        <Ellipse Style="{StaticResource SevDot}" Fill="#38BDF8" Margin="8,0,6,0"/>
+                        <Ellipse Style="{StaticResource SevDot}" Fill="{DynamicResource Info}" Margin="8,0,6,0"/>
                         <TextBlock Text="Info" Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,22,0">

--- a/SysManager/SysManager/Views/NetworkRepairView.xaml
+++ b/SysManager/SysManager/Views/NetworkRepairView.xaml
@@ -64,7 +64,7 @@
                             <Setter Property="BorderBrush" Value="{DynamicResource Border1}"/>
                             <Style.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter Property="Background" Value="#186366F1"/>
+                                    <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
                                     <Setter Property="BorderBrush" Value="#2A3244"/>
                                 </Trigger>
                             </Style.Triggers>
@@ -90,7 +90,7 @@
                             <Setter Property="BorderBrush" Value="{DynamicResource Border1}"/>
                             <Style.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter Property="Background" Value="#186366F1"/>
+                                    <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
                                     <Setter Property="BorderBrush" Value="#2A3244"/>
                                 </Trigger>
                             </Style.Triggers>
@@ -116,7 +116,7 @@
                             <Setter Property="BorderBrush" Value="{DynamicResource Border1}"/>
                             <Style.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter Property="Background" Value="#186366F1"/>
+                                    <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
                                     <Setter Property="BorderBrush" Value="#2A3244"/>
                                 </Trigger>
                             </Style.Triggers>

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -115,7 +115,7 @@
                                                 Margin="-8,-5,0,-5">
                                             <Border.Style>
                                                 <Style TargetType="Border">
-                                                    <Setter Property="Background" Value="#22C55E"/>
+                                                    <Setter Property="Background" Value="{DynamicResource Success}"/>
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding IsEnabled}" Value="False">
                                                             <Setter Property="Background" Value="#475569"/>
@@ -128,7 +128,7 @@
                                             <Ellipse Width="6" Height="6" VerticalAlignment="Center">
                                                 <Ellipse.Style>
                                                     <Style TargetType="Ellipse">
-                                                        <Setter Property="Fill" Value="#22C55E"/>
+                                                        <Setter Property="Fill" Value="{DynamicResource Success}"/>
                                                         <Style.Triggers>
                                                             <DataTrigger Binding="{Binding IsEnabled}" Value="False">
                                                                 <Setter Property="Fill" Value="#475569"/>

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -168,7 +168,7 @@
                                         HorizontalAlignment="Center">
                                     <Border.Style>
                                         <Style TargetType="Border">
-                                            <Setter Property="Background" Value="#146366F1"/>
+                                            <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding Source}" Value="">
                                                     <Setter Property="Background" Value="#14FBBF24"/>

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -45,7 +45,7 @@
                 </Grid>
                 <Border Background="#2D1F1F" CornerRadius="4" Padding="6,2" Margin="4,0"
                         Visibility="{Binding PendingReboot, Converter={StaticResource BoolToVis}}">
-                    <TextBlock Text="⚠ Reboot pending" FontSize="11" Foreground="#F59E0B"/>
+                    <TextBlock Text="⚠ Reboot pending" FontSize="11" Foreground="{DynamicResource Warning}"/>
                 </Border>
                 <Border CornerRadius="10" Padding="10,5" Margin="4,0"
                         Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
@@ -215,13 +215,13 @@
                                                     <Setter Property="Background" Value="#475569"/>
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding Status}" Value="Done">
-                                                            <Setter Property="Background" Value="#22C55E"/>
+                                                            <Setter Property="Background" Value="{DynamicResource Success}"/>
                                                         </DataTrigger>
                                                         <DataTrigger Binding="{Binding Status}" Value="Failed">
-                                                            <Setter Property="Background" Value="#EF4444"/>
+                                                            <Setter Property="Background" Value="{DynamicResource Danger}"/>
                                                         </DataTrigger>
                                                         <DataTrigger Binding="{Binding Status}" Value="Reboot required">
-                                                            <Setter Property="Background" Value="#F59E0B"/>
+                                                            <Setter Property="Background" Value="{DynamicResource Warning}"/>
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>
@@ -234,13 +234,13 @@
                                                         <Setter Property="Fill" Value="#475569"/>
                                                         <Style.Triggers>
                                                             <DataTrigger Binding="{Binding Status}" Value="Done">
-                                                                <Setter Property="Fill" Value="#22C55E"/>
+                                                                <Setter Property="Fill" Value="{DynamicResource Success}"/>
                                                             </DataTrigger>
                                                             <DataTrigger Binding="{Binding Status}" Value="Failed">
-                                                                <Setter Property="Fill" Value="#EF4444"/>
+                                                                <Setter Property="Fill" Value="{DynamicResource Danger}"/>
                                                             </DataTrigger>
                                                             <DataTrigger Binding="{Binding Status}" Value="Reboot required">
-                                                                <Setter Property="Fill" Value="#F59E0B"/>
+                                                                <Setter Property="Fill" Value="{DynamicResource Warning}"/>
                                                             </DataTrigger>
                                                         </Style.Triggers>
                                                     </Style>

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -68,7 +68,7 @@
 
         <!-- Module status: missing -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,0"
-                BorderBrush="#F59E0B" BorderThickness="1"
+                BorderBrush="{DynamicResource Warning}" BorderThickness="1"
                 Visibility="{Binding ModuleAvailable, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <Grid>
                 <Grid.ColumnDefinitions>
@@ -78,9 +78,9 @@
                 <StackPanel Grid.Column="0">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="&#xE946;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                                   FontSize="18" Foreground="#F59E0B" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                                   FontSize="18" Foreground="{DynamicResource Warning}" VerticalAlignment="Center" Margin="0,0,10,0"/>
                         <TextBlock Text="PSWindowsUpdate module is required" FontSize="15" FontWeight="SemiBold"
-                                   Foreground="#F59E0B" VerticalAlignment="Center"/>
+                                   Foreground="{DynamicResource Warning}" VerticalAlignment="Center"/>
                     </StackPanel>
                     <TextBlock Text="{Binding ModuleStatus}" Style="{StaticResource Subtle}" Margin="28,6,0,0" TextWrapping="Wrap"/>
                 </StackPanel>
@@ -95,8 +95,8 @@
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,0"
                 Visibility="{Binding ModuleAvailable, Converter={StaticResource FlexVis}}">
             <StackPanel Orientation="Horizontal">
-                <Ellipse Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,10,0" Fill="#22C55E"/>
-                <TextBlock Text="PSWindowsUpdate is available" FontWeight="SemiBold" Foreground="#22C55E" VerticalAlignment="Center"/>
+                <Ellipse Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,10,0" Fill="{DynamicResource Success}"/>
+                <TextBlock Text="PSWindowsUpdate is available" FontWeight="SemiBold" Foreground="{DynamicResource Success}" VerticalAlignment="Center"/>
             </StackPanel>
         </Border>
 


### PR DESCRIPTION
## Summary
- Replaces all hardcoded hex colors with DynamicResource tokens so every element follows the active theme
- ConsoleView: 5 hardcoded colors → Surface1, Border1, TextPrimary, TextMuted
- Nav hover (MainWindow + App.xaml): `#186366F1`/`#126366F1`/`#146366F1` → AccentSoft
- DataGridRow hover/selected: hardcoded → AccentSoft
- Semantic colors: exact `#22C55E`/`#F59E0B`/`#EF4444`/`#38BDF8` → Success/Warning/Danger/Info across 7 views
- View hover colors (Bulk, Disk, Duplicate, Network, Uninstaller): → AccentSoft
- AccentSoft opacity unified to 9.4% (was 6%)
- ThemeService: AccentSoft alpha updated to 24 (was 15)

## Test plan
- [x] Build: 0 errors, 0 warnings
- [x] App launches stable
- [x] No remaining hardcoded accent/semantic colors in views (verified with grep)