### PR TITLE
ci: exclude WPF-generated useless-assignment alerts from CodeQL

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -5,6 +5,11 @@ paths-ignore:
   - '**/bin/**'
 
 query-filters:
+  # WPF XAML compiler generates .g.cs with useless-assignment patterns —
+  # these are false positives in auto-generated InitializeComponent code.
+  - exclude:
+      id: cs/useless-assignment-to-local
+      path: '**/obj/**'
   # Intentional use of CreateFromSignedFile for Authenticode verification —
   # no modern .NET replacement exists without P/Invoke. Already suppressed
   # with #pragma warning disable SYSLIB0057.


### PR DESCRIPTION
## Summary
All 30 open CodeQL alerts are `cs/useless-assignment-to-local` in auto-generated `obj/**/*.g.cs` files from the WPF XAML compiler. Zero alerts exist in actual source code.

Adds a query-filter exclusion for this rule on `**/obj/**` paths to suppress false positives.

## Test plan
- [x] Verified all 30 alerts are in obj/ paths (0 in real code)
- [x] Config syntax is valid YAML
