### PR TITLE
feat: sidebar slide animation, chevron, full-width hitbox, theme button relocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-05-27
+
+### Added
+- **Sidebar smooth animation** — expand/collapse groups now slide with a 150ms animation
+  instead of instant jump.
+- **Chevron indicator** — rotating arrow on sidebar group headers showing expand/collapse state.
+- **Full-width hitbox** — entire sidebar group header row is clickable, not just the text.
+
+### Changed
+- **Theme button relocated** — moved from content area top-right (caused overlaps) to sidebar
+  footer bottom-right, next to version info. Always accessible, no overlapping.
+
 ## [1.13.3] - 2026-05-27
 
 ### Fixed

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -85,6 +85,80 @@
             <FontFamily x:Key="UiFont">Segoe UI Variable Text, Segoe UI, Inter, Arial</FontFamily>
 
             <!-- ============================================================ -->
+            <!-- Sidebar Expander — smooth slide animation                      -->
+            <!-- ============================================================ -->
+            <Style x:Key="SidebarExpander" TargetType="Expander">
+                <Setter Property="Background" Value="Transparent"/>
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="Padding" Value="0"/>
+                <Setter Property="Margin" Value="0"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Expander">
+                            <DockPanel LastChildFill="True">
+                                <ToggleButton x:Name="HeaderSite" DockPanel.Dock="Top"
+                                              IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
+                                              Content="{TemplateBinding Header}"
+                                              ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                              Background="Transparent" BorderThickness="0"
+                                              HorizontalAlignment="Stretch"
+                                              HorizontalContentAlignment="Stretch"
+                                              Cursor="Hand" Padding="0" Margin="0"
+                                              Focusable="False">
+                                    <ToggleButton.Template>
+                                        <ControlTemplate TargetType="ToggleButton">
+                                            <ContentPresenter HorizontalAlignment="Stretch"/>
+                                        </ControlTemplate>
+                                    </ToggleButton.Template>
+                                </ToggleButton>
+                                <Border x:Name="ContentPanel" ClipToBounds="True">
+                                    <ContentPresenter x:Name="ExpanderContent"
+                                                      ContentSource="Content"
+                                                      Margin="{TemplateBinding Padding}"/>
+                                    <Border.RenderTransform>
+                                        <ScaleTransform ScaleY="0"/>
+                                    </Border.RenderTransform>
+                                    <Border.LayoutTransform>
+                                        <ScaleTransform ScaleY="0"/>
+                                    </Border.LayoutTransform>
+                                </Border>
+                            </DockPanel>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsExpanded" Value="True">
+                                    <Trigger.EnterActions>
+                                        <BeginStoryboard>
+                                            <Storyboard>
+                                                <DoubleAnimation Storyboard.TargetName="ContentPanel"
+                                                                 Storyboard.TargetProperty="(Border.LayoutTransform).(ScaleTransform.ScaleY)"
+                                                                 From="0" To="1" Duration="0:0:0.15"
+                                                                 EasingFunction="{x:Null}"/>
+                                                <DoubleAnimation Storyboard.TargetName="ContentPanel"
+                                                                 Storyboard.TargetProperty="(Border.RenderTransform).(ScaleTransform.ScaleY)"
+                                                                 From="0" To="1" Duration="0:0:0.15"/>
+                                            </Storyboard>
+                                        </BeginStoryboard>
+                                    </Trigger.EnterActions>
+                                    <Trigger.ExitActions>
+                                        <BeginStoryboard>
+                                            <Storyboard>
+                                                <DoubleAnimation Storyboard.TargetName="ContentPanel"
+                                                                 Storyboard.TargetProperty="(Border.LayoutTransform).(ScaleTransform.ScaleY)"
+                                                                 From="1" To="0" Duration="0:0:0.12"/>
+                                                <DoubleAnimation Storyboard.TargetName="ContentPanel"
+                                                                 Storyboard.TargetProperty="(Border.RenderTransform).(ScaleTransform.ScaleY)"
+                                                                 From="1" To="0" Duration="0:0:0.12"/>
+                                            </Storyboard>
+                                        </BeginStoryboard>
+                                    </Trigger.ExitActions>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <!-- ============================================================ -->
             <!-- Theme popup styles                                             -->
             <!-- ============================================================ -->
             <Style x:Key="ModePill" TargetType="RadioButton">

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -83,12 +83,9 @@
                                 <!-- Multi-item group: expander with children -->
                                 <Expander Visibility="{Binding IsSingleItem, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"
                                           IsExpanded="{Binding IsExpanded, Mode=TwoWay}"
-                                          Padding="0" Margin="0"
-                                          Background="Transparent"
-                                          BorderThickness="0"
-                                          Foreground="{DynamicResource TextSecondary}">
+                                          Style="{StaticResource SidebarExpander}">
                                     <Expander.Header>
-                                        <Border CornerRadius="8" Padding="4,4,8,4" Margin="-4,-4,-8,-4"
+                                        <Border CornerRadius="8" Padding="14,10" Cursor="Hand"
                                                 ToolTip="{Binding Tooltip}">
                                             <Border.Style>
                                                 <Style TargetType="Border">
@@ -100,42 +97,83 @@
                                                     </Style.Triggers>
                                                 </Style>
                                             </Border.Style>
-                                        <StackPanel>
-                                            <StackPanel Orientation="Horizontal">
-                                                <TextBlock Text="{Binding Glyph}"
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                </Grid.ColumnDefinitions>
+                                                <StackPanel Grid.Column="0">
+                                                    <StackPanel Orientation="Horizontal">
+                                                        <TextBlock Text="{Binding Glyph}"
+                                                                   FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                                                                   FontSize="13" Margin="0,0,10,0"
+                                                                   VerticalAlignment="Center"
+                                                                   Foreground="{DynamicResource TextSecondary}"/>
+                                                        <TextBlock Text="{Binding Label}"
+                                                                   VerticalAlignment="Center"
+                                                                   FontFamily="{StaticResource UiFont}"
+                                                                   FontSize="12" FontWeight="SemiBold"
+                                                                   Foreground="{DynamicResource TextSecondary}"/>
+                                                        <TextBlock Text="{Binding ChildCount, StringFormat=' ({0})'}"
+                                                                   VerticalAlignment="Center"
+                                                                   FontFamily="{StaticResource UiFont}"
+                                                                   FontSize="10" Foreground="{DynamicResource TextSecondary}"
+                                                                   Opacity="0.7" Margin="2,0,0,0"/>
+                                                    </StackPanel>
+                                                    <!-- Subtitle: visible only when collapsed -->
+                                                    <TextBlock Text="{Binding Subtitle}"
+                                                               FontFamily="{StaticResource UiFont}"
+                                                               FontSize="11" Foreground="{DynamicResource TextSecondary}"
+                                                               Opacity="0.65" Margin="23,2,0,0"
+                                                               TextTrimming="CharacterEllipsis">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding IsExpanded}" Value="True">
+                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </StackPanel>
+                                                <!-- Chevron indicator -->
+                                                <TextBlock Grid.Column="1" x:Name="Chevron"
+                                                           Text="&#xE76C;"
                                                            FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                                                           FontSize="13" Margin="0,0,10,0"
-                                                           VerticalAlignment="Center"
-                                                           Foreground="{DynamicResource TextSecondary}"/>
-                                                <TextBlock Text="{Binding Label}"
-                                                           VerticalAlignment="Center"
-                                                           FontFamily="{StaticResource UiFont}"
-                                                           FontSize="12" FontWeight="SemiBold"
-                                                           Foreground="{DynamicResource TextSecondary}"/>
-                                                <TextBlock Text="{Binding ChildCount, StringFormat=' ({0})'}"
-                                                           VerticalAlignment="Center"
-                                                           FontFamily="{StaticResource UiFont}"
-                                                           FontSize="10" Foreground="{DynamicResource TextSecondary}"
-                                                           Opacity="0.7" Margin="2,0,0,0"/>
-                                            </StackPanel>
-                                            <!-- Subtitle: visible only when collapsed -->
-                                            <TextBlock Text="{Binding Subtitle}"
-                                                       FontFamily="{StaticResource UiFont}"
-                                                       FontSize="11" Foreground="{DynamicResource TextSecondary}"
-                                                       Opacity="0.65" Margin="23,2,0,0"
-                                                       TextTrimming="CharacterEllipsis">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
-                                                        <Setter Property="Visibility" Value="Visible"/>
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding IsExpanded}" Value="True">
-                                                                <Setter Property="Visibility" Value="Collapsed"/>
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
-                                        </StackPanel>
+                                                           FontSize="10" VerticalAlignment="Center"
+                                                           Foreground="{DynamicResource TextMuted}"
+                                                           RenderTransformOrigin="0.5,0.5">
+                                                    <TextBlock.RenderTransform>
+                                                        <RotateTransform x:Name="ChevronRotate" Angle="0"/>
+                                                    </TextBlock.RenderTransform>
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsExpanded}" Value="True">
+                                                                    <DataTrigger.EnterActions>
+                                                                        <BeginStoryboard>
+                                                                            <Storyboard>
+                                                                                <DoubleAnimation Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)"
+                                                                                                 To="180" Duration="0:0:0.15"/>
+                                                                            </Storyboard>
+                                                                        </BeginStoryboard>
+                                                                    </DataTrigger.EnterActions>
+                                                                    <DataTrigger.ExitActions>
+                                                                        <BeginStoryboard>
+                                                                            <Storyboard>
+                                                                                <DoubleAnimation Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)"
+                                                                                                 To="0" Duration="0:0:0.15"/>
+                                                                            </Storyboard>
+                                                                        </BeginStoryboard>
+                                                                    </DataTrigger.ExitActions>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </Grid>
                                         </Border>
                                     </Expander.Header>
                                     <ItemsControl ItemsSource="{Binding Children}" Focusable="False">
@@ -220,8 +258,38 @@
                         </StackPanel>
                     </Border>
 
-                    <TextBlock Text="{Binding About.CurrentVersion, StringFormat=v{0}}" Style="{StaticResource Caption}" Margin="0,8,0,0"/>
-                    <TextBlock Text="by laurentiu021" Style="{StaticResource Caption}" Margin="0,2,0,0" Opacity="0.7"/>
+                    <Grid Margin="0,8,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0">
+                            <TextBlock Text="{Binding About.CurrentVersion, StringFormat=v{0}}" Style="{StaticResource Caption}"/>
+                            <TextBlock Text="by laurentiu021" Style="{StaticResource Caption}" Opacity="0.7" Margin="0,2,0,0"/>
+                        </StackPanel>
+                        <!-- Theme button -->
+                        <Border Grid.Column="1" x:Name="ThemeBtn" Width="28" Height="28" CornerRadius="8"
+                                Background="{DynamicResource Surface3}" BorderBrush="{DynamicResource Border1}"
+                                BorderThickness="1" Cursor="Hand" MouseLeftButtonUp="ThemeBtn_Click"
+                                ToolTip="Appearance" VerticalAlignment="Center">
+                            <Border.Style>
+                                <Style TargetType="Border">
+                                    <Style.Triggers>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter Property="BorderBrush" Value="{DynamicResource Accent}"/>
+                                        </Trigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
+                            <TextBlock Text="&#xE790;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                                       FontSize="13" Foreground="{DynamicResource TextSecondary}"
+                                       HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                    </Grid>
+                    <!-- Theme popup -->
+                    <Popup x:Name="ThemePopupHost" Placement="Top" PlacementTarget="{Binding ElementName=ThemeBtn}"
+                           StaysOpen="False" AllowsTransparency="True" PopupAnimation="Fade"
+                           HorizontalOffset="0" VerticalOffset="-8"/>
                 </StackPanel>
             </Grid>
         </Border>
@@ -263,34 +331,6 @@
                 <ContentControl Grid.Row="1" x:Name="ContentHost"
                                 Content="{Binding SelectedNav.View}"/>
 
-                <!-- Theme button — top right, persistent -->
-                <Border Grid.Row="1" HorizontalAlignment="Right" VerticalAlignment="Top"
-                        Margin="0,16,28,0">
-                    <Grid>
-                        <Border x:Name="ThemeBtn" Width="36" Height="36" CornerRadius="10"
-                                Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                                BorderThickness="1" Cursor="Hand" MouseLeftButtonUp="ThemeBtn_Click"
-                                ToolTip="Appearance">
-                            <Border.Style>
-                                <Style TargetType="Border">
-                                    <Style.Triggers>
-                                        <Trigger Property="IsMouseOver" Value="True">
-                                            <Setter Property="BorderBrush" Value="{DynamicResource Accent}"/>
-                                        </Trigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </Border.Style>
-                            <TextBlock Text="&#xE790;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                                       FontSize="16" Foreground="{DynamicResource TextSecondary}"
-                                       HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                        </Border>
-
-                        <!-- Theme popup (created on demand in code-behind) -->
-                        <Popup x:Name="ThemePopupHost" Placement="Bottom" PlacementTarget="{Binding ElementName=ThemeBtn}"
-                               StaysOpen="False" AllowsTransparency="True" PopupAnimation="Fade"
-                               HorizontalOffset="-304" VerticalOffset="4"/>
-                    </Grid>
-                </Border>
             </Grid>
         </Border>
 


### PR DESCRIPTION
## Summary
- Sidebar group expand/collapse now has smooth 150ms slide animation (was instant jump)
- Rotating chevron indicator (▾) on group headers showing expanded/collapsed state
- Full-width clickable hitbox on group headers (was limited to text only)
- Theme button moved from content area top-right to sidebar footer bottom-right (eliminates overlap with page content)

## Test plan
- [x] Build: 0 errors, 0 warnings
- [x] App launches stable
- [x] Sidebar expand/collapse animates smoothly
- [x] Chevron rotates on expand/collapse
- [x] Full row clickable (not just text)
- [x] Theme button accessible in sidebar footer, popup opens correctly
- [x] No overlap with content area elements