### PR TITLE
feat: add ETA display to SFC, DISM, Bulk Installer, Uninstaller, App Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.15.0] - 2026-05-27
+
+### Added
+- **ETA on long operations** — estimated time remaining now shown on:
+  SFC scan, DISM restore, Bulk Installer, Uninstaller, and App Updates.
+  Uses linear extrapolation from elapsed time and current progress percentage.
+
 ## [1.14.0] - 2026-05-27
 
 ### Added

--- a/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
@@ -15,6 +15,7 @@ namespace SysManager.ViewModels;
 public sealed partial class AppUpdatesViewModel : ViewModelBase
 {
     private readonly WingetService _winget;
+    private readonly EtaCalculator _upgradeEta = new();
     private CancellationTokenSource? _cts;
     private readonly Action<PowerShellLine> _lineHandler;
 
@@ -22,6 +23,7 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
     public ConsoleViewModel Console { get; } = new();
 
     [ObservableProperty] private bool _selectAll = true;
+    [ObservableProperty] private string _upgradeEtaText = string.Empty;
     [ObservableProperty] private bool _isElevated;
 
     public AppUpdatesViewModel(WingetService winget)
@@ -75,6 +77,8 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
         _cts?.Dispose();
         _cts = new CancellationTokenSource();
         int done = 0;
+        UpgradeEtaText = string.Empty;
+        _upgradeEta.Reset();
         try
         {
             foreach (var pkg in toUpgrade)
@@ -83,6 +87,7 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
                 pkg.Status = "Upgrading...";
                 StatusMessage = $"Upgrading {pkg.Name} ({done + 1}/{toUpgrade.Count})";
                 Progress = (int)((done / (double)toUpgrade.Count) * 100);
+                UpgradeEtaText = _upgradeEta.Update(Progress);
                 try
                 {
                     var code = await _winget.UpgradeAsync(pkg.Id, _cts.Token);
@@ -93,10 +98,11 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
                 done++;
             }
             Progress = 100;
+            UpgradeEtaText = string.Empty;
             StatusMessage = $"Completed {done}/{toUpgrade.Count}";
             Log.Information("App upgrade batch completed: {Done}/{Total}", done, toUpgrade.Count);
         }
-        finally { IsBusy = false; }
+        finally { IsBusy = false; UpgradeEtaText = string.Empty; }
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
@@ -21,6 +21,7 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
 {
     private readonly BulkInstallerService _service;
     private readonly AppIconService _iconService;
+    private readonly EtaCalculator _installEta = new();
     private CancellationTokenSource? _cts;
 
     public BulkObservableCollection<InstallableApp> Apps { get; } = new();
@@ -47,6 +48,8 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
         "Runtimes & Frameworks",
         "Custom"
     ];
+
+    [ObservableProperty] private string _installEtaText = string.Empty;
 
     // Custom winget search
     [ObservableProperty] private string _searchQuery = "";
@@ -151,6 +154,8 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
 
         var installed = 0;
         var failed = 0;
+        InstallEtaText = string.Empty;
+        _installEta.Reset();
 
         try
         {
@@ -161,6 +166,7 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
                 var app = selected[i];
                 app.Status = "Installing...";
                 Progress = (int)((double)i / selected.Count * 100);
+                InstallEtaText = _installEta.Update(Progress);
                 StatusMessage = $"Installing {app.Name} ({i + 1}/{selected.Count})…";
 
                 try
@@ -191,6 +197,7 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
             }
 
             Progress = 100;
+            InstallEtaText = string.Empty;
             StatusMessage = $"Done. Installed: {installed}, Failed: {failed}.";
             ToastService.Instance.Show("Bulk Install complete", $"Installed: {installed}, Failed: {failed}");
         }
@@ -201,6 +208,7 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
         finally
         {
             IsBusy = false;
+            InstallEtaText = string.Empty;
         }
     }
 

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -17,6 +17,9 @@ public sealed partial class CleanupViewModel : ViewModelBase
 {
     private readonly PowerShellRunner _runner;
 
+    private readonly EtaCalculator _sfcEta = new();
+    private readonly EtaCalculator _dismEta = new();
+
     private CancellationTokenSource? _tempCts;
     private CancellationTokenSource? _binCts;
     private CancellationTokenSource? _sfcCts;
@@ -39,6 +42,9 @@ public sealed partial class CleanupViewModel : ViewModelBase
     [ObservableProperty] private string _dismStatus = "Idle";
     [ObservableProperty] private string _dismVerdict = "";
     [ObservableProperty] private string _dismVerdictColorHex = "#9AA0A6";
+
+    [ObservableProperty] private string _sfcEtaText = string.Empty;
+    [ObservableProperty] private string _dismEtaText = string.Empty;
 
     // Pre-scan info so the tab doesn't look empty on first load
     [ObservableProperty] private string _tempSizeLabel = "Scanning…";
@@ -237,6 +243,8 @@ public sealed partial class CleanupViewModel : ViewModelBase
         SfcStatus = "Running — can take 5–15 minutes";
         SfcVerdict = "";
         SfcVerdictColorHex = "#9AA0A6";
+        SfcEtaText = string.Empty;
+        _sfcEta.Reset();
         StatusMessage = "SFC running in background. You can keep using the app.";
         _sfcCts?.Dispose();
         _sfcCts = new CancellationTokenSource();
@@ -250,6 +258,7 @@ public sealed partial class CleanupViewModel : ViewModelBase
                 if (m.Success && int.TryParse(m.Groups[1].Value, out var pct) && pct is >= 0 and <= 100)
                 {
                     Progress = pct;
+                    SfcEtaText = _sfcEta.Update(pct);
                     IsProgressIndeterminate = false;
                 }
             }
@@ -267,7 +276,7 @@ public sealed partial class CleanupViewModel : ViewModelBase
         catch (OperationCanceledException) { SfcStatus = "Cancelled."; SfcVerdict = "Scan was cancelled."; SfcVerdictColorHex = "#9AA0A6"; StatusMessage = SfcStatus; }
         catch (InvalidOperationException ex) { SfcStatus = $"Error: {ex.Message}"; SfcVerdict = ex.Message; SfcVerdictColorHex = "#EF4444"; StatusMessage = SfcStatus; }
         catch (System.ComponentModel.Win32Exception ex) { SfcStatus = $"Error: {ex.Message}"; SfcVerdict = ex.Message; SfcVerdictColorHex = "#EF4444"; StatusMessage = SfcStatus; }
-        finally { _runner.LineReceived -= Collect; IsSfcRunning = false; }
+        finally { _runner.LineReceived -= Collect; IsSfcRunning = false; SfcEtaText = string.Empty; }
     }
 
     /// <summary>
@@ -323,6 +332,8 @@ public sealed partial class CleanupViewModel : ViewModelBase
         DismStatus = "Running — can take 10–30 minutes";
         DismVerdict = "";
         DismVerdictColorHex = "#9AA0A6";
+        DismEtaText = string.Empty;
+        _dismEta.Reset();
         StatusMessage = "DISM running in background. You can keep using the app.";
         _dismCts?.Dispose();
         _dismCts = new CancellationTokenSource();
@@ -336,6 +347,7 @@ public sealed partial class CleanupViewModel : ViewModelBase
                 if (m.Success && double.TryParse(m.Groups[1].Value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var pct) && pct is >= 0 and <= 100)
                 {
                     Progress = (int)pct;
+                    DismEtaText = _dismEta.Update((int)pct);
                     IsProgressIndeterminate = false;
                 }
             }
@@ -353,7 +365,7 @@ public sealed partial class CleanupViewModel : ViewModelBase
         catch (OperationCanceledException) { DismStatus = "Cancelled."; DismVerdict = "Repair was cancelled."; DismVerdictColorHex = "#9AA0A6"; StatusMessage = DismStatus; }
         catch (InvalidOperationException ex) { DismStatus = $"Error: {ex.Message}"; DismVerdict = ex.Message; DismVerdictColorHex = "#EF4444"; StatusMessage = DismStatus; }
         catch (System.ComponentModel.Win32Exception ex) { DismStatus = $"Error: {ex.Message}"; DismVerdict = ex.Message; DismVerdictColorHex = "#EF4444"; StatusMessage = DismStatus; }
-        finally { _runner.LineReceived -= Collect; IsDismRunning = false; }
+        finally { _runner.LineReceived -= Collect; IsDismRunning = false; DismEtaText = string.Empty; }
     }
 
     /// <summary>

--- a/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
@@ -18,6 +18,7 @@ namespace SysManager.ViewModels;
 public sealed partial class UninstallerViewModel : ViewModelBase
 {
     private readonly UninstallerService _service;
+    private readonly EtaCalculator _uninstallEta = new();
     private readonly Action<PowerShellLine> _lineHandler;
     private CancellationTokenSource? _cts;
 
@@ -28,6 +29,7 @@ public sealed partial class UninstallerViewModel : ViewModelBase
     [ObservableProperty] private string _filterText = "";
     [ObservableProperty] private int _appCount;
     [ObservableProperty] private string _summary = "Click Scan to list installed applications.";
+    [ObservableProperty] private string _uninstallEtaText = string.Empty;
     [ObservableProperty] private bool _isElevated;
 
     partial void OnFilterTextChanged(string value) => ApplyFilter();
@@ -108,6 +110,8 @@ public sealed partial class UninstallerViewModel : ViewModelBase
         _cts?.Dispose();
         _cts = new CancellationTokenSource();
         int done = 0;
+        UninstallEtaText = string.Empty;
+        _uninstallEta.Reset();
 
         try
         {
@@ -117,6 +121,7 @@ public sealed partial class UninstallerViewModel : ViewModelBase
                 app.Status = "Uninstalling…";
                 StatusMessage = $"Uninstalling {app.Name} ({done + 1}/{toRemove.Count})…";
                 Progress = (int)(done * 100.0 / toRemove.Count);
+                UninstallEtaText = _uninstallEta.Update(Progress);
 
                 try
                 {
@@ -142,6 +147,7 @@ public sealed partial class UninstallerViewModel : ViewModelBase
             }
 
             Progress = 100;
+            UninstallEtaText = string.Empty;
             StatusMessage = $"Completed {done}/{toRemove.Count} uninstalls.";
             ToastService.Instance.Show("Uninstall complete", $"Completed {done}/{toRemove.Count} uninstalls");
             Log.Information("Uninstall batch completed: {Done}/{Total}", done, toRemove.Count);
@@ -149,6 +155,7 @@ public sealed partial class UninstallerViewModel : ViewModelBase
         finally
         {
             IsBusy = false;
+            UninstallEtaText = string.Empty;
             ApplyFilter();
         }
     }

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml
@@ -109,11 +109,14 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
             <ProgressBar AutomationProperties.Name="Progress" Grid.Column="0" Height="6" Minimum="0" Maximum="100"
                          Value="{Binding Progress}"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"/>
-            <TextBlock Grid.Column="1" Margin="12,0,0,0" Text="{Binding StatusMessage}" Style="{StaticResource Subtle}"/>
+            <TextBlock Grid.Column="1" Text="{Binding UpgradeEtaText}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="8,0,0,0" VerticalAlignment="Center"
+                       Visibility="{Binding UpgradeEtaText, Converter={StaticResource FlexVis}}"/>
+            <TextBlock Grid.Column="2" Margin="12,0,0,0" Text="{Binding StatusMessage}" Style="{StaticResource Subtle}"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -261,6 +261,8 @@
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Value="{Binding Progress}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+            <TextBlock Text="{Binding InstallEtaText}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="0,0,8,0" VerticalAlignment="Center"
+                       Visibility="{Binding InstallEtaText, Converter={StaticResource FlexVis}}" DockPanel.Dock="Left"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
         </DockPanel>
     </Grid>

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -102,6 +102,8 @@
                     <Ellipse Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,8,0" Fill="{DynamicResource Success}"/>
                     <TextBlock Text="SFC /scannow is running in background — " Foreground="{DynamicResource Success}" FontWeight="SemiBold" VerticalAlignment="Center"/>
                     <TextBlock Text="{Binding SfcStatus}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
+                    <TextBlock Text="{Binding SfcEtaText}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="8,0,0,0" VerticalAlignment="Center"
+                               Visibility="{Binding SfcEtaText, Converter={StaticResource FlexVis}}"/>
                 </StackPanel>
                 <!-- SFC verdict (shown after completion) -->
                 <Border Margin="0,8,0,0" Padding="12,10" CornerRadius="8"
@@ -121,6 +123,8 @@
                     <Ellipse Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,8,0" Fill="{DynamicResource Info}"/>
                     <TextBlock Text="DISM is running in background — " Foreground="{DynamicResource Info}" FontWeight="SemiBold" VerticalAlignment="Center"/>
                     <TextBlock Text="{Binding DismStatus}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
+                    <TextBlock Text="{Binding DismEtaText}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="8,0,0,0" VerticalAlignment="Center"
+                               Visibility="{Binding DismEtaText, Converter={StaticResource FlexVis}}"/>
                 </StackPanel>
                 <!-- DISM verdict (shown after completion) -->
                 <Border Margin="0,8,0,0" Padding="12,10" CornerRadius="8"

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -255,6 +255,8 @@
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Value="{Binding Progress}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+            <TextBlock Text="{Binding UninstallEtaText}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="0,0,8,0" VerticalAlignment="Center"
+                       Visibility="{Binding UninstallEtaText, Converter={StaticResource FlexVis}}" DockPanel.Dock="Left"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
         </DockPanel>
     </Grid>


### PR DESCRIPTION
## Summary
Adds estimated time remaining (ETA) display to all long-running determinate operations:
- **SFC /scannow** — shows ETA next to progress indicator
- **DISM /RestoreHealth** — shows ETA next to progress indicator
- **Bulk Installer** — shows ETA during multi-app install
- **Uninstaller** — shows ETA during batch uninstall
- **App Updates** — shows ETA during batch upgrade

Uses the existing `EtaCalculator` helper (linear extrapolation from elapsed time + progress %).
ETA text is hidden when not applicable (only visible during active operations).

## Test plan
- [x] Build: 0 errors, 0 warnings
- [x] App launches stable
- [x] ETA text only visible during operations (hidden otherwise via FlexVis converter)
- [x] No regressions in existing progress display
