### PR TITLE
docs: fix README, ARCHITECTURE, CONTRIBUTING, CHANGELOG, align version

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -72,7 +72,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `NetworkRepairViewModel` — DNS flush, Winsock reset, TCP/IP reset.
 - `NetworkSharedState` — shared targets, buffers, pinger, tracer, health for all network VMs.
 - `ServicesViewModel` — Windows services management with gaming recommendations.
-- `DriversViewModel` — driver inventory + Windows Update driver scan.
+- `DriversViewModel` — driver inventory via Win32_PnPSignedDriver.
 - `LogsViewModel` — friendly Event Log viewer.
 - `AboutViewModel` — version info, auto-update, release history.
 - `WindowsFeaturesViewModel` — list, enable, disable Windows optional features.
@@ -140,8 +140,8 @@ Key services:
   system commands with live output capture.
 - `ServiceManagerService` — enumerate Windows services, gaming
   recommendations, start/stop/disable with admin checks.
-- `AppAlertService` — monitors installed apps for available updates and
-  surfaces alerts on the dashboard.
+- `AppAlertService` — monitors for new application installations via
+  FileSystemWatcher and registry polling.
 - `AppBlockerService` — blocks/unblocks app execution via Image File
   Execution Options (IFEO) debugger redirect.
 - `BatteryService` — battery health, charge cycles, wear level, and
@@ -172,6 +172,10 @@ Key services:
   extensions via registry enumeration.
 - `SystemReportService` — generates comprehensive system info reports
   (hardware, OS, network, drivers) for export or clipboard.
+- `AppIconService` — downloads and caches application favicons for UI display.
+- `SafetyDatabase` — curated safety ratings for Windows services.
+- `ThemeService` — runtime theme switching with 12 presets and persistence.
+- `ToastService` — global glass-style toast notifications.
 
 ## Helpers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.16.1] - 2026-05-28
+
+### Fixed
+- **Security hardening** — version bump for security and performance fixes.
+
+## [1.16.0] - 2026-05-28
+
 ### Added
 - **Context Menu redesign** — complete overhaul of the Context Menu Manager tab:
   - **Presets:** Win10 Default (classic full menu), Win11 Default (modern compact), Custom

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ follows, and what to expect when you open a pull request.
 
 ```powershell
 git clone https://github.com/laurentiu021/SystemManager.git
-cd SysManager
+cd SystemManager
 dotnet build -c Debug
 ```
 
@@ -69,6 +69,7 @@ dotnet test -c Release
 ```
 SysManager/
 ├── SysManager/                # main WPF app
+│   ├── Data/                   # static data (ProcessDescriptions.json)
 │   ├── Models/                # POCOs (no logic)
 │   ├── Services/              # Windows / PowerShell / CLI wrappers
 │   ├── ViewModels/            # MVVM, one per tab

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ deleting anything (uses the standard `LegacyDisable` registry mechanism):
 - Requires administrator privileges for modifications
 
 ### Duplicate File Finder
-- Two-pass scan: group by size, then SHA-256 hash only size-matched files
+- Three-pass scan: group by size, partial-hash pre-filter, then full SHA-256
 - Duplicate groups sorted by wasted space (descending)
 - Preset folders or custom folder selection
 - Configurable minimum file size filter
@@ -191,7 +191,7 @@ deleting anything (uses the standard `LegacyDisable` registry mechanism):
 - Lists running Windows processes with PID, memory, threads, and status
 - Real-time filter by name, description, category, or PID
 - Sort by memory, CPU usage, name, or PID via clickable column headers
-- **Built-in description database** — 107 common Windows processes and popular
+- **Built-in description database** — 108 common Windows processes and popular
   applications with plain-language descriptions, categories (System, Browser,
   Development, Communication, Media, Gaming, etc.), and safety indicators
   (System, Trusted, Unknown)
@@ -203,8 +203,8 @@ deleting anything (uses the standard `LegacyDisable` registry mechanism):
 - Operations grouped by category (Disk, Network, SystemModification)
 - If a conflicting operation is already running, the UI shows which operation
   is blocking and refuses to start the new one
-- Integrated into: Deep Cleanup, Disk Analyzer, Duplicate Finder, Quick
-  Cleanup, Speed Test, Traceroute, Network Repair, Shortcut Cleaner
+- Integrated into: Dashboard, Deep Cleanup, Disk Analyzer, Duplicate Finder,
+  Quick Cleanup, Speed Test, Traceroute, Network Repair, Shortcut Cleaner
 
 ### Shortcut Cleaner
 - Scans Desktop, Start Menu, Quick Launch, and Recent Items for broken .lnk
@@ -407,7 +407,7 @@ Prerequisites: Windows 10 or newer and the [.NET 10 SDK](https://dotnet.microsof
 
 ```powershell
 git clone https://github.com/laurentiu021/SystemManager.git
-cd SysManager
+cd SystemManager
 dotnet run --project SysManager/SysManager/SysManager.csproj
 ```
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.16.0</Version>
-    <FileVersion>1.16.0.0</FileVersion>
-    <AssemblyVersion>1.16.0.0</AssemblyVersion>
+    <Version>1.16.1</Version>
+    <FileVersion>1.16.1.0</FileVersion>
+    <AssemblyVersion>1.16.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary
Full documentation audit fix — all issues from the 2026-05-27 codebase audit:

- **README**: fix `cd SysManager` → `cd SystemManager`, process count 107→108, duplicate finder 2-pass→3-pass, add Dashboard to Operation Lock list
- **CONTRIBUTING**: fix `cd` path, add Data/ folder to project layout
- **ARCHITECTURE**: fix AppAlertService description (install monitoring, not updates), fix DriversVM description (no Windows Update scan), add 4 missing services (AppIconService, SafetyDatabase, ThemeService, ToastService)
- **CHANGELOG**: properly structure released versions (1.16.0, 1.16.1), clear Unreleased
- **csproj**: align version to 1.16.1

## Test plan
- [ ] Build succeeds
- [ ] No release triggered (docs: prefix)