### PR TITLE
fix: UI uniformity and collection performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.16.2] - 2026-05-28
+
+### Fixed
+- **UI uniformity** — AppAlertsView fully reworked: proper Card wrappers, styled buttons (Primary/Secondary/Danger), removed DataGrid gridlines, standardized header using Display style, consistent column styling.
+- **DashboardView consistency** — standardized margins (28px), replaced inline admin button template with app-wide AdminButton/elevation banner pattern, added proper button styles to all actions.
+- **Performance** — replaced `ObservableCollection` with `BulkObservableCollection` in UninstallerViewModel, WindowsFeaturesViewModel, WindowsUpdateViewModel, and LogsViewModel (eliminates UI flicker from Clear+Add loops).
+
 ## [1.16.1] - 2026-05-28
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.16.1</Version>
-    <FileVersion>1.16.1.0</FileVersion>
-    <AssemblyVersion>1.16.1.0</AssemblyVersion>
+    <Version>1.16.2</Version>
+    <FileVersion>1.16.2.0</FileVersion>
+    <AssemblyVersion>1.16.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -2,7 +2,6 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -13,6 +12,7 @@ using System.Windows.Data;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Win32;
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -29,7 +29,7 @@ public sealed partial class LogsViewModel : ViewModelBase
     private readonly SynchronizationContext? _sync;
     private CancellationTokenSource? _cts;
 
-    public ObservableCollection<FriendlyEventEntry> Entries { get; } = new();
+    public BulkObservableCollection<FriendlyEventEntry> Entries { get; } = new();
     public ICollectionView EntriesView { get; }
 
     public string[] AvailableLogs { get; } = { "System", "Application", "Security", "Setup" };

--- a/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
@@ -2,7 +2,6 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
@@ -22,8 +21,8 @@ public sealed partial class UninstallerViewModel : ViewModelBase
     private readonly Action<PowerShellLine> _lineHandler;
     private CancellationTokenSource? _cts;
 
-    public ObservableCollection<InstalledApp> AllApps { get; } = new();
-    public ObservableCollection<InstalledApp> FilteredApps { get; } = new();
+    public BulkObservableCollection<InstalledApp> AllApps { get; } = new();
+    public BulkObservableCollection<InstalledApp> FilteredApps { get; } = new();
     public ConsoleViewModel Console { get; } = new();
 
     [ObservableProperty] private string _filterText = "";
@@ -55,7 +54,6 @@ public sealed partial class UninstallerViewModel : ViewModelBase
         IsBusy = true;
         IsProgressIndeterminate = true;
         StatusMessage = "Querying winget list…";
-        AllApps.Clear();
         FilteredApps.Clear();
         _cts?.Dispose();
         _cts = new CancellationTokenSource();
@@ -64,10 +62,8 @@ public sealed partial class UninstallerViewModel : ViewModelBase
         {
             var list = await _service.ListInstalledAsync(_cts.Token);
             foreach (var app in list)
-            {
                 app.Icon ??= IconExtractorService.FallbackIcon;
-                AllApps.Add(app);
-            }
+            AllApps.ReplaceWith(list);
 
             ApplyFilter();
             StatusMessage = $"Found {AllApps.Count} installed applications.";
@@ -196,7 +192,6 @@ public sealed partial class UninstallerViewModel : ViewModelBase
 
     private void ApplyFilter()
     {
-        FilteredApps.Clear();
         IEnumerable<InstalledApp> source = AllApps;
 
         if (!string.IsNullOrWhiteSpace(FilterText))
@@ -207,11 +202,8 @@ public sealed partial class UninstallerViewModel : ViewModelBase
                 a.Id.Contains(f, StringComparison.OrdinalIgnoreCase));
         }
 
-        // Default order by name; DataGrid column headers handle user sorting.
         source = source.OrderBy(a => a.Name, StringComparer.OrdinalIgnoreCase);
-
-        foreach (var app in source)
-            FilteredApps.Add(app);
+        FilteredApps.ReplaceWith(source);
 
         AppCount = FilteredApps.Count;
         Summary = $"{AppCount} apps{(AllApps.Count != AppCount ? $" (of {AllApps.Count} total)" : "")}";

--- a/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
@@ -2,7 +2,6 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
@@ -22,8 +21,8 @@ public sealed partial class WindowsFeaturesViewModel : ViewModelBase
     private CancellationTokenSource? _scanCts;
     private CancellationTokenSource? _toggleCts;
 
-    public ObservableCollection<WindowsFeature> AllFeatures { get; } = new();
-    public ObservableCollection<WindowsFeature> FilteredFeatures { get; } = new();
+    public BulkObservableCollection<WindowsFeature> AllFeatures { get; } = new();
+    public BulkObservableCollection<WindowsFeature> FilteredFeatures { get; } = new();
 
     [ObservableProperty] private string _filterText = "";
     [ObservableProperty] private int _featureCount;
@@ -53,7 +52,6 @@ public sealed partial class WindowsFeaturesViewModel : ViewModelBase
         IsBusy = true;
         IsProgressIndeterminate = true;
         StatusMessage = "Querying Windows optional features…";
-        AllFeatures.Clear();
         FilteredFeatures.Clear();
         _scanCts?.Cancel();
         _scanCts?.Dispose();
@@ -62,8 +60,7 @@ public sealed partial class WindowsFeaturesViewModel : ViewModelBase
         try
         {
             var list = await _service.ListFeaturesAsync(_scanCts.Token);
-            foreach (var feature in list)
-                AllFeatures.Add(feature);
+            AllFeatures.ReplaceWith(list);
 
             ApplyFilter();
             EnabledCount = AllFeatures.Count(f => f.IsEnabled);
@@ -175,7 +172,6 @@ public sealed partial class WindowsFeaturesViewModel : ViewModelBase
 
     private void ApplyFilter()
     {
-        FilteredFeatures.Clear();
         IEnumerable<WindowsFeature> source = AllFeatures;
 
         if (!string.IsNullOrWhiteSpace(FilterText))
@@ -187,9 +183,7 @@ public sealed partial class WindowsFeaturesViewModel : ViewModelBase
                 feat.Category.Contains(f, StringComparison.OrdinalIgnoreCase));
         }
 
-        foreach (var feat in source)
-            FilteredFeatures.Add(feat);
-
+        FilteredFeatures.ReplaceWith(source);
         FeatureCount = FilteredFeatures.Count;
         Summary = $"{FeatureCount} features{(AllFeatures.Count != FeatureCount ? $" (of {AllFeatures.Count} total)" : "")}";
     }

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -2,7 +2,6 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Text.Json;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -19,7 +18,7 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
     private readonly PowerShellRunner _runner;
     private CancellationTokenSource? _cts;
 
-    public ObservableCollection<UpdateEntry> Updates { get; } = new();
+    public BulkObservableCollection<UpdateEntry> Updates { get; } = new();
     public ConsoleViewModel Console { get; } = new();
 
     [ObservableProperty] private bool _moduleAvailable;

--- a/SysManager/SysManager/Views/AppAlertsView.xaml
+++ b/SysManager/SysManager/Views/AppAlertsView.xaml
@@ -6,61 +6,115 @@
              d:DataContext="{d:DesignInstance vm:AppAlertsViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d">
+             mc:Ignorable="d"
+             Background="{DynamicResource Surface0}">
 
-    <Grid Margin="24">
+    <Grid Margin="28,24,28,16">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <!-- Header -->
         <StackPanel Grid.Row="0" Margin="0,0,0,16">
-            <TextBlock Text="App Installation Alerts" FontSize="20" FontWeight="SemiBold"
-                       Foreground="{DynamicResource TextPrimary}" />
-            <TextBlock Text="{Binding MonitorStatus}" Opacity="0.7" Margin="0,4,0,0"
-                       Foreground="{DynamicResource TextSecondary}" />
+            <TextBlock Text="App Installation Alerts" Style="{StaticResource Display}"/>
+            <TextBlock Text="{Binding MonitorStatus}" Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
         </StackPanel>
 
         <!-- Toolbar -->
-        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,12">
-            <Button Content="Start Monitoring" Command="{Binding StartMonitoringCommand}" Padding="12,6" Margin="0,0,8,0" />
-            <Button Content="Stop" Command="{Binding StopMonitoringCommand}" Padding="12,6" Margin="0,0,8,0" />
-            <Separator Margin="0,0,8,0" />
-            <Button Content="Show Installed" Command="{Binding RefreshInstalledAppsCommand}" Padding="12,6" Margin="0,0,8,0" />
-            <Button Content="Acknowledge All" Command="{Binding AcknowledgeAllCommand}" Padding="12,6" Margin="0,0,8,0" />
-            <Button Content="Clear History" Command="{Binding ClearHistoryCommand}" Padding="8,6" />
-        </StackPanel>
+        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+            <DockPanel>
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
+                    <Button Content="Start Monitoring" Command="{Binding StartMonitoringCommand}"
+                            Style="{StaticResource PrimaryButton}" Padding="14,8" Margin="0,0,8,0"/>
+                    <Button Content="Stop" Command="{Binding StopMonitoringCommand}"
+                            Style="{StaticResource SecondaryButton}" Padding="12,8" Margin="0,0,8,0"/>
+                    <Button Content="Show Installed" Command="{Binding RefreshInstalledAppsCommand}"
+                            Style="{StaticResource SecondaryButton}" Padding="12,8" Margin="0,0,8,0"/>
+                    <Button Content="Acknowledge All" Command="{Binding AcknowledgeAllCommand}"
+                            Style="{StaticResource SecondaryButton}" Padding="12,8" Margin="0,0,8,0"/>
+                    <Button Content="Clear History" Command="{Binding ClearHistoryCommand}"
+                            Style="{StaticResource DangerButton}" Padding="12,8"/>
+                </StackPanel>
+                <TextBlock DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right"
+                           Style="{StaticResource Subtle}">
+                    <Run Text="{Binding AlertCount, Mode=OneWay}"/> total ·
+                    <Run Text="{Binding UnacknowledgedCount, Mode=OneWay}"/> new
+                </TextBlock>
+            </DockPanel>
+        </Border>
 
         <!-- Alerts list -->
-        <DataGrid Grid.Row="2" ItemsSource="{Binding Alerts}"
-                  AutoGenerateColumns="False" IsReadOnly="True"
-                  CanUserAddRows="False" CanUserDeleteRows="False"
-                  CanUserResizeColumns="True"
-                  HeadersVisibility="Column" GridLinesVisibility="Horizontal"
-                  BorderThickness="1" BorderBrush="{DynamicResource Border1}"
-                  VirtualizingPanel.IsVirtualizing="True"
-                  VirtualizingPanel.VirtualizationMode="Recycling">
-            <DataGrid.Columns>
-                <DataGridTextColumn Header="Detected" Binding="{Binding DetectedAt, StringFormat='{}{0:HH:mm:ss dd-MMM}'}" Width="120" MinWidth="80" />
-                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="200" MinWidth="100" />
-                <DataGridTextColumn Header="Publisher" Binding="{Binding Publisher}" Width="150" MinWidth="80" />
-                <DataGridTextColumn Header="Path" Binding="{Binding InstallPath}" Width="*" MinWidth="120" />
-                <DataGridTextColumn Header="Source" Binding="{Binding Source}" Width="80" MinWidth="60" />
-            </DataGrid.Columns>
-        </DataGrid>
+        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
+            <DataGrid AutomationProperties.Name="App installation alerts"
+                      ItemsSource="{Binding Alerts}"
+                      AutoGenerateColumns="False" IsReadOnly="True"
+                      CanUserAddRows="False" CanUserDeleteRows="False"
+                      CanUserResizeColumns="True" CanUserSortColumns="True"
+                      HeadersVisibility="Column" GridLinesVisibility="None"
+                      Background="Transparent" BorderThickness="0"
+                      SelectionMode="Single"
+                      VirtualizingPanel.IsVirtualizing="True"
+                      VirtualizingPanel.VirtualizationMode="Recycling">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Detected" Binding="{Binding DetectedAt, StringFormat='{}{0:HH:mm:ss dd-MMM}'}"
+                                        Width="140" MinWidth="100" SortMemberPath="DetectedAt">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
+                                <Setter Property="FontSize" Value="12"/>
+                                <Setter Property="VerticalAlignment" Value="Center"/>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*" MinWidth="150"
+                                        SortMemberPath="Name">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                <Setter Property="FontSize" Value="13"/>
+                                <Setter Property="VerticalAlignment" Value="Center"/>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Header="Publisher" Binding="{Binding Publisher}" Width="160" MinWidth="80"
+                                        SortMemberPath="Publisher">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
+                                <Setter Property="FontSize" Value="12"/>
+                                <Setter Property="VerticalAlignment" Value="Center"/>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Header="Path" Binding="{Binding InstallPath}" Width="*" MinWidth="120"
+                                        SortMemberPath="InstallPath">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
+                                <Setter Property="FontSize" Value="12"/>
+                                <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+                                <Setter Property="VerticalAlignment" Value="Center"/>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Header="Source" Binding="{Binding Source}" Width="90" MinWidth="60"
+                                        SortMemberPath="Source">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
+                                <Setter Property="FontSize" Value="12"/>
+                                <Setter Property="VerticalAlignment" Value="Center"/>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+                </DataGrid.Columns>
+            </DataGrid>
+        </Border>
 
-        <!-- Footer -->
-        <StackPanel Grid.Row="3" Orientation="Horizontal" Margin="0,8,0,0">
-            <TextBlock Opacity="0.6" VerticalAlignment="Center"
-                       Foreground="{DynamicResource TextSecondary}">
-                <Run Text="{Binding AlertCount, Mode=OneWay}" />
-                <Run Text=" total · " />
-                <Run Text="{Binding UnacknowledgedCount, Mode=OneWay}" />
-                <Run Text=" new" />
-            </TextBlock>
-        </StackPanel>
+        <!-- Status bar -->
+        <TextBlock Grid.Row="3" Text="{Binding StatusMessage}" Style="{StaticResource Caption}" Margin="0,8,0,0"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -2,7 +2,7 @@
 <UserControl x:Class="SysManager.Views.DashboardView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Grid Margin="16">
+    <Grid Margin="28,24,28,16">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -10,66 +10,49 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <StackPanel Orientation="Horizontal" Grid.Row="0">
-            <TextBlock Text="System overview" Style="{StaticResource Display}" FontWeight="SemiBold"/>
-            <Border CornerRadius="10" Padding="10,5" Margin="16,2,0,0"
-                    Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
-                    Visibility="{Binding IsElevated, Converter={StaticResource BoolToVis}}">
-                <Grid>
-                    <Border Background="#FBBF24" Width="3" HorizontalAlignment="Left" CornerRadius="2"
-                            Margin="-10,-5,0,-5"/>
-                    <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
-                        <TextBlock Text="&#x1F6E1;" FontSize="12" VerticalAlignment="Center"/>
-                        <TextBlock Text="Administrator" Foreground="#FCD34D" FontSize="12"
-                                   FontWeight="SemiBold" Margin="6,0,0,0" VerticalAlignment="Center"/>
-                    </StackPanel>
-                </Grid>
-            </Border>
-            <Button Margin="16,0,0,0"
-                    Command="{Binding RequestElevationCommand}" Cursor="Hand">
-                <Button.Template>
-                    <ControlTemplate TargetType="Button">
-                        <Border x:Name="Bd" CornerRadius="10" Padding="10,5"
-                                Background="#14FBBF24" BorderBrush="#30FBBF24" BorderThickness="1">
-                            <Grid>
-                                <Border Background="#FBBF24" Width="3" HorizontalAlignment="Left" CornerRadius="2"
-                                        Margin="-10,-5,0,-5" Opacity="0.7"/>
-                                <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
-                                    <TextBlock Text="&#x1F6E1;" FontSize="12" VerticalAlignment="Center"/>
-                                    <TextBlock Text="Request admin" Foreground="#FCD34D" FontSize="12"
-                                               FontWeight="SemiBold" Margin="6,0,0,0" VerticalAlignment="Center"/>
-                                </StackPanel>
-                            </Grid>
-                        </Border>
-                        <ControlTemplate.Triggers>
-                            <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Bd" Property="BorderBrush" Value="#60FBBF24"/>
-                                <Setter TargetName="Bd" Property="Background" Value="#20FBBF24"/>
-                            </Trigger>
-                        </ControlTemplate.Triggers>
-                    </ControlTemplate>
-                </Button.Template>
-                <Button.Style>
-                    <Style TargetType="Button">
-                        <Setter Property="Visibility" Value="Visible"/>
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding IsElevated}" Value="True">
-                                <Setter Property="Visibility" Value="Collapsed"/>
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </Button.Style>
-            </Button>
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,0">
+            <TextBlock Text="System overview" Style="{StaticResource Display}"/>
         </StackPanel>
+
+        <!-- Elevation banner: not elevated -->
+        <Border Grid.Row="0" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,48,0,0"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RequestElevationCommand}"
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
+                    <TextBlock Text="Some system checks require administrator privileges."
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- Elevation banner: elevated -->
+        <Border Grid.Row="0" Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="0,48,0,0"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Border Background="#FBBF24" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — full system access enabled."
+                               Foreground="#FCD34D" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
+        </Border>
 
         <!-- Action buttons row -->
         <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,12,0,12">
-            <Button HorizontalAlignment="Left"
-                    Content="Scan system" Command="{Binding RefreshCommand}"
-                    Padding="14,6" FontWeight="SemiBold"/>
+            <Button Content="Scan system" Command="{Binding RefreshCommand}"
+                    Style="{StaticResource SecondaryButton}" Padding="14,8"/>
 
-            <Button Margin="12,0,0,0" Padding="16,8" FontWeight="SemiBold"
-                    FontSize="14" Command="{Binding RunTuneUpCommand}"
+            <Button Margin="12,0,0,0" Padding="16,8"
+                    Command="{Binding RunTuneUpCommand}"
                     Style="{StaticResource PrimaryButton}"
                     AutomationProperties.Name="Quick Tune-Up">
                 <StackPanel Orientation="Horizontal">
@@ -79,9 +62,9 @@
                 </StackPanel>
             </Button>
 
-            <!-- Cancel button (visible only during tune-up) -->
-            <Button Margin="8,0,0,0" Content="Cancel" Padding="10,6"
+            <Button Margin="8,0,0,0" Content="Cancel" Padding="12,8"
                     Command="{Binding CancelTuneUpCommand}"
+                    Style="{StaticResource SecondaryButton}"
                     Visibility="{Binding IsTuneUpRunning, Converter={StaticResource BoolToVis}}"/>
         </StackPanel>
 
@@ -196,7 +179,7 @@
                             </StackPanel>
                             <Button Grid.Column="1" Content="&#xE711;" FontFamily="Segoe Fluent Icons"
                                     Padding="6,2" Command="{Binding DismissTuneUpResultCommand}"
-                                    ToolTip="Dismiss" FontSize="12"
+                                    Style="{StaticResource GhostButton}" ToolTip="Dismiss" FontSize="12"
                                     AutomationProperties.Name="Dismiss tune-up results"/>
                         </Grid>
 


### PR DESCRIPTION
## Summary
- **AppAlertsView** fully reworked: Card wrappers, styled buttons (Primary/Secondary/Danger), removed DataGrid gridlines, standardized Display header, consistent column element styles
- **DashboardView** consistency: margins 28px (was 16px), replaced 60-line inline admin button ControlTemplate with standard AdminButton + elevation banner pattern (matching CleanupView/ContextMenuView), styled "Scan system" and "Cancel" buttons
- **Performance**: replaced `ObservableCollection` + Clear/Add loops with `BulkObservableCollection.ReplaceWith()` in UninstallerViewModel, WindowsFeaturesViewModel, WindowsUpdateViewModel, LogsViewModel — eliminates UI flicker on refresh

## Test plan
- [ ] AppAlertsView: verify toolbar buttons render with correct styles (primary green, secondary gray, danger red)
- [ ] AppAlertsView: verify DataGrid has no horizontal gridlines, columns properly styled
- [ ] DashboardView: verify admin banner appears correctly when not elevated (shield icon + "Run as administrator" button)
- [ ] DashboardView: verify elevated state shows golden badge (matching CleanupView)
- [ ] DashboardView: verify "Scan system" button has SecondaryButton style, "Quick Tune-Up" has PrimaryButton
- [ ] Uninstaller/Features: verify scan loads apps without visible flicker