### PR TITLE
fix: code quality — GeneratedRegex, naming standardization, dead code removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.16.3] - 2026-05-29
+
+### Fixed
+- **Code quality** — ContextMenuService uses `[GeneratedRegex]` for compile-time regex (performance + AOT-ready).
+- **Naming standardization** — all admin relaunch methods now consistently named `RelaunchAsAdmin` across all 12 ViewModels (was mixed: `RelaunchElevated`, `RequestElevation`).
+- **Naming standardization** — filter properties unified to `FilterText` everywhere (LogsViewModel was `SearchText`, ServicesViewModel was `Filter`).
+- **ConsoleViewModel** — removed dead optimization branch (clear-and-rebuild path was unreachable).
+- **Missing toasts** — added completion notifications to System Health scan and App Alerts "Show Installed".
+
 ## [1.16.2] - 2026-05-28
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DashboardViewModelTests.cs
@@ -67,7 +67,7 @@ public class DashboardViewModelTests
 
     [Theory]
     [InlineData("RefreshCommand")]
-    [InlineData("RequestElevationCommand")]
+    [InlineData("RelaunchAsAdminCommand")]
     public void Command_IsExposedAndNotNull(string name)
     {
         var vm = NewVm();

--- a/SysManager/SysManager.Tests/LogsViewModelExtendedTests.cs
+++ b/SysManager/SysManager.Tests/LogsViewModelExtendedTests.cs
@@ -74,10 +74,10 @@ public class LogsViewModelExtendedTests
     }
 
     [Fact]
-    public void SearchText_DefaultsEmpty()
+    public void FilterText_DefaultsEmpty()
     {
         var vm = new LogsViewModel(new Services.EventLogService());
-        Assert.Equal("", vm.SearchText);
+        Assert.Equal("", vm.FilterText);
     }
 
     [Fact]
@@ -313,7 +313,7 @@ public class LogsViewModelExtendedTests
             ProviderName = "P",
             EventId = 1
         };
-        vm.SearchText = "keyword";
+        vm.FilterText = "keyword";
         Assert.True(Filter(vm, e));
     }
 
@@ -325,7 +325,7 @@ public class LogsViewModelExtendedTests
     [InlineData(nameof(LogsViewModel.ShowWarning))]
     [InlineData(nameof(LogsViewModel.ShowInfo))]
     [InlineData(nameof(LogsViewModel.ShowVerbose))]
-    [InlineData(nameof(LogsViewModel.SearchText))]
+    [InlineData(nameof(LogsViewModel.FilterText))]
     [InlineData(nameof(LogsViewModel.SelectedLog))]
     [InlineData(nameof(LogsViewModel.SelectedTimeRange))]
     [InlineData(nameof(LogsViewModel.SelectedMaxResults))]

--- a/SysManager/SysManager.Tests/LogsViewModelTests.cs
+++ b/SysManager/SysManager.Tests/LogsViewModelTests.cs
@@ -60,16 +60,16 @@ public class LogsViewModelTests
         var vm = new LogsViewModel(new Services.EventLogService());
         var e = Make(EventSeverity.Error, "Disk I/O timeout at sector 500", "disk", 7);
 
-        vm.SearchText = "sector";
+        vm.FilterText = "sector";
         Assert.True(InvokeFilter(vm, e));
 
-        vm.SearchText = "DISK"; // case-insensitive by provider
+        vm.FilterText = "DISK"; // case-insensitive by provider
         Assert.True(InvokeFilter(vm, e));
 
-        vm.SearchText = "7"; // by event id
+        vm.FilterText = "7"; // by event id
         Assert.True(InvokeFilter(vm, e));
 
-        vm.SearchText = "nothing-matches-this";
+        vm.FilterText = "nothing-matches-this";
         Assert.False(InvokeFilter(vm, e));
     }
 
@@ -78,9 +78,9 @@ public class LogsViewModelTests
     {
         var vm = new LogsViewModel(new Services.EventLogService());
         var e = Make(EventSeverity.Warning);
-        vm.SearchText = "";
+        vm.FilterText = "";
         Assert.True(InvokeFilter(vm, e));
-        vm.SearchText = "   ";
+        vm.FilterText = "   ";
         Assert.True(InvokeFilter(vm, e));
     }
 

--- a/SysManager/SysManager.Tests/ServicesViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ServicesViewModelTests.cs
@@ -61,7 +61,7 @@ public class ServicesViewModelTests
     public void Constructor_DefaultFilter_Empty()
     {
         var vm = new ServicesViewModel(new Services.PowerShellRunner());
-        Assert.Equal("", vm.Filter);
+        Assert.Equal("", vm.FilterText);
     }
 
     [Fact]
@@ -134,7 +134,7 @@ public class ServicesViewModelTests
     public void ApplyFilter_TextFilter_MatchesDisplayName()
     {
         var vm = CreateWithData();
-        vm.Filter = "Print";
+        vm.FilterText = "Print";
         Assert.Single(vm.Services);
         Assert.Equal("Print Spooler", vm.Services[0].DisplayName);
     }
@@ -143,7 +143,7 @@ public class ServicesViewModelTests
     public void ApplyFilter_TextFilter_MatchesServiceName()
     {
         var vm = CreateWithData();
-        vm.Filter = "wuauserv";
+        vm.FilterText = "wuauserv";
         Assert.Single(vm.Services);
         Assert.Equal("Windows Update", vm.Services[0].DisplayName);
     }
@@ -152,7 +152,7 @@ public class ServicesViewModelTests
     public void ApplyFilter_TextFilter_MatchesDescription()
     {
         var vm = CreateWithData();
-        vm.Filter = "indexing";
+        vm.FilterText = "indexing";
         Assert.Single(vm.Services);
         Assert.Equal("Windows Search", vm.Services[0].DisplayName);
     }
@@ -161,7 +161,7 @@ public class ServicesViewModelTests
     public void ApplyFilter_TextFilter_CaseInsensitive()
     {
         var vm = CreateWithData();
-        vm.Filter = "XBOX";
+        vm.FilterText = "XBOX";
         Assert.Single(vm.Services);
         Assert.Equal("Xbox Accessory Management", vm.Services[0].DisplayName);
     }
@@ -170,7 +170,7 @@ public class ServicesViewModelTests
     public void ApplyFilter_TextFilter_NoMatch_ReturnsEmpty()
     {
         var vm = CreateWithData();
-        vm.Filter = "zzz_nonexistent_zzz";
+        vm.FilterText = "zzz_nonexistent_zzz";
         Assert.Empty(vm.Services);
     }
 
@@ -181,7 +181,7 @@ public class ServicesViewModelTests
     {
         var vm = CreateWithData();
         vm.SelectedFilter = "Running";
-        vm.Filter = "Update";
+        vm.FilterText = "Update";
         Assert.Single(vm.Services);
         Assert.Equal("Windows Update", vm.Services[0].DisplayName);
     }
@@ -191,7 +191,7 @@ public class ServicesViewModelTests
     {
         var vm = CreateWithData();
         vm.SelectedFilter = "Stopped";
-        vm.Filter = "Windows Update";
+        vm.FilterText = "Windows Update";
         Assert.Empty(vm.Services);
     }
 
@@ -235,7 +235,7 @@ public class ServicesViewModelTests
         var vm = CreateWithData();
         vm.SelectedFilter = "All";
         Assert.Equal(5, vm.Services.Count);
-        vm.Filter = "Xbox";
+        vm.FilterText = "Xbox";
         Assert.Single(vm.Services);
     }
 }

--- a/SysManager/SysManager/Services/ContextMenuService.cs
+++ b/SysManager/SysManager/Services/ContextMenuService.cs
@@ -18,7 +18,7 @@ namespace SysManager.Services;
 /// Windows Explorer respects this value to hide the menu entry without
 /// removing the registration — safe and fully reversible.
 /// </summary>
-public sealed class ContextMenuService
+public sealed partial class ContextMenuService
 {
     // Registry locations that define context menu entries
     private static readonly (string SubKey, string Location)[] ShellLocations =
@@ -522,7 +522,7 @@ public sealed class ContextMenuService
 
             // Try to extract a meaningful name from DLL resource references
             // Format: @C:\Windows\System32\display.dll,-4
-            var dllMatch = Regex.Match(rawName, @"@.*?\\?([^\\,]+)\.dll", RegexOptions.IgnoreCase);
+            var dllMatch = DllResourcePattern().Match(rawName);
             if (dllMatch.Success)
             {
                 var dllName = dllMatch.Groups[1].Value;
@@ -620,14 +620,9 @@ public sealed class ContextMenuService
         // Replace underscores and hyphens with spaces
         input = input.Replace('_', ' ').Replace('-', ' ');
 
-        // Insert space before each uppercase letter that follows a lowercase letter or digit
-        var result = Regex.Replace(input, @"(?<=[a-z0-9])([A-Z])", " $1");
-
-        // Insert space between consecutive uppercase letters followed by lowercase
-        result = Regex.Replace(result, @"(?<=[A-Z])([A-Z])(?=[a-z])", " $1");
-
-        // Collapse multiple spaces
-        result = Regex.Replace(result, @"\s+", " ").Trim();
+        var result = CamelCaseSplitPattern().Replace(input, " $1");
+        result = ConsecutiveUpperPattern().Replace(result, " $1");
+        result = MultiSpacePattern().Replace(result, " ").Trim();
 
         // Capitalize first letter
         if (result.Length > 0)
@@ -673,4 +668,16 @@ public sealed class ContextMenuService
             return "";
         }
     }
+
+    [GeneratedRegex(@"@.*?\\?([^\\,]+)\.dll", RegexOptions.IgnoreCase)]
+    private static partial Regex DllResourcePattern();
+
+    [GeneratedRegex(@"(?<=[a-z0-9])([A-Z])")]
+    private static partial Regex CamelCaseSplitPattern();
+
+    [GeneratedRegex(@"(?<=[A-Z])([A-Z])(?=[a-z])")]
+    private static partial Regex ConsecutiveUpperPattern();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex MultiSpacePattern();
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.16.2</Version>
-    <FileVersion>1.16.2.0</FileVersion>
-    <AssemblyVersion>1.16.2.0</AssemblyVersion>
+    <Version>1.16.3</Version>
+    <FileVersion>1.16.3.0</FileVersion>
+    <AssemblyVersion>1.16.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
@@ -101,6 +101,7 @@ public sealed partial class AppAlertsViewModel : ViewModelBase
             UnacknowledgedCount = 0;
             MonitorStatus = $"Loaded {AlertCount} currently installed applications.";
             StatusMessage = "Done.";
+            ToastService.Instance.Show("Installed apps loaded", $"{AlertCount} applications found");
         }
         catch (System.Security.SecurityException ex)
         {

--- a/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
@@ -131,7 +131,7 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void RelaunchElevated()
+    private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
             System.Windows.Application.Current?.Shutdown();

--- a/SysManager/SysManager/ViewModels/ConsoleViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ConsoleViewModel.cs
@@ -36,26 +36,8 @@ public sealed partial class ConsoleViewModel : ObservableObject
         lock (_gate)
         {
             Lines.Add(line);
-            if (Lines.Count > MaxLines)
-            {
-                // PERF: When excess is large relative to buffer, clear-and-rebuild
-                // is O(n) vs O(n*excess) for repeated RemoveAt(0).
-                var excess = Lines.Count - MaxLines;
-                if (excess > Lines.Count / 4)
-                {
-                    var keep = new PowerShellLine[MaxLines];
-                    for (int i = 0; i < MaxLines; i++)
-                        keep[i] = Lines[excess + i];
-                    Lines.Clear();
-                    foreach (var item in keep)
-                        Lines.Add(item);
-                }
-                else
-                {
-                    for (int i = 0; i < excess; i++)
-                        Lines.RemoveAt(0);
-                }
-            }
+            while (Lines.Count > MaxLines)
+                Lines.RemoveAt(0);
         }
     }
 

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -109,7 +109,7 @@ public sealed partial class DashboardViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void RequestElevation()
+    private void RelaunchAsAdmin()
     {
         Log.Information("Admin elevation requested from Dashboard");
         if (AdminHelper.RelaunchAsAdmin())

--- a/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
@@ -237,7 +237,7 @@ public sealed partial class DnsHostsViewModel : ViewModelBase
     private void RefreshHosts() => LoadHosts();
 
     [RelayCommand]
-    private void RelaunchElevated()
+    private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
             System.Windows.Application.Current?.Shutdown();

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -46,7 +46,7 @@ public sealed partial class LogsViewModel : ViewModelBase
     [ObservableProperty] private bool _showInfo;
     [ObservableProperty] private bool _showVerbose;
 
-    [ObservableProperty] private string _searchText = "";
+    [ObservableProperty] private string _filterText = "";
     [ObservableProperty] private FriendlyEventEntry? _selectedEntry;
 
     [ObservableProperty] private int _criticalCount;
@@ -81,7 +81,7 @@ public sealed partial class LogsViewModel : ViewModelBase
     partial void OnShowWarningChanged(bool value) { EntriesView.Refresh(); UpdateVisibleCount(); }
     partial void OnShowInfoChanged(bool value) { EntriesView.Refresh(); UpdateVisibleCount(); }
     partial void OnShowVerboseChanged(bool value) { EntriesView.Refresh(); UpdateVisibleCount(); }
-    partial void OnSearchTextChanged(string value) { EntriesView.Refresh(); UpdateVisibleCount(); }
+    partial void OnFilterTextChanged(string value) { EntriesView.Refresh(); UpdateVisibleCount(); }
 
     private bool EntryFilter(object o)
     {
@@ -98,8 +98,8 @@ public sealed partial class LogsViewModel : ViewModelBase
         };
         if (!sevOk) return false;
 
-        if (string.IsNullOrWhiteSpace(SearchText)) return true;
-        var q = SearchText.Trim();
+        if (string.IsNullOrWhiteSpace(FilterText)) return true;
+        var q = FilterText.Trim();
         return ContainsCi(e.Message, q)
             || ContainsCi(e.ProviderName, q)
             || ContainsCi(e.FullMessage, q)

--- a/SysManager/SysManager/ViewModels/PrivacyViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PrivacyViewModel.cs
@@ -89,7 +89,7 @@ public sealed partial class PrivacyViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void RelaunchElevated()
+    private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
             System.Windows.Application.Current?.Shutdown();

--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -25,7 +25,7 @@ public sealed partial class ServicesViewModel : ViewModelBase
     public BulkObservableCollection<ServiceEntry> Services { get; } = new();
 
     [ObservableProperty] private bool _isElevated;
-    [ObservableProperty] private string _filter = "";
+    [ObservableProperty] private string _filterText = "";
     [ObservableProperty] private string _selectedFilter = "All";
     [ObservableProperty] private ServiceEntry? _selectedService;
     [ObservableProperty] private int _totalCount;
@@ -45,7 +45,7 @@ public sealed partial class ServicesViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void RelaunchElevated()
+    private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
             System.Windows.Application.Current?.Shutdown();
@@ -58,7 +58,7 @@ public sealed partial class ServicesViewModel : ViewModelBase
         catch (System.ComponentModel.Win32Exception ex) { Log.Warning("Services auto-refresh failed: {Error}", ex.Message); }
     }
 
-    partial void OnFilterChanged(string value) => ApplyFilter();
+    partial void OnFilterTextChanged(string value) => ApplyFilter();
     partial void OnSelectedFilterChanged(string value) => ApplyFilter();
 
     [RelayCommand]
@@ -173,11 +173,11 @@ public sealed partial class ServicesViewModel : ViewModelBase
     {
         var filtered = _allServices.AsEnumerable();
 
-        if (!string.IsNullOrWhiteSpace(Filter))
+        if (!string.IsNullOrWhiteSpace(FilterText))
             filtered = filtered.Where(s =>
-                s.DisplayName.Contains(Filter, StringComparison.OrdinalIgnoreCase) ||
-                s.Name.Contains(Filter, StringComparison.OrdinalIgnoreCase) ||
-                s.Description.Contains(Filter, StringComparison.OrdinalIgnoreCase));
+                s.DisplayName.Contains(FilterText, StringComparison.OrdinalIgnoreCase) ||
+                s.Name.Contains(FilterText, StringComparison.OrdinalIgnoreCase) ||
+                s.Description.Contains(FilterText, StringComparison.OrdinalIgnoreCase));
 
         filtered = SelectedFilter switch
         {

--- a/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
@@ -94,6 +94,7 @@ public sealed partial class SystemHealthViewModel : ViewModelBase
             Disks.ReplaceWith(snap.Disks);
             Summary = $"OS {snap.Os.Caption}  —  CPU {snap.Cpu.Name} ({snap.Cpu.Cores}c/{snap.Cpu.LogicalProcessors}t)  —  RAM {snap.Memory.UsedGB:0.0}/{snap.Memory.TotalGB:0.0} GB  —  Disks {snap.Disks.Count}";
             StatusMessage = $"Scan at {snap.CapturedAt:HH:mm:ss}";
+            ToastService.Instance.Show("System Health scan complete", $"{snap.Disks.Count} disks, {snap.Memory.Modules.Count} RAM modules");
             Log.Information("System health scan completed");
             await RefreshDrivesAsync();
         }

--- a/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
@@ -42,7 +42,7 @@ public sealed partial class UninstallerViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void RelaunchElevated()
+    private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
             System.Windows.Application.Current?.Shutdown();

--- a/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
@@ -40,7 +40,7 @@ public sealed partial class WindowsFeaturesViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void RelaunchElevated()
+    private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
             System.Windows.Application.Current?.Shutdown();

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -31,7 +31,7 @@
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -20,7 +20,7 @@
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,48,0,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RequestElevationCommand}"
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -29,7 +29,7 @@
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -182,7 +182,7 @@
 
                     <TextBlock Text="Search" Style="{StaticResource Subtle}" VerticalAlignment="Center" Margin="0,0,8,0"/>
                     <Grid Width="280">
-                        <TextBox x:Name="SearchBox" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                        <TextBox x:Name="SearchBox" Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
                                  ToolTip="Filters by message, provider, or event ID"/>
                         <TextBlock Text="Filter by message, source, or event ID…"
                                    Foreground="{DynamicResource TextMuted}" FontSize="12"

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -30,7 +30,7 @@
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -30,7 +30,7 @@
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
@@ -63,7 +63,7 @@
                     <StackPanel Orientation="Horizontal">
                         <Button Content="Refresh" Command="{Binding RefreshCommand}"
                                 Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
-                        <TextBox Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged}"
+                        <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
                                  Width="240" VerticalContentAlignment="Center"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Right">

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -31,7 +31,7 @@
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -68,7 +68,7 @@
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchElevatedCommand}"
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"


### PR DESCRIPTION
## Summary
- **ContextMenuService**: replace 4 runtime `Regex.Match/Replace` calls with `[GeneratedRegex]` — compile-time source generation, better perf, AOT-ready
- **Naming standardization**: all admin relaunch methods unified to `RelaunchAsAdmin` (was mixed: `RelaunchElevated` in 5 VMs, `RequestElevation` in Dashboard)
- **Naming standardization**: filter properties unified to `FilterText` everywhere (LogsViewModel was `SearchText`, ServicesViewModel was `Filter`)
- **ConsoleViewModel**: removed dead optimization branch — the clear-and-rebuild path required 1250+ excess lines which never happens (lines append one at a time)
- **Missing toasts**: added completion notifications to System Health scan and App Alerts "Show Installed"
- Updated tests to match renamed properties

## Test plan
- [ ] Build: 0 errors on both projects
- [ ] Services tab: filter textbox still works
- [ ] System Logs tab: search textbox still works
- [ ] All tabs with "Run as administrator" button: still triggers UAC correctly
- [ ] Context Menu tab: entries still show friendly names (regex patterns work)
- [ ] System Health: toast shows after scan
- [ ] App Alerts: toast shows after "Show Installed"
