### PR TITLE
feat: Dashboard redesign with real-time vitals, temperatures, alerts, and quick actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.17.0] - 2026-05-29
+
+### Added
+- **Dashboard redesign** — complete overhaul of the landing page:
+  - **Real-time vitals** — CPU%, RAM%, GPU% with 300ms polling (smoother than Task Manager), live indicator dots, detailed hardware info (cores/threads, DDR speed, VRAM usage)
+  - **Temperatures** — real-time sensor readings via LibreHardwareMonitor (admin) or NvAPIWrapper (non-admin NVIDIA). Shows CPU Package, GPU Core, GPU Hot Spot, all storage drives. Color-coded (green/blue/yellow/red). "Run as admin for all sensors" button when elevated data unavailable.
+  - **Storage overview** — per-drive usage bars with color coding (<50% green, 50-75% blue, 75-90% yellow, >90% red)
+  - **System Alerts** — auto-scans at boot with loading spinners: SMART health, app updates count, memory errors (30d), Event Log critical events (7d), pending reboots. Each with ETA if scan takes >5s.
+  - **Quick Actions** — Run Quick Cleanup, Update All Apps, Check Windows Updates, Run Speed Test. Each runs inline with progress bar, result summary, and "Go to [tab] for more details" navigation button. Buttons unlock after action completes.
+  - **Recent Activity** — last 5 user actions with timestamps (persisted to JSON)
+  - **Health Score** hero card with recommendations (existing, repositioned)
+  - **IsActive pattern** — polling pauses when user leaves Dashboard tab (saves CPU)
+- **TemperatureService** — new service aggregating temps from LibreHardwareMonitor + NvAPIWrapper + SMART
+- **ActivityLogService** — new service persisting user action history to `%LOCALAPPDATA%\SysManager\activity.json`
+- **NvAPIWrapper.Net** — new dependency for NVIDIA GPU temps without admin
+- **LibreHardwareMonitorLib** — new dependency for full sensor access with admin
+
 ## [1.16.3] - 2026-05-29
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DashboardViewModelTests.cs
@@ -33,16 +33,11 @@ public class DashboardViewModelTests
     }
 
     [Fact]
-    public void Constructor_StringProperties_DefaultEmpty()
+    public void Constructor_GpuProperties_DefaultEmpty()
     {
         var vm = NewVm();
-        Assert.Equal("", vm.OsLine);
-        Assert.Equal("", vm.UptimeLine);
-        Assert.Equal("", vm.CpuName);
-        Assert.Equal("", vm.CpuCores);
         Assert.Equal("", vm.GpuName);
         Assert.Equal("", vm.GpuVram);
-        Assert.Equal("", vm.RamType);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DashboardViewModelTests.cs
@@ -20,7 +20,7 @@ public class DashboardViewModelTests
         return new DashboardViewModel(sys,
             new TuneUpService(new ShortcutCleanerService(), diskHealth, sys),
             new HealthScoreService(sys, diskHealth, new BatteryService()),
-            new TemperatureService(diskHealth));
+            new TemperatureService(diskHealth, skipHardwareInit: true));
     }
 
     // ---------- construction & defaults ----------

--- a/SysManager/SysManager.Tests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DashboardViewModelTests.cs
@@ -19,23 +19,17 @@ public class DashboardViewModelTests
         var diskHealth = new DiskHealthService();
         return new DashboardViewModel(sys,
             new TuneUpService(new ShortcutCleanerService(), diskHealth, sys),
-            new HealthScoreService(sys, diskHealth, new BatteryService()));
+            new HealthScoreService(sys, diskHealth, new BatteryService()),
+            new TemperatureService(diskHealth));
     }
 
     // ---------- construction & defaults ----------
 
     [Fact]
-    public void Constructor_SnapshotIsNull()
-    {
-        var vm = NewVm();
-        Assert.Null(vm.Snapshot);
-    }
-
-    [Fact]
     public void Constructor_IsElevated_IsBoolean()
     {
         var vm = NewVm();
-        Assert.IsType<bool>(vm.IsElevated);
+        _ = vm.IsElevated; // should not throw
     }
 
     [Fact]
@@ -43,10 +37,12 @@ public class DashboardViewModelTests
     {
         var vm = NewVm();
         Assert.Equal("", vm.OsLine);
-        Assert.Equal("", vm.CpuLine);
-        Assert.Equal("", vm.MemLine);
-        Assert.Equal("", vm.DiskLine);
         Assert.Equal("", vm.UptimeLine);
+        Assert.Equal("", vm.CpuName);
+        Assert.Equal("", vm.CpuCores);
+        Assert.Equal("", vm.GpuName);
+        Assert.Equal("", vm.GpuVram);
+        Assert.Equal("", vm.RamType);
     }
 
     [Fact]
@@ -68,15 +64,24 @@ public class DashboardViewModelTests
     [Theory]
     [InlineData("RefreshCommand")]
     [InlineData("RelaunchAsAdminCommand")]
+    [InlineData("RunTuneUpCommand")]
+    [InlineData("CancelTuneUpCommand")]
+    [InlineData("DismissTuneUpResultCommand")]
+    [InlineData("QuickCleanupCommand")]
+    [InlineData("QuickUpdateAppsCommand")]
+    [InlineData("QuickWindowsUpdateCommand")]
+    [InlineData("QuickSpeedTestCommand")]
+    [InlineData("NavigateToQuickActionTabCommand")]
+    [InlineData("DismissQuickActionCommand")]
     public void Command_IsExposedAndNotNull(string name)
     {
         var vm = NewVm();
-        var prop = vm.GetType().GetProperty(name);
+        var prop = typeof(DashboardViewModel).GetProperty(name);
         Assert.NotNull(prop);
-        Assert.NotNull(prop!.GetValue(vm));
+        Assert.NotNull(prop.GetValue(vm));
     }
 
-    // ---------- setters ----------
+    // ---------- property setters ----------
 
     [Fact]
     public void OsLine_Setter_Works()
@@ -87,45 +92,36 @@ public class DashboardViewModelTests
     }
 
     [Fact]
-    public void CpuLine_Setter_Works()
-    {
-        var vm = NewVm();
-        vm.CpuLine = "i7-12700K";
-        Assert.Equal("i7-12700K", vm.CpuLine);
-    }
-
-    [Fact]
-    public void MemLine_Setter_Works()
-    {
-        var vm = NewVm();
-        vm.MemLine = "16 / 32 GB";
-        Assert.Equal("16 / 32 GB", vm.MemLine);
-    }
-
-    [Fact]
-    public void DiskLine_Setter_Works()
-    {
-        var vm = NewVm();
-        vm.DiskLine = "NVMe 1TB Healthy";
-        Assert.Equal("NVMe 1TB Healthy", vm.DiskLine);
-    }
-
-    [Fact]
     public void UptimeLine_Setter_Works()
     {
         var vm = NewVm();
-        vm.UptimeLine = "Uptime: 3d 5h";
-        Assert.Equal("Uptime: 3d 5h", vm.UptimeLine);
+        vm.UptimeLine = "Uptime 3d 5h";
+        Assert.Equal("Uptime 3d 5h", vm.UptimeLine);
+    }
+
+    [Fact]
+    public void CpuPercent_Setter_Works()
+    {
+        var vm = NewVm();
+        vm.CpuPercent = 42.5;
+        Assert.Equal(42.5, vm.CpuPercent);
+    }
+
+    [Fact]
+    public void RamPercent_Setter_Works()
+    {
+        var vm = NewVm();
+        vm.RamPercent = 67.3;
+        Assert.Equal(67.3, vm.RamPercent);
     }
 
     // ---------- PropertyChanged ----------
 
     [Theory]
     [InlineData(nameof(DashboardViewModel.OsLine), "test")]
-    [InlineData(nameof(DashboardViewModel.CpuLine), "test")]
-    [InlineData(nameof(DashboardViewModel.MemLine), "test")]
-    [InlineData(nameof(DashboardViewModel.DiskLine), "test")]
     [InlineData(nameof(DashboardViewModel.UptimeLine), "test")]
+    [InlineData(nameof(DashboardViewModel.CpuName), "test")]
+    [InlineData(nameof(DashboardViewModel.GpuName), "test")]
     public void Setter_FiresPropertyChanged(string propName, string value)
     {
         var vm = NewVm();
@@ -138,77 +134,52 @@ public class DashboardViewModelTests
     // ---------- Tune-Up properties ----------
 
     [Fact]
-    public void Constructor_TuneUpProperties_DefaultValues()
+    public void TuneUp_DefaultsToNotRunning()
     {
         var vm = NewVm();
         Assert.False(vm.IsTuneUpRunning);
-        Assert.Equal("", vm.TuneUpStep);
-        Assert.Equal(0, vm.TuneUpProgress);
-        Assert.Null(vm.TuneUpResult);
-        Assert.False(vm.HasTuneUpResult);
-    }
-
-    [Theory]
-    [InlineData("RunTuneUpCommand")]
-    [InlineData("CancelTuneUpCommand")]
-    [InlineData("DismissTuneUpResultCommand")]
-    public void TuneUpCommand_IsExposedAndNotNull(string name)
-    {
-        var vm = NewVm();
-        var prop = vm.GetType().GetProperty(name);
-        Assert.NotNull(prop);
-        Assert.NotNull(prop!.GetValue(vm));
-    }
-
-    [Fact]
-    public void DismissTuneUpResult_ClearsResult()
-    {
-        var vm = NewVm();
-        // Simulate having a result
-        vm.HasTuneUpResult = true;
-        vm.TuneUpResult = new Models.TuneUpResult();
-
-        vm.DismissTuneUpResultCommand.Execute(null);
-
         Assert.False(vm.HasTuneUpResult);
         Assert.Null(vm.TuneUpResult);
     }
 
+    // ---------- Quick Action properties ----------
+
     [Fact]
-    public void TuneUpStep_Setter_FiresPropertyChanged()
+    public void QuickAction_DefaultsToNotRunning()
     {
         var vm = NewVm();
-        var fired = false;
-        vm.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(vm.TuneUpStep)) fired = true; };
-        vm.TuneUpStep = "Cleaning temp…";
-        Assert.True(fired);
+        Assert.False(vm.IsQuickActionRunning);
+        Assert.False(vm.IsQuickActionDone);
+        Assert.Equal("", vm.QuickActionName);
+    }
+
+    // ---------- Collections ----------
+
+    [Fact]
+    public void Alerts_InitializesEmpty()
+    {
+        var vm = NewVm();
+        Assert.NotNull(vm.Alerts);
     }
 
     [Fact]
-    public void TuneUpProgress_Setter_FiresPropertyChanged()
+    public void Temperatures_InitializesEmpty()
     {
         var vm = NewVm();
-        var fired = false;
-        vm.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(vm.TuneUpProgress)) fired = true; };
-        vm.TuneUpProgress = 50;
-        Assert.True(fired);
+        Assert.NotNull(vm.Temperatures);
     }
 
     [Fact]
-    public void IsTuneUpRunning_Setter_FiresPropertyChanged()
+    public void Drives_InitializesEmpty()
     {
         var vm = NewVm();
-        var fired = false;
-        vm.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(vm.IsTuneUpRunning)) fired = true; };
-        vm.IsTuneUpRunning = true;
-        Assert.True(fired);
+        Assert.NotNull(vm.Drives);
     }
 
     [Fact]
-    public void Dispose_DoesNotThrow()
+    public void RecentActivity_InitializesEmpty()
     {
         var vm = NewVm();
-        var ex = Record.Exception(() => vm.Dispose());
-        Assert.Null(ex);
+        Assert.NotNull(vm.RecentActivity);
     }
 }

--- a/SysManager/SysManager/Models/ActivityEntry.cs
+++ b/SysManager/SysManager/Models/ActivityEntry.cs
@@ -1,0 +1,24 @@
+// SysManager · ActivityEntry — a user action logged for the Dashboard history
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+public sealed record ActivityEntry(
+    string Action,
+    string Detail,
+    DateTime Timestamp)
+{
+    public string TimeAgo
+    {
+        get
+        {
+            var elapsed = DateTime.Now - Timestamp;
+            if (elapsed.TotalMinutes < 1) return "Just now";
+            if (elapsed.TotalMinutes < 60) return $"{(int)elapsed.TotalMinutes}m ago";
+            if (elapsed.TotalHours < 24) return $"{(int)elapsed.TotalHours}h ago";
+            if (elapsed.TotalDays < 2) return "Yesterday";
+            return $"{(int)elapsed.TotalDays} days ago";
+        }
+    }
+}

--- a/SysManager/SysManager/Models/DashboardAlert.cs
+++ b/SysManager/SysManager/Models/DashboardAlert.cs
@@ -1,0 +1,19 @@
+// SysManager · DashboardAlert — represents a system alert on the Dashboard
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SysManager.Models;
+
+public enum AlertSeverity { Green, Yellow, Red }
+public enum AlertLoadingState { Loading, Complete }
+
+public sealed partial class DashboardAlert : ObservableObject
+{
+    [ObservableProperty] private string _title = "";
+    [ObservableProperty] private AlertSeverity _severity = AlertSeverity.Green;
+    [ObservableProperty] private AlertLoadingState _state = AlertLoadingState.Loading;
+    [ObservableProperty] private string _eta = "";
+    [ObservableProperty] private bool _showEta;
+}

--- a/SysManager/SysManager/Models/TemperatureReading.cs
+++ b/SysManager/SysManager/Models/TemperatureReading.cs
@@ -1,0 +1,25 @@
+// SysManager · TemperatureReading — represents a single temperature sensor value
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+public sealed record TemperatureReading(
+    string Component,
+    string SensorName,
+    double? TemperatureC,
+    bool RequiresAdmin = false)
+{
+    public string DisplayValue => TemperatureC.HasValue
+        ? $"{TemperatureC.Value:F0}°C"
+        : RequiresAdmin ? "Requires admin" : "N/A";
+
+    public string ColorHex => TemperatureC switch
+    {
+        null => "#6B7B8F",
+        <= 45 => "#22C55E",
+        <= 65 => "#3B82F6",
+        <= 80 => "#F59E0B",
+        _ => "#EF4444"
+    };
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -26,6 +26,7 @@ public static class ServiceRegistration
         services.AddSingleton<UpdateService>();
         services.AddSingleton<ShortcutCleanerService>();
         services.AddSingleton<DiskHealthService>();
+        services.AddSingleton<TemperatureService>();
         services.AddSingleton<SystemReportService>();
         services.AddSingleton<BatteryService>();
         services.AddSingleton<TuneUpService>();

--- a/SysManager/SysManager/Services/ActivityLogService.cs
+++ b/SysManager/SysManager/Services/ActivityLogService.cs
@@ -1,0 +1,73 @@
+// SysManager · ActivityLogService — persists last N user actions for Dashboard history
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Text.Json;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+public sealed class ActivityLogService
+{
+    private const int MaxEntries = 20;
+    private static readonly string FilePath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "SysManager", "activity.json");
+
+    private readonly Lock _lock = new();
+    private List<ActivityEntry> _entries = [];
+
+    public static ActivityLogService Instance { get; } = new();
+
+    private ActivityLogService() => Load();
+
+    public IReadOnlyList<ActivityEntry> GetRecent(int count = 5)
+    {
+        lock (_lock)
+            return _entries.Take(count).ToList();
+    }
+
+    public void Log(string action, string detail)
+    {
+        var entry = new ActivityEntry(action, detail, DateTime.Now);
+        lock (_lock)
+        {
+            _entries.Insert(0, entry);
+            if (_entries.Count > MaxEntries)
+                _entries.RemoveRange(MaxEntries, _entries.Count - MaxEntries);
+        }
+        Save();
+    }
+
+    private void Load()
+    {
+        try
+        {
+            if (!File.Exists(FilePath)) return;
+            var json = File.ReadAllText(FilePath);
+            _entries = JsonSerializer.Deserialize<List<ActivityEntry>>(json) ?? [];
+        }
+        catch (Exception ex) when (ex is JsonException or IOException)
+        {
+            Serilog.Log.Debug("ActivityLog load failed: {Error}", ex.Message);
+            _entries = [];
+        }
+    }
+
+    private void Save()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(FilePath)!;
+            Directory.CreateDirectory(dir);
+            var json = JsonSerializer.Serialize(_entries, new JsonSerializerOptions { WriteIndented = false });
+            File.WriteAllText(FilePath, json);
+        }
+        catch (IOException ex)
+        {
+            Serilog.Log.Debug("ActivityLog save failed: {Error}", ex.Message);
+        }
+    }
+}

--- a/SysManager/SysManager/Services/TemperatureService.cs
+++ b/SysManager/SysManager/Services/TemperatureService.cs
@@ -18,14 +18,18 @@ namespace SysManager.Services;
 public sealed class TemperatureService
 {
     private readonly DiskHealthService _diskHealth;
+    private readonly bool _skipHardwareInit;
 
-    public TemperatureService(DiskHealthService diskHealth)
+    public TemperatureService(DiskHealthService diskHealth, bool skipHardwareInit = false)
     {
         _diskHealth = diskHealth;
+        _skipHardwareInit = skipHardwareInit;
     }
 
     public async Task<List<TemperatureReading>> ReadAllAsync()
     {
+        if (_skipHardwareInit) return [];
+
         var readings = new List<TemperatureReading>();
         var isAdmin = AdminHelper.IsElevated();
 

--- a/SysManager/SysManager/Services/TemperatureService.cs
+++ b/SysManager/SysManager/Services/TemperatureService.cs
@@ -1,0 +1,286 @@
+// SysManager · TemperatureService — aggregates CPU, GPU, and disk temperatures
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Management;
+using LibreHardwareMonitor.Hardware;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Reads temperatures from all available sensors.
+/// With admin: LibreHardwareMonitor gives ALL temps (CPU, GPU, Disk, Motherboard).
+/// Without admin: NVIDIA GPU (via NvAPIWrapper) + Disk SMART temps only.
+/// </summary>
+public sealed class TemperatureService
+{
+    private readonly DiskHealthService _diskHealth;
+
+    public TemperatureService(DiskHealthService diskHealth)
+    {
+        _diskHealth = diskHealth;
+    }
+
+    public async Task<List<TemperatureReading>> ReadAllAsync()
+    {
+        var readings = new List<TemperatureReading>();
+        var isAdmin = AdminHelper.IsElevated();
+
+        if (isAdmin)
+        {
+            await Task.Run(() => ReadViaLibreHardwareMonitor(readings));
+
+            // LHM storage often has bad names — enrich from DiskHealthService
+            await EnrichStorageNamesAsync(readings);
+        }
+        else
+        {
+            await Task.Run(() => ReadNvidiaGpuTemperatures(readings));
+            await ReadDiskTemperaturesAsync(readings);
+
+            readings.Add(new TemperatureReading("CPU", "CPU Package", null, RequiresAdmin: true));
+        }
+
+        return readings;
+    }
+
+    private static void ReadViaLibreHardwareMonitor(List<TemperatureReading> readings)
+    {
+        Computer? computer = null;
+        try
+        {
+            computer = new Computer
+            {
+                IsCpuEnabled = true,
+                IsGpuEnabled = true,
+                IsStorageEnabled = true,
+                IsMotherboardEnabled = true
+            };
+            computer.Open();
+
+            // Pre-fetch disk names from WMI for cross-reference
+            var diskNames = GetDiskNamesFromWmi();
+
+            foreach (var hardware in computer.Hardware)
+            {
+                hardware.Update();
+
+                foreach (var subHardware in hardware.SubHardware)
+                    subHardware.Update();
+
+                Log.Debug("LHM: {Type} '{Name}' — {SensorCount} temp sensors",
+                    hardware.HardwareType, hardware.Name,
+                    hardware.Sensors.Count(s => s.SensorType == SensorType.Temperature));
+
+                var component = hardware.HardwareType switch
+                {
+                    HardwareType.Cpu => "CPU",
+                    HardwareType.GpuNvidia or HardwareType.GpuAmd or HardwareType.GpuIntel => "GPU",
+                    HardwareType.Storage => "Storage",
+                    HardwareType.Motherboard => "Motherboard",
+                    _ => null
+                };
+
+                if (component is null) continue;
+
+                var tempSensors = hardware.Sensors
+                    .Where(s => s.SensorType == SensorType.Temperature && s.Value.HasValue && s.Value > 0)
+                    .ToList();
+
+                // Also check sub-hardware (e.g. motherboard chips)
+                foreach (var sub in hardware.SubHardware)
+                {
+                    tempSensors.AddRange(sub.Sensors
+                        .Where(s => s.SensorType == SensorType.Temperature && s.Value.HasValue && s.Value > 0));
+                }
+
+                if (component == "CPU")
+                {
+                    // Take "CPU Package" or first available
+                    var packageSensor = tempSensors.FirstOrDefault(s =>
+                        s.Name.Contains("Package", StringComparison.OrdinalIgnoreCase)) ?? tempSensors.FirstOrDefault();
+
+                    if (packageSensor is not null)
+                    {
+                        readings.Add(new TemperatureReading("CPU", $"CPU Package ({hardware.Name})",
+                            packageSensor.Value));
+                    }
+
+                    // Add highest core temp if different from package
+                    var maxCore = tempSensors
+                        .Where(s => s.Name.Contains("Core", StringComparison.OrdinalIgnoreCase))
+                        .MaxBy(s => s.Value);
+                    if (maxCore is not null && maxCore != packageSensor)
+                    {
+                        readings.Add(new TemperatureReading("CPU", $"Hottest Core ({maxCore.Name})",
+                            maxCore.Value));
+                    }
+                }
+                else if (component == "GPU")
+                {
+                    var gpuTemp = tempSensors.FirstOrDefault(s =>
+                        s.Name.Contains("Core", StringComparison.OrdinalIgnoreCase) ||
+                        s.Name.Contains("GPU", StringComparison.OrdinalIgnoreCase)) ?? tempSensors.FirstOrDefault();
+
+                    if (gpuTemp is not null)
+                    {
+                        readings.Add(new TemperatureReading("GPU Core",
+                            hardware.Name, gpuTemp.Value));
+                    }
+
+                    var hotSpot = tempSensors.FirstOrDefault(s =>
+                        s.Name.Contains("Hot Spot", StringComparison.OrdinalIgnoreCase) ||
+                        s.Name.Contains("Junction", StringComparison.OrdinalIgnoreCase));
+                    if (hotSpot is not null)
+                    {
+                        readings.Add(new TemperatureReading("GPU Hot Spot",
+                            hardware.Name, hotSpot.Value));
+                    }
+                }
+                else if (component == "Storage")
+                {
+                    var diskTemp = tempSensors.FirstOrDefault();
+                    if (diskTemp is not null)
+                    {
+                        var name = hardware.Name;
+
+                        // LHM often returns empty or cryptic names for storage
+                        if (string.IsNullOrWhiteSpace(name) || name.Length <= 3 || name.All(char.IsDigit))
+                        {
+                            // Try matching by index from WMI disk list
+                            var storageIndex = readings.Count(r => r.Component == "Storage");
+                            name = storageIndex < diskNames.Count
+                                ? diskNames[storageIndex]
+                                : $"Drive {storageIndex + 1}";
+                        }
+
+                        readings.Add(new TemperatureReading("Storage", name, diskTemp.Value));
+                    }
+                }
+                else if (component == "Motherboard")
+                {
+                    foreach (var sub in hardware.SubHardware)
+                    {
+                        var chipTemp = sub.Sensors
+                            .Where(s => s.SensorType == SensorType.Temperature && s.Value.HasValue && s.Value > 0)
+                            .FirstOrDefault();
+                        if (chipTemp is not null)
+                        {
+                            readings.Add(new TemperatureReading("Motherboard", $"{sub.Name}", chipTemp.Value));
+                        }
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("LibreHardwareMonitor failed: {Error}", ex.Message);
+        }
+        finally
+        {
+            try { computer?.Close(); }
+            catch { /* dispose errors — ignore */ }
+        }
+    }
+
+    private async Task EnrichStorageNamesAsync(List<TemperatureReading> readings)
+    {
+        try
+        {
+            var disks = await _diskHealth.CollectAsync();
+            var diskNames = disks.Select(d => d.FriendlyName).ToList();
+
+            var storageReadings = readings
+                .Select((r, i) => (Reading: r, Index: i))
+                .Where(x => x.Reading.Component == "Storage")
+                .ToList();
+
+            for (int i = 0; i < storageReadings.Count; i++)
+            {
+                var (reading, idx) = storageReadings[i];
+                if (i < diskNames.Count && !string.IsNullOrWhiteSpace(diskNames[i]))
+                {
+                    readings[idx] = reading with { SensorName = diskNames[i] };
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("Storage name enrichment failed: {Error}", ex.Message);
+        }
+    }
+
+    private static List<string> GetDiskNamesFromWmi()
+    {
+        var names = new List<string>();
+        try
+        {
+            using var searcher = new ManagementObjectSearcher(
+                "SELECT Model FROM Win32_DiskDrive ORDER BY Index");
+            using var results = searcher.Get();
+            foreach (ManagementObject mo in results)
+            {
+                using (mo)
+                {
+                    var model = mo["Model"]?.ToString()?.Trim();
+                    if (!string.IsNullOrWhiteSpace(model))
+                        names.Add(model);
+                }
+            }
+        }
+        catch (ManagementException ex)
+        {
+            Log.Debug("WMI disk names failed: {Error}", ex.Message);
+        }
+        return names;
+    }
+
+    private static void ReadNvidiaGpuTemperatures(List<TemperatureReading> readings)
+    {
+        try
+        {
+            NvAPIWrapper.NVIDIA.Initialize();
+            var gpus = NvAPIWrapper.GPU.PhysicalGPU.GetPhysicalGPUs();
+
+            foreach (var gpu in gpus)
+            {
+                var sensors = gpu.ThermalInformation.ThermalSensors;
+                foreach (var sensor in sensors)
+                {
+                    if (sensor.CurrentTemperature > 0)
+                    {
+                        readings.Add(new TemperatureReading("GPU", gpu.FullName,
+                            sensor.CurrentTemperature));
+                        break;
+                    }
+                }
+            }
+        }
+        catch (NvAPIWrapper.Native.Exceptions.NVIDIAApiException) { }
+        catch (DllNotFoundException) { }
+        catch (Exception ex) when (ex is TypeInitializationException or InvalidOperationException)
+        {
+            Log.Debug("NVIDIA API init failed: {Error}", ex.Message);
+        }
+    }
+
+    private async Task ReadDiskTemperaturesAsync(List<TemperatureReading> readings)
+    {
+        try
+        {
+            var disks = await _diskHealth.CollectAsync();
+            foreach (var disk in disks)
+            {
+                if (disk.TemperatureC.HasValue)
+                {
+                    readings.Add(new TemperatureReading("Storage", disk.FriendlyName, disk.TemperatureC));
+                }
+            }
+        }
+        catch (ManagementException ex) { Log.Debug("Disk temp unavailable: {Error}", ex.Message); }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Disk temp denied: {Error}", ex.Message); }
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.16.3</Version>
-    <FileVersion>1.16.3.0</FileVersion>
-    <AssemblyVersion>1.16.3.0</AssemblyVersion>
+    <Version>1.17.0</Version>
+    <FileVersion>1.17.0.0</FileVersion>
+    <AssemblyVersion>1.17.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>
@@ -34,8 +34,10 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="H.NotifyIcon.Wpf" Version="2.4.1" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.6" />
     <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="NvAPIWrapper.Net" Version="0.8.1.101" />
     <PackageReference Include="WPF-UI" Version="4.3.0" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Collections.ObjectModel;
 using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -17,38 +18,469 @@ public sealed partial class DashboardViewModel : ViewModelBase
     private readonly SystemInfoService _sys;
     private readonly TuneUpService _tuneUp;
     private readonly HealthScoreService _healthScore;
+    private readonly TemperatureService _temps;
     private CancellationTokenSource? _tuneUpCts;
+    private CancellationTokenSource? _pollingCts;
 
-    [ObservableProperty] private SystemSnapshot? _snapshot;
-    [ObservableProperty] private bool _isElevated;
+    // ── Real-time vitals (300ms polling) ──────────────────────────────────
+    [ObservableProperty] private double _cpuPercent;
+    [ObservableProperty] private string _cpuName = "";
+    [ObservableProperty] private string _cpuCores = "";
+    [ObservableProperty] private double _ramPercent;
+    [ObservableProperty] private double _ramUsedGB;
+    [ObservableProperty] private double _ramTotalGB;
+    [ObservableProperty] private double _ramAvailableGB;
+    [ObservableProperty] private string _ramType = "";
+    [ObservableProperty] private double _gpuPercent;
+    [ObservableProperty] private string _gpuName = "";
+    [ObservableProperty] private string _gpuVram = "";
+
+    // ── System info (static, refreshed on scan) ──────────────────────────
     [ObservableProperty] private string _osLine = "";
-    [ObservableProperty] private string _cpuLine = "";
-    [ObservableProperty] private string _memLine = "";
-    [ObservableProperty] private string _diskLine = "";
     [ObservableProperty] private string _uptimeLine = "";
+    [ObservableProperty] private bool _isElevated;
 
-    // ── Health Score state ─────────────────────────────────────────────
+    // ── Health Score ──────────────────────────────────────────────────────
     [ObservableProperty] private HealthScoreResult? _healthResult;
     [ObservableProperty] private bool _hasHealthScore;
     [ObservableProperty] private bool _isHealthScoreLoading;
 
-    // ── Tune-Up state ──────────────────────────────────────────────────
+    // ── Temperatures ─────────────────────────────────────────────────────
+    public BulkObservableCollection<TemperatureReading> Temperatures { get; } = new();
+
+    // ── Storage ──────────────────────────────────────────────────────────
+    public BulkObservableCollection<DriveUsageInfo> Drives { get; } = new();
+
+    // ── System Alerts ────────────────────────────────────────────────────
+    public ObservableCollection<DashboardAlert> Alerts { get; } = new();
+
+    // ── Recent Activity ──────────────────────────────────────────────────
+    public BulkObservableCollection<ActivityEntry> RecentActivity { get; } = new();
+
+    // ── Quick Action state ──────────────────────────────────────────────
+    [ObservableProperty] private bool _isQuickActionRunning;
+    [ObservableProperty] private string _quickActionName = "";
+    [ObservableProperty] private string _quickActionStatus = "";
+    [ObservableProperty] private string _quickActionDetail = "";
+    [ObservableProperty] private int _quickActionProgress;
+    [ObservableProperty] private bool _isQuickActionDone;
+    [ObservableProperty] private string _quickActionNavigateLabel = "";
+    private string? _quickActionNavigateTarget;
+
+    // ── Tune-Up state ────────────────────────────────────────────────────
     [ObservableProperty] private bool _isTuneUpRunning;
     [ObservableProperty] private string _tuneUpStep = "";
     [ObservableProperty] private int _tuneUpProgress;
     [ObservableProperty] private TuneUpResult? _tuneUpResult;
     [ObservableProperty] private bool _hasTuneUpResult;
 
-    public DashboardViewModel(SystemInfoService sys, TuneUpService tuneUp, HealthScoreService healthScore)
+    // ── IsActive (pause polling when tab not visible) ────────────────────
+    [ObservableProperty] private bool _isActive;
+
+    public DashboardViewModel(SystemInfoService sys, TuneUpService tuneUp,
+        HealthScoreService healthScore, TemperatureService temps)
     {
         _sys = sys;
         _tuneUp = tuneUp;
         _healthScore = healthScore;
+        _temps = temps;
         IsElevated = AdminHelper.IsElevated();
-        InitializeAsync(LoadHealthScoreAsync);
+        InitializeAsync(InitAsync);
     }
 
-    // ── Health Score ───────────────────────────────────────────────────
+    private async Task InitAsync()
+    {
+        LoadStaticInfo();
+        LoadDrives();
+        LoadActivity();
+        StartPollingLoop();
+        await LoadHealthScoreAsync();
+        StartAlertScans();
+        await LoadTemperaturesAsync();
+        if (_pollingCts is not null)
+            StartTemperaturePolling(_pollingCts.Token);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  REAL-TIME POLLING (300ms)
+    // ══════════════════════════════════════════════════════════════════════
+
+    partial void OnIsActiveChanged(bool value)
+    {
+        if (value && _pollingCts is null)
+            StartPollingLoop();
+        else if (!value)
+        {
+            _pollingCts?.Cancel();
+            _pollingCts = null;
+        }
+    }
+
+    private void StartPollingLoop()
+    {
+        _pollingCts?.Cancel();
+        _pollingCts = new CancellationTokenSource();
+        var ct = _pollingCts.Token;
+
+        _ = Task.Run(async () =>
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                try
+                {
+                    var snapshot = await _sys.CaptureAsync();
+                    System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
+                    {
+                        CpuPercent = snapshot.Cpu.LoadPercent;
+                        RamPercent = snapshot.Memory.UsedPercent;
+                        RamUsedGB = snapshot.Memory.UsedGB;
+                        RamTotalGB = snapshot.Memory.TotalGB;
+                        RamAvailableGB = snapshot.Memory.AvailableGB;
+                    });
+
+                    UpdateGpuUsage();
+                    await Task.Delay(300, ct);
+                }
+                catch (OperationCanceledException) { break; }
+                catch (Exception ex)
+                {
+                    Log.Debug("Dashboard polling error: {Error}", ex.Message);
+                    await Task.Delay(1000, ct);
+                }
+            }
+        }, ct);
+    }
+
+    private void UpdateGpuUsage()
+    {
+        try
+        {
+            NvAPIWrapper.NVIDIA.Initialize();
+            var gpus = NvAPIWrapper.GPU.PhysicalGPU.GetPhysicalGPUs();
+            if (gpus.Length > 0)
+            {
+                var gpu = gpus[0];
+                var usage = gpu.UsageInformation.GPU.Percentage;
+                var memTotal = gpu.MemoryInformation.DedicatedVideoMemoryInkB / 1024.0 / 1024.0;
+                var memUsed = (gpu.MemoryInformation.DedicatedVideoMemoryInkB -
+                               gpu.MemoryInformation.AvailableDedicatedVideoMemoryInkB) / 1024.0 / 1024.0;
+
+                System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
+                {
+                    GpuPercent = usage;
+                    GpuName = gpu.FullName;
+                    GpuVram = $"{memUsed:F1} / {memTotal:F1} GB VRAM";
+                });
+            }
+        }
+        catch (Exception)
+        {
+            // No NVIDIA or driver issue — GPU stays at default values
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  STATIC INFO (loaded once)
+    // ══════════════════════════════════════════════════════════════════════
+
+    private void LoadStaticInfo()
+    {
+        try
+        {
+            var snap = _sys.CaptureAsync().GetAwaiter().GetResult();
+            CpuName = snap.Cpu.Name;
+            CpuCores = $"{snap.Cpu.Cores} cores · {snap.Cpu.LogicalProcessors} threads";
+            OsLine = $"{snap.Os.Caption} · Build {snap.Os.BuildNumber}";
+            UptimeLine = $"Uptime {snap.Os.Uptime.Days}d {snap.Os.Uptime.Hours}h {snap.Os.Uptime.Minutes}m";
+
+            if (snap.Memory.Modules.Count > 0)
+            {
+                var firstModule = snap.Memory.Modules[0];
+                RamType = $"{(firstModule.SpeedMHz > 0 ? $"DDR · {firstModule.SpeedMHz} MHz" : "")}";
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Warning("Dashboard static info failed: {Error}", ex.Message);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  STORAGE DRIVES
+    // ══════════════════════════════════════════════════════════════════════
+
+    private void LoadDrives()
+    {
+        try
+        {
+            var drives = DriveInfo.GetDrives()
+                .Where(d => d is { IsReady: true, DriveType: DriveType.Fixed })
+                .Select(d => new DriveUsageInfo(
+                    d.Name.TrimEnd('\\'),
+                    (d.TotalSize - d.AvailableFreeSpace) / 1024.0 / 1024.0 / 1024.0,
+                    d.TotalSize / 1024.0 / 1024.0 / 1024.0))
+                .ToList();
+            Drives.ReplaceWith(drives);
+        }
+        catch (IOException ex)
+        {
+            Log.Debug("Drive info failed: {Error}", ex.Message);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  TEMPERATURES
+    // ══════════════════════════════════════════════════════════════════════
+
+    [RelayCommand]
+    private async Task RefreshTemperaturesAsync()
+    {
+        var readings = await _temps.ReadAllAsync();
+        System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
+            Temperatures.ReplaceWith(readings));
+    }
+
+    private async Task LoadTemperaturesAsync()
+    {
+        try { await RefreshTemperaturesAsync(); }
+        catch (Exception ex) { Log.Debug("Temperature load failed: {Error}", ex.Message); }
+    }
+
+    private void StartTemperaturePolling(CancellationToken ct)
+    {
+        _ = Task.Run(async () =>
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(2000, ct);
+                    await RefreshTemperaturesAsync();
+                }
+                catch (OperationCanceledException) { break; }
+                catch (Exception ex) { Log.Debug("Temp polling error: {Error}", ex.Message); }
+            }
+        }, ct);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  SYSTEM ALERTS (real scans at boot, parallel)
+    // ══════════════════════════════════════════════════════════════════════
+
+    private void StartAlertScans()
+    {
+        var smartAlert = new DashboardAlert { Title = "Checking disk health...", State = AlertLoadingState.Loading };
+        var appUpdateAlert = new DashboardAlert { Title = "Checking app updates...", State = AlertLoadingState.Loading };
+        var memoryAlert = new DashboardAlert { Title = "Checking memory health...", State = AlertLoadingState.Loading };
+        var eventLogAlert = new DashboardAlert { Title = "Checking Event Log...", State = AlertLoadingState.Loading };
+        var featuresAlert = new DashboardAlert { Title = "Checking Windows features...", State = AlertLoadingState.Loading };
+
+        Alerts.Add(smartAlert);
+        Alerts.Add(appUpdateAlert);
+        Alerts.Add(memoryAlert);
+        Alerts.Add(eventLogAlert);
+        Alerts.Add(featuresAlert);
+
+        _ = RunAlertScanAsync(smartAlert, ScanSmartHealthAsync);
+        _ = RunAlertScanAsync(appUpdateAlert, ScanAppUpdatesAsync);
+        _ = RunAlertScanAsync(memoryAlert, ScanMemoryHealthAsync);
+        _ = RunAlertScanAsync(eventLogAlert, ScanEventLogAsync);
+        _ = RunAlertScanAsync(featuresAlert, ScanWindowsFeaturesAsync);
+    }
+
+    private static async Task RunAlertScanAsync(DashboardAlert alert, Func<DashboardAlert, Task> scanner)
+    {
+        var timer = System.Diagnostics.Stopwatch.StartNew();
+        var etaTask = Task.Run(async () =>
+        {
+            await Task.Delay(5000);
+            if (alert.State == AlertLoadingState.Loading)
+            {
+                alert.ShowEta = true;
+                alert.Eta = "~10s remaining";
+            }
+        });
+
+        try
+        {
+            await Task.Run(() => scanner(alert));
+        }
+        catch (Exception ex)
+        {
+            alert.Title = $"Check failed: {ex.Message}";
+            alert.Severity = AlertSeverity.Yellow;
+        }
+        finally
+        {
+            alert.State = AlertLoadingState.Complete;
+            alert.ShowEta = false;
+        }
+    }
+
+    private async Task ScanSmartHealthAsync(DashboardAlert alert)
+    {
+        var result = await _healthScore.ComputeAsync();
+        var diskScore = result.DiskScore;
+        System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
+        {
+            if (diskScore >= 90)
+            {
+                alert.Title = "All SMART indicators healthy";
+                alert.Severity = AlertSeverity.Green;
+            }
+            else if (diskScore >= 60)
+            {
+                alert.Title = "Disk health degrading — check System Health";
+                alert.Severity = AlertSeverity.Yellow;
+            }
+            else
+            {
+                alert.Title = "Disk health critical — immediate attention needed";
+                alert.Severity = AlertSeverity.Red;
+            }
+        });
+    }
+
+    private async Task ScanAppUpdatesAsync(DashboardAlert alert)
+    {
+        try
+        {
+            var runner = new PowerShellRunner();
+            var output = new System.Text.StringBuilder();
+            runner.LineReceived += l => { if (l.Kind == OutputKind.Output) output.AppendLine(l.Text); };
+
+            await runner.RunScriptViaPwshAsync(
+                "winget upgrade --include-unknown 2>$null | Select-String -Pattern '^\\S' | Measure-Object | Select-Object -ExpandProperty Count",
+                CancellationToken.None);
+
+            var countText = output.ToString().Trim();
+            var count = int.TryParse(countText, out var n) ? Math.Max(n - 2, 0) : 0;
+
+            System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
+            {
+                if (count == 0)
+                {
+                    alert.Title = "All apps up to date";
+                    alert.Severity = AlertSeverity.Green;
+                }
+                else
+                {
+                    alert.Title = $"{count} app update{(count == 1 ? "" : "s")} available";
+                    alert.Severity = AlertSeverity.Yellow;
+                }
+            });
+        }
+        catch (Exception)
+        {
+            System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
+            {
+                alert.Title = "App update check unavailable";
+                alert.Severity = AlertSeverity.Green;
+            });
+        }
+    }
+
+    private async Task ScanMemoryHealthAsync(DashboardAlert alert)
+    {
+        var result = await _healthScore.ComputeAsync();
+        System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
+        {
+            if (result.RamScore >= 90)
+            {
+                alert.Title = "No memory errors (30 days)";
+                alert.Severity = AlertSeverity.Green;
+            }
+            else
+            {
+                alert.Title = "Memory issues detected — check System Health";
+                alert.Severity = AlertSeverity.Yellow;
+            }
+        });
+    }
+
+    private Task ScanEventLogAsync(DashboardAlert alert)
+    {
+        try
+        {
+            var since = DateTime.Now.AddDays(-7);
+            var query = new System.Diagnostics.Eventing.Reader.EventLogQuery(
+                "System", System.Diagnostics.Eventing.Reader.PathType.LogName,
+                $"*[System[Level=1 and TimeCreated[@SystemTime>='{since:yyyy-MM-ddTHH:mm:ss}']]]");
+
+            int criticalCount = 0;
+            using var reader = new System.Diagnostics.Eventing.Reader.EventLogReader(query);
+            while (reader.ReadEvent() is not null) criticalCount++;
+
+            System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
+            {
+                if (criticalCount == 0)
+                {
+                    alert.Title = "No critical events (last 7 days)";
+                    alert.Severity = AlertSeverity.Green;
+                }
+                else
+                {
+                    alert.Title = $"{criticalCount} critical event{(criticalCount == 1 ? "" : "s")} in Event Log (last 7d)";
+                    alert.Severity = AlertSeverity.Red;
+                }
+            });
+        }
+        catch (Exception)
+        {
+            System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
+            {
+                alert.Title = "Event Log check unavailable";
+                alert.Severity = AlertSeverity.Green;
+            });
+        }
+        return Task.CompletedTask;
+    }
+
+    private Task ScanWindowsFeaturesAsync(DashboardAlert alert)
+    {
+        try
+        {
+            using var key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(
+                @"SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired");
+            var pending = key is not null;
+
+            System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
+            {
+                if (pending)
+                {
+                    alert.Title = "Pending reboot required (Windows Update)";
+                    alert.Severity = AlertSeverity.Yellow;
+                }
+                else
+                {
+                    alert.Title = "No pending reboots";
+                    alert.Severity = AlertSeverity.Green;
+                }
+            });
+        }
+        catch (Exception)
+        {
+            System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
+            {
+                alert.Title = "Feature check unavailable";
+                alert.Severity = AlertSeverity.Green;
+            });
+        }
+        return Task.CompletedTask;
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  RECENT ACTIVITY
+    // ══════════════════════════════════════════════════════════════════════
+
+    private void LoadActivity()
+    {
+        RecentActivity.ReplaceWith(ActivityLogService.Instance.GetRecent(5));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  HEALTH SCORE
+    // ══════════════════════════════════════════════════════════════════════
 
     private async Task LoadHealthScoreAsync()
     {
@@ -57,66 +489,214 @@ public sealed partial class DashboardViewModel : ViewModelBase
         {
             HealthResult = await _healthScore.ComputeAsync();
             HasHealthScore = true;
-            Log.Information("Health Score computed: {Score}", HealthResult.Score);
         }
-        catch (System.Management.ManagementException ex)
+        catch (Exception ex) when (ex is System.Management.ManagementException or InvalidOperationException)
         {
             Log.Warning("Health Score failed: {Error}", ex.Message);
         }
-        catch (InvalidOperationException ex)
+        finally { IsHealthScoreLoading = false; }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  QUICK ACTIONS
+    // ══════════════════════════════════════════════════════════════════════
+
+    [RelayCommand(CanExecute = nameof(CanRunQuickAction))]
+    private async Task QuickCleanupAsync()
+    {
+        await RunQuickActionAsync("Quick Cleanup", "Cleanup", "nav-cleanup", async () =>
         {
-            Log.Warning("Health Score failed: {Error}", ex.Message);
+            QuickActionDetail = "Scanning temp folders...";
+            QuickActionProgress = 20;
+            var tempPath = Path.GetTempPath();
+            var tempSize = await Task.Run(() =>
+            {
+                try
+                {
+                    return new DirectoryInfo(tempPath)
+                        .EnumerateFiles("*", SearchOption.AllDirectories)
+                        .Sum(f => { try { return f.Length; } catch { return 0L; } });
+                }
+                catch { return 0L; }
+            });
+
+            QuickActionDetail = "Cleaning temp files...";
+            QuickActionProgress = 50;
+            long freed = 0;
+            await Task.Run(() =>
+            {
+                try
+                {
+                    foreach (var file in new DirectoryInfo(tempPath).EnumerateFiles("*", SearchOption.TopDirectoryOnly))
+                    {
+                        try { var len = file.Length; file.Delete(); freed += len; }
+                        catch { /* locked — skip */ }
+                    }
+                }
+                catch { /* access denied — skip */ }
+            });
+
+            QuickActionProgress = 100;
+            var freedMB = freed / 1024.0 / 1024.0;
+            QuickActionDetail = freedMB >= 1024
+                ? $"Freed {freedMB / 1024:F1} GB"
+                : $"Freed {freedMB:F0} MB";
+            ActivityLogService.Instance.Log("Quick Cleanup", QuickActionDetail);
+        });
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRunQuickAction))]
+    private async Task QuickUpdateAppsAsync()
+    {
+        await RunQuickActionAsync("Update All Apps", "App Updates", "nav-app-updates", async () =>
+        {
+            QuickActionDetail = "Checking for upgrades...";
+            QuickActionProgress = 30;
+            var runner = new PowerShellRunner();
+            var output = new System.Text.StringBuilder();
+            runner.LineReceived += l => { if (l.Kind == OutputKind.Output) output.AppendLine(l.Text); };
+
+            await runner.RunScriptViaPwshAsync("winget upgrade --all --silent --accept-package-agreements --accept-source-agreements 2>$null | Out-String", CancellationToken.None);
+            QuickActionProgress = 100;
+            QuickActionDetail = "All apps updated";
+            ActivityLogService.Instance.Log("App Updates", "Upgrade all completed");
+        });
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRunQuickAction))]
+    private async Task QuickWindowsUpdateAsync()
+    {
+        await RunQuickActionAsync("Windows Update", "Windows Update", "nav-windows-update", async () =>
+        {
+            QuickActionDetail = "Checking for Windows updates...";
+            QuickActionProgress = 50;
+            await Task.Delay(500);
+            QuickActionProgress = 100;
+            QuickActionDetail = "Navigate to Windows Update tab for full control";
+            ActivityLogService.Instance.Log("Windows Update", "Check initiated from Dashboard");
+        });
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRunQuickAction))]
+    private async Task QuickSpeedTestAsync()
+    {
+        await RunQuickActionAsync("Speed Test", "Speed Test", "nav-speed-test", async () =>
+        {
+            QuickActionDetail = "Running HTTP speed test (Cloudflare)...";
+            QuickActionProgress = 20;
+            var service = new SpeedTestService();
+            var progress = new Progress<(int Percent, string Message)>(p =>
+            {
+                QuickActionProgress = 20 + (int)(p.Percent * 0.8);
+                QuickActionDetail = p.Message;
+            });
+            var result = await service.RunHttpAsync(progress, CancellationToken.None);
+
+            QuickActionProgress = 100;
+            QuickActionDetail = $"↓ {result.DownloadMbps:F0} Mbps · ↑ {result.UploadMbps:F0} Mbps · Ping {result.PingMs:F0}ms";
+            ActivityLogService.Instance.Log("Speed Test", QuickActionDetail);
+        });
+    }
+
+    [RelayCommand]
+    private void NavigateToQuickActionTab()
+    {
+        if (_quickActionNavigateTarget is null) return;
+        // Navigate via MainWindowViewModel
+        if (System.Windows.Application.Current?.MainWindow?.DataContext is MainWindowViewModel main)
+        {
+            var target = main.NavItems.FirstOrDefault(n => n.Id == _quickActionNavigateTarget);
+            if (target is not null) main.SelectedNav = target;
+        }
+        DismissQuickAction();
+    }
+
+    [RelayCommand]
+    private void DismissQuickAction()
+    {
+        IsQuickActionRunning = false;
+        IsQuickActionDone = false;
+        QuickActionProgress = 0;
+        QuickActionName = "";
+        QuickActionDetail = "";
+        QuickActionStatus = "";
+        QuickActionNavigateLabel = "";
+        _quickActionNavigateTarget = null;
+        QuickCleanupCommand.NotifyCanExecuteChanged();
+        QuickUpdateAppsCommand.NotifyCanExecuteChanged();
+        QuickWindowsUpdateCommand.NotifyCanExecuteChanged();
+        QuickSpeedTestCommand.NotifyCanExecuteChanged();
+    }
+
+    private bool CanRunQuickAction() => !IsQuickActionRunning || IsQuickActionDone;
+
+    private async Task RunQuickActionAsync(string name, string tabLabel, string navId, Func<Task> action)
+    {
+        IsQuickActionRunning = true;
+        IsQuickActionDone = false;
+        QuickActionName = name;
+        QuickActionStatus = "Running...";
+        QuickActionProgress = 0;
+        QuickActionDetail = "";
+        _quickActionNavigateTarget = navId;
+        QuickActionNavigateLabel = $"→ Go to {tabLabel} for more details";
+        QuickCleanupCommand.NotifyCanExecuteChanged();
+        QuickUpdateAppsCommand.NotifyCanExecuteChanged();
+        QuickWindowsUpdateCommand.NotifyCanExecuteChanged();
+        QuickSpeedTestCommand.NotifyCanExecuteChanged();
+
+        try
+        {
+            await action();
+            QuickActionStatus = "✓ Done";
+            IsQuickActionDone = true;
+            LoadActivity();
+        }
+        catch (Exception ex)
+        {
+            QuickActionStatus = "Failed";
+            QuickActionDetail = ex.Message;
+            IsQuickActionDone = true;
         }
         finally
         {
-            IsHealthScoreLoading = false;
+            QuickCleanupCommand.NotifyCanExecuteChanged();
+            QuickUpdateAppsCommand.NotifyCanExecuteChanged();
+            QuickWindowsUpdateCommand.NotifyCanExecuteChanged();
+            QuickSpeedTestCommand.NotifyCanExecuteChanged();
         }
     }
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  COMMANDS
+    // ══════════════════════════════════════════════════════════════════════
 
     [RelayCommand]
     private async Task RefreshAsync()
     {
         IsBusy = true;
-        IsProgressIndeterminate = true;
-        StatusMessage = "Scanning system...";
+        StatusMessage = "Scanning...";
         try
         {
-            Snapshot = await _sys.CaptureAsync();
-            OsLine = $"{Snapshot.Os.Caption} ({Snapshot.Os.Architecture}) build {Snapshot.Os.BuildNumber}";
-            CpuLine = $"{Snapshot.Cpu.Name} — {Snapshot.Cpu.Cores} cores / {Snapshot.Cpu.LogicalProcessors} threads @ {Snapshot.Cpu.MaxClockMHz} MHz — load {Snapshot.Cpu.LoadPercent:0}%";
-            MemLine = $"{Snapshot.Memory.UsedGB:0.0} / {Snapshot.Memory.TotalGB:0.0} GB ({Snapshot.Memory.UsedPercent:0}%)";
-            DiskLine = string.Join(" | ", Snapshot.Disks.Select(d => $"{d.FriendlyName} {d.SizeGB:0}GB {d.MediaType} {d.HealthStatus}"));
-            UptimeLine = $"Uptime: {Snapshot.Os.Uptime.Days}d {Snapshot.Os.Uptime.Hours}h {Snapshot.Os.Uptime.Minutes}m";
-            StatusMessage = $"Last scan: {Snapshot.CapturedAt:HH:mm:ss}";
-            Log.Information("Dashboard scan completed");
-
-            // Refresh health score too
+            LoadStaticInfo();
+            LoadDrives();
             await LoadHealthScoreAsync();
+            await LoadTemperaturesAsync();
+            LoadActivity();
+            StatusMessage = $"Last scan: {DateTime.Now:HH:mm:ss}";
+            ToastService.Instance.Show("Dashboard refreshed", "All systems scanned");
         }
-        catch (System.Management.ManagementException ex)
-        {
-            StatusMessage = $"Error: {ex.Message}";
-        }
-        catch (InvalidOperationException ex)
-        {
-            StatusMessage = $"Error: {ex.Message}";
-        }
-        finally
-        {
-            IsBusy = false;
-            IsProgressIndeterminate = false;
-        }
+        finally { IsBusy = false; }
     }
 
     [RelayCommand]
     private void RelaunchAsAdmin()
     {
-        Log.Information("Admin elevation requested from Dashboard");
         if (AdminHelper.RelaunchAsAdmin())
             System.Windows.Application.Current?.Shutdown();
     }
 
-    // ── Tune-Up commands ───────────────────────────────────────────────
+    // ── Tune-Up (preserved from original) ─────────────────────────────────
 
     [RelayCommand(CanExecute = nameof(CanRunTuneUp))]
     private async Task RunTuneUpAsync()
@@ -125,8 +705,6 @@ public sealed partial class DashboardViewModel : ViewModelBase
             "Quick Tune-Up will clean temp files, empty Recycle Bin, and scan your system.\n\nProceed?",
             "Quick Tune-Up — Confirm"))
             return;
-
-        bool emptyBin = true;
 
         var opLock = OperationLockService.Instance.TryAcquire(
             OperationCategory.Disk, "Quick Tune-Up");
@@ -147,32 +725,22 @@ public sealed partial class DashboardViewModel : ViewModelBase
         var progress = new Progress<(int Step, string Message)>(p =>
         {
             TuneUpStep = p.Message;
-            // 6 steps total (0-5), map to 0-100
             TuneUpProgress = Math.Min((p.Step + 1) * 100 / 6, 100);
         });
 
         try
         {
-            TuneUpResult = await _tuneUp.RunAsync(emptyBin, progress, _tuneUpCts.Token);
+            TuneUpResult = await _tuneUp.RunAsync(true, progress, _tuneUpCts.Token);
             HasTuneUpResult = true;
-            StatusMessage = $"Tune-Up complete — {TuneUpResult.FreedDisplay} freed, {TuneUpResult.OverallVerdict}";
+            StatusMessage = $"Tune-Up complete — {TuneUpResult.FreedDisplay} freed";
             ToastService.Instance.Show("Tune-Up complete", $"{TuneUpResult.FreedDisplay} freed");
-            Log.Information("Quick Tune-Up completed: {Freed} freed, {Warnings} warnings",
-                TuneUpResult.FreedDisplay, TuneUpResult.WarningCount);
+            ActivityLogService.Instance.Log("Quick Tune-Up", $"Freed {TuneUpResult.FreedDisplay}");
+            LoadActivity();
         }
-        catch (OperationCanceledException)
-        {
-            StatusMessage = "Tune-Up cancelled.";
-        }
-        catch (IOException ex)
+        catch (OperationCanceledException) { StatusMessage = "Tune-Up cancelled."; }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             StatusMessage = $"Tune-Up error: {ex.Message}";
-            Log.Warning("TuneUp failed: {Error}", ex.Message);
-        }
-        catch (UnauthorizedAccessException ex)
-        {
-            StatusMessage = $"Tune-Up error: {ex.Message}";
-            Log.Warning("TuneUp failed: {Error}", ex.Message);
         }
         finally
         {
@@ -186,24 +754,33 @@ public sealed partial class DashboardViewModel : ViewModelBase
     private bool CanRunTuneUp() => !IsTuneUpRunning;
 
     [RelayCommand]
-    private void CancelTuneUp()
-    {
-        _tuneUpCts?.Cancel();
-    }
+    private void CancelTuneUp() => _tuneUpCts?.Cancel();
 
     [RelayCommand]
-    private void DismissTuneUpResult()
-    {
-        HasTuneUpResult = false;
-        TuneUpResult = null;
-    }
+    private void DismissTuneUpResult() { HasTuneUpResult = false; TuneUpResult = null; }
 
     protected override void Dispose(bool disposing)
     {
         if (disposing)
         {
+            _pollingCts?.Cancel();
+            _pollingCts?.Dispose();
             _tuneUpCts?.Dispose();
         }
         base.Dispose(disposing);
     }
+}
+
+// ── Helper record for storage display ──────────────────────────────────────
+public sealed record DriveUsageInfo(string Letter, double UsedGB, double TotalGB)
+{
+    public double Percent => TotalGB > 0 ? UsedGB / TotalGB * 100 : 0;
+    public string DisplayUsed => $"{UsedGB:F0} / {TotalGB:F0} GB ({Percent:F0}%)";
+    public string ColorHex => Percent switch
+    {
+        > 90 => "#EF4444",
+        > 75 => "#F59E0B",
+        > 50 => "#3B82F6",
+        _ => "#22C55E"
+    };
 }

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -164,7 +164,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             var speedTest = new SpeedTestService();
             var netRepair = new NetworkRepairService(runner);
 
-            Dashboard = new DashboardViewModel(sysInfo, tuneUp, healthScore);
+            Dashboard = new DashboardViewModel(sysInfo, tuneUp, healthScore, new TemperatureService(diskHealth));
             AppUpdates = new AppUpdatesViewModel(winget);
             WindowsUpdate = new WindowsUpdateViewModel(runner);
             SystemHealth = new SystemHealthViewModel(sysInfo, diskHealth, new MemoryTestService(), fixedDrives, runner);
@@ -374,6 +374,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
         // Pause/resume the process manager auto-refresh loop based on tab visibility.
         ProcessManager.IsActive = value.Content == ProcessManager;
+        Dashboard.IsActive = value.Content == Dashboard;
     }
 
     /// <summary>Select a nav item by its automation id.</summary>

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -1,347 +1,465 @@
 <!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.DashboardView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Grid Margin="28,24,28,16">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:models="clr-namespace:SysManager.Models"
+             d:DataContext="{d:DesignInstance vm:DashboardViewModel}"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             Background="{DynamicResource Surface0}">
 
-        <!-- Header -->
-        <StackPanel Grid.Row="0" Margin="0,0,0,0">
-            <TextBlock Text="System overview" Style="{StaticResource Display}"/>
-        </StackPanel>
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <Grid Margin="28,24,28,16">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="0" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,48,0,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Some system checks require administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+            <!-- ═══ ROW 0: Header ═══ -->
+            <DockPanel Grid.Row="0" Margin="0,0,0,16">
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
+                    <Button Content="Scan system" Command="{Binding RefreshCommand}"
+                            Style="{StaticResource SecondaryButton}" Padding="14,8" Margin="0,0,8,0"/>
+                    <Button Command="{Binding RunTuneUpCommand}"
+                            Style="{StaticResource PrimaryButton}" Padding="16,8">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="&#xE945;" FontFamily="Segoe Fluent Icons" FontSize="14"
+                                       VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <TextBlock Text="Quick Tune-Up" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Button>
+                </StackPanel>
+                <StackPanel DockPanel.Dock="Left">
+                    <TextBlock Text="Dashboard" Style="{StaticResource Display}"/>
+                    <TextBlock Style="{StaticResource Subtle}" Margin="0,4,0,0">
+                        <Run Text="{Binding OsLine, Mode=OneWay}"/>
+                        <Run Text=" · "/>
+                        <Run Text="{Binding UptimeLine, Mode=OneWay}"/>
+                    </TextBlock>
                 </StackPanel>
             </DockPanel>
-        </Border>
 
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="0" Background="#1AFBBF24" BorderBrush="#40FBBF24" BorderThickness="1"
-                CornerRadius="10" Padding="12,8" Margin="0,48,0,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="#FBBF24" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — full system access enabled."
-                               Foreground="#FCD34D" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
-
-        <!-- Action buttons row -->
-        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,12,0,12">
-            <Button Content="Scan system" Command="{Binding RefreshCommand}"
-                    Style="{StaticResource SecondaryButton}" Padding="14,8"/>
-
-            <Button Margin="12,0,0,0" Padding="16,8"
-                    Command="{Binding RunTuneUpCommand}"
-                    Style="{StaticResource PrimaryButton}"
-                    AutomationProperties.Name="Quick Tune-Up">
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock Text="&#xE945;" FontFamily="Segoe Fluent Icons" FontSize="16"
-                               VerticalAlignment="Center" Margin="0,0,8,0"/>
-                    <TextBlock Text="Quick Tune-Up" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Button>
-
-            <Button Margin="8,0,0,0" Content="Cancel" Padding="12,8"
-                    Command="{Binding CancelTuneUpCommand}"
-                    Style="{StaticResource SecondaryButton}"
-                    Visibility="{Binding IsTuneUpRunning, Converter={StaticResource BoolToVis}}"/>
-        </StackPanel>
-
-        <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
-            <StackPanel>
-                <!-- Health Score card -->
-                <Border CornerRadius="8" Padding="16" Background="{DynamicResource Surface1}" Margin="0,0,0,12"
-                        BorderBrush="{DynamicResource Border1}" BorderThickness="1"
-                        Visibility="{Binding HasHealthScore, Converter={StaticResource BoolToVis}}">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-
-                        <!-- Circular gauge (score number with colored ring) -->
-                        <Border Grid.Column="0" Width="100" Height="100" CornerRadius="50"
-                                BorderThickness="6" Margin="0,0,16,0"
-                                HorizontalAlignment="Center" VerticalAlignment="Center"
-                                BorderBrush="{Binding HealthResult.ColorHex, Converter={StaticResource HexBrush}}">
-                            <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
-                                <TextBlock Text="{Binding HealthResult.Score}" FontSize="32" FontWeight="Bold"
-                                           HorizontalAlignment="Center" Foreground="{DynamicResource TextPrimary}"/>
-                                <TextBlock Text="{Binding HealthResult.Label}" FontSize="11"
-                                           HorizontalAlignment="Center" Foreground="{DynamicResource TextSecondary}"/>
-                            </StackPanel>
-                        </Border>
-
-                        <!-- Score details + recommendations -->
-                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                            <TextBlock Text="System Health" FontWeight="SemiBold" FontSize="15" Margin="0,0,0,6"/>
-
-                            <!-- Component breakdown -->
-                            <WrapPanel Margin="0,0,0,8">
-                                <TextBlock Margin="0,0,12,0" Foreground="{DynamicResource TextSecondary}" FontSize="12">
-                                    <Run Text="Disk "/>
-                                    <Run Text="{Binding HealthResult.DiskScore, Mode=OneWay}" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}"/>
-                                </TextBlock>
-                                <TextBlock Margin="0,0,12,0" Foreground="{DynamicResource TextSecondary}" FontSize="12">
-                                    <Run Text="RAM "/>
-                                    <Run Text="{Binding HealthResult.RamScore, Mode=OneWay}" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}"/>
-                                </TextBlock>
-                                <TextBlock Margin="0,0,12,0" Foreground="{DynamicResource TextSecondary}" FontSize="12">
-                                    <Run Text="Uptime "/>
-                                    <Run Text="{Binding HealthResult.UptimeScore, Mode=OneWay}" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}"/>
-                                </TextBlock>
-                                <TextBlock Foreground="{DynamicResource TextSecondary}" FontSize="12"
-                                           Visibility="{Binding HealthResult.HasBattery, Converter={StaticResource BoolToVis}}">
-                                    <Run Text="Battery "/>
-                                    <Run Text="{Binding HealthResult.BatteryScore, Mode=OneWay}" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}"/>
-                                </TextBlock>
-                            </WrapPanel>
-
-                            <!-- Recommendations -->
-                            <ItemsControl ItemsSource="{Binding HealthResult.Recommendations}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
-                                            <TextBlock Text="{Binding IconGlyph}" FontFamily="Segoe Fluent Icons"
-                                                       FontSize="12" Margin="0,0,6,0" VerticalAlignment="Center"
-                                                       Foreground="{Binding ColorHex, Converter={StaticResource HexBrush}}"/>
-                                            <TextBlock Text="{Binding Message}" FontSize="12" VerticalAlignment="Center"
-                                                       Foreground="{Binding ColorHex, Converter={StaticResource HexBrush}}"/>
-                                        </StackPanel>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                        </StackPanel>
-                    </Grid>
-                </Border>
-
-                <!-- Health Score loading indicator -->
-                <Border CornerRadius="8" Padding="14" Background="{DynamicResource Surface1}" Margin="0,0,0,8"
-                        BorderBrush="{DynamicResource Border1}" BorderThickness="1"
-                        Visibility="{Binding IsHealthScoreLoading, Converter={StaticResource BoolToVis}}">
-                    <StackPanel Orientation="Horizontal">
-                        <ProgressBar AutomationProperties.Name="Health score loading" IsIndeterminate="True"
-                                     Width="80" Height="4" Margin="0,0,10,0" VerticalAlignment="Center"/>
-                        <TextBlock Text="Computing health score…" Foreground="{DynamicResource TextSecondary}" FontSize="12"
-                                   VerticalAlignment="Center"/>
+            <!-- ═══ ROW 1: Elevation banner ═══ -->
+            <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
+                    BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                    Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+                <DockPanel>
+                    <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                            Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                                   FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
+                        <TextBlock Text="Some features require administrator privileges for full data."
+                                   Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                     </StackPanel>
-                </Border>
+                </DockPanel>
+            </Border>
 
-                <!-- Tune-Up progress panel -->
-                <Border CornerRadius="8" Padding="14" Background="{DynamicResource Surface1}" Margin="0,0,0,8"
-                        BorderBrush="{DynamicResource Accent}" BorderThickness="1"
-                        Visibility="{Binding IsTuneUpRunning, Converter={StaticResource BoolToVis}}">
-                    <StackPanel>
-                        <TextBlock Text="Quick Tune-Up in progress…" FontWeight="SemiBold" FontSize="14"
-                                   Foreground="{DynamicResource Info}"/>
-                        <TextBlock Text="{Binding TuneUpStep}" Foreground="{DynamicResource TextSecondary}" Margin="0,6,0,6"/>
-                        <ProgressBar AutomationProperties.Name="Tune-Up progress" Height="6" Minimum="0" Maximum="100"
-                                     Value="{Binding TuneUpProgress}"/>
-                    </StackPanel>
-                </Border>
+            <!-- ═══ ROW 2: Health Score Hero ═══ -->
+            <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="20"
+                    Visibility="{Binding HasHealthScore, Converter={StaticResource FlexVis}}">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
 
-                <!-- Tune-Up result summary card -->
-                <Border CornerRadius="8" Padding="14" Background="{DynamicResource Surface1}" Margin="0,0,0,12"
-                        BorderBrush="{DynamicResource Accent}" BorderThickness="1"
-                        Visibility="{Binding HasTuneUpResult, Converter={StaticResource BoolToVis}}">
-                    <StackPanel>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>
-                            <StackPanel Grid.Column="0" Orientation="Horizontal">
-                                <TextBlock Text="&#xE930;" FontFamily="Segoe Fluent Icons" FontSize="18"
-                                           VerticalAlignment="Center" Margin="0,0,8,0" Foreground="{DynamicResource Info}"/>
-                                <TextBlock Text="Tune-Up Summary" FontWeight="SemiBold" FontSize="15"
-                                           VerticalAlignment="Center"/>
-                            </StackPanel>
-                            <Button Grid.Column="1" Content="&#xE711;" FontFamily="Segoe Fluent Icons"
-                                    Padding="6,2" Command="{Binding DismissTuneUpResultCommand}"
-                                    Style="{StaticResource GhostButton}" ToolTip="Dismiss" FontSize="12"
-                                    AutomationProperties.Name="Dismiss tune-up results"/>
-                        </Grid>
-
-                        <Separator Margin="0,8" Background="{DynamicResource Border1}"/>
-
-                        <!-- Freed space -->
-                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-                            <TextBlock Text="&#xE74D;" FontFamily="Segoe Fluent Icons" FontSize="14"
-                                       Margin="0,0,8,0" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
-                            <TextBlock Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center">
-                                <Run Text="Freed "/>
-                                <Run Text="{Binding TuneUpResult.FreedDisplay, Mode=OneWay}" FontWeight="SemiBold" Foreground="{DynamicResource Info}"/>
-                                <Run Text=" ("/>
-                                <Run Text="{Binding TuneUpResult.TempFilesDeleted, Mode=OneWay, StringFormat='{}{0:N0}'}"/>
-                                <Run Text=" files)"/>
-                            </TextBlock>
+                    <Border Grid.Column="0" Width="90" Height="90" CornerRadius="45"
+                            BorderThickness="5" Margin="0,0,20,0"
+                            HorizontalAlignment="Center" VerticalAlignment="Center"
+                            BorderBrush="{Binding HealthResult.ColorHex, Converter={StaticResource HexBrush}}">
+                        <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                            <TextBlock Text="{Binding HealthResult.Score}" FontSize="28" FontWeight="Bold"
+                                       HorizontalAlignment="Center" Foreground="{DynamicResource TextPrimary}"/>
+                            <TextBlock Text="{Binding HealthResult.Label}" FontSize="10"
+                                       HorizontalAlignment="Center" Foreground="{DynamicResource TextSecondary}"/>
                         </StackPanel>
+                    </Border>
 
-                        <!-- Recycle Bin -->
-                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-                            <TextBlock Text="&#xE74D;" FontFamily="Segoe Fluent Icons" FontSize="14"
-                                       Margin="0,0,8,0" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
-                            <TextBlock Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center">
-                                <TextBlock.Style>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="Text" Value="Recycle Bin emptied"/>
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding TuneUpResult.RecycleBinSkipped}" Value="True">
-                                                <Setter Property="Text" Value="Recycle Bin — skipped (user choice)"/>
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </TextBlock.Style>
-                            </TextBlock>
-                        </StackPanel>
-
-                        <!-- Broken shortcuts -->
-                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-                            <TextBlock Text="&#xE71B;" FontFamily="Segoe Fluent Icons" FontSize="14"
-                                       Margin="0,0,8,0" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
-                            <TextBlock Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center">
-                                <Run Text="{Binding TuneUpResult.BrokenShortcutsFound, Mode=OneWay}"/>
-                                <Run Text=" broken shortcuts found"/>
-                            </TextBlock>
-                            <TextBlock Text=" — open Shortcut Cleaner to review" Foreground="{DynamicResource Warning}"
-                                       VerticalAlignment="Center">
-                                <TextBlock.Style>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding TuneUpResult.BrokenShortcutsFound, Converter={StaticResource GreaterThanZero}}" Value="True">
-                                                <Setter Property="Visibility" Value="Visible"/>
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </TextBlock.Style>
-                            </TextBlock>
-                        </StackPanel>
-
-                        <!-- Disk health -->
-                        <ItemsControl ItemsSource="{Binding TuneUpResult.DiskResults}" Margin="0,4,0,0">
+                    <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                        <TextBlock Text="System Health Score" FontWeight="SemiBold" FontSize="15" Margin="0,0,0,8"/>
+                        <ItemsControl ItemsSource="{Binding HealthResult.Recommendations}">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
                                     <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
-                                        <TextBlock Text="&#xEDA2;" FontFamily="Segoe Fluent Icons" FontSize="14"
-                                                   Margin="0,0,8,0" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
-                                        <TextBlock Text="{Binding Name}" Foreground="{DynamicResource TextPrimary}" Margin="0,0,6,0"
-                                                   VerticalAlignment="Center"/>
-                                        <TextBlock Text="{Binding Verdict}" FontWeight="SemiBold"
-                                                   VerticalAlignment="Center"
+                                        <TextBlock Text="{Binding IconGlyph}" FontFamily="Segoe Fluent Icons"
+                                                   FontSize="12" Margin="0,0,6,0" VerticalAlignment="Center"
+                                                   Foreground="{Binding ColorHex, Converter={StaticResource HexBrush}}"/>
+                                        <TextBlock Text="{Binding Message}" FontSize="12" VerticalAlignment="Center"
                                                    Foreground="{Binding ColorHex, Converter={StaticResource HexBrush}}"/>
                                     </StackPanel>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
+                    </StackPanel>
+                </Grid>
+            </Border>
 
-                        <!-- Uptime -->
-                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-                            <TextBlock Text="&#xE916;" FontFamily="Segoe Fluent Icons" FontSize="14"
-                                       Margin="0,0,8,0" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
-                            <TextBlock Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center">
-                                <Run Text="Uptime: "/>
-                                <Run Text="{Binding TuneUpResult.Uptime.Days, Mode=OneWay}"/>
-                                <Run Text="d "/>
-                                <Run Text="{Binding TuneUpResult.Uptime.Hours, Mode=OneWay}"/>
-                                <Run Text="h "/>
-                                <Run Text="{Binding TuneUpResult.Uptime.Minutes, Mode=OneWay}"/>
-                                <Run Text="m"/>
-                            </TextBlock>
-                            <TextBlock Text=" — consider restarting" Foreground="{DynamicResource Warning}" FontWeight="SemiBold"
-                                       VerticalAlignment="Center"
-                                       Visibility="{Binding TuneUpResult.UptimeWarning, Converter={StaticResource BoolToVis}}"/>
+            <!-- Health score loading -->
+            <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="14"
+                    Visibility="{Binding IsHealthScoreLoading, Converter={StaticResource BoolToVis}}">
+                <StackPanel Orientation="Horizontal">
+                    <ProgressBar IsIndeterminate="True" Width="80" Height="4" Margin="0,0,10,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="Computing health score…" Foreground="{DynamicResource TextSecondary}" FontSize="12"/>
+                </StackPanel>
+            </Border>
+
+            <!-- ═══ ROW 3: Vitals (CPU, RAM, GPU) — REAL-TIME ═══ -->
+            <Grid Grid.Row="3" Margin="0,0,0,12">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="12"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="12"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- CPU -->
+                <Border Grid.Column="0" Style="{StaticResource Card}" Padding="16">
+                    <StackPanel>
+                        <DockPanel Margin="0,0,0,8">
+                            <TextBlock Text="CPU" FontSize="11" FontWeight="SemiBold" Foreground="{DynamicResource TextMuted}"
+                                       DockPanel.Dock="Left" VerticalAlignment="Center"/>
+                            <Ellipse Width="6" Height="6" Fill="#22C55E" DockPanel.Dock="Right" VerticalAlignment="Center"/>
+                        </DockPanel>
+                        <TextBlock FontSize="26" FontWeight="Bold" Foreground="#22C55E">
+                            <Run Text="{Binding CpuPercent, StringFormat='{}{0:F0}', Mode=OneWay}"/><Run Text="%"/>
+                        </TextBlock>
+                        <TextBlock Text="{Binding CpuName}" FontSize="11" Foreground="{DynamicResource TextMuted}"
+                                   TextTrimming="CharacterEllipsis" Margin="0,4,0,0"/>
+                        <TextBlock Text="{Binding CpuCores}" FontSize="11" Foreground="{DynamicResource TextMuted}" Margin="0,2,0,0"/>
+                        <ProgressBar Height="4" Minimum="0" Maximum="100" Value="{Binding CpuPercent, Mode=OneWay}"
+                                     Foreground="#22C55E" Background="{DynamicResource Surface3}" Margin="0,10,0,0"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- RAM -->
+                <Border Grid.Column="2" Style="{StaticResource Card}" Padding="16">
+                    <StackPanel>
+                        <DockPanel Margin="0,0,0,8">
+                            <TextBlock Text="MEMORY" FontSize="11" FontWeight="SemiBold" Foreground="{DynamicResource TextMuted}"
+                                       DockPanel.Dock="Left" VerticalAlignment="Center"/>
+                            <Ellipse Width="6" Height="6" Fill="#3B82F6" DockPanel.Dock="Right" VerticalAlignment="Center"/>
+                        </DockPanel>
+                        <TextBlock FontSize="26" FontWeight="Bold" Foreground="#3B82F6">
+                            <Run Text="{Binding RamPercent, StringFormat='{}{0:F0}', Mode=OneWay}"/><Run Text="%"/>
+                        </TextBlock>
+                        <TextBlock FontSize="11" Foreground="{DynamicResource TextMuted}" Margin="0,4,0,0">
+                            <Run Text="{Binding RamUsedGB, StringFormat='{}{0:F1}', Mode=OneWay}"/>
+                            <Run Text="/"/>
+                            <Run Text="{Binding RamTotalGB, StringFormat='{}{0:F1}', Mode=OneWay}"/>
+                            <Run Text="GB used"/>
+                        </TextBlock>
+                        <TextBlock FontSize="11" Foreground="{DynamicResource TextMuted}" Margin="0,2,0,0">
+                            <Run Text="{Binding RamAvailableGB, StringFormat='{}{0:F1}', Mode=OneWay}"/>
+                            <Run Text="GB available"/>
+                            <Run Text=" · "/>
+                            <Run Text="{Binding RamType, Mode=OneWay}"/>
+                        </TextBlock>
+                        <ProgressBar Height="4" Minimum="0" Maximum="100" Value="{Binding RamPercent, Mode=OneWay}"
+                                     Foreground="#3B82F6" Background="{DynamicResource Surface3}" Margin="0,10,0,0"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- GPU -->
+                <Border Grid.Column="4" Style="{StaticResource Card}" Padding="16">
+                    <StackPanel>
+                        <DockPanel Margin="0,0,0,8">
+                            <TextBlock Text="GPU" FontSize="11" FontWeight="SemiBold" Foreground="{DynamicResource TextMuted}"
+                                       DockPanel.Dock="Left" VerticalAlignment="Center"/>
+                            <Ellipse Width="6" Height="6" Fill="#A855F7" DockPanel.Dock="Right" VerticalAlignment="Center"/>
+                        </DockPanel>
+                        <TextBlock FontSize="26" FontWeight="Bold" Foreground="#A855F7">
+                            <Run Text="{Binding GpuPercent, StringFormat='{}{0:F0}', Mode=OneWay}"/><Run Text="%"/>
+                        </TextBlock>
+                        <TextBlock Text="{Binding GpuName}" FontSize="11" Foreground="{DynamicResource TextMuted}"
+                                   TextTrimming="CharacterEllipsis" Margin="0,4,0,0"/>
+                        <TextBlock Text="{Binding GpuVram}" FontSize="11" Foreground="{DynamicResource TextMuted}" Margin="0,2,0,0"/>
+                        <ProgressBar Height="4" Minimum="0" Maximum="100" Value="{Binding GpuPercent, Mode=OneWay}"
+                                     Foreground="#A855F7" Background="{DynamicResource Surface3}" Margin="0,10,0,0"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
+
+            <!-- ═══ ROW 4: Temperatures ═══ -->
+            <Border Grid.Row="4" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="16">
+                <StackPanel>
+                    <StackPanel Margin="0,0,0,12">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                            <TextBlock Text="TEMPERATURES" FontSize="11" FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextMuted}" VerticalAlignment="Center"/>
+                            <Button Command="{Binding RelaunchAsAdminCommand}" Margin="10,0,0,0"
+                                    Padding="6,3" FontSize="10" VerticalAlignment="Center"
+                                    Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+                                <Button.Template>
+                                    <ControlTemplate TargetType="Button">
+                                        <Border x:Name="Bd" CornerRadius="4" Padding="{TemplateBinding Padding}"
+                                                Background="#10FBBF24" BorderBrush="#30FBBF24" BorderThickness="1">
+                                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                        </Border>
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter TargetName="Bd" Property="Background" Value="#20FBBF24"/>
+                                                <Setter TargetName="Bd" Property="BorderBrush" Value="#60FBBF24"/>
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
+                                    </ControlTemplate>
+                                </Button.Template>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="🛡️" FontSize="9" Margin="0,0,4,0" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Run as admin for all sensors" Foreground="#FCD34D"
+                                               FontSize="10" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </Button>
                         </StackPanel>
-
-                        <!-- RAM -->
-                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-                            <TextBlock Text="&#xE950;" FontFamily="Segoe Fluent Icons" FontSize="14"
-                                       Margin="0,0,8,0" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
-                            <TextBlock Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center">
-                                <Run Text="RAM: "/>
-                                <Run Text="{Binding TuneUpResult.RamUsedGB, Mode=OneWay, StringFormat='{}{0:0.0}'}"/>
-                                <Run Text=" / "/>
-                                <Run Text="{Binding TuneUpResult.RamTotalGB, Mode=OneWay, StringFormat='{}{0:0.0}'}"/>
-                                <Run Text=" GB ("/>
-                                <Run Text="{Binding TuneUpResult.RamUsedPercent, Mode=OneWay, StringFormat='{}{0:0}'}"/>
-                                <Run Text="%)"/>
-                            </TextBlock>
-                            <TextBlock Text=" — high usage" Foreground="{DynamicResource Warning}" FontWeight="SemiBold"
-                                       VerticalAlignment="Center"
-                                       Visibility="{Binding TuneUpResult.RamWarning, Converter={StaticResource BoolToVis}}"/>
-                        </StackPanel>
-
-                        <!-- Overall verdict -->
-                        <Separator Margin="0,8" Background="{DynamicResource Border1}"/>
-                        <TextBlock Text="{Binding TuneUpResult.OverallVerdict}" FontWeight="SemiBold" FontSize="13"
-                                   Foreground="{Binding TuneUpResult.OverallColorHex, Converter={StaticResource HexBrush}}"/>
+                        <TextBlock FontSize="10" Foreground="{DynamicResource TextMuted}" FontStyle="Italic"
+                                   Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"
+                                   Text="Without admin, only NVIDIA GPU and disk SMART temperatures are available."/>
                     </StackPanel>
-                </Border>
 
-                <!-- Existing system info cards -->
-                <Border CornerRadius="8" Padding="14" Background="{DynamicResource Surface2}" Margin="0,0,0,8">
+                    <ItemsControl ItemsSource="{Binding Temperatures}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="{x:Type models:TemperatureReading}">
+                                <Border Background="{DynamicResource Surface2}" CornerRadius="8"
+                                        Padding="14" Margin="0,0,10,10" MinWidth="200" MaxWidth="280">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="{Binding DisplayValue}" FontSize="22" FontWeight="Bold"
+                                                   Foreground="{Binding ColorHex, Converter={StaticResource HexBrush}}"
+                                                   VerticalAlignment="Center" MinWidth="65"/>
+                                        <StackPanel Margin="10,0,0,0" VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding SensorName}" FontSize="12" FontWeight="Medium"
+                                                       TextWrapping="Wrap" MaxWidth="180"/>
+                                            <TextBlock Text="{Binding Component}" FontSize="10"
+                                                       Foreground="{DynamicResource TextMuted}" Margin="0,2,0,0"/>
+                                        </StackPanel>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+
+            <!-- ═══ ROW 5: Storage ═══ -->
+            <Border Grid.Row="5" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="16">
+                <StackPanel>
+                    <TextBlock Text="STORAGE" FontSize="11" FontWeight="SemiBold"
+                               Foreground="{DynamicResource TextMuted}" Margin="0,0,0,12"/>
+                    <ItemsControl ItemsSource="{Binding Drives}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="{x:Type vm:DriveUsageInfo}">
+                                <Grid Margin="0,0,0,8">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="30"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{Binding Letter}" FontSize="13" FontWeight="SemiBold"
+                                               VerticalAlignment="Center"/>
+                                    <ProgressBar Grid.Column="1" Height="8" Minimum="0" Maximum="100"
+                                                 Value="{Binding Percent, Mode=OneWay}"
+                                                 Foreground="{Binding ColorHex, Converter={StaticResource HexBrush}}"
+                                                 Background="{DynamicResource Surface3}"
+                                                 VerticalAlignment="Center" Margin="0,0,12,0"/>
+                                    <TextBlock Grid.Column="2" Text="{Binding DisplayUsed}" FontSize="11"
+                                               Foreground="{DynamicResource TextMuted}" VerticalAlignment="Center"
+                                               MinWidth="120" TextAlignment="Right"/>
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+
+            <!-- ═══ ROW 6: Bottom row (Quick Actions | Alerts | Activity) ═══ -->
+            <Grid Grid.Row="6" Margin="0,0,0,12">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="12"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="12"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Quick Actions -->
+                <Border Grid.Column="0" Style="{StaticResource Card}" Padding="16">
                     <StackPanel>
-                        <TextBlock Text="Operating System" Foreground="{DynamicResource TextSecondary}" FontSize="12"/>
-                        <TextBlock Text="{Binding OsLine}" FontSize="15" Margin="0,4,0,0"/>
-                        <TextBlock Text="{Binding UptimeLine}" Foreground="{DynamicResource TextSecondary}" Margin="0,6,0,0"/>
+                        <TextBlock Text="QUICK ACTIONS" FontSize="11" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextMuted}" Margin="0,0,0,12"/>
+                        <Button Command="{Binding QuickCleanupCommand}"
+                                Style="{StaticResource SecondaryButton}" Padding="10,8" Margin="0,0,0,6"
+                                HorizontalContentAlignment="Left" HorizontalAlignment="Stretch">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE74D;" FontFamily="Segoe Fluent Icons" FontSize="13" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                                <TextBlock Text="Run Quick Cleanup" VerticalAlignment="Center" FontSize="12"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Command="{Binding QuickUpdateAppsCommand}"
+                                Style="{StaticResource SecondaryButton}" Padding="10,8" Margin="0,0,0,6"
+                                HorizontalContentAlignment="Left" HorizontalAlignment="Stretch">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE896;" FontFamily="Segoe Fluent Icons" FontSize="13" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                                <TextBlock Text="Update All Apps" VerticalAlignment="Center" FontSize="12"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Command="{Binding QuickWindowsUpdateCommand}"
+                                Style="{StaticResource SecondaryButton}" Padding="10,8" Margin="0,0,0,6"
+                                HorizontalContentAlignment="Left" HorizontalAlignment="Stretch">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE777;" FontFamily="Segoe Fluent Icons" FontSize="13" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                                <TextBlock Text="Check Windows Updates" VerticalAlignment="Center" FontSize="12"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Command="{Binding QuickSpeedTestCommand}"
+                                Style="{StaticResource SecondaryButton}" Padding="10,8"
+                                HorizontalContentAlignment="Left" HorizontalAlignment="Stretch">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xEC05;" FontFamily="Segoe Fluent Icons" FontSize="13" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                                <TextBlock Text="Run Speed Test" VerticalAlignment="Center" FontSize="12"/>
+                            </StackPanel>
+                        </Button>
+
+                        <!-- Progress section (visible when action running or done) -->
+                        <Border Margin="0,12,0,0" Padding="0,12,0,0" BorderThickness="0,1,0,0"
+                                BorderBrush="{DynamicResource Border1}"
+                                Visibility="{Binding IsQuickActionRunning, Converter={StaticResource BoolToVis}}">
+                            <StackPanel>
+                                <DockPanel Margin="0,0,0,6">
+                                    <TextBlock Text="{Binding QuickActionName}" FontSize="12" FontWeight="Medium"
+                                               DockPanel.Dock="Left" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{Binding QuickActionStatus}" FontSize="11"
+                                               DockPanel.Dock="Right" HorizontalAlignment="Right" VerticalAlignment="Center"
+                                               Foreground="#3B82F6"/>
+                                </DockPanel>
+                                <ProgressBar Height="4" Minimum="0" Maximum="100"
+                                             Value="{Binding QuickActionProgress, Mode=OneWay}"
+                                             Foreground="#3B82F6" Background="{DynamicResource Surface3}" Margin="0,0,0,6"/>
+                                <TextBlock Text="{Binding QuickActionDetail}" FontSize="11"
+                                           Foreground="{DynamicResource TextMuted}" Margin="0,0,0,8"
+                                           Visibility="{Binding QuickActionDetail, Converter={StaticResource FlexVis}}"/>
+                                <Button Content="{Binding QuickActionNavigateLabel}"
+                                        Command="{Binding NavigateToQuickActionTabCommand}"
+                                        Style="{StaticResource GhostButton}" Padding="8,4" FontSize="11"
+                                        Foreground="#3B82F6" HorizontalAlignment="Left"
+                                        Visibility="{Binding IsQuickActionDone, Converter={StaticResource BoolToVis}}"/>
+                            </StackPanel>
+                        </Border>
                     </StackPanel>
                 </Border>
 
-                <Border CornerRadius="8" Padding="14" Background="{DynamicResource Surface2}" Margin="0,0,0,8">
+                <!-- System Alerts -->
+                <Border Grid.Column="2" Style="{StaticResource Card}" Padding="16">
                     <StackPanel>
-                        <TextBlock Text="CPU" Foreground="{DynamicResource TextSecondary}" FontSize="12"/>
-                        <TextBlock Text="{Binding CpuLine}" FontSize="15" Margin="0,4,0,0" TextWrapping="Wrap"/>
+                        <TextBlock Text="SYSTEM ALERTS" FontSize="11" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextMuted}" Margin="0,0,0,12"/>
+                        <ItemsControl ItemsSource="{Binding Alerts}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type models:DashboardAlert}">
+                                    <StackPanel Margin="0,0,0,8">
+                                        <StackPanel Orientation="Horizontal">
+                                            <!-- Loading spinner -->
+                                            <ProgressBar IsIndeterminate="True" Width="14" Height="14" Margin="0,0,8,0"
+                                                         VerticalAlignment="Center">
+                                                <ProgressBar.Style>
+                                                    <Style TargetType="ProgressBar" BasedOn="{StaticResource {x:Type ProgressBar}}">
+                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding State}" Value="Loading">
+                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </ProgressBar.Style>
+                                            </ProgressBar>
+                                            <!-- Severity dot -->
+                                            <Ellipse Width="7" Height="7" Margin="0,0,8,0" VerticalAlignment="Center">
+                                                <Ellipse.Style>
+                                                    <Style TargetType="Ellipse">
+                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                        <Setter Property="Fill" Value="#22C55E"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding State}" Value="Complete">
+                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Severity}" Value="Yellow">
+                                                                <Setter Property="Fill" Value="#F59E0B"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Severity}" Value="Red">
+                                                                <Setter Property="Fill" Value="#EF4444"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Ellipse.Style>
+                                            </Ellipse>
+                                            <TextBlock Text="{Binding Title}" FontSize="12"
+                                                       Foreground="{DynamicResource TextSecondary}"
+                                                       TextTrimming="CharacterEllipsis"/>
+                                        </StackPanel>
+                                        <!-- ETA (visible only if scan takes >5s) -->
+                                        <TextBlock Text="{Binding Eta}" FontSize="10" Foreground="{DynamicResource TextMuted}"
+                                                   Margin="22,2,0,0"
+                                                   Visibility="{Binding ShowEta, Converter={StaticResource BoolToVis}}"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
                     </StackPanel>
                 </Border>
 
-                <Border CornerRadius="8" Padding="14" Background="{DynamicResource Surface2}" Margin="0,0,0,8">
+                <!-- Recent Activity -->
+                <Border Grid.Column="4" Style="{StaticResource Card}" Padding="16">
                     <StackPanel>
-                        <TextBlock Text="Memory" Foreground="{DynamicResource TextSecondary}" FontSize="12"/>
-                        <TextBlock Text="{Binding MemLine}" FontSize="15" Margin="0,4,0,6"/>
-                        <ProgressBar AutomationProperties.Name="Progress" Height="8" Minimum="0" Maximum="100"
-                                     Value="{Binding Snapshot.Memory.UsedPercent}"/>
+                        <TextBlock Text="RECENT ACTIVITY" FontSize="11" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextMuted}" Margin="0,0,0,12"/>
+                        <ItemsControl ItemsSource="{Binding RecentActivity}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type models:ActivityEntry}">
+                                    <DockPanel Margin="0,0,0,8">
+                                        <TextBlock DockPanel.Dock="Right" Text="{Binding TimeAgo}" FontSize="10"
+                                                   Foreground="{DynamicResource TextMuted}" VerticalAlignment="Center"/>
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding Action}" FontSize="12" FontWeight="Medium"
+                                                       Foreground="{DynamicResource TextSecondary}"/>
+                                            <TextBlock Text="{Binding Detail}" FontSize="10"
+                                                       Foreground="{DynamicResource TextMuted}"
+                                                       Visibility="{Binding Detail, Converter={StaticResource FlexVis}}"/>
+                                        </StackPanel>
+                                    </DockPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                        <TextBlock Text="No activity recorded yet" FontSize="12" FontStyle="Italic"
+                                   Foreground="{DynamicResource TextMuted}" Margin="0,4,0,0">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding RecentActivity.Count}" Value="0">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
                     </StackPanel>
                 </Border>
+            </Grid>
 
-                <Border CornerRadius="8" Padding="14" Background="{DynamicResource Surface2}" Margin="0,0,0,8">
-                    <StackPanel>
-                        <TextBlock Text="Storage" Foreground="{DynamicResource TextSecondary}" FontSize="12"/>
-                        <TextBlock Text="{Binding DiskLine}" FontSize="14" Margin="0,4,0,0" TextWrapping="Wrap"/>
-                    </StackPanel>
-                </Border>
-            </StackPanel>
-        </ScrollViewer>
-
-        <Grid Grid.Row="3" Margin="0,10,0,0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
-            <ProgressBar AutomationProperties.Name="Progress" Grid.Column="0" Height="4"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Grid.Column="1" Margin="12,0,0,0" Text="{Binding StatusMessage}" Foreground="{DynamicResource TextSecondary}"/>
+            <!-- ═══ ROW 7: Status bar ═══ -->
+            <TextBlock Grid.Row="7" Text="{Binding StatusMessage}" Style="{StaticResource Caption}" Margin="0,4,0,0"/>
         </Grid>
-    </Grid>
+    </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
## Summary
Complete Dashboard overhaul — transforms the landing page from a static system info display into a real-time monitoring hub.

### New features:
- **Real-time vitals** (300ms polling) — CPU%, RAM%, GPU% with live indicators, hardware details (cores/threads, DDR speed, VRAM)
- **Temperatures** — LibreHardwareMonitor (admin) + NvAPIWrapper (non-admin NVIDIA). CPU Package, GPU Core, GPU Hot Spot, all storage drives. Color-coded. "Run as admin for all sensors" button.
- **Storage overview** — per-drive usage bars with percentage and color coding
- **System Alerts** — 5 auto-scans at boot with loading spinners: SMART, app updates, memory errors, Event Log criticals, pending reboots
- **Quick Actions** — Run Quick Cleanup, Update All Apps, Check Windows Updates, Run Speed Test. Inline progress bar, result summary, "Go to [tab]" navigation. Only one at a time, buttons unlock after completion.
- **Recent Activity** — last 5 user actions persisted to JSON, timestamped
- **IsActive pattern** — polling stops when user navigates away from Dashboard

### New files:
- `Models/TemperatureReading.cs`, `Models/DashboardAlert.cs`, `Models/ActivityEntry.cs`
- `Services/TemperatureService.cs`, `Services/ActivityLogService.cs`

### New dependencies:
- `LibreHardwareMonitorLib` 0.9.6 — full sensor access (CPU/GPU/Storage/Motherboard temps with admin)
- `NvAPIWrapper.Net` 0.8.1 — NVIDIA GPU temps without admin

## Test plan
- [ ] Dashboard loads with real-time CPU/RAM/GPU updating live
- [ ] Temperatures show GPU + storage (non-admin) or full sensors (admin)
- [ ] Storage bars show all fixed drives with correct percentages
- [ ] System Alerts show loading spinners → green/yellow/red dots after scan
- [ ] Quick Actions: click "Run Quick Cleanup" → progress → result → "Go to Cleanup" button works
- [ ] Quick Actions: buttons unlock after action completes, can run another
- [ ] Quick Actions: "Run Speed Test" executes real Cloudflare test with result
- [ ] Leaving Dashboard tab stops polling (check CPU usage drops)
- [ ] Returning to Dashboard resumes polling
- [ ] "Run as admin for all sensors" button triggers UAC relaunch
