### PR TITLE
fix: update ARCHITECTURE.md with new services and Dashboard description

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,7 +53,10 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Info | `DriversViewModel` · `BatteryHealthViewModel` · `LogsViewModel` · `PlaceholderViewModel` (System Report) · `AboutViewModel` |
 | Advanced | `PlaceholderViewModel` (Profile Export/Import · CLI Interface) |
 
-- `DashboardViewModel` — OS / CPU / RAM / disk snapshot + live uptime.
+- `DashboardViewModel` — real-time system vitals (CPU/RAM/GPU at 300ms polling),
+  temperatures (LibreHardwareMonitor + NvAPIWrapper), storage overview, system
+  alerts (auto-scan at boot), quick actions with inline progress, health score,
+  and recent activity log. IsActive pattern pauses polling when tab not visible.
 - `AppUpdatesViewModel` — winget scan and bulk upgrade.
 - `WindowsUpdateViewModel` — PSWindowsUpdate wrapper with auto-check.
 - `SystemHealthViewModel` — SMART, memory diagnostic, multi-drive chkdsk.
@@ -173,6 +176,11 @@ Key services:
 - `SystemReportService` — generates comprehensive system info reports
   (hardware, OS, network, drivers) for export or clipboard.
 - `AppIconService` — downloads and caches application favicons for UI display.
+- `TemperatureService` — aggregates CPU, GPU, and disk temperatures from
+  LibreHardwareMonitor (admin) and NvAPIWrapper (non-admin NVIDIA). Real-time
+  polling with 2s interval.
+- `ActivityLogService` — persists last 20 user actions to JSON file for
+  Dashboard recent activity display.
 - `SafetyDatabase` — curated safety ratings for Windows services.
 - `ThemeService` — runtime theme switching with 12 presets and persistence.
 - `ToastService` — global glass-style toast notifications.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.17.1] - 2026-05-29
+
+### Fixed
+- **Documentation** — ARCHITECTURE.md updated with new TemperatureService, ActivityLogService, and rewritten DashboardViewModel description to reflect v1.17.0 redesign.
+
 ## [1.17.0] - 2026-05-29
 
 ### Added

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.17.0</Version>
-    <FileVersion>1.17.0.0</FileVersion>
-    <AssemblyVersion>1.17.0.0</AssemblyVersion>
+    <Version>1.17.1</Version>
+    <FileVersion>1.17.1.0</FileVersion>
+    <AssemblyVersion>1.17.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary
- Add TemperatureService and ActivityLogService to ARCHITECTURE.md services list
- Rewrite DashboardViewModel description (was "OS/CPU/RAM snapshot + uptime", now reflects full v1.17.0 redesign)
- Version bump to 1.17.1 to trigger fresh winget release (previous 1.17.0 winget PR had validation issues)

## Test plan
- [ ] ARCHITECTURE.md renders correctly
- [ ] Winget PR created automatically after merge
