### PR TITLE
fix: remaining audit findings — performance and visual consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.17.3] - 2026-05-29
+
+### Fixed
+- **Performance** — NetworkSharedState TracerouteHops converted to BulkObservableCollection with ReplaceWith() (eliminates per-hop UI notifications during route updates).
+- **Performance** — ServicesViewModel safety level counts now computed in a single pass instead of 3 separate LINQ queries.
+- **Consistency** — DnsHostsView removed stale `HorizontalGridLinesBrush` property (no visual impact, code cleanliness).
+- **Consistency** — AppBlockerView DataGrid BorderThickness set to 0 matching all other views.
+
 ## [1.17.2] - 2026-05-29
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.17.2</Version>
-    <FileVersion>1.17.2.0</FileVersion>
-    <AssemblyVersion>1.17.2.0</AssemblyVersion>
+    <Version>1.17.3</Version>
+    <FileVersion>1.17.3.0</FileVersion>
+    <AssemblyVersion>1.17.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/NetworkSharedState.cs
+++ b/SysManager/SysManager/ViewModels/NetworkSharedState.cs
@@ -50,7 +50,7 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
     private readonly Dictionary<string, PropertyChangedEventHandler> _targetHandlers = new();
 
     public ObservableCollection<PingTarget> Targets { get; } = new();
-    public ObservableCollection<TracerouteHop> TracerouteHops { get; } = new();
+    public BulkObservableCollection<TracerouteHop> TracerouteHops { get; } = new();
 
     // ── Chart infrastructure ──
     public ObservableCollection<ISeries> LatencySeries { get; } = new();
@@ -470,10 +470,10 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
 
     internal void RefreshHopTable()
     {
-        TracerouteHops.Clear();
-        foreach (var target in Targets.Where(t => LatestRoutes.ContainsKey(t.Host)))
-            foreach (var h in LatestRoutes[target.Host])
-                TracerouteHops.Add(h);
+        var hops = Targets
+            .Where(t => LatestRoutes.ContainsKey(t.Host))
+            .SelectMany(t => LatestRoutes[t.Host]);
+        TracerouteHops.ReplaceWith(hops);
     }
 
     internal void TrimBuffer(BulkObservableCollection<DateTimePoint> buffer)

--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -191,9 +191,19 @@ public sealed partial class ServicesViewModel : ViewModelBase
 
         Services.ReplaceWith(filtered.OrderBy(s => s.DisplayName, StringComparer.OrdinalIgnoreCase));
 
-        SafeCount = _allServices.Count(s => s.SafetyLevel == SafetyLevel.Safe);
-        CautionCount = _allServices.Count(s => s.SafetyLevel == SafetyLevel.Caution);
-        CriticalCount = _allServices.Count(s => s.SafetyLevel == SafetyLevel.Critical);
+        int safe = 0, caution = 0, critical = 0;
+        foreach (var s in _allServices)
+        {
+            switch (s.SafetyLevel)
+            {
+                case SafetyLevel.Safe: safe++; break;
+                case SafetyLevel.Caution: caution++; break;
+                case SafetyLevel.Critical: critical++; break;
+            }
+        }
+        SafeCount = safe;
+        CautionCount = caution;
+        CriticalCount = critical;
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/Views/AppBlockerView.xaml
+++ b/SysManager/SysManager/Views/AppBlockerView.xaml
@@ -79,7 +79,7 @@
                   CanUserAddRows="False" CanUserDeleteRows="False"
                   CanUserResizeColumns="True"
                   HeadersVisibility="Column" GridLinesVisibility="None"
-                  BorderThickness="1" BorderBrush="{DynamicResource Border1}"
+                  BorderThickness="0"
                   Background="Transparent"
                   AutomationProperties.Name="Data table"
                   VirtualizingPanel.IsVirtualizing="True"

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -121,7 +121,6 @@
                           Background="Transparent"
                           AutomationProperties.Name="Data table"
                           Foreground="{DynamicResource TextPrimary}" FontSize="12"
-                          HorizontalGridLinesBrush="#1E293B"
                           SelectionMode="Single" IsReadOnly="False"
                           VirtualizingPanel.IsVirtualizing="True"
                           VirtualizingPanel.VirtualizationMode="Recycling">


### PR DESCRIPTION
## Summary
Final batch of audit findings (Low priority):

- **NetworkSharedState** — `TracerouteHops` converted from `ObservableCollection` to `BulkObservableCollection` with `ReplaceWith()`. Eliminates per-hop UI change notifications during route refreshes.
- **ServicesViewModel** — safety level counts (Safe/Caution/Critical) now computed in a single `foreach` pass instead of 3 separate LINQ `.Count()` queries over 200+ items.
- **DnsHostsView** — removed stale `HorizontalGridLinesBrush="#1E293B"` property (no visual effect since `GridLinesVisibility="None"`).
- **AppBlockerView** — DataGrid `BorderThickness` set to 0, matching all other DataGrids in the app.
- **ConsoleViewModel RemoveAt(0)** — left as-is (O(1) in practice with MaxLines trim of 1 item; no WPF-bindable deque alternative).

## Test plan
- [ ] Traceroute tab: route updates display correctly without flicker
- [ ] Services tab: filter works, safety counts correct
- [ ] DNS & Hosts tab: table displays correctly (no border artifacts)
- [ ] App Blocker tab: DataGrid blends with dark background