### PR TITLE
docs: align CHANGELOG header and csproj version with v1.18.0 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.17.5] - 2026-06-03
+## [1.18.0] - 2026-06-03
 
 ### Fixed
 - **Windows Update install actually works** — replaced PSWindowsUpdate's `Install-WindowsUpdate` with direct calls to the Windows Update Agent COM API (`Microsoft.Update.Session`). PSWindowsUpdate filters out optional driver updates client-side even when the COM API can install them; the new code installs everything WUA reports as available, including drivers, firmware, Defender Definitions, cumulative updates, and feature upgrades.

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.17.5</Version>
-    <FileVersion>1.17.5.0</FileVersion>
-    <AssemblyVersion>1.17.5.0</AssemblyVersion>
+    <Version>1.18.0</Version>
+    <FileVersion>1.18.0.0</FileVersion>
+    <AssemblyVersion>1.18.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Sync CHANGELOG entry header and csproj Version/FileVersion/AssemblyVersion to match the v1.18.0 tag (semantic-release picked minor bump for the feat:, but the entry was authored as 1.17.5).