### PR TITLE
ci: fail release when CHANGELOG entry is missing or empty

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,12 +90,18 @@ jobs:
           $pattern = "(?ms)^## \[$([regex]::Escape($version))\].*?(?=^## \[|\z)"
           $match = [regex]::Match($changelog, $pattern)
           $notesPath = "release-notes.md"
-          if ($match.Success) {
-              $match.Value.Trim() | Out-File -FilePath $notesPath -Encoding utf8
-          } else {
-              "Release $version. See [CHANGELOG.md](CHANGELOG.md) for details." |
-                  Out-File -FilePath $notesPath -Encoding utf8
+          if (-not $match.Success) {
+              # Fail loud: a release with no CHANGELOG entry would otherwise ship a
+              # generic "see CHANGELOG" placeholder. Stop here so the missing entry
+              # is added before the release is published.
+              throw "No CHANGELOG.md entry found for version $version. Add a '## [$version] - <date>' section before releasing."
           }
+          $body = $match.Value.Trim()
+          if ($body -match "(?m)^## \[$([regex]::Escape($version))\].*$\s*\z") {
+              # Header exists but the section is empty (no notes beneath it).
+              throw "CHANGELOG.md entry for version $version is empty. Add release notes under the '## [$version]' header before releasing."
+          }
+          $body | Out-File -FilePath $notesPath -Encoding utf8
           "path=$notesPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Append verification instructions to release notes


### PR DESCRIPTION
## Problem

The release workflow (`release.yml`) extracted release notes by matching a `## [version]` section in `CHANGELOG.md`. When no match was found, it silently fell back to a generic placeholder:

```
Release X. See [CHANGELOG.md](CHANGELOG.md) for details.
```

This shipped placeholder release notes with no signal that anything was wrong. Result: several releases on the repo carry the generic body instead of real notes (e.g. v1.18.3, and the v1.7.9–v1.7.16 range).

## Fix

Replace the silent fallback with two hard failures in the *Extract release notes* step:

- **No matching `## [version]` header** → `throw` (release stops).
- **Header present but section body empty** → `throw` (release stops).

A missing or empty CHANGELOG entry now fails the release loudly, so the entry gets added *before* publishing rather than shipping a placeholder.

## Notes

- `ci:` change — does not trigger a release (Auto-release only fires on `SysManager/SysManager/**` path changes).
- No app code touched.
- Existing releases with generic notes are being backfilled separately.