### PR TITLE
fix: resolve mechanical CodeQL quality alerts in source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.19.1] - 2026-06-05
+
+### Fixed
+- **Code-scanning cleanup (mechanical, no behavior change).** Resolved a batch of low-risk CodeQL quality alerts in hand-written code:
+  - Empty `catch` blocks now log at Debug level (`ContextMenuService` registry-write fallbacks and command-path parse, `App.OnExit` service-provider disposal) or carry an explanatory comment where the caught exception is expected (`DnsHostsViewModel` cancellation on teardown).
+  - `Path.Combine` → `Path.Join` in `ActivityLogService` to avoid silently dropping earlier path segments.
+  - Object `==`/`!=` comparisons made explicit with `ReferenceEquals` where reference identity is intended (`MainWindowViewModel` tab activation, `TemperatureService` core-vs-package sensor check).
+  - Implicit `foreach` filtering/mapping replaced with explicit LINQ (`Where`/`Select`/`FirstOrDefault`) in `TemperatureService`, `FileShredderService`, `HostsFileService`, and `ContextMenuViewModel`.
+  - Removed useless local assignments in `DashboardViewModel` (an unused `Stopwatch`, an unread temp-scan size) while preserving the scans' side effects.
+
 ## [1.19.0] - 2026-06-05
 
 ### Changed

--- a/SysManager/SysManager/App.xaml.cs
+++ b/SysManager/SysManager/App.xaml.cs
@@ -90,7 +90,7 @@ public partial class App : Application
         _pipeCts?.Dispose();
         _trayService?.Dispose();
         try { (Services as IDisposable)?.Dispose(); }
-        catch (ObjectDisposedException) { }
+        catch (ObjectDisposedException ex) { LogService.Logger?.Debug(ex, "Service provider already disposed at exit"); }
         LogService.Shutdown();
         try { _instanceMutex?.ReleaseMutex(); }
         catch (ApplicationException) { /* mutex not owned by this thread */ }

--- a/SysManager/SysManager/Services/ActivityLogService.cs
+++ b/SysManager/SysManager/Services/ActivityLogService.cs
@@ -12,7 +12,7 @@ namespace SysManager.Services;
 public sealed class ActivityLogService
 {
     private const int MaxEntries = 20;
-    private static readonly string FilePath = Path.Combine(
+    private static readonly string FilePath = Path.Join(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "SysManager", "activity.json");
 

--- a/SysManager/SysManager/Services/ContextMenuService.cs
+++ b/SysManager/SysManager/Services/ContextMenuService.cs
@@ -221,8 +221,8 @@ public sealed partial class ContextMenuService
                 return true;
             }
         }
-        catch (SecurityException) { }
-        catch (UnauthorizedAccessException) { }
+        catch (SecurityException ex) { Log.Debug(ex, "Context menu HKLM write blocked (security) — falling back to HKCU"); }
+        catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Context menu HKLM write denied — falling back to HKCU"); }
 
         // Attempt 2: HKCU override (for system-owned entries in HKLM)
         var hkcuPath = @"Software\Classes\" + relativePath;
@@ -439,7 +439,7 @@ public sealed partial class ContextMenuService
                 if (!string.IsNullOrEmpty(exeName) && KnownExeExplanations.TryGetValue(exeName, out var exeExplanation))
                     return exeExplanation;
             }
-            catch (ArgumentException) { }
+            catch (ArgumentException ex) { Log.Debug(ex, "Context menu command path parse failed: {Command}", command); }
         }
 
         return "";

--- a/SysManager/SysManager/Services/FileShredderService.cs
+++ b/SysManager/SysManager/Services/FileShredderService.cs
@@ -197,10 +197,9 @@ public sealed class FileShredderService
             catch (UnauthorizedAccessException) { continue; }
             catch (IOException) { continue; }
 
-            foreach (var sub in subDirs)
+            // Skip junctions/symlinks to avoid following reparse points out of the tree.
+            foreach (var sub in subDirs.Where(s => (s.Attributes & FileAttributes.ReparsePoint) == 0))
             {
-                if ((sub.Attributes & FileAttributes.ReparsePoint) != 0)
-                    continue; // skip junctions/symlinks
                 stack.Push(sub);
             }
         }

--- a/SysManager/SysManager/Services/HostsFileService.cs
+++ b/SysManager/SysManager/Services/HostsFileService.cs
@@ -33,9 +33,8 @@ public sealed partial class HostsFileService
         if (!File.Exists(HostsPath)) return entries;
 
         var lines = await File.ReadAllLinesAsync(HostsPath, ct).ConfigureAwait(false);
-        foreach (string rawLine in lines)
+        foreach (string line in lines.Select(l => l.Trim()))
         {
-            string line = rawLine.Trim();
             if (string.IsNullOrEmpty(line)) continue;
 
             bool isDisabled = false;

--- a/SysManager/SysManager/Services/TemperatureService.cs
+++ b/SysManager/SysManager/Services/TemperatureService.cs
@@ -117,7 +117,7 @@ public sealed class TemperatureService
                     var maxCore = tempSensors
                         .Where(s => s.Name.Contains("Core", StringComparison.OrdinalIgnoreCase))
                         .MaxBy(s => s.Value);
-                    if (maxCore is not null && maxCore != packageSensor)
+                    if (maxCore is not null && !ReferenceEquals(maxCore, packageSensor))
                     {
                         readings.Add(new TemperatureReading("CPU", $"Hottest Core ({maxCore.Name})",
                             maxCore.Value));
@@ -251,15 +251,12 @@ public sealed class TemperatureService
 
             foreach (var gpu in gpus)
             {
-                var sensors = gpu.ThermalInformation.ThermalSensors;
-                foreach (var sensor in sensors)
+                var sensor = gpu.ThermalInformation.ThermalSensors
+                    .FirstOrDefault(s => s.CurrentTemperature > 0);
+                if (sensor is not null)
                 {
-                    if (sensor.CurrentTemperature > 0)
-                    {
-                        readings.Add(new TemperatureReading("GPU", gpu.FullName,
-                            sensor.CurrentTemperature));
-                        break;
-                    }
+                    readings.Add(new TemperatureReading("GPU", gpu.FullName,
+                        sensor.CurrentTemperature));
                 }
             }
         }
@@ -276,12 +273,9 @@ public sealed class TemperatureService
         try
         {
             var disks = await _diskHealth.CollectAsync();
-            foreach (var disk in disks)
+            foreach (var disk in disks.Where(d => d.TemperatureC.HasValue))
             {
-                if (disk.TemperatureC.HasValue)
-                {
-                    readings.Add(new TemperatureReading("Storage", disk.FriendlyName, disk.TemperatureC));
-                }
+                readings.Add(new TemperatureReading("Storage", disk.FriendlyName, disk.TemperatureC));
             }
         }
         catch (ManagementException ex) { Log.Debug("Disk temp unavailable: {Error}", ex.Message); }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.19.0</Version>
-    <FileVersion>1.19.0.0</FileVersion>
-    <AssemblyVersion>1.19.0.0</AssemblyVersion>
+    <Version>1.19.1</Version>
+    <FileVersion>1.19.1.0</FileVersion>
+    <AssemblyVersion>1.19.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ContextMenuViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ContextMenuViewModel.cs
@@ -183,24 +183,18 @@ public sealed partial class ContextMenuViewModel : ViewModelBase
 
             // Disable all third-party entries to restore clean default
             var disabled = 0;
-            foreach (var entry in _allEntries)
+            foreach (var entry in _allEntries.Where(e =>
+                         !e.IsSystemEntry && e.IsEnabled && !IsDefaultWindowsEntry(e)))
             {
-                if (entry.IsSystemEntry) continue;
-                if (!entry.IsEnabled) continue;
-                if (IsDefaultWindowsEntry(entry)) continue;
-
                 if (_service.DisableEntry(entry))
                     disabled++;
             }
 
             // Enable any default Windows entries that were previously disabled
             var enabled = 0;
-            foreach (var entry in _allEntries)
+            foreach (var entry in _allEntries.Where(e =>
+                         !e.IsSystemEntry && !e.IsEnabled && IsDefaultWindowsEntry(e)))
             {
-                if (entry.IsSystemEntry) continue;
-                if (entry.IsEnabled) continue;
-                if (!IsDefaultWindowsEntry(entry)) continue;
-
                 if (_service.EnableEntry(entry))
                     enabled++;
             }

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -290,8 +290,8 @@ public sealed partial class DashboardViewModel : ViewModelBase
 
     private static async Task RunAlertScanAsync(DashboardAlert alert, Func<DashboardAlert, Task> scanner)
     {
-        var timer = System.Diagnostics.Stopwatch.StartNew();
-        var etaTask = Task.Run(async () =>
+        // Fire-and-forget ETA hint: after 5s of loading, surface a "remaining" note.
+        _ = Task.Run(async () =>
         {
             await Task.Delay(5000);
             if (alert.State == AlertLoadingState.Loading)
@@ -509,7 +509,7 @@ public sealed partial class DashboardViewModel : ViewModelBase
             QuickActionDetail = "Scanning temp folders...";
             QuickActionProgress = 20;
             var tempPath = Path.GetTempPath();
-            var tempSize = await Task.Run(() =>
+            await Task.Run(() =>
             {
                 try
                 {

--- a/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
@@ -88,7 +88,7 @@ public sealed partial class DnsHostsViewModel : ViewModelBase
             HostEntries.ReplaceWith(entries);
             HostsStatus = $"Loaded {entries.Count} entries.";
         }
-        catch (OperationCanceledException) { }
+        catch (OperationCanceledException) { /* expected on view teardown — nothing to report */ }
         catch (UnauthorizedAccessException)
         {
             HostsStatus = "Access denied — run as administrator to read hosts file.";

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -373,8 +373,8 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         if (parentGroup is not null) parentGroup.IsExpanded = true;
 
         // Pause/resume the process manager auto-refresh loop based on tab visibility.
-        ProcessManager.IsActive = value.Content == ProcessManager;
-        Dashboard.IsActive = value.Content == Dashboard;
+        ProcessManager.IsActive = ReferenceEquals(value.Content, ProcessManager);
+        Dashboard.IsActive = ReferenceEquals(value.Content, Dashboard);
     }
 
     /// <summary>Select a nav item by its automation id.</summary>


### PR DESCRIPTION
## What

Round E1 of the CodeQL cleanup — the **mechanical, behavior-preserving** alerts in hand-written source. (Behavioral alerts — `catch-of-all-exceptions`, `useless-upcast` on COM `dynamic` — are deferred to a separate E2 PR for careful review.)

## Alerts resolved

| Rule | Fix |
|---|---|
| `cs/empty-catch-block` | Log at Debug (`ContextMenuService` ×3, `App.OnExit`) or explanatory comment where the exception is expected (`DnsHostsViewModel` teardown cancellation) |
| `cs/path-combine` | `Path.Combine` → `Path.Join` in `ActivityLogService` |
| `cs/reference-equality-with-object` | Explicit `ReferenceEquals` in `MainWindowViewModel` (×2) and `TemperatureService` |
| `cs/linq/missed-where` / `cs/linq/missed-select` | Explicit `Where`/`Select`/`FirstOrDefault` in `TemperatureService` (×2), `FileShredderService`, `HostsFileService`, `ContextMenuViewModel` (×2) |
| `cs/useless-assignment-to-local` | Removed unused `Stopwatch` and unread temp-scan size in `DashboardViewModel`; scans' side effects preserved |

## Verification

- `dotnet build -c Release` → **0 errors, 0 warnings**
- No functional change: reference comparisons, LINQ rewrites, and discards are semantically identical to the originals
- No `==` operator overloads on the affected types (verified `ReferenceEquals` is equivalent)

## Notes

- `fix:` → patch release (1.19.0 → 1.19.1)
- CHANGELOG updated in this PR
- The 46 `obj/` false-positives (generated code) are handled separately via CodeQL config + build-side exclusion
