### PR TITLE
ci: exclude cs/useless-assignment-to-local from CodeQL (generated-only)

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -5,11 +5,16 @@ paths-ignore:
   - '**/bin/**'
 
 query-filters:
-  # WPF XAML compiler generates .g.cs with useless-assignment patterns —
-  # these are false positives in auto-generated InitializeComponent code.
+  # cs/useless-assignment-to-local fires only on build-generated code for this
+  # project: WPF XAML-compiler output (*.g.cs) and the [GeneratedRegex] source
+  # generator, all under obj/. Because the CodeQL database is built (manual build
+  # mode), it traces those generated files into analysis and neither paths-ignore
+  # nor a query-filter "path" key suppresses them for compiled C#. There are zero
+  # hand-written occurrences of this pattern, so excluding the query by id removes
+  # the false positives without losing real coverage. Re-enable this rule (drop the
+  # exclude) if a genuine useless-assignment is ever introduced in source.
   - exclude:
       id: cs/useless-assignment-to-local
-      path: '**/obj/**'
   # Intentional use of CreateFromSignedFile for Authenticode verification —
   # no modern .NET replacement exists without P/Invoke. Already suppressed
   # with #pragma warning disable SYSLIB0057.


### PR DESCRIPTION
## Problem

46 of the repo's open CodeQL alerts are rule `cs/useless-assignment-to-local`, **all in build-generated code** under `obj/`:
- 35 in WPF XAML-compiler output (`*.g.cs`, `App.g.cs`, `MainWindow.g.cs`)
- 11 in the `[GeneratedRegex]` source-generator output

The existing filter tried to scope the exclusion with `path: '**/obj/**'`, but **`query-filters` has no `path` property** — CodeQL's schema accepts the key and silently ignores it, so the filter never did anything. And for a **built** C# database (manual build mode), `paths-ignore` does not drop results either: the extractor traces whatever the compiler compiled, including generated files. (Confirmed against GitHub's advanced-setup and compiled-language docs.)

## Fix

Drop the no-op `path:` and exclude the query **by id** (the only mechanism the schema honors):

```yaml
- exclude:
    id: cs/useless-assignment-to-local
```

## Why this doesn't lose coverage

After the source cleanup in #624, there are **zero hand-written occurrences** of `useless-assignment-to-local` — every remaining hit is generated code. So a global exclude removes exactly the 46 false positives and nothing real. The inline comment documents how to re-enable the rule if a genuine useless assignment is ever introduced in source.

## Notes

- `ci:` change — does not trigger a release.
- The second filter (`cs/call-to-obsolete-method`) is left untouched: its two findings are already dismissed manually, and changing it is out of scope here.
- Expected result after merge + CodeQL re-run on main: open alert count drops by 46 (100 → ~39, all hand-written behavioral alerts for a later pass).