### PR TITLE
ci: skip release workflow when the release already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,40 @@ permissions:
   discussions: write
 
 jobs:
+  guard:
+    name: Skip if release already exists (tag move / re-push)
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+    steps:
+      - name: Check for an existing release
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Manual dispatch is an explicit, intentional request — always allow it.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch — proceeding."
+            exit 0
+          fi
+          tag="${{ github.ref_name }}"
+          # A push event fires both for brand-new tags AND for moved/re-pushed tags.
+          # A brand-new release has no GitHub Release yet; a moved tag already does.
+          # Only release when none exists, so moving old tags can't re-trigger a
+          # full release (which would hijack the "Latest" flag and flood Discussions).
+          if gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "Release for $tag already exists — skipping (tag move or re-push)."
+          else
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "No release for $tag yet — proceeding."
+          fi
+
   build-and-release:
     name: Build single-file exe & publish release
+    needs: guard
+    if: needs.guard.outputs.should_release == 'true'
     runs-on: windows-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
## Problem

The Release workflow triggers on `push: tags: v*.*.*`. A tag push fires for **both** brand-new tags and **moved/re-pushed** tags. When historical tags are moved (e.g. during a maintenance retag), the full release pipeline re-ran for each one, causing two regressions:

1. **"Latest" flag hijacked** — re-publishing an old release (e.g. v1.7.1) made GitHub mark it as the latest release instead of the real newest version, misdirecting downloaders.
2. **Discussions flooded** — the "Post announcement to Discussions" step re-posted announcements for ancient versions.

## Fix

Add a lightweight `guard` job that runs first and checks whether a GitHub Release already exists for the tag:

- **Brand-new release** → no Release exists yet → proceed normally.
- **Moved/re-pushed tag** → Release already exists → skip the build/publish job.
- **Manual `workflow_dispatch`** → always proceeds (explicit override).

`build-and-release` now `needs: guard` and runs only `if: needs.guard.outputs.should_release == 'true'`.

## Behavior guarantee

Normal release flow (new tag → new release) is unchanged. Only re-pushes/moves of already-released tags are now skipped.
