### PR TITLE
fix: resolve UI test executable path for .NET 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.19.2] - 2026-06-08
+
+### Fixed
+- **UI test harness could never locate the app executable.** `AppFixture` hardcoded a `net8.0-windows` output path while the project targets `net10.0-windows`, so `FindExecutable()` always threw `FileNotFoundException` when running the UI automation tests locally. The path is now resolved dynamically from the `net*-windows` build folder, so it survives future framework bumps.
+
 ## [1.19.1] - 2026-06-05
 
 ### Fixed

--- a/SysManager/SysManager.UITests/AppFixture.cs
+++ b/SysManager/SysManager.UITests/AppFixture.cs
@@ -80,10 +80,21 @@ public sealed class AppFixture : IDisposable
     {
         var repoRoot = Path.GetFullPath(Path.Combine(
             AppContext.BaseDirectory, "..", "..", "..", ".."));
-        var candidate = Path.Combine(repoRoot, "SysManager", "bin", "Debug", "net8.0-windows", "SysManager.exe");
-        if (File.Exists(candidate)) return candidate;
+        var binDir = Path.Combine(repoRoot, "SysManager", "bin", "Debug");
+
+        // Resolve the target-framework folder dynamically (e.g. net10.0-windows)
+        // so the path survives .NET version bumps instead of hardcoding one.
+        if (Directory.Exists(binDir))
+        {
+            var candidate = Directory
+                .EnumerateDirectories(binDir, "net*-windows")
+                .Select(tfm => Path.Combine(tfm, "SysManager.exe"))
+                .FirstOrDefault(File.Exists);
+            if (candidate is not null) return candidate;
+        }
+
         throw new FileNotFoundException(
-            $"Expected SysManager.exe at {candidate}. Build SysManager in Debug before running UI tests.");
+            $"Expected SysManager.exe under {binDir}\\net*-windows. Build SysManager in Debug before running UI tests.");
     }
 
     public void Dispose()

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.19.1</Version>
-    <FileVersion>1.19.1.0</FileVersion>
-    <AssemblyVersion>1.19.1.0</AssemblyVersion>
+    <Version>1.19.2</Version>
+    <FileVersion>1.19.2.0</FileVersion>
+    <AssemblyVersion>1.19.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem

`AppFixture.FindExecutable()` (UI automation harness) hardcoded the output path `SysManager/bin/Debug/**net8.0-windows**/SysManager.exe`, but the project targets `net10.0-windows`. The executable is built into `net10.0-windows`, so the fixture always threw `FileNotFoundException` when UI tests ran locally — they could never actually launch the app.

## Fix

Resolve the executable dynamically by enumerating the `net*-windows` folder under `SysManager/bin/Debug` and picking the first one that contains `SysManager.exe`. This fixes the immediate bug and makes the path resilient to future .NET version bumps (no more hardcoded framework moniker).

## Verification

- `dotnet build SysManager/SysManager.UITests/SysManager.UITests.csproj -c Release` → 0 warnings, 0 errors.
- `System.Linq` available via ImplicitUsings.
- Error message updated to reflect the `net*-windows` glob.

Closes the stale-path bug surfaced during the documentation/version audit.