### PR TITLE
docs: fix accuracy drift in README, CHANGELOG, ARCHITECTURE

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -103,6 +103,8 @@ Key services:
   and stream output line-by-line. Always launches spawned processes from
   `System32` so `Access is denied` never bites on `chkdsk` etc.
 - `WingetService` — shells out to `winget` and parses its table output.
+- `WindowsUpdateService` — drives Windows Update through the WUA COM API
+  (scan, select, install) with progress reporting; backs `WindowsUpdateViewModel`.
 - `DiskHealthService` — pulls SMART data through WMI.
 - `MemoryTestService` — scans WHEA / MemoryDiagnostics events.
 - `EventLogService` + `EventExplainer` — read Windows Event Log and attach

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Pipe listener no longer fire-and-forgets via `async void`.** `App.StartPipeListener` was an async-void method, meaning any exception escaping the loop would crash the process via the AppDomain handler. Renamed to `StartPipeListenerAsync` returning `Task`; `OnStartup` calls it as `_ = StartPipeListenerAsync()` so a stray exception flows through `TaskScheduler.UnobservedTaskException` (logged) instead of terminating the app.
 - **StartupService — removed sync wrapper over async.** `SetEnabled` (sync) was a thin wrapper around `SetEnabledAsync` using `.GetAwaiter().GetResult()`. The wrapper is gone; tests now call `SetEnabledAsync` directly via xUnit `Task` test methods.
 - **Schtasks stderr read** — replaced `stderrTask.Wait(timeout) ? .GetAwaiter().GetResult() : ""` with `await stderrTask.WaitAsync(timeout)` so the read is fully async with a clean timeout fallback.
-
-### Fixed
 - **Privacy Toggles no longer write to the registry on every click.** Toggling a switch now updates local state only; the user must press **Apply** to write pending changes. A live counter shows how many changes are pending, and **Discard** reverts them without touching the registry. Prevents accidental system changes when scrolling through the toggle list.
 - **Dashboard no longer freezes on first load.** Static system info (CPU, OS, RAM modules) is now loaded asynchronously instead of blocking the UI thread on a synchronous WMI capture. The Dashboard tab is responsive immediately on startup.
 - **DNS / Hosts tab loads asynchronously.** Reading the hosts file is now async (`File.ReadAllLinesAsync`); Refresh no longer freezes the UI on slow disks.
@@ -392,6 +390,27 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Subtitle and Tooltip are auto-generated from child labels.
 - **Version** aligned to 1.7.17.
 
+## [1.7.16] - 2026-05-22
+
+### Fixed
+- **Tray icon creation is now forced**, ensuring the system-tray icon appears even when the platform delays its initial creation.
+
+### Changed
+- **Upgraded H.NotifyIcon to 2.3.0** for more reliable tray-icon handling.
+
+## [1.7.15] - 2026-05-22
+
+### Fixed
+- **Tray icon reliability** — follow-up adjustments to ensure the system-tray icon initializes correctly during startup.
+
+## [1.7.14] - 2026-05-22
+
+### Added
+- **Real app icons in Bulk Installer** — app icons are fetched via the Google Favicon service and cached locally, so the catalog shows recognizable icons instead of placeholders.
+
+### Fixed
+- **Tray icon always visible** — falls back to a system icon when an app icon fails to load, so the tray icon is never missing.
+
 ## [1.7.13] - 2026-05-22
 
 ### Fixed
@@ -402,6 +421,30 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **File Shredder** — fixed white page (transparent DataGrid background).
 - **Column resize** — CanUserResizeColumns on all remaining DataGrids.
 - **Tray icon** — shows real app icon from exe (not generic).
+
+## [1.7.12] - 2026-05-22
+
+### Fixed
+- **Tray icon loads from the executable**, which is reliable under single-file publishing, with a pack-URI fallback if the embedded icon cannot be read.
+
+## [1.7.11] - 2026-05-22
+
+### Fixed
+- **Tray icon visibility** is now set explicitly, so the system-tray icon shows reliably.
+
+## [1.7.10] - 2026-05-22
+
+### Fixed
+- **Uniform elevation banners** across App Updates, Uninstaller, and Bulk Installer, so every tab presents the admin-elevation prompt the same way.
+- **File Shredder no longer shows a blank page** when the tab is opened.
+
+### Changed
+- **Resizable grid columns everywhere** — `CanUserResizeColumns` is now enabled on all data grids for consistent behavior.
+
+## [1.7.9] - 2026-05-22
+
+### Fixed
+- **Services tab — consistent banner ordering.** The admin elevation banner now sits above the toolbar, matching the layout used by the other tabs.
 
 ## [1.7.8] - 2026-05-22
 
@@ -449,6 +492,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `DefWindowProcW` entry point.
 - **Shutdown crash** — fixed ObjectDisposedException when closing the app
   (DnsHostsViewModel CTS disposal race condition).
+
+## [1.7.2] - 2026-05-22
+
+### Fixed
+- **Shutdown crash** — prevented `ObjectDisposedException` in `DnsHostsViewModel` when the app is closed while a refresh is in flight.
+
+## [1.7.1] - 2026-05-21
+
+### Fixed
+- **Code review findings** — addressed security, thread-safety, and disposal issues surfaced during review (#487).
 
 ## [1.7.0] - 2026-05-21
 
@@ -2779,7 +2832,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - One-click "Install" button that launches the downloaded build and
   closes the current instance so the new version takes over.
 
-### Safety
+### Security
 - Deep cleanup **never** touches: browser caches / cookies / passwords,
   launcher login tokens, the registry, active drivers, Program Files,
   `AppData\Roaming` (live app settings), `ProgramData\NVIDIA` root, or

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ deleting anything (uses the standard `LegacyDisable` registry mechanism):
   at your ISP, or at the far-end service
 - **Presets for gamers & streamers**:
   - Global (Google, Cloudflare, your router)
-  - **CS2 Europe** — Valve Frankfurt, Vienna, Stockholm relays
-  - **FACEIT Europe** — competitive CS2 servers in DE, UK, FR, NL, SE
-  - **PUBG Europe** — Krafton EU matchmaking endpoints
-  - **Streaming** — YouTube and Twitch ingest
+  - **CS2 Europe** — Valve matchmaking relays (Vienna, Luxembourg, Warsaw, EU West/Central/East)
+  - **FACEIT Europe** — competitive CS2 servers in DE, NL, UK
+  - **PUBG Europe** — EU matchmaking cloud regions (Frankfurt, Ireland, London)
+  - **Streaming** — YouTube, Twitch, Cloudflare
 - Auto-traceroute on a configurable interval (30 s – 10 min)
 - Speed tests: HTTP (Cloudflare) and the official Ookla CLI (auto-downloaded)
   with persistent history (last 20 results per engine) for tracking service
@@ -456,17 +456,18 @@ to stay on the latest version.
 
 ### Direct download
 
-Grab `SysManager.exe` from the [latest release](https://github.com/laurentiu021/SystemManager/releases/latest)
+Grab `SysManager-v<version>.exe` (e.g. `SysManager-v1.19.2.exe`) from the
+[latest release](https://github.com/laurentiu021/SystemManager/releases/latest)
 and double-click it. The executable is self-contained — no installer, no .NET
 runtime required.
 
 ### Verifying the download
 
-Each release ships a matching `SysManager.exe.sha256`. Verify before running:
+Each release ships a matching `SysManager-v<version>.exe.sha256`. Verify before running:
 
 ```powershell
-Get-FileHash .\SysManager.exe -Algorithm SHA256
-# Compare the output to the contents of SysManager.exe.sha256.
+Get-FileHash .\SysManager-v1.19.2.exe -Algorithm SHA256
+# Compare the output to the contents of SysManager-v1.19.2.exe.sha256.
 ```
 
 The build is not currently code-signed, so Windows SmartScreen may warn on


### PR DESCRIPTION
Documentation accuracy pass surfaced during the full audit. No code changes.

## README
- **Ping presets corrected to match `TargetPreset.cs`.** The old list named relays/regions that don't exist in code:
  - CS2 Europe: was "Frankfurt, Vienna, Stockholm" → actually Vienna, Luxembourg, Warsaw, EU West/Central/East.
  - FACEIT Europe: was "DE, UK, FR, NL, SE" → actually DE, NL, UK only.
  - PUBG Europe: was "Krafton EU matchmaking endpoints" → actually EU matchmaking cloud regions (Frankfurt, Ireland, London).
- **Versioned download/verify instructions** — `SysManager-v<version>.exe` (matching real release asset names) instead of the generic `SysManager.exe`.

## CHANGELOG
- **Backfilled 9 missing version headers** (1.7.1, 1.7.2, 1.7.9–1.7.12, 1.7.14–1.7.16) reconstructed from their GitHub release notes and commit history.
- **Merged the duplicate `### Fixed` block** in 1.18.2.
- **Renamed `### Safety` → `### Security`** (Keep a Changelog compliance).
- **Fixed 1.7.13 ordering** so the 1.7.x series descends contiguously.

## ARCHITECTURE
- **Documented `WindowsUpdateService`** (WUA COM API), previously the only service omitted from the services list.

(`v1.18.1` was flagged by the audit but never released — no entry needed.)