### PR TITLE
fix: stop Deep Cleanup following junctions and Dashboard alert overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.19.3] - 2026-06-08
+
+### Fixed
+- **Deep Cleanup no longer follows junctions / symbolic links (data-loss fix).** The cleanup traversal descended into reparse points, so a junction inside a cache folder could lead `File.Delete` to remove files **outside** the target tree — for example real user data behind a junction. Traversal now detects reparse points (`FileAttributes.ReparsePoint`) and skips them entirely, never entering or deleting through a link.
+- **Dashboard alerts no longer always show "unavailable".** The App Updates, Event Log, and Pending Reboot scanners each had a free code block after their `catch` that ran unconditionally and overwrote the real scan result with an "unavailable / green" status. The Dashboard therefore reported false-OK for these three checks regardless of the actual system state. The decision logic is now extracted into pure, unit-tested methods and the overwrite is gone, so real results surface.
+
 ## [1.19.2] - 2026-06-08
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DashboardViewModelTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
 
@@ -176,5 +177,62 @@ public class DashboardViewModelTests
     {
         var vm = NewVm();
         Assert.NotNull(vm.RecentActivity);
+    }
+
+    // ---------- alert classification (regression for the dead-block-after-catch bug) ----------
+    // Before the fix, a free block after each scanner's catch ran unconditionally and
+    // overwrote the real result with an "unavailable / Green" alert. These assert the
+    // real scan outcome is what surfaces.
+
+    [Fact]
+    public void ClassifyAppUpdates_Zero_IsGreenUpToDate()
+    {
+        var (title, severity) = DashboardViewModel.ClassifyAppUpdates(0);
+        Assert.Equal("All apps up to date", title);
+        Assert.Equal(AlertSeverity.Green, severity);
+    }
+
+    [Theory]
+    [InlineData(1, "1 app update available")]
+    [InlineData(5, "5 app updates available")]
+    public void ClassifyAppUpdates_Positive_IsYellowWithCount(int count, string expectedTitle)
+    {
+        var (title, severity) = DashboardViewModel.ClassifyAppUpdates(count);
+        Assert.Equal(expectedTitle, title);
+        Assert.Equal(AlertSeverity.Yellow, severity);
+    }
+
+    [Fact]
+    public void ClassifyEventLog_Zero_IsGreenNoCriticalEvents()
+    {
+        var (title, severity) = DashboardViewModel.ClassifyEventLog(0);
+        Assert.Equal("No critical events (last 7 days)", title);
+        Assert.Equal(AlertSeverity.Green, severity);
+    }
+
+    [Theory]
+    [InlineData(1, "1 critical event in Event Log (last 7d)")]
+    [InlineData(3, "3 critical events in Event Log (last 7d)")]
+    public void ClassifyEventLog_Positive_IsRedWithCount(int count, string expectedTitle)
+    {
+        var (title, severity) = DashboardViewModel.ClassifyEventLog(count);
+        Assert.Equal(expectedTitle, title);
+        Assert.Equal(AlertSeverity.Red, severity);
+    }
+
+    [Fact]
+    public void ClassifyPendingReboot_True_IsYellow()
+    {
+        var (title, severity) = DashboardViewModel.ClassifyPendingReboot(true);
+        Assert.Equal("Pending reboot required (Windows Update)", title);
+        Assert.Equal(AlertSeverity.Yellow, severity);
+    }
+
+    [Fact]
+    public void ClassifyPendingReboot_False_IsGreen()
+    {
+        var (title, severity) = DashboardViewModel.ClassifyPendingReboot(false);
+        Assert.Equal("No pending reboots", title);
+        Assert.Equal(AlertSeverity.Green, severity);
     }
 }

--- a/SysManager/SysManager.Tests/DeepCleanupServiceTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupServiceTests.cs
@@ -386,4 +386,67 @@ public class DeepCleanupServiceTests
             try { Directory.Delete(root, recursive: true); } catch { }
         }
     }
+
+    [Fact]
+    public async Task CleanAsync_DoesNotFollowJunctionOutsideTarget()
+    {
+        // Regression: cleanup traversal must NOT descend into reparse points
+        // (junctions / symlinks). Following one would let CleanAsync delete files
+        // that live outside the cleanup target tree — a data-loss bug.
+        var baseDir = Path.Combine(Path.GetTempPath(), "smtest_junc_" + Guid.NewGuid().ToString("N"));
+        var target = Path.Combine(baseDir, "outside");   // simulates real user data
+        var cleanRoot = Path.Combine(baseDir, "cache");   // the folder being cleaned
+        Directory.CreateDirectory(target);
+        Directory.CreateDirectory(cleanRoot);
+
+        var precious = Path.Combine(target, "precious.dat");
+        File.WriteAllText(precious, "do not delete me");
+
+        var link = Path.Combine(cleanRoot, "link");
+        // mklink /J creates a directory junction; no admin rights required.
+        var psi = new System.Diagnostics.ProcessStartInfo("cmd.exe", $"/c mklink /J \"{link}\" \"{target}\"")
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+        try
+        {
+            using (var proc = System.Diagnostics.Process.Start(psi)!)
+            {
+                proc.WaitForExit(10_000);
+                if (proc.ExitCode != 0 || !IsReparse(link))
+                {
+                    // Environment can't create junctions (rare) — nothing to assert.
+                    return;
+                }
+            }
+
+            var cat = new CleanupCategory
+            {
+                Name = "Cache",
+                Description = "Cleanup root containing a junction",
+                Paths = new[] { cleanRoot },
+                TotalSizeBytes = 1,
+                FileCount = 1,
+                IsSelected = true
+            };
+            var s = new DeepCleanupService();
+            await s.CleanAsync(new[] { cat });
+
+            // The file behind the junction must survive: traversal never entered it.
+            Assert.True(File.Exists(precious), "Cleanup followed a junction and deleted data outside the target tree");
+        }
+        finally
+        {
+            try { Directory.Delete(baseDir, recursive: true); } catch { }
+        }
+
+        static bool IsReparse(string p)
+        {
+            try { return (File.GetAttributes(p) & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint; }
+            catch { return false; }
+        }
+    }
 }

--- a/SysManager/SysManager/Services/DeepCleanupService.cs
+++ b/SysManager/SysManager/Services/DeepCleanupService.cs
@@ -405,7 +405,13 @@ public sealed class DeepCleanupService
                 yield return item;
             }
 
-            foreach (var d in dirs) stack.Push(d);
+            // Never descend into reparse points (junctions / symbolic links):
+            // following one could enumerate — and the caller could then delete —
+            // files that live outside the cleanup target tree (data-loss risk).
+            foreach (var d in dirs)
+            {
+                if (!IsReparsePoint(d)) stack.Push(d);
+            }
         }
     }
 
@@ -419,10 +425,30 @@ public sealed class DeepCleanupService
             var cur = stack.Pop();
             IEnumerable<string> dirs;
             try { dirs = Directory.EnumerateDirectories(cur); } catch (IOException) { continue; } catch (UnauthorizedAccessException) { continue; }
-            foreach (var d in dirs) stack.Push(d);
+            // Skip reparse points: deleting the target's contents (or even the
+            // link recursively) could reach outside the cleanup tree.
+            foreach (var d in dirs)
+            {
+                if (!IsReparsePoint(d)) stack.Push(d);
+            }
             if (!string.Equals(cur, root, StringComparison.OrdinalIgnoreCase)) all.Add(cur);
         }
         all.Sort((a, b) => b.Length.CompareTo(a.Length));
         return all;
+    }
+
+    /// <summary>
+    /// True when the directory is a reparse point (junction or symbolic link).
+    /// Such entries are skipped during traversal so cleanup can never follow a
+    /// link out of the target tree and delete unrelated user data.
+    /// </summary>
+    private static bool IsReparsePoint(string path)
+    {
+        try
+        {
+            return (File.GetAttributes(path) & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+        }
+        catch (IOException) { return true; }
+        catch (UnauthorizedAccessException) { return true; }
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.19.2</Version>
-    <FileVersion>1.19.2.0</FileVersion>
-    <AssemblyVersion>1.19.2.0</AssemblyVersion>
+    <Version>1.19.3</Version>
+    <FileVersion>1.19.3.0</FileVersion>
+    <AssemblyVersion>1.19.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -356,22 +356,16 @@ public sealed partial class DashboardViewModel : ViewModelBase
             var countText = output.ToString().Trim();
             var count = int.TryParse(countText, out var n) ? Math.Max(n - 2, 0) : 0;
 
+            var (title, severity) = ClassifyAppUpdates(count);
             System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
             {
-                if (count == 0)
-                {
-                    alert.Title = "All apps up to date";
-                    alert.Severity = AlertSeverity.Green;
-                }
-                else
-                {
-                    alert.Title = $"{count} app update{(count == 1 ? "" : "s")} available";
-                    alert.Severity = AlertSeverity.Yellow;
-                }
+                alert.Title = title;
+                alert.Severity = severity;
             });
         }
-        catch (Exception ex) { Log.Debug("Alert scan failed: {Error}", ex.Message); }//
+        catch (Exception ex)
         {
+            Log.Debug("Alert scan failed: {Error}", ex.Message);
             System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
             {
                 alert.Title = "App update check unavailable";
@@ -379,6 +373,12 @@ public sealed partial class DashboardViewModel : ViewModelBase
             });
         }
     }
+
+    /// <summary>Pure decision for the App Updates alert. Testable without WPF.</summary>
+    internal static (string Title, AlertSeverity Severity) ClassifyAppUpdates(int count) =>
+        count == 0
+            ? ("All apps up to date", AlertSeverity.Green)
+            : ($"{count} app update{(count == 1 ? "" : "s")} available", AlertSeverity.Yellow);
 
     private async Task ScanMemoryHealthAsync(DashboardAlert alert)
     {
@@ -411,22 +411,16 @@ public sealed partial class DashboardViewModel : ViewModelBase
             using var reader = new System.Diagnostics.Eventing.Reader.EventLogReader(query);
             while (reader.ReadEvent() is not null) criticalCount++;
 
+            var (title, severity) = ClassifyEventLog(criticalCount);
             System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
             {
-                if (criticalCount == 0)
-                {
-                    alert.Title = "No critical events (last 7 days)";
-                    alert.Severity = AlertSeverity.Green;
-                }
-                else
-                {
-                    alert.Title = $"{criticalCount} critical event{(criticalCount == 1 ? "" : "s")} in Event Log (last 7d)";
-                    alert.Severity = AlertSeverity.Red;
-                }
+                alert.Title = title;
+                alert.Severity = severity;
             });
         }
-        catch (Exception ex) { Log.Debug("Alert scan failed: {Error}", ex.Message); }//
+        catch (Exception ex)
         {
+            Log.Debug("Alert scan failed: {Error}", ex.Message);
             System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
             {
                 alert.Title = "Event Log check unavailable";
@@ -436,6 +430,12 @@ public sealed partial class DashboardViewModel : ViewModelBase
         return Task.CompletedTask;
     }
 
+    /// <summary>Pure decision for the Event Log alert. Testable without WPF.</summary>
+    internal static (string Title, AlertSeverity Severity) ClassifyEventLog(int criticalCount) =>
+        criticalCount == 0
+            ? ("No critical events (last 7 days)", AlertSeverity.Green)
+            : ($"{criticalCount} critical event{(criticalCount == 1 ? "" : "s")} in Event Log (last 7d)", AlertSeverity.Red);
+
     private Task ScanWindowsFeaturesAsync(DashboardAlert alert)
     {
         try
@@ -444,22 +444,16 @@ public sealed partial class DashboardViewModel : ViewModelBase
                 @"SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired");
             var pending = key is not null;
 
+            var (title, severity) = ClassifyPendingReboot(pending);
             System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
             {
-                if (pending)
-                {
-                    alert.Title = "Pending reboot required (Windows Update)";
-                    alert.Severity = AlertSeverity.Yellow;
-                }
-                else
-                {
-                    alert.Title = "No pending reboots";
-                    alert.Severity = AlertSeverity.Green;
-                }
+                alert.Title = title;
+                alert.Severity = severity;
             });
         }
-        catch (Exception ex) { Log.Debug("Alert scan failed: {Error}", ex.Message); }//
+        catch (Exception ex)
         {
+            Log.Debug("Alert scan failed: {Error}", ex.Message);
             System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
             {
                 alert.Title = "Feature check unavailable";
@@ -468,6 +462,12 @@ public sealed partial class DashboardViewModel : ViewModelBase
         }
         return Task.CompletedTask;
     }
+
+    /// <summary>Pure decision for the pending-reboot alert. Testable without WPF.</summary>
+    internal static (string Title, AlertSeverity Severity) ClassifyPendingReboot(bool pending) =>
+        pending
+            ? ("Pending reboot required (Windows Update)", AlertSeverity.Yellow)
+            : ("No pending reboots", AlertSeverity.Green);
 
     // ══════════════════════════════════════════════════════════════════════
     //  RECENT ACTIVITY


### PR DESCRIPTION
Round 1 of the exhaustive audit — the two highest-impact P0 defects, both confirmed present in current code.

## 1. Data-loss: Deep Cleanup followed junctions / symlinks
`DeepCleanupService` traversal (`EnumerateFiles`, `EnumerateDirectoriesDepthFirst`) pushed every subdirectory onto its walk stack without checking for reparse points. A junction or symbolic link inside a cleanup target (e.g. a cache folder) pointed traversal at files **outside** the target tree, which `File.Delete` / `Directory.Delete` would then remove — real data loss.

**Fix:** traversal now skips any entry with `FileAttributes.ReparsePoint` (and treats unreadable entries as links, failing safe). It never enters or deletes through a link.
**Test:** `CleanAsync_DoesNotFollowJunctionOutsideTarget` creates a real directory junction (`mklink /J`, no admin needed) and asserts the linked file survives a clean.

## 2. Dashboard reported false-OK for 3 alerts
`ScanAppUpdatesAsync`, `ScanEventLogAsync`, and `ScanWindowsFeaturesAsync` each had a free `{ }` block **after** their `catch` that executed unconditionally and overwrote the real scan result with an "unavailable / Green" alert. App-update, Event-Log, and pending-reboot alerts were therefore always wrong regardless of system state.

**Fix:** removed the dead blocks. Extracted each scanner's title/severity decision into pure `internal static` methods — `ClassifyAppUpdates`, `ClassifyEventLog`, `ClassifyPendingReboot` — so the real result surfaces and is unit-testable without WPF.
**Tests:** 8 new assertions in `DashboardViewModelTests` covering zero/positive/true/false cases.

## Verification
- `dotnet build` main + tests: 0 warnings, 0 errors.
- Behavior change is the bug fix itself; no public API signatures changed.
- Author headers present; CHANGELOG + version bump (1.19.3) included.