### PR TITLE
fix: require confirmation before destructive cleanup actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.19.4] - 2026-06-08
+
+### Fixed
+- **Destructive cleanup actions now require confirmation.** Three deletion paths ran immediately with no prompt: Deep Cleanup (`CleanAsync`), Temp Cleanup, and Empty Recycle Bin. Each now shows a `DialogService.Confirm` dialog first — Deep Cleanup states the file count and total size and warns the files bypass the Recycle Bin. Declining cancels with no changes. Adds regression tests covering both the decline (nothing deleted) and confirm (files deleted) paths.
+
 ## [1.19.3] - 2026-06-08
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DeepCleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupViewModelTests.cs
@@ -2,8 +2,11 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using System.Reflection;
+using NSubstitute;
 using SysManager.Models;
+using SysManager.Services;
 using SysManager.ViewModels;
 
 namespace SysManager.Tests;
@@ -515,5 +518,73 @@ public class DeepCleanupViewModelTests
         vm.IsCleaning = true;
         vm.IsScanning = false;
         Assert.True(vm.IsBusy); // IsCleaning still true
+    }
+
+    // ---------- deletion confirmation gate (Round 2a) ----------
+
+    [Fact]
+    public async Task Clean_WhenUserDeclinesConfirm_DeletesNothing()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "smtest_clean_no_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var file = Path.Combine(dir, "keep.dat");
+        File.WriteAllText(file, "x");
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false); // user clicks "No"
+        DialogService.Instance = dialog;
+        try
+        {
+            var vm = NewVm();
+            vm.Categories.Add(new CleanupCategory
+            {
+                Name = "Temp", Description = "test", Paths = new[] { dir },
+                TotalSizeBytes = 1, FileCount = 1, IsSelected = true
+            });
+
+            await vm.CleanCommand.ExecuteAsync(null);
+
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            Assert.True(File.Exists(file), "Files were deleted even though the user declined the confirmation");
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public async Task Clean_WhenUserConfirms_DeletesSelectedFiles()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "smtest_clean_yes_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var file = Path.Combine(dir, "delete.dat");
+        File.WriteAllText(file, "x");
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true); // user clicks "Yes"
+        DialogService.Instance = dialog;
+        try
+        {
+            var vm = NewVm();
+            vm.Categories.Add(new CleanupCategory
+            {
+                Name = "Temp", Description = "test", Paths = new[] { dir },
+                TotalSizeBytes = 1, FileCount = 1, IsSelected = true
+            });
+
+            await vm.CleanCommand.ExecuteAsync(null);
+
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            Assert.False(File.Exists(file), "File survived even though the user confirmed deletion");
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.19.3</Version>
-    <FileVersion>1.19.3.0</FileVersion>
-    <AssemblyVersion>1.19.3.0</AssemblyVersion>
+    <Version>1.19.4</Version>
+    <FileVersion>1.19.4.0</FileVersion>
+    <AssemblyVersion>1.19.4.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -163,6 +163,13 @@ public sealed partial class CleanupViewModel : ViewModelBase
     private async Task CleanTempAsync()
     {
         if (IsTempRunning) return;
+        if (!DialogService.Instance.Confirm(
+                "Delete temporary files from your user and Windows Temp folders?\n\n" +
+                "Files in use may be skipped. This cannot be undone.",
+                "Confirm Temp Cleanup"))
+        {
+            return;
+        }
         using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.Disk, "Temp Cleanup");
         if (opLock is null)
         {
@@ -202,6 +209,12 @@ public sealed partial class CleanupViewModel : ViewModelBase
     private async Task EmptyRecycleBinAsync()
     {
         if (IsBinRunning) return;
+        if (!DialogService.Instance.Confirm(
+                "Permanently empty the Recycle Bin? Its contents cannot be recovered.",
+                "Confirm Empty Recycle Bin"))
+        {
+            return;
+        }
         IsBinRunning = true;
         StatusMessage = "Emptying Recycle Bin...";
         _binCts?.Dispose();

--- a/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
@@ -203,6 +203,21 @@ public sealed partial class DeepCleanupViewModel : ViewModelBase
     private async Task CleanAsync()
     {
         if (IsCleaning || !Categories.Any(c => c.IsSelected)) return;
+
+        // Deletion is permanent (files are not sent to the Recycle Bin). Confirm
+        // first, showing how much will be removed so the choice is informed.
+        var selected = Categories.Where(c => c.IsSelected).ToList();
+        var totalBytes = selected.Sum(c => c.TotalSizeBytes);
+        var fileCount = selected.Sum(c => c.FileCount);
+        if (!DialogService.Instance.Confirm(
+                $"Permanently delete {fileCount:N0} files (~{FormatHelper.FormatSize(totalBytes)}) " +
+                $"across {selected.Count} categor{(selected.Count == 1 ? "y" : "ies")}?\n\n" +
+                "These files are removed directly, not sent to the Recycle Bin.",
+                "Confirm Deep Cleanup"))
+        {
+            return;
+        }
+
         using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.Disk, "Deep Cleanup");
         if (opLock is null)
         {


### PR DESCRIPTION
Round 2a of the audit — confirmation gates for irreversible deletion.

Three deletion paths ran immediately with no confirmation:

| Action | Before | After |
|---|---|---|
| Deep Cleanup (`CleanAsync`) | permanent delete, no prompt | `Confirm` showing file count + total size + "bypasses Recycle Bin" warning |
| Temp Cleanup | wiped Temp, no prompt | `Confirm` before deleting |
| Empty Recycle Bin | emptied, no prompt | `Confirm` before emptying |

Declining returns with zero changes — and Deep Cleanup now confirms **before** taking the operation lock, so a cancelled prompt doesn't briefly block other disk operations.

## Tests
`DeepCleanupViewModelTests` injects a fake `IDialogService` (via the existing `DialogService.Instance` setter seam) and asserts:
- **Decline** → `Confirm` called once, the on-disk file still exists (nothing deleted).
- **Confirm** → `Confirm` called once, the selected file is deleted.

## Verification
- `dotnet build` main + tests: 0 warnings, 0 errors.
- No public API change. CHANGELOG + version bump (1.19.4) included.