### PR TITLE
fix: WMI DBNull crash in drive scan and uninstaller prefix bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.3] - 2026-06-08
+
+### Fixed
+- **Drive enumeration no longer crashes on missing WMI properties.** `FixedDriveService` read `MediaType`/`BusType` with `Convert.ToUInt32(value ?? 0u)`, but WMI returns `DBNull.Value` (not null) for absent properties, so `Convert.ToUInt32(DBNull.Value)` threw and aborted the whole scan on some hardware. Reads now go through a `ToUInt32Safe` helper that treats null and `DBNull` as 0.
+- **Uninstaller trusted-directory check no longer accepts sibling folders.** `IsUnderTrustedDirectory` used a bare `StartsWith`, so `C:\Program Files Evil\…` passed the `C:\Program Files` check. It now compares on a normalized directory boundary (trailing separator) so only true sub-paths of a trusted directory are accepted.
+
 ## [1.20.2] - 2026-06-08
 
 ### Fixed

--- a/SysManager/SysManager.Tests/FixedDriveServiceTests.cs
+++ b/SysManager/SysManager.Tests/FixedDriveServiceTests.cs
@@ -76,4 +76,25 @@ public class FixedDriveServiceTests
         Assert.Equal("NVMe", b.BusType);
         Assert.Equal("", a.MediaType); // original unchanged
     }
+
+    // Regression: WMI returns DBNull.Value (not null) for absent properties, and
+    // Convert.ToUInt32(DBNull.Value) throws — which crashed drive enumeration.
+    [Fact]
+    public void ToUInt32Safe_DBNull_ReturnsZero()
+        => Assert.Equal(0u, FixedDriveService.ToUInt32Safe(DBNull.Value));
+
+    [Fact]
+    public void ToUInt32Safe_Null_ReturnsZero()
+        => Assert.Equal(0u, FixedDriveService.ToUInt32Safe(null));
+
+    [Theory]
+    [InlineData(4, 4u)]
+    [InlineData((uint)17, 17u)]
+    [InlineData("11", 11u)]
+    public void ToUInt32Safe_ConvertibleValue_ReturnsValue(object input, uint expected)
+        => Assert.Equal(expected, FixedDriveService.ToUInt32Safe(input));
+
+    [Fact]
+    public void ToUInt32Safe_Unconvertible_ReturnsZero()
+        => Assert.Equal(0u, FixedDriveService.ToUInt32Safe("not-a-number"));
 }

--- a/SysManager/SysManager.Tests/UninstallerServiceTests.cs
+++ b/SysManager/SysManager.Tests/UninstallerServiceTests.cs
@@ -13,6 +13,28 @@ namespace SysManager.Tests;
 /// </summary>
 public class UninstallerServiceTests
 {
+    // ── IsUnderTrustedDirectory (regression: prefix-boundary bypass) ──
+
+    [Fact]
+    public void IsUnderTrustedDirectory_PathInsideProgramFiles_IsTrusted()
+    {
+        var pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        Assert.True(UninstallerService.IsUnderTrustedDirectory(System.IO.Path.Combine(pf, "Vendor", "app.exe")));
+    }
+
+    [Fact]
+    public void IsUnderTrustedDirectory_SiblingWithSharedPrefix_IsNotTrusted()
+    {
+        // "C:\Program Files Evil\..." must NOT pass the "C:\Program Files" check.
+        var pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        var evil = pf + " Evil\\malware.exe";
+        Assert.False(UninstallerService.IsUnderTrustedDirectory(evil));
+    }
+
+    [Fact]
+    public void IsUnderTrustedDirectory_UntrustedLocation_IsNotTrusted()
+        => Assert.False(UninstallerService.IsUnderTrustedDirectory(@"C:\Temp\random\app.exe"));
+
     // ── ParseListTable ──
 
     [Fact]

--- a/SysManager/SysManager/Services/FixedDriveService.cs
+++ b/SysManager/SysManager/Services/FixedDriveService.cs
@@ -64,8 +64,8 @@ public sealed class FixedDriveService
                 {
                     var id = mo["DeviceId"]?.ToString() ?? "";
                     media[id] = (
-                        MapMedia(Convert.ToUInt32(mo["MediaType"] ?? 0u)),
-                        MapBus(Convert.ToUInt32(mo["BusType"] ?? 0u)));
+                        MapMedia(ToUInt32Safe(mo["MediaType"])),
+                        MapBus(ToUInt32Safe(mo["BusType"])));
                 }
             }
 
@@ -112,6 +112,21 @@ public sealed class FixedDriveService
         }
 
         return drives;
+    }
+
+    /// <summary>
+    /// Converts a WMI property value to uint, treating both null and
+    /// <see cref="DBNull"/> as 0. WMI returns <c>DBNull.Value</c> (not null) for
+    /// absent properties, and <c>Convert.ToUInt32(DBNull.Value)</c> throws —
+    /// which previously crashed drive enumeration on common hardware.
+    /// </summary>
+    internal static uint ToUInt32Safe(object? value)
+    {
+        if (value is null || value is DBNull) return 0u;
+        try { return Convert.ToUInt32(value); }
+        catch (InvalidCastException) { return 0u; }
+        catch (FormatException) { return 0u; }
+        catch (OverflowException) { return 0u; }
     }
 
     private static string MapMedia(uint v) => v switch

--- a/SysManager/SysManager/Services/UninstallerService.cs
+++ b/SysManager/SysManager/Services/UninstallerService.cs
@@ -364,7 +364,7 @@ public sealed partial class UninstallerService
     /// Checks whether the given absolute path resides under a trusted system directory
     /// (Program Files, Windows, ProgramData, or LocalApplicationData).
     /// </summary>
-    private static bool IsUnderTrustedDirectory(string fullPath)
+    internal static bool IsUnderTrustedDirectory(string fullPath)
     {
         var trustedDirs = new[]
         {
@@ -375,8 +375,15 @@ public sealed partial class UninstallerService
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
         };
 
+        // Compare on a directory boundary, not a raw prefix. A bare StartsWith lets
+        // "C:\Program Files Evil\x.exe" pass the "C:\Program Files" check — so append
+        // a trailing separator to both sides before comparing.
+        static string WithSep(string p) =>
+            p.EndsWith(System.IO.Path.DirectorySeparatorChar) ? p : p + System.IO.Path.DirectorySeparatorChar;
+
+        var candidate = WithSep(System.IO.Path.GetFullPath(fullPath));
         return trustedDirs.Any(dir =>
             !string.IsNullOrEmpty(dir) &&
-            fullPath.StartsWith(dir, StringComparison.OrdinalIgnoreCase));
+            candidate.StartsWith(WithSep(System.IO.Path.GetFullPath(dir)), StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.2</Version>
-    <FileVersion>1.20.2.0</FileVersion>
-    <AssemblyVersion>1.20.2.0</AssemblyVersion>
+    <Version>1.20.3</Version>
+    <FileVersion>1.20.3.0</FileVersion>
+    <AssemblyVersion>1.20.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Round 3 of the audit — P1 crash/security safety (the two highest-impact items in this round).

## Drive enumeration crashed on missing WMI properties
`FixedDriveService` read `MediaType`/`BusType` via `Convert.ToUInt32(value ?? 0u)`. WMI returns `DBNull.Value` (**not** null) for absent properties, so the `??` never fired and `Convert.ToUInt32(DBNull.Value)` threw — aborting the entire drive scan on hardware that doesn't report those fields. Reads now go through a `ToUInt32Safe` helper that maps both null and `DBNull` to 0.

## Uninstaller trusted-directory check accepted sibling folders
`IsUnderTrustedDirectory` used a bare `StartsWith`, so `C:\Program Files Evil\malware.exe` passed the `C:\Program Files` check. It now compares on a normalized directory boundary (trailing separator + `GetFullPath`), so only genuine sub-paths of a trusted directory qualify.

## Tests
Both methods made `internal` (InternalsVisibleTo already present) for direct unit testing:
- `ToUInt32Safe`: DBNull → 0, null → 0, convertible values, unconvertible string → 0.
- `IsUnderTrustedDirectory`: path inside Program Files trusted; `Program Files Evil` sibling rejected; unrelated temp path rejected.

## Regression
Full-solution build clean (main + Tests + IntegrationTests + UITests). Version 1.20.3.

Remaining Round-3 items (PingMonitor CTS, LogsVM UI-thread COM, StartupVM cross-thread, Dashboard NVIDIA-only GPU) will follow in a separate PR.