### PR TITLE
docs: add Support section linking GitHub Sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,17 @@ PRs welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for the build
 setup, coding conventions, and pull-request workflow. New contributors are
 expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 
+## Support
+
+SysManager is free and open source, built by one person in their spare time.
+If it saved you a reinstall or a clean-up headache, you can back its development:
+
+[![Sponsor](https://img.shields.io/badge/Sponsor-laurentiu021-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/laurentiu021)
+
+Sponsorships go toward a code-signing certificate, so Windows stops warning on
+first launch, plus the build pipeline and time to fix bugs and finish the tools
+that are still half-built. The app stays free either way.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
## What

Adds a **Support** section to the README, between Contributing and License, with a Sponsor badge linking to the GitHub Sponsors profile.

## Why

The repo already exposes the Sponsor button via `.github/FUNDING.yml` (GitHub + Ko-fi), but the README never mentioned sponsorship. This adds a short, honest ask tied to the concrete goal (code-signing certificate to clear the SmartScreen warning), the build pipeline, and finishing in-progress tools. Reassures readers the app stays free either way.

## Notes

- `docs:` only — no version bump, no release, no CHANGELOG entry required.
- No new images or claims; honest framing preserved (does not imply WIP tabs are complete).