### PR TITLE
refactor: extract IPowerShellRunner seam for DNS/network/winget services

### DIFF
--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -18,8 +18,11 @@ public static class ServiceRegistration
     {
         // ── Core services ──────────────────────────────────────────────
         // PowerShellRunner is Transient — each consumer gets its own instance
-        // to avoid LineReceived event cross-talk between tabs.
+        // to avoid LineReceived event cross-talk between tabs. Registered under
+        // both the concrete type (legacy consumers) and the IPowerShellRunner
+        // seam (DNS / network repair / winget install — substitutable in tests).
         services.AddTransient<PowerShellRunner>();
+        services.AddTransient<IPowerShellRunner, PowerShellRunner>();
         services.AddSingleton<SystemInfoService>();
         services.AddSingleton<WingetService>();
         services.AddSingleton<TrayIconService>();

--- a/SysManager/SysManager/Services/BulkInstallerService.cs
+++ b/SysManager/SysManager/Services/BulkInstallerService.cs
@@ -12,9 +12,9 @@ namespace SysManager.Services;
 /// </summary>
 public sealed partial class BulkInstallerService
 {
-    private readonly PowerShellRunner _runner;
+    private readonly IPowerShellRunner _runner;
 
-    public BulkInstallerService(PowerShellRunner runner) => _runner = runner;
+    public BulkInstallerService(IPowerShellRunner runner) => _runner = runner;
 
     public event Action<PowerShellLine>? LineReceived
     {

--- a/SysManager/SysManager/Services/DnsService.cs
+++ b/SysManager/SysManager/Services/DnsService.cs
@@ -14,10 +14,10 @@ namespace SysManager.Services;
 /// </summary>
 public sealed class DnsService : IDisposable
 {
-    private readonly PowerShellRunner _ps;
+    private readonly IPowerShellRunner _ps;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
-    public DnsService(PowerShellRunner ps) => _ps = ps;
+    public DnsService(IPowerShellRunner ps) => _ps = ps;
 
     public void Dispose() => _gate.Dispose();
 

--- a/SysManager/SysManager/Services/IPowerShellRunner.cs
+++ b/SysManager/SysManager/Services/IPowerShellRunner.cs
@@ -1,0 +1,61 @@
+// SysManager · IPowerShellRunner
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+using System.Text;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Abstraction over <see cref="PowerShellRunner"/> — the single seam through which
+/// services run PowerShell scripts and external processes. Extracting this interface
+/// lets system-mutating services (DNS, network repair, winget install) be unit-tested
+/// with a substituted runner instead of touching the live OS (Gate-ARCH: "external
+/// process/PowerShell calls route through the single runner seam").
+///
+/// <para>The same <b>SECURITY CONTRACT</b> as <see cref="PowerShellRunner"/> applies:
+/// callers MUST only pass hard-coded script strings to <see cref="RunAsync"/> and
+/// <see cref="RunScriptViaPwshAsync"/>. User input MUST NEVER be interpolated into
+/// scripts.</para>
+/// </summary>
+public interface IPowerShellRunner
+{
+    /// <summary>
+    /// Raised for each line of output from any stream. Fires on a thread-pool thread —
+    /// subscribers that update UI elements must marshal to the dispatcher.
+    /// </summary>
+    event Action<PowerShellLine>? LineReceived;
+
+    /// <summary>Raised with a 0-100 percentage as PowerShell progress records arrive.</summary>
+    event Action<int>? ProgressChanged;
+
+    /// <summary>
+    /// Execute a script in-process and return the collected PSObject results.
+    /// All streams are forwarded via <see cref="LineReceived"/> for live UI display.
+    /// </summary>
+    Task<Collection<PSObject>> RunAsync(
+        string script,
+        IDictionary<string, object?>? parameters = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Run a PowerShell script via an external powershell.exe (Windows PS 5.1),
+    /// returning the process exit code. Output is streamed via <see cref="LineReceived"/>.
+    /// </summary>
+    Task<int> RunScriptViaPwshAsync(
+        string script,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Run an external process (winget, netsh, ipconfig, …) with live line streaming,
+    /// returning the process exit code.
+    /// </summary>
+    Task<int> RunProcessAsync(
+        string fileName,
+        string arguments,
+        CancellationToken cancellationToken = default,
+        Encoding? outputEncoding = null);
+}

--- a/SysManager/SysManager/Services/NetworkRepairService.cs
+++ b/SysManager/SysManager/Services/NetworkRepairService.cs
@@ -12,10 +12,10 @@ namespace SysManager.Services;
 /// </summary>
 public sealed class NetworkRepairService : IDisposable
 {
-    private readonly PowerShellRunner _ps;
+    private readonly IPowerShellRunner _ps;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
-    public NetworkRepairService(PowerShellRunner ps) => _ps = ps;
+    public NetworkRepairService(IPowerShellRunner ps) => _ps = ps;
 
     /// <inheritdoc />
     public void Dispose() => _gate.Dispose();

--- a/SysManager/SysManager/Services/PowerShellRunner.cs
+++ b/SysManager/SysManager/Services/PowerShellRunner.cs
@@ -23,7 +23,7 @@ namespace SysManager.Services;
 /// Violation of this contract creates a code injection vulnerability. The Bypass policy
 /// is safe ONLY because the script content is fully controlled by SysManager's source code.</para>
 /// </summary>
-public sealed class PowerShellRunner
+public sealed class PowerShellRunner : IPowerShellRunner
 {
     /// <summary>
     /// Raised for each line of output from any stream (stdout, stderr, information,


### PR DESCRIPTION
## What

Audit **Round 4 / PR2** — Gate-ARCH seam extraction (covers test findings #7, #8, #9). Introduces `IPowerShellRunner` over the concrete `PowerShellRunner`:

- New `IPowerShellRunner` exposing `RunAsync`, `RunScriptViaPwshAsync`, `RunProcessAsync`, and the `LineReceived`/`ProgressChanged` events.
- `PowerShellRunner : IPowerShellRunner` (members unchanged).
- `DnsService`, `NetworkRepairService`, `BulkInstallerService` constructors now take `IPowerShellRunner`.
- DI registers `IPowerShellRunner -> PowerShellRunner` (Transient) **alongside** the existing concrete registration, kept for the remaining consumers that still resolve the concrete type.

## Why

These three services mutate live state (DNS servers, Winsock/TCP-IP, winget install) but depend on the concrete `sealed PowerShellRunner`, so NSubstitute can't substitute them — every test was forced to `new XxxService(new PowerShellRunner())` and avoid the Apply paths entirely. This seam is the precondition for the install/repair/DNS-script unit tests in the next PR.

## Behavior guarantee (Protocol Q)

Behavior is **byte-for-byte identical** — only the dependency *type* the three services accept changes. No logic touched. The static `PowerShellRunner.OemEncoding` stays on the concrete class and is still referenced as `PowerShellRunner.OemEncoding` everywhere.

## Verification

- Build: main + unit tests + integration tests, **0 errors / 0 warnings** (Release).
- Gate-ARCH: interface surface matches the concrete public instance members exactly (5/5).
- Propagate check: the 5 sites that `new` these services (MainWindowViewModel + 2 test helpers) still compile unchanged (`PowerShellRunner` IS `IPowerShellRunner`). No half-migration.

## Notes

- `refactor:` — no version bump, no release, no CHANGELOG entry required.