### PR TITLE
refactor: make AppBlockerService instance-based behind IAppBlockerService

### DIFF
--- a/SysManager/SysManager.Tests/AppBlockerServiceRegistryTests.cs
+++ b/SysManager/SysManager.Tests/AppBlockerServiceRegistryTests.cs
@@ -1,0 +1,107 @@
+// SysManager · AppBlockerServiceRegistryTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using Microsoft.Win32;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Round-trip tests for <see cref="AppBlockerService"/>'s IFEO registry writes
+/// (audit finding tests #12). The service takes an injectable registry root; here
+/// we point it at a disposable subkey under HKCU so block/unblock can be verified
+/// against a real registry hive without administrator rights and without touching
+/// the machine's actual HKLM IFEO configuration.
+/// </summary>
+public sealed class AppBlockerServiceRegistryTests : IDisposable
+{
+    private const string IfeoPath = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options";
+    private const string BlockerDebugger = @"C:\Windows\System32\SysManager_Blocked.exe";
+
+    private readonly string _rootName = @"Software\SysManagerTests\AppBlocker_" + Guid.NewGuid().ToString("N");
+    private readonly RegistryKey _root;
+    private readonly AppBlockerService _svc;
+
+    public AppBlockerServiceRegistryTests()
+    {
+        // A writable, user-scoped root standing in for Registry.LocalMachine.
+        _root = Registry.CurrentUser.CreateSubKey(_rootName, writable: true)!;
+        // The service expects to find the IFEO path under the root; pre-create it.
+        _root.CreateSubKey(IfeoPath, writable: true)!.Dispose();
+        _svc = new AppBlockerService(_root);
+    }
+
+    public void Dispose()
+    {
+        _root.Dispose();
+        try { Registry.CurrentUser.DeleteSubKeyTree(_rootName, throwOnMissingSubKey: false); } catch { /* best-effort cleanup */ }
+    }
+
+    private string? ReadDebugger(string exeName)
+    {
+        using var appKey = _root.OpenSubKey($@"{IfeoPath}\{exeName}");
+        return appKey?.GetValue("Debugger") as string;
+    }
+
+    [Fact]
+    public void BlockApp_WritesBlockerDebuggerValue()
+    {
+        Assert.True(_svc.BlockApp("notepad.exe"));
+        Assert.Equal(BlockerDebugger, ReadDebugger("notepad.exe"));
+        Assert.True(_svc.IsBlocked("notepad.exe"));
+    }
+
+    [Fact]
+    public void BlockApp_AppendsExeExtension()
+    {
+        Assert.True(_svc.BlockApp("calc"));
+        Assert.Equal(BlockerDebugger, ReadDebugger("calc.exe"));
+    }
+
+    [Fact]
+    public void UnblockApp_RemovesTheDebuggerValueAndKey()
+    {
+        _svc.BlockApp("game.exe");
+        Assert.True(_svc.IsBlocked("game.exe"));
+
+        Assert.True(_svc.UnblockApp("game.exe"));
+        Assert.False(_svc.IsBlocked("game.exe"));
+        Assert.Null(ReadDebugger("game.exe"));
+    }
+
+    [Fact]
+    public void GetBlockedApps_ListsOnlySysManagerBlockedEntries()
+    {
+        _svc.BlockApp("one.exe");
+        _svc.BlockApp("two.exe");
+
+        var blocked = _svc.GetBlockedApps().Select(b => b.ExecutableName).ToList();
+
+        Assert.Contains("one.exe", blocked);
+        Assert.Contains("two.exe", blocked);
+    }
+
+    [Fact]
+    public void BlockApp_DoesNotClobberExternalDebuggerValue()
+    {
+        // A legitimately-debugged app already has a foreign Debugger value.
+        using (var external = _root.CreateSubKey($@"{IfeoPath}\debugged.exe", writable: true)!)
+            external.SetValue("Debugger", @"C:\Tools\mydebugger.exe", RegistryValueKind.String);
+
+        Assert.False(_svc.BlockApp("debugged.exe"));
+        // The external value must be left intact.
+        Assert.Equal(@"C:\Tools\mydebugger.exe", ReadDebugger("debugged.exe"));
+    }
+
+    [Fact]
+    public void UnblockApp_LeavesForeignDebuggerKeyUntouched()
+    {
+        using (var external = _root.CreateSubKey($@"{IfeoPath}\external.exe", writable: true)!)
+            external.SetValue("Debugger", @"C:\Tools\dbg.exe", RegistryValueKind.String);
+
+        // Unblock should be a no-op on a key we did not set.
+        Assert.True(_svc.UnblockApp("external.exe"));
+        Assert.Equal(@"C:\Tools\dbg.exe", ReadDebugger("external.exe"));
+    }
+}

--- a/SysManager/SysManager.Tests/AppBlockerServiceValidationTests.cs
+++ b/SysManager/SysManager.Tests/AppBlockerServiceValidationTests.cs
@@ -5,13 +5,15 @@ namespace SysManager.Tests;
 
 public class AppBlockerServiceValidationTests
 {
+    private static AppBlockerService NewService() => new();
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
     public void BlockApp_NullOrWhitespace_ReturnsFalse(string? exeName)
     {
-        Assert.False(AppBlockerService.BlockApp(exeName!));
+        Assert.False(NewService().BlockApp(exeName!));
     }
 
     [Theory]
@@ -25,7 +27,7 @@ public class AppBlockerServiceValidationTests
     [InlineData(@"app"".exe")]
     public void BlockApp_InvalidCharsInName_ReturnsFalse(string exeName)
     {
-        Assert.False(AppBlockerService.BlockApp(exeName));
+        Assert.False(NewService().BlockApp(exeName));
     }
 
     [Theory]
@@ -42,7 +44,7 @@ public class AppBlockerServiceValidationTests
         // not because of invalid input. We can't distinguish in the return value,
         // but we verify the format is accepted by checking IsBlocked (which also
         // requires registry access and will return false gracefully).
-        var result = AppBlockerService.IsBlocked(exeName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) ? exeName : exeName + ".exe");
+        var result = NewService().IsBlocked(exeName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) ? exeName : exeName + ".exe");
         // IsBlocked reads registry - will return false if no access, but won't throw
         Assert.False(result); // expected since nothing is actually blocked
     }
@@ -51,20 +53,20 @@ public class AppBlockerServiceValidationTests
     public void GetBlockedApps_ReturnsListWithoutThrowing()
     {
         // Should not throw even without admin
-        var result = AppBlockerService.GetBlockedApps();
+        var result = NewService().GetBlockedApps();
         Assert.NotNull(result);
     }
 
     [Fact]
     public void IsBlocked_EmptyName_ReturnsFalse()
     {
-        Assert.False(AppBlockerService.IsBlocked(""));
+        Assert.False(NewService().IsBlocked(""));
     }
 
     [Fact]
     public void IsBlocked_NormalExeName_DoesNotThrow()
     {
-        var ex = Record.Exception(() => AppBlockerService.IsBlocked("notepad.exe"));
+        var ex = Record.Exception(() => NewService().IsBlocked("notepad.exe"));
         Assert.Null(ex);
     }
 }

--- a/SysManager/SysManager.Tests/AppBlockerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppBlockerViewModelTests.cs
@@ -2,7 +2,9 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using NSubstitute;
 using SysManager.Models;
+using SysManager.Services;
 using SysManager.ViewModels;
 using Xunit;
 
@@ -10,10 +12,19 @@ namespace SysManager.Tests;
 
 public class AppBlockerViewModelTests
 {
+    // A blocker that reports nothing blocked — keeps the VM ctor's RefreshList()
+    // a no-op so these tests exercise pure VM logic without registry access.
+    private static AppBlockerViewModel NewVm()
+    {
+        var blocker = Substitute.For<IAppBlockerService>();
+        blocker.GetBlockedApps().Returns([]);
+        return new AppBlockerViewModel(blocker);
+    }
+
     [Fact]
     public void InitialState_IsCorrect()
     {
-        var vm = new AppBlockerViewModel();
+        var vm = NewVm();
         Assert.Equal("", vm.NewExeName);
         Assert.NotNull(vm.BlockedApps);
     }
@@ -21,7 +32,7 @@ public class AppBlockerViewModelTests
     [Fact]
     public void SelectAll_SetsAllSelected()
     {
-        var vm = new AppBlockerViewModel();
+        var vm = NewVm();
         vm.BlockedApps.Add(new BlockedApp { ExecutableName = "a.exe", IsSelected = false });
         vm.BlockedApps.Add(new BlockedApp { ExecutableName = "b.exe", IsSelected = false });
 
@@ -33,7 +44,7 @@ public class AppBlockerViewModelTests
     [Fact]
     public void DeselectAll_ClearsAllSelected()
     {
-        var vm = new AppBlockerViewModel();
+        var vm = NewVm();
         vm.BlockedApps.Add(new BlockedApp { ExecutableName = "a.exe", IsSelected = true });
         vm.BlockedApps.Add(new BlockedApp { ExecutableName = "b.exe", IsSelected = true });
 

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -35,7 +35,7 @@ public static class ServiceRegistration
         services.AddSingleton<TuneUpService>();
         services.AddSingleton<HealthScoreService>();
         services.AddSingleton<AppAlertService>();
-        services.AddSingleton<AppBlockerService>();
+        services.AddSingleton<IAppBlockerService, AppBlockerService>();
         services.AddSingleton<DeepCleanupService>();
         services.AddSingleton<DiskAnalyzerService>();
         services.AddSingleton<DuplicateFileService>();

--- a/SysManager/SysManager/Services/AppBlockerService.cs
+++ b/SysManager/SysManager/Services/AppBlockerService.cs
@@ -16,16 +16,31 @@ namespace SysManager.Services;
 /// to launch the debugger (a non-existent path) instead of the target app,
 /// effectively preventing it from running. Fully reversible by removing the key.
 /// Requires administrator privileges.
+///
+/// <para>The registry root is injectable (defaulting to
+/// <see cref="Registry.LocalMachine"/>) so the IFEO writes can be unit-tested
+/// against a redirected hive (e.g. a key under HKCU) without admin or touching
+/// the machine's real configuration.</para>
 /// </summary>
-public sealed partial class AppBlockerService
+public sealed partial class AppBlockerService : IAppBlockerService
 {
     private const string IfeoPath = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options";
     private const string BlockerDebugger = @"C:\Windows\System32\SysManager_Blocked.exe";
 
+    private readonly RegistryKey _baseKey;
+
+    /// <summary>
+    /// Creates the service over a registry root. Defaults to
+    /// <see cref="Registry.LocalMachine"/> (the real IFEO hive); tests pass a
+    /// redirected root (e.g. an HKCU subkey) to avoid admin and machine writes.
+    /// </summary>
+    public AppBlockerService(RegistryKey? baseKey = null)
+        => _baseKey = baseKey ?? Registry.LocalMachine;
+
     /// <summary>
     /// Blocks an executable from running.
     /// </summary>
-    public static bool BlockApp(string exeName)
+    public bool BlockApp(string exeName)
     {
         if (string.IsNullOrWhiteSpace(exeName)) return false;
 
@@ -41,7 +56,7 @@ public sealed partial class AppBlockerService
 
         try
         {
-            using var ifeo = Registry.LocalMachine.OpenSubKey(IfeoPath, writable: true);
+            using var ifeo = _baseKey.OpenSubKey(IfeoPath, writable: true);
             if (ifeo is null) return false;
 
             using var appKey = ifeo.CreateSubKey(exeName, writable: true);
@@ -83,7 +98,7 @@ public sealed partial class AppBlockerService
     /// <summary>
     /// Unblocks an executable, allowing it to run again.
     /// </summary>
-    public static bool UnblockApp(string exeName)
+    public bool UnblockApp(string exeName)
     {
         if (string.IsNullOrWhiteSpace(exeName)) return false;
 
@@ -99,7 +114,7 @@ public sealed partial class AppBlockerService
 
         try
         {
-            using var ifeo = Registry.LocalMachine.OpenSubKey(IfeoPath, writable: true);
+            using var ifeo = _baseKey.OpenSubKey(IfeoPath, writable: true);
             if (ifeo is null) return false;
 
             using var appKey = ifeo.OpenSubKey(exeName, writable: true);
@@ -140,7 +155,7 @@ public sealed partial class AppBlockerService
     /// <summary>
     /// Checks if an executable is currently blocked by SysManager.
     /// </summary>
-    public static bool IsBlocked(string exeName)
+    public bool IsBlocked(string exeName)
     {
         if (string.IsNullOrWhiteSpace(exeName)) return false;
 
@@ -149,7 +164,7 @@ public sealed partial class AppBlockerService
 
         try
         {
-            using var ifeo = Registry.LocalMachine.OpenSubKey(IfeoPath);
+            using var ifeo = _baseKey.OpenSubKey(IfeoPath);
             if (ifeo is null) return false;
 
             using var appKey = ifeo.OpenSubKey(exeName);
@@ -166,13 +181,13 @@ public sealed partial class AppBlockerService
     /// <summary>
     /// Gets all currently blocked applications (blocked by SysManager).
     /// </summary>
-    public static IReadOnlyList<BlockedApp> GetBlockedApps()
+    public IReadOnlyList<BlockedApp> GetBlockedApps()
     {
         List<BlockedApp> blocked = [];
 
         try
         {
-            using var ifeo = Registry.LocalMachine.OpenSubKey(IfeoPath);
+            using var ifeo = _baseKey.OpenSubKey(IfeoPath);
             if (ifeo is null) return blocked;
 
             foreach (var subKeyName in ifeo.GetSubKeyNames())

--- a/SysManager/SysManager/Services/IAppBlockerService.cs
+++ b/SysManager/SysManager/Services/IAppBlockerService.cs
@@ -1,0 +1,28 @@
+// SysManager · IAppBlockerService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Blocks/unblocks applications via the Image File Execution Options (IFEO)
+/// registry mechanism. Extracted as an interface so the registry-mutating logic
+/// can be unit-tested against a redirectable registry root instead of writing to
+/// the machine's real HKLM hive (Gate-ARCH: system-mutating services are testable).
+/// </summary>
+public interface IAppBlockerService
+{
+    /// <summary>Blocks an executable from running. Returns true on success.</summary>
+    bool BlockApp(string exeName);
+
+    /// <summary>Unblocks an executable, allowing it to run again. Returns true on success.</summary>
+    bool UnblockApp(string exeName);
+
+    /// <summary>Checks whether an executable is currently blocked by SysManager.</summary>
+    bool IsBlocked(string exeName);
+
+    /// <summary>Gets all applications currently blocked by SysManager.</summary>
+    IReadOnlyList<BlockedApp> GetBlockedApps();
+}

--- a/SysManager/SysManager/ViewModels/AppBlockerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppBlockerViewModel.cs
@@ -25,8 +25,11 @@ public sealed partial class AppBlockerViewModel : ViewModelBase
     [ObservableProperty] private int _blockedCount;
     [ObservableProperty] private bool _isElevated;
 
-    public AppBlockerViewModel()
+    private readonly IAppBlockerService _blocker;
+
+    public AppBlockerViewModel(IAppBlockerService blocker)
     {
+        _blocker = blocker;
         IsElevated = AdminHelper.IsElevated();
         RefreshList();
     }
@@ -41,7 +44,7 @@ public sealed partial class AppBlockerViewModel : ViewModelBase
     [RelayCommand]
     private void RefreshList()
     {
-        var apps = AppBlockerService.GetBlockedApps();
+        var apps = _blocker.GetBlockedApps();
         BlockedApps.ReplaceWith(apps);
         BlockedCount = BlockedApps.Count;
         BlockStatus = BlockedCount == 0
@@ -68,7 +71,7 @@ public sealed partial class AppBlockerViewModel : ViewModelBase
         if (!exeName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
             exeName += ".exe";
 
-        if (AppBlockerService.IsBlocked(exeName))
+        if (_blocker.IsBlocked(exeName))
         {
             BlockStatus = $"{exeName} is already blocked.";
             return;
@@ -78,7 +81,7 @@ public sealed partial class AppBlockerViewModel : ViewModelBase
             $"Block \"{exeName}\" from running?\n\nThis will prevent the application from launching until you unblock it.",
             "Block Application — Confirm")) return;
 
-        var success = AppBlockerService.BlockApp(exeName);
+        var success = _blocker.BlockApp(exeName);
         if (success)
         {
             NewExeName = "";
@@ -109,7 +112,7 @@ public sealed partial class AppBlockerViewModel : ViewModelBase
         int unblocked = 0;
         foreach (var app in selected)
         {
-            if (AppBlockerService.UnblockApp(app.ExecutableName))
+            if (_blocker.UnblockApp(app.ExecutableName))
                 unblocked++;
         }
 

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -188,7 +188,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Services = new ServicesViewModel(runner);
             AppAlerts = new AppAlertsViewModel(new AppAlertService());
             ShortcutCleaner = new ShortcutCleanerViewModel(shortcuts);
-            AppBlocker = new AppBlockerViewModel();
+            AppBlocker = new AppBlockerViewModel(new AppBlockerService());
             BulkInstaller = new BulkInstallerViewModel(new BulkInstallerService(new PowerShellRunner()), new AppIconService());
             FileShredder = new FileShredderViewModel(new FileShredderService());
             DnsHosts = new DnsHostsViewModel(new DnsService(new PowerShellRunner()), new HostsFileService());


### PR DESCRIPTION
## What

Audit **Round 4 / PR5** — Gate-ARCH seam extraction (test finding #12). `AppBlockerService` was an all-static class registered (pointlessly) as a DI singleton, writing straight to HKLM's IFEO key — untestable without admin + machine writes, and the VM was coupled to the statics.

- New `IAppBlockerService` (`BlockApp`/`UnblockApp`/`IsBlocked`/`GetBlockedApps`).
- `AppBlockerService` implements it; methods are now **instance** methods over an injectable `RegistryKey` root (defaults to `Registry.LocalMachine` — production behavior unchanged).
- `AppBlockerViewModel` takes `IAppBlockerService`; the non-DI fallback in `MainWindowViewModel` passes `new AppBlockerService()`.
- DI: `AddSingleton<IAppBlockerService, AppBlockerService>` replaces the dead concrete-only registration.

## Tests

- Validation tests converted to an instance (no behavior change).
- New `AppBlockerServiceRegistryTests` drives a **real round-trip against an HKCU-redirected root** — block writes the Debugger value, unblock removes it, `GetBlockedApps` lists only SysManager entries, and a foreign Debugger value is never clobbered. No admin, no HKLM writes.
- VM tests use a substituted `IAppBlockerService`.

## Behavior guarantee (Protocol Q)

Identical — only the registry root becomes injectable. The IFEO path, debugger sentinel, validation regex, and clobber-protection logic are byte-for-byte unchanged.

## Verification

- Build: main + unit + integration, **0 errors / 0 warnings** (Release).
- Gate-ARCH: interface surface matches impl 4/4.
- Propagate check: zero remaining static `AppBlockerService.` calls; no `new AppBlockerViewModel()` without the arg.

## Notes

- `refactor:` — no version bump, no release, no CHANGELOG entry required.