### PR TITLE
test: serialize DialogService.Instance tests to fix flaky confirm-gate assertion

### DIFF
--- a/SysManager/SysManager.Tests/DeepCleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupViewModelTests.cs
@@ -15,6 +15,7 @@ namespace SysManager.Tests;
 /// Pure unit tests for <see cref="DeepCleanupViewModel"/>.
 /// Heavier scan/clean tests that hit the real filesystem live in IntegrationTests.
 /// </summary>
+[Collection("DialogService")]
 public class DeepCleanupViewModelTests
 {
     private static DeepCleanupViewModel NewVm() => new(new Services.DeepCleanupService(), new Services.LargeFileScanner(), new Services.FixedDriveService());

--- a/SysManager/SysManager.Tests/FileShredderViewModelTests.cs
+++ b/SysManager/SysManager.Tests/FileShredderViewModelTests.cs
@@ -17,6 +17,7 @@ namespace SysManager.Tests;
 /// ShredAll command routes through <see cref="DialogService.Instance"/>.Confirm
 /// (audit finding tests #2 — the "every destructive op needs Confirm" contract).
 /// </summary>
+[Collection("DialogService")]
 public class FileShredderViewModelTests
 {
     private static FileShredderViewModel CreateVm() =>

--- a/SysManager/SysManager.Tests/PrivacyViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PrivacyViewModelTests.cs
@@ -13,6 +13,7 @@ namespace SysManager.Tests;
 /// category filtering, pending-change tracking, and discard behavior
 /// without writing to the registry.
 /// </summary>
+[Collection("DialogService")]
 public class PrivacyViewModelTests
 {
     private static PrivacyViewModel CreateVm() => new(new PrivacyService());

--- a/SysManager/SysManager.Tests/TestCollections.cs
+++ b/SysManager/SysManager.Tests/TestCollections.cs
@@ -23,3 +23,12 @@ public class OperationLockCollection { }
 /// </summary>
 [CollectionDefinition("IconCache", DisableParallelization = true)]
 public class IconCacheCollection { }
+
+/// <summary>
+/// Groups tests that swap the global <c>DialogService.Instance</c> static so they
+/// run sequentially. Without this, two collections setting the shared static in
+/// parallel race each other — one test's substitute receives (or misses) another's
+/// Confirm call, making the confirmation-gate tests flaky.
+/// </summary>
+[CollectionDefinition("DialogService", DisableParallelization = true)]
+public class DialogServiceCollection { }


### PR DESCRIPTION
## What

Fixes an intermittent test failure that surfaced on `main` after #827: `FileShredderViewModelTests.ShredAll_WhenUserDeclinesConfirm_ShredsNothing` failed with NSubstitute *'Expected to receive exactly 1 call'* — **1 of 2428 tests**, flaky.

## Root cause

Three test classes — `FileShredderViewModelTests`, `DeepCleanupViewModelTests`, `PrivacyViewModelTests` — each swap the **global `DialogService.Instance` static** and restore it in a `finally`. The runner config (`xunit.runner.json`) has `parallelizeTestCollections: true`, so these ran as separate collections **in parallel**. One test could overwrite `DialogService.Instance` between another's setup and its awaited command, so the substitute received (or missed) the other's `Confirm` call.

## Fix

Add a serial `[CollectionDefinition("DialogService", DisableParallelization = true)]` — the **same pattern already used** for the Network / OperationLock / IconCache collections — and place all three classes in it. They no longer touch the shared static concurrently. This removes the race at its root (not a retry/sleep mask).

## Notes

- `test:` only — **no production code changed**, no release.
- Build: tests project 0 errors / 0 warnings (Release).
- The underlying tested behavior (the Confirm gates themselves) is unchanged and was always correct; only the test isolation was wrong.