### PR TITLE
fix: add accessible names to icon-only row actions and App Blocker input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.6] - 2026-06-10
+
+### Fixed
+- **Screen readers now announce row actions and the App Blocker input by name.** Several icon-only and unlabeled controls had no accessible name, so assistive technology announced them generically (e.g. "X button"). Added `AutomationProperties.Name` to the Process Manager Kill/Open buttons (with the process name), the Ping remove-target button (with the target name), the File Shredder row Remove button (with the file name), and the App Blocker executable-name input.
+
 ## [1.20.5] - 2026-06-08
 
 ### Added

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.5</Version>
-    <FileVersion>1.20.5.0</FileVersion>
-    <AssemblyVersion>1.20.5.0</AssemblyVersion>
+    <Version>1.20.6</Version>
+    <FileVersion>1.20.6.0</FileVersion>
+    <AssemblyVersion>1.20.6.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AppBlockerView.xaml
+++ b/SysManager/SysManager/Views/AppBlockerView.xaml
@@ -59,7 +59,8 @@
         <!-- Block input -->
         <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,0,0,12">
             <TextBox Text="{Binding NewExeName, UpdateSourceTrigger=PropertyChanged}" Width="250" Padding="6,4"
-                     VerticalAlignment="Center" Margin="0,0,8,0" />
+                     VerticalAlignment="Center" Margin="0,0,8,0"
+                     AutomationProperties.Name="Executable name to block" />
             <Button Content="Block" Command="{Binding BlockAppCommand}" Style="{StaticResource PrimaryButton}" Padding="12,6" Margin="0,0,8,0" />
             <Button Content="Browse..." Command="{Binding BrowseForExeCommand}" Style="{StaticResource SecondaryButton}" Padding="8,6" />
         </StackPanel>

--- a/SysManager/SysManager/Views/FileShredderView.xaml
+++ b/SysManager/SysManager/Views/FileShredderView.xaml
@@ -91,6 +91,7 @@
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <Button Content="Remove"
+                                    AutomationProperties.Name="{Binding Name, StringFormat='Remove {0} from shred queue'}"
                                     Command="{Binding DataContext.RemoveItemCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
                                     CommandParameter="{Binding}"
                                     Style="{StaticResource GhostButton}"

--- a/SysManager/SysManager/Views/PingView.xaml
+++ b/SysManager/SysManager/Views/PingView.xaml
@@ -118,6 +118,8 @@
                                         </StackPanel>
                                         <Button Content="&#x2715;" DockPanel.Dock="Right" Padding="6,2" FontSize="10"
                                                 VerticalAlignment="Center" Style="{StaticResource GhostButton}"
+                                                ToolTip="Remove target"
+                                                AutomationProperties.Name="{Binding Name, StringFormat='Remove {0}'}"
                                                 Command="{Binding DataContext.RemoveTargetCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                 CommandParameter="{Binding}"
                                                 Visibility="{Binding IsCustom, Converter={StaticResource FlexVis}}"/>

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -168,12 +168,14 @@
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal">
                                     <Button Content="Open" ToolTip="Open file location"
+                                            AutomationProperties.Name="{Binding Name, StringFormat='Open file location for {0}'}"
                                             Command="{Binding DataContext.OpenFileLocationCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                             CommandParameter="{Binding}"
                                             IsEnabled="{Binding CanOpenFileLocation}"
                                             Style="{StaticResource GhostButton}" Padding="4,2" FontSize="12"
                                             Margin="0,0,4,0"/>
                                     <Button Content="X" ToolTip="Kill process"
+                                            AutomationProperties.Name="{Binding Name, StringFormat='Kill {0}'}"
                                             Command="{Binding DataContext.KillProcessCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                             CommandParameter="{Binding}"
                                             Style="{StaticResource GhostButton}" Padding="6,2" FontSize="12"


### PR DESCRIPTION
## What

Audit **Round 7** (accessibility, Gate-UX) — first batch. Several icon-only / unlabeled controls had no `AutomationProperties.Name`, so screen readers and UI automation announced them generically (e.g. the Process Manager kill button as *'X button'*). Added context-bearing accessible names:

| View | Control | Accessible name |
|---|---|---|
| Process Manager | Kill button | `Kill {process}` |
| Process Manager | Open button | `Open file location for {process}` |
| Ping | remove-target ✕ | `Remove {target}` (+ 'Remove target' tooltip) |
| File Shredder | row Remove | `Remove {file} from shred queue` |
| App Blocker | exe-name input | `Executable name to block` |

(Audit findings #12, #13, #38, #27.)

## Behavior

Visual appearance and behavior are **unchanged** — this only adds accessibility metadata consumed by assistive technology and the UI-automation test layer. Names are bound to the row's existing `Name` where applicable, so they stay correct per row.

## Verification

- Build: main + unit + integration, **0 errors / 0 warnings** (Release).
- Gate-UX: each targeted control now exposes a name; checked against sibling row-action conventions.

## Notes

- `fix:` (accessibility is user-visible) — version bumped to **1.20.6**, CHANGELOG updated in this PR. Triggers a release.