### PR TITLE
test: make shred-progress test deterministic with synchronous IProgress

### DIFF
--- a/SysManager/SysManager.Tests/FileShredderServiceTests.cs
+++ b/SysManager/SysManager.Tests/FileShredderServiceTests.cs
@@ -139,22 +139,33 @@ public class FileShredderServiceTests
         }
     }
 
+    /// <summary>
+    /// Synchronous <see cref="IProgress{T}"/> that records reports on the calling
+    /// thread. Unlike <see cref="Progress{T}"/> (which marshals callbacks via the
+    /// captured SynchronizationContext asynchronously), this captures every report
+    /// deterministically by the time the awaited call returns — no timing race.
+    /// </summary>
+    private sealed class SyncProgress : IProgress<int>
+    {
+        public List<int> Reports { get; } = [];
+        public void Report(int value) => Reports.Add(value);
+    }
+
     [Fact]
     public async Task ShredFileAsync_ReportsProgressToCompletion()
     {
         var svc = NewService();
         var file = Path.Combine(Path.GetTempPath(), "smtest_progress_" + Guid.NewGuid().ToString("N") + ".dat");
         await File.WriteAllTextAsync(file, "some bytes");
-        var reports = new List<int>();
-        var progress = new Progress<int>(reports.Add);
+        var progress = new SyncProgress();
 
         try
         {
             await svc.ShredFileAsync(file, ShredMethod.Standard, progress, CancellationToken.None);
 
-            // Progress is marshaled via the captured SynchronizationContext; give it a beat.
-            await Task.Delay(50);
-            Assert.Contains(100, reports);
+            // The service reports synchronously during the awaited shred, so the
+            // final 100% report is guaranteed present once the call completes.
+            Assert.Contains(100, progress.Reports);
         }
         finally
         {


### PR DESCRIPTION
## What

Fixes the flaky `FileShredderServiceTests.ShredFileAsync_ReportsProgressToCompletion` that **failed in the release pipeline and blocked publishing 1.20.6**.

## Root cause

The test used `Progress<int>` — which marshals its callback via the captured `SynchronizationContext` **asynchronously** — plus a fixed `Task.Delay(50)` before asserting the 100% report had arrived. On a slow CI runner the report landed after the delay window, so the assertion saw an empty list. (Same class of bug as the DialogService race fixed in #828: timing-dependent test, not a product defect.)

## Fix

Replace `Progress<int>` with a tiny synchronous `IProgress<int>` that records on the calling thread. `FileShredderService` calls `progress?.Report(...)` **synchronously inside the awaited shred loop**, so every report (including the final 100%) is guaranteed captured by the time the awaited call returns. No delay, no race.

## Notes

- `test:` only — no production code changed, no release.
- The product behavior (progress reporting) was always correct; only the test's capture mechanism was racy.
- Build: tests project 0 errors / 0 warnings (Release).