### PR TITLE
fix: add accessible names to search and filter inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.7] - 2026-06-10
+
+### Fixed
+- **Search and filter boxes now have accessible names.** The category/filter/search inputs on Apps (Bulk Installer), Uninstaller, Process Manager, Services, and Windows Features had no `AutomationProperties.Name`, so screen readers announced them as anonymous edit fields. Each now states what it filters (e.g. "Filter installed apps", "Search winget packages", "Filter Windows features").
+
 ## [1.20.6] - 2026-06-10
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.6</Version>
-    <FileVersion>1.20.6.0</FileVersion>
-    <AssemblyVersion>1.20.6.0</AssemblyVersion>
+    <Version>1.20.7</Version>
+    <FileVersion>1.20.7.0</FileVersion>
+    <AssemblyVersion>1.20.7.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -64,11 +64,13 @@
                            Style="{StaticResource Subtle}"/>
                 <ComboBox ItemsSource="{Binding Categories}"
                           SelectedItem="{Binding SelectedCategory}"
-                          Width="140" Margin="0,0,12,0"/>
+                          Width="140" Margin="0,0,12,0"
+                          AutomationProperties.Name="Filter apps by category"/>
                 <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0"
                            Style="{StaticResource Subtle}"/>
                 <Grid Width="200" Margin="0,0,12,0">
-                    <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"/>
+                    <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
+                             AutomationProperties.Name="Filter catalog apps"/>
                     <TextBlock Text="Search apps…" IsHitTestVisible="False"
                                Foreground="{DynamicResource TextMuted}" Margin="6,0,0,0"
                                VerticalAlignment="Center" FontSize="12"
@@ -97,7 +99,8 @@
                     <Button Content="Search" Command="{Binding SearchWingetCommand}"
                             Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right" Margin="8,0,0,0"/>
                     <Grid>
-                        <TextBox Text="{Binding SearchQuery, UpdateSourceTrigger=PropertyChanged}"/>
+                        <TextBox Text="{Binding SearchQuery, UpdateSourceTrigger=PropertyChanged}"
+                                 AutomationProperties.Name="Search winget packages"/>
                         <TextBlock Text="Search apps…" IsHitTestVisible="False"
                                    Foreground="{DynamicResource TextMuted}" Margin="6,0,0,0"
                                    VerticalAlignment="Center" FontSize="12"

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -33,7 +33,8 @@
                 <TextBlock Text="Search:" VerticalAlignment="Center" Margin="8,0,8,0"
                            Style="{StaticResource Subtle}"/>
                 <Grid Width="200" Margin="0,0,12,0">
-                    <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"/>
+                    <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
+                             AutomationProperties.Name="Filter processes"/>
                     <TextBlock Text="Search processes…" IsHitTestVisible="False"
                                Foreground="{DynamicResource TextMuted}" Margin="6,0,0,0"
                                VerticalAlignment="Center" FontSize="12"

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -64,7 +64,8 @@
                         <Button Content="Refresh" Command="{Binding RefreshCommand}"
                                 Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
                         <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
-                                 Width="240" VerticalContentAlignment="Center"/>
+                                 Width="240" VerticalContentAlignment="Center"
+                                 AutomationProperties.Name="Filter services"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Right">
                         <TextBlock Style="{StaticResource Subtle}" VerticalAlignment="Center">

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -70,7 +70,8 @@
                 <TextBlock Text="Search:" VerticalAlignment="Center" Margin="8,0,8,0"
                            Style="{StaticResource Subtle}"/>
                 <Grid Width="220" Margin="0,0,12,0">
-                    <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"/>
+                    <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
+                             AutomationProperties.Name="Filter installed apps"/>
                     <TextBlock Text="Search apps…" IsHitTestVisible="False"
                                Foreground="{DynamicResource TextMuted}" Margin="6,0,0,0"
                                VerticalAlignment="Center" FontSize="12"

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -37,7 +37,8 @@
                 <TextBlock Text="Search:" VerticalAlignment="Center" Margin="8,0,8,0"
                            Style="{StaticResource Subtle}"/>
                 <Grid Width="220" Margin="0,0,12,0">
-                    <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"/>
+                    <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
+                             AutomationProperties.Name="Filter Windows features"/>
                     <TextBlock Text="Search features…" IsHitTestVisible="False"
                                Foreground="{DynamicResource TextMuted}" Margin="6,0,0,0"
                                VerticalAlignment="Center" FontSize="12"


### PR DESCRIPTION
## What

Audit **Round 7** (accessibility, Gate-UX) — second batch. The category/filter/search inputs across five tabs had no `AutomationProperties.Name`, so screen readers announced them as anonymous edit fields. Each now states what it filters:

| View | Control | Accessible name |
|---|---|---|
| Bulk Installer | category ComboBox | `Filter apps by category` |
| Bulk Installer | catalog filter | `Filter catalog apps` |
| Bulk Installer | winget search | `Search winget packages` |
| Uninstaller | filter | `Filter installed apps` |
| Process Manager | filter | `Filter processes` |
| Services | filter | `Filter services` |
| Windows Features | filter | `Filter Windows features` |

(Audit finding #26 and its siblings.)

## Behavior

Visual appearance and behavior are **unchanged** — this only adds accessibility metadata consumed by assistive technology and the UI-automation layer.

## Verification

- Build: main + unit + integration, **0 errors / 0 warnings** (Release).
- All targeted inputs now expose a name.

## Notes

- `fix:` (accessibility is user-visible) — version bumped to **1.20.7**, CHANGELOG updated in this PR. Triggers a release.