### PR TITLE
fix: make theme presets keyboard-accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.8] - 2026-06-10
+
+### Fixed
+- **Theme presets are now keyboard-accessible.** The preset cards in the appearance popup were mouse-only — not reachable by Tab, not activatable from the keyboard, and unnamed to screen readers. They are now focusable, activate with Enter or Space, and announce their preset name. The custom-color hex inputs (accent, background, surface, text) also gained accessible names.
+
 ## [1.20.7] - 2026-06-10
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.7</Version>
-    <FileVersion>1.20.7.0</FileVersion>
-    <AssemblyVersion>1.20.7.0</AssemblyVersion>
+    <Version>1.20.8</Version>
+    <FileVersion>1.20.8.0</FileVersion>
+    <AssemblyVersion>1.20.8.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/ThemePopup.xaml
+++ b/SysManager/SysManager/Views/ThemePopup.xaml
@@ -79,6 +79,7 @@
                                          FontFamily="{StaticResource MonoFont}" FontSize="12"
                                          Background="Transparent" BorderThickness="0"
                                          Foreground="{DynamicResource TextPrimary}"
+                                         AutomationProperties.Name="Accent color hex value"
                                          LostFocus="CustomHex_LostFocus" Tag="accent"/>
                             </Grid>
                         </Border>
@@ -103,6 +104,7 @@
                                          FontFamily="{StaticResource MonoFont}" FontSize="12"
                                          Background="Transparent" BorderThickness="0"
                                          Foreground="{DynamicResource TextPrimary}"
+                                         AutomationProperties.Name="Background color hex value"
                                          LostFocus="CustomHex_LostFocus" Tag="bg"/>
                             </Grid>
                         </Border>
@@ -127,6 +129,7 @@
                                          FontFamily="{StaticResource MonoFont}" FontSize="12"
                                          Background="Transparent" BorderThickness="0"
                                          Foreground="{DynamicResource TextPrimary}"
+                                         AutomationProperties.Name="Surface color hex value"
                                          LostFocus="CustomHex_LostFocus" Tag="surface"/>
                             </Grid>
                         </Border>
@@ -151,6 +154,7 @@
                                          FontFamily="{StaticResource MonoFont}" FontSize="12"
                                          Background="Transparent" BorderThickness="0"
                                          Foreground="{DynamicResource TextPrimary}"
+                                         AutomationProperties.Name="Text color hex value"
                                          LostFocus="CustomHex_LostFocus" Tag="text"/>
                             </Grid>
                         </Border>

--- a/SysManager/SysManager/Views/ThemePopup.xaml.cs
+++ b/SysManager/SysManager/Views/ThemePopup.xaml.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -108,10 +109,16 @@ public partial class ThemePopup : UserControl
             Margin = new Thickness(0, 0, 6, 8),
             Width = 140,
             Tag = id,
-            Child = content
+            Child = content,
+            // Keyboard accessibility: make the card Tab-reachable, activatable with
+            // Enter/Space, and announced by its preset name to assistive technology.
+            Focusable = true
         };
+        AutomationProperties.SetName(card, $"{preset.Name} theme");
+        KeyboardNavigation.SetIsTabStop(card, true);
 
         card.MouseLeftButtonUp += Preset_Click;
+        card.KeyDown += Preset_KeyDown;
         return card;
     }
 
@@ -133,8 +140,20 @@ public partial class ThemePopup : UserControl
 
 
     private void Preset_Click(object sender, MouseButtonEventArgs e)
+        => SelectPreset((Border)sender);
+
+    private void Preset_KeyDown(object sender, KeyEventArgs e)
     {
-        var card = (Border)sender;
+        // Enter/Space activate the focused preset card, matching standard button semantics.
+        if (e.Key is Key.Enter or Key.Space)
+        {
+            SelectPreset((Border)sender);
+            e.Handled = true;
+        }
+    }
+
+    private void SelectPreset(Border card)
+    {
         var id = (string)card.Tag;
         ThemeService.Instance.SetPreset(id);
 


### PR DESCRIPTION
## What

Audit **Round 7** (accessibility, Gate-UX) — third batch (finding #57/#58). The preset cards in the appearance popup were mouse-only `Border`s: not reachable by Tab, not activatable from the keyboard, and unnamed to screen readers.

- Each preset card is now `Focusable` + a tab stop, activates on **Enter/Space** (same path as a click), and exposes `AutomationProperties.Name` with its preset name.
- The four custom-color hex inputs (accent / background / surface / text) gained accessible names.

## Behavior guarantee

Mouse behavior is **unchanged**. `Preset_Click` and the new `Preset_KeyDown` both route through a shared `SelectPreset(Border)` that calls `ThemeService.SetPreset` and re-highlights exactly as before — the theme-selection logic is untouched. The change only *adds* a keyboard activation path and accessibility metadata.

## Why not RadioButtons

The audit suggested converting the cards to RadioButtons. I kept them as focusable Borders to preserve the existing, working visual + selection logic byte-for-byte (the cards are built in code-behind with a custom mini-swatch layout); a full RadioButton restyle carries visual-regression risk on a component that isn't covered by automated UI tests. This change delivers the actual accessibility win (keyboard + screen reader) with zero visual change.

## Verification

- Build: main + unit + integration, **0 errors / 0 warnings** (Release).

## Notes

- `fix:` (accessibility is user-visible) — version bumped to **1.20.8**, CHANGELOG updated in this PR. Triggers a release.