### PR TITLE
fix: convert Logs time-range chips to a selectable radio-button group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.9] - 2026-06-10
+
+### Fixed
+- **System Logs time-range chips now show which range is active and are keyboard-navigable.** The 1h / 24h / 7d / 30d / All chips were unlabeled buttons with no selected state, so you couldn't tell which range was applied. They are now a proper radio-button group (matching the Services tab filter chips): the active range is highlighted, the group is arrow-key navigable, and each chip is named for screen readers.
+
 ## [1.20.8] - 2026-06-10
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.8</Version>
-    <FileVersion>1.20.8.0</FileVersion>
-    <AssemblyVersion>1.20.8.0</AssemblyVersion>
+    <Version>1.20.9</Version>
+    <FileVersion>1.20.9.0</FileVersion>
+    <AssemblyVersion>1.20.9.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -195,13 +195,6 @@ public sealed partial class LogsViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void SetTimeRange(string? range)
-    {
-        if (!string.IsNullOrEmpty(range))
-            SelectedTimeRange = range;
-    }
-
-    [RelayCommand]
     private void OpenLogFolder()
     {
         try

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -125,16 +125,26 @@
 
                     <TextBlock Text="Time" Style="{StaticResource Subtle}" VerticalAlignment="Center"/>
                     <StackPanel Orientation="Horizontal" Margin="8,0,18,0">
-                        <Button Content="1h" Command="{Binding SetTimeRangeCommand}" CommandParameter="Last hour"
-                                Style="{StaticResource GhostButton}" Padding="10,5" FontSize="12" Margin="0,0,4,0"/>
-                        <Button Content="24h" Command="{Binding SetTimeRangeCommand}" CommandParameter="Last 24 hours"
-                                Style="{StaticResource GhostButton}" Padding="10,5" FontSize="12" Margin="0,0,4,0"/>
-                        <Button Content="7d" Command="{Binding SetTimeRangeCommand}" CommandParameter="Last 7 days"
-                                Style="{StaticResource GhostButton}" Padding="10,5" FontSize="12" Margin="0,0,4,0"/>
-                        <Button Content="30d" Command="{Binding SetTimeRangeCommand}" CommandParameter="Last 30 days"
-                                Style="{StaticResource GhostButton}" Padding="10,5" FontSize="12" Margin="0,0,4,0"/>
-                        <Button Content="All" Command="{Binding SetTimeRangeCommand}" CommandParameter="All"
-                                Style="{StaticResource GhostButton}" Padding="10,5" FontSize="12"/>
+                        <RadioButton Content="1h" GroupName="TimeRange" Margin="0,0,4,0"
+                                     AutomationProperties.Name="Time range: last hour"
+                                     IsChecked="{Binding SelectedTimeRange, Converter={StaticResource IsEqual}, ConverterParameter='Last hour'}"
+                                     Style="{StaticResource FilterChip}"/>
+                        <RadioButton Content="24h" GroupName="TimeRange" Margin="0,0,4,0"
+                                     AutomationProperties.Name="Time range: last 24 hours"
+                                     IsChecked="{Binding SelectedTimeRange, Converter={StaticResource IsEqual}, ConverterParameter='Last 24 hours'}"
+                                     Style="{StaticResource FilterChip}"/>
+                        <RadioButton Content="7d" GroupName="TimeRange" Margin="0,0,4,0"
+                                     AutomationProperties.Name="Time range: last 7 days"
+                                     IsChecked="{Binding SelectedTimeRange, Converter={StaticResource IsEqual}, ConverterParameter='Last 7 days'}"
+                                     Style="{StaticResource FilterChip}"/>
+                        <RadioButton Content="30d" GroupName="TimeRange" Margin="0,0,4,0"
+                                     AutomationProperties.Name="Time range: last 30 days"
+                                     IsChecked="{Binding SelectedTimeRange, Converter={StaticResource IsEqual}, ConverterParameter='Last 30 days'}"
+                                     Style="{StaticResource FilterChip}"/>
+                        <RadioButton Content="All" GroupName="TimeRange"
+                                     AutomationProperties.Name="Time range: all time"
+                                     IsChecked="{Binding SelectedTimeRange, Converter={StaticResource IsEqual}, ConverterParameter='All'}"
+                                     Style="{StaticResource FilterChip}"/>
                     </StackPanel>
 
                     <TextBlock Text="Max results" Style="{StaticResource Subtle}" VerticalAlignment="Center"/>


### PR DESCRIPTION
## What

Audit **Round 7** (accessibility, Gate-UX) — finding #10. The System Logs time-range chips (1h / 24h / 7d / 30d / All) were unlabeled `GhostButton`s firing `SetTimeRangeCommand` with **no selected state**, so you couldn't see which range was active and the group had no keyboard/grouping semantics.

Converted to the **existing `FilterChip` RadioButton pattern** (the same one the Services tab safety filter already uses):
- `GroupName="TimeRange"` — arrow-key navigable as one group.
- `IsChecked` two-way bound to `SelectedTimeRange` via the `IsEqual` converter.
- `FilterChip` style — the active chip is visibly highlighted.
- Per-chip `AutomationProperties.Name` ("Time range: last 24 hours", etc.).

## Behavior guarantee

Identical. The two-way `EqualityConverter` pushes its parameter back to `SelectedTimeRange` when a chip is checked, so clicking sets **exactly the same property** the old command set. Default remains "Last 24 hours", so the 24h chip shows checked on load. Removed the now-unused `SetTimeRange` command (no XAML or test references).

## Verification

- Build: main + unit + integration, **0 errors / 0 warnings** (Release).
- UNIFORMITY: copied the ServicesView FilterChip pattern exactly (style, GroupName, IsEqual binding).

## Notes

- `fix:` (user-visible: selected-state + accessibility) — version bumped to **1.20.9**, CHANGELOG updated in this PR. Triggers a release.