### PR TITLE
fix: standardize console toolbar buttons and name the output list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.10] - 2026-06-10
+
+### Fixed
+- **Console output toolbar is now consistent and screen-reader friendly.** The Clear and Copy buttons on the live-output console (shown on App Updates, Cleanup, System Health, and Windows Update) used the implicit default button style; they now use the standard `SecondaryButton` style like the rest of the app. The output list also gained an accessible name ("Live output").
+
 ## [1.20.9] - 2026-06-10
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.9</Version>
-    <FileVersion>1.20.9.0</FileVersion>
-    <AssemblyVersion>1.20.9.0</AssemblyVersion>
+    <Version>1.20.10</Version>
+    <FileVersion>1.20.10.0</FileVersion>
+    <AssemblyVersion>1.20.10.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/ConsoleView.xaml
+++ b/SysManager/SysManager/Views/ConsoleView.xaml
@@ -11,14 +11,17 @@
 
             <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="8,6" >
                 <TextBlock Text="Live output" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
-                <Button Margin="12,0,0,0" Padding="8,2" Content="Clear" Command="{Binding ClearCommand}"/>
-                <Button Margin="6,0,0,0" Padding="8,2" Content="Copy" Command="{Binding CopyAllCommand}"/>
+                <Button Margin="12,0,0,0" Padding="8,2" Content="Clear" Command="{Binding ClearCommand}"
+                        Style="{StaticResource SecondaryButton}"/>
+                <Button Margin="6,0,0,0" Padding="8,2" Content="Copy" Command="{Binding CopyAllCommand}"
+                        Style="{StaticResource SecondaryButton}"/>
                 <CheckBox Margin="12,0,0,0" Content="Auto-scroll" IsChecked="{Binding AutoScroll}" Foreground="{DynamicResource TextPrimary}"/>
             </StackPanel>
 
             <ListBox x:Name="ListBox_Output"
                      Grid.Row="1"
                      ItemsSource="{Binding Lines}"
+                     AutomationProperties.Name="Live output"
                      Background="Transparent"
                      BorderThickness="0"
                      ScrollViewer.HorizontalScrollBarVisibility="Auto"


### PR DESCRIPTION
## What

Audit **Round 7** (accessibility + uniformity, Gate-UX) — finding #7 (the safe subset). The live-output console (embedded in App Updates, Cleanup, System Health, Windows Update):

- **Clear / Copy buttons** used the implicit default button style; now use the app-standard `SecondaryButton` like every other toolbar.
- **Output ListBox** had no accessible name; added `AutomationProperties.Name="Live output"`.

## Scope note

Finding #7 also suggested swapping the outer `Border` for the `Card` style. I deliberately **did not** do that: the console's outer Border uses `Padding="0"` intentionally (the toolbar and list manage their own spacing), while `Card` injects `Padding="16"`. Since ConsoleView is embedded in four host views, that swap risks a layout regression on all of them and isn't run-verifiable here. The button-style + accessible-name fixes deliver the real value with zero layout risk.

## Behavior

Layout unchanged (same padding/margins); only the button visual style and the list's accessibility name change.

## Verification

- Build: main + unit + integration, **0 errors / 0 warnings** (Release).

## Notes

- `fix:` (user-visible style + accessibility) — version bumped to **1.20.10**, CHANGELOG updated in this PR. Triggers a release.