### PR TITLE
fix: name Logs severity tiles and distinguish Critical from Error without color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.11] - 2026-06-10
+
+### Fixed
+- **System Logs severity tiles are now screen-reader friendly and colorblind-safe.** The Critical / Errors / Warnings / Info count tiles conveyed their value only through color and an unlabeled number. Each tile now exposes an accessible name with its count (e.g. "Critical events: 3"), and the Critical and Errors tiles — both previously red and indistinguishable to colorblind users — are now told apart by a leading glyph (▲ vs ●) and weight, not hue alone.
+
 ## [1.20.10] - 2026-06-10
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.10</Version>
-    <FileVersion>1.20.10.0</FileVersion>
-    <AssemblyVersion>1.20.10.0</AssemblyVersion>
+    <Version>1.20.11</Version>
+    <FileVersion>1.20.11.0</FileVersion>
+    <AssemblyVersion>1.20.11.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -43,7 +43,8 @@
         <!-- Severity count glass cards -->
         <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="28,16,28,0">
             <!-- Critical -->
-            <Border Style="{StaticResource GlassCard}" Background="#14FF3B30" Margin="0,0,12,0">
+            <Border Style="{StaticResource GlassCard}" Background="#14FF3B30" Margin="0,0,12,0"
+                    AutomationProperties.Name="{Binding CriticalCount, StringFormat='Critical events: {0}'}">
                 <Grid>
                     <Border Background="#FF3B30" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                             Margin="-16,-12,0,-12"/>
@@ -55,13 +56,18 @@
                         </Ellipse>
                         <TextBlock Text="{Binding CriticalCount}" FontSize="20" FontWeight="Bold"
                                    Foreground="#FF6B6B" VerticalAlignment="Center" Margin="10,0,0,0"/>
-                        <TextBlock Text="Critical" FontSize="12" Foreground="#64748B"
-                                   VerticalAlignment="Center" Margin="10,0,0,0"/>
+                        <!-- Bold + ▲ glyph distinguish Critical from Error without relying on hue
+                             (both are reds — a colorblind-safe, non-color cue). -->
+                        <TextBlock FontSize="12" Foreground="#64748B" FontWeight="SemiBold"
+                                   VerticalAlignment="Center" Margin="10,0,0,0">
+                            <Run Text="&#x25B2; Critical"/>
+                        </TextBlock>
                     </StackPanel>
                 </Grid>
             </Border>
             <!-- Errors -->
-            <Border Style="{StaticResource GlassCard}" Background="#14F87171" Margin="0,0,12,0">
+            <Border Style="{StaticResource GlassCard}" Background="#14F87171" Margin="0,0,12,0"
+                    AutomationProperties.Name="{Binding ErrorCount, StringFormat='Errors: {0}'}">
                 <Grid>
                     <Border Background="#F87171" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                             Margin="-16,-12,0,-12"/>
@@ -73,13 +79,16 @@
                         </Ellipse>
                         <TextBlock Text="{Binding ErrorCount}" FontSize="20" FontWeight="Bold"
                                    Foreground="#FCA5A5" VerticalAlignment="Center" Margin="10,0,0,0"/>
-                        <TextBlock Text="Errors" FontSize="12" Foreground="#64748B"
-                                   VerticalAlignment="Center" Margin="10,0,0,0"/>
+                        <TextBlock FontSize="12" Foreground="#64748B"
+                                   VerticalAlignment="Center" Margin="10,0,0,0">
+                            <Run Text="&#x25CF; Errors"/>
+                        </TextBlock>
                     </StackPanel>
                 </Grid>
             </Border>
             <!-- Warnings -->
-            <Border Style="{StaticResource GlassCard}" Background="#14FBBF24" Margin="0,0,12,0">
+            <Border Style="{StaticResource GlassCard}" Background="#14FBBF24" Margin="0,0,12,0"
+                    AutomationProperties.Name="{Binding WarningCount, StringFormat='Warnings: {0}'}">
                 <Grid>
                     <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                             Margin="-16,-12,0,-12"/>
@@ -97,7 +106,8 @@
                 </Grid>
             </Border>
             <!-- Info -->
-            <Border Style="{StaticResource GlassCard}" Background="#1438BDF8">
+            <Border Style="{StaticResource GlassCard}" Background="#1438BDF8"
+                    AutomationProperties.Name="{Binding InfoCount, StringFormat='Info events: {0}'}">
                 <Grid>
                     <Border Background="{DynamicResource Info}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                             Margin="-16,-12,0,-12"/>


### PR DESCRIPTION
## What

Audit **Round 7** (accessibility, Gate-UX) — finding #44. The System Logs severity-count tiles (Critical / Errors / Warnings / Info) conveyed their value only through color plus an unlabeled number, and Critical (`#FF3B30`) and Errors (`#F87171`) were **both reds** — indistinguishable to colorblind users.

- Each tile Border now exposes `AutomationProperties.Name` with its live count (e.g. "Critical events: 3"), so a screen reader announces the full meaning instead of a bare number.
- Critical vs Errors are now told apart **beyond hue**: Critical shows a leading filled triangle (▲) with a SemiBold label, Errors a filled circle (●). Warnings/Info labels unchanged.

## Behavior

Layout unchanged; only the accessible names and the two red labels' leading glyph/weight change. Counts still bind live to the same VM properties.

## Verification

- Build: main + unit + integration, **0 errors / 0 warnings** (Release).
- Glyphs are XML entities (`&#x25B2;` / `&#x25CF;`) — no raw non-ASCII in the file.

## Notes

- `fix:` (accessibility + colorblind safety, user-visible) — version bumped to **1.20.11**, CHANGELOG updated in this PR. Triggers a release.