### PR TITLE
test: stop About default-state tests racing the startup network check

### DIFF
--- a/SysManager/SysManager.Tests/AboutViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AboutViewModelTests.cs
@@ -10,6 +10,15 @@ namespace SysManager.Tests;
 
 public class AboutViewModelTests
 {
+    /// <summary>
+    /// Builds an AboutViewModel WITHOUT the startup update-check, so default-state
+    /// assertions don't race the constructor's async network fetch (which populates
+    /// UpdateStatus / LatestNotes / LatestVersionLabel / LatestPublishedLabel /
+    /// UpdateAvailable).
+    /// </summary>
+    private static AboutViewModel NewVmNoAutoCheck() =>
+        new(new UpdateService(), new SystemReportService(new SystemInfoService(), new DiskHealthService()), autoCheck: false);
+
     [Fact]
     public void Constructs_WithDefaultService()
     {
@@ -50,14 +59,14 @@ public class AboutViewModelTests
     [Fact]
     public void UpdateStatus_HasInitialMessage()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVmNoAutoCheck();
         Assert.False(string.IsNullOrWhiteSpace(vm.UpdateStatus));
     }
 
     [Fact]
     public void UpdateAvailable_DefaultsFalse()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVmNoAutoCheck();
         Assert.False(vm.UpdateAvailable);
     }
 
@@ -192,21 +201,21 @@ public class AboutViewModelTests
     [Fact]
     public void LatestVersionLabel_DefaultsEmpty()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVmNoAutoCheck();
         Assert.Equal(string.Empty, vm.LatestVersionLabel);
     }
 
     [Fact]
     public void LatestPublishedLabel_DefaultsEmpty()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVmNoAutoCheck();
         Assert.Equal(string.Empty, vm.LatestPublishedLabel);
     }
 
     [Fact]
     public void LatestNotes_DefaultsEmpty()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVmNoAutoCheck();
         Assert.Equal(string.Empty, vm.LatestNotes);
     }
 

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -57,10 +57,20 @@ public sealed partial class AboutViewModel : ViewModelBase
     public AboutViewModel() : this(new UpdateService(), new SystemReportService(new SystemInfoService(), new DiskHealthService())) { }
 
     public AboutViewModel(UpdateService updates, SystemReportService reportService)
+        : this(updates, reportService, autoCheck: true) { }
+
+    /// <summary>
+    /// Core constructor. <paramref name="autoCheck"/> controls whether the
+    /// startup update-check (a live network call that populates the update
+    /// properties) runs. Production always passes true; tests pass false to
+    /// assert the constructor's default state without racing the async fetch.
+    /// </summary>
+    internal AboutViewModel(UpdateService updates, SystemReportService reportService, bool autoCheck)
     {
         _updates = updates;
         _reportService = reportService;
-        InitializeAsync(InitAsync);
+        if (autoCheck)
+            InitializeAsync(InitAsync);
     }
 
     private async Task InitAsync()


### PR DESCRIPTION
## What

Fixes a **pre-existing flaky test** in the suite: `AboutViewModelTests.LatestNotes_DefaultsEmpty` (and four siblings) failed intermittently on slow CI — it tripped once in PR #843's pipeline run, passed on re-run.

## Root cause

`AboutViewModel`'s constructor fires `InitializeAsync(InitAsync)` — a fire-and-forget network call (`CheckForUpdatesAsync` → GitHub) that populates `UpdateStatus`, `LatestNotes`, `LatestVersionLabel`, `LatestPublishedLabel`, and `UpdateAvailable`. Five tests assert those default (empty) values right after construction, racing that async fetch. When the network call won the race, the assert saw populated values and failed.

## Fix

Added an `internal AboutViewModel(updates, reportService, bool autoCheck)` constructor. **Both public constructors pass `autoCheck: true`, so production behavior is byte-identical** — the startup check still runs in the app. The five default-state tests now construct with `autoCheck: false` (via a `NewVmNoAutoCheck` helper), asserting the constructor's real defaults deterministically with no network and no race.

`InternalsVisibleTo("SysManager.Tests")` is already declared, so the internal ctor is visible to the test project.

## Verification

- Build: main + unit + integration, **0 errors / 0 warnings** (Release).
- Production paths (both public ctors) still trigger the startup check — confirmed.

## Notes

- `test:` only — no release. The production change is a single additive internal constructor used solely as a test seam; no app behavior changes.