### PR TITLE
fix: use the shared Card style for the live-output console container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.13] - 2026-06-11
+
+### Fixed
+- **The live-output console now matches the app's card styling.** Its container used a one-off border with a smaller corner radius than every other card; it now uses the shared `Card` style (same surface, border, and 10px radius) while keeping its zero inner padding, so the console looks consistent on the App Updates, Cleanup, System Health, and Windows Update tabs.
+
 ## [1.20.12] - 2026-06-10
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.12</Version>
-    <FileVersion>1.20.12.0</FileVersion>
-    <AssemblyVersion>1.20.12.0</AssemblyVersion>
+    <Version>1.20.13</Version>
+    <FileVersion>1.20.13.0</FileVersion>
+    <AssemblyVersion>1.20.13.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/ConsoleView.xaml
+++ b/SysManager/SysManager/Views/ConsoleView.xaml
@@ -2,7 +2,9 @@
 <UserControl x:Class="SysManager.Views.ConsoleView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Border BorderThickness="1" BorderBrush="{DynamicResource Border1}" CornerRadius="6" Background="{DynamicResource Surface1}" Padding="0">
+    <!-- Card style for uniform surface/border/radius; Padding kept at 0 because the
+         toolbar and output list manage their own spacing. -->
+    <Border Style="{StaticResource Card}" Padding="0">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>


### PR DESCRIPTION
## What

Audit **Round 7** (uniformity) — finishes finding #7. The live-output console's outer `Border` was a one-off (`CornerRadius="6"`) duplicating the `Card` style's surface/border but with a smaller radius than every other card. Switched it to `Style="{StaticResource Card}"` (same Surface1 background, Border1 brush, 1px border, 10px radius), keeping `Padding="0"` since the toolbar and output list manage their own spacing.

The only visual change is the corner radius (6 → 10), bringing the console in line with the surrounding cards on App Updates, Cleanup, System Health, and Windows Update.

## Why this was deferred earlier

In PR #839 I skipped the Card swap because `Card` carries `Padding="16"` and the console intentionally uses `Padding="0"` — a blind swap risked injecting inner padding on four host views. This PR does it safely by **overriding `Padding="0"` on the styled Border**, so the radius unifies but the zero inner gap is preserved.

## Verification

- Build: main + unit + integration, **0 errors / 0 warnings** (Release).
- **Visually verified**: launched the published single-file build, opened the Cleanup tab, and confirmed the console card's corners, zero inner padding, and alignment match the sibling cards (no double-border, no extra gap).

## Notes

- `fix:` (user-visible styling) — version bumped to **1.20.13**, CHANGELOG updated in this PR. Triggers a release.