### PR TITLE
refactor: use [GeneratedRegex] and SearchValues on log hot paths

### DIFF
--- a/SysManager/SysManager/Services/EventLogService.cs
+++ b/SysManager/SysManager/Services/EventLogService.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Buffers;
 using System.Diagnostics.Eventing.Reader;
 using SysManager.Models;
 
@@ -113,10 +114,14 @@ public sealed class EventLogService
         catch (InvalidOperationException) { return "(message not available)"; }
     }
 
+    // Hoisted so the newline scan in FirstLine — run once per projected event
+    // record, potentially thousands per query — doesn't allocate a char[] per call.
+    private static readonly SearchValues<char> Newlines = SearchValues.Create("\r\n");
+
     private static string FirstLine(string s)
     {
         if (string.IsNullOrEmpty(s)) return "";
-        var i = s.IndexOfAny(new[] { '\r', '\n' });
+        var i = s.AsSpan().IndexOfAny(Newlines);
         return (i < 0 ? s : s[..i]).Trim();
     }
 

--- a/SysManager/SysManager/Services/LogService.cs
+++ b/SysManager/SysManager/Services/LogService.cs
@@ -9,7 +9,7 @@ using Serilog.Core;
 
 namespace SysManager.Services;
 
-public static class LogService
+public static partial class LogService
 {
     public static Logger? Logger { get; private set; }
 
@@ -33,9 +33,13 @@ public static class LogService
                 return new Regex($@"(?i)({escaped})[^\\]+", RegexOptions.Compiled);
             }
         }
-        // Fallback: match any drive letter followed by \Users\<username>
-        return new Regex(@"(?i)([A-Z]:\\Users\\)[^\\]+", RegexOptions.Compiled);
+        // Fallback: match any drive letter followed by \Users\<username>.
+        // This branch is a constant pattern, so it is source-generated.
+        return FallbackUserPathRegex();
     }
+
+    [GeneratedRegex(@"(?i)([A-Z]:\\Users\\)[^\\]+")]
+    private static partial Regex FallbackUserPathRegex();
 
     public static void Init()
     {


### PR DESCRIPTION
## What

Audit **Round 8** (.NET 10 modernization) — findings #21 and #22. Two idiom upgrades on hot/testable paths, behavior unchanged:

- **`LogService`** is now a `static partial class`. The constant fallback user-path pattern is source-generated via `[GeneratedRegex]` (`FallbackUserPathRegex`) instead of `new Regex(..., RegexOptions.Compiled)` — build-time compiled, no runtime IL emit, AOT-friendly. The dynamic interpolated branch (built from the real user-profile directory) stays a runtime `Regex`, since an interpolated pattern can't be source-generated.
- **`EventLogService.FirstLine`** hoists a static `SearchValues<char>` for the `\r\n` scan and uses span `IndexOfAny`, removing the per-call `char[]` allocation. This runs once per projected event record (potentially thousands per query).

## Behavior guarantee (Protocol Q)

Identical. The fallback regex pattern is byte-for-byte `(?i)([A-Z]:\Users\)[^\]+` (only the compilation strategy changes — same matches), and `FirstLine` scans the same `\r\n` set with the same trim. Existing `SanitizePath` and Event Log tests cover both.

## Verification

- Build: main + unit + integration, **0 errors / 0 warnings** (Release). The `[GeneratedRegex]` source generator ran cleanly.

## Notes

- `refactor:` — no version bump, no release, no CHANGELOG entry required.