### PR TITLE
refactor: use collection expressions for empty list initializers

### DIFF
--- a/SysManager/SysManager/Helpers/WingetTableParser.cs
+++ b/SysManager/SysManager/Helpers/WingetTableParser.cs
@@ -46,7 +46,7 @@ internal static partial class WingetTableParser
         Regex headerPattern,
         Regex summaryPattern)
     {
-        var rows = new List<RawRow>();
+        List<RawRow> rows = [];
 
         int headerIdx = lines.FindIndex(l => headerPattern.IsMatch(l));
         if (headerIdx < 0) return rows;

--- a/SysManager/SysManager/Services/FileShredderService.cs
+++ b/SysManager/SysManager/Services/FileShredderService.cs
@@ -176,7 +176,7 @@ public sealed class FileShredderService
     /// </summary>
     private static List<string> EnumerateFilesSafe(string rootPath)
     {
-        var results = new List<string>();
+        List<string> results = [];
         var stack = new Stack<DirectoryInfo>();
         stack.Push(new DirectoryInfo(rootPath));
 

--- a/SysManager/SysManager/Services/TemperatureService.cs
+++ b/SysManager/SysManager/Services/TemperatureService.cs
@@ -30,7 +30,7 @@ public sealed class TemperatureService
     {
         if (_skipHardwareInit) return [];
 
-        var readings = new List<TemperatureReading>();
+        List<TemperatureReading> readings = [];
         var isAdmin = AdminHelper.IsElevated();
 
         if (isAdmin)
@@ -219,7 +219,7 @@ public sealed class TemperatureService
 
     private static List<string> GetDiskNamesFromWmi()
     {
-        var names = new List<string>();
+        List<string> names = [];
         try
         {
             using var searcher = new ManagementObjectSearcher(

--- a/SysManager/SysManager/Services/WindowsUpdateService.cs
+++ b/SysManager/SysManager/Services/WindowsUpdateService.cs
@@ -249,7 +249,7 @@ public sealed class WindowsUpdateService
 
     private static List<string> ExtractKbIds(dynamic u)
     {
-        var list = new List<string>();
+        List<string> list = [];
         try
         {
             var ids = u.KBArticleIDs;

--- a/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
@@ -265,7 +265,7 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
 
     private List<InstallableApp> SearchWingetPackages(string query)
     {
-        var results = new List<InstallableApp>();
+        List<InstallableApp> results = [];
 
         var psi = new System.Diagnostics.ProcessStartInfo
         {

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -284,7 +284,7 @@ public sealed partial class LogsViewModel : ViewModelBase
 
     private List<EventSeverity> BuildSeverityFilter()
     {
-        var list = new List<EventSeverity>();
+        List<EventSeverity> list = [];
         if (ShowCritical) list.Add(EventSeverity.Critical);
         if (ShowError) list.Add(EventSeverity.Error);
         if (ShowWarning) list.Add(EventSeverity.Warning);

--- a/SysManager/SysManager/ViewModels/TracerouteViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TracerouteViewModel.cs
@@ -72,7 +72,7 @@ public sealed partial class TracerouteViewModel : ViewModelBase
 
         _traceCts?.Dispose();
         _traceCts = new CancellationTokenSource();
-        var collected = new List<TracerouteHop>();
+        List<TracerouteHop> collected = [];
         _totalHops = 0;
         void OnHop(TracerouteHop hop)
         {


### PR DESCRIPTION
## What

Audit **Round 8** (.NET 10 modernization). Replaced `var x = new List<T>()` with `List<T> x = []` across 7 files (8 sites): WingetTableParser, FileShredderService, TemperatureService (×2), WindowsUpdateService, BulkInstallerViewModel, LogsViewModel, TracerouteViewModel.

## Behavior guarantee (Protocol Q)

Byte-identical. A collection expression `[]` for a `List<T>` target compiles to the same `new List<T>()` construction — pure compiler sugar. The declaration uses an explicit type because a collection expression needs a target type (it can't be inferred from `var`).

## Scope note

I deliberately limited this to the unambiguous empty-list initializers. The blanket `catch (Exception)` clauses (also in the R8 backlog) are **not** included — converting those changes which exceptions are caught and needs per-site judgement (many are intentional top-of-command catch-alls that keep the UI from crashing), so they don't belong in a mechanical, behavior-identical sweep.

## Verification

- Build: main + unit + integration, **0 errors / 0 warnings** (Release).
- Diff is exactly 8 insertions / 8 deletions, all list-init lines.

## Notes

- `refactor:` — no version bump, no release, no CHANGELOG entry required.