### PR TITLE
test: make IconExtractor cache tests deterministic (per-key, not global count)

### DIFF
--- a/SysManager/SysManager.Tests/IconExtractorServiceTests.cs
+++ b/SysManager/SysManager.Tests/IconExtractorServiceTests.cs
@@ -105,24 +105,33 @@ public class IconExtractorServiceTests
     // ── Cache ──
 
     [Fact]
-    public void ClearCache_ResetsCount()
+    public void ClearCache_RemovesEntries()
     {
+        // Per-key assertion: ClearCache must drop a key we just added. Asserting the
+        // global CacheCount == 0 would be racy — tests in other collections touch the
+        // shared static cache in parallel and can re-add entries after the clear.
+        var bogus = @"C:\NonExistent\ClearTest_" + Guid.NewGuid().ToString("N") + ".exe";
+        _ = IconExtractorService.GetIcon(bogus);
+        Assert.True(IconExtractorService.IsCached(bogus));
+
         IconExtractorService.ClearCache();
-        Assert.Equal(0, IconExtractorService.CacheCount);
+        Assert.False(IconExtractorService.IsCached(bogus));
     }
 
     [Fact]
-    public void GetIcon_SamePath_UsesCachedResult()
+    public void GetIcon_SamePath_CachesByKey()
     {
-        IconExtractorService.ClearCache();
-        // Use a GUID-based path to avoid interference from parallel tests.
+        // Use a GUID-based path and assert this specific key's caching, not the global
+        // count (which parallel tests can change by touching the shared static cache).
         var bogus = @"C:\NonExistent\CacheTest_" + Guid.NewGuid().ToString("N") + ".exe";
+
+        Assert.False(IconExtractorService.IsCached(bogus)); // not cached before first call
         _ = IconExtractorService.GetIcon(bogus);
-        var countAfterFirst = IconExtractorService.CacheCount;
+        Assert.True(IconExtractorService.IsCached(bogus));  // cached after first call
+
+        // A second call for the same key returns the cached value (no exception, still cached).
         _ = IconExtractorService.GetIcon(bogus);
-        var countAfterSecond = IconExtractorService.CacheCount;
-        // Second call to the same path must not increase the cache count.
-        Assert.Equal(countAfterFirst, countAfterSecond);
+        Assert.True(IconExtractorService.IsCached(bogus));
     }
 
     // ── Model Icon property defaults ──

--- a/SysManager/SysManager/Services/IconExtractorService.cs
+++ b/SysManager/SysManager/Services/IconExtractorService.cs
@@ -159,6 +159,19 @@ public sealed partial class IconExtractorService
     /// <summary>Number of cached icons (for diagnostics/testing).</summary>
     public static int CacheCount => _cache.Count;
 
+    /// <summary>
+    /// Whether a specific path is currently cached (keyed by its normalized form).
+    /// For testing: lets a test assert one key's caching deterministically, without
+    /// depending on the global <see cref="CacheCount"/>, which other parallel tests
+    /// may change by touching the shared cache.
+    /// </summary>
+    internal static bool IsCached(string? filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath)) return false;
+        var normalized = NormalizePath(filePath);
+        return !string.IsNullOrEmpty(normalized) && _cache.ContainsKey(normalized);
+    }
+
     // ── Core extraction ──
 
     private static ImageSource? ExtractIcon(string path)


### PR DESCRIPTION
## What

Fixes a **pre-existing flaky test** that failed once in PR #849's CI (and would keep failing randomly): `IconExtractorServiceTests.GetIcon_SamePath_UsesCachedResult`.

## Root cause

`GetIcon_SamePath_UsesCachedResult` and `ClearCache_ResetsCount` asserted on the **global `CacheCount`** of the shared static icon cache. That cache is touched by tests in *other* collections — VMs (Process Manager, Startup, Uninstaller) call `GetIcon` — which run in parallel. An entry added between the test's two count reads broke the assertion. `[Collection("IconCache")]` only serializes tests *within* this class, not the parallel VMs elsewhere.

## Fix

Added `internal static bool IconExtractorService.IsCached(string? path)` (checks one normalized key), and rewrote both tests to assert **per-key** caching:
- `GetIcon_SamePath_CachesByKey`: not cached before, cached after the first call, still cached after the second.
- `ClearCache_RemovesEntries`: a key we added is gone after `ClearCache()`.

Deterministic regardless of what parallel tests do to the shared cache.

## Behavior

Production unchanged — `IsCached` is an additive internal test helper; `InternalsVisibleTo("SysManager.Tests")` is already declared.

## Verification

- Build: main + unit + integration, **0 errors / 0 warnings** (Release).

## Notes

- `test:` only — no release. This is the 4th static-state suite flake fixed (after DialogService #828, FileShredder progress #831, About #845).