### PR TITLE
refactor: use System.Threading.Lock for the remaining monitor locks

### DIFF
--- a/SysManager/SysManager/Services/AppAlertService.cs
+++ b/SysManager/SysManager/Services/AppAlertService.cs
@@ -17,7 +17,7 @@ namespace SysManager.Services;
 public sealed class AppAlertService : IDisposable
 {
     private readonly List<FileSystemWatcher> _watchers = new();
-    private readonly object _watcherLock = new();
+    private readonly Lock _watcherLock = new();
     private readonly ConcurrentDictionary<string, bool> _knownFolders = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, bool> _knownRegistryApps = new(StringComparer.OrdinalIgnoreCase);
     private readonly SynchronizationContext? _syncContext;

--- a/SysManager/SysManager/Services/IconExtractorService.cs
+++ b/SysManager/SysManager/Services/IconExtractorService.cs
@@ -24,7 +24,7 @@ public sealed partial class IconExtractorService
 {
     private static readonly ConcurrentDictionary<string, ImageSource?> _cache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly Queue<string> _insertionOrder = new();
-    private static readonly object _evictionLock = new();
+    private static readonly Lock _evictionLock = new();
 
     /// <summary>Maximum number of cached icons before eviction kicks in.</summary>
     public static int MaxCacheSize { get; set; } = 500;

--- a/SysManager/SysManager/Services/PingMonitorService.cs
+++ b/SysManager/SysManager/Services/PingMonitorService.cs
@@ -31,7 +31,7 @@ public sealed class PingMonitorService : IDisposable
 
     private CancellationTokenSource? _cts;
     private Task? _loop;
-    private readonly object _stateLock = new();
+    private readonly Lock _stateLock = new();
 
     public bool IsRunning => _loop is { IsCompleted: false };
 

--- a/SysManager/SysManager/Services/SystemInfoService.cs
+++ b/SysManager/SysManager/Services/SystemInfoService.cs
@@ -18,7 +18,7 @@ public sealed class SystemInfoService
     private OsInfo? _cachedOs;
     private CpuInfo? _cachedCpuStatic;
     private List<DiskInfo>? _cachedDisks;
-    private readonly object _cacheLock = new();
+    private readonly Lock _cacheLock = new();
 
     public Task<SystemSnapshot> CaptureAsync(CancellationToken ct = default)
         => Task.Run(() => Capture(), ct);

--- a/SysManager/SysManager/Services/TracerouteMonitorService.cs
+++ b/SysManager/SysManager/Services/TracerouteMonitorService.cs
@@ -32,7 +32,7 @@ public sealed class TracerouteMonitorService : IDisposable
 
     private CancellationTokenSource? _cts;
     private Task? _loop;
-    private readonly object _stateLock = new();
+    private readonly Lock _stateLock = new();
 
     public bool IsRunning => _loop is { IsCompleted: false };
 

--- a/SysManager/SysManager/ViewModels/ConsoleViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ConsoleViewModel.cs
@@ -17,7 +17,7 @@ namespace SysManager.ViewModels;
 public sealed partial class ConsoleViewModel : ObservableObject
 {
     private const int MaxLines = 5000;
-    private readonly object _gate = new();
+    private readonly Lock _gate = new();
 
     public ObservableCollection<PowerShellLine> Lines { get; } = new();
 


### PR DESCRIPTION
## Summary

Completes the `System.Threading.Lock` migration. `ActivityLogService` was already
converted; this brings the remaining six monitor locks to the same idiom. No
behavior change — `lock(Lock)` lowers to `EnterScope()`/`Dispose()`, identical
mutual exclusion to a `lock(object)` monitor.

## Changes

`private readonly object _x = new()` → `private readonly Lock _x = new()` in:

- `Services/AppAlertService.cs` — `_watcherLock`
- `Services/IconExtractorService.cs` — `_evictionLock` (static)
- `Services/PingMonitorService.cs` — `_stateLock`
- `Services/SystemInfoService.cs` — `_cacheLock`
- `Services/TracerouteMonitorService.cs` — `_stateLock`
- `ViewModels/ConsoleViewModel.cs` — `_gate`

## Why `Lock`

The dedicated lock type makes "this field exists only to be locked on" explicit at
the type level, lets the analyzer flag accidental `Monitor`/`Wait`/`Pulse` misuse,
and uses the lighter `EnterScope` lock path. `System.Threading` is already in the
project's implicit usings, so no `using` change is needed.

## Verification

- Every field verified to be used **only** as a `lock()` target — no `Monitor.Wait/Pulse`,
  not passed as an argument, not locked from outside the declaring type.
- Build: main + Tests + IntegrationTests all **0 warnings / 0 errors**.
- The 13 `lock()` statement sites compile unchanged against the new type.

Behavior identical (Protocol Q). `refactor:` → no release.
