### PR TITLE
refactor: use [GeneratedRegex] for SFC/DISM/speedtest literal patterns

### DIFF
--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -267,7 +267,7 @@ public sealed partial class CleanupViewModel : ViewModelBase
             if (l.Kind == OutputKind.Output) captured.Add(l.Text);
             if (l.Text.Contains('%') || l.Text.Contains("complete", StringComparison.OrdinalIgnoreCase))
             {
-                var m = Regex.Match(l.Text, @"(\d+)\s*%");
+                var m = SfcPercentRegex().Match(l.Text);
                 if (m.Success && int.TryParse(m.Groups[1].Value, out var pct) && pct is >= 0 and <= 100)
                 {
                     Progress = pct;
@@ -356,7 +356,7 @@ public sealed partial class CleanupViewModel : ViewModelBase
             if (l.Kind == OutputKind.Output) captured.Add(l.Text);
             if (l.Text.Contains('%'))
             {
-                var m = Regex.Match(l.Text, @"([\d.]+)%");
+                var m = DismPercentRegex().Match(l.Text);
                 if (m.Success && double.TryParse(m.Groups[1].Value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var pct) && pct is >= 0 and <= 100)
                 {
                     Progress = (int)pct;
@@ -410,4 +410,12 @@ public sealed partial class CleanupViewModel : ViewModelBase
         _sfcCts?.Cancel();
         _dismCts?.Cancel();
     }
+
+    // SFC reports progress as a whole-number percentage, e.g. "50 %".
+    [GeneratedRegex(@"(\d+)\s*%")]
+    private static partial Regex SfcPercentRegex();
+
+    // DISM reports progress as a decimal percentage, e.g. "50.0%".
+    [GeneratedRegex(@"([\d.]+)%")]
+    private static partial Regex DismPercentRegex();
 }

--- a/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Collections.ObjectModel;
+using System.Text.RegularExpressions;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
@@ -173,9 +174,13 @@ public sealed partial class SpeedTestViewModel : ViewModelBase
     private static int? ParseServerId(string option)
     {
         if (option.StartsWith("Auto")) return null;
-        var match = System.Text.RegularExpressions.Regex.Match(option, @"ID:\s*(\d+)");
+        var match = ServerIdRegex().Match(option);
         return match.Success ? int.Parse(match.Groups[1].Value) : null;
     }
+
+    // Speedtest server options are formatted "Name (ID: 1234)".
+    [GeneratedRegex(@"ID:\s*(\d+)")]
+    private static partial Regex ServerIdRegex();
 
     protected override void Dispose(bool disposing)
     {


### PR DESCRIPTION
## Summary

Converts the three remaining literal-pattern `Regex.Match` call sites to
source-generated `[GeneratedRegex]` partial methods. The pattern strings are
unchanged, so matching behavior is byte-identical — `[GeneratedRegex]` just moves
compilation from runtime to build time (no startup `Regex` construction, no
per-call interpreter overhead).

## Changes

- `ViewModels/CleanupViewModel.cs`
  - SFC progress: `Regex.Match(l.Text, @"(\d+)\s*%")` → `SfcPercentRegex().Match(...)`
  - DISM progress: `Regex.Match(l.Text, @"([\d.]+)%")` → `DismPercentRegex().Match(...)`
- `ViewModels/SpeedTestViewModel.cs`
  - Server-id parse: `Regex.Match(option, @"ID:\s*(\d+)")` → `ServerIdRegex().Match(...)`
  - Added `using System.Text.RegularExpressions;` (was fully-qualified before).

## Not converted (deliberately)

- `LogService` line 33 builds its regex from an **interpolated** pattern
  (`$@"(?i)({escaped})..."`) — a runtime value, so it cannot be source-generated.
  It stays a runtime `Regex`. The constant fallback pattern there was already
  converted in the earlier `[GeneratedRegex]` PR.

## Verification

- Pattern strings verified identical old→new (diff-checked, no character changed).
- Both VMs are already `sealed partial class` — the prerequisite for `[GeneratedRegex]`.
- Build: main + Tests + IntegrationTests all **0 warnings / 0 errors**.

Behavior identical (Protocol Q). `refactor:` → no release.
