### PR TITLE
refactor: use [LibraryImport] for SHEmptyRecycleBin

### DIFF
--- a/SysManager/SysManager/Services/TuneUpService.cs
+++ b/SysManager/SysManager/Services/TuneUpService.cs
@@ -19,7 +19,7 @@ namespace SysManager.Services;
 ///
 /// No admin required. No registry edits. No service changes.
 /// </summary>
-public sealed class TuneUpService
+public sealed partial class TuneUpService
 {
     private readonly ShortcutCleanerService _shortcuts;
     private readonly DiskHealthService _diskHealth;
@@ -232,9 +232,9 @@ public sealed class TuneUpService
         }
     }
 
-    private static class NativeMethods
+    private static partial class NativeMethods
     {
-        [System.Runtime.InteropServices.DllImport("shell32.dll", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
-        internal static extern int SHEmptyRecycleBin(IntPtr hwnd, string? pszRootPath, uint dwFlags);
+        [System.Runtime.InteropServices.LibraryImport("shell32.dll", StringMarshalling = System.Runtime.InteropServices.StringMarshalling.Utf16, EntryPoint = "SHEmptyRecycleBinW")]
+        internal static partial int SHEmptyRecycleBin(IntPtr hwnd, string? pszRootPath, uint dwFlags);
     }
 }


### PR DESCRIPTION
## Summary

Converts the `SHEmptyRecycleBin` P/Invoke from the runtime-marshalled `[DllImport]`
to the source-generated `[LibraryImport]`. Behavior is identical — the generator
emits the same UTF-16, W-suffixed entry-point call, just with the marshalling stub
produced at build time instead of by the runtime.

## Change

`Services/TuneUpService.cs`:
- `TuneUpService` and its nested `NativeMethods` are now `partial` (required so the
  generator can emit the implementation).
- `[DllImport("shell32.dll", CharSet = CharSet.Unicode)] static extern` →
  `[LibraryImport("shell32.dll", StringMarshalling = StringMarshalling.Utf16, EntryPoint = "SHEmptyRecycleBinW")] static partial`.

## Why identical

- `CharSet.Unicode` ⇒ `StringMarshalling.Utf16` — same UTF-16 string marshalling.
- `EntryPoint = "SHEmptyRecycleBinW"` names the exact W-suffixed export that
  `CharSet.Unicode` was already selecting implicitly.
- Signature is otherwise blittable (`IntPtr`, `uint`, `int` HRESULT return) — no
  marshalling behavior changes. Neither the old nor new declaration sets
  `SetLastError`, so error handling (the `hr >= 0 || 0x80070012` check) is unchanged.

## Not converted (deliberately)

The other two `[DllImport]`s — `SHGetFileInfo` (`ref SHFILEINFO`, `ByValTStr` inline
buffers) and `SHFileOperation` (`ref SHFILEOPSTRUCT`, `LPWStr` fields) — pass
**non-blittable structs** the source generator cannot marshal without a custom
`[NativeMarshalling]` rewrite, which would not be byte-identical. They stay
`[DllImport]`.

## Verification

- Build: main + Tests + IntegrationTests all **0 warnings / 0 errors** (the generator
  accepted the signature).

Behavior identical (Protocol Q). `refactor:` → no release.
