### PR TITLE
refactor: drop two orphan DI registrations for static-only services

### DIFF
--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -41,14 +41,12 @@ public static class ServiceRegistration
         services.AddSingleton<DuplicateFileService>();
         services.AddSingleton<EventLogService>();
         services.AddSingleton<FixedDriveService>();
-        services.AddSingleton<IconExtractorService>();
         services.AddSingleton<LargeFileScanner>();
         services.AddSingleton<MemoryTestService>();
         services.AddSingleton<NetworkRepairService>();
         services.AddSingleton<PerformanceService>();
         services.AddSingleton<PingMonitorService>();
         services.AddSingleton<ProcessManagerService>();
-        services.AddSingleton<ServiceManagerService>();
         services.AddSingleton<SpeedTestHistoryService>();
         services.AddSingleton<SpeedTestService>();
         services.AddSingleton<StartupService>();


### PR DESCRIPTION
## Summary

Removes two dead DI registrations. `IconExtractorService` and `ServiceManagerService`
expose **only static members** and every call site is a static call — the container
constructed an unused empty singleton of each at startup that nothing ever resolved.
Deleting the registrations removes that dead wiring without touching any call site.

## Changes

`ServiceRegistration.cs`:
- Removed `services.AddSingleton<IconExtractorService>();`
- Removed `services.AddSingleton<ServiceManagerService>();`

Both classes remain exactly as-is (static utility classes); all static call sites are
untouched.

## Why this is safe / behavior-identical

- Verified neither type is ever resolved from the container
  (`GetService`/`GetRequiredService`) or constructor-injected anywhere — both are
  pure static-method utilities. The build proves there is no compile-time dependency.
- No test (unit or integration) asserts these registrations exist.
- The only runtime effect was the container eagerly `new`-ing one unused instance of
  each on first build of the provider; nothing read those instances, so removing them
  changes no observable behavior.

Note: `AppBlockerService` — flagged alongside these in the original audit — is **not**
an orphan anymore; it was converted to an injected instance behind `IAppBlockerService`
in an earlier PR and is correctly registered. Left untouched.

## Verification

- Build: main + Tests + IntegrationTests all **0 warnings / 0 errors**.

Behavior identical (Protocol Q). `refactor:` → no release.
