### PR TITLE
fix: make app shutdown disposal idempotent and ownership-correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.14] - 2026-06-11
+
+### Fixed
+- **No more hidden shutdown errors when closing the app.** Cleanup ran more than once on exit (it is triggered by both the window-close and the application-exit events), which double-released the network charts' underlying graphics resources — an error that was caught and hidden but still occurred on every exit. Cleanup is now guarded so it runs exactly once, and the shared network monitors are stopped rather than disposed twice, so the app shuts down cleanly.
+
 ## [1.20.13] - 2026-06-11
 
 ### Fixed

--- a/SysManager/SysManager.Tests/NetworkSharedStateTests.cs
+++ b/SysManager/SysManager.Tests/NetworkSharedStateTests.cs
@@ -171,4 +171,18 @@ public class NetworkSharedStateTests
         Assert.Null(state.LatencyXAxes[0].MinLimit);
         Assert.Null(state.LatencyXAxes[0].MaxLimit);
     }
+
+    [Fact]
+    public void Dispose_CalledTwice_DoesNotThrow()
+    {
+        // Regression: Dispose is wired to two shutdown paths (OnClosed + Application.Exit)
+        // and the provider disposes this singleton again on teardown, so it runs 2-3 times.
+        // Without the _disposed guard, the second pass double-freed the unmanaged SkiaSharp
+        // paint/typeface handles — undefined behavior. The guard must make it a no-op.
+        var state = new NetworkSharedState(new Services.PingMonitorService(), new Services.TracerouteService(), new Services.TracerouteMonitorService(), new Services.SpeedTestService(), new Services.NetworkRepairService(new Services.PowerShellRunner()));
+
+        state.Dispose();
+        var ex = Record.Exception(() => state.Dispose());
+        Assert.Null(ex);
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.13</Version>
-    <FileVersion>1.20.13.0</FileVersion>
-    <AssemblyVersion>1.20.13.0</AssemblyVersion>
+    <Version>1.20.14</Version>
+    <FileVersion>1.20.14.0</FileVersion>
+    <AssemblyVersion>1.20.14.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -103,6 +103,8 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     [ObservableProperty] private bool _isElevated;
     [ObservableProperty] private string _elevationBadge = "";
 
+    private bool _disposed;
+
     /// <summary>
     /// Parameterless constructor — used by XAML designer and tests.
     /// When DI container is available (runtime), resolves child VMs from it.
@@ -404,6 +406,12 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
     public void Dispose()
     {
+        // Idempotency guard: Dispose is wired to two shutdown paths (OnClosed and
+        // Application.Exit), so it can run more than once. Disposing the SkiaSharp
+        // paint handles (via NetworkShared) twice is undefined behavior.
+        if (_disposed) return;
+        _disposed = true;
+
         // Dispose NavItems to unsubscribe PropertyChanged handlers
         foreach (var item in NavItems)
             item.Dispose();

--- a/SysManager/SysManager/ViewModels/NetworkSharedState.cs
+++ b/SysManager/SysManager/ViewModels/NetworkSharedState.cs
@@ -45,6 +45,8 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
     internal int PaletteIndex;
 
     internal readonly ConcurrentDictionary<string, BulkObservableCollection<DateTimePoint>> Buffers = new();
+
+    private bool _disposed;
     internal readonly ConcurrentDictionary<string, BulkObservableCollection<ObservablePoint>> TraceBuffers = new();
     internal readonly Dictionary<string, IReadOnlyList<TracerouteHop>> LatestRoutes = new();
     private readonly Dictionary<string, PropertyChangedEventHandler> _targetHandlers = new();
@@ -551,12 +553,16 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
 
     public void Dispose()
     {
+        if (_disposed) return;
+        _disposed = true;
+
         Pinger.SampleReceived -= OnSample;
         TraceMonitor.RouteCompleted -= OnRouteCompleted;
+        // Stop, do not Dispose: Pinger / TraceMonitor are DI singletons the container
+        // owns and disposes on teardown. Stopping halts their monitoring loops without
+        // double-freeing a dependency this type does not own.
         Pinger.Stop();
-        Pinger.Dispose();
         TraceMonitor.Stop();
-        TraceMonitor.Dispose();
         FlushTimer?.Stop();
 
         // Unsubscribe target PropertyChanged handlers to prevent memory leaks


### PR DESCRIPTION
## Summary

Makes the application's shutdown teardown idempotent and ownership-correct. App cleanup
ran 2–3 times on every exit; the redundant passes double-released the network charts'
unmanaged SkiaSharp paint/typeface handles. The resulting `ObjectDisposedException` was
caught and hidden (in `App.OnExit` and the global handler) but happened on every close.

## Root cause

`MainWindowViewModel.Dispose()` is wired to **two** shutdown paths — the window's
`OnClosed` override and `Application.Current.Exit` (`MainWindow.xaml.cs:54, 133`) — and
the child VMs/services it disposes are DI singletons the `ServiceProvider` disposes
**again** on teardown (`App.xaml.cs:92`). Neither `MainWindowViewModel` nor
`NetworkSharedState` had a `_disposed` guard (they derive from `ObservableObject`, not
`ViewModelBase`, so they didn't inherit the existing guard), so the unmanaged paint
handles in `NetworkSharedState.Dispose()` were freed more than once — undefined behavior.

Additionally, `NetworkSharedState.Dispose()` called `Pinger.Dispose()` /
`TraceMonitor.Dispose()` on monitor services that are themselves DI singletons — an
ownership inversion (a consumer disposing a container-owned dependency).

## Changes

- **`NetworkSharedState`**: added a `private bool _disposed;` guard (`if (_disposed) return; _disposed = true;`) — same pattern as `ViewModelBase`/`TrayIconService`. Replaced `Pinger.Dispose()` / `TraceMonitor.Dispose()` with `Pinger.Stop()` / `TraceMonitor.Stop()` — stop the loops, let the container own disposal of the singletons. (It already called `Stop()` before `Dispose()`, so this just drops the redundant, ownership-inverting `Dispose`.)
- **`MainWindowViewModel`**: added the same `_disposed` guard at the top of `Dispose()`.
- **Test**: `Dispose_CalledTwice_DoesNotThrow` in `NetworkSharedStateTests` pins the bug — a second `Dispose()` must be a no-op.

## Why behavior is otherwise unchanged

The first `Dispose()` does exactly what it did before (minus the redundant singleton
`Dispose` that `Stop()` already covered). Child VMs derived from `ViewModelBase` were
already idempotent via their own guard; this adds the guard to the two `ObservableObject`
roots that lacked it. Runtime behavior on a single clean shutdown is identical; the
double/triple passes are now safe no-ops instead of hidden exceptions.

## Verification

- Build: main + Tests + IntegrationTests all **0 warnings / 0 errors**.
- Regression test compiles and pins the double-dispose scenario.
- Self-review (Protocol I): leak/debug scan clean, author headers present, CHANGELOG +
  version bump (1.20.13 → 1.20.14) in this same PR.

`fix:` → patch release (1.20.14). Protocol C to follow after merge.
