### PR TITLE
fix: resolve symlinks before File Shredder protected-path validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.20.14] - 2026-06-11
+## [1.20.15] - 2026-06-12
+
+### Fixed
+- **File Shredder can no longer be tricked into destroying a protected system file.** The safety check that blocks shredding inside Windows, System32, and Program Files compared the path you gave it without first following symbolic links — so a link placed in an allowed folder but pointing at a protected system file slipped past the check, and the real file was overwritten. The check now resolves link targets before validating and matches protected folders on an exact directory boundary (so an unrelated folder that merely starts with the same name is no longer falsely blocked). If a file's contents are securely overwritten but the entry can't be removed, the app now reports that clearly instead of surfacing a raw error.
 
 ### Fixed
 - **No more hidden shutdown errors when closing the app.** Cleanup ran more than once on exit (it is triggered by both the window-close and the application-exit events), which double-released the network charts' underlying graphics resources — an error that was caught and hidden but still occurred on every exit. Cleanup is now guarded so it runs exactly once, and the shared network monitors are stopped rather than disposed twice, so the app shuts down cleanly.

--- a/SysManager/SysManager.Tests/FileShredderServiceTests.cs
+++ b/SysManager/SysManager.Tests/FileShredderServiceTests.cs
@@ -217,4 +217,57 @@ public class FileShredderServiceTests
             if (File.Exists(file)) File.Delete(file);
         }
     }
+
+    // ---------- symlink bypass regression (P0) ----------
+
+    [Fact]
+    public async Task ShredFileAsync_SymlinkToProtectedFile_ThrowsSecurityException()
+    {
+        // Regression: ValidatePath used Path.GetFullPath, which does NOT resolve
+        // symlinks. A link sitting at an unprotected path but pointing into System32
+        // previously passed validation and the real protected file was shredded
+        // through the link. The guard must resolve the link target and block it.
+        var svc = NewService();
+        var sys32 = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "System32");
+        // A file that reliably exists under System32; the link's *target* is what matters.
+        var protectedTarget = Path.Combine(sys32, "drivers", "etc", "hosts");
+        if (!File.Exists(protectedTarget))
+            protectedTarget = Path.Combine(sys32, "notepad.exe");
+
+        var link = Path.Combine(Path.GetTempPath(), "smtest_symlink_" + Guid.NewGuid().ToString("N") + ".dat");
+
+        try
+        {
+            // Creating a file symlink needs privilege/developer-mode. If unavailable,
+            // skip the assertion rather than fail on an environment limitation.
+            try { File.CreateSymbolicLink(link, protectedTarget); }
+            catch (IOException) { return; }
+            catch (UnauthorizedAccessException) { return; }
+
+            await Assert.ThrowsAsync<SecurityException>(
+                () => svc.ShredFileAsync(link, ShredMethod.Quick, null, CancellationToken.None));
+        }
+        finally
+        {
+            // Delete only the link, never its target. File.Delete on a symlink removes
+            // the link itself.
+            if (File.Exists(link)) File.Delete(link);
+        }
+    }
+
+    [Fact]
+    public async Task ValidatePath_SiblingOfProtectedRoot_IsAllowed()
+    {
+        // Boundary regression: the guard now matches on a directory boundary, so a
+        // sibling whose name merely shares the protected prefix (e.g. a "<Windows>Apps"
+        // style sibling) must NOT be blocked. Use a path that starts with the Windows
+        // root string but is not under it.
+        var windows = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+        var sibling = windows + "Sibling_smtest"; // e.g. C:\WindowsSibling_smtest — shares prefix, not under root
+        var svc = NewService();
+        // Not a protected path → ShredFileAsync should fail on FileNotFound, NOT SecurityException.
+        var ex = await Record.ExceptionAsync(
+            () => svc.ShredFileAsync(Path.Combine(sibling, "x.dat"), ShredMethod.Quick, null, CancellationToken.None));
+        Assert.IsNotType<SecurityException>(ex);
+    }
 }

--- a/SysManager/SysManager/Services/FileShredderService.cs
+++ b/SysManager/SysManager/Services/FileShredderService.cs
@@ -112,7 +112,25 @@ public sealed class FileShredderService
             await finalStream.FlushAsync(ct).ConfigureAwait(false);
         }
 
-        File.Delete(filePath);
+        // The file contents are already securely overwritten and truncated to zero at
+        // this point, so the shred guarantee holds even if the directory-entry removal
+        // fails. Surface a delete failure as a clear IOException rather than letting a
+        // raw one escape — the caller can report "overwritten but not removed".
+        try
+        {
+            File.Delete(filePath);
+        }
+        catch (IOException ex)
+        {
+            throw new IOException(
+                $"File contents were securely overwritten, but the file could not be removed: {ex.Message}", ex);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            throw new IOException(
+                $"File contents were securely overwritten, but removal was denied: {ex.Message}", ex);
+        }
+
         Log.Information("File shredded successfully: {Path} ({Method})", filePath, method);
     }
 
@@ -211,9 +229,29 @@ public sealed class FileShredderService
     {
         var fullPath = Path.GetFullPath(path);
 
+        // Resolve symlinks/junctions before validating. Path.GetFullPath only
+        // canonicalizes '.'/'..' — it does NOT follow reparse points, so a symlink
+        // at an unprotected location (e.g. C:\temp\link -> C:\Windows\System32\...)
+        // would otherwise pass this check and be shredded through. Validate the real
+        // target instead. ResolveLinkTarget(true) walks the full chain to the final
+        // target; it returns null when the path is not a link.
+        try
+        {
+            var info = new FileInfo(fullPath);
+            var finalTarget = info.ResolveLinkTarget(returnFinalTarget: true);
+            if (finalTarget is not null)
+                fullPath = Path.GetFullPath(finalTarget.FullName);
+        }
+        catch (IOException) { /* not a link or cannot resolve — validate the literal path */ }
+        catch (UnauthorizedAccessException) { /* cannot probe — validate the literal path */ }
+
         foreach (var prefix in ProtectedPrefixes)
         {
-            if (fullPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            // Match on a directory boundary, not a raw prefix: the path must equal the
+            // protected root or sit beneath it (prefix + separator). Without this,
+            // "C:\Windows" would also block an unrelated sibling like "C:\WindowsApps".
+            if (fullPath.Equals(prefix, StringComparison.OrdinalIgnoreCase) ||
+                fullPath.StartsWith(prefix + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
             {
                 throw new SecurityException(
                     $"Shredding system-protected paths is not allowed: {fullPath}");

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.14</Version>
-    <FileVersion>1.20.14.0</FileVersion>
-    <AssemblyVersion>1.20.14.0</AssemblyVersion>
+    <Version>1.20.15</Version>
+    <FileVersion>1.20.15.0</FileVersion>
+    <AssemblyVersion>1.20.15.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

**P0 security fix.** `FileShredderService.ValidatePath` used `Path.GetFullPath`, which
canonicalizes `.`/`..` but does **not** resolve symbolic links. A symlink placed at an
allowed path but pointing into a protected root (Windows / System32 / Program Files)
passed validation, and `ShredFileAsync` then opened and securely overwrote the **real
protected file** through the link — silent destruction of a system file.

## Fix

`Services/FileShredderService.cs` — `ValidatePath`:
- Resolve the link target with `FileInfo.ResolveLinkTarget(returnFinalTarget: true)` and
  validate the **canonical target** against the protected prefixes. Non-links and
  unresolvable paths fall back to validating the literal path (no behavior change for them).
- Match protected roots on a **directory boundary** (`Equals` or `prefix + separator`)
  instead of a raw `StartsWith`, so a sibling that merely shares the prefix
  (e.g. `C:\WindowsSibling`) is no longer falsely blocked, while everything under a
  protected root stays blocked.

Also hardened the related destructive path: `ShredFileAsync`'s final `File.Delete` is now
wrapped so a delete failure (after the contents are already securely overwritten) surfaces
as a clear `IOException` ("overwritten but not removed") rather than a raw, ambiguous one.

## Tests

- `ShredFileAsync_SymlinkToProtectedFile_ThrowsSecurityException` — creates a real file
  symlink pointing into System32 and asserts the shred is blocked. Skips gracefully if the
  environment can't create symlinks (no privilege/developer-mode) rather than failing.
- `ValidatePath_SiblingOfProtectedRoot_IsAllowed` — pins the directory-boundary behavior
  (a prefix-sharing sibling is not a `SecurityException`).

## Verification

- Build: main + Tests + IntegrationTests all **0 warnings / 0 errors**.
- Existing protected-root / case-insensitive / arg-guard / cancellation tests unchanged.

`fix:` → patch release (1.20.15). Protocol C to follow.
