### PR TITLE
fix: harden service/registry/lock operations against uncaught exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.16] - 2026-06-12
+
+### Fixed
+- **Starting or stopping a Windows service no longer crashes the app on failure.** If a service couldn't be started or stopped (access denied, a dependency problem, or the service state changing mid-operation), the underlying error escaped unhandled. Those failures are now caught and shown as a clear status message.
+- **Privacy toggles no longer crash on a registry write error.** Applying a privacy toggle only handled permission errors; a registry I/O error or an invalid key/value now logs a warning instead of bringing down the app.
+- **Disabling Xbox Game Bar no longer crashes on a registry I/O error.** The Performance tab's Xbox Game Bar action now handles I/O failures the same way it already handled permission and state errors.
+- **A misbehaving UI subscriber can no longer permanently lock an operation category.** If a property-change notification threw while acquiring an operation lock, the category could stay locked forever (blocking all future disk/network/system operations of that kind). The lock is now rolled back cleanly if that happens.
+
 ## [1.20.15] - 2026-06-12
 
 ### Fixed

--- a/SysManager/SysManager.Tests/OperationLockServiceEdgeCaseTests.cs
+++ b/SysManager/SysManager.Tests/OperationLockServiceEdgeCaseTests.cs
@@ -137,6 +137,35 @@ public class OperationLockServiceEdgeCaseTests
     }
 
     [Fact]
+    public void TryAcquire_PropertyChangedThrows_DoesNotDeadlockCategory()
+    {
+        // Regression: if a PropertyChanged subscriber throws, TryAcquire must roll back
+        // the entry it added — otherwise the category would be locked forever (no handle
+        // was returned, so the caller can never Release it).
+        void throwingHandler(object? _, System.ComponentModel.PropertyChangedEventArgs __)
+            => throw new InvalidOperationException("subscriber boom");
+
+        // Make sure the category starts free.
+        Service.TryAcquire(OperationCategory.SystemModification, "preClean")?.Dispose();
+
+        Service.PropertyChanged += throwingHandler;
+        try
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Service.TryAcquire(OperationCategory.SystemModification, "WillThrow"));
+        }
+        finally
+        {
+            Service.PropertyChanged -= throwingHandler;
+        }
+
+        // The category must NOT be stuck locked — a fresh acquire has to succeed.
+        Assert.False(Service.IsLocked(OperationCategory.SystemModification));
+        using var handle = Service.TryAcquire(OperationCategory.SystemModification, "AfterRollback");
+        Assert.NotNull(handle);
+    }
+
+    [Fact]
     public async Task ConcurrentAcquire_OnlyOneSucceeds()
     {
         // Release any existing network lock

--- a/SysManager/SysManager/Services/OperationLockService.cs
+++ b/SysManager/SysManager/Services/OperationLockService.cs
@@ -51,8 +51,21 @@ public sealed partial class OperationLockService : ObservableObject
         if (!_active.TryAdd(category, info))
             return null;
 
-        OnPropertyChanged(nameof(ActiveOperations));
-        OnPropertyChanged(nameof(HasActiveOperations));
+        try
+        {
+            OnPropertyChanged(nameof(ActiveOperations));
+            OnPropertyChanged(nameof(HasActiveOperations));
+        }
+        catch
+        {
+            // A PropertyChanged subscriber threw. The entry is already in _active but no
+            // handle has been returned, so the caller could never release it — that would
+            // lock this category forever. Roll back the add and rethrow so the lock state
+            // stays consistent.
+            _active.TryRemove(category, out _);
+            throw;
+        }
+
         return new OperationHandle(this, category);
     }
 

--- a/SysManager/SysManager/Services/PrivacyService.cs
+++ b/SysManager/SysManager/Services/PrivacyService.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using System.Security;
 using Microsoft.Win32;
 using Serilog;
@@ -59,6 +60,16 @@ public sealed class PrivacyService
         catch (SecurityException ex)
         {
             Log.Warning(ex, "Security exception writing privacy toggle {Name} at {Path} — elevation required",
+                toggle.Name, toggle.RegistryPath);
+        }
+        catch (IOException ex)
+        {
+            Log.Warning(ex, "Registry I/O error writing privacy toggle {Name} at {Path}",
+                toggle.Name, toggle.RegistryPath);
+        }
+        catch (ArgumentException ex)
+        {
+            Log.Warning(ex, "Invalid registry key or value writing privacy toggle {Name} at {Path}",
                 toggle.Name, toggle.RegistryPath);
         }
     }

--- a/SysManager/SysManager/Services/ServiceManagerService.cs
+++ b/SysManager/SysManager/Services/ServiceManagerService.cs
@@ -94,15 +94,23 @@ public sealed partial class ServiceManagerService
             sc.Status == ServiceControllerStatus.StartPending)
             return;
 
-        sc.Start();
         try
         {
+            sc.Start();
             await Task.Run(() => sc.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromSeconds(30))).ConfigureAwait(false);
         }
         catch (System.ServiceProcess.TimeoutException)
         {
             throw new InvalidOperationException(
                 $"Service '{serviceName}' did not start within 30 seconds. It may still be starting — check Services again in a moment.");
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            // sc.Start() surfaces the underlying Win32 error (e.g. access denied,
+            // dependency failure) as a Win32Exception. Normalize to the type the
+            // ViewModel layer already handles.
+            throw new InvalidOperationException(
+                $"Could not start service '{serviceName}': {ex.Message}", ex);
         }
     }
 
@@ -112,15 +120,22 @@ public sealed partial class ServiceManagerService
         using var sc = new ServiceController(serviceName);
         if (sc.CanStop && sc.Status != ServiceControllerStatus.Stopped)
         {
-            sc.Stop();
             try
             {
+                sc.Stop();
                 await Task.Run(() => sc.WaitForStatus(ServiceControllerStatus.Stopped, TimeSpan.FromSeconds(30))).ConfigureAwait(false);
             }
             catch (System.ServiceProcess.TimeoutException)
             {
                 throw new InvalidOperationException(
                     $"Service '{serviceName}' did not stop within 30 seconds. It may still be stopping — check Services again in a moment.");
+            }
+            catch (System.ComponentModel.Win32Exception ex)
+            {
+                // The service state can change between the CanStop check and Stop(),
+                // or the caller may lack rights — sc.Stop() then throws Win32Exception.
+                throw new InvalidOperationException(
+                    $"Could not stop service '{serviceName}': {ex.Message}", ex);
             }
         }
     }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.15</Version>
-    <FileVersion>1.20.15.0</FileVersion>
-    <AssemblyVersion>1.20.15.0</AssemblyVersion>
+    <Version>1.20.16</Version>
+    <FileVersion>1.20.16.0</FileVersion>
+    <AssemblyVersion>1.20.16.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
@@ -276,6 +276,7 @@ public sealed partial class PerformanceViewModel : ViewModelBase
         catch (InvalidOperationException ex) { StatusMessage = $"Xbox Game Bar change failed: {ex.Message}"; }
         catch (SecurityException ex) { StatusMessage = $"Xbox Game Bar change failed: {ex.Message}"; }
         catch (UnauthorizedAccessException ex) { StatusMessage = $"Xbox Game Bar change failed: {ex.Message}"; }
+        catch (System.IO.IOException ex) { StatusMessage = $"Xbox Game Bar change failed: {ex.Message}"; }
     }
 
     // ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Exception-safety hardening across service-control, registry-write, and operation-lock
paths. Each fix targets an uncaught exception class that could crash the app or, in one
case, permanently deadlock an operation category.

## Fixes

- **`ServiceManagerService.StartServiceAsync` / `StopServiceAsync`** — `sc.Start()` /
  `sc.Stop()` sat *outside* the try block. They throw `Win32Exception` (access denied,
  dependency failure, state changed after the `CanStop` check) which bypassed the
  ViewModel's handlers. Moved them inside the try and normalized `Win32Exception` to
  `InvalidOperationException` (the type the VM layer already handles).
- **`PrivacyService.ApplyToggle`** — only caught `UnauthorizedAccessException` /
  `SecurityException`. A registry `IOException` or an invalid key/value
  (`ArgumentException`) from `CreateSubKey`/`SetValue` escaped and crashed. Both are now
  caught and logged (consistent with `AppBlockerService.BlockApp`).
- **`PerformanceViewModel` Xbox Game Bar command** — caught `InvalidOperationException` /
  `SecurityException` / `UnauthorizedAccessException` but not `IOException` from the
  registry write. Added the missing `catch`, matching the sibling commands.
- **`OperationLockService.TryAcquire`** — if a `PropertyChanged` subscriber threw, the
  entry was already in `_active` but no handle was returned, so the caller could never
  release it → the category was locked **forever**. The notifications are now wrapped so
  the entry is rolled back (and the exception rethrown) on failure.

## Test

`TryAcquire_PropertyChangedThrows_DoesNotDeadlockCategory` — subscribes a throwing
`PropertyChanged` handler, asserts `TryAcquire` rethrows, then asserts the category is
**not** stuck locked and a fresh acquire succeeds.

## Verification

- Build: main + Tests + IntegrationTests all **0 warnings / 0 errors**.
- Behavior on the success path is unchanged; only failure paths are now contained.

`fix:` → patch release (1.20.16). Protocol C to follow.
