### PR TITLE
fix: release leaked tray icon, process, and WMI collection handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.20.16] - 2026-06-12
+## [1.20.17] - 2026-06-12
+
+### Fixed
+- **Plugged several resource leaks.** The system-tray icon's underlying graphics handle was never released on shutdown; the elevated-relaunch helper left a process handle open; and a memory-module query left a WMI result set undisposed. All are now released properly. Also added handling for a WMI namespace being unavailable when reading drive media/bus details, so that case fails quietly instead of surfacing an error.
 
 ### Fixed
 - **Starting or stopping a Windows service no longer crashes the app on failure.** If a service couldn't be started or stopped (access denied, a dependency problem, or the service state changing mid-operation), the underlying error escaped unhandled. Those failures are now caught and shown as a clear status message.

--- a/SysManager/SysManager/Helpers/AdminHelper.cs
+++ b/SysManager/SysManager/Helpers/AdminHelper.cs
@@ -40,7 +40,8 @@ public static class AdminHelper
                 Verb = "runas",
                 Arguments = argumentHint ?? string.Empty
             };
-            Process.Start(psi);
+            // Dispose the returned Process handle — we don't track the elevated instance.
+            Process.Start(psi)?.Dispose();
             return true;
         }
         catch (InvalidOperationException ex)

--- a/SysManager/SysManager/Services/FixedDriveService.cs
+++ b/SysManager/SysManager/Services/FixedDriveService.cs
@@ -110,6 +110,11 @@ public sealed class FixedDriveService
         {
             // Non-fatal — leave media/bus empty.
         }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            // scope.Connect() can throw COMException when the Storage WMI namespace is
+            // unavailable (older/headless Windows). Non-fatal — leave media/bus empty.
+        }
 
         return drives;
     }

--- a/SysManager/SysManager/Services/MemoryTestService.cs
+++ b/SysManager/SysManager/Services/MemoryTestService.cs
@@ -102,7 +102,8 @@ public sealed class MemoryTestService
             {
                 using var s = new ManagementObjectSearcher(
                     "SELECT BankLabel, DeviceLocator, Manufacturer, Capacity, Speed, ConfiguredClockSpeed, PartNumber FROM Win32_PhysicalMemory");
-                foreach (ManagementObject mo in s.Get())
+                using var moc = s.Get();
+                foreach (ManagementObject mo in moc)
                 {
                     using (mo)
                     {

--- a/SysManager/SysManager/Services/TrayIconService.cs
+++ b/SysManager/SysManager/Services/TrayIconService.cs
@@ -21,6 +21,10 @@ public sealed class TrayIconService : IDisposable
     private readonly SystemInfoService _sysInfo;
     private readonly DispatcherTimer _timer;
     private TaskbarIcon? _trayIcon;
+    // The GDI Icon handle we created (via ExtractAssociatedIcon or new Icon(stream)) and
+    // must dispose ourselves. Null when we fell back to the shared SystemIcons.Application,
+    // which is process-wide and must NOT be disposed.
+    private System.Drawing.Icon? _ownedIcon;
     private bool _disposed;
     private int _updating; // PERF-M4: re-entrancy guard for WMI calls
 
@@ -51,7 +55,10 @@ public sealed class TrayIconService : IDisposable
     /// </summary>
     public void Initialize(Window mainWindow)
     {
-        var icon = LoadAppIcon() ?? System.Drawing.SystemIcons.Application;
+        // Track only an icon we own so Dispose can free its GDI handle. The shared
+        // SystemIcons.Application fallback is process-wide and must not be disposed.
+        _ownedIcon = LoadAppIcon();
+        var icon = _ownedIcon ?? System.Drawing.SystemIcons.Application;
         _trayIcon = new TaskbarIcon
         {
             ToolTipText = "SysManager",
@@ -240,5 +247,6 @@ public sealed class TrayIconService : IDisposable
         _disposed = true;
         _timer.Stop();
         _trayIcon?.Dispose();
+        _ownedIcon?.Dispose();
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.16</Version>
-    <FileVersion>1.20.16.0</FileVersion>
-    <AssemblyVersion>1.20.16.0</AssemblyVersion>
+    <Version>1.20.17</Version>
+    <FileVersion>1.20.17.0</FileVersion>
+    <AssemblyVersion>1.20.17.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Releases three genuinely-leaked handles and adds one missing WMI exception handler. All
verified against the actual code (see the note on a discarded false positive below).

## Fixes

- **`TrayIconService`** — the GDI `Icon` from `LoadAppIcon` (via `ExtractAssociatedIcon`
  or `new Icon(stream)`) was assigned to the tray icon but never disposed; `Dispose`
  only disposed the `TaskbarIcon`. The owned icon is now tracked in a field and disposed
  on teardown. The shared `SystemIcons.Application` fallback is deliberately **not**
  disposed (it is process-wide).
- **`AdminHelper.RelaunchAsAdmin`** — `Process.Start(psi)` returned a `Process` handle
  that was discarded undisposed. Now `?.Dispose()`d (we don't track the elevated instance).
- **`MemoryTestService`** — `searcher.Get()` returned a `ManagementObjectCollection` that
  was iterated but never disposed. Now captured in a `using`.
- **`FixedDriveService`** — `scope.Connect()` can throw `COMException` when the Storage
  WMI namespace is unavailable; only `ManagementException` was caught. Added a
  `COMException` handler (non-fatal — leaves media/bus info empty).

## Note: a false positive was discarded

The audit flagged "`ManagementScope` leak — wrap in `using`" for `DiskHealthService`,
`FixedDriveService`, and `SystemInfoService`. That is **incorrect**: `ManagementScope`
does **not** implement `IDisposable` (the compiler rejects `using var scope`). The COM
resources live in the `ManagementObjectSearcher`/`ManagementObjectCollection`, which are
already disposed. Those three "fixes" were reverted; only the real leaks above remain.

## Verification

- Build: main + Tests + IntegrationTests all **0 warnings / 0 errors**.

`fix:` → patch release (1.20.17). Protocol C to follow.
