### PR TITLE
fix: guard WMI value conversions and winget column parsing against bad data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.20.17] - 2026-06-12
+## [1.20.18] - 2026-06-12
+
+### Fixed
+- **More resilient reading of battery, memory, and app-list data.** Unexpected values from Windows (battery stats, memory-module details) could throw a conversion error and interrupt a scan; those conversions now fall back safely. The winget output parser also no longer throws when the tool reports columns in an unusual order.
 
 ### Fixed
 - **Plugged several resource leaks.** The system-tray icon's underlying graphics handle was never released on shutdown; the elevated-relaunch helper left a process handle open; and a memory-module query left a WMI result set undisposed. All are now released properly. Also added handling for a WMI namespace being unavailable when reading drive media/bus details, so that case fails quietly instead of surfacing an error.

--- a/SysManager/SysManager/Helpers/WingetTableParser.cs
+++ b/SysManager/SysManager/Helpers/WingetTableParser.cs
@@ -97,6 +97,10 @@ internal static partial class WingetTableParser
     {
         if (start < 0 || start >= line.Length) return string.Empty;
         int actualEnd = end < 0 ? line.Length : Math.Min(end, line.Length);
+        // Guard against out-of-order columns (start > end): winget can emit headers
+        // whose detected positions don't increase monotonically, which would make the
+        // range operator throw ArgumentOutOfRangeException.
+        if (actualEnd <= start) return string.Empty;
         return line[start..actualEnd].Trim();
     }
 }

--- a/SysManager/SysManager/Services/BatteryService.cs
+++ b/SysManager/SysManager/Services/BatteryService.cs
@@ -33,13 +33,13 @@ public sealed class BatteryService
                     info.HasBattery = true;
                     info.Name = obj["Name"]?.ToString() ?? "";
                     info.Manufacturer = obj["DeviceID"]?.ToString() ?? "";
-                    info.ChargePercent = Convert.ToInt32(obj["EstimatedChargeRemaining"] ?? 0);
-                    info.Chemistry = MapChemistry(Convert.ToUInt16(obj["Chemistry"] ?? 0));
+                    info.ChargePercent = ToInt32Safe(obj["EstimatedChargeRemaining"]);
+                    info.Chemistry = MapChemistry(ToUInt16Safe(obj["Chemistry"]));
 
-                    var statusCode = Convert.ToUInt16(obj["BatteryStatus"] ?? 0);
+                    var statusCode = ToUInt16Safe(obj["BatteryStatus"]);
                     info.Status = MapBatteryStatus(statusCode);
 
-                    var runtime = Convert.ToInt64(obj["EstimatedRunTime"] ?? 0);
+                    var runtime = ToInt64Safe(obj["EstimatedRunTime"]);
                     info.EstimatedRuntimeMinutes = runtime >= 71_582_788 ? -1 : (int)runtime;
 
                     break; // first battery only
@@ -66,7 +66,7 @@ public sealed class BatteryService
             {
                 using (obj)
                 {
-                    info.DesignCapacityMWh = Convert.ToUInt32(obj["DesignedCapacity"] ?? 0);
+                    info.DesignCapacityMWh = ToUInt32Safe(obj["DesignedCapacity"]);
                     break;
                 }
             }
@@ -85,7 +85,7 @@ public sealed class BatteryService
             {
                 using (obj)
                 {
-                    info.FullChargeCapacityMWh = Convert.ToUInt32(obj["FullChargedCapacity"] ?? 0);
+                    info.FullChargeCapacityMWh = ToUInt32Safe(obj["FullChargedCapacity"]);
                     break;
                 }
             }
@@ -104,7 +104,7 @@ public sealed class BatteryService
             {
                 using (obj)
                 {
-                    info.CycleCount = Convert.ToInt32(obj["CycleCount"] ?? 0);
+                    info.CycleCount = ToInt32Safe(obj["CycleCount"]);
                     break;
                 }
             }
@@ -143,4 +143,39 @@ public sealed class BatteryService
         8 => "Lithium Polymer",
         _ => "Unknown"
     };
+
+    // Safe WMI-value converters: a malformed/unexpected value would make Convert.To*
+    // throw InvalidCastException/FormatException/OverflowException, which the WMI
+    // try-blocks above don't catch — falling back to a default keeps the scan resilient.
+    private static int ToInt32Safe(object? value, int fallback = 0)
+    {
+        try { return Convert.ToInt32(value ?? fallback); }
+        catch (InvalidCastException) { return fallback; }
+        catch (FormatException) { return fallback; }
+        catch (OverflowException) { return fallback; }
+    }
+
+    private static ushort ToUInt16Safe(object? value, ushort fallback = 0)
+    {
+        try { return Convert.ToUInt16(value ?? fallback); }
+        catch (InvalidCastException) { return fallback; }
+        catch (FormatException) { return fallback; }
+        catch (OverflowException) { return fallback; }
+    }
+
+    private static uint ToUInt32Safe(object? value, uint fallback = 0)
+    {
+        try { return Convert.ToUInt32(value ?? fallback); }
+        catch (InvalidCastException) { return fallback; }
+        catch (FormatException) { return fallback; }
+        catch (OverflowException) { return fallback; }
+    }
+
+    private static long ToInt64Safe(object? value, long fallback = 0)
+    {
+        try { return Convert.ToInt64(value ?? fallback); }
+        catch (InvalidCastException) { return fallback; }
+        catch (FormatException) { return fallback; }
+        catch (OverflowException) { return fallback; }
+    }
 }

--- a/SysManager/SysManager/Services/MemoryTestService.cs
+++ b/SysManager/SysManager/Services/MemoryTestService.cs
@@ -122,6 +122,11 @@ public sealed class MemoryTestService
             }
             catch (ManagementException) { /* WMI class not available */ }
             catch (UnauthorizedAccessException) { /* WMI access denied */ }
+            // Convert.To* on an unexpected WMI value can throw these; a malformed module
+            // entry shouldn't abort the whole memory scan.
+            catch (InvalidCastException) { /* malformed WMI value */ }
+            catch (FormatException) { /* malformed WMI value */ }
+            catch (OverflowException) { /* WMI value out of range */ }
             return list;
         });
     }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.17</Version>
-    <FileVersion>1.20.17.0</FileVersion>
-    <AssemblyVersion>1.20.17.0</AssemblyVersion>
+    <Version>1.20.18</Version>
+    <FileVersion>1.20.18.0</FileVersion>
+    <AssemblyVersion>1.20.18.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Crash-safety hardening for WMI value conversion and winget output parsing — both
turn malformed external data into a safe fallback instead of an unhandled exception.

## Fixes

- **`BatteryService`** — the WMI try-blocks caught `ManagementException` /
  `UnauthorizedAccessException` but not the `InvalidCastException` /
  `FormatException` / `OverflowException` that `Convert.ToInt32/ToUInt16/ToUInt32/ToInt64`
  throw on an unexpected value. Added `ToInt32Safe` / `ToUInt16Safe` / `ToUInt32Safe` /
  `ToInt64Safe` helpers (catch those three, fall back to a default) and routed all 7
  conversions through them.
- **`MemoryTestService`** — same gap on the `Win32_PhysicalMemory` query
  (`Convert.ToDouble` / `Convert.ToUInt32`). Added `InvalidCastException` /
  `FormatException` / `OverflowException` to the existing catch so one malformed module
  entry can't abort the whole scan.
- **`WingetTableParser.Slice`** — the existing guard checked `start >= line.Length` but
  not `start > end`. If winget reported columns whose detected positions weren't
  monotonically increasing, `line[start..end]` threw `ArgumentOutOfRangeException`. Added
  an `actualEnd <= start` guard returning empty.

## Verification

- Build: main + Tests all **0 warnings / 0 errors**.
- Existing `WingetTableParserTests` / `WingetParserDeepTests` cover the parser; the new
  guard only adds a defensive early-return for the out-of-order case.

`fix:` → patch release (1.20.18). Protocol C to follow.
