### PR TITLE
fix: snapshot activity log under lock and guard updater download path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.20.18] - 2026-06-12
+## [1.20.19] - 2026-06-12
+
+### Fixed
+- **Activity history can no longer be corrupted by concurrent updates.** The recent-actions log saved its data outside the lock that protects it, so two actions logged at the same time could clash and produce a "collection modified" error or a truncated file. It now writes a consistent snapshot taken under the lock.
+- **The in-app updater fails gracefully when the download location can't be determined.** Installing an update now checks the downloaded file's folder up front and shows a clear message instead of risking a crash.
 
 ### Fixed
 - **More resilient reading of battery, memory, and app-list data.** Unexpected values from Windows (battery stats, memory-module details) could throw a conversion error and interrupt a scan; those conversions now fall back safely. The winget output parser also no longer throws when the tool reports columns in an unusual order.

--- a/SysManager/SysManager/Services/ActivityLogService.cs
+++ b/SysManager/SysManager/Services/ActivityLogService.cs
@@ -32,13 +32,18 @@ public sealed class ActivityLogService
     public void Log(string action, string detail)
     {
         var entry = new ActivityEntry(action, detail, DateTime.Now);
+        List<ActivityEntry> snapshot;
         lock (_lock)
         {
             _entries.Insert(0, entry);
             if (_entries.Count > MaxEntries)
                 _entries.RemoveRange(MaxEntries, _entries.Count - MaxEntries);
+            // Take the snapshot to persist while still holding the lock — serializing
+            // _entries directly (outside the lock) could race a concurrent Log() that is
+            // mutating the list, throwing "collection was modified" or writing torn JSON.
+            snapshot = [.. _entries];
         }
-        Save();
+        Save(snapshot);
     }
 
     private void Load()
@@ -56,13 +61,13 @@ public sealed class ActivityLogService
         }
     }
 
-    private void Save()
+    private static void Save(List<ActivityEntry> snapshot)
     {
         try
         {
             var dir = Path.GetDirectoryName(FilePath)!;
             Directory.CreateDirectory(dir);
-            var json = JsonSerializer.Serialize(_entries, new JsonSerializerOptions { WriteIndented = false });
+            var json = JsonSerializer.Serialize(snapshot, new JsonSerializerOptions { WriteIndented = false });
             File.WriteAllText(FilePath, json);
         }
         catch (IOException ex)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.18</Version>
-    <FileVersion>1.20.18.0</FileVersion>
-    <AssemblyVersion>1.20.18.0</AssemblyVersion>
+    <Version>1.20.19</Version>
+    <FileVersion>1.20.19.0</FileVersion>
+    <AssemblyVersion>1.20.19.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -514,13 +514,24 @@ public sealed partial class AboutViewModel : ViewModelBase
             return;
         }
 
+        // The updater script is written next to the downloaded binary. Resolve that
+        // directory up front: Path.GetDirectoryName returns null for a rooted/invalid
+        // path, which would otherwise NRE inside Path.Join below.
+        var downloadDir = string.IsNullOrWhiteSpace(DownloadedPath)
+            ? null : Path.GetDirectoryName(DownloadedPath);
+        if (string.IsNullOrEmpty(downloadDir))
+        {
+            DownloadStatus = "Cannot determine the downloaded update's location.";
+            return;
+        }
+
         // Step 3: Write an updater script that waits for this process to exit,
         // copies the new exe over the old one, then launches the new version.
         try
         {
             var pid = Environment.ProcessId;
             var scriptPath = Path.Join(
-                Path.GetDirectoryName(DownloadedPath)!,
+                downloadDir,
                 $"update-{Guid.NewGuid():N}.cmd");
 
             var script = $"""


### PR DESCRIPTION
## Summary

Two robustness fixes: a thread-safety race in the activity log and a null-path guard in
the in-app updater.

## Fixes

- **`ActivityLogService`** — `Log()` mutated `_entries` under `_lock` but then called
  `Save()`, which serialized `_entries` **outside** the lock. Two concurrent `Log()`
  calls could have one serializing the list while the other was inserting/trimming it →
  `InvalidOperationException` ("collection was modified") or torn JSON. `Log()` now takes
  a snapshot under the lock (`[.. _entries]`) and `Save(snapshot)` writes that.
- **`AboutViewModel`** update install — `Path.GetDirectoryName(DownloadedPath)!` used the
  null-forgiving operator; a rooted/invalid `DownloadedPath` returns null and would NRE
  inside `Path.Join`. Now resolved and validated up front with a clear status message and
  early return (same pattern as the existing `currentExe` check).

## Verification

- Build: main + Tests + IntegrationTests all **0 warnings / 0 errors**.

Note on tests: `ActivityLogService` is a private-ctor singleton that writes to a real
file under `%LocalAppData%`; a concurrency test would touch the filesystem and be
timing-dependent (the project has had flaky-test issues with exactly that shape). The
snapshot-under-lock fix is correct by inspection, so no flaky test was added.

`fix:` → patch release (1.20.19). Protocol C to follow.
