### PR TITLE
fix: add accessible names to interactive controls across 21 views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.20.19] - 2026-06-12
+## [1.20.20] - 2026-06-12
+
+### Fixed
+- **Much better screen-reader support across the app.** Many buttons, toggles, drop-downs, search/filter boxes, data grids, and per-row actions had no accessible name, so screen readers announced them generically (or not at all). Added clear, specific accessible names to interactive controls across 21 tabs — including destructive actions (Delete, Shred, Clear History), per-row buttons (now named after the item they act on), and unlabeled inputs. No visual change.
 
 ### Fixed
 - **Activity history can no longer be corrupted by concurrent updates.** The recent-actions log saved its data outside the lock that protects it, so two actions logged at the same time could clash and produce a "collection modified" error or a truncated file. It now writes a consistent snapshot taken under the lock.

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.19</Version>
-    <FileVersion>1.20.19.0</FileVersion>
-    <AssemblyVersion>1.20.19.0</AssemblyVersion>
+    <Version>1.20.20</Version>
+    <FileVersion>1.20.20.0</FileVersion>
+    <AssemblyVersion>1.20.20.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AppAlertsView.xaml
+++ b/SysManager/SysManager/Views/AppAlertsView.xaml
@@ -28,14 +28,19 @@
             <DockPanel>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
                     <Button Content="Start Monitoring" Command="{Binding StartMonitoringCommand}"
+                            AutomationProperties.Name="Start monitoring app installations"
                             Style="{StaticResource PrimaryButton}" Padding="14,8" Margin="0,0,8,0"/>
                     <Button Content="Stop" Command="{Binding StopMonitoringCommand}"
+                            AutomationProperties.Name="Stop monitoring"
                             Style="{StaticResource SecondaryButton}" Padding="12,8" Margin="0,0,8,0"/>
                     <Button Content="Show Installed" Command="{Binding RefreshInstalledAppsCommand}"
+                            AutomationProperties.Name="Show installed apps"
                             Style="{StaticResource SecondaryButton}" Padding="12,8" Margin="0,0,8,0"/>
                     <Button Content="Acknowledge All" Command="{Binding AcknowledgeAllCommand}"
+                            AutomationProperties.Name="Acknowledge all alerts"
                             Style="{StaticResource SecondaryButton}" Padding="12,8" Margin="0,0,8,0"/>
                     <Button Content="Clear History" Command="{Binding ClearHistoryCommand}"
+                            AutomationProperties.Name="Clear alert history"
                             Style="{StaticResource DangerButton}" Padding="12,8"/>
                 </StackPanel>
                 <TextBlock DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right"

--- a/SysManager/SysManager/Views/AppBlockerView.xaml
+++ b/SysManager/SysManager/Views/AppBlockerView.xaml
@@ -86,7 +86,8 @@
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling">
             <DataGrid.Columns>
-                <DataGridCheckBoxColumn Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" Width="40" MinWidth="40" CanUserResize="False" />
+                <DataGridCheckBoxColumn Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" Width="40" MinWidth="40" CanUserResize="False"
+                                        AutomationProperties.Name="Select application" />
                 <DataGridTextColumn Header="Executable" Binding="{Binding ExecutableName}" Width="*" MinWidth="120" IsReadOnly="True" />
             </DataGrid.Columns>
         </DataGrid>

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml
@@ -26,6 +26,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        AutomationProperties.Name="Relaunch as administrator"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
@@ -53,10 +54,10 @@
 
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,0">
             <StackPanel Orientation="Horizontal">
-                <Button Content="Scan for updates" Command="{Binding ScanCommand}" Style="{StaticResource PrimaryButton}"/>
-                <Button Content="Upgrade selected" Command="{Binding UpgradeSelectedCommand}" Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"/>
-                <Button Content="Cancel" Command="{Binding CancelCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>
-                <CheckBox Content="Select all" IsChecked="{Binding SelectAll}" Margin="16,0,0,0" VerticalAlignment="Center"/>
+                <Button Content="Scan for updates" Command="{Binding ScanCommand}" AutomationProperties.Name="Scan for updates" Style="{StaticResource PrimaryButton}"/>
+                <Button Content="Upgrade selected" Command="{Binding UpgradeSelectedCommand}" AutomationProperties.Name="Upgrade selected packages" Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"/>
+                <Button Content="Cancel" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel update operation" Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>
+                <CheckBox Content="Select all" IsChecked="{Binding SelectAll}" AutomationProperties.Name="Select all packages" Margin="16,0,0,0" VerticalAlignment="Center"/>
             </StackPanel>
         </Border>
 
@@ -75,12 +76,14 @@
                             <Style TargetType="CheckBox">
                                 <Setter Property="HorizontalAlignment" Value="Center"/>
                                 <Setter Property="Margin" Value="4,0"/>
+                                <Setter Property="AutomationProperties.Name" Value="{Binding Name, StringFormat='Select {0}'}"/>
                             </Style>
                         </DataGridCheckBoxColumn.ElementStyle>
                         <DataGridCheckBoxColumn.EditingElementStyle>
                             <Style TargetType="CheckBox">
                                 <Setter Property="HorizontalAlignment" Value="Center"/>
                                 <Setter Property="Margin" Value="4,0"/>
+                                <Setter Property="AutomationProperties.Name" Value="{Binding Name, StringFormat='Select {0}'}"/>
                             </Style>
                         </DataGridCheckBoxColumn.EditingElementStyle>
                     </DataGridCheckBoxColumn>

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -146,6 +146,7 @@
                                             Command="{Binding DataContext.AddToInstallListCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                             CommandParameter="{Binding}"
                                             Style="{StaticResource GhostButton}"
+                                            AutomationProperties.Name="{Binding Name, StringFormat='Add {0} to install list'}"
                                             Padding="10,4" FontSize="11"/>
                                 </Grid>
                             </Border>
@@ -204,6 +205,7 @@
                                     <!-- Checkbox -->
                                     <CheckBox Grid.Column="0" VerticalAlignment="Center"
                                               IsChecked="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}"
+                                              AutomationProperties.Name="{Binding Name, StringFormat='Select {0}'}"
                                               Margin="0,0,12,0"/>
 
                                     <!-- App icon (real favicon or category glyph fallback) -->

--- a/SysManager/SysManager/Views/ContextMenuView.xaml
+++ b/SysManager/SysManager/Views/ContextMenuView.xaml
@@ -32,6 +32,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        AutomationProperties.Name="Run as administrator"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
@@ -65,6 +66,7 @@
                 <StackPanel Orientation="Horizontal">
                     <!-- Win10 button with hover preview -->
                     <Button Content="Win10 Default" Margin="0,0,8,0"
+                            AutomationProperties.Name="Apply Win10 Default menu style"
                             Command="{Binding ApplyPresetCommand}" CommandParameter="win10"
                             Style="{StaticResource SecondaryButton}" Padding="12,8" FontSize="12">
                         <Button.ToolTip>
@@ -90,6 +92,7 @@
                     </Button>
                     <!-- Win11 button with hover preview -->
                     <Button Content="Win11 Default" Margin="0,0,8,0"
+                            AutomationProperties.Name="Apply Win11 Default menu style"
                             Command="{Binding ApplyPresetCommand}" CommandParameter="win11"
                             Style="{StaticResource SecondaryButton}" Padding="12,8" FontSize="12">
                         <Button.ToolTip>
@@ -119,6 +122,7 @@
                     </Button>
                     <!-- Custom indicator -->
                     <Button Content="Custom" Margin="0,0,8,0"
+                            AutomationProperties.Name="Apply Custom menu style"
                             Command="{Binding ApplyPresetCommand}" CommandParameter="custom"
                             Style="{StaticResource SecondaryButton}" Padding="12,8" FontSize="12"
                             ToolTip="Active menu style + your manual entry toggles from the list below. Toggle any entry to switch to Custom mode."/>
@@ -137,9 +141,11 @@
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
                     <ComboBox ItemsSource="{Binding LocationFilters}"
                               SelectedItem="{Binding SelectedLocation}"
+                              AutomationProperties.Name="Filter by location"
                               Width="160" Margin="0,0,8,0"
                               VerticalAlignment="Center"/>
                     <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
+                             AutomationProperties.Name="Search entries"
                              Width="200" Margin="0,0,8,0"
                              VerticalAlignment="Center">
                         <TextBox.Style>
@@ -153,9 +159,11 @@
                         </TextBox.Style>
                     </TextBox>
                     <Button Content="Refresh" Command="{Binding RefreshCommand}"
+                            AutomationProperties.Name="Refresh entries"
                             Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
                     <CheckBox Content="Show system entries"
                               IsChecked="{Binding ShowSystemEntries}"
+                              AutomationProperties.Name="Show system entries"
                               VerticalAlignment="Center" Margin="8,0,0,0"/>
                 </StackPanel>
                 <TextBlock DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right"
@@ -187,6 +195,7 @@
                                               IsChecked="{Binding IsEnabled, UpdateSourceTrigger=PropertyChanged}"
                                               Command="{Binding DataContext.ToggleEntryCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                               CommandParameter="{Binding}"
+                                              AutomationProperties.Name="{Binding Name, StringFormat='Toggle {0}'}"
                                               VerticalAlignment="Center" HorizontalAlignment="Center"/>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>

--- a/SysManager/SysManager/Views/DeepCleanupView.xaml
+++ b/SysManager/SysManager/Views/DeepCleanupView.xaml
@@ -71,7 +71,7 @@
                                                 <ColumnDefinition Width="*"/>
                                                 <ColumnDefinition Width="Auto"/>
                                             </Grid.ColumnDefinitions>
-                                            <CheckBox Grid.Column="0" IsChecked="{Binding IsSelected, Mode=TwoWay}" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                                            <CheckBox Grid.Column="0" AutomationProperties.Name="{Binding Name, StringFormat='Select {0} for cleanup'}" IsChecked="{Binding IsSelected, Mode=TwoWay}" VerticalAlignment="Center" Margin="0,0,12,0"/>
                                             <StackPanel Grid.Column="1">
                                                 <StackPanel Orientation="Horizontal">
                                                     <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource TextPrimary}"/>
@@ -109,7 +109,7 @@
                                     <Button Content="Clean selected" Command="{Binding CleanCommand}"
                                             Style="{StaticResource PrimaryButton}"
                                             IsEnabled="{Binding IsCleaning, Converter={StaticResource BoolInvert}}"/>
-                                    <Button Content="Cancel" Command="{Binding CancelCommand}" Style="{StaticResource GhostButton}" Margin="8,0,0,0"/>
+                                    <Button Content="Cancel" AutomationProperties.Name="Cancel cleanup" Command="{Binding CancelCommand}" Style="{StaticResource GhostButton}" Margin="8,0,0,0"/>
                                 </StackPanel>
                             </Grid>
                         </Border>
@@ -154,12 +154,12 @@
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
                             <TextBlock Grid.Column="0" Text="Location:" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                            <ComboBox Grid.Column="1" ItemsSource="{Binding ScanLocations}" SelectedItem="{Binding SelectedLocation, Mode=TwoWay}"
+                            <ComboBox Grid.Column="1" AutomationProperties.Name="Scan location" ItemsSource="{Binding ScanLocations}" SelectedItem="{Binding SelectedLocation, Mode=TwoWay}"
                                       DisplayMemberPath="Label" MaxWidth="380" HorizontalAlignment="Left"/>
                             <TextBlock Grid.Column="2" Text="Min size (MB):" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center" Margin="16,0,8,0"/>
-                            <TextBox Grid.Column="3" Text="{Binding MinSizeMB, Mode=TwoWay}" Width="80"/>
+                            <TextBox Grid.Column="3" AutomationProperties.Name="Minimum file size in megabytes" Text="{Binding MinSizeMB, Mode=TwoWay}" Width="80"/>
                             <TextBlock Grid.Column="4" Text="Top:" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center" Margin="16,0,8,0"/>
-                            <TextBox Grid.Column="5" Text="{Binding TopCount, Mode=TwoWay}" Width="60"/>
+                            <TextBox Grid.Column="5" AutomationProperties.Name="Number of top results to show" Text="{Binding TopCount, Mode=TwoWay}" Width="60"/>
                         </Grid>
 
                         <TextBlock Text="{Binding LargeScanStatus}" Style="{StaticResource Subtle}" Margin="0,0,0,8"
@@ -178,7 +178,7 @@
                                 <TextBlock Grid.Column="0" Text="{Binding LargeFilesScanned, StringFormat={}{0:N0} files}" Foreground="{DynamicResource TextPrimary}" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                 <TextBlock Grid.Column="1" Text="  ·  " Foreground="{DynamicResource TextMuted}" VerticalAlignment="Center"/>
                                 <TextBlock Grid.Column="2" Text="{Binding LargeBytesScannedDisplay, StringFormat=scanned {0}}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
-                                <Button Grid.Column="3" Content="Cancel" Command="{Binding CancelCommand}" Style="{StaticResource GhostButton}" Padding="10,4"/>
+                                <Button Grid.Column="3" Content="Cancel" AutomationProperties.Name="Cancel large file scan" Command="{Binding CancelCommand}" Style="{StaticResource GhostButton}" Padding="10,4"/>
                             </Grid>
                             <TextBlock Text="{Binding LargeCurrentFolder}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="0,4,0,0" TextTrimming="CharacterEllipsis"/>
                         </StackPanel>
@@ -201,10 +201,12 @@
                                         <DataTemplate>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Content="Show" Padding="10,4"
+                                                        AutomationProperties.Name="{Binding Name, StringFormat='Show {0} in Explorer'}"
                                                         Command="{Binding DataContext.ShowInExplorerCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                         CommandParameter="{Binding Path}"
                                                         Style="{StaticResource SecondaryButton}"/>
                                                 <Button Content="Copy" Padding="10,4" Margin="6,0,0,0"
+                                                        AutomationProperties.Name="{Binding Name, StringFormat='Copy path of {0}'}"
                                                         Command="{Binding DataContext.CopyPathCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                         CommandParameter="{Binding Path}"
                                                         Style="{StaticResource GhostButton}"/>

--- a/SysManager/SysManager/Views/DiskAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/DiskAnalyzerView.xaml
@@ -30,16 +30,17 @@
             <WrapPanel>
                 <TextBlock Text="Path:" VerticalAlignment="Center" Margin="0,0,8,0"
                            Style="{StaticResource Subtle}"/>
-                <ComboBox ItemsSource="{Binding PresetPaths}"
+                <ComboBox AutomationProperties.Name="Folder path to analyze"
+                          ItemsSource="{Binding PresetPaths}"
                           SelectedItem="{Binding SelectedPath}"
                           Width="300" Margin="0,0,8,0" IsEditable="True"/>
-                <Button Content="Browse" Command="{Binding BrowseFolderCommand}"
+                <Button Content="Browse" AutomationProperties.Name="Browse for folder" Command="{Binding BrowseFolderCommand}"
                         Style="{StaticResource GhostButton}" Margin="0,0,8,0"/>
-                <Button Content="Up" Command="{Binding GoUpCommand}"
+                <Button Content="Up" AutomationProperties.Name="Go up one folder" Command="{Binding GoUpCommand}"
                         Style="{StaticResource GhostButton}" Margin="0,0,12,0"/>
-                <Button Content="Analyze" Command="{Binding AnalyzeCommand}"
+                <Button Content="Analyze" AutomationProperties.Name="Analyze folder" Command="{Binding AnalyzeCommand}"
                         Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
-                <Button Content="Cancel" Command="{Binding CancelAnalysisCommand}"
+                <Button Content="Cancel" AutomationProperties.Name="Cancel analysis" Command="{Binding CancelAnalysisCommand}"
                         Style="{StaticResource GhostButton}"
                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             </WrapPanel>
@@ -68,7 +69,7 @@
 
         <!-- Folder list -->
         <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
-            <ListView ItemsSource="{Binding Entries}" Background="Transparent" BorderThickness="0"
+            <ListView AutomationProperties.Name="Folder size list" ItemsSource="{Binding Entries}" Background="Transparent" BorderThickness="0"
                       ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                       HorizontalContentAlignment="Stretch">
                 <ListView.ItemContainerStyle>
@@ -106,6 +107,7 @@
 
                             <!-- Drill-down button -->
                             <Button Grid.Column="0" Content="→" ToolTip="Drill into folder"
+                                    AutomationProperties.Name="{Binding Name, StringFormat='Drill into {0}'}"
                                     Command="{Binding DataContext.DrillDownCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
                                     CommandParameter="{Binding}"
                                     Style="{StaticResource GhostButton}" Padding="4,2" FontSize="12"
@@ -134,6 +136,7 @@
 
                             <!-- Open in Explorer -->
                             <Button Grid.Column="4" Content="📂" ToolTip="Show in Explorer"
+                                    AutomationProperties.Name="{Binding Name, StringFormat='Show {0} in Explorer'}"
                                     Command="{Binding DataContext.ShowInExplorerCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
                                     CommandParameter="{Binding}"
                                     Style="{StaticResource GhostButton}" Padding="4,2" FontSize="12"

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -23,7 +23,8 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
+                        AutomationProperties.Name="Run as administrator"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
@@ -64,11 +65,13 @@
                     <Button Content="Reset to DHCP" Command="{Binding ResetDnsCommand}"
                             Style="{StaticResource SecondaryButton}" DockPanel.Dock="Right"
                             Padding="14,8" Margin="8,0,0,0"
-                            IsEnabled="{Binding IsDnsApplying, Converter={StaticResource BoolInvert}}"/>
+                            IsEnabled="{Binding IsDnsApplying, Converter={StaticResource BoolInvert}}"
+                            AutomationProperties.Name="Reset DNS to DHCP (automatic)"/>
                     <Button Content="Apply" Command="{Binding ApplyDnsCommand}"
                             Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right"
                             Padding="18,8" Margin="8,0,0,0"
-                            IsEnabled="{Binding IsDnsApplying, Converter={StaticResource BoolInvert}}"/>
+                            IsEnabled="{Binding IsDnsApplying, Converter={StaticResource BoolInvert}}"
+                            AutomationProperties.Name="Apply selected DNS servers"/>
                     <Button Content="Undo" Command="{Binding RestorePreviousDnsCommand}"
                             Style="{StaticResource SecondaryButton}" DockPanel.Dock="Right"
                             Padding="14,8" Margin="8,0,0,0"
@@ -78,7 +81,8 @@
                     <ComboBox ItemsSource="{Binding Presets}"
                               SelectedItem="{Binding SelectedPreset}"
                               DisplayMemberPath="Name"
-                              MinWidth="200" VerticalAlignment="Center"/>
+                              MinWidth="200" VerticalAlignment="Center"
+                              AutomationProperties.Name="DNS server preset"/>
                 </DockPanel>
 
                 <TextBlock Text="{Binding SelectedPreset.Description}" Style="{StaticResource Subtle}"
@@ -105,12 +109,14 @@
                                VerticalAlignment="Center"/>
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Right">
                         <Button Content="Refresh" Command="{Binding RefreshHostsCommand}"
-                                Style="{StaticResource SecondaryButton}" Padding="12,6" Margin="0,0,8,0"/>
+                                Style="{StaticResource SecondaryButton}" Padding="12,6" Margin="0,0,8,0"
+                                AutomationProperties.Name="Refresh hosts file entries"/>
                         <Button Content="Restore original" Command="{Binding RestoreHostsCommand}"
                                 Style="{StaticResource SecondaryButton}" Padding="12,6" Margin="0,0,8,0"
                                 AutomationProperties.Name="Restore original hosts file from backup"/>
                         <Button Content="Save" Command="{Binding SaveHostsCommand}"
-                                Style="{StaticResource PrimaryButton}" Padding="18,6"/>
+                                Style="{StaticResource PrimaryButton}" Padding="18,6"
+                                AutomationProperties.Name="Save hosts file"/>
                     </StackPanel>
                 </DockPanel>
 
@@ -137,7 +143,8 @@
                                     <Button Content="X" Command="{Binding DataContext.RemoveEntryCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
                                             CommandParameter="{Binding}"
                                             Style="{StaticResource SecondaryButton}"
-                                            Padding="6,2" FontSize="10" VerticalAlignment="Center"/>
+                                            Padding="6,2" FontSize="10" VerticalAlignment="Center"
+                                            AutomationProperties.Name="{Binding Hostname, StringFormat='Remove host entry {0}'}"/>
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>
                         </DataGridTemplateColumn>
@@ -148,14 +155,17 @@
                 <DockPanel Grid.Row="2" Margin="0,12,0,0">
                     <Button Content="Add" Command="{Binding AddEntryCommand}"
                             Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right"
-                            Padding="18,8" Margin="8,0,0,0"/>
+                            Padding="18,8" Margin="8,0,0,0"
+                            AutomationProperties.Name="Add host entry"/>
                     <TextBox Text="{Binding NewHostname, UpdateSourceTrigger=PropertyChanged}"
                              DockPanel.Dock="Right" MinWidth="200" Margin="8,0,0,0"
-                             VerticalAlignment="Center"/>
+                             VerticalAlignment="Center"
+                             AutomationProperties.Name="New host entry hostname"/>
                     <TextBlock Text="Hostname:" DockPanel.Dock="Right" VerticalAlignment="Center"
                                Style="{StaticResource Subtle}" Margin="12,0,4,0"/>
                     <TextBox Text="{Binding NewIp, UpdateSourceTrigger=PropertyChanged}"
-                             MinWidth="140" VerticalAlignment="Center"/>
+                             MinWidth="140" VerticalAlignment="Center"
+                             AutomationProperties.Name="New host entry IP address"/>
                     <TextBlock Text="IP:" VerticalAlignment="Center"
                                Style="{StaticResource Subtle}" Margin="0,0,4,0"
                                Visibility="Collapsed"/>

--- a/SysManager/SysManager/Views/DuplicateFileView.xaml
+++ b/SysManager/SysManager/Views/DuplicateFileView.xaml
@@ -30,19 +30,24 @@
             <WrapPanel>
                 <TextBlock Text="Folder:" VerticalAlignment="Center" Margin="0,0,8,0"
                            Style="{StaticResource Subtle}"/>
-                <ComboBox ItemsSource="{Binding PresetFolders}"
+                <ComboBox AutomationProperties.Name="Folder to scan"
+                          ItemsSource="{Binding PresetFolders}"
                           SelectedItem="{Binding SelectedFolder}"
                           Width="320" Margin="0,0,8,0"
                           IsEditable="True"/>
-                <Button Content="Browse" Command="{Binding BrowseFolderCommand}"
+                <Button Content="Browse" AutomationProperties.Name="Browse for folder"
+                        Command="{Binding BrowseFolderCommand}"
                         Style="{StaticResource GhostButton}" Margin="0,0,12,0"/>
                 <TextBlock Text="Min size (KB):" VerticalAlignment="Center" Margin="0,0,8,0"
                            Style="{StaticResource Subtle}"/>
-                <TextBox Text="{Binding MinSizeKb, UpdateSourceTrigger=PropertyChanged}"
+                <TextBox AutomationProperties.Name="Minimum file size in kilobytes"
+                         Text="{Binding MinSizeKb, UpdateSourceTrigger=PropertyChanged}"
                          Width="70" Margin="0,0,12,0"/>
-                <Button Content="Scan" Command="{Binding ScanCommand}"
+                <Button Content="Scan" AutomationProperties.Name="Scan for duplicates"
+                        Command="{Binding ScanCommand}"
                         Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
-                <Button Content="Cancel" Command="{Binding CancelScanCommand}"
+                <Button Content="Cancel" AutomationProperties.Name="Cancel scan"
+                        Command="{Binding CancelScanCommand}"
                         Style="{StaticResource GhostButton}"
                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             </WrapPanel>
@@ -55,7 +60,8 @@
 
         <!-- Results: grouped list (virtualized for performance) -->
         <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
-            <ListView ItemsSource="{Binding Groups}"
+            <ListView AutomationProperties.Name="Duplicate file groups"
+                      ItemsSource="{Binding Groups}"
                       Background="Transparent" BorderThickness="0"
                       ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                       VirtualizingPanel.IsVirtualizing="True"
@@ -99,11 +105,13 @@
                                             <DockPanel Margin="16,3,0,3">
                                                 <StackPanel DockPanel.Dock="Left" Orientation="Horizontal">
                                                     <Button Content="Open" ToolTip="Show in Explorer"
+                                                            AutomationProperties.Name="{Binding Name, Mode=OneWay, StringFormat='Show {0} in Explorer'}"
                                                             Command="{Binding DataContext.ShowInExplorerCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                             CommandParameter="{Binding}"
                                                             Style="{StaticResource GhostButton}" Padding="4,2" FontSize="12"
                                                             Margin="0,0,4,0"/>
                                                     <Button Content="Copy" ToolTip="Copy path"
+                                                            AutomationProperties.Name="{Binding Name, Mode=OneWay, StringFormat='Copy path of {0}'}"
                                                             Command="{Binding DataContext.CopyPathCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                             CommandParameter="{Binding}"
                                                             Style="{StaticResource GhostButton}" Padding="4,2" FontSize="12"

--- a/SysManager/SysManager/Views/FileShredderView.xaml
+++ b/SysManager/SysManager/Views/FileShredderView.xaml
@@ -48,6 +48,7 @@
                            Foreground="{DynamicResource TextSecondary}"/>
                 <ComboBox ItemsSource="{Binding Source={StaticResource ShredMethods}}"
                           SelectedItem="{Binding SelectedMethod}"
+                          AutomationProperties.Name="Shred method"
                           Width="120" Margin="0,0,16,0" VerticalAlignment="Center"/>
                 <Button Content="Add Files" Command="{Binding AddFilesCommand}"
                         Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"/>
@@ -63,6 +64,7 @@
 
         <!-- Items DataGrid -->
         <DataGrid Grid.Row="2" ItemsSource="{Binding Items}"
+                  AutomationProperties.Name="Files queued for shredding"
                   AutoGenerateColumns="False" IsReadOnly="True"
                   CanUserAddRows="False" CanUserDeleteRows="False"
                   CanUserSortColumns="True"

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -34,9 +34,9 @@
                            Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
             </StackPanel>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Right" VerticalAlignment="Center">
-                <Button Content="Open Event Viewer" Command="{Binding OpenEventViewerCommand}" Style="{StaticResource GhostButton}"/>
-                <Button Content="Open log folder" Command="{Binding OpenLogFolderCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>
-                <Button Content="Export CSV" Command="{Binding ExportCsvCommand}" Style="{StaticResource SecondaryButton}" Margin="6,0,0,0"/>
+                <Button Content="Open Event Viewer" AutomationProperties.Name="Open Event Viewer" Command="{Binding OpenEventViewerCommand}" Style="{StaticResource GhostButton}"/>
+                <Button Content="Open log folder" AutomationProperties.Name="Open log folder" Command="{Binding OpenLogFolderCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>
+                <Button Content="Export CSV" AutomationProperties.Name="Export logs to CSV" Command="{Binding ExportCsvCommand}" Style="{StaticResource SecondaryButton}" Margin="6,0,0,0"/>
             </StackPanel>
         </DockPanel>
 
@@ -131,7 +131,7 @@
             <StackPanel>
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Text="Log" Style="{StaticResource Subtle}" VerticalAlignment="Center"/>
-                    <ComboBox ItemsSource="{Binding AvailableLogs}" SelectedItem="{Binding SelectedLog}" Width="130" Margin="8,0,18,0"/>
+                    <ComboBox ItemsSource="{Binding AvailableLogs}" SelectedItem="{Binding SelectedLog}" AutomationProperties.Name="Log source" Width="130" Margin="8,0,18,0"/>
 
                     <TextBlock Text="Time" Style="{StaticResource Subtle}" VerticalAlignment="Center"/>
                     <StackPanel Orientation="Horizontal" Margin="8,0,18,0">
@@ -158,10 +158,10 @@
                     </StackPanel>
 
                     <TextBlock Text="Max results" Style="{StaticResource Subtle}" VerticalAlignment="Center"/>
-                    <ComboBox ItemsSource="{Binding MaxResultOptions}" SelectedItem="{Binding SelectedMaxResults}" Width="88" Margin="8,0,18,0"/>
+                    <ComboBox ItemsSource="{Binding MaxResultOptions}" SelectedItem="{Binding SelectedMaxResults}" AutomationProperties.Name="Maximum results" Width="88" Margin="8,0,18,0"/>
 
-                    <Button Content="Refresh" Command="{Binding RefreshCommand}" Style="{StaticResource PrimaryButton}"/>
-                    <Button Content="Cancel" Command="{Binding CancelCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>
+                    <Button Content="Refresh" AutomationProperties.Name="Refresh logs" Command="{Binding RefreshCommand}" Style="{StaticResource PrimaryButton}"/>
+                    <Button Content="Cancel" AutomationProperties.Name="Cancel log loading" Command="{Binding CancelCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
@@ -169,27 +169,27 @@
 
                     <!-- Each toggle has its own colored dot next to the label -->
                     <StackPanel Orientation="Horizontal" Margin="0,0,14,0">
-                        <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding ShowCritical}" VerticalAlignment="Center"/>
+                        <ToggleButton Style="{StaticResource ToggleSwitch}" AutomationProperties.Name="Show Critical events" IsChecked="{Binding ShowCritical}" VerticalAlignment="Center"/>
                         <Ellipse Style="{StaticResource SevDot}" Fill="#FF3B30" Margin="8,0,6,0"/>
                         <TextBlock Text="Critical" Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,14,0">
-                        <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding ShowError}" VerticalAlignment="Center"/>
+                        <ToggleButton Style="{StaticResource ToggleSwitch}" AutomationProperties.Name="Show Error events" IsChecked="{Binding ShowError}" VerticalAlignment="Center"/>
                         <Ellipse Style="{StaticResource SevDot}" Fill="#F87171" Margin="8,0,6,0"/>
                         <TextBlock Text="Error" Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,14,0">
-                        <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding ShowWarning}" VerticalAlignment="Center"/>
+                        <ToggleButton Style="{StaticResource ToggleSwitch}" AutomationProperties.Name="Show Warning events" IsChecked="{Binding ShowWarning}" VerticalAlignment="Center"/>
                         <Ellipse Style="{StaticResource SevDot}" Fill="{DynamicResource WarningStripe}" Margin="8,0,6,0"/>
                         <TextBlock Text="Warning" Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,14,0">
-                        <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding ShowInfo}" VerticalAlignment="Center"/>
+                        <ToggleButton Style="{StaticResource ToggleSwitch}" AutomationProperties.Name="Show Info events" IsChecked="{Binding ShowInfo}" VerticalAlignment="Center"/>
                         <Ellipse Style="{StaticResource SevDot}" Fill="{DynamicResource Info}" Margin="8,0,6,0"/>
                         <TextBlock Text="Info" Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,22,0">
-                        <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding ShowVerbose}" VerticalAlignment="Center"/>
+                        <ToggleButton Style="{StaticResource ToggleSwitch}" AutomationProperties.Name="Show Verbose events" IsChecked="{Binding ShowVerbose}" VerticalAlignment="Center"/>
                         <Ellipse Style="{StaticResource SevDot}" Fill="#9AA0A6" Margin="8,0,6,0"/>
                         <TextBlock Text="Verbose" Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
                     </StackPanel>
@@ -197,6 +197,7 @@
                     <TextBlock Text="Search" Style="{StaticResource Subtle}" VerticalAlignment="Center" Margin="0,0,8,0"/>
                     <Grid Width="280">
                         <TextBox x:Name="SearchBox" Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
+                                 AutomationProperties.Name="Search logs by message, source, or event ID"
                                  ToolTip="Filters by message, provider, or event ID"/>
                         <TextBlock Text="Filter by message, source, or event ID…"
                                    Foreground="{DynamicResource TextMuted}" FontSize="12"
@@ -357,14 +358,15 @@
                             </Border>
 
                             <StackPanel Orientation="Horizontal" Margin="0,14,0,0">
-                                <Button Content="Copy details" Command="{Binding CopySelectedCommand}" Style="{StaticResource SecondaryButton}"/>
-                                <Button Content="Search online" Command="{Binding SearchOnlineCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>
+                                <Button Content="Copy details" AutomationProperties.Name="Copy event details" Command="{Binding CopySelectedCommand}" Style="{StaticResource SecondaryButton}"/>
+                                <Button Content="Search online" AutomationProperties.Name="Search this event online" Command="{Binding SearchOnlineCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>
                             </StackPanel>
 
                             <Expander Header="Full system message" Margin="0,16,0,0" Foreground="{DynamicResource TextSecondary}">
                                 <Border Padding="10" CornerRadius="8" Background="{DynamicResource Surface0}"
                                         BorderBrush="{DynamicResource Border1}" BorderThickness="1">
                                     <TextBox Text="{Binding SelectedEntry.FullMessage, Mode=OneWay}"
+                                             AutomationProperties.Name="Full system message"
                                              IsReadOnly="True" TextWrapping="Wrap"
                                              Background="Transparent" BorderThickness="0"
                                              FontFamily="{StaticResource MonoFont}" FontSize="11"
@@ -378,6 +380,7 @@
                                 <Border Padding="10" CornerRadius="8" Background="{DynamicResource Surface0}"
                                         BorderBrush="{DynamicResource Border1}" BorderThickness="1">
                                     <TextBox Text="{Binding SelectedEntry.Xml, Mode=OneWay}"
+                                             AutomationProperties.Name="Raw event XML"
                                              IsReadOnly="True" TextWrapping="NoWrap"
                                              Background="Transparent" BorderThickness="0"
                                              FontFamily="{StaticResource MonoFont}" FontSize="11"

--- a/SysManager/SysManager/Views/PerformanceView.xaml
+++ b/SysManager/SysManager/Views/PerformanceView.xaml
@@ -32,6 +32,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        AutomationProperties.Name="Run as administrator"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
@@ -61,8 +62,10 @@
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
             <WrapPanel>
                 <Button Content="Refresh" Command="{Binding RefreshCommand}"
+                        AutomationProperties.Name="Refresh performance settings"
                         Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
                 <Button Content="Restore All" Command="{Binding RestoreAllCommand}"
+                        AutomationProperties.Name="Restore all settings to original state"
                         Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"
                         IsEnabled="{Binding HasSnapshot}"/>
             </WrapPanel>
@@ -92,17 +95,21 @@
                         <StackPanel>
                             <RadioButton x:Name="RbBalanced"
                                          Content="Balanced (default — recommended for laptops)"
+                                         AutomationProperties.Name="Balanced power plan"
                                          GroupName="PowerPlan" Margin="0,0,0,8"
                                          IsChecked="{Binding SelectedPlan, Converter={StaticResource IsEqual}, ConverterParameter=balanced}"/>
                             <RadioButton x:Name="RbHigh"
                                          Content="High Performance"
+                                         AutomationProperties.Name="High Performance power plan"
                                          GroupName="PowerPlan" Margin="0,0,0,8"
                                          IsChecked="{Binding SelectedPlan, Converter={StaticResource IsEqual}, ConverterParameter=high}"/>
                             <RadioButton x:Name="RbUltimate"
                                          Content="Ultimate Performance (max clocks, no throttling)"
+                                         AutomationProperties.Name="Ultimate Performance power plan"
                                          GroupName="PowerPlan" Margin="0,0,0,12"
                                          IsChecked="{Binding SelectedPlan, Converter={StaticResource IsEqual}, ConverterParameter=ultimate}"/>
                             <Button Content="Apply Power Plan" Command="{Binding ApplyPowerPlanCommand}"
+                                    AutomationProperties.Name="Apply power plan"
                                     Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"/>
                         </StackPanel>
                     </Border>
@@ -112,12 +119,13 @@
                     <Border Style="{StaticResource Card}" Padding="16" Margin="0,0,0,16">
                         <StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-                                <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding WantVisualEffectsReduced}" VerticalAlignment="Center"/>
+                                <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding WantVisualEffectsReduced}" AutomationProperties.Name="Reduce visual effects" VerticalAlignment="Center"/>
                                 <TextBlock Text="Reduce visual effects (disable animations, fades, shadows)" VerticalAlignment="Center" Margin="8,0,0,0"/>
                             </StackPanel>
                             <TextBlock Text="Uses SystemParametersInfo — takes effect instantly, no logout needed."
                                        Style="{StaticResource Subtle}" FontSize="11" Margin="20,0,0,8"/>
                             <Button Content="Apply Visual Effects" Command="{Binding ApplyVisualEffectsCommand}"
+                                    AutomationProperties.Name="Apply visual effects"
                                     Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"/>
                         </StackPanel>
                     </Border>
@@ -127,10 +135,11 @@
                     <Border Style="{StaticResource Card}" Padding="16" Margin="0,0,0,16">
                         <StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                                <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding WantGameModeOff}" VerticalAlignment="Center"/>
+                                <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding WantGameModeOff}" AutomationProperties.Name="Disable Game Mode" VerticalAlignment="Center"/>
                                 <TextBlock Text="Disable Game Mode (stop Windows from prioritizing game processes)" VerticalAlignment="Center" Margin="8,0,0,0"/>
                             </StackPanel>
                             <Button Content="Apply Game Mode" Command="{Binding ApplyGameModeCommand}"
+                                    AutomationProperties.Name="Apply Game Mode"
                                     Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"/>
                         </StackPanel>
                     </Border>
@@ -140,12 +149,13 @@
                     <Border Style="{StaticResource Card}" Padding="16" Margin="0,0,0,16">
                         <StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-                                <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding WantXboxGameBarOff}" VerticalAlignment="Center"/>
+                                <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding WantXboxGameBarOff}" AutomationProperties.Name="Disable Xbox Game Bar overlay" VerticalAlignment="Center"/>
                                 <TextBlock Text="Disable Xbox Game Bar / Game DVR overlay" VerticalAlignment="Center" Margin="8,0,0,0"/>
                             </StackPanel>
                             <TextBlock Text="Disables AppCaptureEnabled and GameDVR_Enabled via registry. Instant, reversible."
                                        Style="{StaticResource Subtle}" FontSize="11" Margin="20,0,0,8"/>
                             <Button Content="Apply Xbox Game Bar" Command="{Binding ApplyXboxGameBarCommand}"
+                                    AutomationProperties.Name="Apply Xbox Game Bar setting"
                                     Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"
                                     Margin="0,0,0,12"/>
 
@@ -169,7 +179,7 @@
                     <Border Style="{StaticResource Card}" Padding="16" Margin="0,0,0,16">
                         <StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-                                <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding WantGpuMaxPerformance}" IsEnabled="{Binding HasNvidiaGpu}" VerticalAlignment="Center"/>
+                                <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding WantGpuMaxPerformance}" IsEnabled="{Binding HasNvidiaGpu}" AutomationProperties.Name="NVIDIA GPU prefer maximum performance" VerticalAlignment="Center"/>
                                 <TextBlock Text="NVIDIA GPU — Prefer Maximum Performance (requires reboot)" VerticalAlignment="Center" Margin="8,0,0,0"/>
                             </StackPanel>
                             <TextBlock Style="{StaticResource Subtle}" FontSize="11" Margin="20,0,0,4"
@@ -182,6 +192,7 @@
                                        Style="{StaticResource Subtle}" FontSize="11" Margin="20,2,0,4"
                                        Visibility="{Binding HasNvidiaGpu, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                             <Button Content="Apply GPU Setting" Command="{Binding ApplyGpuCommand}"
+                                    AutomationProperties.Name="Apply GPU setting"
                                     Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"
                                     IsEnabled="{Binding HasNvidiaGpu}"/>
                         </StackPanel>
@@ -192,7 +203,7 @@
                     <Border Style="{StaticResource Card}" Padding="16" Margin="0,0,0,16">
                         <StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-                                <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding WantProcessorMaxState}" IsEnabled="{Binding IsProcessorStateEditable}" VerticalAlignment="Center"/>
+                                <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding WantProcessorMaxState}" IsEnabled="{Binding IsProcessorStateEditable}" AutomationProperties.Name="Processor minimum state 100 percent" VerticalAlignment="Center"/>
                                 <TextBlock Text="Processor min state 100% (force max CPU frequency)" VerticalAlignment="Center" Margin="8,0,0,0"/>
                             </StackPanel>
                             <TextBlock Text="Prevents CPU from downclocking. Increases power consumption."
@@ -202,6 +213,7 @@
                                        TextWrapping="Wrap"
                                        Visibility="{Binding IsProcessorStateLocked, Converter={StaticResource BoolToVis}}"/>
                             <Button Content="Apply Processor State" Command="{Binding ApplyProcessorStateCommand}"
+                                    AutomationProperties.Name="Apply processor state"
                                     Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"
                                     IsEnabled="{Binding IsProcessorStateEditable}"
                                     Margin="0,4,0,0"/>
@@ -215,6 +227,7 @@
                             <TextBlock Text="Create a Windows System Restore point before making changes. Requires admin."
                                        Style="{StaticResource Subtle}" FontSize="11" Margin="0,0,0,8"/>
                             <Button Content="Create Restore Point" Command="{Binding CreateRestorePointCommand}"
+                                    AutomationProperties.Name="Create system restore point"
                                     Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"/>
                         </StackPanel>
                     </Border>
@@ -231,6 +244,7 @@
                             <TextBlock Text="⚠ Apps may feel briefly slower on next access as pages are faulted back in."
                                        Foreground="{DynamicResource Warning}" FontSize="11" Margin="0,0,0,8"/>
                             <Button Content="Trim RAM Now" Command="{Binding TrimRamCommand}"
+                                    AutomationProperties.Name="Trim RAM working set now"
                                     Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"/>
                         </StackPanel>
                     </Border>
@@ -254,6 +268,7 @@
                                            Visibility="{Binding IsHibernationEnabled, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                             </StackPanel>
                             <Button Content="Toggle Hibernation" Command="{Binding ToggleHibernationCommand}"
+                                    AutomationProperties.Name="Toggle hibernation"
                                     Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"/>
                         </StackPanel>
                     </Border>

--- a/SysManager/SysManager/Views/PingView.xaml
+++ b/SysManager/SysManager/Views/PingView.xaml
@@ -24,15 +24,18 @@
                         DockPanel.Dock="Right" VerticalAlignment="Center">
                 <Button Content="Start" Command="{Binding StartCommand}"
                         Style="{StaticResource PrimaryButton}"
+                        AutomationProperties.Name="Start ping monitoring"
                         Visibility="{Binding Shared.IsMonitoring,
                             Converter={StaticResource FlexVis},
                             ConverterParameter=Inverse}"/>
                 <Button Content="Stop" Command="{Binding StopCommand}"
                         Style="{StaticResource SecondaryButton}"
+                        AutomationProperties.Name="Stop ping monitoring"
                         Visibility="{Binding Shared.IsMonitoring,
                             Converter={StaticResource FlexVis}}"/>
                 <Button Content="Clear" Command="{Binding ClearHistoryCommand}"
-                        Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>
+                        Style="{StaticResource GhostButton}" Margin="6,0,0,0"
+                        AutomationProperties.Name="Clear ping history"/>
             </StackPanel>
         </DockPanel>
 
@@ -89,7 +92,8 @@
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Right" VerticalAlignment="Center">
                         <TextBlock Text="Preset" Style="{StaticResource Subtle}" VerticalAlignment="Center" Margin="0,0,10,0"/>
                         <ComboBox ItemsSource="{Binding Shared.Presets}" DisplayMemberPath="Name"
-                                  SelectedItem="{Binding Shared.SelectedPreset, Mode=TwoWay}" Width="200"/>
+                                  SelectedItem="{Binding Shared.SelectedPreset, Mode=TwoWay}" Width="200"
+                                  AutomationProperties.Name="Target preset"/>
                     </StackPanel>
                 </DockPanel>
                 <TextBlock Text="{Binding Shared.SelectedPreset.Description}"
@@ -111,7 +115,8 @@
                                     <DockPanel Margin="6,0,0,0">
                                         <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" MinWidth="100">
                                             <StackPanel Orientation="Horizontal">
-                                                <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding IsEnabled}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                                <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding IsEnabled}" VerticalAlignment="Center" Margin="0,0,6,0"
+                                                              AutomationProperties.Name="{Binding Name, StringFormat='Enable {0}'}"/>
                                                 <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13" VerticalAlignment="Center"/>
                                             </StackPanel>
                                             <TextBlock Text="{Binding Host}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="22,2,0,0"/>
@@ -152,8 +157,10 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
                 <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-                    <TextBox Text="{Binding Shared.NewTargetHost, UpdateSourceTrigger=PropertyChanged}" Width="240"/>
-                    <Button Content="Add target" Command="{Binding AddCustomTargetCommand}" Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"/>
+                    <TextBox Text="{Binding Shared.NewTargetHost, UpdateSourceTrigger=PropertyChanged}" Width="240"
+                             AutomationProperties.Name="New target host"/>
+                    <Button Content="Add target" Command="{Binding AddCustomTargetCommand}" Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"
+                            AutomationProperties.Name="Add target"/>
                 </StackPanel>
             </StackPanel>
         </Border>
@@ -169,10 +176,12 @@
                     <TextBlock Text="Latency" Style="{StaticResource SectionTitle}"/>
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Right" VerticalAlignment="Center">
                         <TextBlock Text="Ping every" Style="{StaticResource Subtle}" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding Shared.IntervalSeconds, UpdateSourceTrigger=PropertyChanged}" Width="48" Margin="8,0,6,0" TextAlignment="Center"/>
+                        <TextBox Text="{Binding Shared.IntervalSeconds, UpdateSourceTrigger=PropertyChanged}" Width="48" Margin="8,0,6,0" TextAlignment="Center"
+                                 AutomationProperties.Name="Ping interval in seconds"/>
                         <TextBlock Text="s" Style="{StaticResource Subtle}" VerticalAlignment="Center"/>
                         <TextBlock Text="Window" Style="{StaticResource Subtle}" VerticalAlignment="Center" Margin="16,0,0,0"/>
-                        <ComboBox SelectedValue="{Binding Shared.WindowSeconds}" ItemsSource="{Binding Shared.WindowOptions}" Width="82" Margin="8,0,0,0"/>
+                        <ComboBox SelectedValue="{Binding Shared.WindowSeconds}" ItemsSource="{Binding Shared.WindowOptions}" Width="82" Margin="8,0,0,0"
+                                  AutomationProperties.Name="Chart time window"/>
                     </StackPanel>
                 </DockPanel>
                 <lvc:CartesianChart Grid.Row="1" Background="Transparent" MinHeight="200"

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -31,6 +31,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        AutomationProperties.Name="Restart SysManager as administrator"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
@@ -61,13 +62,16 @@
             <WrapPanel>
                 <Button Content="Apply" Command="{Binding ApplyChangesCommand}"
                         IsEnabled="{Binding HasPendingChanges}"
+                        AutomationProperties.Name="Apply pending privacy changes"
                         Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"
                         ToolTip="Write pending toggle changes to the registry."/>
                 <Button Content="Discard" Command="{Binding DiscardChangesCommand}"
                         IsEnabled="{Binding HasPendingChanges}"
+                        AutomationProperties.Name="Discard pending privacy changes"
                         Style="{StaticResource GhostButton}" Margin="0,0,8,0"
                         ToolTip="Revert pending toggle changes back to the last applied state."/>
                 <Button Content="Refresh" Command="{Binding RefreshCommand}"
+                        AutomationProperties.Name="Refresh privacy toggle states"
                         Style="{StaticResource GhostButton}" Margin="0,0,16,0"
                         ToolTip="Re-read all toggle states from the registry."/>
 
@@ -75,6 +79,7 @@
                            Style="{StaticResource Subtle}"/>
                 <ComboBox ItemsSource="{Binding Categories}"
                           SelectedItem="{Binding SelectedCategory}"
+                          AutomationProperties.Name="Filter toggles by category"
                           Width="140" Margin="0,0,12,0"/>
 
                 <Border CornerRadius="10" Padding="10,4" Margin="4,0"
@@ -142,6 +147,7 @@
 
                                     <ToggleButton Grid.Column="1" Style="{StaticResource ToggleSwitch}"
                                                   IsChecked="{Binding IsEnabled}"
+                                                  AutomationProperties.Name="{Binding Name, StringFormat='Toggle privacy protection: {0}'}"
                                                   VerticalAlignment="Center" Margin="8,0,0,0"
                                                   ToolTip="Toggle privacy protection on/off"/>
                                 </Grid>

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -29,7 +29,8 @@
         <Border Grid.Row="1" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
             <WrapPanel>
                 <Button Content="Refresh" Command="{Binding RefreshCommand}"
-                        Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
+                        Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"
+                        AutomationProperties.Name="Refresh process list"/>
                 <TextBlock Text="Search:" VerticalAlignment="Center" Margin="8,0,8,0"
                            Style="{StaticResource Subtle}"/>
                 <Grid Width="200" Margin="0,0,12,0">
@@ -42,7 +43,8 @@
                 </Grid>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="4,0,0,0"
                             ToolTip="Hide system processes and show only applications with a visible window">
-                    <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding ShowOnlyApps}" VerticalAlignment="Center"/>
+                    <ToggleButton Style="{StaticResource ToggleSwitch}" IsChecked="{Binding ShowOnlyApps}" VerticalAlignment="Center"
+                                  AutomationProperties.Name="Show only apps"/>
                     <TextBlock Text="Show only apps" VerticalAlignment="Center" Margin="8,0,0,0"/>
                 </StackPanel>
             </WrapPanel>

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -31,7 +31,8 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
+                        AutomationProperties.Name="Run as administrator"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
@@ -62,7 +63,8 @@
                 <DockPanel>
                     <StackPanel Orientation="Horizontal">
                         <Button Content="Refresh" Command="{Binding RefreshCommand}"
-                                Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
+                                Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"
+                                AutomationProperties.Name="Refresh services"/>
                         <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
                                  Width="240" VerticalContentAlignment="Center"
                                  AutomationProperties.Name="Filter services"/>
@@ -82,18 +84,22 @@
                     <RadioButton Content="{Binding SafeCount, StringFormat='Safe ({0})'}"
                                  GroupName="SafetyFilter" Margin="0,0,6,0"
                                  IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=Safe}"
-                                 Style="{StaticResource FilterChip}"/>
+                                 Style="{StaticResource FilterChip}"
+                                 AutomationProperties.Name="Filter safe services"/>
                     <RadioButton Content="{Binding CautionCount, StringFormat='Caution ({0})'}"
                                  GroupName="SafetyFilter" Margin="0,0,6,0"
                                  IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=Caution}"
-                                 Style="{StaticResource FilterChipCaution}"/>
+                                 Style="{StaticResource FilterChipCaution}"
+                                 AutomationProperties.Name="Filter caution services"/>
                     <RadioButton Content="{Binding CriticalCount, StringFormat='Critical ({0})'}"
                                  GroupName="SafetyFilter" Margin="0,0,6,0"
                                  IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=Critical}"
-                                 Style="{StaticResource FilterChipCritical}"/>
+                                 Style="{StaticResource FilterChipCritical}"
+                                 AutomationProperties.Name="Filter critical services"/>
                     <RadioButton Content="All" GroupName="SafetyFilter" Margin="0,0,6,0"
                                  IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=All}"
-                                 Style="{StaticResource FilterChip}"/>
+                                 Style="{StaticResource FilterChip}"
+                                 AutomationProperties.Name="Show all services"/>
                 </StackPanel>
             </StackPanel>
         </Border>
@@ -147,19 +153,23 @@
                                 <Button Content="Start" Padding="8,2" Margin="0,0,4,0"
                                         Style="{StaticResource GhostButton}"
                                         Command="{Binding DataContext.StartServiceCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                        CommandParameter="{Binding}"/>
+                                        CommandParameter="{Binding}"
+                                        AutomationProperties.Name="{Binding DisplayName, StringFormat='Start {0}'}"/>
                                 <Button Content="Stop" Padding="8,2" Margin="0,0,4,0"
                                         Style="{StaticResource GhostButton}"
                                         Command="{Binding DataContext.StopServiceCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                        CommandParameter="{Binding}"/>
+                                        CommandParameter="{Binding}"
+                                        AutomationProperties.Name="{Binding DisplayName, StringFormat='Stop {0}'}"/>
                                 <Button Content="Disable" Padding="8,2" Margin="0,0,4,0"
                                         Style="{StaticResource GhostButton}"
                                         Command="{Binding DataContext.DisableServiceCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                        CommandParameter="{Binding}"/>
+                                        CommandParameter="{Binding}"
+                                        AutomationProperties.Name="{Binding DisplayName, StringFormat='Disable {0}'}"/>
                                 <Button Content="Enable" Padding="8,2"
                                         Style="{StaticResource GhostButton}"
                                         Command="{Binding DataContext.EnableServiceCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                        CommandParameter="{Binding}"/>
+                                        CommandParameter="{Binding}"
+                                        AutomationProperties.Name="{Binding DisplayName, StringFormat='Enable {0}'}"/>
                             </StackPanel>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml
@@ -29,23 +29,30 @@
         <Border Grid.Row="1" Style="{StaticResource Card}" Margin="28,16,28,0" Padding="12">
             <WrapPanel>
                 <Button Content="Scan" Command="{Binding ScanCommand}"
+                        AutomationProperties.Name="Scan for broken shortcuts"
                         Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"/>
                 <Button Content="Delete Selected" Command="{Binding DeleteSelectedCommand}"
+                        AutomationProperties.Name="Delete selected shortcuts"
                         Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
                 <Button Content="Cancel" Command="{Binding CancelCommand}"
+                        AutomationProperties.Name="Cancel scan"
                         Style="{StaticResource GhostButton}" Margin="0,0,16,0"
                         Visibility="{Binding IsScanning, Converter={StaticResource BoolToVis}}"/>
                 <Button Content="Select All" Command="{Binding SelectAllCommand}"
+                        AutomationProperties.Name="Select all shortcuts"
                         Style="{StaticResource GhostButton}" Margin="0,0,4,0"/>
                 <Button Content="Deselect All" Command="{Binding DeselectAllCommand}"
+                        AutomationProperties.Name="Deselect all shortcuts"
                         Style="{StaticResource GhostButton}" Margin="0,0,16,0"/>
                 <CheckBox Content="Move to Recycle Bin" IsChecked="{Binding MoveToRecycleBin}"
+                          AutomationProperties.Name="Move deleted shortcuts to Recycle Bin"
                           VerticalAlignment="Center" Foreground="{DynamicResource TextSecondary}"/>
             </WrapPanel>
         </Border>
 
         <!-- Results DataGrid -->
         <DataGrid Grid.Row="2" ItemsSource="{Binding BrokenShortcuts}"
+                  AutomationProperties.Name="Broken shortcuts"
                   AutoGenerateColumns="False" IsReadOnly="False"
                   CanUserAddRows="False" CanUserDeleteRows="False"
                   CanUserSortColumns="True" CanUserResizeColumns="True"

--- a/SysManager/SysManager/Views/SpeedTestView.xaml
+++ b/SysManager/SysManager/Views/SpeedTestView.xaml
@@ -36,10 +36,12 @@
                                 <TextBlock Text="Official CLI, downloaded on first run" Style="{StaticResource Subtle}" Margin="0,2,0,0"/>
                             </StackPanel>
                             <Button Content="Run" Command="{Binding RunOoklaSpeedCommand}" Style="{StaticResource PrimaryButton}"
+                                    AutomationProperties.Name="Run Ookla speed test"
                                     HorizontalAlignment="Right" DockPanel.Dock="Right" Padding="18,8"
                                     IsEnabled="{Binding IsSpeedTesting, Converter={StaticResource BoolInvert}}"/>
                             <ComboBox ItemsSource="{Binding OoklaServerOptions}"
                                       SelectedItem="{Binding SelectedOoklaServer}"
+                                      AutomationProperties.Name="Ookla server"
                                       Width="180" Margin="0,0,8,0" VerticalAlignment="Center"
                                       DockPanel.Dock="Right"/>
                         </DockPanel>
@@ -52,7 +54,7 @@
                         <TextBlock Text="{Binding OoklaResult.Server}" Style="{StaticResource Caption}" Margin="0,10,0,0" Visibility="{Binding OoklaResult, Converter={StaticResource FlexVis}}"/>
                         <ProgressBar AutomationProperties.Name="Progress" Value="{Binding SpeedProgress}" Maximum="100" Height="4" Margin="0,14,0,0" Visibility="{Binding IsOoklaTesting, Converter={StaticResource FlexVis}}"/>
                         <TextBlock Text="{Binding OoklaStatus}" Style="{StaticResource Subtle}" Margin="0,6,0,0"/>
-                        <Button Content="Cancel" Command="{Binding CancelSpeedCommand}" Style="{StaticResource GhostButton}" Margin="0,6,0,0" HorizontalAlignment="Left" Visibility="{Binding IsOoklaTesting, Converter={StaticResource FlexVis}}"/>
+                        <Button Content="Cancel" Command="{Binding CancelSpeedCommand}" Style="{StaticResource GhostButton}" AutomationProperties.Name="Cancel Ookla speed test" Margin="0,6,0,0" HorizontalAlignment="Left" Visibility="{Binding IsOoklaTesting, Converter={StaticResource FlexVis}}"/>
                     </StackPanel>
                 </Border>
 
@@ -65,6 +67,7 @@
                                 <TextBlock Text="Measured against speed.cloudflare.com" Style="{StaticResource Subtle}" Margin="0,2,0,0"/>
                             </StackPanel>
                             <Button Content="Run" Command="{Binding RunHttpSpeedCommand}" Style="{StaticResource PrimaryButton}"
+                                    AutomationProperties.Name="Run HTTP speed test"
                                     HorizontalAlignment="Right" DockPanel.Dock="Right" Padding="18,8"
                                     IsEnabled="{Binding IsSpeedTesting, Converter={StaticResource BoolInvert}}"/>
                         </DockPanel>
@@ -76,7 +79,7 @@
                         </Grid>
                         <ProgressBar AutomationProperties.Name="Progress" Value="{Binding SpeedProgress}" Maximum="100" Height="4" Margin="0,14,0,0" Visibility="{Binding IsHttpTesting, Converter={StaticResource FlexVis}}"/>
                         <TextBlock Text="{Binding HttpStatus}" Style="{StaticResource Subtle}" Margin="0,6,0,0"/>
-                        <Button Content="Cancel" Command="{Binding CancelSpeedCommand}" Style="{StaticResource GhostButton}" Margin="0,6,0,0" HorizontalAlignment="Left" Visibility="{Binding IsHttpTesting, Converter={StaticResource FlexVis}}"/>
+                        <Button Content="Cancel" Command="{Binding CancelSpeedCommand}" Style="{StaticResource GhostButton}" AutomationProperties.Name="Cancel HTTP speed test" Margin="0,6,0,0" HorizontalAlignment="Left" Visibility="{Binding IsHttpTesting, Converter={StaticResource FlexVis}}"/>
                     </StackPanel>
                 </Border>
 
@@ -99,6 +102,7 @@
                         <DockPanel>
                             <TextBlock Text="Ookla History" Style="{StaticResource SectionTitle}"/>
                             <Button Content="Clear" Command="{Binding ClearOoklaHistoryCommand}" Style="{StaticResource GhostButton}"
+                                    AutomationProperties.Name="Clear Ookla history"
                                     HorizontalAlignment="Right" DockPanel.Dock="Right" Padding="12,4" FontSize="12"/>
                         </DockPanel>
                         <DataGrid ItemsSource="{Binding OoklaHistory}" AutoGenerateColumns="False"
@@ -129,6 +133,7 @@
                         <DockPanel>
                             <TextBlock Text="HTTP History" Style="{StaticResource SectionTitle}"/>
                             <Button Content="Clear" Command="{Binding ClearHttpHistoryCommand}" Style="{StaticResource GhostButton}"
+                                    AutomationProperties.Name="Clear HTTP history"
                                     HorizontalAlignment="Right" DockPanel.Dock="Right" Padding="12,4" FontSize="12"/>
                         </DockPanel>
                         <DataGrid ItemsSource="{Binding HttpHistory}" AutoGenerateColumns="False"

--- a/SysManager/SysManager/Views/ThemePopup.xaml
+++ b/SysManager/SysManager/Views/ThemePopup.xaml
@@ -32,10 +32,13 @@
                             BorderBrush="{DynamicResource Border1}" BorderThickness="1" Margin="0,0,0,16">
                         <UniformGrid Columns="3">
                             <RadioButton x:Name="DarkMode" Content="Dark" GroupName="Mode"
+                                         AutomationProperties.Name="Dark mode"
                                          Style="{StaticResource ModePill}" IsChecked="True"/>
                             <RadioButton x:Name="LightMode" Content="Light" GroupName="Mode"
+                                         AutomationProperties.Name="Light mode"
                                          Style="{StaticResource ModePill}"/>
                             <RadioButton x:Name="CustomMode" Content="Custom" GroupName="Mode"
+                                         AutomationProperties.Name="Custom mode"
                                          Style="{StaticResource ModePill}"/>
                         </UniformGrid>
                     </Border>
@@ -51,6 +54,7 @@
                         <Slider x:Name="ShadeSlider" Minimum="0" Maximum="1" Value="0.5"
                                 LargeChange="0.05" SmallChange="0.01"
                                 IsMoveToPointEnabled="True"
+                                AutomationProperties.Name="Background shade"
                                 Margin="0,0,0,4"/>
                     </StackPanel>
 

--- a/SysManager/SysManager/Views/TracerouteView.xaml
+++ b/SysManager/SysManager/Views/TracerouteView.xaml
@@ -46,7 +46,8 @@
                         <TextBlock Text="Latency per hop" Style="{StaticResource SectionTitle}"/>
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Right" VerticalAlignment="Center">
                             <TextBlock Text="Every" Style="{StaticResource Subtle}" VerticalAlignment="Center"/>
-                            <ComboBox ItemsSource="{Binding Shared.TraceIntervalOptions}"
+                            <ComboBox AutomationProperties.Name="Auto-trace interval in seconds"
+                                      ItemsSource="{Binding Shared.TraceIntervalOptions}"
                                       SelectedValue="{Binding Shared.TraceIntervalSeconds}" Width="72" Margin="8,0,4,0"/>
                             <TextBlock Text="s" Style="{StaticResource Subtle}" VerticalAlignment="Center"/>
                         </StackPanel>
@@ -73,7 +74,7 @@
                     <StackPanel Grid.Row="1" Margin="0,12,0,12">
                         <TextBlock Text="Run a one-off trace to any host:" Style="{StaticResource Subtle}" Margin="0,0,0,6"/>
                         <StackPanel Orientation="Horizontal">
-                            <TextBox Text="{Binding TraceHost, UpdateSourceTrigger=PropertyChanged}" Width="180"/>
+                            <TextBox AutomationProperties.Name="Host to trace" Text="{Binding TraceHost, UpdateSourceTrigger=PropertyChanged}" Width="180"/>
                             <Button Content="Trace now" Command="{Binding TraceCommand}" Style="{StaticResource PrimaryButton}" Margin="8,0,0,0"
                                     IsEnabled="{Binding IsTracing, Converter={StaticResource BoolInvert}}"/>
                             <Button Content="Cancel" Command="{Binding CancelTraceCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -107,11 +107,13 @@
                         <DataGridCheckBoxColumn.ElementStyle>
                             <Style TargetType="CheckBox">
                                 <Setter Property="HorizontalAlignment" Value="Center"/>
+                                <Setter Property="AutomationProperties.Name" Value="{Binding Name, StringFormat='Select {0} for uninstall'}"/>
                             </Style>
                         </DataGridCheckBoxColumn.ElementStyle>
                         <DataGridCheckBoxColumn.EditingElementStyle>
                             <Style TargetType="CheckBox">
                                 <Setter Property="HorizontalAlignment" Value="Center"/>
+                                <Setter Property="AutomationProperties.Name" Value="{Binding Name, StringFormat='Select {0} for uninstall'}"/>
                             </Style>
                         </DataGridCheckBoxColumn.EditingElementStyle>
                     </DataGridCheckBoxColumn>


### PR DESCRIPTION
## Summary

Adds `AutomationProperties.Name` to interactive controls across **21 views** that lacked
accessible names, so screen readers announce them meaningfully. Generated by a per-view
pass where each view was checked first (a prior accessibility pass — #830/833/835/837/
839/841/843 — already named many controls; those were left untouched and not duplicated).

## Scope

~144 names added across: DnsHosts, DiskAnalyzer, DuplicateFile, AppBlocker,
ShortcutCleaner, ContextMenu, BulkInstaller, DeepCleanup, FileShredder, Logs, Ping,
Privacy, ProcessManager, Services, SpeedTest, ThemePopup, Traceroute, Uninstaller,
AppAlerts, AppUpdates, Performance.

Covers: destructive buttons (Delete/Shred/Clear History), icon-only and per-row actions
(named after the row item, e.g. `Remove host entry {0}`, `Add {0} to install list`),
toggles, ComboBoxes, search/filter TextBoxes, DataGrids, and theme RadioButtons.

## Guarantees

- **Only** the `AutomationProperties.Name` attribute was added — no layout, style,
  binding, value, or any other attribute changed. Zero visual change. (Verified by diff:
  every removed line is the same element re-emitted with the new attribute appended.)
- Controls that already had names were skipped (not duplicated).
- Build: main + Tests + IntegrationTests all **0 warnings / 0 errors** — every added
  attribute compiles, so the XAML stays well-formed.

`fix:` → patch release (1.20.20). Protocol C to follow.
