### PR TITLE
ci: validate release tag input and skip Codecov on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,11 @@ jobs:
           --collect:"XPlat Code Coverage"
           --results-directory TestResults
 
+      # Skip Codecov on fork PRs: forked pull requests have no access to repository
+      # secrets, so CODECOV_TOKEN is empty there and the upload would fail noisily for
+      # no benefit. Same-repo pushes/PRs upload normally.
       - name: Upload coverage to Codecov
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -74,7 +78,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,8 +66,20 @@ jobs:
       - name: Extract tag version
         id: version
         shell: pwsh
+        env:
+          # Pass the tag through the environment instead of interpolating ${{ }} directly
+          # into the script body — that avoids any script-injection from a crafted manual
+          # dispatch input and keeps the value as plain data.
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          $tag = if ("${{ github.event_name }}" -eq "workflow_dispatch") { "${{ inputs.tag }}" } else { "${{ github.ref_name }}" }
+          $tag = if ($env:EVENT_NAME -eq "workflow_dispatch") { $env:INPUT_TAG } else { $env:REF_NAME }
+          # Validate the tag shape (vMAJOR.MINOR.PATCH[...]) before using it anywhere.
+          if ($tag -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+') {
+            Write-Error "Invalid release tag '$tag' — expected a semver tag like v1.2.3."
+            exit 1
+          }
           $version = $tag -replace '^v', ''
           "tag=$tag"          | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "version=$version"  | Out-File -FilePath $env:GITHUB_OUTPUT -Append


### PR DESCRIPTION
## Summary

Two CI/CD hardening changes (no application code; `ci:` → no release).

## Changes

- **`ci.yml`** — guard the two Codecov steps to skip on fork PRs. Forked pull requests
  have no access to repository secrets, so `CODECOV_TOKEN` is empty there and the upload
  would fail noisily for no benefit. Same-repo pushes/PRs upload normally. (The UI-tests
  job already had this fork guard; this brings the coverage steps in line.)
- **`release.yml`** — validate the `workflow_dispatch` `tag` input before use:
  - Pass the tag through the environment (`INPUT_TAG`/`EVENT_NAME`/`REF_NAME`) instead of
    interpolating `${{ inputs.tag }}` directly into the pwsh script body — avoids any
    script injection from a crafted manual-dispatch value.
  - Reject anything that isn't a `vMAJOR.MINOR.PATCH` tag with a clear error before it
    reaches checkout / version extraction.

## Verification

- YAML is well-formed (no tabs; structure unchanged besides the additions).
- No application code touched; behavior of normal tag-push releases is unchanged.

`ci:` → no release.
