### PR TITLE
fix: use theme brushes for exact-match hardcoded colors in four views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.20.20] - 2026-06-12
+## [1.20.21] - 2026-06-12
+
+### Changed
+- **Some status/accent colors now follow the theme instead of being hardcoded.** Replaced hardcoded color values that exactly matched a theme color (success green, warning amber, danger red, accent, hover border) with theme references on the Dashboard, Network Repair, Privacy, and Uninstaller tabs. The colors render identically today but will track the theme going forward.
 
 ### Fixed
 - **Much better screen-reader support across the app.** Many buttons, toggles, drop-downs, search/filter boxes, data grids, and per-row actions had no accessible name, so screen readers announced them generically (or not at all). Added clear, specific accessible names to interactive controls across 21 tabs — including destructive actions (Delete, Shred, Clear History), per-row buttons (now named after the item they act on), and unlabeled inputs. No visual change.

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.20</Version>
-    <FileVersion>1.20.20.0</FileVersion>
-    <AssemblyVersion>1.20.20.0</AssemblyVersion>
+    <Version>1.20.21</Version>
+    <FileVersion>1.20.21.0</FileVersion>
+    <AssemblyVersion>1.20.21.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -128,16 +128,16 @@
                         <DockPanel Margin="0,0,0,8">
                             <TextBlock Text="CPU" FontSize="11" FontWeight="SemiBold" Foreground="{DynamicResource TextMuted}"
                                        DockPanel.Dock="Left" VerticalAlignment="Center"/>
-                            <Ellipse Width="6" Height="6" Fill="#22C55E" DockPanel.Dock="Right" VerticalAlignment="Center"/>
+                            <Ellipse Width="6" Height="6" Fill="{DynamicResource Success}" DockPanel.Dock="Right" VerticalAlignment="Center"/>
                         </DockPanel>
-                        <TextBlock FontSize="26" FontWeight="Bold" Foreground="#22C55E">
+                        <TextBlock FontSize="26" FontWeight="Bold" Foreground="{DynamicResource Success}">
                             <Run Text="{Binding CpuPercent, StringFormat='{}{0:F0}', Mode=OneWay}"/><Run Text="%"/>
                         </TextBlock>
                         <TextBlock Text="{Binding CpuName}" FontSize="11" Foreground="{DynamicResource TextMuted}"
                                    TextTrimming="CharacterEllipsis" Margin="0,4,0,0"/>
                         <TextBlock Text="{Binding CpuCores}" FontSize="11" Foreground="{DynamicResource TextMuted}" Margin="0,2,0,0"/>
                         <ProgressBar Height="4" Minimum="0" Maximum="100" Value="{Binding CpuPercent, Mode=OneWay}"
-                                     Foreground="#22C55E" Background="{DynamicResource Surface3}" Margin="0,10,0,0"/>
+                                     Foreground="{DynamicResource Success}" Background="{DynamicResource Surface3}" Margin="0,10,0,0"/>
                     </StackPanel>
                 </Border>
 
@@ -389,16 +389,16 @@
                                                 <Ellipse.Style>
                                                     <Style TargetType="Ellipse">
                                                         <Setter Property="Visibility" Value="Collapsed"/>
-                                                        <Setter Property="Fill" Value="#22C55E"/>
+                                                        <Setter Property="Fill" Value="{DynamicResource Success}"/>
                                                         <Style.Triggers>
                                                             <DataTrigger Binding="{Binding State}" Value="Complete">
                                                                 <Setter Property="Visibility" Value="Visible"/>
                                                             </DataTrigger>
                                                             <DataTrigger Binding="{Binding Severity}" Value="Yellow">
-                                                                <Setter Property="Fill" Value="#F59E0B"/>
+                                                                <Setter Property="Fill" Value="{DynamicResource Warning}"/>
                                                             </DataTrigger>
                                                             <DataTrigger Binding="{Binding Severity}" Value="Red">
-                                                                <Setter Property="Fill" Value="#EF4444"/>
+                                                                <Setter Property="Fill" Value="{DynamicResource Danger}"/>
                                                             </DataTrigger>
                                                         </Style.Triggers>
                                                     </Style>

--- a/SysManager/SysManager/Views/NetworkRepairView.xaml
+++ b/SysManager/SysManager/Views/NetworkRepairView.xaml
@@ -58,7 +58,7 @@
                             <Style.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
-                                    <Setter Property="BorderBrush" Value="#2A3244"/>
+                                    <Setter Property="BorderBrush" Value="{DynamicResource Border2}"/>
                                 </Trigger>
                             </Style.Triggers>
                         </Style>
@@ -84,7 +84,7 @@
                             <Style.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
-                                    <Setter Property="BorderBrush" Value="#2A3244"/>
+                                    <Setter Property="BorderBrush" Value="{DynamicResource Border2}"/>
                                 </Trigger>
                             </Style.Triggers>
                         </Style>
@@ -110,7 +110,7 @@
                             <Style.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
-                                    <Setter Property="BorderBrush" Value="#2A3244"/>
+                                    <Setter Property="BorderBrush" Value="{DynamicResource Border2}"/>
                                 </Trigger>
                             </Style.Triggers>
                         </Style>

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -124,7 +124,7 @@
                                         <Style.Triggers>
                                             <Trigger Property="IsMouseOver" Value="True">
                                                 <Setter Property="Background" Value="#10141D"/>
-                                                <Setter Property="BorderBrush" Value="#2A3244"/>
+                                                <Setter Property="BorderBrush" Value="{DynamicResource Border2}"/>
                                             </Trigger>
                                         </Style.Triggers>
                                     </Style>

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -197,7 +197,7 @@
                                             <Ellipse Width="5" Height="5" VerticalAlignment="Center">
                                                 <Ellipse.Style>
                                                     <Style TargetType="Ellipse">
-                                                        <Setter Property="Fill" Value="#6366F1"/>
+                                                        <Setter Property="Fill" Value="{DynamicResource Accent}"/>
                                                         <Style.Triggers>
                                                             <DataTrigger Binding="{Binding Source}" Value="">
                                                                 <Setter Property="Fill" Value="{DynamicResource WarningStripe}"/>


### PR DESCRIPTION
## Summary

Replaces hardcoded color literals with theme `DynamicResource` brushes — but **only**
where the hex exactly matches an existing theme color, so every color renders identically
today and now tracks the theme going forward.

## Changes (11 exact-match replacements, 4 views)

- **DashboardView** — CPU vitals dot/percent/progress `#22C55E`→`Success`; System-Alerts
  severity-dot setters `#22C55E`→`Success`, `#F59E0B`→`Warning`, `#EF4444`→`Danger`.
- **NetworkRepairView** — hover `BorderBrush` `#2A3244`→`Border2` on the three repair cards.
- **PrivacyView** — per-toggle hover `BorderBrush` `#2A3244`→`Border2`.
- **UninstallerView** — source-badge default `Fill` `#6366F1`→`Accent`.

## Safety

- A workflow processed 17 candidate views; agents were instructed to replace a hex **only**
  on an exact match against the authoritative App.xaml palette, and to **skip and report**
  anything else. They left **104 non-matching hexes untouched** (one-off per-metric accents
  like `#3B82F6`/`#A855F7`, and 8-digit ARGB values with alpha) — those would need new
  theme tokens, which is a design decision, not a mechanical swap.
- Each replacement verified against App.xaml: `Success`=#22C55E, `Warning`=#F59E0B,
  `Danger`=#EF4444, `Accent`=#6366F1, `Border2`=#2A3244 — byte-identical render.
- Only color values changed; no layout/binding/structure touched.
- Build: main **0 warnings / 0 errors**.

`fix:` → patch release (1.20.21). Protocol C to follow.
