### PR TITLE
refactor: use collection expressions and is-null pattern in remaining sites

### DIFF
--- a/SysManager/SysManager.Tests/EventLogServiceTests.cs
+++ b/SysManager/SysManager.Tests/EventLogServiceTests.cs
@@ -34,7 +34,7 @@ public class EventLogServiceTests
     {
         var opt = new EventLogQueryOptions
         {
-            Severities = new List<EventSeverity> { EventSeverity.Error }
+            Severities = [EventSeverity.Error]
         };
         var result = InvokeBuildXPath(opt);
         Assert.Contains("Level=2", result);

--- a/SysManager/SysManager/Helpers/EqualityConverter.cs
+++ b/SysManager/SysManager/Helpers/EqualityConverter.cs
@@ -17,7 +17,7 @@ public sealed class EqualityConverter : IValueConverter
 {
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (value == null || parameter == null)
+        if (value is null || parameter is null)
             return false;
         return string.Equals(value.ToString(), parameter.ToString(), StringComparison.Ordinal);
     }

--- a/SysManager/SysManager/Models/TargetPreset.cs
+++ b/SysManager/SysManager/Models/TargetPreset.cs
@@ -74,8 +74,8 @@ public static class TargetPresets
             ("FACEIT UK",    "82.145.38.1"),
         });
 
-    public static readonly IReadOnlyList<TargetPreset> All = new[]
-    {
+    public static readonly IReadOnlyList<TargetPreset> All =
+    [
         Global, CS2Europe, FaceitEurope, PubgEurope, Streaming
-    };
+    ];
 }

--- a/SysManager/SysManager/Services/AppAlertService.cs
+++ b/SysManager/SysManager/Services/AppAlertService.cs
@@ -116,11 +116,11 @@ public sealed class AppAlertService : IDisposable
     public static IReadOnlyList<AppInstallEntry> GetRegistryApps()
     {
         List<AppInstallEntry> apps = [];
-        var paths = new[]
-        {
+        string[] paths =
+        [
             @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
             @"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
-        };
+        ];
 
         foreach (var path in paths)
         {

--- a/SysManager/SysManager/Services/DeepCleanupService.cs
+++ b/SysManager/SysManager/Services/DeepCleanupService.cs
@@ -253,11 +253,11 @@ public sealed class DeepCleanupService
 
     private static string[] SteamRoots(string pfx86, string pf)
     {
-        var roots = new List<string>
-        {
+        List<string> roots =
+        [
             Path.Combine(pfx86, "Steam"),
             Path.Combine(pf, "Steam"),
-        };
+        ];
         foreach (var drive in DriveInfo.GetDrives().Where(d => d.DriveType == DriveType.Fixed && d.IsReady))
         {
             var candidate = Path.Combine(drive.RootDirectory.FullName, "Steam");

--- a/SysManager/SysManager/Services/DuplicateFileService.cs
+++ b/SysManager/SysManager/Services/DuplicateFileService.cs
@@ -59,7 +59,7 @@ public sealed class DuplicateFileService
             return [];
 
         // ── Pass 1: discover files and group by size ──
-        var sizeGroups = new Dictionary<long, List<FileInfo>>();
+        Dictionary<long, List<FileInfo>> sizeGroups = [];
         long discovered = 0;
         var stack = new Stack<string>();
         stack.Push(rootPath);

--- a/SysManager/SysManager/Services/FileShredderService.cs
+++ b/SysManager/SysManager/Services/FileShredderService.cs
@@ -195,7 +195,7 @@ public sealed class FileShredderService
     private static List<string> EnumerateFilesSafe(string rootPath)
     {
         List<string> results = [];
-        var stack = new Stack<DirectoryInfo>();
+        Stack<DirectoryInfo> stack = [];
         stack.Push(new DirectoryInfo(rootPath));
 
         while (stack.Count > 0)


### PR DESCRIPTION
## Summary

Byte-identical .NET 10 / C# idiom cleanups — the remaining mechanical modernization sites
from the audit. No behavior change.

## Changes

- **Collection expressions** replacing the older initializer syntax:
  - `Models/TargetPreset.cs` — `All = new[] { ... }` → `[ ... ]`
  - `Services/AppAlertService.cs` — uninstall `paths` `new[] { ... }` → `string[] paths = [ ... ]`
  - `Services/DeepCleanupService.cs` — `roots = new List<string> { ... }` → `List<string> roots = [ ... ]` (still a mutable List; later `.Add()` preserved)
  - `Services/DuplicateFileService.cs` — `new Dictionary<long, List<FileInfo>>()` → `Dictionary<long, List<FileInfo>> sizeGroups = []`
  - `Services/FileShredderService.cs` — `new Stack<DirectoryInfo>()` → `Stack<DirectoryInfo> stack = []`
  - `SysManager.Tests/EventLogServiceTests.cs` — `new List<EventSeverity> { ... }` → `[ ... ]`
- **Pattern matching**: `Helpers/EqualityConverter.cs` — `value == null || parameter == null`
  → `value is null || parameter is null`.

## Not converted (deliberately)

- `Models/ContextMenuPreset.cs` dictionary-with-indexer-initializer — collection expressions
  don't cleanly express keyed dictionary initializers, so it's left as `new Dictionary<...>{ [k]=v }`.

## Verification

- Build: main + Tests **0 warnings / 0 errors** (clean `--no-incremental` rebuild).
- Every change is byte-identical in behavior (same collection contents / same null check).

`refactor:` → no release.
