### PR TITLE
chore: remove duplicate author header block in AssemblyInfo

### DIFF
--- a/SysManager/SysManager/AssemblyInfo.cs
+++ b/SysManager/SysManager/AssemblyInfo.cs
@@ -1,8 +1,5 @@
-// SysManager — Windows system monitoring toolkit
+// SysManager · AssemblyInfo
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
-// License: MIT
-// Author : laurentiu021
-// Source : https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 using System.Reflection;


### PR DESCRIPTION
Removes a duplicated author/license header block at the top of `AssemblyInfo.cs` (two stacked headers: 'Author: laurentiu021 ... License: MIT' followed by 'Author : laurentiu021 / Source : ... / License: MIT'). Collapsed to the single canonical author-header format used across the codebase. No code change. `chore:` → no release.