### PR TITLE
fix: handle Storage-WMI COM errors, dispose explorer handle, log swallowed exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.20.21] - 2026-06-12
+## [1.20.22] - 2026-06-12
+
+### Fixed
+- **Drive/disk health reads survive systems without the Storage WMI namespace.** Disk Health and System Info could throw an unhandled COM error on older or headless Windows where the `root\Microsoft\Windows\Storage` namespace isn't present; both now handle that case and fall back gracefully (mirrors the earlier Fixed Drives fix).
+- **No leaked process handle when opening a file location.** "Open file location" in Process Manager left the launched Explorer process handle undisposed; it's now released.
+- **Swallowed errors are now diagnosable.** Several silent `catch` blocks now log at Debug level with the full exception (update-file cleanup, Deep Cleanup directory deletion, Windows Update size extraction, and the Dashboard polling loop), so failures leave a trace in the log instead of vanishing.
 
 ### Changed
 - **Some status/accent colors now follow the theme instead of being hardcoded.** Replaced hardcoded color values that exactly matched a theme color (success green, warning amber, danger red, accent, hover border) with theme references on the Dashboard, Network Repair, Privacy, and Uninstaller tabs. The colors render identically today but will track the theme going forward.

--- a/SysManager/SysManager/Services/DeepCleanupService.cs
+++ b/SysManager/SysManager/Services/DeepCleanupService.cs
@@ -361,7 +361,9 @@ public sealed class DeepCleanupService
                     }
                     foreach (var dir in EnumerateDirectoriesDepthFirst(path, ct))
                     {
-                        try { Directory.Delete(dir, recursive: false); } catch (IOException) { } catch (UnauthorizedAccessException) { }
+                        try { Directory.Delete(dir, recursive: false); }
+                        catch (IOException ex) { Log.Debug(ex, "Deep cleanup: failed to delete directory {Dir}", dir); }
+                        catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Deep cleanup: access denied deleting directory {Dir}", dir); }
                     }
                 }
                 catch (Exception ex)

--- a/SysManager/SysManager/Services/DiskHealthService.cs
+++ b/SysManager/SysManager/Services/DiskHealthService.cs
@@ -63,6 +63,11 @@ public sealed partial class DiskHealthService
         {
             // WMI access denied without elevation.
         }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            // scope.Connect() can throw COMException when the Storage WMI namespace
+            // is unavailable (older/headless Windows). Non-fatal — return what we have.
+        }
         return results;
     }
 

--- a/SysManager/SysManager/Services/ProcessManagerService.cs
+++ b/SysManager/SysManager/Services/ProcessManagerService.cs
@@ -126,12 +126,13 @@ public sealed class ProcessManagerService
         if (string.IsNullOrWhiteSpace(filePath) || !System.IO.File.Exists(filePath)) return;
         try
         {
+            // Dispose the returned Process handle — we don't track the launched explorer.
             Process.Start(new ProcessStartInfo
             {
                 FileName = "explorer.exe",
                 Arguments = $"/select,\"{filePath}\"",
                 UseShellExecute = true
-            });
+            })?.Dispose();
         }
         catch (InvalidOperationException ex) { Log.Warning(ex, "Failed to open file location: {Path}", filePath); }
         catch (System.ComponentModel.Win32Exception ex) { Log.Warning(ex, "Failed to open file location: {Path}", filePath); }

--- a/SysManager/SysManager/Services/SystemInfoService.cs
+++ b/SysManager/SysManager/Services/SystemInfoService.cs
@@ -226,9 +226,10 @@ public sealed class SystemInfoService
                 }
             }
         }
-        catch (ManagementException)
+        catch (Exception ex) when (ex is ManagementException or System.Runtime.InteropServices.COMException)
         {
-            // Fallback to Win32_DiskDrive if MSFT_PhysicalDisk isn't available
+            // Fallback to Win32_DiskDrive if MSFT_PhysicalDisk / the Storage WMI namespace
+            // isn't available (older/headless Windows — scope.Connect() throws COMException).
             using var s = new ManagementObjectSearcher("SELECT Model,Size,Status FROM Win32_DiskDrive");
             using var fallbackCollection = s.Get();
             foreach (ManagementObject mo in fallbackCollection)

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -342,8 +342,8 @@ public sealed class UpdateService
     private static void CleanupFile(string path)
     {
         try { if (File.Exists(path)) File.Delete(path); }
-        catch (IOException) { }
-        catch (UnauthorizedAccessException) { }
+        catch (IOException ex) { Serilog.Log.Debug(ex, "Update cleanup: could not delete {Path}", path); }
+        catch (UnauthorizedAccessException ex) { Serilog.Log.Debug(ex, "Update cleanup: access denied deleting {Path}", path); }
     }
 
     // ---------- internals ----------

--- a/SysManager/SysManager/Services/WindowsUpdateService.cs
+++ b/SysManager/SysManager/Services/WindowsUpdateService.cs
@@ -233,8 +233,8 @@ public sealed class WindowsUpdateService
         var kb = kbList.Count > 0 ? "KB" + string.Join(",", kbList) : string.Empty;
         long size = 0;
         try { size = (long)(decimal)u.MaxDownloadSize; }
-        catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) { }
-        catch (COMException) { }
+        catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException ex) { Serilog.Log.Debug(ex, "Windows Update: MaxDownloadSize not exposed for {Title}", title); }
+        catch (COMException ex) { Serilog.Log.Debug(ex, "Windows Update: COM error reading size for {Title}", title); }
         return new UpdateEntry
         {
             Title = title,

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.21</Version>
-    <FileVersion>1.20.21.0</FileVersion>
-    <AssemblyVersion>1.20.21.0</AssemblyVersion>
+    <Version>1.20.22</Version>
+    <FileVersion>1.20.22.0</FileVersion>
+    <AssemblyVersion>1.20.22.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -144,7 +144,7 @@ public sealed partial class DashboardViewModel : ViewModelBase
                 catch (OperationCanceledException) { break; }
                 catch (Exception ex)
                 {
-                    Log.Debug("Dashboard polling error: {Error}", ex.Message);
+                    Log.Debug(ex, "Dashboard polling error");
                     await Task.Delay(1000, ct);
                 }
             }


### PR DESCRIPTION
## Summary

Error-handling and reliability batch from the audit: missing COM-error handlers, a leaked
process handle, and several silent `catch` blocks that now log.

## Fixes

- **`DiskHealthService` / `SystemInfoService`** — the Storage-namespace WMI query caught
  `ManagementException` / `UnauthorizedAccessException` but not the `COMException` that
  `scope.Connect()` throws when `root\Microsoft\Windows\Storage` is absent (older/headless
  Windows). DiskHealth now catches it (returns what it has); SystemInfo routes it to the
  existing `Win32_DiskDrive` fallback. Mirrors the FixedDriveService fix shipped earlier.
- **`ProcessManagerService.OpenFileLocation`** — `Process.Start(...)` returned a `Process`
  handle that was discarded undisposed (same leak class as the AdminHelper fix). Now `?.Dispose()`d.
- **Logging on swallowed exceptions** (Debug level, full exception):
  - `UpdateService.CleanupFile` — empty `IOException`/`UnauthorizedAccessException` catches.
  - `DeepCleanupService` — silent inline directory-delete catches.
  - `WindowsUpdateService.MapToEntry` — empty COM/RuntimeBinder catches on size extraction.
  - `DashboardViewModel` polling loop — logged `ex.Message` only → now logs the full exception.

## Verification

- Build: main + Tests **0 warnings / 0 errors**.
- Used `Serilog.Log` (fully-qualified) in `UpdateService` and `WindowsUpdateService`, where
  `Log` is otherwise taken (an `event Action<string>? Log` in the latter) — verified against
  each file's existing logging style.

`fix:` → patch release (1.20.22). Protocol C to follow.
