### PR TITLE
fix: dispose Process.Start handles in explorer/link launch sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.20.22] - 2026-06-12
+## [1.20.23] - 2026-06-12
+
+### Fixed
+- **No more leaked process handles when opening Explorer / links.** Ten places that launch Explorer ("show in folder"/"open file location"), Event Viewer, the browser, or the updater left the returned process handle undisposed. Each now releases it. The launched program is unaffected; only the orphaned handle is cleaned up. Covers Deep Cleanup, Disk Analyzer, Duplicate Finder, Startup Manager, Logs, About, and the Context Menu refresh.
 
 ### Fixed
 - **Drive/disk health reads survive systems without the Storage WMI namespace.** Disk Health and System Info could throw an unhandled COM error on older or headless Windows where the `root\Microsoft\Windows\Storage` namespace isn't present; both now handle that case and fall back gracefully (mirrors the earlier Fixed Drives fix).

--- a/SysManager/SysManager/Services/ContextMenuService.cs
+++ b/SysManager/SysManager/Services/ContextMenuService.cs
@@ -358,7 +358,7 @@ public sealed partial class ContextMenuService
                 proc.Dispose();
             }
 
-            Process.Start(new ProcessStartInfo("explorer.exe") { UseShellExecute = true });
+            Process.Start(new ProcessStartInfo("explorer.exe") { UseShellExecute = true })?.Dispose();
             Log.Information("Explorer restarted to apply context menu changes");
         }
         catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.22</Version>
-    <FileVersion>1.20.22.0</FileVersion>
-    <AssemblyVersion>1.20.22.0</AssemblyVersion>
+    <Version>1.20.23</Version>
+    <FileVersion>1.20.23.0</FileVersion>
+    <AssemblyVersion>1.20.23.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -567,7 +567,7 @@ public sealed partial class AboutViewModel : ViewModelBase
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 WindowStyle = ProcessWindowStyle.Hidden
-            });
+            })?.Dispose();
 
             // Give the script a moment to start before we exit.
             await Task.Delay(500);
@@ -598,7 +598,7 @@ public sealed partial class AboutViewModel : ViewModelBase
         var dir = Path.GetDirectoryName(DownloadedPath);
         if (!string.IsNullOrEmpty(dir) && Directory.Exists(dir))
         {
-            try { Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{DownloadedPath}\"") { UseShellExecute = true }); }
+            try { Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{DownloadedPath}\"") { UseShellExecute = true })?.Dispose(); }
             catch (InvalidOperationException) { /* explorer launch is best-effort */ }
             catch (System.ComponentModel.Win32Exception) { /* explorer launch is best-effort */ }
         }
@@ -607,7 +607,7 @@ public sealed partial class AboutViewModel : ViewModelBase
     private static void OpenUrl(string url)
     {
         if (System.Windows.Application.Current == null) return;
-        try { Process.Start(new ProcessStartInfo(url) { UseShellExecute = true }); }
+        try { Process.Start(new ProcessStartInfo(url) { UseShellExecute = true })?.Dispose(); }
         catch (InvalidOperationException) { /* best-effort */ }
         catch (System.ComponentModel.Win32Exception) { /* best-effort */ }
     }

--- a/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
@@ -324,7 +324,7 @@ public sealed partial class DeepCleanupViewModel : ViewModelBase
     private void ShowInExplorer(string? path)
     {
         if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) return;
-        try { Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{path}\"") { UseShellExecute = true }); }
+        try { Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{path}\"") { UseShellExecute = true })?.Dispose(); }
         catch (InvalidOperationException) { /* best-effort */ }
         catch (System.ComponentModel.Win32Exception) { /* best-effort */ }
     }

--- a/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
@@ -160,7 +160,7 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
                 FileName = "explorer.exe",
                 Arguments = $"\"{entry.FullPath}\"",
                 UseShellExecute = true
-            });
+            })?.Dispose();
         }
         catch (InvalidOperationException ex) { Log.Debug(ex, "Failed to open explorer for {Path}", entry.FullPath); }
         catch (System.ComponentModel.Win32Exception ex) { Log.Debug(ex, "Failed to open explorer for {Path}", entry.FullPath); }

--- a/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
@@ -160,7 +160,7 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
                 FileName = "explorer.exe",
                 Arguments = $"/select,\"{entry.Path}\"",
                 UseShellExecute = true
-            });
+            })?.Dispose();
         }
         catch (InvalidOperationException ex) { Log.Debug(ex, "Failed to open explorer for {Path}", entry.Path); }
         catch (System.ComponentModel.Win32Exception ex) { Log.Debug(ex, "Failed to open explorer for {Path}", entry.Path); }

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -200,7 +200,7 @@ public sealed partial class LogsViewModel : ViewModelBase
         try
         {
             Directory.CreateDirectory(LogFolder);
-            Process.Start(new ProcessStartInfo("explorer.exe", LogFolder) { UseShellExecute = true });
+            Process.Start(new ProcessStartInfo("explorer.exe", LogFolder) { UseShellExecute = true })?.Dispose();
         }
         catch (IOException ex) { StatusMessage = ex.Message; }
         catch (UnauthorizedAccessException ex) { StatusMessage = ex.Message; }
@@ -213,7 +213,7 @@ public sealed partial class LogsViewModel : ViewModelBase
     {
         try
         {
-            Process.Start(new ProcessStartInfo("eventvwr.msc") { UseShellExecute = true });
+            Process.Start(new ProcessStartInfo("eventvwr.msc") { UseShellExecute = true })?.Dispose();
         }
         catch (InvalidOperationException ex) { StatusMessage = ex.Message; }
         catch (System.ComponentModel.Win32Exception ex) { StatusMessage = ex.Message; }
@@ -275,7 +275,7 @@ public sealed partial class LogsViewModel : ViewModelBase
     {
         if (SelectedEntry is null) return;
         var q = Uri.EscapeDataString($"Event ID {SelectedEntry.EventId} {SelectedEntry.ProviderName}");
-        try { Process.Start(new ProcessStartInfo($"https://www.google.com/search?q={q}") { UseShellExecute = true }); }
+        try { Process.Start(new ProcessStartInfo($"https://www.google.com/search?q={q}") { UseShellExecute = true })?.Dispose(); }
         catch (InvalidOperationException ex) { StatusMessage = ex.Message; }
         catch (System.ComponentModel.Win32Exception ex) { StatusMessage = ex.Message; }
     }

--- a/SysManager/SysManager/ViewModels/StartupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StartupViewModel.cs
@@ -136,7 +136,7 @@ public sealed partial class StartupViewModel : ViewModelBase
                     FileName = "explorer.exe",
                     Arguments = $"/select,\"{path}\"",
                     UseShellExecute = true
-                });
+                })?.Dispose();
             }
             else
             {


### PR DESCRIPTION
## Summary

Disposes the `Process` handle returned by `Process.Start(...)` at 10 fire-and-launch sites that previously discarded it — a handle leak (same class as the AdminHelper/ProcessManager fixes shipped earlier).

## Sites fixed (`...)?.Dispose()`)
- `ContextMenuService` — explorer restart after applying context-menu changes
- `AboutViewModel` — updater `cmd.exe` launch, 'show in folder', open-URL
- `DeepCleanupViewModel`, `DiskAnalyzerViewModel`, `DuplicateFileViewModel`, `StartupViewModel` — 'show in Explorer' row actions
- `LogsViewModel` — open log folder, open Event Viewer, search online

## Why safe
`Process.Start` with `UseShellExecute=true` returns a handle to the launched process; disposing the handle does **not** terminate the process — it only releases the local handle we weren't tracking. Behavior is otherwise identical.

## Verification
- Propagate check: grepped every `Process.Start(` in the app; all results are now disposed, assigned, or returned (none discarded).
- Build: main + Tests **0 warnings / 0 errors**.

`fix:` → patch release (1.20.23). Protocol C to follow.