### PR TITLE
refactor: use SearchValues for char-set scans in CSV export and version parsing

### DIFF
--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Buffers;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Json;
@@ -35,6 +36,10 @@ public sealed class UpdateService
         assetName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase);
 
     private static readonly HttpClient Http = CreateClient();
+
+    // Version-suffix separators (pre-release / build / trailing space). Hoisted to a
+    // SearchValues so ParseVersion's scan doesn't allocate a char[] per call.
+    private static readonly SearchValues<char> VersionSuffixSeparators = SearchValues.Create("-+ ");
 
     private static HttpClient CreateClient()
     {
@@ -381,7 +386,7 @@ public sealed class UpdateService
             s = s[1..];
         // Reject if still starts with a letter (e.g. "vv1.2.3" → "v1.2.3" → still starts with v).
         if (s.Length == 0 || char.IsLetter(s[0])) return null;
-        var cut = s.IndexOfAny(new[] { '-', '+', ' ' });
+        var cut = s.AsSpan().IndexOfAny(VersionSuffixSeparators);
         if (cut > 0) s = s[..cut];
         return Version.TryParse(s, out var v) ? v : null;
     }

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Buffers;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -28,6 +29,10 @@ public sealed partial class LogsViewModel : ViewModelBase
     private readonly EventLogService _eventLogs;
     private readonly SynchronizationContext? _sync;
     private CancellationTokenSource? _cts;
+
+    // Characters that force a CSV field to be quoted. Hoisted to a SearchValues so the
+    // per-field scan in Csv() doesn't allocate a char[] on every call during export.
+    private static readonly SearchValues<char> CsvSpecials = SearchValues.Create(",\"\n\r");
 
     public BulkObservableCollection<FriendlyEventEntry> Entries { get; } = new();
     public ICollectionView EntriesView { get; }
@@ -330,7 +335,7 @@ public sealed partial class LogsViewModel : ViewModelBase
     private static string Csv(string? s)
     {
         s ??= "";
-        if (s.IndexOfAny(new[] { ',', '"', '\n', '\r' }) >= 0)
+        if (s.AsSpan().IndexOfAny(CsvSpecials) >= 0)
             return "\"" + s.Replace("\"", "\"\"") + "\"";
         return s;
     }


### PR DESCRIPTION
## Summary

Replaces two `IndexOfAny(new char[] { ... })` calls — which allocate a `char[]` on every invocation — with hoisted static `SearchValues<char>` and span-based `IndexOfAny` (.NET 10 idiom). Byte-identical result, no per-call allocation.

## Changes
- `LogsViewModel.Csv` (CSV export, called per-field × per-row) — `s.IndexOfAny(new[]{',','"','\n','\r'})` → static `CsvSpecials = SearchValues.Create(",\"\n\r")` + `s.AsSpan().IndexOfAny(CsvSpecials)`.
- `UpdateService.ParseVersion` — `s.IndexOfAny(new[]{'-','+',' '})` → static `VersionSuffixSeparators` + span IndexOfAny.

## Why byte-identical
`SearchValues<char>.IndexOfAny` over a span returns the same first-match index as `string.IndexOfAny(char[])`; only the allocation is removed.

## Verification
- Build: main + Tests **0 warnings / 0 errors**.

`refactor:` → no release.