### PR TITLE
test: remove tautological asserts and de-flake Progress<T> tests via SyncProgress

### DIFF
--- a/SysManager/SysManager.Tests/AdminHelperTests.cs
+++ b/SysManager/SysManager.Tests/AdminHelperTests.cs
@@ -13,15 +13,12 @@ namespace SysManager.Tests;
 public class AdminHelperTests
 {
     [Fact]
-    public void IsElevated_ReturnsBoolean()
-    {
-        var result = AdminHelper.IsElevated();
-        Assert.IsType<bool>(result);
-    }
-
-    [Fact]
     public void IsElevated_IsConsistentAcrossCalls()
     {
+        // Elevation state cannot change during the test process's lifetime, so two
+        // calls must agree. (The former IsElevated_ReturnsBoolean test asserted
+        // Assert.IsType<bool> on a bool-returning method — always true, tested nothing —
+        // and was folded into this real invariant.)
         var a = AdminHelper.IsElevated();
         var b = AdminHelper.IsElevated();
         Assert.Equal(a, b);
@@ -45,10 +42,8 @@ public class AdminHelperTests
         Assert.Null(ex);
     }
 
-    [Fact]
-    public void RelaunchAsAdmin_ReturnsBoolean()
-    {
-        var result = AdminHelper.RelaunchAsAdmin();
-        Assert.IsType<bool>(result);
-    }
+    // Removed RelaunchAsAdmin_ReturnsBoolean: it asserted Assert.IsType<bool> on a
+    // bool-returning method (always true, tested nothing) while needlessly invoking the
+    // side-effecting relaunch a third time. RelaunchAsAdmin_DoesNotThrow already covers
+    // the call.
 }

--- a/SysManager/SysManager.Tests/AppUpdatesViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppUpdatesViewModelTests.cs
@@ -39,10 +39,13 @@ public class AppUpdatesViewModelTests
     }
 
     [Fact]
-    public void Constructor_IsElevated_IsBoolean()
+    public void Constructor_IsElevated_MatchesAdminHelper()
     {
+        // The VM seeds IsElevated from AdminHelper.IsElevated(); assert it reflects that
+        // source of truth rather than the old tautological Assert.IsType<bool> (which
+        // always passed on a bool property).
         var vm = NewVm();
-        Assert.IsType<bool>(vm.IsElevated);
+        Assert.Equal(SysManager.Helpers.AdminHelper.IsElevated(), vm.IsElevated);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/DiskAnalyzerServiceTests.cs
+++ b/SysManager/SysManager.Tests/DiskAnalyzerServiceTests.cs
@@ -183,14 +183,14 @@ public class DiskAnalyzerServiceTests : IDisposable
         CreateFile(Path.Combine("a", "f.bin"), 1024);
         CreateFile(Path.Combine("b", "f.bin"), 1024);
 
-        var reports = new List<DiskAnalyzerService.AnalysisProgress>();
-        var progress = new Progress<DiskAnalyzerService.AnalysisProgress>(p => reports.Add(p));
+        // SyncProgress captures every report synchronously, so by the time AnalyzeAsync
+        // returns all reports are present — no Task.Delay race.
+        var progress = new SyncProgress<DiskAnalyzerService.AnalysisProgress>();
 
         await _service.AnalyzeAsync(_root, progress);
-        await Task.Delay(100);
 
-        Assert.True(reports.Count >= 1);
-        Assert.Contains(reports, r => r.CurrentFolder == "Done");
+        Assert.True(progress.Reports.Count >= 1);
+        Assert.Contains(progress.Reports, r => r.CurrentFolder == "Done");
     }
 
     // ── ShouldSkip ──

--- a/SysManager/SysManager.Tests/DuplicateFileServiceTests.cs
+++ b/SysManager/SysManager.Tests/DuplicateFileServiceTests.cs
@@ -247,14 +247,13 @@ public class DuplicateFileServiceTests : IDisposable
         CreateFile("a.bin", content);
         CreateFile("b.bin", content);
 
-        var reports = new List<DuplicateFileService.ScanProgress>();
-        var progress = new Progress<DuplicateFileService.ScanProgress>(p => reports.Add(p));
+        // SyncProgress captures reports synchronously — no Task.Delay race.
+        var progress = new SyncProgress<DuplicateFileService.ScanProgress>();
 
         await _service.ScanAsync(_root, progress: progress);
-        await Task.Delay(100); // let Progress<T> flush
 
-        Assert.True(reports.Count >= 1);
-        Assert.Contains(reports, r => r.Phase == "Complete");
+        Assert.True(progress.Reports.Count >= 1);
+        Assert.Contains(progress.Reports, r => r.Phase == "Complete");
     }
 
     // ── Hash correctness ──

--- a/SysManager/SysManager.Tests/LargeFileScannerTests.cs
+++ b/SysManager/SysManager.Tests/LargeFileScannerTests.cs
@@ -170,15 +170,13 @@ public class LargeFileScannerTests : IDisposable
     public async Task Scan_ReportsProgress()
     {
         CreateFile("big.bin", 2000);
-        var reports = new List<LargeFileScanner.LargeFileProgress>();
-        var progress = new Progress<LargeFileScanner.LargeFileProgress>(p => reports.Add(p));
+        // SyncProgress captures reports synchronously — no Task.Delay race.
+        var progress = new SyncProgress<LargeFileScanner.LargeFileProgress>();
 
         await _scanner.ScanAsync(_root, minSizeBytes: 500, top: 10, progress: progress);
 
-        // Give Progress<T> a moment to flush (it posts to SynchronizationContext)
-        await Task.Delay(100);
-        // At minimum, the final "Done" report should be there
-        Assert.True(reports.Count >= 1);
+        // At minimum, the final "Done" report should be there.
+        Assert.True(progress.Reports.Count >= 1);
     }
 
     // ---------- LargeFileEntry model ----------

--- a/SysManager/SysManager.Tests/SyncProgress.cs
+++ b/SysManager/SysManager.Tests/SyncProgress.cs
@@ -1,0 +1,18 @@
+// SysManager · SyncProgress
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Synchronous <see cref="IProgress{T}"/> that records every report on the calling
+/// thread. Unlike <see cref="System.Progress{T}"/> — which marshals callbacks via the
+/// captured <see cref="System.Threading.SynchronizationContext"/> asynchronously — this
+/// captures each report deterministically by the time the awaited call returns, so tests
+/// need no <c>Task.Delay</c> guess and never race the callback pump.
+/// </summary>
+public sealed class SyncProgress<T> : IProgress<T>
+{
+    public List<T> Reports { get; } = [];
+    public void Report(T value) => Reports.Add(value);
+}


### PR DESCRIPTION
## Summary

Test-quality cleanup: removes assertions that always pass and de-flakes the
`Progress<T>` race tests. Touches only the test project — no product code.

## Changes

**Tautological assertions** (`Assert.IsType<bool>(x)` on a `bool`-returning member always
passes — tests nothing):
- `AdminHelperTests.IsElevated_ReturnsBoolean` — removed; folded into the existing
  `IsElevated_IsConsistentAcrossCalls` (a real invariant).
- `AdminHelperTests.RelaunchAsAdmin_ReturnsBoolean` — removed; it also needlessly invoked
  the side-effecting relaunch a third time. `RelaunchAsAdmin_DoesNotThrow` already covers it.
- `AppUpdatesViewModelTests.Constructor_IsElevated_IsBoolean` → `..._MatchesAdminHelper`:
  now asserts `vm.IsElevated == AdminHelper.IsElevated()` (the VM's actual source of truth).

**Flaky `Progress<T>` tests** — `Progress<T>` marshals callbacks asynchronously via the
captured `SynchronizationContext`, so these tests slept `Task.Delay(100)` and hoped the
callbacks had flushed (a race on slow CI). Replaced with a new shared
`SyncProgress<T>` helper that records reports synchronously on the calling thread, so all
reports are present by the time the awaited call returns — no sleep, no race:
- `DiskAnalyzerServiceTests.Analyze_ReportsProgress`
- `DuplicateFileServiceTests.Scan_ReportsProgress`
- `LargeFileScannerTests.Scan_ReportsProgress`

New file `SyncProgress.cs` generalizes the pattern already used privately in
`FileShredderServiceTests`.

## Verification

- Build: Tests project **0 warnings / 0 errors**.

`test:` → no release.
