### PR TITLE
test: cover ShortcutCleaner delete and NetworkRepair flush-DNS confirmation gates

### DIFF
--- a/SysManager/SysManager.Tests/NetworkRepairViewModelTests.cs
+++ b/SysManager/SysManager.Tests/NetworkRepairViewModelTests.cs
@@ -2,16 +2,24 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using NSubstitute;
+using SysManager.Services;
 using SysManager.ViewModels;
 
 namespace SysManager.Tests;
 
+// Serialized: the flush-DNS gate test swaps the static DialogService.Instance.
+[Collection("DialogService")]
 public class NetworkRepairViewModelTests
 {
+    private static NetworkSharedState NewShared() =>
+        new(new PingMonitorService(), new TracerouteService(), new TracerouteMonitorService(),
+            new SpeedTestService(), new NetworkRepairService(new PowerShellRunner()));
+
     [Fact]
     public void Constructor_SetsShared()
     {
-        var shared = new NetworkSharedState(new Services.PingMonitorService(), new Services.TracerouteService(), new Services.TracerouteMonitorService(), new Services.SpeedTestService(), new Services.NetworkRepairService(new Services.PowerShellRunner()));
+        var shared = NewShared();
         var vm = new NetworkRepairViewModel(shared);
         Assert.Same(shared, vm.Shared);
     }
@@ -19,10 +27,35 @@ public class NetworkRepairViewModelTests
     [Fact]
     public void DefaultState_NotRepairing()
     {
-        var shared = new NetworkSharedState(new Services.PingMonitorService(), new Services.TracerouteService(), new Services.TracerouteMonitorService(), new Services.SpeedTestService(), new Services.NetworkRepairService(new Services.PowerShellRunner()));
+        var shared = NewShared();
         var vm = new NetworkRepairViewModel(shared);
         Assert.False(vm.IsRepairing);
         Assert.Equal("", vm.RepairStatus);
         Assert.False(vm.RepairNeedsReboot);
+    }
+
+    [Fact]
+    public async Task FlushDns_WhenUserDeclinesConfirm_DoesNothing()
+    {
+        var vm = new NetworkRepairViewModel(NewShared());
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false); // user clicks "No"
+        DialogService.Instance = dialog;
+        try
+        {
+            await vm.FlushDnsCommand.ExecuteAsync(null);
+
+            // Declining must prompt once and then short-circuit before any repair runs:
+            // status stays empty and the VM never enters the repairing state.
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            Assert.Equal("", vm.RepairStatus);
+            Assert.False(vm.IsRepairing);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
     }
 }

--- a/SysManager/SysManager.Tests/ShortcutCleanerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ShortcutCleanerViewModelTests.cs
@@ -2,12 +2,16 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using NSubstitute;
 using SysManager.Models;
+using SysManager.Services;
 using SysManager.ViewModels;
 using Xunit;
 
 namespace SysManager.Tests;
 
+// Serialized: the DeleteSelected gate tests swap the static DialogService.Instance.
+[Collection("DialogService")]
 public class ShortcutCleanerViewModelTests
 {
     [Fact]
@@ -68,5 +72,53 @@ public class ShortcutCleanerViewModelTests
 
         s.IsSelected = false;
         Assert.Equal("IsSelected", changedProp);
+    }
+
+    // ── DeleteSelected confirmation gate (destructive — removes broken .lnk files) ──
+
+    [Fact]
+    public void DeleteSelected_WhenUserDeclinesConfirm_DeletesNothing()
+    {
+        var vm = new ShortcutCleanerViewModel(new ShortcutCleanerService());
+        vm.BrokenShortcuts.Add(new BrokenShortcut { Name = "A", ShortcutPath = @"C:\nope\a.lnk", IsSelected = true });
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false); // user clicks "No"
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.DeleteSelectedCommand.Execute(null);
+
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            // Declining must leave the list untouched — nothing was deleted.
+            Assert.Single(vm.BrokenShortcuts);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public void DeleteSelected_WithNoSelection_NeverPromptsConfirm()
+    {
+        var vm = new ShortcutCleanerViewModel(new ShortcutCleanerService());
+        vm.BrokenShortcuts.Add(new BrokenShortcut { Name = "A", IsSelected = false });
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.DeleteSelectedCommand.Execute(null);
+
+            // No items selected → the destructive prompt must not appear at all.
+            dialog.DidNotReceive().Confirm(Arg.Any<string>(), Arg.Any<string>());
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds confirmation-gate coverage for two more destructive ViewModels that had none.

## Tests added
- **ShortcutCleanerViewModel** (deletes broken .lnk files):
  - `DeleteSelected_WhenUserDeclinesConfirm_DeletesNothing` — decline ⇒ Confirm received once, the selected shortcut stays in the list.
  - `DeleteSelected_WithNoSelection_NeverPromptsConfirm` — no selection ⇒ no prompt at all.
- **NetworkRepairViewModel**:
  - `FlushDns_WhenUserDeclinesConfirm_DoesNothing` — decline ⇒ Confirm received once, `RepairStatus` stays empty and `IsRepairing` false (short-circuits before any repair). (Winsock/TCP-IP reset gates require elevation and exit before Confirm on CI, so the un-gated flush-DNS path is the testable one.)

## Pattern
Same established idiom: `Substitute.For<IDialogService>()` swapped into `DialogService.Instance` (restored in `finally`), both classes now `[Collection("DialogService")]` to serialize the shared-static swap. ShortcutCleaner's delete uses a static service method, so the decline test asserts observable VM state (list unchanged) rather than mocking the static.

## Verification
- Build: Tests project **0 warnings / 0 errors**.

`test:` → no release.