### PR TITLE
fix: preserve hosts file permissions by replacing in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Saving the hosts file now preserves its original permissions.** The atomic save introduced in 1.20.24 replaced the file by moving a freshly written temporary file over it, which left the new file with the folder's default permissions instead of the hosts file's own (more restrictive) access-control settings. Saving now replaces the file in place, keeping its existing permissions and attributes intact.
+
 ## [1.20.24] - 2026-06-12
 
 ### Fixed

--- a/SysManager/SysManager.Tests/HostsFileServiceTests.cs
+++ b/SysManager/SysManager.Tests/HostsFileServiceTests.cs
@@ -117,6 +117,38 @@ public class HostsFileServiceTests
     }
 
     [Fact]
+    public void SaveHosts_PreservesOriginalFileIdentity_NotJustContent()
+    {
+        // Regression (ACL/attribute loss): SaveHosts must REPLACE the existing hosts
+        // file in place (File.Replace) rather than relink a brand-new inode over it
+        // (File.Move overwrite). A brand-new file would inherit the directory's default
+        // security descriptor instead of the security-hardened hosts file's own DACL.
+        // We can't assert the System32 DACL without admin, but File.Replace preserves the
+        // replaced file's creation time whereas File.Move resets it to "now" — so a
+        // preserved (old) creation time proves the in-place replace path is taken.
+        var (svc, hosts, dir) = NewServiceWithTempHosts("127.0.0.1 localhost\n");
+        try
+        {
+            var original = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            File.SetCreationTimeUtc(hosts, original);
+
+            svc.SaveHosts(new List<HostsEntry>
+            {
+                new() { IpAddress = "10.0.0.1", Hostname = "managed", IsEnabled = true }
+            });
+
+            // File.Replace keeps the original creation timestamp; File.Move(overwrite)
+            // would have stamped it with the moment the temp file was written.
+            Assert.Equal(original, File.GetCreationTimeUtc(hosts));
+            Assert.Contains("managed", File.ReadAllText(hosts));
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void SaveHosts_LeavesNoTempFileBehind()
     {
         // Regression (atomic write): SaveHosts writes to a temp file then moves it

--- a/SysManager/SysManager/Services/HostsFileService.cs
+++ b/SysManager/SysManager/Services/HostsFileService.cs
@@ -129,12 +129,23 @@ public sealed partial class HostsFileService
 
         // Write atomically: a crash midway through File.WriteAllLines would otherwise
         // leave the hosts file truncated or empty. Write to a temp file in the same
-        // directory, then replace the target in one move.
+        // directory, then swap it into place in one operation.
         var tempPath = HostsPath + ".sysmanager.tmp";
         try
         {
             File.WriteAllLines(tempPath, lines);
-            File.Move(tempPath, HostsPath, overwrite: true);
+
+            // File.Replace preserves the target's existing ACL/owner and attributes
+            // (it copies the security descriptor of the file being replaced onto the
+            // replacement), so the security-hardened system hosts file keeps its DACL.
+            // File.Move(overwrite:true) would instead relink a brand-new inode that
+            // inherits only the directory's default ACL — silently weakening the file.
+            // File.Replace requires the destination to already exist; on the very first
+            // creation there is no descriptor to preserve, so a plain Move is correct.
+            if (File.Exists(HostsPath))
+                File.Replace(tempPath, HostsPath, destinationBackupFileName: null);
+            else
+                File.Move(tempPath, HostsPath, overwrite: false);
         }
         finally
         {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.24</Version>
-    <FileVersion>1.20.24.0</FileVersion>
-    <AssemblyVersion>1.20.24.0</AssemblyVersion>
+    <Version>1.20.25</Version>
+    <FileVersion>1.20.25.0</FileVersion>
+    <AssemblyVersion>1.20.25.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## What

The atomic hosts-file save introduced in 1.20.24 replaced the target with `File.Move(tempPath, HostsPath, overwrite: true)`. `File.Move` relinks a brand-new inode into place, so the resulting hosts file inherited the parent directory's **default** ACL and attributes rather than the security-hardened original's own DACL/owner. On `System32\drivers\etc\hosts` that silently weakens the file's access-control settings (and can drop Read-only/Hidden/System attributes the original carried).

## Fix

Use `File.Replace(tempPath, HostsPath, destinationBackupFileName: null)`, which copies the **replaced** file's security descriptor and attributes onto the replacement while staying atomic on the same NTFS volume — so we keep both crash-safety and permission preservation. A plain `File.Move` is kept only for first-time creation, when there is no existing descriptor to preserve.

## Test

Adds `SaveHosts_PreservesOriginalFileIdentity_NotJustContent`: stamps the temp hosts file with a known creation time, saves, and asserts the creation time survives. `File.Replace` preserves it; the old `File.Move` would have reset it to "now" — so the test pins the in-place-replace behaviour without needing admin/ACL APIs.

## Notes

- No behaviour change for callers; the saved content is identical.
- Existing backup/restore/atomic-temp regression tests unchanged and still pass.
- Builds clean (Release, main + tests): 0 warnings, 0 errors.