### PR TITLE
fix: dispose WMI query result sets in About diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **The About → System Info diagnostics no longer leak system handles.** Building the environment summary (CPU, RAM, GPU, display, and OS lines) queried Windows for hardware details but never released the query result sets, leaking a small COM handle on each refresh. Every query now disposes its results, matching how the rest of the app handles these reads. No change to the information shown.
+
 ## [1.20.24] - 2026-06-12
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.24</Version>
-    <FileVersion>1.20.24.0</FileVersion>
-    <AssemblyVersion>1.20.24.0</AssemblyVersion>
+    <Version>1.20.26</Version>
+    <FileVersion>1.20.26.0</FileVersion>
+    <AssemblyVersion>1.20.26.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -287,7 +287,8 @@ public sealed partial class AboutViewModel : ViewModelBase
             {
                 using var cpuSearch = new System.Management.ManagementObjectSearcher(
                     "SELECT Name,NumberOfCores,NumberOfLogicalProcessors,MaxClockSpeed FROM Win32_Processor");
-                foreach (System.Management.ManagementObject mo in cpuSearch.Get())
+                using var cpuResults = cpuSearch.Get();
+                foreach (System.Management.ManagementObject mo in cpuResults)
                     using (mo)
                     {
                         var name = mo["Name"]?.ToString()?.Trim() ?? "unknown";
@@ -308,7 +309,8 @@ public sealed partial class AboutViewModel : ViewModelBase
             {
                 using var memSearch = new System.Management.ManagementObjectSearcher(
                     "SELECT TotalVisibleMemorySize,FreePhysicalMemory FROM Win32_OperatingSystem");
-                foreach (System.Management.ManagementObject mo in memSearch.Get())
+                using var memResults = memSearch.Get();
+                foreach (System.Management.ManagementObject mo in memResults)
                     using (mo)
                     {
                         var totalKb = mo["TotalVisibleMemorySize"] as ulong? ?? 0;
@@ -325,7 +327,8 @@ public sealed partial class AboutViewModel : ViewModelBase
             {
                 using var gpuSearch = new System.Management.ManagementObjectSearcher(
                     "SELECT Name,DriverVersion,AdapterRAM FROM Win32_VideoController");
-                foreach (System.Management.ManagementObject mo in gpuSearch.Get())
+                using var gpuResults = gpuSearch.Get();
+                foreach (System.Management.ManagementObject mo in gpuResults)
                     using (mo)
                     {
                         var name = mo["Name"]?.ToString()?.Trim() ?? "unknown";
@@ -353,7 +356,8 @@ public sealed partial class AboutViewModel : ViewModelBase
             {
                 using var dispSearch = new System.Management.ManagementObjectSearcher(
                     "SELECT CurrentHorizontalResolution,CurrentVerticalResolution,CurrentRefreshRate FROM Win32_VideoController");
-                foreach (System.Management.ManagementObject mo in dispSearch.Get())
+                using var dispResults = dispSearch.Get();
+                foreach (System.Management.ManagementObject mo in dispResults)
                     using (mo)
                     {
                         var w = mo["CurrentHorizontalResolution"];
@@ -390,7 +394,8 @@ public sealed partial class AboutViewModel : ViewModelBase
             // WMI Caption gives a friendly name like "Microsoft Windows 11 Pro"
             using var searcher = new System.Management.ManagementObjectSearcher(
                 "SELECT Caption,BuildNumber FROM Win32_OperatingSystem");
-            foreach (System.Management.ManagementObject mo in searcher.Get())
+            using var results = searcher.Get();
+            foreach (System.Management.ManagementObject mo in results)
                 using (mo)
                 {
                     var caption = mo["Caption"]?.ToString()?.Trim() ?? "";


### PR DESCRIPTION
## What

`AboutViewModel.BuildEnvironmentInfo` (CPU/RAM/GPU/display) and `DescribeWindows` disposed each `ManagementObjectSearcher` and the inner `ManagementObject` (`using (mo)`), but the `ManagementObjectCollection` returned by `.Get()` was iterated inline in the `foreach` header and never disposed. That collection is itself `IDisposable` — it wraps a COM `IEnumWbemClassObject` enumerator — so each diagnostics refresh leaked a handle, reclaimed only non-deterministically by the GC finalizer.

This was the lone inconsistency: every other WMI call site in the codebase (SystemInfoService, SystemReportService, DiskHealthService, FixedDriveService, BatteryService, TemperatureService, MemoryTestService, DashboardViewModel) already captures the collection with `using var`.

## Fix

Capture each `.Get()` in a `using var …Results` local before the loop, at all 5 sites (CPU, RAM, GPU, display, OS). No change to the diagnostics text.

## Test

No new test: handle counts are non-deterministic and the path requires live WMI (the existing WMI-collection sites are likewise covered by integration/runtime checks, not unit leak assertions). Verified by Release build (main + tests): 0 warnings, 0 errors.