### PR TITLE
chore: ignore local working artifacts and scratch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,26 @@ _ReSharper*/
 !.vscode/tasks.json
 !.vscode/extensions.json
 .commitmsg
+
+# Local working artifacts — review reports, scratch notes, and temp scratch that
+# tooling generates next to the source tree. These are never part of the project
+# and must never be committed.
+*_REPORT.json
+*_AUDIT.json
+*-REVIEW*.json
+*_REVIEW.json
+AUDIT-*.md
+audit-findings/
+temp_releases/
+temp_bugs.json
+pr-body.md
+pr_body.md
+mockup-*.html
+ui-test-results.txt
+*-results.txt
+
+# Temp / scratch files (any tmp_ or .tmp_ prefix, scratch query files)
+tmp_*.json
+.tmp_*
+*.graphql
+docs/screenshots/temp/


### PR DESCRIPTION
## What

Local tooling and review passes drop report/scratch files next to the source tree — review reports, audit JSON, temp release notes, scratch queries, temp screenshots. None of them belong in the project, but `.gitignore` did not cover them, so a blanket `git add -A` could accidentally stage them.

## Change

Add ignore patterns for these working artifacts:

```
*_REPORT.json   *_AUDIT.json   *-REVIEW*.json   *_REVIEW.json   AUDIT-*.md
audit-findings/   temp_releases/   temp_bugs.json
pr-body.md   pr_body.md   mockup-*.html   ui-test-results.txt   *-results.txt
tmp_*.json   .tmp_*   *.graphql   docs/screenshots/temp/
```

## Safety

Verified `git ls-files` against every new pattern: **none match any currently tracked file**, so nothing in the repo is newly ignored — only future scratch is blocked. No behavior change to the app.