### PR TITLE
docs: promote hosts-permissions fix to 1.20.25 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.25] - 2026-06-16
+
 ### Fixed
 - **Saving the hosts file now preserves its original permissions.** The atomic save introduced in 1.20.24 replaced the file by moving a freshly written temporary file over it, which left the new file with the folder's default permissions instead of the hosts file's own (more restrictive) access-control settings. Saving now replaces the file in place, keeping its existing permissions and attributes intact.
 


### PR DESCRIPTION
## Why

The 1.20.25 release never published. PR #887 (hosts file permission preservation) bumped the version and tagged `v1.20.25`, but its CHANGELOG note was left under `## [Unreleased]` instead of a versioned `## [1.20.25]` section. The release workflow fails loud when it can't find a `## [X.Y.Z]` block (to avoid shipping a generic 'see CHANGELOG' placeholder), so the run errored at *Extract release notes* and no GitHub Release was created.

## Fix

Promote the note to a dated `## [1.20.25] - 2026-06-16` section and leave a fresh empty `[Unreleased]` on top (Keep a Changelog convention). After merge, the `v1.20.25` tag will be moved to the fixed commit and the release re-run.

Docs-only; no code change.