### PR TITLE
fix: empty Recycle Bin via shell API in Deep Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.27] - 2026-06-17
+
+### Fixed
+- **Deep Cleanup now empties the Recycle Bin through the Windows shell instead of deleting its files directly.** The "Recycle Bin (all drives)" category used the same raw file-delete path as ordinary caches, removing the internal `$Recycle.Bin` index/data files and per-account folders directly. That could leave the Recycle Bin in an inconsistent state (ghost or undeletable items in Explorer) until the next sign-in. It now empties the bin via the documented shell API, the same safe method used elsewhere in the app.
+
 ## [1.20.26] - 2026-06-16
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DeepCleanupServiceTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupServiceTests.cs
@@ -135,6 +135,23 @@ public class DeepCleanupServiceTests
     }
 
     [Fact]
+    public async Task ScanAsync_RecycleBinCategory_IsFlaggedForShellApi()
+    {
+        // The Recycle Bin must be emptied through the shell API (SHEmptyRecycleBin),
+        // not the generic file-delete path which corrupts the per-SID bin metadata.
+        // CleanAsync routes on IsRecycleBin, so a regression that drops the flag would
+        // silently send the bin back to raw delete. Pin the flag here.
+        var s = new DeepCleanupService();
+        var r = await s.ScanAsync();
+        var bin = r.FirstOrDefault(c => c.Name.Contains("Recycle", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(bin);
+        Assert.True(bin!.IsRecycleBin, "Recycle Bin category must be flagged IsRecycleBin so cleanup uses the shell API");
+        // And no other category should carry the flag.
+        Assert.All(r.Where(c => !c.Name.Contains("Recycle", StringComparison.OrdinalIgnoreCase)),
+            c => Assert.False(c.IsRecycleBin));
+    }
+
+    [Fact]
     public async Task ScanAsync_IncludesSteam()
     {
         var s = new DeepCleanupService();

--- a/SysManager/SysManager/Models/CleanupCategory.cs
+++ b/SysManager/SysManager/Models/CleanupCategory.cs
@@ -24,6 +24,13 @@ public sealed partial class CleanupCategory : ObservableObject
     public TimeSpan? OlderThan { get; init; }
     public bool IsDestructiveHint { get; init; }
 
+    /// <summary>
+    /// True for the Recycle Bin category, which must be emptied through the shell
+    /// API (SHEmptyRecycleBin) rather than the generic file-delete path — deleting
+    /// the per-SID <c>$Recycle.Bin</c> contents directly corrupts the bin's state.
+    /// </summary>
+    public bool IsRecycleBin { get; init; }
+
     public string SizeDisplay => FormatHelper.FormatSize(TotalSizeBytes);
     public string CountDisplay => SkippedCount > 0 ? $"{FileCount:N0} files · {SkippedCount:N0} skipped" : $"{FileCount:N0} files";
 }

--- a/SysManager/SysManager/Services/DeepCleanupService.cs
+++ b/SysManager/SysManager/Services/DeepCleanupService.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.IO;
+using System.Runtime.InteropServices;
 using Serilog;
 using SysManager.Models;
 
@@ -16,7 +17,7 @@ namespace SysManager.Services;
 /// Both Scan and Clean accept an <see cref="IProgress{T}"/> so the UI can
 /// show a determinate progress bar and the current bucket being scanned.
 /// </summary>
-public sealed class DeepCleanupService
+public sealed partial class DeepCleanupService
 {
     public sealed record ScanProgress(int Current, int Total, string CategoryName);
 
@@ -38,7 +39,8 @@ public sealed class DeepCleanupService
         string Description,
         string[] Paths,
         TimeSpan? OlderThan = null,
-        bool IsDestructiveHint = false);
+        bool IsDestructiveHint = false,
+        bool IsRecycleBin = false);
 
     private static List<Def> BuildDefinitions()
     {
@@ -118,7 +120,8 @@ public sealed class DeepCleanupService
                 DriveInfo.GetDrives()
                     .Where(d => d.DriveType == DriveType.Fixed && d.IsReady)
                     .Select(d => Path.Combine(d.RootDirectory.FullName, "$Recycle.Bin"))
-                    .ToArray()),
+                    .ToArray(),
+                IsRecycleBin: true),
 
             new("Steam — browser & depot cache",
                 "Steam web browser cache, HTML cache, app cache and depot lookup cache. Doesn't touch game files, downloads or logins.",
@@ -241,6 +244,7 @@ public sealed class DeepCleanupService
                 SkippedCount = skipped,
                 OlderThan = d.OlderThan,
                 IsDestructiveHint = d.IsDestructiveHint,
+                IsRecycleBin = d.IsRecycleBin,
                 IsSelected = size > 0 && !d.IsDestructiveHint
             });
         }
@@ -328,6 +332,27 @@ public sealed class DeepCleanupService
             if (ct.IsCancellationRequested) break;
             var cat = selected[idx];
             progress?.Report(new ScanProgress(idx + 1, total, "Cleaning " + cat.Name));
+
+            // The Recycle Bin is not an ordinary folder: each `$Recycle.Bin\<SID>`
+            // holds paired $I/$R index/data files plus a system desktop.ini, and the
+            // shell tracks bin state in its own structures. Deleting those files
+            // directly — and removing the per-SID folder out from under the shell —
+            // leaves the bin inconsistent (ghost/undeletable items in Explorer).
+            // Empty it through the documented shell API instead, matching TuneUp.
+            if (cat.IsRecycleBin)
+            {
+                var sizeBefore = cat.TotalSizeBytes;
+                if (EmptyRecycleBin())
+                {
+                    freed += sizeBefore;
+                    filesDeleted += cat.FileCount;
+                }
+                else
+                {
+                    errors.Add($"{cat.Name}: the Recycle Bin could not be emptied.");
+                }
+                continue;
+            }
 
             var cutoff = cat.OlderThan.HasValue ? DateTime.UtcNow - cat.OlderThan.Value : (DateTime?)null;
             foreach (var path in cat.Paths)
@@ -452,5 +477,33 @@ public sealed class DeepCleanupService
         }
         catch (IOException) { return true; }
         catch (UnauthorizedAccessException) { return true; }
+    }
+
+    // ---------- Recycle Bin (shell API, not raw file delete) ----------
+
+    /// <summary>
+    /// Empties the Recycle Bin on all drives via the documented shell API.
+    /// Returns true on success (or when the bin is already empty).
+    /// </summary>
+    private static bool EmptyRecycleBin()
+    {
+        try
+        {
+            // SHEmptyRecycleBin with SHERB_NOCONFIRMATION | SHERB_NOPROGRESSUI | SHERB_NOSOUND.
+            int hr = NativeMethods.SHEmptyRecycleBin(IntPtr.Zero, null, 0x00000007);
+            // S_OK (0) = success, 0x80070012 (ERROR_NO_MORE_FILES) = bin already empty.
+            return hr >= 0 || unchecked((uint)hr) == 0x80070012;
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            Log.Warning("Deep cleanup: empty recycle bin failed: {Error}", ex.Message);
+            return false;
+        }
+    }
+
+    private static partial class NativeMethods
+    {
+        [LibraryImport("shell32.dll", StringMarshalling = StringMarshalling.Utf16, EntryPoint = "SHEmptyRecycleBinW")]
+        internal static partial int SHEmptyRecycleBin(IntPtr hwnd, string? pszRootPath, uint dwFlags);
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.26</Version>
-    <FileVersion>1.20.26.0</FileVersion>
-    <AssemblyVersion>1.20.26.0</AssemblyVersion>
+    <Version>1.20.27</Version>
+    <FileVersion>1.20.27.0</FileVersion>
+    <AssemblyVersion>1.20.27.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## What

Deep Cleanup's "Recycle Bin (all drives)" category routed through the generic file-delete path in `Clean()`: it walked each `$Recycle.Bin` tree and deleted the paired `$I`/`$R` index/data files and per-SID folders directly.

The Recycle Bin is **not** an ordinary folder — the Windows shell tracks its state in its own structures. Deleting those files (and removing the per-SID folder) out from under the shell can leave the bin inconsistent: ghost or undeletable items in Explorer until the next sign-in. This category is auto-selected by default, so a routine cleanup could trigger it.

## Fix

Route the Recycle Bin category through `SHEmptyRecycleBin` (`SHERB_NOCONFIRMATION | SHERB_NOPROGRESSUI | SHERB_NOSOUND`) — the same documented shell API `TuneUpService` already uses — instead of the raw file walk.

- New `IsRecycleBin` flag on the internal `Def` record and the `CleanupCategory` model carries the category from scan → clean, so **only** that bucket takes the shell path; every other category is byte-for-byte unchanged.
- P/Invoke uses `[LibraryImport]` with `EntryPoint = "SHEmptyRecycleBinW"` (mirrors the existing TuneUp declaration).

## Test

Adds `ScanAsync_RecycleBinCategory_IsFlaggedForShellApi`: asserts the scanned Recycle Bin category is flagged `IsRecycleBin` and no other category is — a regression dropping the flag would silently send the bin back to raw delete. Builds clean (main + tests): 0 warnings, 0 errors.