### PR TITLE
fix: marshal Dashboard ETA hint to UI thread and log swallowed errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.28] - 2026-06-17
+
+### Fixed
+- **Dashboard alert checks are more robust.** The "estimated time remaining" hint that appears while a dashboard check is still running updated its on-screen state from a background thread, which could occasionally fail to display or glitch; it now updates on the UI thread like every other dashboard check. Separately, two error paths (a failed dashboard check and a failed quick action) now record the underlying error in the log so failures can be diagnosed instead of vanishing silently. No visible change in normal use.
+
 ## [1.20.26] - 2026-06-16
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.26</Version>
-    <FileVersion>1.20.26.0</FileVersion>
-    <AssemblyVersion>1.20.26.0</AssemblyVersion>
+    <Version>1.20.28</Version>
+    <FileVersion>1.20.28.0</FileVersion>
+    <AssemblyVersion>1.20.28.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -329,14 +329,20 @@ public sealed partial class DashboardViewModel : ViewModelBase
     private static async Task RunAlertScanAsync(DashboardAlert alert, Func<DashboardAlert, Task> scanner)
     {
         // Fire-and-forget ETA hint: after 5s of loading, surface a "remaining" note.
+        // The mutation must run on the UI thread — `alert` is a bound ObservableObject,
+        // so raising PropertyChanged off the thread-pool thread can throw or fail to
+        // update. Marshal onto the dispatcher exactly like the scanner bodies do.
         _ = Task.Run(async () =>
         {
             await Task.Delay(5000);
-            if (alert.State == AlertLoadingState.Loading)
+            System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
             {
-                alert.ShowEta = true;
-                alert.Eta = "~10s remaining";
-            }
+                if (alert.State == AlertLoadingState.Loading)
+                {
+                    alert.ShowEta = true;
+                    alert.Eta = "~10s remaining";
+                }
+            });
         });
 
         try
@@ -345,6 +351,7 @@ public sealed partial class DashboardViewModel : ViewModelBase
         }
         catch (Exception ex)
         {
+            Log.Debug(ex, "Dashboard alert scan failed: {Alert}", alert.Title);
             alert.Title = $"Check failed: {ex.Message}";
             alert.Severity = AlertSeverity.Yellow;
         }
@@ -692,6 +699,7 @@ public sealed partial class DashboardViewModel : ViewModelBase
         }
         catch (Exception ex)
         {
+            Log.Debug(ex, "Quick action {Name} failed", name);
             QuickActionStatus = "Failed";
             QuickActionDetail = ex.Message;
             IsQuickActionDone = true;


### PR DESCRIPTION
## What

Two robustness issues in `DashboardViewModel`:

1. **Off-UI-thread mutation of a bound object.** The fire-and-forget ETA hint in `RunAlertScanAsync` ("~10s remaining" after 5s of loading) set `alert.ShowEta` / `alert.Eta` directly from the `Task.Run` thread-pool thread. `DashboardAlert` is an `ObservableObject` bound to the alerts `ItemsControl`, so raising `PropertyChanged` off the UI thread can throw `InvalidOperationException` or intermittently fail to update — and the `alert.State` read races the scanner's writes. Every scanner body in this file already marshals via `Application.Current?.Dispatcher.BeginInvoke`; this path didn't.

2. **Two silent `catch (Exception)` blocks.** The alert-scan failure path and the quick-action failure path surfaced the message to the UI but never logged, leaving no trace for diagnosis — inconsistent with the other catches in the same file.

## Fix

- Wrap the ETA mutation (including the `alert.State` check) in `Dispatcher.BeginInvoke`.
- Add `Log.Debug(ex, ...)` to both catch blocks.

## Test

No unit test: both paths are fire-and-forget UI-thread-marshaling concerns that can't be asserted without a live WPF dispatcher (the sibling scanner paths are likewise covered by runtime/UI checks, not unit tests). Builds clean (main + tests): 0 warnings, 0 errors.