### PR TITLE
fix: measure actual bytes sent in Speed Test upload, fail on rejected POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.29] - 2026-06-17
+
+### Fixed
+- **Speed Test no longer reports an inflated upload speed when the server cuts the upload short.** The upload test always credited the full 50 MB payload against the elapsed time, even when the server rejected the request early and only part of the data was sent — producing an unrealistically high number. It now reports a failed measurement if the server rejects the upload, and otherwise measures the bytes actually sent, so the upload speed reflects reality.
+
 ## [1.20.26] - 2026-06-16
 
 ### Fixed

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -118,10 +118,23 @@ public sealed class SpeedTestService
         using var resp = await _http.PostAsync(CfUploadUrl, content, ct).ConfigureAwait(false);
         sw.Stop();
 
-        // Some responses are rejected with 4xx on POST size — treat as best-effort.
+        // If the server rejects the POST (e.g. 4xx on size) it can return before the
+        // full payload is sent. Reporting PayloadBytes over the now-tiny elapsed time
+        // would fabricate a grossly inflated upload speed, so treat a non-success
+        // response as a failed measurement (0) rather than a real number.
+        if (!resp.IsSuccessStatusCode)
+        {
+            progress?.Report((95, $"Upload measurement failed (HTTP {(int)resp.StatusCode})"));
+            return 0;
+        }
+
+        // Measure the bytes actually consumed by the HTTP stack (the stream's final
+        // position), not the intended payload — so a short-circuited upload reports
+        // the true transferred amount instead of the full 50 MB.
+        var sentBytes = stream.Position;
         var seconds = Math.Max(sw.Elapsed.TotalSeconds, 0.001);
-        progress?.Report((95, $"Upload complete: {PayloadBytes / 1024 / 1024} MB"));
-        return PayloadBytes * 8.0 / 1_000_000.0 / seconds;
+        progress?.Report((95, $"Upload complete: {sentBytes / 1024 / 1024} MB"));
+        return sentBytes * 8.0 / 1_000_000.0 / seconds;
     }
 
     /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.26</Version>
-    <FileVersion>1.20.26.0</FileVersion>
-    <AssemblyVersion>1.20.26.0</AssemblyVersion>
+    <Version>1.20.29</Version>
+    <FileVersion>1.20.29.0</FileVersion>
+    <AssemblyVersion>1.20.29.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## What

`MeasureUploadAsync` always returned `PayloadBytes * 8 / seconds` — crediting the full 50 MB regardless of how much was actually transferred. When the server rejects the POST early (Cloudflare returns 4xx on payload size, which the code's own comment acknowledged), `PostAsync` returns quickly having sent only part of the body, yet the formula still divides the full 50 MB by the now-tiny elapsed time — producing a grossly **inflated** upload speed shown to the user as a real measurement.

Unlike `MeasureDownloadAsync`, which counts bytes actually read and calls `EnsureSuccessStatusCode`, the upload path measured intended payload, not delivered payload.

## Fix

1. **Fail loud on rejection:** if `resp.IsSuccessStatusCode` is false, return `0` (failed measurement) instead of a fabricated rate.
2. **Measure actual bytes:** compute throughput from `stream.Position` — the bytes the HTTP stack actually consumed from `RandomChunkStream` — rather than `PayloadBytes`. A short-circuited upload now reports the true transferred amount.

## Test

No unit test: the upload path is `private static`, uses a shared static `HttpClient`, and requires a live Cloudflare endpoint (network calls are out of scope for the unit suite). The fix reuses the stream's existing `_position` accounting. Builds clean (main + tests): 0 warnings, 0 errors.