### PR TITLE
test: cover Uninstaller confirm gate and bulk select-all guard

### DIFF
--- a/SysManager/SysManager.Tests/UninstallerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/UninstallerViewModelTests.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using NSubstitute;
+using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
 
@@ -77,5 +79,154 @@ public class UninstallerViewModelTests
     {
         var result = UninstallerViewModel.DescribeUninstallFailure(9999, "Test");
         Assert.Contains("exit code 9999", result);
+    }
+}
+
+/// <summary>
+/// Confirmation-gate coverage for the Uninstaller. These swap the process-wide
+/// <see cref="DialogService.Instance"/>, so they run in the serialized
+/// "DialogService" collection. <see cref="UninstallerService"/> takes a concrete
+/// <see cref="PowerShellRunner"/> (not mockable), so the "confirm DOES uninstall"
+/// direction belongs in integration tests; here we cover the decline path and the
+/// pure-VM select-all guard, which are fully deterministic.
+/// </summary>
+[Collection("DialogService")]
+public class UninstallerViewModelGateTests
+{
+    private static UninstallerViewModel NewVm() => new(new UninstallerService(new PowerShellRunner()));
+
+    // Populate FilteredApps deterministically through the public filter path:
+    // add to AllApps, then toggle FilterText so ApplyFilter() repopulates.
+    private static void Seed(UninstallerViewModel vm, int count)
+    {
+        for (int i = 0; i < count; i++)
+            vm.AllApps.Add(new InstalledApp { Name = $"app{i:000}", Id = $"id{i:000}" });
+        vm.FilterText = "app"; // matches all → triggers ApplyFilter
+        vm.FilterText = "";    // back to empty (the SelectAll guard requires empty filter)
+    }
+
+    // ── UninstallSelected (permanent, non-undoable batch removal) ─────────
+
+    [Fact]
+    public void UninstallSelected_WhenUserDeclinesConfirm_RemovesNothing()
+    {
+        var vm = NewVm();
+        Seed(vm, 3);
+        vm.FilteredApps[0].IsSelected = true;
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false); // "No"
+        DialogService.Instance = dialog;
+        try
+        {
+            var countBefore = vm.FilteredApps.Count;
+            vm.UninstallSelectedCommand.Execute(null);
+
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            // Declining must short-circuit before any uninstall: the list is intact
+            // and the VM never entered the busy/uninstalling state.
+            Assert.Equal(countBefore, vm.FilteredApps.Count);
+            Assert.False(vm.IsBusy);
+            Assert.DoesNotContain("Uninstalling", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public void UninstallSelected_WithNoSelection_NeverPromptsConfirm()
+    {
+        var vm = NewVm();
+        Seed(vm, 3); // none selected
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.UninstallSelectedCommand.Execute(null);
+
+            // Nothing selected → the destructive prompt must not appear.
+            dialog.DidNotReceive().Confirm(Arg.Any<string>(), Arg.Any<string>());
+            Assert.Contains("No apps selected", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    // ── SelectAll bulk guard (>20 apps, no active filter) ─────────────────
+
+    [Fact]
+    public void SelectAll_Over20AppsNoFilter_WhenUserDeclines_SelectsNothing()
+    {
+        var vm = NewVm();
+        Seed(vm, 21); // > 20, filter empty → guard fires
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false); // "No"
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.SelectAllCommand.Execute(null);
+
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            Assert.All(vm.FilteredApps, a => Assert.False(a.IsSelected));
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public void SelectAll_Over20AppsNoFilter_WhenUserConfirms_SelectsAll()
+    {
+        var vm = NewVm();
+        Seed(vm, 21);
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true); // "Yes"
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.SelectAllCommand.Execute(null);
+
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            Assert.All(vm.FilteredApps, a => Assert.True(a.IsSelected));
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public void SelectAll_AtMost20Apps_SkipsGuardAndSelectsAll()
+    {
+        var vm = NewVm();
+        Seed(vm, 5); // <= 20 → no guard
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.SelectAllCommand.Execute(null);
+
+            // Small list → the bulk-select guard must not prompt at all.
+            dialog.DidNotReceive().Confirm(Arg.Any<string>(), Arg.Any<string>());
+            Assert.All(vm.FilteredApps, a => Assert.True(a.IsSelected));
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
     }
 }


### PR DESCRIPTION
## What

`UninstallerViewModelTests` covered command existence, filter logic, and the `DescribeUninstallFailure` map — but **neither confirmation gate** was exercised:

1. The permanent, non-undoable **batch-uninstall** `Confirm` (`UninstallSelectedAsync`).
2. The **>20-app bulk select-all guard** (`SelectAll`).

A regression dropping or inverting either would silently uninstall apps, or let a single click pre-arm a mass selection, with no failing test.

## Tests added

A serialized `[Collection("DialogService")]` class (swaps the process-wide `DialogService.Instance`):

- **UninstallSelected** — declining `Confirm` removes nothing and never enters the busy/uninstalling state; an empty selection never prompts. (`UninstallerService` takes a concrete `PowerShellRunner`, so the *confirm-side* uninstall isn't unit-mockable and belongs in integration tests — decline side covered here.)
- **SelectAll** — with >20 apps and no active filter, declining selects nothing and confirming selects all; a ≤20-app list skips the guard entirely (no prompt).

`FilteredApps` is seeded deterministically through the public filter path (add to `AllApps`, toggle `FilterText`).

Test-only; no production change. `test:` does not trigger a release. Builds clean (main + tests): 0 warnings, 0 errors.

## Follow-up (not in this PR)

PerformanceViewModel's decline gates are all P3 and their confirm-side drives static service methods (registry / `SystemParametersInfo`) that aren't unit-mockable without an injectable `IPerformanceActions` seam — better addressed as a small Gate-ARCH refactor than a brittle decline-only test.