### PR TITLE
fix: surface failed system mutations instead of reporting false success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.31] - 2026-06-17
+
+### Fixed
+- **DNS changes now report failure honestly instead of a false success.** Applying, resetting, or restoring DNS ran the underlying command without treating its errors as fatal, so a change that was actually rejected (for example without administrator rights, or when the adapter dropped) could still be reported as applied. These operations now surface the real error.
+- **DNS now targets the same network adapter for reading and changing.** The current-DNS display, the saved snapshot, and the apply/reset/restore actions used slightly different rules to pick the active adapter, so on a PC with several adapters (Wi-Fi + Ethernet + VPN) a change could land on a different adapter than the one shown — breaking the undo. All paths now select the adapter by one shared rule.
+- **Disabling a service now reports failure honestly.** Changing a service's startup type ignored the result of the underlying `sc.exe` call, so a change blocked by Windows (for example on a protected service) was still reported as "set to Disabled". The real exit code is now surfaced as a clear error.
+- **Refreshing a service's status after a change can no longer crash the app.** Reading a service's status right after stopping or disabling it could throw if the handle had just become invalid; that error is now handled and the status shows as "Unknown" instead.
+- **Enabling or disabling a Windows optional feature now reports failure honestly.** A failed feature change could still be reported as successful because the command's error was not propagated; failures now surface correctly.
+- **Privacy toggles that fail to apply no longer look like they succeeded.** Toggles backed by machine-wide (HKLM) settings need administrator rights; without elevation the write was silently swallowed and the toggle appeared applied. The app now reports how many changes need administrator rights and keeps the unapplied ones marked as pending.
+
 ## [1.20.30] - 2026-06-17
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DnsServiceTests.cs
+++ b/SysManager/SysManager.Tests/DnsServiceTests.cs
@@ -103,6 +103,68 @@ public class DnsServiceTests
             Arg.Any<CancellationToken>());
     }
 
+    // ---------- fail-loud: cmdlet failures must be made terminating (regression) ----------
+
+    [Fact]
+    public async Task SetDnsAsync_MutationScript_RequestsTerminatingErrors()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+              .Returns(Result("5"));
+        using var svc = new DnsService(runner);
+
+        await svc.SetDnsAsync("1.1.1.1", "1.0.0.1");
+
+        // The Set call must request terminating errors so a non-terminating cmdlet
+        // failure surfaces instead of being reported as a false success.
+        await runner.Received(1).RunAsync(
+            Arg.Is<string>(s =>
+                s.Contains("Set-DnsClientServerAddress") &&
+                s.Contains("-ErrorAction Stop") &&
+                s.Contains("$ErrorActionPreference = 'Stop'")),
+            Arg.Any<IDictionary<string, object?>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResetToDhcpAsync_MutationScript_RequestsTerminatingErrors()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+              .Returns(Result("3"));
+        using var svc = new DnsService(runner);
+
+        await svc.ResetToDhcpAsync();
+
+        await runner.Received(1).RunAsync(
+            Arg.Is<string>(s =>
+                s.Contains("-ResetServerAddresses") && s.Contains("-ErrorAction Stop")),
+            Arg.Any<IDictionary<string, object?>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetActiveInterfaceIndex_UsesSameOrderedNonVirtualSelectorAsDisplay()
+    {
+        // Read and mutate must select the active adapter by the SAME rule (Up,
+        // non-virtual, ordered by ifIndex) so display/capture and set target the
+        // same NIC on a multi-adapter machine. The Set path's index resolution must
+        // therefore carry the ordered, non-virtual selector.
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+              .Returns(Result("7"));
+        using var svc = new DnsService(runner);
+
+        await svc.SetDnsAsync("9.9.9.9", "149.112.112.112");
+
+        await runner.Received().RunAsync(
+            Arg.Is<string>(s =>
+                s.Contains("Virtual -eq $false") &&
+                s.Contains("Sort-Object -Property ifIndex")),
+            Arg.Any<IDictionary<string, object?>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
     [Fact]
     public async Task GetCurrentDnsAsync_ReturnsFirstResultLine()
     {

--- a/SysManager/SysManager.Tests/PrivacyServiceTests.cs
+++ b/SysManager/SysManager.Tests/PrivacyServiceTests.cs
@@ -1,0 +1,58 @@
+// SysManager · PrivacyServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="PrivacyService"/>'s apply-result signalling (regression for
+/// the "false success on a swallowed write failure" defect). Uses toggles whose
+/// registry path has an unrecognized hive so <c>ApplyToggle</c> returns false WITHOUT
+/// touching the real registry — deterministic and side-effect-free.
+/// </summary>
+public class PrivacyServiceTests
+{
+    private static PrivacyToggle BadHiveToggle(string name = "bad") => new()
+    {
+        Name = name,
+        Description = "unrecognized hive — write cannot succeed",
+        Category = "Telemetry",
+        RegistryPath = @"NOPE\Software\SysManagerTests\Privacy",
+        ValueName = "Value",
+        EnabledValue = 0,
+        DisabledValue = 1
+    };
+
+    [Fact]
+    public void ApplyToggle_UnwritableHive_ReturnsFalse()
+    {
+        var svc = new PrivacyService();
+        Assert.False(svc.ApplyToggle(BadHiveToggle()));
+    }
+
+    [Fact]
+    public void ApplyAll_ReturnsTheTogglesThatFailed()
+    {
+        var svc = new PrivacyService();
+        var a = BadHiveToggle("a");
+        var b = BadHiveToggle("b");
+
+        var failed = svc.ApplyAll([a, b]);
+
+        // Both writes fail (unrecognized hive) so both come back in the failed list —
+        // the caller must not treat them as applied.
+        Assert.Equal(2, failed.Count);
+        Assert.Contains(a, failed);
+        Assert.Contains(b, failed);
+    }
+
+    [Fact]
+    public void ApplyToggle_NullToggle_Throws()
+    {
+        var svc = new PrivacyService();
+        Assert.Throws<ArgumentNullException>(() => svc.ApplyToggle(null!));
+    }
+}

--- a/SysManager/SysManager/Services/DnsService.cs
+++ b/SysManager/SysManager/Services/DnsService.cs
@@ -41,17 +41,13 @@ public sealed class DnsService : IDisposable
         await _gate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            const string script = """
-                $adapters = Get-NetAdapter | Where-Object { $_.Status -eq 'Up' -and $_.Virtual -eq $false } | Sort-Object -Property ifIndex
-                if (-not $adapters) { $adapters = Get-NetAdapter | Where-Object { $_.Status -eq 'Up' } | Sort-Object -Property ifIndex }
-                foreach ($adapter in $adapters) {
+            const string script = ActiveAdapterSelector + """
+
+                if ($adapter) {
                     $dns = Get-DnsClientServerAddress -InterfaceIndex $adapter.ifIndex -AddressFamily IPv4
-                    if ($dns.ServerAddresses.Count -gt 0) {
-                        $dns.ServerAddresses -join ', '
-                        return
-                    }
-                }
-                if ($adapters) { 'Automatic (DHCP)' } else { 'No active adapter' }
+                    if ($dns.ServerAddresses.Count -gt 0) { $dns.ServerAddresses -join ', ' }
+                    else { 'Automatic (DHCP)' }
+                } else { 'No active adapter' }
                 """;
 
             Collection<PSObject> results = await _ps.RunAsync(script, cancellationToken: ct)
@@ -62,14 +58,25 @@ public sealed class DnsService : IDisposable
         finally { _gate.Release(); }
     }
 
+    // Single source of truth for "the active adapter": prefer a non-virtual adapter
+    // that is Up, fall back to any Up adapter, and always order by ifIndex so the
+    // SAME adapter is chosen for reading, snapshotting, and mutating. Without this,
+    // display/capture and set/reset/restore could target different NICs on a
+    // multi-adapter machine (Wi-Fi + Ethernet + VPN), breaking reversibility.
+    private const string ActiveAdapterSelector =
+        "$adapter = Get-NetAdapter | Where-Object { $_.Status -eq 'Up' -and $_.Virtual -eq $false } | Sort-Object -Property ifIndex | Select-Object -First 1; " +
+        "if (-not $adapter) { $adapter = Get-NetAdapter | Where-Object { $_.Status -eq 'Up' } | Sort-Object -Property ifIndex | Select-Object -First 1 }";
+
     /// <summary>
-    /// Detects the interface index of the first active network adapter.
-    /// Uses the integer index to avoid command injection through adapter names.
+    /// Detects the interface index of the active network adapter using the shared
+    /// <see cref="ActiveAdapterSelector"/> rule. Uses the integer index to avoid
+    /// command injection through adapter names.
     /// </summary>
     private async Task<int> GetActiveInterfaceIndexAsync(CancellationToken ct)
     {
-        const string script = """
-            Get-NetAdapter | Where-Object { $_.Status -eq 'Up' } | Select-Object -First 1 -ExpandProperty ifIndex
+        const string script = ActiveAdapterSelector + """
+
+            if ($adapter) { $adapter.ifIndex }
             """;
 
         Collection<PSObject> results = await _ps.RunAsync(script, cancellationToken: ct)
@@ -92,8 +99,8 @@ public sealed class DnsService : IDisposable
         await _gate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            const string script = """
-                $adapter = Get-NetAdapter | Where-Object { $_.Status -eq 'Up' } | Sort-Object -Property ifIndex | Select-Object -First 1
+            const string script = ActiveAdapterSelector + """
+
                 if ($adapter) {
                     $dns = Get-DnsClientServerAddress -InterfaceIndex $adapter.ifIndex -AddressFamily IPv4
                     $dns.ServerAddresses
@@ -139,8 +146,12 @@ public sealed class DnsService : IDisposable
         {
             int ifIndex = await GetActiveInterfaceIndexAsync(ct).ConfigureAwait(false);
             string joined = string.Join(",", servers.Select(s => $"\"{s}\""));
+            // -ErrorAction Stop makes a non-terminating cmdlet failure (denied
+            // privilege, adapter down, RPC failure) terminating, so RunAsync's
+            // EndInvoke throws instead of the call silently reporting success.
             string script = $"""
-                Set-DnsClientServerAddress -InterfaceIndex {ifIndex} -ServerAddresses @({joined})
+                $ErrorActionPreference = 'Stop'
+                Set-DnsClientServerAddress -InterfaceIndex {ifIndex} -ServerAddresses @({joined}) -ErrorAction Stop
                 """;
 
             await _ps.RunAsync(script, cancellationToken: ct).ConfigureAwait(false);
@@ -163,7 +174,8 @@ public sealed class DnsService : IDisposable
         {
             int ifIndex = await GetActiveInterfaceIndexAsync(ct).ConfigureAwait(false);
             string script = $"""
-                Set-DnsClientServerAddress -InterfaceIndex {ifIndex} -ServerAddresses @("{primary}","{secondary}")
+                $ErrorActionPreference = 'Stop'
+                Set-DnsClientServerAddress -InterfaceIndex {ifIndex} -ServerAddresses @("{primary}","{secondary}") -ErrorAction Stop
                 """;
 
             await _ps.RunAsync(script, cancellationToken: ct).ConfigureAwait(false);
@@ -181,7 +193,8 @@ public sealed class DnsService : IDisposable
         {
             int ifIndex = await GetActiveInterfaceIndexAsync(ct).ConfigureAwait(false);
             string script = $"""
-                Set-DnsClientServerAddress -InterfaceIndex {ifIndex} -ResetServerAddresses
+                $ErrorActionPreference = 'Stop'
+                Set-DnsClientServerAddress -InterfaceIndex {ifIndex} -ResetServerAddresses -ErrorAction Stop
                 """;
 
             await _ps.RunAsync(script, cancellationToken: ct).ConfigureAwait(false);

--- a/SysManager/SysManager/Services/PrivacyService.cs
+++ b/SysManager/SysManager/Services/PrivacyService.cs
@@ -34,9 +34,11 @@ public sealed class PrivacyService
 
     /// <summary>
     /// Writes a single toggle's current <see cref="PrivacyToggle.IsEnabled"/> state
-    /// to the registry.
+    /// to the registry. Returns <c>true</c> if the write succeeded, <c>false</c> if it
+    /// was rejected (e.g. an HKLM-backed toggle without elevation) or the hive was
+    /// unrecognized — so the caller can avoid reporting an unwritten change as applied.
     /// </summary>
-    public void ApplyToggle(PrivacyToggle toggle)
+    public bool ApplyToggle(PrivacyToggle toggle)
     {
         ArgumentNullException.ThrowIfNull(toggle);
 
@@ -45,47 +47,60 @@ public sealed class PrivacyService
         try
         {
             using var key = OpenOrCreateKey(toggle.RegistryPath, writable: true);
-            if (key is not null)
+            if (key is null)
             {
-                key.SetValue(toggle.ValueName, valueToWrite, RegistryValueKind.DWord);
-                Log.Information("Privacy toggle applied: {Name} = {Value} at {Path}\\{ValueName}",
-                    toggle.Name, valueToWrite, toggle.RegistryPath, toggle.ValueName);
+                Log.Warning("Privacy toggle {Name} not applied — could not open/create {Path}",
+                    toggle.Name, toggle.RegistryPath);
+                return false;
             }
+
+            key.SetValue(toggle.ValueName, valueToWrite, RegistryValueKind.DWord);
+            Log.Information("Privacy toggle applied: {Name} = {Value} at {Path}\\{ValueName}",
+                toggle.Name, valueToWrite, toggle.RegistryPath, toggle.ValueName);
+            return true;
         }
         catch (UnauthorizedAccessException ex)
         {
             Log.Warning(ex, "Access denied writing privacy toggle {Name} at {Path} — elevation required",
                 toggle.Name, toggle.RegistryPath);
+            return false;
         }
         catch (SecurityException ex)
         {
             Log.Warning(ex, "Security exception writing privacy toggle {Name} at {Path} — elevation required",
                 toggle.Name, toggle.RegistryPath);
+            return false;
         }
         catch (IOException ex)
         {
             Log.Warning(ex, "Registry I/O error writing privacy toggle {Name} at {Path}",
                 toggle.Name, toggle.RegistryPath);
+            return false;
         }
         catch (ArgumentException ex)
         {
             Log.Warning(ex, "Invalid registry key or value writing privacy toggle {Name} at {Path}",
                 toggle.Name, toggle.RegistryPath);
+            return false;
         }
     }
 
     /// <summary>
-    /// Applies all toggles in sequence. Errors on individual toggles are
-    /// logged but do not stop the batch.
+    /// Applies all toggles in sequence. Errors on individual toggles are logged but do
+    /// not stop the batch. Returns the toggles that failed to apply (empty when all
+    /// succeeded) so the caller can report failures and avoid rebasing their baseline.
     /// </summary>
-    public void ApplyAll(IEnumerable<PrivacyToggle> toggles)
+    public IReadOnlyList<PrivacyToggle> ApplyAll(IEnumerable<PrivacyToggle> toggles)
     {
         ArgumentNullException.ThrowIfNull(toggles);
 
+        List<PrivacyToggle> failed = [];
         foreach (var toggle in toggles)
         {
-            ApplyToggle(toggle);
+            if (!ApplyToggle(toggle))
+                failed.Add(toggle);
         }
+        return failed;
     }
 
     // ── Private helpers ───────────────────────────────────────────────────

--- a/SysManager/SysManager/Services/ServiceManagerService.cs
+++ b/SysManager/SysManager/Services/ServiceManagerService.cs
@@ -154,8 +154,15 @@ public sealed partial class ServiceManagerService
         if (!allowedTypes.Contains(startType, StringComparer.OrdinalIgnoreCase))
             throw new ArgumentException($"Invalid start type: {startType}", nameof(startType));
 
-        await ps.RunProcessAsync("sc.exe", $"config \"{serviceName}\" start= {startType}", ct, PowerShellRunner.OemEncoding)
+        var exit = await ps.RunProcessAsync("sc.exe", $"config \"{serviceName}\" start= {startType}", ct, PowerShellRunner.OemEncoding)
             .ConfigureAwait(false);
+
+        // sc.exe config can fail even when elevated — e.g. a TrustedInstaller-owned
+        // service returns exit 5 (Access denied). Fail loud so the caller reports the
+        // real outcome instead of a false "set to Disabled" success.
+        if (exit != 0)
+            throw new InvalidOperationException(
+                $"Could not change startup type of '{serviceName}' to '{startType}' (sc.exe exit code {exit}).");
     }
 
     /// <summary>Refresh the status of a single service entry.</summary>
@@ -168,6 +175,11 @@ public sealed partial class ServiceManagerService
             entry.StartType = sc.StartType.ToString();
         }
         catch (InvalidOperationException) { entry.Status = "Unknown"; }
+        // The status/start-type getters call into the SCM and can throw
+        // Win32Exception (access denied, or the handle became invalid right after a
+        // stop/disable). Mirror GetAllServices/RefreshAsync which already catch it,
+        // so refreshing one entry after a mutation can't crash the command.
+        catch (System.ComponentModel.Win32Exception) { entry.Status = "Unknown"; }
     }
 
     private static string GetServiceDescription(ServiceController sc)

--- a/SysManager/SysManager/Services/WindowsFeaturesService.cs
+++ b/SysManager/SysManager/Services/WindowsFeaturesService.cs
@@ -64,10 +64,13 @@ public sealed partial class WindowsFeaturesService
         _runner.LineReceived += Collect;
         try
         {
+            // Wrap in try/catch + `exit 1` so a DISM cmdlet failure propagates to the
+            // process exit code. Without this the cmdlet's non-terminating error is
+            // ignored and powershell.exe still exits 0, reporting a false success.
             var code = await _runner.RunProcessAsync("powershell",
-                $"-NoProfile -Command \"Enable-WindowsOptionalFeature -Online " +
-                $"-FeatureName '{featureName}' -NoRestart -All | " +
-                $"Select-Object RestartNeeded | ForEach-Object {{ $_.RestartNeeded }}\"", ct).ConfigureAwait(false);
+                $"-NoProfile -Command \"try {{ Enable-WindowsOptionalFeature -Online " +
+                $"-FeatureName '{featureName}' -NoRestart -All -ErrorAction Stop | " +
+                $"Select-Object RestartNeeded | ForEach-Object {{ $_.RestartNeeded }} }} catch {{ exit 1 }}\"", ct).ConfigureAwait(false);
 
             var reboot = captured.Any(l =>
                 l.Contains("True", StringComparison.OrdinalIgnoreCase));
@@ -98,10 +101,13 @@ public sealed partial class WindowsFeaturesService
         _runner.LineReceived += Collect;
         try
         {
+            // Wrap in try/catch + `exit 1` so a DISM cmdlet failure propagates to the
+            // process exit code. Without this the cmdlet's non-terminating error is
+            // ignored and powershell.exe still exits 0, reporting a false success.
             var code = await _runner.RunProcessAsync("powershell",
-                $"-NoProfile -Command \"Disable-WindowsOptionalFeature -Online " +
-                $"-FeatureName '{featureName}' -NoRestart | " +
-                $"Select-Object RestartNeeded | ForEach-Object {{ $_.RestartNeeded }}\"", ct).ConfigureAwait(false);
+                $"-NoProfile -Command \"try {{ Disable-WindowsOptionalFeature -Online " +
+                $"-FeatureName '{featureName}' -NoRestart -ErrorAction Stop | " +
+                $"Select-Object RestartNeeded | ForEach-Object {{ $_.RestartNeeded }} }} catch {{ exit 1 }}\"", ct).ConfigureAwait(false);
 
             var reboot = captured.Any(l =>
                 l.Contains("True", StringComparison.OrdinalIgnoreCase));

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.30</Version>
-    <FileVersion>1.20.30.0</FileVersion>
-    <AssemblyVersion>1.20.30.0</AssemblyVersion>
+    <Version>1.20.31</Version>
+    <FileVersion>1.20.31.0</FileVersion>
+    <AssemblyVersion>1.20.31.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/PrivacyViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PrivacyViewModel.cs
@@ -126,15 +126,29 @@ public sealed partial class PrivacyViewModel : ViewModelBase
             return;
         }
 
-        _service.ApplyAll(changed);
+        var failed = _service.ApplyAll(changed);
+        var failedSet = failed.ToHashSet();
 
-        // Refresh baseline to the just-applied state.
-        foreach (var t in changed)
+        // Only rebase the baseline for toggles that actually succeeded — a failed
+        // (e.g. needs-elevation HKLM) toggle stays "pending" so the user sees it
+        // wasn't applied rather than the change silently vanishing.
+        var applied = changed.Where(t => !failedSet.Contains(t)).ToList();
+        foreach (var t in applied)
             _baselineStates[t] = t.IsEnabled;
         RecomputePendingChanges();
 
-        StatusMessage = $"Applied {changed.Count} change{(changed.Count == 1 ? "" : "s")}.";
-        Log.Information("Privacy: applied {Count} pending changes", changed.Count);
+        if (failed.Count == 0)
+        {
+            StatusMessage = $"Applied {applied.Count} change{(applied.Count == 1 ? "" : "s")}.";
+            Log.Information("Privacy: applied {Count} pending changes", applied.Count);
+        }
+        else
+        {
+            StatusMessage = $"Applied {applied.Count} change{(applied.Count == 1 ? "" : "s")}; " +
+                $"{failed.Count} need administrator rights — relaunch as admin and try again.";
+            Log.Warning("Privacy: {Applied} applied, {Failed} failed (likely elevation required)",
+                applied.Count, failed.Count);
+        }
     }
 
     [RelayCommand]


### PR DESCRIPTION
Closes a recurring correctness defect class found across the system-mutating services: the operation reports success even when the underlying OS change was rejected. This erodes the project's "every mutation is honest and reversible" contract. Each fix is small and pinned by a regression test.

## Changes

### DnsService — fail loud + consistent adapter selection
- `SetDnsAsync` / `ResetToDhcpAsync` / `RestoreServersAsync` ran `Set-DnsClientServerAddress` without making errors terminating. The cmdlet emits a **non-terminating** error on failure (denied privilege, adapter down, RPC failure), so the awaited call completed normally and reported a false success. Added `$ErrorActionPreference='Stop'` + `-ErrorAction Stop` so the failure surfaces.
- The current-DNS **display**, the **snapshot** (`CaptureCurrentServersAsync`), and the **mutate/restore** index resolution each used a slightly different adapter-selection rule (`Virtual -eq $false` + `Sort-Object ifIndex` vs plain `Select -First 1`). On a multi-adapter PC (Wi-Fi + Ethernet + VPN) the change could land on a different NIC than the one shown, breaking the undo. Introduced one shared `ActiveAdapterSelector` used by read, capture, and the index resolver.

### ServiceManagerService — honest exit code + crash-safe refresh
- `SetStartupTypeAsync` discarded `sc.exe`'s exit code, so a failed `config` (e.g. exit 5 on a TrustedInstaller-owned service) was reported as "set to Disabled". It now throws `InvalidOperationException` on a non-zero exit (the VM layer already turns that into a status message).
- `RefreshStatus` only caught `InvalidOperationException`; the `ServiceController` status getters can throw `Win32Exception` (handle invalid right after a stop/disable), which would crash the command. Added the `Win32Exception` catch → status `"Unknown"`, matching the scan path.

### WindowsFeaturesService — propagate DISM failure
- `EnableFeatureAsync` / `DisableFeatureAsync` derived success from `powershell.exe`'s exit code, but the DISM cmdlet ran without `-ErrorAction Stop` and no `exit` mapping, so a cmdlet failure still exited 0 → false success. Wrapped in `try { … -ErrorAction Stop } catch { exit 1 }`.

### PrivacyService — signal failed writes
- `ApplyToggle` returned void and swallowed write failures; the six HKLM-backed toggles silently failed without elevation but appeared applied. `ApplyToggle` now returns `bool` and `ApplyAll` returns the failed toggles. `PrivacyViewModel.ApplyChanges` only rebases the baseline for toggles that **succeeded** and reports "N need administrator rights — relaunch as admin", keeping failed toggles pending.

## Tests
- `DnsServiceTests`: Set/Reset scripts request terminating errors; the index resolver carries the ordered non-virtual selector.
- `PrivacyServiceTests` (new): `ApplyToggle` returns false for an unwritable hive; `ApplyAll` returns the failed list; null-toggle throws.
- Existing `ServiceManagerServiceTests.RefreshStatus_*` cover the Win32Exception-safe refresh.

Build: main + tests compile 0 warnings / 0 errors. Version 1.20.31.