### PR TITLE
fix: release all Windows Update COM objects on error and cancellation paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.32] - 2026-06-17
+
+### Fixed
+- **Windows Update no longer leaks system resources during scan and install.** Each scanned and installed update holds several underlying Windows Update COM objects (the update's identity, category list, downloader, and child collections). Some of these were only released on the success path, so a cancelled scan, a failed download, or a category match leaked a handle every time. All of them are now released on every path, including errors and cancellation.
+
 ## [1.20.31] - 2026-06-17
 
 ### Fixed

--- a/SysManager/SysManager.Tests/WindowsUpdateServiceTests.cs
+++ b/SysManager/SysManager.Tests/WindowsUpdateServiceTests.cs
@@ -1,0 +1,57 @@
+// SysManager · WindowsUpdateServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="WindowsUpdateService"/>'s pure classification/formatting
+/// helpers. The COM-lifetime fixes (releasing every IUpdate child RCW) can't be unit
+/// tested without a live WUA feed, but these tests pin that the title-only
+/// classification path — restructured when the Categories collection release was
+/// wrapped in try/finally — still behaves identically.
+/// </summary>
+public class WindowsUpdateServiceTests
+{
+    [Theory]
+    [InlineData("2024-06 Cumulative Update for Windows 11", "Cumulative")]
+    [InlineData("Security Update for Microsoft Windows", "Security")]
+    [InlineData("Windows Malicious Software Removal Tool - Defender", "Defender")]
+    [InlineData("Security Intelligence Update for Microsoft Defender Antivirus", "Defender")]
+    [InlineData("NVIDIA driver update", "Driver")]
+    [InlineData("Intel - Firmware", "Driver")]
+    [InlineData("Servicing Stack Update for Windows", "Servicing")]
+    [InlineData("Feature update to Windows 11", "Update")]
+    [InlineData("", "Update")]
+    public void ClassifyCategory_TitleOnly_ClassifiesByKeyword(string title, string expected)
+    {
+        // u = null exercises the title-only path (no COM Categories collection).
+        Assert.Equal(expected, WindowsUpdateService.ClassifyCategory(title, null));
+    }
+
+    [Fact]
+    public void ClassifyCategory_DotNetSecurity_PrefersSecurity()
+    {
+        // "Security Update" is checked before ".NET", so a .NET security update is Security.
+        Assert.Equal("Security", WindowsUpdateService.ClassifyCategory(".NET 8 Security Update", null));
+    }
+
+    [Fact]
+    public void ClassifyCategory_DotNetNonSecurity_IsDotNet()
+    {
+        Assert.Equal(".NET", WindowsUpdateService.ClassifyCategory("Update for .NET Runtime", null));
+    }
+
+    [Theory]
+    [InlineData(0, "")]
+    [InlineData(512, "512 B")]
+    [InlineData(1536, "1.5 KB")]
+    [InlineData(157286400, "150.0 MB")]
+    [InlineData(2147483648, "2.0 GB")]
+    public void FormatSize_FormatsHumanReadable(long bytes, string expected)
+    {
+        Assert.Equal(expected, WindowsUpdateService.FormatSize(bytes));
+    }
+}

--- a/SysManager/SysManager/Services/WindowsUpdateService.cs
+++ b/SysManager/SysManager/Services/WindowsUpdateService.cs
@@ -87,24 +87,12 @@ public sealed class WindowsUpdateService
 
             ct.ThrowIfCancellationRequested();
             Emit("Connecting to Windows Update…");
-            var session = CreateSession();
-            var searcher = session.CreateUpdateSearcher();
-            var search = searcher.Search("IsInstalled=0");
-            var liveUpdates = search.Updates;
-            ct.ThrowIfCancellationRequested();
 
-            // Build a UpdateID -> live COM object map for the requested entries.
+            // Declared outside the try so the finally releases every COM object even
+            // when a cancellation check or the map-build throws during setup (these
+            // previously sat on the happy path and leaked on any throw).
+            dynamic? session = null, searcher = null, search = null, liveUpdates = null;
             var byId = new Dictionary<string, dynamic>(StringComparer.OrdinalIgnoreCase);
-            var liveCount = (int)liveUpdates.Count;
-            for (int i = 0; i < liveCount; i++)
-            {
-                var u = liveUpdates.Item(i);
-                var id = (string)u.Identity.UpdateID;
-                if (!byId.ContainsKey(id))
-                    byId[id] = u;
-                else
-                    Marshal.FinalReleaseComObject(u);
-            }
 
             int installed = 0;
             int failed = 0;
@@ -112,6 +100,27 @@ public sealed class WindowsUpdateService
 
             try
             {
+                session = CreateSession();
+                searcher = session.CreateUpdateSearcher();
+                search = searcher.Search("IsInstalled=0");
+                liveUpdates = search.Updates;
+                ct.ThrowIfCancellationRequested();
+
+                // Build a UpdateID -> live COM object map for the requested entries.
+                var liveCount = (int)liveUpdates.Count;
+                for (int i = 0; i < liveCount; i++)
+                {
+                    var u = liveUpdates.Item(i);
+                    dynamic? idObj = null;
+                    string id;
+                    try { idObj = u.Identity; id = (string)idObj.UpdateID; }
+                    finally { if (idObj is not null) Marshal.FinalReleaseComObject(idObj); }
+                    if (!byId.ContainsKey(id))
+                        byId[id] = u;
+                    else
+                        Marshal.FinalReleaseComObject(u);
+                }
+
                 int idx = 0;
                 foreach (var entry in entries)
                 {
@@ -137,11 +146,20 @@ public sealed class WindowsUpdateService
                         {
                             Emit("  Downloading…");
                             var dl = session.CreateUpdateDownloader();
-                            dl.Updates = coll;
-                            var dlResult = dl.Download();
-                            var dlCode = (int)dlResult.ResultCode;
-                            Marshal.FinalReleaseComObject(dlResult);
-                            Marshal.FinalReleaseComObject(dl);
+                            int dlCode;
+                            try
+                            {
+                                dl.Updates = coll;
+                                var dlResult = dl.Download();
+                                dlCode = (int)dlResult.ResultCode;
+                                Marshal.FinalReleaseComObject(dlResult);
+                            }
+                            finally
+                            {
+                                // Release the downloader even if Download() throws,
+                                // otherwise a failed download leaks the COM object.
+                                Marshal.FinalReleaseComObject(dl);
+                            }
 
                             if (dlCode != 2)
                             {
@@ -201,10 +219,10 @@ public sealed class WindowsUpdateService
             finally
             {
                 foreach (var u in byId.Values) Marshal.FinalReleaseComObject(u);
-                Marshal.FinalReleaseComObject(liveUpdates);
-                Marshal.FinalReleaseComObject(search);
-                Marshal.FinalReleaseComObject(searcher);
-                Marshal.FinalReleaseComObject(session);
+                if (liveUpdates is not null) Marshal.FinalReleaseComObject(liveUpdates);
+                if (search is not null) Marshal.FinalReleaseComObject(search);
+                if (searcher is not null) Marshal.FinalReleaseComObject(searcher);
+                if (session is not null) Marshal.FinalReleaseComObject(session);
             }
 
             return new InstallReport(installed, failed, reboot);
@@ -235,12 +253,27 @@ public sealed class WindowsUpdateService
         try { size = (long)(decimal)u.MaxDownloadSize; }
         catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException ex) { Serilog.Log.Debug(ex, "Windows Update: MaxDownloadSize not exposed for {Title}", title); }
         catch (COMException ex) { Serilog.Log.Debug(ex, "Windows Update: COM error reading size for {Title}", title); }
+
+        // u.Identity returns a fresh IUpdateIdentity RCW each access — capture once and
+        // release it, otherwise every scanned update leaks an Identity COM object.
+        string updateId;
+        dynamic? identity = null;
+        try
+        {
+            identity = u.Identity;
+            updateId = (string)identity.UpdateID;
+        }
+        finally
+        {
+            if (identity is not null) Marshal.FinalReleaseComObject(identity);
+        }
+
         return new UpdateEntry
         {
             Title = title,
             KB = kb,
             Size = FormatSize(size),
-            UpdateId = (string)u.Identity.UpdateID,
+            UpdateId = updateId,
             IsHidden = (bool)u.IsHidden,
             Category = ClassifyCategory(title, u),
             Status = "Available",
@@ -281,9 +314,10 @@ public sealed class WindowsUpdateService
         // COM Categories collection — check Type when available.
         if (u is not null)
         {
+            dynamic? cats = null;
             try
             {
-                var cats = u.Categories;
+                cats = u.Categories;
                 int n = (int)cats.Count;
                 for (int i = 0; i < n; i++)
                 {
@@ -294,10 +328,15 @@ public sealed class WindowsUpdateService
                     if (name.Equals("Upgrades", StringComparison.OrdinalIgnoreCase)) return "Feature upgrade";
                     if (name.Contains("Servicing", StringComparison.OrdinalIgnoreCase)) return "Servicing";
                 }
-                Marshal.FinalReleaseComObject(cats);
             }
             catch (COMException ex) { Serilog.Log.Debug(ex, "ClassifyCategory: COM error reading Categories"); }
             catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException ex) { Serilog.Log.Debug(ex, "ClassifyCategory: dynamic binding error"); }
+            finally
+            {
+                // Release the Categories collection even when an early return fires on
+                // a match inside the loop (previously the release was skipped on match).
+                if (cats is not null) Marshal.FinalReleaseComObject(cats);
+            }
         }
 
         if (title.Contains("Driver", StringComparison.OrdinalIgnoreCase) ||

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.31</Version>
-    <FileVersion>1.20.31.0</FileVersion>
-    <AssemblyVersion>1.20.31.0</AssemblyVersion>
+    <Version>1.20.32</Version>
+    <FileVersion>1.20.32.0</FileVersion>
+    <AssemblyVersion>1.20.32.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
The WUA COM wrapper released several update RCWs only on the happy path, leaking a native COM handle on cancellation, a failed download, or an early category match. Fixes four leak sites, all behavior-preserving.

## Changes (`WindowsUpdateService`)
- **`MapToEntry`** — `u.Identity` returns a fresh `IUpdateIdentity` RCW on each access; it was read for `UpdateID` and never released, leaking one per scanned update. Now captured once and released in a `finally`.
- **`InstallAsync` setup** — `session`/`searcher`/`search`/`liveUpdates` were created *before* the `try`, so a cancellation check or the id-map build throwing left them unreleased. Moved inside the `try`; the `finally` now null-checks and releases them. The per-update `Identity` RCW used to build the id map is also released.
- **Downloader** — `dl` (`IUpdateDownloader`) leaked if `dl.Download()` threw. Wrapped in `try/finally`.
- **`ClassifyCategory`** — the `Categories` collection RCW was released only after the loop, so an early `return "Driver"/"Feature upgrade"/"Servicing"` on a match skipped the release. Wrapped in `try/finally`.

## Tests
- New `WindowsUpdateServiceTests`: pins the title-only `ClassifyCategory` path (restructured by the `Categories` try/finally) and `FormatSize`. The COM-release paths themselves need a live WUA feed and remain covered by integration/runtime use.

Build: main + tests compile 0 warnings / 0 errors. Version 1.20.32. Behavior unchanged — pure resource-lifetime hardening.