### PR TITLE
fix: stop temp cleanup from following junctions and deleting data outside %TEMP%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.33] - 2026-06-17
+
+### Fixed
+- **Temp cleanup can no longer delete files outside the temp folders by following a junction or symbolic link.** Both the Quick Cleanup temp sweep and the background tune-up temp cleanup recursed into reparse points (directory junctions / symbolic links) inside `%TEMP%`, so a link pointing elsewhere could cause real user data outside the temp tree to be deleted. Both now skip reparse points during the walk and only ever remove the link itself, never its target.
+
 ## [1.20.32] - 2026-06-17
 
 ### Fixed

--- a/SysManager/SysManager.Tests/TuneUpServiceTests.cs
+++ b/SysManager/SysManager.Tests/TuneUpServiceTests.cs
@@ -278,4 +278,54 @@ public class TuneUpServiceTests
         Assert.Equal("Healthy", summary.Verdict);
         Assert.Equal("#22C55E", summary.ColorHex);
     }
+
+    // ---------- reparse-point safety (data-loss regression) ----------
+
+    [Fact]
+    public void EnumerateFilesSkippingReparsePoints_DoesNotFollowDirectorySymlink()
+    {
+        // Build:  root/real/secret.txt   (the "outside" data that must NOT be reached)
+        //         root/temp/file.txt     (a normal temp file — should be enumerated)
+        //         root/temp/link -> root/real   (a junction/symlink inside temp)
+        // Walking temp must yield temp/file.txt but NEVER root/real/secret.txt.
+        var root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "smtu_" + Guid.NewGuid().ToString("N"));
+        var real = System.IO.Path.Combine(root, "real");
+        var temp = System.IO.Path.Combine(root, "temp");
+        System.IO.Directory.CreateDirectory(real);
+        System.IO.Directory.CreateDirectory(temp);
+        var secret = System.IO.Path.Combine(real, "secret.txt");
+        var normal = System.IO.Path.Combine(temp, "file.txt");
+        System.IO.File.WriteAllText(secret, "must never be enumerated");
+        System.IO.File.WriteAllText(normal, "ordinary temp file");
+
+        var link = System.IO.Path.Combine(temp, "link");
+        try
+        {
+            System.IO.Directory.CreateSymbolicLink(link, real);
+        }
+        catch (Exception)
+        {
+            // Creating a symbolic link can require privilege/Developer Mode. If it
+            // fails the data-loss scenario can't be set up here — skip rather than
+            // fail (the production guard is still exercised by DeepCleanup's tests).
+            System.IO.Directory.Delete(root, recursive: true);
+            return;
+        }
+
+        try
+        {
+            var found = TuneUpService
+                .EnumerateFilesSkippingReparsePoints(temp, CancellationToken.None)
+                .ToList();
+
+            Assert.Contains(found, f => f.EndsWith("file.txt", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(found, f => f.EndsWith("secret.txt", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            // Remove the link first (without recursing through it), then the tree.
+            try { System.IO.Directory.Delete(link, recursive: false); } catch { /* best effort */ }
+            try { System.IO.Directory.Delete(root, recursive: true); } catch { /* best effort */ }
+        }
+    }
 }

--- a/SysManager/SysManager/Services/TuneUpService.cs
+++ b/SysManager/SysManager/Services/TuneUpService.cs
@@ -166,7 +166,11 @@ public sealed partial class TuneUpService
             ct.ThrowIfCancellationRequested();
             try
             {
-                foreach (var file in Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories))
+                // Walk manually and NEVER descend into reparse points (junctions /
+                // symbolic links). SearchOption.AllDirectories follows them, so a
+                // junction inside %TEMP% pointing elsewhere would let this delete real
+                // user data outside TEMP. Mirrors DeepCleanupService's safe traversal.
+                foreach (var file in EnumerateFilesSkippingReparsePoints(dir, ct))
                 {
                     ct.ThrowIfCancellationRequested();
                     try
@@ -181,11 +185,10 @@ public sealed partial class TuneUpService
                     catch (UnauthorizedAccessException) { errors++; }
                 }
 
-                // Try to remove empty subdirectories
-                // FUNC-M3: Sort by directory depth (separator count) descending,
-                // not string length. A path like "C:\a\b\c" is deeper than
-                // "C:\longname" despite being shorter — we must delete deepest first.
-                foreach (var sub in Directory.EnumerateDirectories(dir, "*", SearchOption.AllDirectories)
+                // Try to remove empty subdirectories, deepest first. Reparse points are
+                // excluded so a junction is never deleted/recursed as if it were a real
+                // directory. Depth = separator count (a deeper path can be shorter).
+                foreach (var sub in EnumerateDirectoriesSkippingReparsePoints(dir, ct)
                              .OrderByDescending(d => d.Count(c => c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar)))
                 {
                     ct.ThrowIfCancellationRequested();
@@ -209,6 +212,62 @@ public sealed partial class TuneUpService
         }
 
         return (freed, deleted, errors);
+    }
+
+    /// <summary>
+    /// Enumerates files under <paramref name="root"/> without ever descending into
+    /// reparse points (junctions / symbolic links), so cleanup can never follow a
+    /// link out of the temp tree and delete unrelated user data. Internal for testing.
+    /// </summary>
+    internal static IEnumerable<string> EnumerateFilesSkippingReparsePoints(string root, CancellationToken ct)
+    {
+        var stack = new Stack<string>();
+        stack.Push(root);
+        while (stack.Count > 0 && !ct.IsCancellationRequested)
+        {
+            var cur = stack.Pop();
+            IEnumerable<string> files;
+            IEnumerable<string> dirs;
+            try { files = Directory.EnumerateFiles(cur); } catch (IOException) { continue; } catch (UnauthorizedAccessException) { continue; }
+            try { dirs = Directory.EnumerateDirectories(cur); } catch (IOException) { dirs = []; } catch (UnauthorizedAccessException) { dirs = []; }
+
+            foreach (var file in files)
+                yield return file;
+
+            foreach (var d in dirs)
+                if (!IsReparsePoint(d)) stack.Push(d);
+        }
+    }
+
+    /// <summary>
+    /// Enumerates sub-directories under <paramref name="root"/> (excluding the root),
+    /// skipping reparse points so a junction is never deleted or recursed as a real dir.
+    /// </summary>
+    private static IEnumerable<string> EnumerateDirectoriesSkippingReparsePoints(string root, CancellationToken ct)
+    {
+        List<string> all = [];
+        var stack = new Stack<string>();
+        stack.Push(root);
+        while (stack.Count > 0 && !ct.IsCancellationRequested)
+        {
+            var cur = stack.Pop();
+            IEnumerable<string> dirs;
+            try { dirs = Directory.EnumerateDirectories(cur); } catch (IOException) { continue; } catch (UnauthorizedAccessException) { continue; }
+            foreach (var d in dirs)
+                if (!IsReparsePoint(d)) { stack.Push(d); all.Add(d); }
+        }
+        return all;
+    }
+
+    /// <summary>True when the directory is a reparse point (junction or symbolic link).</summary>
+    private static bool IsReparsePoint(string path)
+    {
+        try
+        {
+            return (File.GetAttributes(path) & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+        }
+        catch (IOException) { return true; }
+        catch (UnauthorizedAccessException) { return true; }
     }
 
     // ── Recycle Bin ────────────────────────────────────────────────────

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.32</Version>
-    <FileVersion>1.20.32.0</FileVersion>
-    <AssemblyVersion>1.20.32.0</AssemblyVersion>
+    <Version>1.20.33</Version>
+    <FileVersion>1.20.33.0</FileVersion>
+    <AssemblyVersion>1.20.33.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -184,17 +184,39 @@ public sealed partial class CleanupViewModel : ViewModelBase
         {
             await _runner.RunScriptViaPwshAsync(@"
                 $paths = @($env:TEMP, ""$env:SystemRoot\Temp"")
-                $totalBytes = 0
-                foreach ($p in $paths) {
-                    if (Test-Path $p) {
-                        Get-ChildItem -Path $p -Recurse -Force -ErrorAction SilentlyContinue |
-                            ForEach-Object {
-                                try { $totalBytes += $_.Length } catch {}
-                                try { Remove-Item $_.FullName -Force -Recurse -ErrorAction SilentlyContinue } catch {}
+                $script:totalBytes = 0
+                $reparse = [IO.FileAttributes]::ReparsePoint
+                # Windows PowerShell 5.1's Get-ChildItem -Recurse FOLLOWS junctions and
+                # symbolic links, so a reparse point inside %TEMP% pointing elsewhere
+                # could let Remove-Item delete real user data outside the temp tree.
+                # Walk manually with an explicit stack and never descend into a reparse
+                # point; delete a reparse point itself WITHOUT -Recurse (removes the link,
+                # not its target).
+                function Clear-TempDir([string]$root) {
+                    $stack = New-Object System.Collections.Stack
+                    $stack.Push($root)
+                    while ($stack.Count -gt 0) {
+                        $cur = $stack.Pop()
+                        try { $children = Get-ChildItem -LiteralPath $cur -Force -ErrorAction SilentlyContinue } catch { continue }
+                        foreach ($c in $children) {
+                            $isReparse = ($c.Attributes -band $reparse) -eq $reparse
+                            if ($c.PSIsContainer) {
+                                if ($isReparse) {
+                                    try { [IO.Directory]::Delete($c.FullName, $false) } catch {}
+                                } else {
+                                    $stack.Push($c.FullName)
+                                }
+                            } else {
+                                try { $script:totalBytes += $c.Length } catch {}
+                                try { Remove-Item -LiteralPath $c.FullName -Force -ErrorAction SilentlyContinue } catch {}
                             }
+                        }
                     }
                 }
-                ""Freed approximately $([Math]::Round($totalBytes/1MB,1)) MB""
+                foreach ($p in $paths) {
+                    if (Test-Path $p) { Clear-TempDir $p }
+                }
+                ""Freed approximately $([Math]::Round($script:totalBytes/1MB,1)) MB""
             ", cancellationToken: _tempCts.Token);
             StatusMessage = "Temp cleanup done";
             Log.Information("Temp cleanup completed");


### PR DESCRIPTION
Both temp-cleanup paths recursed into reparse points (directory junctions / symbolic links) inside `%TEMP%`. A link pointing outside the temp tree could therefore cause real user data to be enumerated and deleted — a data-loss risk. Both paths now skip reparse points and only ever remove the link itself.

## Changes
- **`TuneUpService.CleanTempFiles`** — replaced `Directory.EnumerateFiles(dir, "*", AllDirectories)` (which follows links) with a manual stack walk (`EnumerateFilesSkippingReparsePoints` / `EnumerateDirectoriesSkippingReparsePoints`) that never descends into a reparse point. Mirrors the already-hardened traversal in `DeepCleanupService`.
- **`CleanupViewModel`** (Quick Cleanup temp sweep) — the inline Windows PowerShell 5.1 script used `Get-ChildItem -Recurse` + `Remove-Item -Recurse`, both of which follow junctions in 5.1. Rewrote it as an explicit stack walk that skips reparse points and deletes a reparse-point directory with `[IO.Directory]::Delete($path, $false)` (removes the link, not its target).

## Tests
- `TuneUpServiceTests.EnumerateFilesSkippingReparsePoints_DoesNotFollowDirectorySymlink`: builds `temp/link -> real/` with `secret.txt` behind the link and a normal `temp/file.txt`; asserts the walk yields the normal file but never the file behind the link. Skips gracefully if symlink creation needs privilege.

Build: main + tests compile 0 warnings / 0 errors. Version 1.20.33.