### PR TITLE
fix: restore a service's original startup type when re-enabling it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.34] - 2026-06-17
+
+### Fixed
+- **Re-enabling a service now restores its original startup type instead of always setting it to Manual.** When you disabled a service, SysManager forgot what its startup type had been, and "Enable" always set it to Manual — so a service that was originally Automatic (for example) would not start on the next boot as it used to. Disabling now remembers the previous startup type and Enable restores it exactly.
+
 ## [1.20.33] - 2026-06-17
 
 ### Fixed

--- a/SysManager/SysManager.Tests/ServiceManagerServiceTests.cs
+++ b/SysManager/SysManager.Tests/ServiceManagerServiceTests.cs
@@ -78,6 +78,24 @@ public class ServiceManagerServiceTests
         Assert.Equal("Unknown", entry.Status);
     }
 
+    // ── StartTypeToScToken (regression: enable restores the previous start type) ──
+
+    [Theory]
+    [InlineData("Automatic", "auto")]
+    [InlineData("Manual", "demand")]
+    [InlineData("Boot", "boot")]
+    [InlineData("System", "system")]
+    public void StartTypeToScToken_MapsKnownStartTypes(string startType, string expected)
+        => Assert.Equal(expected, ServiceManagerService.StartTypeToScToken(startType));
+
+    [Theory]
+    [InlineData("Disabled")]   // re-enabling to Disabled is a no-op → fall back to Manual
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("Weird")]
+    public void StartTypeToScToken_FallsBackToDemand_ForDisabledOrUnknown(string? startType)
+        => Assert.Equal("demand", ServiceManagerService.StartTypeToScToken(startType));
+
     [Fact]
     public void ServiceEntry_ObservableProperties()
     {

--- a/SysManager/SysManager/Models/ServiceEntry.cs
+++ b/SysManager/SysManager/Models/ServiceEntry.cs
@@ -19,6 +19,14 @@ public sealed partial class ServiceEntry : ObservableObject
     [ObservableProperty] private string _startType = "";
     [ObservableProperty] private bool _isHighlighted;
 
+    /// <summary>
+    /// The startup type in effect immediately before SysManager last disabled this
+    /// service, captured so "Enable" can restore the exact previous type (Automatic /
+    /// Manual / Boot / System) instead of always falling back to Manual. Null when
+    /// SysManager has not disabled it this session.
+    /// </summary>
+    public string? PreviousStartType { get; set; }
+
     /// <summary>Gaming recommendation: "safe-to-disable", "keep-enabled", "advanced", or "" (no recommendation).</summary>
     public string Recommendation { get; init; } = "";
 

--- a/SysManager/SysManager/Services/ServiceManagerService.cs
+++ b/SysManager/SysManager/Services/ServiceManagerService.cs
@@ -165,6 +165,23 @@ public sealed partial class ServiceManagerService
                 $"Could not change startup type of '{serviceName}' to '{startType}' (sc.exe exit code {exit}).");
     }
 
+    /// <summary>
+    /// Maps a <see cref="ServiceController.StartType"/> string (the
+    /// <see cref="ServiceStartMode"/> name, e.g. "Automatic", "Manual", "Disabled")
+    /// to the corresponding sc.exe <c>start=</c> token, so a disabled service can be
+    /// re-enabled to its exact previous startup type instead of always to Manual.
+    /// Falls back to "demand" (Manual) for "Disabled" or any unrecognized value, since
+    /// re-enabling to Disabled would be a no-op.
+    /// </summary>
+    internal static string StartTypeToScToken(string? startType) => startType switch
+    {
+        "Automatic" => "auto",
+        "Manual" => "demand",
+        "Boot" => "boot",
+        "System" => "system",
+        _ => "demand",
+    };
+
     /// <summary>Refresh the status of a single service entry.</summary>
     public static void RefreshStatus(ServiceEntry entry)
     {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.33</Version>
-    <FileVersion>1.20.33.0</FileVersion>
-    <AssemblyVersion>1.20.33.0</AssemblyVersion>
+    <Version>1.20.34</Version>
+    <FileVersion>1.20.34.0</FileVersion>
+    <AssemblyVersion>1.20.34.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -156,12 +156,17 @@ public sealed partial class ServicesViewModel : ViewModelBase
             $"Disable service \"{entry.DisplayName}\"?\n\nThis prevents the service from starting automatically.",
             "Disable Service — Confirm")) return;
 
+        // Snapshot the current startup type BEFORE disabling so Enable can restore the
+        // exact previous type (e.g. Automatic) instead of always falling back to Manual.
+        var previous = entry.StartType;
+
         try
         {
             await ServiceManagerService.SetStartupTypeAsync(entry.Name, "disabled", _ps);
+            entry.PreviousStartType = previous;
             ServiceManagerService.RefreshStatus(entry);
             StatusMessage = $"✓ {entry.DisplayName} set to Disabled.";
-            Log.Information("Service disabled: {ServiceName}", entry.Name);
+            Log.Information("Service disabled: {ServiceName} (was {Previous})", entry.Name, previous);
         }
         catch (InvalidOperationException ex) { StatusMessage = $"Disable service failed: {ex.Message}"; }
     }
@@ -172,12 +177,17 @@ public sealed partial class ServicesViewModel : ViewModelBase
         if (entry is null) return;
         if (!AdminHelper.IsElevated()) { StatusMessage = "⚠ Changing startup type requires admin."; return; }
 
+        // Restore the startup type the service had before SysManager disabled it. If we
+        // never disabled it this session, fall back to Manual (the conservative default).
+        var targetToken = ServiceManagerService.StartTypeToScToken(entry.PreviousStartType);
+
         try
         {
-            await ServiceManagerService.SetStartupTypeAsync(entry.Name, "demand", _ps);
+            await ServiceManagerService.SetStartupTypeAsync(entry.Name, targetToken, _ps);
+            entry.PreviousStartType = null;
             ServiceManagerService.RefreshStatus(entry);
-            StatusMessage = $"✓ {entry.DisplayName} set to Manual.";
-            Log.Information("Service enabled (manual): {ServiceName}", entry.Name);
+            StatusMessage = $"✓ {entry.DisplayName} set to {entry.StartType}.";
+            Log.Information("Service enabled: {ServiceName} -> {StartType}", entry.Name, entry.StartType);
         }
         catch (InvalidOperationException ex) { StatusMessage = $"Enable service failed: {ex.Message}"; }
     }


### PR DESCRIPTION
Disabling a service did not remember its previous startup type, and "Enable" always set it to Manual (`demand`). A service that was originally Automatic would therefore no longer auto-start after a disable→enable round-trip — a silent, non-reversible change to system behavior.

## Changes
- **`ServiceEntry`** — added `PreviousStartType` snapshot field.
- **`ServiceManagerService.StartTypeToScToken`** — maps a `ServiceController.StartType` string ("Automatic"/"Manual"/"Boot"/"System") to its sc.exe `start=` token; falls back to `demand` for "Disabled"/unknown.
- **`ServicesViewModel.DisableService`** — captures `entry.StartType` into `PreviousStartType` before disabling.
- **`ServicesViewModel.EnableService`** — restores the snapshotted type via the mapper instead of hardcoding `demand`; clears the snapshot afterward and reports the actual restored type.

## Tests
- `ServiceManagerServiceTests.StartTypeToScToken_*`: maps the four known start types and falls back to `demand` for Disabled/empty/null/unknown.

Build: main + tests compile 0 warnings / 0 errors. Version 1.20.34. (Stacks on #915/#917 — will rebase to the final version before merge.)