### PR TITLE
fix: use theme-aware colors for cards and badges so light themes stay legible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.35] - 2026-06-17
+
+### Fixed
+- **Several panels are now legible in light themes.** A number of cards, banners, and badges (Deep Cleanup safety note and action row, Privacy toggle rows, the File Shredder SSD warning, Quick Cleanup SFC/DISM result cards, the Speed Test info banner, the Windows Features "reboot pending" badge, the Bulk Installer status/installed badges, and the work-in-progress badge) used fixed dark colours that did not change with the theme, so their text became hard to read on the light presets. They now use theme-aware colours and adapt to the active theme.
+- **The File Shredder "Shred All" button is readable again.** It showed red text on the indigo primary-button background (very low contrast); it now uses the standard red danger-button style with white text.
+
 ## [1.20.34] - 2026-06-17
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.34</Version>
-    <FileVersion>1.20.34.0</FileVersion>
-    <AssemblyVersion>1.20.34.0</AssemblyVersion>
+    <Version>1.20.35</Version>
+    <FileVersion>1.20.35.0</FileVersion>
+    <AssemblyVersion>1.20.35.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -227,9 +227,9 @@
                                             <TextBlock Text="{Binding Name}"
                                                        FontWeight="SemiBold" FontSize="13"
                                                        Foreground="{DynamicResource TextPrimary}"/>
-                                            <Border CornerRadius="4" Padding="4,2" Margin="8,0,0,0" Background="#1422C55E" BorderBrush="#3022C55E" BorderThickness="1"
+                                            <Border CornerRadius="4" Padding="4,2" Margin="8,0,0,0" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Success}" BorderThickness="1"
                                                     Visibility="{Binding IsInstalled, Converter={StaticResource BoolToVis}}">
-                                                <TextBlock Text="Installed" FontSize="9" Foreground="#4ADE80" FontWeight="SemiBold"/>
+                                                <TextBlock Text="Installed" FontSize="9" Foreground="{DynamicResource Success}" FontWeight="SemiBold"/>
                                             </Border>
                                         </StackPanel>
                                         <TextBlock Text="{Binding Description}"
@@ -240,13 +240,13 @@
 
                                     <!-- Status badge -->
                                     <Border Grid.Column="3" CornerRadius="8" Padding="8,4"
-                                            Background="#14475569" BorderBrush="#0AFFFFFF" BorderThickness="1"
+                                            Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}" BorderThickness="1"
                                             VerticalAlignment="Center" Margin="12,0,0,0"
                                             Visibility="{Binding Status, Converter={StaticResource FlexVis}}">
                                         <Grid>
-                                            <Border Background="#475569" Width="3" HorizontalAlignment="Left"
+                                            <Border Background="{DynamicResource Border2}" Width="3" HorizontalAlignment="Left"
                                                     CornerRadius="2" Margin="-8,-4,0,-4"/>
-                                            <TextBlock Text="{Binding Status}" FontSize="11" Foreground="#94A3B8"
+                                            <TextBlock Text="{Binding Status}" FontSize="11" Foreground="{DynamicResource TextMuted}"
                                                        FontWeight="SemiBold" Margin="4,0,0,0"
                                                        TextTrimming="CharacterEllipsis" MaxWidth="120"/>
                                         </Grid>

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -100,10 +100,8 @@
                 </StackPanel>
                 <!-- SFC verdict (shown after completion) -->
                 <Border Margin="0,8,0,0" Padding="12,10" CornerRadius="8"
+                        Background="{DynamicResource Surface1}"
                         Visibility="{Binding SfcVerdict, Converter={StaticResource FlexVis}}">
-                    <Border.Background>
-                        <SolidColorBrush Color="#0D1117" Opacity="0.8"/>
-                    </Border.Background>
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="SFC result:" FontWeight="SemiBold" Foreground="{DynamicResource TextSecondary}"
                                    VerticalAlignment="Center" Margin="0,0,8,0"/>
@@ -121,10 +119,8 @@
                 </StackPanel>
                 <!-- DISM verdict (shown after completion) -->
                 <Border Margin="0,8,0,0" Padding="12,10" CornerRadius="8"
+                        Background="{DynamicResource Surface1}"
                         Visibility="{Binding DismVerdict, Converter={StaticResource FlexVis}}">
-                    <Border.Background>
-                        <SolidColorBrush Color="#0D1117" Opacity="0.8"/>
-                    </Border.Background>
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="DISM result:" FontWeight="SemiBold" Foreground="{DynamicResource TextSecondary}"
                                    VerticalAlignment="Center" Margin="0,0,8,0"/>

--- a/SysManager/SysManager/Views/DeepCleanupView.xaml
+++ b/SysManager/SysManager/Views/DeepCleanupView.xaml
@@ -18,7 +18,7 @@
 
                 <!-- Safety note -->
                 <Border Style="{StaticResource Card}" Margin="0,16,0,0"
-                        Background="#122030" BorderBrush="{DynamicResource Accent}" BorderThickness="1">
+                        Background="{DynamicResource AccentSoft}" BorderBrush="{DynamicResource Accent}" BorderThickness="1">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="&#xE946;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                    FontSize="18" Foreground="{DynamicResource Accent}" VerticalAlignment="Top" Margin="0,2,12,0"/>
@@ -94,7 +94,7 @@
                         </ItemsControl>
 
                         <!-- Clean action row -->
-                        <Border Style="{StaticResource CardInner}" Margin="0,8,0,0" Background="#0E141D">
+                        <Border Style="{StaticResource CardInner}" Margin="0,8,0,0" Background="{DynamicResource Surface2}">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*"/>

--- a/SysManager/SysManager/Views/FileShredderView.xaml
+++ b/SysManager/SysManager/Views/FileShredderView.xaml
@@ -30,12 +30,12 @@
             <TextBlock Text="File Shredder" Style="{StaticResource Display}"/>
             <TextBlock Text="Securely delete files beyond recovery with multi-pass overwrite."
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
-            <Border Background="#1C1A0F" BorderBrush="#3D3A20" BorderThickness="1" CornerRadius="6"
+            <Border Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1" CornerRadius="6"
                     Margin="0,10,0,0" Padding="10,8">
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Text="&#xE7BA;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="14" Foreground="#EAB308" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                    <TextBlock Foreground="#EAB308" FontSize="12" TextWrapping="Wrap" VerticalAlignment="Center"
+                               FontSize="14" Foreground="{DynamicResource WarningText}" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                    <TextBlock Foreground="{DynamicResource WarningText}" FontSize="12" TextWrapping="Wrap" VerticalAlignment="Center"
                                Text="SSD users: overwrite-based shredding is unreliable on solid-state drives due to wear-leveling. Use full-disk encryption (BitLocker/VeraCrypt) for secure data disposal on SSDs."/>
                 </StackPanel>
             </Border>
@@ -55,7 +55,7 @@
                 <Button Content="Add Folder" Command="{Binding AddFolderCommand}"
                         Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
                 <Button Content="Shred All" Command="{Binding ShredAllCommand}"
-                        Style="{StaticResource PrimaryButton}" Foreground="{DynamicResource Danger}" Margin="0,0,8,0"/>
+                        Style="{StaticResource DangerButton}" Margin="0,0,8,0"/>
                 <Button Content="Cancel" Command="{Binding CancelCommand}"
                         Style="{StaticResource GhostButton}"
                         Visibility="{Binding IsShredding, Converter={StaticResource BoolToVis}}"/>

--- a/SysManager/SysManager/Views/PlaceholderView.xaml
+++ b/SysManager/SysManager/Views/PlaceholderView.xaml
@@ -16,7 +16,7 @@
                        TextWrapping="Wrap" TextAlignment="Center"/>
 
             <!-- WIP badge -->
-            <Border Background="#2A1A3A" CornerRadius="4" Padding="12,6"
+            <Border Background="{DynamicResource AccentSoft}" CornerRadius="4" Padding="12,6"
                     HorizontalAlignment="Center" Margin="0,12,0,0">
                 <TextBlock Text="Work in Progress" FontSize="14" FontWeight="SemiBold"
                            Foreground="{DynamicResource Accent}"/>

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -119,11 +119,11 @@
                                     BorderThickness="1">
                                 <Border.Style>
                                     <Style TargetType="Border">
-                                        <Setter Property="Background" Value="#0A0E14"/>
-                                        <Setter Property="BorderBrush" Value="#1A1F2E"/>
+                                        <Setter Property="Background" Value="{DynamicResource Surface2}"/>
+                                        <Setter Property="BorderBrush" Value="{DynamicResource Border1}"/>
                                         <Style.Triggers>
                                             <Trigger Property="IsMouseOver" Value="True">
-                                                <Setter Property="Background" Value="#10141D"/>
+                                                <Setter Property="Background" Value="{DynamicResource Surface3}"/>
                                                 <Setter Property="BorderBrush" Value="{DynamicResource Border2}"/>
                                             </Trigger>
                                         </Style.Triggers>

--- a/SysManager/SysManager/Views/SpeedTestView.xaml
+++ b/SysManager/SysManager/Views/SpeedTestView.xaml
@@ -84,7 +84,7 @@
                 </Border>
 
                 <!-- Info: Ookla vs HTTP explanation -->
-                <Border Grid.Row="1" Grid.ColumnSpan="2" Background="#0F1A2E" BorderBrush="#1E3A5F" BorderThickness="1"
+                <Border Grid.Row="1" Grid.ColumnSpan="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}" BorderThickness="1"
                         CornerRadius="8" Padding="12,10" Margin="0,12,0,0">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="&#xE946;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -44,7 +44,7 @@
                                VerticalAlignment="Center" FontSize="12"
                                Visibility="{Binding FilterText, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                 </Grid>
-                <Border Background="#2D1F1F" CornerRadius="4" Padding="6,2" Margin="4,0"
+                <Border Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1" CornerRadius="4" Padding="6,2" Margin="4,0"
                         Visibility="{Binding PendingReboot, Converter={StaticResource BoolToVis}}">
                     <TextBlock Text="⚠ Reboot pending" FontSize="11" Foreground="{DynamicResource Warning}"/>
                 </Border>


### PR DESCRIPTION
Several cards, banners, and badges used hardcoded dark hex colours that don't participate in the dark/light theme switch (ThemeService recomputes the Surface/Text/Border/Warning tokens per preset, but literal hex stays put). On the six light presets the text re-themed to dark while the background stayed dark, breaking contrast. All replaced with the existing DynamicResource theme tokens.

## Changes (XAML only)
- **DeepCleanupView** — safety note (`#122030` → `AccentSoft`), clean-action row (`#0E141D` → `Surface2`).
- **PrivacyView** — toggle rows (`#0A0E14`/`#1A1F2E`/hover `#10141D` → `Surface2`/`Border1`/`Surface3`).
- **FileShredderView** — SSD warning banner (`#1C1A0F`/`#3D3A20`/`#EAB308` → `WarningBgSubtle`/`WarningBg`/`WarningText`); **"Shred All"** changed from `PrimaryButton` + red `Foreground` override (red-on-indigo ~1.3:1) to `DangerButton`.
- **PlaceholderView** — WIP badge (`#2A1A3A` → `AccentSoft`).
- **SpeedTestView** — Ookla-vs-HTTP info banner (`#0F1A2E`/`#1E3A5F` → `Surface2`/`Border1`).
- **WindowsFeaturesView** — "reboot pending" badge (`#2D1F1F` → `WarningBgSubtle` + `WarningBg` border, matching its sibling Administrator pill).
- **CleanupView** — SFC/DISM verdict cards (`#0D1117` → `Surface1`).
- **BulkInstallerView** — "Installed" badge (green hex → `Surface2` + `Success`) and status badge (gray hex → `Surface2`/`Border1`/`Border2`/`TextMuted`).

All tokens used are ThemeService-managed (Surface0-4, Border1/2, AccentSoft, TextMuted, Warning*, Success), verified present. Build 0 warnings / 0 errors. Version 1.20.35. XAML-only — no logic change.