### PR TITLE
fix: resume Dashboard temperature polling on tab re-show and dispose event-log handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.36] - 2026-06-17
+
+### Fixed
+- **The Dashboard's live temperature readings now resume after you leave and return to the tab.** Temperature polling was started only once at launch; navigating away stopped it permanently, so on returning to the Dashboard the temperatures stopped updating until the app was restarted. Temperature polling now restarts together with the rest of the live vitals whenever the Dashboard is shown again.
+- **The Dashboard Event Log check no longer leaks system handles.** Counting recent critical events read each event record without releasing it, leaking a Windows event-log handle per event on every scan. Each record is now disposed as it is read.
+
 ## [1.20.35] - 2026-06-17
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.35</Version>
-    <FileVersion>1.20.35.0</FileVersion>
-    <AssemblyVersion>1.20.35.0</AssemblyVersion>
+    <Version>1.20.36</Version>
+    <FileVersion>1.20.36.0</FileVersion>
+    <AssemblyVersion>1.20.36.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -93,12 +93,10 @@ public sealed partial class DashboardViewModel : ViewModelBase
         await LoadStaticInfoAsync();
         LoadDrives();
         LoadActivity();
-        StartPollingLoop();
+        StartPollingLoop();   // starts BOTH the vitals and temperature loops
         await LoadHealthScoreAsync();
         StartAlertScans();
         await LoadTemperaturesAsync();
-        if (_pollingCts is not null)
-            StartTemperaturePolling(_pollingCts.Token);
     }
 
     // ══════════════════════════════════════════════════════════════════════
@@ -111,16 +109,25 @@ public sealed partial class DashboardViewModel : ViewModelBase
             StartPollingLoop();
         else if (!value)
         {
-            _pollingCts?.Cancel();
+            var old = _pollingCts;
             _pollingCts = null;
+            old?.Cancel();
+            old?.Dispose();
         }
     }
 
     private void StartPollingLoop()
     {
-        _pollingCts?.Cancel();
+        var old = _pollingCts;
         _pollingCts = new CancellationTokenSource();
+        old?.Cancel();
+        old?.Dispose();
         var ct = _pollingCts.Token;
+
+        // Temperature polling shares this CTS so it restarts whenever the tab is
+        // re-shown (previously it was started once in InitAsync and never resumed
+        // after OnIsActiveChanged cancelled the original token).
+        StartTemperaturePolling(ct);
 
         _ = Task.Run(async () =>
         {
@@ -454,7 +461,13 @@ public sealed partial class DashboardViewModel : ViewModelBase
 
             int criticalCount = 0;
             using var reader = new System.Diagnostics.Eventing.Reader.EventLogReader(query);
-            while (reader.ReadEvent() is not null) criticalCount++;
+            // Each EventRecord wraps an unmanaged EVT_HANDLE and must be disposed —
+            // discarding them (as before) leaked a native handle per critical event.
+            System.Diagnostics.Eventing.Reader.EventRecord? rec;
+            while ((rec = reader.ReadEvent()) is not null)
+            {
+                using (rec) criticalCount++;
+            }
 
             var (title, severity) = ClassifyEventLog(criticalCount);
             System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>


### PR DESCRIPTION
Two Dashboard lifecycle defects, one file.

## Changes (`DashboardViewModel`)
- **Temperature polling never resumed after the tab was hidden and re-shown.** It was started once in `InitAsync` with the initial `_pollingCts.Token`. `OnIsActiveChanged` cancels+nulls `_pollingCts` on hide; on re-show `StartPollingLoop()` creates a fresh CTS but only restarted the vitals loop — temperatures stayed frozen until an app restart. Moved `StartTemperaturePolling(ct)` inside `StartPollingLoop()` so both loops share the CTS lifecycle and restart together. Also dispose the old CTS before replacing/nulling it (previously cancelled-but-never-disposed).
- **Event Log scan leaked a native handle per event.** `ScanEventLogAsync` did `while (reader.ReadEvent() is not null) criticalCount++;`, discarding each `EventRecord` (IDisposable, wraps an unmanaged EVT_HANDLE). Now each record is captured and disposed (`using (rec)`), mirroring `EventLogService`.

## Notes
- The audit also flagged the two inline `new PowerShellRunner()` quick-action calls in this VM (DI-seam bypass). That's an architecture refactor (constructor injection + DI registration) and is deferred to the Gate-ARCH / Protocol-Q seam batch to keep this PR a focused, behavior-only fix.

Build: 0 warnings / 0 errors. Version 1.20.36. (Stacks on #920; will rebase to final version before merge.)