### PR TITLE
fix: disable long-running commands while busy to prevent shared-CTS disposal races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.37] - 2026-06-17
+
+### Fixed
+- **Windows Update and Bulk Installer buttons no longer cause an error when clicked during a running operation.** The toolbar actions (List updates / History / Pending reboot / Install selected, and Bulk Installer's Install Selected) stayed clickable while one was already running; a second click could cancel the first operation's work and crash it. These actions are now disabled while one is in progress and re-enable when it finishes.
+
 ## [1.20.36] - 2026-06-17
 
 ### Fixed

--- a/SysManager/SysManager.Tests/BulkInstallerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/BulkInstallerViewModelTests.cs
@@ -98,4 +98,19 @@ public class BulkInstallerViewModelTests
         Assert.Contains("Custom", vm.Categories);
         Assert.Equal(13, vm.Categories.Count);
     }
+
+    // ── re-entrancy guard (regression: shared CTS disposed mid-install) ──
+
+    [Fact]
+    public void InstallSelectedCommand_DisabledWhileBusy()
+    {
+        var vm = CreateVm();
+        Assert.True(vm.InstallSelectedCommand.CanExecute(null));   // idle → clickable
+
+        vm.IsBusy = true;
+        Assert.False(vm.InstallSelectedCommand.CanExecute(null));  // running → blocked (no re-entry)
+
+        vm.IsBusy = false;
+        Assert.True(vm.InstallSelectedCommand.CanExecute(null));   // done → clickable again
+    }
 }

--- a/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
+++ b/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
@@ -292,6 +292,27 @@ public class WindowsUpdateViewModelTests
         Assert.False(vm.AllSelected);
         Assert.All(vm.Updates, u => Assert.False(u.IsSelected));
     }
+
+    // ── re-entrancy guard (regression: shared CTS disposed mid-flight) ──
+
+    [Fact]
+    public void LongRunningCommands_DisabledWhileBusy()
+    {
+        var vm = NewVm();
+        Assert.True(vm.ListUpdatesCommand.CanExecute(null));
+        Assert.True(vm.ShowHistoryCommand.CanExecute(null));
+        Assert.True(vm.CheckPendingRebootCommand.CanExecute(null));
+        Assert.True(vm.InstallUpdatesCommand.CanExecute(null));
+
+        vm.IsBusy = true;
+        Assert.False(vm.ListUpdatesCommand.CanExecute(null));
+        Assert.False(vm.ShowHistoryCommand.CanExecute(null));
+        Assert.False(vm.CheckPendingRebootCommand.CanExecute(null));
+        Assert.False(vm.InstallUpdatesCommand.CanExecute(null));
+
+        vm.IsBusy = false;
+        Assert.True(vm.ListUpdatesCommand.CanExecute(null));
+    }
 }
 
 // ---------- UpdateEntry model ----------

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.36</Version>
-    <FileVersion>1.20.36.0</FileVersion>
-    <AssemblyVersion>1.20.36.0</AssemblyVersion>
+    <Version>1.20.37</Version>
+    <FileVersion>1.20.37.0</FileVersion>
+    <AssemblyVersion>1.20.37.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
@@ -63,6 +63,10 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
     {
         _service = service;
         _iconService = iconService;
+        // IsBusy lives in the base class; observe it to re-evaluate the install
+        // command's CanExecute so the button disables while an install runs (a second
+        // click would otherwise dispose the shared CTS mid-flight).
+        PropertyChanged += OnVmPropertyChanged;
         IsElevated = AdminHelper.IsElevated();
         Apps.ReplaceWith(BuildCuratedApps());
         ApplyFilter();
@@ -137,7 +141,21 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
             System.Windows.Application.Current?.Shutdown();
     }
 
-    [RelayCommand]
+    /// <summary>
+    /// Gate for the install command. Without it the "Install Selected" button stays
+    /// clickable during a running install; a second click re-enters the handler and
+    /// disposes the shared CTS the first invocation is still awaiting
+    /// (ObjectDisposedException). Disabling the button while busy prevents that.
+    /// </summary>
+    private bool NotBusy => !IsBusy;
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(IsBusy))
+            InstallSelectedCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task InstallSelectedAsync()
     {
         var selected = Apps.Where(a => a.IsSelected).ToList();
@@ -149,6 +167,8 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
 
         IsBusy = true;
         IsProgressIndeterminate = false;
+        // Re-entrancy is prevented by the NotBusy CanExecute gate, so the running
+        // install can never have its CTS disposed out from under it by a second click.
         _cts?.Dispose();
         _cts = new CancellationTokenSource();
 
@@ -454,6 +474,7 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
     {
         if (disposing)
         {
+            PropertyChanged -= OnVmPropertyChanged;
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -44,6 +44,10 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
         _runner.LineReceived += OnRunnerLineReceived;
         _runner.ProgressChanged += OnRunnerProgressChanged;
         _wu.Log += OnWuLog;
+        // IsBusy lives in the base class, so observe it here to re-evaluate the
+        // long-running commands' CanExecute (disabling them while one runs prevents
+        // a second command disposing the shared CTS the first is still awaiting).
+        PropertyChanged += OnVmPropertyChanged;
         IsElevated = AdminHelper.IsElevated();
         // PSWindowsUpdate is only needed for the History view, so we don't
         // probe for it at startup — the History command checks itself if
@@ -57,6 +61,25 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
     private void OnRunnerProgressChanged(int p) => Progress = p;
     private void OnWuLog(string text) => Console.Append(PowerShellLine.Output(text));
 
+    /// <summary>
+    /// Gate for the long-running commands. They all share <see cref="_cts"/> and each
+    /// recreates it; without a re-entrancy guard a second command could dispose the CTS
+    /// the first is still awaiting (ObjectDisposedException). Disabling the buttons
+    /// while one runs makes that impossible. <see cref="ViewModelBase.IsBusy"/> lives in
+    /// the base class, so each command notifies the gate manually around its run
+    /// (mirroring WindowsFeaturesViewModel) rather than via an OnIsBusyChanged hook.
+    /// </summary>
+    private bool NotBusy => !IsBusy;
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(IsBusy)) return;
+        ListUpdatesCommand.NotifyCanExecuteChanged();
+        ShowHistoryCommand.NotifyCanExecuteChanged();
+        CheckPendingRebootCommand.NotifyCanExecuteChanged();
+        InstallUpdatesCommand.NotifyCanExecuteChanged();
+    }
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)
@@ -64,6 +87,7 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
             _runner.LineReceived -= OnRunnerLineReceived;
             _runner.ProgressChanged -= OnRunnerProgressChanged;
             _wu.Log -= OnWuLog;
+            PropertyChanged -= OnVmPropertyChanged;
             _cts?.Dispose();
         }
         base.Dispose(disposing);
@@ -135,7 +159,7 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
         finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task ListUpdatesAsync()
     {
         IsBusy = true;
@@ -178,7 +202,7 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
         finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task ShowHistoryAsync()
     {
         IsBusy = true;
@@ -231,7 +255,7 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
         finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task CheckPendingRebootAsync()
     {
         IsBusy = true;
@@ -266,7 +290,7 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
         finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task InstallUpdatesAsync()
     {
         var selected = Updates.Where(u => u.IsSelected).ToList();


### PR DESCRIPTION
Both VMs share a single `_cts` field that each command disposes and recreates. With no re-entrancy guard, clicking a second command (or the same one twice) while one is running disposes the CTS the first is still awaiting → `ObjectDisposedException`.

## Changes
- **WindowsUpdateViewModel** — `ListUpdates` / `ShowHistory` / `CheckPendingReboot` / `InstallUpdates` gated with `[RelayCommand(CanExecute = nameof(NotBusy))]`. `IsBusy` lives in the base class, so the VM subscribes to `PropertyChanged` and calls `NotifyCanExecuteChanged()` on all four when `IsBusy` flips (mirroring how WindowsFeaturesViewModel notifies manually). Unsubscribed in `Dispose`.
- **BulkInstallerViewModel** — `InstallSelected` gated the same way; the button no longer stays clickable during an install.

## Tests
- `BulkInstallerViewModelTests.InstallSelectedCommand_DisabledWhileBusy` and `WindowsUpdateViewModelTests.LongRunningCommands_DisabledWhileBusy`: assert each command's `CanExecute(null)` is true when idle, false while `IsBusy`, true again after.

Build: main + tests compile 0 warnings / 0 errors. Version 1.20.37.