### PR TITLE
fix: drain process output before returning, kill orphaned speedtest, thread-safe capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.38] - 2026-06-17
+
+### Fixed
+- **External command output is no longer occasionally truncated.** Results from tools like the network repair commands, chkdsk, and winget are read on background threads; the app could snapshot the captured text a moment before the last lines arrived, dropping them. The runner now waits for the output streams to fully drain before returning.
+- **The Speed Test no longer leaves a stray `speedtest.exe` running if it is cancelled or times out mid-transfer.** Cancellation during the result read could skip the cleanup that kills the CLI process; the process is now always terminated on cancellation.
+- **Captured output from chkdsk and the winget upgrade scan is now collected safely.** Both gathered command output into a list that two background reader threads wrote to at once, which could drop or corrupt lines; they now use a thread-safe collector.
+
 ## [1.20.37] - 2026-06-17
 
 ### Fixed

--- a/SysManager/SysManager/Services/PowerShellRunner.cs
+++ b/SysManager/SysManager/Services/PowerShellRunner.cs
@@ -212,6 +212,14 @@ public sealed class PowerShellRunner : IPowerShellRunner
         using var reg = cancellationToken.Register(() => { try { if (!proc.HasExited) proc.Kill(entireProcessTree: true); } catch (InvalidOperationException) { } });
         await proc.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
 
+        // WaitForExitAsync returns when the process exits, but the asynchronous
+        // BeginOutputReadLine/BeginErrorReadLine pumps may not have raised their final
+        // lines yet — callers that snapshot captured output immediately can lose the
+        // last lines. The parameterless WaitForExit() blocks until both readers have
+        // flushed and reached end-of-stream. Cheap here (the process has already exited)
+        // and only reached when not cancelled.
+        await Task.Run(proc.WaitForExit, CancellationToken.None).ConfigureAwait(false);
+
         return proc.ExitCode;
     }
 

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -229,19 +229,23 @@ public sealed class SpeedTestService
         // Read stdout and stderr in parallel to prevent pipe buffer deadlock.
         // If one pipe fills while the other is being read sequentially, the
         // child process blocks indefinitely (classic Windows pipe deadlock).
-        var stdoutTask = proc.StandardOutput.ReadToEndAsync(linked);
-        var stderrTask = proc.StandardError.ReadToEndAsync(linked);
-        await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
-        var stdout = await stdoutTask.ConfigureAwait(false);
-        var stderr = await stderrTask.ConfigureAwait(false);
-
+        string stdout, stderr;
         try
         {
+            var stdoutTask = proc.StandardOutput.ReadToEndAsync(linked);
+            var stderrTask = proc.StandardError.ReadToEndAsync(linked);
+            await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
+            stdout = await stdoutTask.ConfigureAwait(false);
+            stderr = await stderrTask.ConfigureAwait(false);
+
             await proc.WaitForExitAsync(linked).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
-            // Timeout or user cancellation — kill the orphan process
+            // Timeout or user cancellation can hit during the pipe reads OR the wait —
+            // kill the child either way so speedtest.exe is never orphaned. (Previously
+            // the kill only covered WaitForExitAsync, so a cancel during the reads
+            // leaked the process.)
             try { if (!proc.HasExited) proc.Kill(entireProcessTree: true); }
             catch (InvalidOperationException) { /* already exited */ }
             throw;

--- a/SysManager/SysManager/Services/WingetService.cs
+++ b/SysManager/SysManager/Services/WingetService.cs
@@ -27,11 +27,14 @@ public sealed partial class WingetService
     /// </summary>
     public async Task<List<AppPackage>> ListUpgradableAsync(CancellationToken ct = default)
     {
-        List<string> captured = [];
+        // LineReceived fires from both the stdout and stderr reader threads
+        // concurrently, so the sink must be thread-safe — a plain List<T>.Add can
+        // corrupt the backing array or drop a line under the race.
+        var captured = new System.Collections.Concurrent.ConcurrentQueue<string>();
 
         void Collect(PowerShellLine l)
         {
-            if (l.Kind == OutputKind.Output) captured.Add(l.Text);
+            if (l.Kind == OutputKind.Output) captured.Enqueue(l.Text);
         }
 
         _runner.LineReceived += Collect;
@@ -42,7 +45,7 @@ public sealed partial class WingetService
         }
         finally { _runner.LineReceived -= Collect; }
 
-        return ParseUpgradeTable(captured);
+        return ParseUpgradeTable(captured.ToList());
     }
 
     private static List<AppPackage> ParseUpgradeTable(List<string> lines)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.37</Version>
-    <FileVersion>1.20.37.0</FileVersion>
-    <AssemblyVersion>1.20.37.0</AssemblyVersion>
+    <Version>1.20.38</Version>
+    <FileVersion>1.20.38.0</FileVersion>
+    <AssemblyVersion>1.20.38.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
@@ -269,8 +269,11 @@ public sealed partial class SystemHealthViewModel : ViewModelBase
             // the text rather than relying solely on the exit code. chkdsk
             // may return non-zero even on healthy disks (e.g. when the
             // volume is in use or /scan is not supported on the filesystem).
-            var captured = new System.Collections.Generic.List<string>();
-            void OnLine(PowerShellLine l) => captured.Add(l.Text);
+            // LineReceived fires from both the stdout and stderr reader threads
+            // concurrently, so the sink must be thread-safe — a plain List<T>.Add can
+            // corrupt the backing array or drop a line under the race.
+            var captured = new System.Collections.Concurrent.ConcurrentQueue<string>();
+            void OnLine(PowerShellLine l) => captured.Enqueue(l.Text);
             _runner.LineReceived += OnLine;
 
             int exit;
@@ -280,7 +283,7 @@ public sealed partial class SystemHealthViewModel : ViewModelBase
             }
             finally { _runner.LineReceived -= OnLine; }
 
-            var verdict = ParseChkdskVerdict(captured, exit);
+            var verdict = ParseChkdskVerdict(captured.ToArray(), exit);
             if (target is not null) target.Status = verdict;
             StatusMessage = $"chkdsk {driveLetter} done — {verdict}.";
             Log.Information("chkdsk completed on {Drive}: exit {ExitCode}, verdict {Verdict}", driveLetter, exit, verdict);


### PR DESCRIPTION
External-process plumbing defects across the shared runner and two consumers.

## Changes
- **PowerShellRunner.RunProcessAsync** — `WaitForExitAsync` returns when the process exits, but the async `BeginOutputReadLine`/`BeginErrorReadLine` pumps may not have raised their final lines, so callers that snapshot output immediately lost the last lines (e.g. NetworkRepair, chkdsk, winget). Added a `proc.WaitForExit()` (on a thread-pool thread, only when not cancelled) to block until both readers reach end-of-stream. Fixes the truncation at the seam for all consumers.
- **SpeedTestService.RunOoklaAsync** — cancellation/timeout during the parallel stdout/stderr `ReadToEndAsync` propagated *before* the try/catch that kills the child, orphaning `speedtest.exe`. Wrapped the reads + wait in one try; the `OperationCanceledException` catch now kills the process tree on any cancellation path.
- **SystemHealthViewModel (chkdsk)** and **WingetService (upgrade scan)** — both collected output into a plain `List<string>` written by the concurrent stdout+stderr reader threads (data race: dropped/corrupted lines). Switched to `ConcurrentQueue<string>`, materialized (`ToArray()`/`ToList()`) before parsing.

## Tests
- Existing `WingetService`/`SystemHealth` parse tests still pass (the parsers are unchanged; only the collector type changed). The concurrency/orphan-kill paths require live process I/O and aren't unit-testable; they mirror the audit's recommended fixes.

Build: 0 warnings / 0 errors. Version 1.20.38.