### PR TITLE
fix: keep transient WMI failures in the tray timer from crashing the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.39] - 2026-06-17
+
+### Fixed
+- **A transient system-info failure can no longer crash the app from the tray.** The system tray refreshes a CPU/RAM/uptime tooltip on a background timer; if the underlying WMI query failed transiently (for example "RPC server unavailable"), the error could go unhandled and bring the whole app down. The tray refresh now handles those failures and simply skips that tick.
+
 ## [1.20.38] - 2026-06-17
 
 ### Fixed

--- a/SysManager/SysManager/Services/TrayIconService.cs
+++ b/SysManager/SysManager/Services/TrayIconService.cs
@@ -161,6 +161,13 @@ public sealed class TrayIconService : IDisposable
             // async void must never throw — unhandled exceptions crash the app.
             Log.Warning("TrayIcon timer tick failed: {Error}", ex.Message);
         }
+        catch (Exception ex)
+        {
+            // Last-resort net: this is an async-void background timer, so ANY escaping
+            // exception (e.g. an unexpected WMI/COM fault) would crash the process.
+            // Swallow and log — a failed tooltip refresh must never take the app down.
+            Log.Warning(ex, "TrayIcon timer tick failed unexpectedly");
+        }
     }
 
     private async Task UpdateTooltipAsync()
@@ -188,6 +195,14 @@ public sealed class TrayIconService : IDisposable
         catch (System.Management.ManagementException ex)
         {
             Log.Warning("TrayIcon tooltip update failed: {Error}", ex.Message);
+        }
+        catch (System.Runtime.InteropServices.COMException ex)
+        {
+            // WMI commonly throws COMException on transient failures (RPC server
+            // unavailable 0x800706BA, repository errors). The background timer must
+            // never let this escape — OnTimerTick is async void, so an unhandled
+            // throw would crash the whole app.
+            Log.Warning("TrayIcon tooltip update failed (WMI COM error): 0x{HResult:X8}", ex.HResult);
         }
         catch (InvalidOperationException ex)
         {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.38</Version>
-    <FileVersion>1.20.38.0</FileVersion>
-    <AssemblyVersion>1.20.38.0</AssemblyVersion>
+    <Version>1.20.39</Version>
+    <FileVersion>1.20.39.0</FileVersion>
+    <AssemblyVersion>1.20.39.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
The system-tray tooltip refreshes CPU/RAM/uptime on a background timer. `OnTimerTick` is `async void`, and `UpdateTooltipAsync` → `SystemInfoService.CaptureAsync()` runs WMI queries. WMI commonly throws `COMException` on transient faults (RPC server unavailable `0x800706BA`, repository errors), which `UpdateTooltipAsync` did NOT catch — so it escaped the async-void handler and crashed the whole app.

## Changes (`TrayIconService`)
- Added a `catch (COMException)` arm to `UpdateTooltipAsync` (logs the HRESULT, skips the tick), alongside the existing `ManagementException`/`InvalidOperationException` catches.
- Added a final last-resort `catch (Exception)` to `OnTimerTick` (logged) — an async-void background poller must never let anything escape and take the process down.

Build: 0 warnings / 0 errors. Version 1.20.39. (Stacks on #927; will rebase to final version before merge.)