### PR TITLE
chore: exclude cs/useless-upcast by id so WUApiLib COM-interop alerts clear

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -32,9 +32,16 @@ query-filters:
   # or (string)u.Identity.UpdateID are load-bearing runtime conversions from dynamic
   # to the concrete type the code needs — removing them would propagate `dynamic` and
   # lose type safety. CodeQL sees the static type as object and reports a self-upcast.
+  # NOTE: the `path:` key is NOT honoured inside query-filters (only `id`/`tags` are),
+  # so a path-scoped exclude silently failed to suppress these. Exclude by id alone —
+  # this rule has zero legitimate hand-written hits across the codebase.
   - exclude:
       id: cs/useless-upcast
-      path: SysManager/SysManager/Services/WindowsUpdateService.cs
+  # cs/nested-if-statements is a pure readability suggestion (collapse nested ifs). The
+  # nested forms here read more clearly with their separate guard comments, and the rule
+  # also fires on [GeneratedRegex] source-generator output under obj/. Style, not a defect.
+  - exclude:
+      id: cs/nested-if-statements
   # cs/path-combine flags Path.Combine arguments that embed a directory separator
   # (which can silently discard earlier segments). Every occurrence here passes only
   # separator-free literals ("$Recycle.Bin", "Steam", "drivers"/"etc"/"hosts"), i.e.


### PR DESCRIPTION
Six CodeQL alerts reappeared after the Windows Update COM-lifetime work (#915): `cs/useless-upcast` on the WUApiLib `dynamic` casts in `WindowsUpdateService`, plus `cs/nested-if-statements`.

## Root cause
The existing `cs/useless-upcast` exclude used a `path:` key inside `query-filters` — but `path` is **not** a valid key there (only `id` and `tags` are honoured), so the path-scoped exclude silently never matched and the alerts were never suppressed.

## Fix (`.github/codeql-config.yml`, no release)
- Drop the dead `path:` key from the `cs/useless-upcast` exclude so it filters by `id` (matching the other working excludes). These casts (`(bool)u.IsDownloaded`, `(string)u.Identity.UpdateID`, …) are load-bearing conversions from late-bound COM `dynamic` to the concrete type — removing them would propagate `dynamic` and lose type safety. Zero legitimate hand-written hits exist.
- Add `cs/nested-if-statements` (pure readability suggestion; also fires on `[GeneratedRegex]` output under obj/).

`chore:` — config only, no code change, no release.