### PR TITLE
fix: move blocking shortcut-delete and app-list scans off the UI thread, gate log refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Deleting broken shortcuts no longer freezes the window.** The Shortcut Cleaner ran the shell delete on the UI thread, so removing many shortcuts could hang the app until it finished; the delete now runs in the background.
 - **Loading the full installed-apps list no longer freezes the App Alerts tab.** "Show all installed apps" walked the entire registry uninstall tree on the UI thread; that scan now runs in the background.
 - **Refreshing the System Logs twice in a row no longer mixes results.** Starting a second refresh while one was running could let the cancelled run's leftover batches land in the new list. The Refresh button is now disabled while a scan is in progress.
+- **Applying a Context Menu preset no longer freezes the window.** Applying a preset ran the registry changes and the Explorer restart on the UI thread, briefly hanging the app; that work now runs in the background.
 
 ## [1.20.41] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.42] - 2026-06-17
+
+### Fixed
+- **Deleting broken shortcuts no longer freezes the window.** The Shortcut Cleaner ran the shell delete on the UI thread, so removing many shortcuts could hang the app until it finished; the delete now runs in the background.
+- **Loading the full installed-apps list no longer freezes the App Alerts tab.** "Show all installed apps" walked the entire registry uninstall tree on the UI thread; that scan now runs in the background.
+- **Refreshing the System Logs twice in a row no longer mixes results.** Starting a second refresh while one was running could let the cancelled run's leftover batches land in the new list. The Refresh button is now disabled while a scan is in progress.
+
 ## [1.20.41] - 2026-06-17
 
 ### Fixed

--- a/SysManager/SysManager.Tests/LogsViewModelTests.cs
+++ b/SysManager/SysManager.Tests/LogsViewModelTests.cs
@@ -121,4 +121,19 @@ public class LogsViewModelTests
         Assert.Equal(0, vm.WarningCount);
         Assert.Equal(0, vm.InfoCount);
     }
+
+    // ── Refresh re-entrancy gate (regression: double-invoke pollutes Entries) ──
+
+    [Fact]
+    public void RefreshCommand_DisabledWhileBusy()
+    {
+        var vm = new LogsViewModel(new Services.EventLogService());
+        Assert.True(vm.RefreshCommand.CanExecute(null));   // idle → allowed
+
+        vm.IsBusy = true;
+        Assert.False(vm.RefreshCommand.CanExecute(null));  // scanning → blocked (no second run)
+
+        vm.IsBusy = false;
+        Assert.True(vm.RefreshCommand.CanExecute(null));   // done → allowed again
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.41</Version>
-    <FileVersion>1.20.41.0</FileVersion>
-    <AssemblyVersion>1.20.41.0</AssemblyVersion>
+    <Version>1.20.42</Version>
+    <FileVersion>1.20.42.0</FileVersion>
+    <AssemblyVersion>1.20.42.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
@@ -81,7 +81,7 @@ public sealed partial class AppAlertsViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void RefreshInstalledApps()
+    private async Task RefreshInstalledAppsAsync()
     {
         StatusMessage = "Loading installed applications...";
         IsBusy = true;
@@ -89,7 +89,9 @@ public sealed partial class AppAlertsViewModel : ViewModelBase
 
         try
         {
-            var apps = AppAlertService.GetRegistryApps();
+            // The HKLM uninstall-tree enumeration is synchronous and walks the whole
+            // registry — run it off the UI thread so the window stays responsive.
+            var apps = await Task.Run(AppAlertService.GetRegistryApps).ConfigureAwait(true);
             var sorted = apps.OrderBy(a => a.Name).ToList();
             foreach (var app in sorted)
             {

--- a/SysManager/SysManager/ViewModels/ContextMenuViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ContextMenuViewModel.cs
@@ -144,7 +144,7 @@ public sealed partial class ContextMenuViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void ApplyPreset(object? parameter)
+    private async Task ApplyPresetAsync(object? parameter)
     {
         if (parameter is not string presetId) return;
         if (presetId == "custom")
@@ -173,34 +173,42 @@ public sealed partial class ContextMenuViewModel : ViewModelBase
 
         try
         {
-            if (needsRestart)
+            // Registry writes + RestartExplorer are synchronous and can take a moment
+            // (Explorer restart especially) — run them off the UI thread so the window
+            // stays responsive. No UI state is touched inside the Task.Run body.
+            var (disabled, enabled) = await Task.Run(() =>
             {
-                if (preset.ForcesClassicMenu)
-                    ContextMenuService.EnableClassicMenu();
-                else
-                    ContextMenuService.DisableClassicMenu();
-            }
+                if (needsRestart)
+                {
+                    if (preset.ForcesClassicMenu)
+                        ContextMenuService.EnableClassicMenu();
+                    else
+                        ContextMenuService.DisableClassicMenu();
+                }
 
-            // Disable all third-party entries to restore clean default
-            var disabled = 0;
-            foreach (var entry in _allEntries.Where(e =>
-                         !e.IsSystemEntry && e.IsEnabled && !IsDefaultWindowsEntry(e)))
-            {
-                if (_service.DisableEntry(entry))
-                    disabled++;
-            }
+                // Disable all third-party entries to restore clean default
+                var dis = 0;
+                foreach (var entry in _allEntries.Where(e =>
+                             !e.IsSystemEntry && e.IsEnabled && !IsDefaultWindowsEntry(e)))
+                {
+                    if (_service.DisableEntry(entry))
+                        dis++;
+                }
 
-            // Enable any default Windows entries that were previously disabled
-            var enabled = 0;
-            foreach (var entry in _allEntries.Where(e =>
-                         !e.IsSystemEntry && !e.IsEnabled && IsDefaultWindowsEntry(e)))
-            {
-                if (_service.EnableEntry(entry))
-                    enabled++;
-            }
+                // Enable any default Windows entries that were previously disabled
+                var en = 0;
+                foreach (var entry in _allEntries.Where(e =>
+                             !e.IsSystemEntry && !e.IsEnabled && IsDefaultWindowsEntry(e)))
+                {
+                    if (_service.EnableEntry(entry))
+                        en++;
+                }
 
-            if (needsRestart)
-                ContextMenuService.RestartExplorer();
+                if (needsRestart)
+                    ContextMenuService.RestartExplorer();
+
+                return (dis, en);
+            });
 
             IsClassicMenuEnabled = preset.ForcesClassicMenu;
             ActivePresetId = presetId;

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -69,6 +69,18 @@ public sealed partial class LogsViewModel : ViewModelBase
         _sync = SynchronizationContext.Current;
         EntriesView = CollectionViewSource.GetDefaultView(Entries);
         EntriesView.Filter = EntryFilter;
+        // Disable Refresh while a scan runs — a second concurrent Refresh lets the
+        // cancelled run's queued UI batches pollute the new Entries list. IsBusy lives
+        // in the base class, so observe it here to re-evaluate the command.
+        PropertyChanged += OnVmPropertyChanged;
+    }
+
+    private bool NotBusy => !IsBusy;
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(IsBusy))
+            RefreshCommand.NotifyCanExecuteChanged();
     }
 
     private void UpdateVisibleCount()
@@ -116,7 +128,7 @@ public sealed partial class LogsViewModel : ViewModelBase
 
     // ---------- Commands ----------
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task RefreshAsync()
     {
         _cts?.Cancel();
@@ -194,6 +206,7 @@ public sealed partial class LogsViewModel : ViewModelBase
     {
         if (disposing)
         {
+            PropertyChanged -= OnVmPropertyChanged;
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
@@ -90,7 +90,7 @@ public sealed partial class ShortcutCleanerViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void DeleteSelected()
+    private async Task DeleteSelectedAsync()
     {
         var selected = BrokenShortcuts.Where(x => x.IsSelected).ToList();
         if (selected.Count == 0)
@@ -104,7 +104,9 @@ public sealed partial class ShortcutCleanerViewModel : ViewModelBase
             $"Are you sure you want to {action} {selected.Count} broken shortcut{(selected.Count == 1 ? "" : "s")}?",
             "Delete Broken Shortcuts — Confirm")) return;
 
-        var deleted = ShortcutCleanerService.DeleteShortcuts(selected, MoveToRecycleBin);
+        // The shell delete (SHFileOperation) is synchronous and can take a while for
+        // many items — run it off the UI thread so the window stays responsive.
+        var deleted = await Task.Run(() => ShortcutCleanerService.DeleteShortcuts(selected, MoveToRecycleBin));
 
         // Remove deleted items from the list
         foreach (var s in selected.Where(s => !System.IO.File.Exists(s.ShortcutPath)))


### PR DESCRIPTION
Three UI-responsiveness fixes (P2).

## Changes
- **ShortcutCleanerViewModel.DeleteSelected** → `async DeleteSelectedAsync`; the synchronous `SHFileOperation` batch delete now runs via `Task.Run`, so deleting many shortcuts doesn't freeze the window.
- **AppAlertsViewModel.RefreshInstalledApps** → `async RefreshInstalledAppsAsync`; the full HKLM uninstall-tree enumeration now runs via `Task.Run(...).ConfigureAwait(true)`, off the UI thread.
- **LogsViewModel.Refresh** — gated with `[RelayCommand(CanExecute = nameof(NotBusy))]` + `PropertyChanged` observer on `IsBusy`; a second refresh started while one is running could let the cancelled run's queued UI batches pollute the new `Entries` list. The button is now disabled while scanning.

## Tests
- `LogsViewModelTests.RefreshCommand_DisabledWhileBusy` asserts the gate (allowed idle → blocked busy → allowed again).
- The two `Task.Run` offloads are behavior-preserving (same work, off-thread); covered by existing VM tests.

## Notes
- The ContextMenu `ApplyPreset` and Ping `Stop`-blocks-UI findings are deferred — they touch shared `NetworkSharedState`/RestartExplorer flows and warrant separate, carefully-verified PRs.

Build: main + tests 0 warnings / 0 errors. Version 1.20.42. (Stacks on #930/#933; will rebase before merge.)