### PR TITLE
docs: CHANGELOG cleanup, three-pass duplicate finder, de-versioned examples, tech-stack accuracy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -128,7 +128,7 @@ Key services:
   `SocketsHttpHandler`, retry, and surfaced error messages.
 - `StartupService` — enumerate and toggle startup programs via registry
   Run / RunOnce keys.
-- `DuplicateFileService` — two-pass duplicate finder (size grouping →
+- `DuplicateFileService` — three-pass duplicate finder (size grouping →
   partial hash pre-filter → full SHA-256). Read-only, never deletes.
 - `DiskAnalyzerService` — folder-level space breakdown with progress
   reporting and system-path skipping.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,36 +120,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Hosts entries with multiple hostnames per IP are no longer silently lost.** A line like `127.0.0.1 a b c` was read keeping only the first hostname, so editing and saving dropped the rest. Each hostname is now read as its own entry and survives a round trip.
 - **The hosts file is now written atomically.** Saving wrote directly over the file, so a crash mid-write could leave it empty or truncated. It now writes to a temporary file and atomically replaces the target, cleaning up the temp file afterward.
 
-### Fixed
-- **No more leaked process handles when opening Explorer / links.** Ten places that launch Explorer ("show in folder"/"open file location"), Event Viewer, the browser, or the updater left the returned process handle undisposed. Each now releases it. The launched program is unaffected; only the orphaned handle is cleaned up. Covers Deep Cleanup, Disk Analyzer, Duplicate Finder, Startup Manager, Logs, About, and the Context Menu refresh.
-
-### Fixed
-- **Drive/disk health reads survive systems without the Storage WMI namespace.** Disk Health and System Info could throw an unhandled COM error on older or headless Windows where the `root\Microsoft\Windows\Storage` namespace isn't present; both now handle that case and fall back gracefully (mirrors the earlier Fixed Drives fix).
-- **No leaked process handle when opening a file location.** "Open file location" in Process Manager left the launched Explorer process handle undisposed; it's now released.
-- **Swallowed errors are now diagnosable.** Several silent `catch` blocks now log at Debug level with the full exception (update-file cleanup, Deep Cleanup directory deletion, Windows Update size extraction, and the Dashboard polling loop), so failures leave a trace in the log instead of vanishing.
-
-### Changed
-- **Some status/accent colors now follow the theme instead of being hardcoded.** Replaced hardcoded color values that exactly matched a theme color (success green, warning amber, danger red, accent, hover border) with theme references on the Dashboard, Network Repair, Privacy, and Uninstaller tabs. The colors render identically today but will track the theme going forward.
-
-### Fixed
-- **Much better screen-reader support across the app.** Many buttons, toggles, drop-downs, search/filter boxes, data grids, and per-row actions had no accessible name, so screen readers announced them generically (or not at all). Added clear, specific accessible names to interactive controls across 21 tabs — including destructive actions (Delete, Shred, Clear History), per-row buttons (now named after the item they act on), and unlabeled inputs. No visual change.
-
-### Fixed
-- **Activity history can no longer be corrupted by concurrent updates.** The recent-actions log saved its data outside the lock that protects it, so two actions logged at the same time could clash and produce a "collection modified" error or a truncated file. It now writes a consistent snapshot taken under the lock.
-- **The in-app updater fails gracefully when the download location can't be determined.** Installing an update now checks the downloaded file's folder up front and shows a clear message instead of risking a crash.
-
-### Fixed
-- **More resilient reading of battery, memory, and app-list data.** Unexpected values from Windows (battery stats, memory-module details) could throw a conversion error and interrupt a scan; those conversions now fall back safely. The winget output parser also no longer throws when the tool reports columns in an unusual order.
-
-### Fixed
-- **Plugged several resource leaks.** The system-tray icon's underlying graphics handle was never released on shutdown; the elevated-relaunch helper left a process handle open; and a memory-module query left a WMI result set undisposed. All are now released properly. Also added handling for a WMI namespace being unavailable when reading drive media/bus details, so that case fails quietly instead of surfacing an error.
-
-### Fixed
-- **Starting or stopping a Windows service no longer crashes the app on failure.** If a service couldn't be started or stopped (access denied, a dependency problem, or the service state changing mid-operation), the underlying error escaped unhandled. Those failures are now caught and shown as a clear status message.
-- **Privacy toggles no longer crash on a registry write error.** Applying a privacy toggle only handled permission errors; a registry I/O error or an invalid key/value now logs a warning instead of bringing down the app.
-- **Disabling Xbox Game Bar no longer crashes on a registry I/O error.** The Performance tab's Xbox Game Bar action now handles I/O failures the same way it already handled permission and state errors.
-- **A misbehaving UI subscriber can no longer permanently lock an operation category.** If a property-change notification threw while acquiring an operation lock, the category could stay locked forever (blocking all future disk/network/system operations of that kind). The lock is now rolled back cleanly if that happens.
-
 ## [1.20.23] - 2026-06-12
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,8 +180,9 @@ Prefixes aren't required, but if you want a convention: `fix:`, `feat:`,
    ARCHITECTURE where relevant).
 5. **Open the PR** against `main`. Fill out the PR template honestly —
    if you didn't add tests, say why.
-6. **CI must be green** before review starts. CI runs build + both test
-   projects on a Windows runner.
+6. **CI must be green** before review starts. On a Windows runner, CI builds
+   the app, runs the unit-test project, compile-checks the integration-test
+   project, and runs the UI-automation tests as a separate non-blocking job.
 7. **Review and iterate.** I try to respond within a few days. If a PR
    goes silent, ping me with a comment.
 8. **Squash merge** is the default. Your individual commits are

--- a/README.md
+++ b/README.md
@@ -456,18 +456,19 @@ to stay on the latest version.
 
 ### Direct download
 
-Grab `SysManager-v<version>.exe` (e.g. `SysManager-v1.19.2.exe`) from the
+Grab `SysManager-v<version>.exe` (the `<version>` shown on the latest release) from the
 [latest release](https://github.com/laurentiu021/SystemManager/releases/latest)
 and double-click it. The executable is self-contained — no installer, no .NET
 runtime required.
 
 ### Verifying the download
 
-Each release ships a matching `SysManager-v<version>.exe.sha256`. Verify before running:
+Each release ships a matching `SysManager-v<version>.exe.sha256`. Verify before running
+(replace `<version>` with the version you downloaded):
 
 ```powershell
-Get-FileHash .\SysManager-v1.19.2.exe -Algorithm SHA256
-# Compare the output to the contents of SysManager-v1.19.2.exe.sha256.
+Get-FileHash .\SysManager-v<version>.exe -Algorithm SHA256
+# Compare the output to the contents of SysManager-v<version>.exe.sha256.
 ```
 
 The build is not currently code-signed, so Windows SmartScreen may warn on
@@ -549,6 +550,7 @@ and elevation state in a format ready to paste into a bug report.
 - WPF-UI (lepoco/wpfui) for Fluent Design theme and controls
 - LiveCharts2 for the real-time latency chart
 - H.NotifyIcon.Wpf for system tray integration
+- LibreHardwareMonitor and NvAPIWrapper for CPU/GPU/disk temperature sensors
 - Serilog for structured logging
 - xUnit, NSubstitute, and FlaUI for unit, integration, and UI-automation tests
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -95,12 +95,12 @@ What the app can and cannot do by design:
 
 ## Verifying a release
 
-Every release on GitHub ships a versioned `SysManager-v<version>.exe` (e.g.
-`SysManager-v1.20.21.exe`) and a matching `SysManager-v<version>.exe.sha256`
-file. You can verify the binary before running it:
+Every release on GitHub ships a versioned `SysManager-v<version>.exe` and a
+matching `SysManager-v<version>.exe.sha256` file. You can verify the binary
+before running it (replace `<version>` with the version you downloaded):
 
 ```powershell
-Get-FileHash .\SysManager-v1.20.21.exe -Algorithm SHA256
+Get-FileHash .\SysManager-v<version>.exe -Algorithm SHA256
 # Compare the output to the contents of the .sha256 file from the release page.
 ```
 

--- a/SysManager/SysManager/Services/DuplicateFileService.cs
+++ b/SysManager/SysManager/Services/DuplicateFileService.cs
@@ -10,9 +10,12 @@ using SysManager.Models;
 namespace SysManager.Services;
 
 /// <summary>
-/// Scans a folder tree for duplicate files. Two-pass approach:
+/// Scans a folder tree for duplicate files. Three-pass approach:
 /// 1. Group files by size (files with unique sizes can't be duplicates).
-/// 2. For each size group with 2+ files, compute SHA-256 and group by hash.
+/// 2. Within each size group, pre-filter by a partial hash (first 4 KB) to
+///    cheaply rule out files that differ early.
+/// 3. Full SHA-256 only on files whose partial hash matched 2+ others, then
+///    group by the full hash.
 ///
 /// Read-only — never modifies or deletes anything.
 /// </summary>


### PR DESCRIPTION
Docs-accuracy P3 sweep (no release).

## Changes
- **CHANGELOG** — the `[1.20.24]` entry had 9 stacked `### Fixed/Changed` sections (it had absorbed the history of 1.20.16–23 before those got their own headers in the prior PR). Trimmed to its own content (the two hosts-file fixes); the duplicated content now lives in the correct per-version sections.
- **Duplicate Finder algorithm** — labeled "two-pass" in `DuplicateFileService`'s doc-comment and in `ARCHITECTURE.md`, but it's actually three passes (size group → partial-hash pre-filter → full SHA-256), as README already states. Comment + ARCHITECTURE now say three-pass and the comment lists all three stages.
- **De-versioned download/verify examples** — `README.md` pinned `1.19.2` and `SECURITY.md` pinned `1.20.21` (both stale vs current). Replaced with `<version>` placeholders + "replace with the version you downloaded" so they can't drift again.
- **README Tech stack** — added LibreHardwareMonitor + NvAPIWrapper (used for CPU/GPU/disk temperature sensors), which were omitted.
- **CONTRIBUTING** — "CI runs both test projects" was inaccurate (there are three). Corrected to: builds the app, runs the unit-test project, compile-checks integration tests, and runs UI tests as a separate non-blocking job (matches `ci.yml`).

`docs:` — documentation + code-comment only, no behavior change, no release.