### PR TITLE
chore: remove dead traceroute hop counter, make memory DTO immutable, anchor WorkFolders category match

### DIFF
--- a/SysManager/SysManager.Tests/WindowsFeaturesTests.cs
+++ b/SysManager/SysManager.Tests/WindowsFeaturesTests.cs
@@ -92,6 +92,10 @@ public class WindowsFeaturesTests
     [InlineData("MediaPlayback", "Media & Print")]
     [InlineData("Printing-XPSServices-Features", "Media & Print")]
     [InlineData("DirectPlay", "Legacy")]
+    [InlineData("WorkFolders-Client", "Legacy")]
+    // Regression: a bare "WORK" substring used to drop any "...work..." feature into
+    // Legacy. An unknown feature that merely contains "work" must NOT be Legacy now.
+    [InlineData("SomeFrameworkThing", "Other")]
     [InlineData("SomeRandomFeature", "Other")]
     public void CategorizeFeature_AssignsCorrectCategory(string featureName, string expected)
     {

--- a/SysManager/SysManager/Models/MemoryModuleHealth.cs
+++ b/SysManager/SysManager/Models/MemoryModuleHealth.cs
@@ -6,10 +6,10 @@ namespace SysManager.Models;
 
 public sealed class MemoryModuleHealth
 {
-    public string Slot { get; set; } = "";
-    public string Manufacturer { get; set; } = "";
-    public double CapacityGB { get; set; }
-    public uint SpeedMHz { get; set; }
-    public uint ConfiguredSpeedMHz { get; set; }
-    public string PartNumber { get; set; } = "";
+    public string Slot { get; init; } = "";
+    public string Manufacturer { get; init; } = "";
+    public double CapacityGB { get; init; }
+    public uint SpeedMHz { get; init; }
+    public uint ConfiguredSpeedMHz { get; init; }
+    public string PartNumber { get; init; } = "";
 }

--- a/SysManager/SysManager/Models/WindowsFeature.cs
+++ b/SysManager/SysManager/Models/WindowsFeature.cs
@@ -49,8 +49,10 @@ public sealed partial class WindowsFeature : ObservableObject
             name.Contains("SCAN") || name.Contains("FAX"))
             return "Media & Print";
 
+        // "WORKFOLDERS" specifically — NOT a bare "WORK" substring, which also matches
+        // "netWORK" and "frameWORK" and would mis-bucket unrelated features into Legacy.
         if (name.Contains("LEGACY") || name.Contains("DIRECTPLAY") ||
-            name.Contains("INDEXING") || name.Contains("WORK"))
+            name.Contains("INDEXING") || name.Contains("WORKFOLDERS"))
             return "Legacy";
 
         return "Other";

--- a/SysManager/SysManager/ViewModels/TracerouteViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TracerouteViewModel.cs
@@ -18,7 +18,6 @@ public sealed partial class TracerouteViewModel : ViewModelBase
 {
     public NetworkSharedState Shared { get; }
     private CancellationTokenSource? _traceCts;
-    private int _totalHops;
 
     [ObservableProperty] private string _traceHost = "8.8.8.8";
     [ObservableProperty] private bool _isTracing;
@@ -73,11 +72,9 @@ public sealed partial class TracerouteViewModel : ViewModelBase
         _traceCts?.Dispose();
         _traceCts = new CancellationTokenSource();
         List<TracerouteHop> collected = [];
-        _totalHops = 0;
         void OnHop(TracerouteHop hop)
         {
             collected.Add(hop);
-            _totalHops = collected.Count;
             Shared.InvokeOnUi(() =>
             {
                 TraceStatus = $"Tracing {TraceHost}… hop {hop.HopNumber}";


### PR DESCRIPTION
Behavior-neutral P3 cleanups (chore, no release).

## Changes
- **TracerouteViewModel** — removed the `_totalHops` field: it was written in two places (`OnHop`/reset) but never read. Dead state.
- **MemoryModuleHealth** — converted the DTO's mutable `set` accessors to `init`. It's constructed once via object-initializer in the WMI read and never mutated afterward; this makes the immutability explicit (matches the other read-model DTOs).
- **WindowsFeature.CategorizeFeature** — `name.Contains("WORK")` (intended for WorkFolders) also matched "net**work**"/"frame**work**", so an unknown feature containing "work" was mis-bucketed into Legacy. Anchored to `"WORKFOLDERS"`.

## Tests
- `WindowsFeaturesTests.CategorizeFeature_AssignsCorrectCategory`: added `WorkFolders-Client → Legacy` and regression cases asserting a generic "...work..." feature is no longer forced into Legacy.

Build: main + tests 0 warnings / 0 errors. `chore:` — no release.