### PR TITLE
fix: guard re-entrant monitor start, drive TOCTOU, icon caches, shortcut delete count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.20.43] - 2026-06-18
+## [1.20.43] - 2026-06-22
 
 ### Fixed
 - **App-install monitoring can no longer start twice and leak a timer.** Starting the App Alerts monitor a second time without stopping it first orphaned the previous background timer and added duplicate folder watchers. Starting now does nothing if monitoring is already running.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.43] - 2026-06-18
+
+### Fixed
+- **App-install monitoring can no longer start twice and leak a timer.** Starting the App Alerts monitor a second time without stopping it first orphaned the previous background timer and added duplicate folder watchers. Starting now does nothing if monitoring is already running.
+- **Listing fixed drives no longer aborts if one drive becomes unavailable mid-scan.** Reading a volume's label/size could throw if the drive dropped out or was locked (e.g. BitLocker) right after it was checked as ready; that one drive is now skipped instead of failing the whole list.
+- **Process icons resolve correctly for apps installed after launch.** A failed icon-path lookup was cached permanently, so a program installed later never got its icon until restart. Only successful lookups are cached now.
+- **A corrupt cached app icon no longer sticks forever.** If a downloaded icon was truncated/corrupt, the bad cache file was kept and reused; it's now deleted and re-downloaded on next use.
+- **Shortcut Cleaner reports an accurate deletion count.** Moving a broken shortcut to the Recycle Bin could silently fail (the shell reports failure without throwing) yet still be counted as deleted; only genuinely recycled items are counted now.
+
 ## [1.20.42] - 2026-06-17
 
 ### Fixed

--- a/SysManager/SysManager/Services/AppAlertService.cs
+++ b/SysManager/SysManager/Services/AppAlertService.cs
@@ -68,6 +68,12 @@ public sealed class AppAlertService : IDisposable
 
         lock (_watcherLock)
         {
+            // Re-entrancy guard: a second Start() without an intervening Stop() would
+            // orphan the first registry Timer (overwritten below, never disposed) and
+            // add a duplicate set of FileSystemWatchers. Bail if already running.
+            if (_registryTimer is not null || _watchers.Count > 0)
+                return;
+
             foreach (var dir in GetMonitoredDirectories().Where(Directory.Exists))
             {
                 try
@@ -84,9 +90,13 @@ public sealed class AppAlertService : IDisposable
                 catch (IOException ex) { Log.Debug(ex, "Failed to watch {Dir}", dir); }
                 catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Access denied watching {Dir}", dir); }
             }
+
+            // Create the timer inside the lock so it's covered by the re-entrancy
+            // guard above (a concurrent Start() can't both pass the guard and each
+            // create a timer).
+            _registryTimer = new Timer(CheckRegistry, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
         }
 
-        _registryTimer = new Timer(CheckRegistry, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
         Log.Information("App alert monitoring started ({Watchers} watchers)", _watchers.Count);
     }
 

--- a/SysManager/SysManager/Services/AppIconService.cs
+++ b/SysManager/SysManager/Services/AppIconService.cs
@@ -48,9 +48,17 @@ public sealed class AppIconService
         Directory.CreateDirectory(CacheDir);
         var cachePath = Path.Combine(CacheDir, $"{SanitizeFileName(appId)}.png");
 
-        // Return cached icon if it exists and is not empty
+        // Return cached icon if it exists and is not empty. If the file is present
+        // but fails to decode (truncated/corrupt download), delete it so we re-download
+        // instead of being permanently poisoned by the bad cache entry.
         if (File.Exists(cachePath) && new FileInfo(cachePath).Length > 0)
-            return LoadFromFile(cachePath);
+        {
+            var cachedIcon = LoadFromFile(cachePath);
+            if (cachedIcon is not null) return cachedIcon;
+            try { File.Delete(cachePath); }
+            catch (IOException ex) { Log.Debug(ex, "Could not delete corrupt icon cache for {AppId}", appId); }
+            catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Could not delete corrupt icon cache for {AppId}", appId); }
+        }
 
         // Determine the download URL
         var url = GetFaviconUrl(appId);

--- a/SysManager/SysManager/Services/FixedDriveService.cs
+++ b/SysManager/SysManager/Services/FixedDriveService.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Management;
+using Serilog;
 
 namespace SysManager.Services;
 
@@ -37,15 +38,25 @@ public sealed class FixedDriveService
 
         foreach (var di in fixedReady)
         {
-            var letter = di.Name.TrimEnd('\\', '/');
-            drives.Add(new FixedDrive(
-                Letter: letter,
-                Label: string.IsNullOrWhiteSpace(di.VolumeLabel) ? letter : di.VolumeLabel,
-                FileSystem: di.DriveFormat ?? "NTFS",
-                SizeGB: Math.Round(di.TotalSize / 1024d / 1024d / 1024d, 0),
-                FreeGB: Math.Round(di.AvailableFreeSpace / 1024d / 1024d / 1024d, 0),
-                MediaType: "",
-                BusType: ""));
+            // DriveInfo getters (VolumeLabel/TotalSize/AvailableFreeSpace) hit the
+            // volume and can throw IOException/UnauthorizedAccessException if it goes
+            // away or is denied between the IsReady check and the read (e.g. a
+            // BitLocker-locked or transiently-busy volume). Skip that one drive
+            // instead of aborting enumeration of the rest.
+            try
+            {
+                var letter = di.Name.TrimEnd('\\', '/');
+                drives.Add(new FixedDrive(
+                    Letter: letter,
+                    Label: string.IsNullOrWhiteSpace(di.VolumeLabel) ? letter : di.VolumeLabel,
+                    FileSystem: di.DriveFormat ?? "NTFS",
+                    SizeGB: Math.Round(di.TotalSize / 1024d / 1024d / 1024d, 0),
+                    FreeGB: Math.Round(di.AvailableFreeSpace / 1024d / 1024d / 1024d, 0),
+                    MediaType: "",
+                    BusType: ""));
+            }
+            catch (IOException ex) { Log.Debug(ex, "Skipped drive that became unavailable mid-enumeration"); }
+            catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Skipped drive — access denied mid-enumeration"); }
         }
 
         // Enrich with MSFT_PhysicalDisk media/bus info when possible.

--- a/SysManager/SysManager/Services/IconExtractorService.cs
+++ b/SysManager/SysManager/Services/IconExtractorService.cs
@@ -379,7 +379,16 @@ public sealed partial class IconExtractorService
         var exeName = processName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
             ? processName : processName + ".exe";
 
-        return _pathCache.GetOrAdd(exeName, static name => ResolveExecutablePath(name));
+        // Only cache POSITIVE results. GetOrAdd would store a null (not-found) result
+        // permanently, so an exe installed after the first lookup would never resolve
+        // for the lifetime of the process. Re-resolve on a miss instead.
+        if (_pathCache.TryGetValue(exeName, out var cached))
+            return cached;
+
+        var resolved = ResolveExecutablePath(exeName);
+        if (resolved is not null)
+            _pathCache[exeName] = resolved;
+        return resolved;
     }
 
     private static string? ResolveExecutablePath(string exeName)

--- a/SysManager/SysManager/Services/ShortcutCleanerService.cs
+++ b/SysManager/SysManager/Services/ShortcutCleanerService.cs
@@ -89,11 +89,18 @@ public sealed partial class ShortcutCleanerService
                 if (!File.Exists(s.ShortcutPath)) continue;
 
                 if (toRecycleBin)
-                    MoveToRecycleBin(s.ShortcutPath);
+                {
+                    // Only count it if the shell actually recycled the file.
+                    if (MoveToRecycleBin(s.ShortcutPath))
+                        deleted++;
+                    else
+                        Log.Warning("Recycle failed (shell reported error): {Path}", s.ShortcutPath);
+                }
                 else
+                {
                     File.Delete(s.ShortcutPath);
-
-                deleted++;
+                    deleted++;
+                }
             }
             catch (IOException ex) { Log.Warning(ex, "Failed to delete shortcut: {Path}", s.ShortcutPath); }
             catch (UnauthorizedAccessException ex) { Log.Warning(ex, "Access denied deleting shortcut: {Path}", s.ShortcutPath); }
@@ -160,7 +167,7 @@ public sealed partial class ShortcutCleanerService
     [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
     private static extern int SHFileOperation(ref SHFILEOPSTRUCT lpFileOp);
 
-    private static void MoveToRecycleBin(string path)
+    private static bool MoveToRecycleBin(string path)
     {
         var op = new SHFILEOPSTRUCT
         {
@@ -168,7 +175,11 @@ public sealed partial class ShortcutCleanerService
             pFrom = path + '\0' + '\0',
             fFlags = 0x0040 | 0x0010
         };
-        SHFileOperation(ref op);
+        // SHFileOperation returns non-zero (and/or sets fAnyOperationsAborted) on
+        // failure WITHOUT throwing. Returning that result lets the caller avoid
+        // counting a silently-failed recycle as a successful deletion.
+        var rc = SHFileOperation(ref op);
+        return rc == 0 && !op.fAnyOperationsAborted;
     }
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.42</Version>
-    <FileVersion>1.20.42.0</FileVersion>
-    <AssemblyVersion>1.20.42.0</AssemblyVersion>
+    <Version>1.20.43</Version>
+    <FileVersion>1.20.43.0</FileVersion>
+    <AssemblyVersion>1.20.43.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Five self-contained service-robustness fixes (P3).

## Changes
- **AppAlertService.Start** — no re-entrancy guard: a second `Start()` overwrote `_registryTimer` (orphaning the first, leaking a 30s callback) and added duplicate watchers. Added an "already running" guard inside the lock and moved the timer creation inside the lock so it's covered.
- **FixedDriveService.Enumerate** — the per-drive `DriveInfo` property reads (label/size/free) ran with no try/catch after a lazy `IsReady` filter, so a drive dropping out or being locked (BitLocker) mid-enumeration threw and aborted the whole list. Each drive is now wrapped; a failing one is skipped.
- **IconExtractorService.FindExecutableByName** — `GetOrAdd` cached a null (not-found) result permanently, so an exe installed after the first lookup never resolved. Only positive results are cached now.
- **AppIconService.GetIconAsync** — a truncated/corrupt cached icon passed the `Length > 0` check but failed to decode, and the bad file was kept forever. It's now deleted on decode failure so the icon re-downloads.
- **ShortcutCleanerService.MoveToRecycleBin** — discarded `SHFileOperation`'s return value and `fAnyOperationsAborted`, so a silently-failed recycle was still counted as deleted. Now returns bool; `DeleteShortcuts` only counts genuine successes.

Build: 0 warnings / 0 errors. Version 1.20.43.