### PR TITLE
fix: give data tables and per-row toggles content-specific accessible names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.44] - 2026-06-22
+
+### Fixed
+- **Better screen-reader support for tables and per-row toggles.** Every data table announced itself generically as "Data table"; each now has a content-specific name (Installed applications, Running processes, Windows services, Event log entries, etc.). The per-row enable/disable toggles in Startup Manager and Windows Features, the Startup "hide system entries" toggle, and the Shortcut Cleaner selection checkboxes also gained clear accessible names. No visual change.
+
 ## [1.20.43] - 2026-06-22
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.43</Version>
-    <FileVersion>1.20.43.0</FileVersion>
-    <AssemblyVersion>1.20.43.0</AssemblyVersion>
+    <Version>1.20.44</Version>
+    <FileVersion>1.20.44.0</FileVersion>
+    <AssemblyVersion>1.20.44.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AppBlockerView.xaml
+++ b/SysManager/SysManager/Views/AppBlockerView.xaml
@@ -82,7 +82,7 @@
                   HeadersVisibility="Column" GridLinesVisibility="None"
                   BorderThickness="0"
                   Background="Transparent"
-                  AutomationProperties.Name="Data table"
+                  AutomationProperties.Name="Blocked applications"
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling">
             <DataGrid.Columns>

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml
@@ -62,7 +62,7 @@
         </Border>
 
         <Border Grid.Row="3" Style="{StaticResource Card}" Margin="28,16,28,0" Padding="0">
-            <DataGrid AutomationProperties.Name="Data table" ItemsSource="{Binding Packages}"
+            <DataGrid AutomationProperties.Name="Upgradable packages" ItemsSource="{Binding Packages}"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
                       GridLinesVisibility="None" CanUserAddRows="False"
                       CanUserSortColumns="True"

--- a/SysManager/SysManager/Views/DeepCleanupView.xaml
+++ b/SysManager/SysManager/Views/DeepCleanupView.xaml
@@ -183,7 +183,7 @@
                             <TextBlock Text="{Binding LargeCurrentFolder}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="0,4,0,0" TextTrimming="CharacterEllipsis"/>
                         </StackPanel>
 
-                        <DataGrid AutomationProperties.Name="Data table" ItemsSource="{Binding LargeFiles}"
+                        <DataGrid AutomationProperties.Name="Large files" ItemsSource="{Binding LargeFiles}"
                                   AutoGenerateColumns="False" HeadersVisibility="Column"
                                   GridLinesVisibility="None" IsReadOnly="True"
                                   CanUserResizeColumns="True"

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -127,7 +127,7 @@
                           CanUserResizeColumns="True"
                           GridLinesVisibility="None" BorderThickness="0"
                           Background="Transparent"
-                          AutomationProperties.Name="Data table"
+                          AutomationProperties.Name="Hosts file entries"
                           Foreground="{DynamicResource TextPrimary}" FontSize="12"
                           SelectionMode="Single" IsReadOnly="False"
                           VirtualizingPanel.IsVirtualizing="True"

--- a/SysManager/SysManager/Views/DriversView.xaml
+++ b/SysManager/SysManager/Views/DriversView.xaml
@@ -43,7 +43,7 @@
 
             <!-- Driver table -->
             <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0" MinHeight="200" MaxHeight="600">
-                <DataGrid AutomationProperties.Name="Data table" ItemsSource="{Binding Drivers}"
+                <DataGrid AutomationProperties.Name="Installed drivers" ItemsSource="{Binding Drivers}"
                           AutoGenerateColumns="False" HeadersVisibility="Column"
                           Background="Transparent" BorderThickness="0"
                           GridLinesVisibility="None" IsReadOnly="True"

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -230,7 +230,7 @@
             <!-- List -->
             <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
                 <Grid>
-                    <DataGrid AutomationProperties.Name="Data table" ItemsSource="{Binding EntriesView}"
+                    <DataGrid AutomationProperties.Name="Event log entries" ItemsSource="{Binding EntriesView}"
                               SelectedItem="{Binding SelectedEntry}"
                               AutoGenerateColumns="False"
                               HeadersVisibility="Column"

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -57,7 +57,7 @@
 
         <!-- Process list -->
         <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
-            <DataGrid AutomationProperties.Name="Data table" ItemsSource="{Binding FilteredProcesses}"
+            <DataGrid AutomationProperties.Name="Running processes" ItemsSource="{Binding FilteredProcesses}"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
                       Background="Transparent" BorderThickness="0"
                       GridLinesVisibility="None" IsReadOnly="True"

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -105,7 +105,7 @@
         </Border>
 
         <!-- Services list -->
-        <DataGrid AutomationProperties.Name="Data table" Grid.Row="3" ItemsSource="{Binding Services}"
+        <DataGrid AutomationProperties.Name="Windows services" Grid.Row="3" ItemsSource="{Binding Services}"
                   SelectedItem="{Binding SelectedService}"
                   AutoGenerateColumns="False" HeadersVisibility="Column"
                   Background="Transparent" BorderThickness="0"

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml
@@ -62,7 +62,18 @@
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling">
             <DataGrid.Columns>
-                <DataGridCheckBoxColumn Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" Width="40" MinWidth="40" CanUserResize="False"/>
+                <DataGridCheckBoxColumn Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" Width="40" MinWidth="40" CanUserResize="False">
+                    <DataGridCheckBoxColumn.ElementStyle>
+                        <Style TargetType="CheckBox">
+                            <Setter Property="AutomationProperties.Name" Value="{Binding Name, StringFormat='Select {0} for deletion'}"/>
+                        </Style>
+                    </DataGridCheckBoxColumn.ElementStyle>
+                    <DataGridCheckBoxColumn.EditingElementStyle>
+                        <Style TargetType="CheckBox">
+                            <Setter Property="AutomationProperties.Name" Value="{Binding Name, StringFormat='Select {0} for deletion'}"/>
+                        </Style>
+                    </DataGridCheckBoxColumn.EditingElementStyle>
+                </DataGridCheckBoxColumn>
                 <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="200" MinWidth="100" IsReadOnly="True"/>
                 <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="150" MinWidth="80" IsReadOnly="True"/>
                 <DataGridTextColumn Header="Target (missing)" Binding="{Binding TargetPath}" Width="*" MinWidth="120" IsReadOnly="True"/>

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -34,7 +34,8 @@
                             Style="{StaticResource GhostButton}" Margin="0,0,8,0"/>
                     <ToggleButton Style="{StaticResource ToggleSwitch}"
                                   IsChecked="{Binding HideWindowsEntries}" Margin="12,0,6,0"
-                                  VerticalAlignment="Center" ToolTip="Hide Windows/Microsoft system entries"/>
+                                  VerticalAlignment="Center" ToolTip="Hide Windows/Microsoft system entries"
+                                  AutomationProperties.Name="Hide Windows/Microsoft system entries"/>
                     <TextBlock Text="Hide system" FontSize="11" Foreground="{DynamicResource TextMuted}"
                                VerticalAlignment="Center"/>
                 </StackPanel>
@@ -45,7 +46,7 @@
 
         <!-- Startup items list -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
-            <DataGrid AutomationProperties.Name="Data table" ItemsSource="{Binding Entries}"
+            <DataGrid AutomationProperties.Name="Startup programs" ItemsSource="{Binding Entries}"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
                       CanUserAddRows="False"
                       Background="Transparent" BorderThickness="0"
@@ -62,6 +63,7 @@
                                               IsChecked="{Binding IsEnabled, UpdateSourceTrigger=PropertyChanged}"
                                               Command="{Binding DataContext.ToggleEntryCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                               CommandParameter="{Binding}"
+                                              AutomationProperties.Name="{Binding Name, StringFormat='Toggle startup entry: {0}'}"
                                               VerticalAlignment="Center" HorizontalAlignment="Center"/>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -62,7 +62,7 @@
                 <Border Style="{StaticResource Card}" Margin="0,16,0,0">
                     <StackPanel>
                         <TextBlock Text="Memory modules" Style="{StaticResource SectionTitle}"/>
-                        <DataGrid AutomationProperties.Name="Data table" ItemsSource="{Binding Modules}"
+                        <DataGrid AutomationProperties.Name="Memory modules" ItemsSource="{Binding Modules}"
                                   AutoGenerateColumns="False" HeadersVisibility="Column"
                                   GridLinesVisibility="None" IsReadOnly="True"
                                   CanUserResizeColumns="True"
@@ -115,7 +115,7 @@
                 <Border Style="{StaticResource Card}" Margin="0,16,0,0">
                     <StackPanel>
                         <TextBlock Text="Storage devices" Style="{StaticResource SectionTitle}"/>
-                        <DataGrid AutomationProperties.Name="Data table" ItemsSource="{Binding Disks}"
+                        <DataGrid AutomationProperties.Name="Disk drives" ItemsSource="{Binding Disks}"
                                   AutoGenerateColumns="False" HeadersVisibility="Column"
                                   GridLinesVisibility="None" IsReadOnly="True"
                                   CanUserResizeColumns="True"

--- a/SysManager/SysManager/Views/TracerouteView.xaml
+++ b/SysManager/SysManager/Views/TracerouteView.xaml
@@ -81,7 +81,7 @@
                         </StackPanel>
                         <TextBlock Text="{Binding TraceStatus}" Style="{StaticResource Subtle}" Margin="0,6,0,0"/>
                     </StackPanel>
-                    <DataGrid AutomationProperties.Name="Data table" Grid.Row="2" ItemsSource="{Binding Shared.TracerouteHops}"
+                    <DataGrid AutomationProperties.Name="Traceroute hops" Grid.Row="2" ItemsSource="{Binding Shared.TracerouteHops}"
                               AutoGenerateColumns="False" HeadersVisibility="Column"
                               CanUserResizeColumns="True"
                               Background="Transparent" BorderThickness="0"

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -91,7 +91,7 @@
 
         <!-- App list -->
         <Border Grid.Row="4" Style="{StaticResource Card}" Padding="0">
-            <DataGrid AutomationProperties.Name="Data table" ItemsSource="{Binding FilteredApps}"
+            <DataGrid AutomationProperties.Name="Installed applications" ItemsSource="{Binding FilteredApps}"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
                       Background="Transparent" BorderThickness="0"
                       GridLinesVisibility="None" IsReadOnly="False"

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -180,6 +180,7 @@
                                               IsChecked="{Binding IsEnabled, Mode=OneWay}"
                                               Command="{Binding DataContext.ToggleFeatureCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
                                               CommandParameter="{Binding}"
+                                              AutomationProperties.Name="{Binding DisplayName, StringFormat='Toggle Windows feature: {0}'}"
                                               VerticalAlignment="Center" HorizontalAlignment="Center"/>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -120,7 +120,7 @@
 
         <!-- Update table (DataGrid) -->
         <Border Grid.Row="5" Style="{StaticResource Card}" Margin="28,16,28,0" Padding="0">
-            <DataGrid AutomationProperties.Name="Data table" ItemsSource="{Binding Updates}"
+            <DataGrid AutomationProperties.Name="Windows updates" ItemsSource="{Binding Updates}"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
                       Background="Transparent" BorderThickness="0"
                       GridLinesVisibility="None"


### PR DESCRIPTION
Accessibility (Gate-UX) P3 sweep — screen-reader names only, no visual or behavior change.

## Changes
- **14 DataGrids** across 13 views announced themselves generically as "Data table". Each now has a content-specific `AutomationProperties.Name`: Installed applications, Upgradable packages, Large files, Hosts file entries, Installed drivers, Event log entries, Running processes, Windows services, Startup programs, Memory modules, Disk drives, Traceroute hops, Blocked applications, Windows updates.
- **Per-row toggles** in Startup Manager (`Toggle startup entry: {name}`) and Windows Features (`Toggle Windows feature: {name}`) — previously unnamed.
- **Startup "hide system entries"** header toggle — was labeled only by a ToolTip; added an accessible name.
- **Shortcut Cleaner** per-row selection checkbox — added a bound `Select {name} for deletion` name via the column's element styles.

## Deferred (need visual verification on a running app, which isn't available here)
- App.xaml ControlTemplate focus-ring triggers (ToggleSwitch / AdminButton / DataGridCell / PillTabItem) and the new app-level ComboBox style — these change shared visuals and should be verified live before merging.

Build: 0 warnings / 0 errors. Version 1.20.44. (Stacks on #941; will rebase before merge.)