### PR TITLE
ci: pin workflow actions to commit SHAs and drop dead Discussions lookup

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup .NET 10 SDK
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: 10.0.x
 
       - name: Cache NuGet packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -71,7 +71,7 @@ jobs:
       # no benefit. Same-repo pushes/PRs upload normally.
       - name: Upload coverage to Codecov
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: test-results
           path: TestResults/**
@@ -104,10 +104,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup .NET 10 SDK
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: 10.0.x
 
@@ -133,7 +133,7 @@ jobs:
 
       - name: Upload UI test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ui-test-results
           path: TestResults/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup .NET 10 SDK
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: 10.0.x
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: csharp
           queries: security-and-quality
@@ -38,6 +38,6 @@ jobs:
         run: dotnet build SysManager/SysManager/SysManager.csproj -c Release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: csharp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,12 +54,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Setup .NET 10 SDK
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: 10.0.x
 
@@ -157,7 +157,7 @@ jobs:
 
       - name: Create GitHub Release
         id: release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: SysManager ${{ steps.version.outputs.version }}
@@ -169,7 +169,7 @@ jobs:
             publish/SysManager-v${{ steps.version.outputs.version }}.exe.sha256
 
       - name: Update winget package
-        uses: vedantmgoyal9/winget-releaser@v2
+        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: laurentiu021.SysManager
           installers-regex: '\.exe$'
@@ -177,7 +177,7 @@ jobs:
           token: ${{ secrets.WINGET_TOKEN }}
 
       - name: Post announcement to Discussions
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require('fs');
@@ -186,12 +186,7 @@ jobs:
             const notes = fs.readFileSync('release-notes.md', 'utf8');
             const releaseUrl = '${{ steps.release.outputs.url }}';
 
-            // Find the Announcements category
-            const { data: cats } = await github.rest.repos.getAllTopics({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-
+            // Find the Announcements discussion category
             const query = `
               query($owner: String!, $repo: String!) {
                 repository(owner: $owner, name: $repo) {


### PR DESCRIPTION
## Summary
Hardens the CI/CD supply chain by pinning every GitHub Action to a full commit SHA instead of a floating tag, and removes a dead API call from the release workflow.

## Changes
- **Pin all actions to commit SHA** (with a `# vX` comment so Dependabot still tracks and bumps them):
  - `actions/checkout`, `actions/setup-dotnet`, `actions/cache`, `actions/upload-artifact`, `actions/github-script`
  - `codecov/codecov-action`, `github/codeql-action/{init,analyze}`
  - `softprops/action-gh-release`, `vedantmgoyal9/winget-releaser`
- **Remove dead code in release.yml**: the announcement step called `repos.getAllTopics` and discarded the result — it returned repository *topics*, not Discussion *categories* (the real category lookup is the GraphQL query right below it). Removed the unused call.

## Why
Floating tags (`@v6`) are mutable: a compromised or force-pushed tag silently changes what runs in CI with write/secrets access. Pinning to an immutable SHA is the OpenSSF-recommended hardening for third-party actions. Dependabot's `github-actions` ecosystem (already configured) keeps the SHAs current via the version comment.

## Risk
None to runtime behavior — workflow logic is identical; only the action references are now immutable and one unused API call is gone.

## Verification
- All four workflow files parse as valid YAML.
- No floating-tag `uses:` references remain.
- The removed call was provably unused (its return value `cats` was never read).