### PR TITLE
fix: write and restore the hosts file off the UI thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.45] - 2026-06-22
+
+### Fixed
+- **Saving or restoring the hosts file no longer freezes the window.** The Hosts editor wrote the system hosts file (and restored it from backup) synchronously on the UI thread, so the app could hang briefly while the file was written to or copied from System32. Both operations now run in the background.
+
 ## [1.20.44] - 2026-06-22
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DnsHostsViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DnsHostsViewModelTests.cs
@@ -120,7 +120,7 @@ public class DnsHostsViewModelGateTests
     // ── SaveHosts (overwrites the system hosts file) ──────────────────────
 
     [StaFact]
-    public void SaveHosts_WhenUserDeclinesConfirm_DoesNotWrite()
+    public async Task SaveHosts_WhenUserDeclinesConfirm_DoesNotWrite()
     {
         var (vm, hostsPath, dir, _) = NewVm();
         var prevDialog = DialogService.Instance;
@@ -132,7 +132,7 @@ public class DnsHostsViewModelGateTests
             var before = File.ReadAllText(hostsPath);
             vm.HostEntries.Add(new HostsEntry { IpAddress = "10.0.0.1", Hostname = "managed.local" });
 
-            vm.SaveHostsCommand.Execute(null);
+            await vm.SaveHostsCommand.ExecuteAsync(null);
 
             dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
             // Declining must leave the hosts file byte-for-byte untouched.
@@ -147,7 +147,7 @@ public class DnsHostsViewModelGateTests
     }
 
     [StaFact]
-    public void SaveHosts_WhenUserConfirms_WritesEntries()
+    public async Task SaveHosts_WhenUserConfirms_WritesEntries()
     {
         var (vm, hostsPath, dir, _) = NewVm();
         var prevDialog = DialogService.Instance;
@@ -158,7 +158,7 @@ public class DnsHostsViewModelGateTests
         {
             vm.HostEntries.Add(new HostsEntry { IpAddress = "10.0.0.1", Hostname = "managed.local", IsEnabled = true });
 
-            vm.SaveHostsCommand.Execute(null);
+            await vm.SaveHostsCommand.ExecuteAsync(null);
 
             dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
             // Confirming writes the entries through the SysManager-managed hosts file.
@@ -174,7 +174,7 @@ public class DnsHostsViewModelGateTests
     }
 
     [StaFact]
-    public void SaveHosts_WhenNotElevated_NeverPromptsConfirm()
+    public async Task SaveHosts_WhenNotElevated_NeverPromptsConfirm()
     {
         var (vm, _, dir, _) = NewVm();
         vm.IsElevated = false; // admin guard sits before the gate
@@ -184,7 +184,7 @@ public class DnsHostsViewModelGateTests
         try
         {
             vm.HostEntries.Add(new HostsEntry { IpAddress = "10.0.0.1", Hostname = "x.local" });
-            vm.SaveHostsCommand.Execute(null);
+            await vm.SaveHostsCommand.ExecuteAsync(null);
 
             // Non-elevated short-circuits before the destructive prompt.
             dialog.DidNotReceive().Confirm(Arg.Any<string>(), Arg.Any<string>());

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.44</Version>
-    <FileVersion>1.20.44.0</FileVersion>
-    <AssemblyVersion>1.20.44.0</AssemblyVersion>
+    <Version>1.20.45</Version>
+    <FileVersion>1.20.45.0</FileVersion>
+    <AssemblyVersion>1.20.45.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
@@ -297,7 +297,7 @@ public sealed partial class DnsHostsViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void SaveHosts()
+    private async Task SaveHostsAsync()
     {
         if (!IsElevated)
         {
@@ -315,11 +315,15 @@ public sealed partial class DnsHostsViewModel : ViewModelBase
             return;
         }
 
+        // Snapshot the entries on the UI thread, then write off-thread: SaveHosts does
+        // synchronous file I/O (WriteAllLines + File.Replace on the System32 hosts file)
+        // that would otherwise block the UI until the disk write completes.
+        var snapshot = HostEntries.ToList();
         try
         {
-            _hostsService.SaveHosts(HostEntries.ToList());
-            HostsStatus = $"Saved {HostEntries.Count} entries. Original preserved at hosts.bak.";
-            Log.Information("Hosts file saved with {Count} entries", HostEntries.Count);
+            await Task.Run(() => _hostsService.SaveHosts(snapshot)).ConfigureAwait(true);
+            HostsStatus = $"Saved {snapshot.Count} entries. Original preserved at hosts.bak.";
+            Log.Information("Hosts file saved with {Count} entries", snapshot.Count);
         }
         catch (UnauthorizedAccessException)
         {
@@ -358,7 +362,10 @@ public sealed partial class DnsHostsViewModel : ViewModelBase
 
         try
         {
-            if (_hostsService.RestoreBackup())
+            // RestoreBackup copies the .bak over the System32 hosts file synchronously;
+            // run it off the UI thread so the window stays responsive during the copy.
+            bool restored = await Task.Run(_hostsService.RestoreBackup).ConfigureAwait(true);
+            if (restored)
             {
                 await LoadHostsAsync();
                 HostsStatus = "Original hosts file restored from backup.";


### PR DESCRIPTION
## Summary
The Hosts editor performed synchronous file I/O on the UI thread when saving or restoring the system hosts file, briefly freezing the window while the file was written to / copied from System32.

## Root cause
- `SaveHostsCommand` was a **synchronous** `[RelayCommand]` that called `HostsFileService.SaveHosts`, which does `File.WriteAllLines` + `File.Replace` on the System32 hosts file inline.
- `RestoreHostsAsync` called `HostsFileService.RestoreBackup` (a synchronous `File.Copy`) directly on the UI thread.

## Fix
- `SaveHosts` → `SaveHostsAsync`: snapshots the entries on the UI thread, then runs the write via `await Task.Run(...)`. The generated command name stays `SaveHostsCommand`, so the XAML binding is unchanged.
- `RestoreHostsAsync`: the `RestoreBackup` copy now runs via `await Task.Run(...)`.
- Both keep `.ConfigureAwait(true)` so the status-message and reload continuation resume on the UI thread.

## Tests
- Updated the three `SaveHosts_*` unit tests to `await ...ExecuteAsync(null)` so they deterministically wait for the now-async write before asserting (previously `Execute(null)` on an async command would race the file read). Behavior asserted is unchanged: decline = untouched, confirm = written, non-elevated = no prompt.

## Verification
- `dotnet build` (app + tests): 0 warnings, 0 errors.
- Write output is byte-for-byte identical — only the thread it runs on changed.