### PR TITLE
fix: release KBArticleIDs collection and installer COM objects on the error path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.46] - 2026-06-22
+
+### Fixed
+- **Windows Update scans and installs no longer leak COM objects on error paths.** Reading an update's KB article list left its underlying COM collection unreleased on every scanned update, and a failed install (one that threw a COM error) leaked the update-installer object. Both are now released deterministically even when the operation throws.
+
 ## [1.20.45] - 2026-06-22
 
 ### Fixed

--- a/SysManager/SysManager/Services/WindowsUpdateService.cs
+++ b/SysManager/SysManager/Services/WindowsUpdateService.cs
@@ -181,13 +181,29 @@ public sealed class WindowsUpdateService
                         Emit("  Installing…");
                         entry.Status = "Installing…";
 
+                        int iCode;
+                        bool needsReboot;
                         var inst = session.CreateUpdateInstaller();
-                        inst.Updates = coll;
-                        var iResult = inst.Install();
-                        var iCode = (int)iResult.ResultCode;
-                        bool needsReboot = (bool)iResult.RebootRequired;
-                        Marshal.FinalReleaseComObject(iResult);
-                        Marshal.FinalReleaseComObject(inst);
+                        try
+                        {
+                            inst.Updates = coll;
+                            var iResult = inst.Install();
+                            try
+                            {
+                                iCode = (int)iResult.ResultCode;
+                                needsReboot = (bool)iResult.RebootRequired;
+                            }
+                            finally
+                            {
+                                Marshal.FinalReleaseComObject(iResult);
+                            }
+                        }
+                        finally
+                        {
+                            // Release the installer even if Install() (or reading its
+                            // result) throws — a failed install otherwise leaks it.
+                            Marshal.FinalReleaseComObject(inst);
+                        }
 
                         if (iCode == 2)
                         {
@@ -283,9 +299,12 @@ public sealed class WindowsUpdateService
     private static List<string> ExtractKbIds(dynamic u)
     {
         List<string> list = [];
+        // u.KBArticleIDs returns a fresh COM string collection (RCW) each access;
+        // release it in a finally so every scanned update doesn't leak one.
+        dynamic? ids = null;
         try
         {
-            var ids = u.KBArticleIDs;
+            ids = u.KBArticleIDs;
             int n = (int)ids.Count;
             for (int i = 0; i < n; i++)
             {
@@ -295,6 +314,10 @@ public sealed class WindowsUpdateService
         }
         catch (COMException ex) { Serilog.Log.Debug(ex, "ExtractKbIds: COM error"); }
         catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException ex) { Serilog.Log.Debug(ex, "ExtractKbIds: dynamic binding error"); }
+        finally
+        {
+            if (ids is not null) Marshal.FinalReleaseComObject(ids);
+        }
         return list;
     }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.45</Version>
-    <FileVersion>1.20.45.0</FileVersion>
-    <AssemblyVersion>1.20.45.0</AssemblyVersion>
+    <Version>1.20.46</Version>
+    <FileVersion>1.20.46.0</FileVersion>
+    <AssemblyVersion>1.20.46.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary
Two remaining COM-object leaks in the Windows Update Agent wrapper, both on paths that throw or run per-update at scale.

## Root cause
- **`ExtractKbIds`**: `u.KBArticleIDs` returns a fresh COM string-collection RCW on each access, but it was never released — so every scanned update leaked one collection object.
- **`InstallAsync`**: the update-installer (`session.CreateUpdateInstaller()`) was released only on the happy path. If `inst.Install()` (or reading its result) threw a `COMException` — caught further down — the installer RCW leaked.

## Fix
- `ExtractKbIds`: release the `KBArticleIDs` collection in a `finally`.
- `InstallAsync`: wrap the installer in `try/finally` (and its result in a nested `try/finally`) so both are released even when `Install()` throws.
- Mirrors the existing deterministic-release pattern already applied elsewhere in the file (downloader, download result, categories collection, identity).

## Tests
- No behavioral change — these are resource-cleanup fixes on live-COM paths that can't be unit-tested without a real WUA session. Existing `WindowsUpdateServiceTests` (ClassifyCategory, FormatSize — the pure functions) remain green.

## Verification
- `dotnet build` (app + tests): 0 warnings, 0 errors.