### PR TITLE
fix: skip a single unreadable disk instead of dropping the whole health scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.47] - 2026-06-22
+
+### Fixed
+- **Disk health no longer drops every disk when one reports a bad value.** If a single physical disk returned an unexpected value for its media type, bus type, size, or health status, the conversion threw and aborted the whole scan — so no disks were shown. A disk with an unreadable field is now skipped individually and the rest still appear.
+
 ## [1.20.46] - 2026-06-22
 
 ### Fixed

--- a/SysManager/SysManager/Services/DiskHealthService.cs
+++ b/SysManager/SysManager/Services/DiskHealthService.cs
@@ -36,22 +36,33 @@ public sealed partial class DiskHealthService
             {
                 using (mo)
                 {
-                    var report = new DiskHealthReport
+                    // Convert the WMI fields per disk inside a guard: a single disk whose
+                    // MediaType/BusType/Size/HealthStatus comes back as an unexpected type
+                    // would otherwise throw from Convert.* and abort the whole enumeration,
+                    // dropping every other (healthy) disk. Skip the bad disk instead.
+                    try
                     {
-                        FriendlyName = mo["FriendlyName"]?.ToString() ?? "Disk",
-                        MediaType = MapMedia(Convert.ToUInt32(mo["MediaType"] ?? 0u)),
-                        BusType = MapBus(Convert.ToUInt32(mo["BusType"] ?? 0u)),
-                        SizeGB = Math.Round(Convert.ToDouble(mo["Size"] ?? 0) / 1024d / 1024d / 1024d, 0),
-                        HealthStatus = MapHealth(Convert.ToUInt32(mo["HealthStatus"] ?? 0u))
-                    };
+                        var report = new DiskHealthReport
+                        {
+                            FriendlyName = mo["FriendlyName"]?.ToString() ?? "Disk",
+                            MediaType = MapMedia(Convert.ToUInt32(mo["MediaType"] ?? 0u)),
+                            BusType = MapBus(Convert.ToUInt32(mo["BusType"] ?? 0u)),
+                            SizeGB = Math.Round(Convert.ToDouble(mo["Size"] ?? 0) / 1024d / 1024d / 1024d, 0),
+                            HealthStatus = MapHealth(Convert.ToUInt32(mo["HealthStatus"] ?? 0u))
+                        };
 
-                    // Get reliability counters for this disk.
-                    var objectId = mo["ObjectId"]?.ToString();
-                    if (!string.IsNullOrEmpty(objectId))
-                        EnrichWithReliability(scope, objectId, report);
+                        // Get reliability counters for this disk.
+                        var objectId = mo["ObjectId"]?.ToString();
+                        if (!string.IsNullOrEmpty(objectId))
+                            EnrichWithReliability(scope, objectId, report);
 
-                    ApplyVerdict(report);
-                    results.Add(report);
+                        ApplyVerdict(report);
+                        results.Add(report);
+                    }
+                    catch (Exception ex) when (ex is FormatException or OverflowException or InvalidCastException)
+                    {
+                        Log.Debug(ex, "DiskHealth: skipping a disk with an unreadable WMI field");
+                    }
                 }
             }
         }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.46</Version>
-    <FileVersion>1.20.46.0</FileVersion>
-    <AssemblyVersion>1.20.46.0</AssemblyVersion>
+    <Version>1.20.47</Version>
+    <FileVersion>1.20.47.0</FileVersion>
+    <AssemblyVersion>1.20.47.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary
A single physical disk returning an unexpected WMI value no longer wipes out the entire disk-health list.

## Root cause
`DiskHealthService.Collect` built each `DiskHealthReport` by calling `Convert.ToUInt32`/`Convert.ToDouble` directly on the WMI `MediaType`/`BusType`/`Size`/`HealthStatus` fields. If one disk returned a value of an unexpected type, the conversion threw — and because that sat inside the outer `foreach`, the exception was caught by the method-level handlers and aborted the **whole** enumeration, so *no* disks were reported.

## Fix
- Wrap the per-disk report construction (and its reliability enrichment) in a `try/catch (FormatException or OverflowException or InvalidCastException)` that logs at Debug and `continue`s to the next disk.
- A disk with one unreadable field is skipped individually; every healthy disk still appears.
- Mirrors the per-item guard pattern already used in `FixedDriveService` (PR #941).

## Tests
- No behavioral change for well-formed WMI data — the conversion helpers (`ToDouble`/`ToInt`/`ToLong`) were already guarded; this extends the same resilience to the four base fields. The thrown-mid-enumeration path requires a malformed live WMI provider that can't be reproduced in a unit test without a fake CIM namespace.

## Verification
- `dotnet build` (app + tests): 0 warnings, 0 errors.