### PR TITLE
fix: require a separator boundary in the speed-test Zip Slip guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.48] - 2026-06-22
+
+### Fixed
+- **Hardened the Zip Slip guard on the speed-test CLI download.** The containment check that keeps extracted archive entries inside the tools directory used a plain prefix test, which a sibling folder whose name merely started with the target's name could slip past. The check now requires a directory-separator boundary, closing that edge case.
+
 ## [1.20.47] - 2026-06-22
 
 ### Fixed

--- a/SysManager/SysManager.Tests/SpeedTestServiceTests.cs
+++ b/SysManager/SysManager.Tests/SpeedTestServiceTests.cs
@@ -1,0 +1,51 @@
+// SysManager · SpeedTestServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="SpeedTestService"/>'s Zip Slip containment check, which
+/// guards the Ookla CLI extraction against crafted archive entries escaping the
+/// target tools directory.
+/// </summary>
+public class SpeedTestServiceTests
+{
+    private static readonly string Root =
+        Path.Combine(Path.GetTempPath(), "smtest_tools");
+
+    [Fact]
+    public void IsInsideDirectory_NormalEntry_IsAccepted()
+    {
+        var dest = Path.GetFullPath(Path.Join(Root, "speedtest.exe"));
+        Assert.True(SpeedTestService.IsInsideDirectory(Root, dest));
+    }
+
+    [Fact]
+    public void IsInsideDirectory_NestedEntry_IsAccepted()
+    {
+        var dest = Path.GetFullPath(Path.Join(Root, "sub", "license.txt"));
+        Assert.True(SpeedTestService.IsInsideDirectory(Root, dest));
+    }
+
+    [Fact]
+    public void IsInsideDirectory_TraversalEntry_IsRejected()
+    {
+        // A "../" entry that resolves to the parent directory must be rejected.
+        var dest = Path.GetFullPath(Path.Join(Root, "..", "evil.exe"));
+        Assert.False(SpeedTestService.IsInsideDirectory(Root, dest));
+    }
+
+    [Fact]
+    public void IsInsideDirectory_SiblingWithSharedPrefix_IsRejected()
+    {
+        // Regression: a sibling directory whose name merely starts with the target's
+        // name (e.g. "smtest_tools-evil") must NOT pass the containment check. A naive
+        // StartsWith(fullToolsDir) without a trailing separator would wrongly accept it.
+        var dest = Path.GetFullPath(Path.Combine(Root + "-evil", "payload.exe"));
+        Assert.False(SpeedTestService.IsInsideDirectory(Root, dest));
+    }
+}

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -375,11 +375,10 @@ public sealed class SpeedTestService
             // stay within the target directory — a crafted zip with "../"
             // entries could write files outside toolsDir.
             using var archive = ZipFile.OpenRead(zipPath);
-            var fullToolsDir = Path.GetFullPath(toolsDir);
             foreach (var entry in archive.Entries.Where(e => !string.IsNullOrEmpty(e.Name)))
             {
                 var destinationPath = Path.GetFullPath(Path.Join(toolsDir, entry.FullName));
-                if (!destinationPath.StartsWith(fullToolsDir, StringComparison.OrdinalIgnoreCase))
+                if (!IsInsideDirectory(toolsDir, destinationPath))
                 {
                     Log.Warning("Zip Slip attempt blocked: {Entry} resolves outside target dir", entry.FullName);
                     continue;
@@ -430,5 +429,21 @@ public sealed class SpeedTestService
         }, ct).ConfigureAwait(false);
 
         return exe;
+    }
+
+    /// <summary>
+    /// True if <paramref name="candidateFullPath"/> resolves to a location strictly
+    /// inside <paramref name="directory"/> — the Zip Slip containment check.
+    /// The target directory is normalized to end in a separator so a sibling whose
+    /// name merely starts with the target's name (e.g. "…\tools-evil" vs "…\tools")
+    /// cannot pass a naive prefix test. Internal for unit testing.
+    /// </summary>
+    internal static bool IsInsideDirectory(string directory, string candidateFullPath)
+    {
+        var fullDir = Path.GetFullPath(directory);
+        var prefix = fullDir.EndsWith(Path.DirectorySeparatorChar)
+            ? fullDir
+            : fullDir + Path.DirectorySeparatorChar;
+        return candidateFullPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.47</Version>
-    <FileVersion>1.20.47.0</FileVersion>
-    <AssemblyVersion>1.20.47.0</AssemblyVersion>
+    <Version>1.20.48</Version>
+    <FileVersion>1.20.48.0</FileVersion>
+    <AssemblyVersion>1.20.48.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary
Closes an edge case in the Zip Slip containment check used when extracting the Ookla speed-test CLI.

## Root cause
`EnsureOoklaAsync` validated each archive entry's destination with `destinationPath.StartsWith(fullToolsDir, OrdinalIgnoreCase)` — a plain prefix test with no trailing separator. A sibling directory whose name merely *starts with* the target's name (e.g. target `…\tools` vs `…\tools-evil\payload`) would satisfy the prefix and be wrongly accepted as 'inside' the tools directory.

## Fix
- Extracted the containment logic into an `internal static bool IsInsideDirectory(directory, candidateFullPath)` that normalizes the target directory to end in `Path.DirectorySeparatorChar` before the prefix comparison — so only paths under a real separator boundary pass.
- The extraction loop now calls this helper instead of the inline check. Behavior for legitimate entries (and the existing `../` traversal rejection) is unchanged.

## Tests
- New `SpeedTestServiceTests` covering: normal entry accepted, nested entry accepted, `../` traversal rejected, and the regression — a shared-prefix sibling (`tools-evil`) rejected.

## Verification
- `dotnet build` (app + tests): 0 warnings, 0 errors.