### PR TITLE
fix: actually cancel slow reverse-DNS lookups during traceroute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.50] - 2026-06-22
+
+### Fixed
+- **Reverse-DNS lookups during a traceroute no longer keep running after they time out.** Each hop's host-name lookup had an 800 ms budget, but the timeout only abandoned the wait — the lookup itself kept running in the background. It is now actually cancelled when the budget elapses, freeing the resource immediately.
+
 ## [1.20.49] - 2026-06-22
 
 ### Fixed

--- a/SysManager/SysManager/Services/TracerouteService.cs
+++ b/SysManager/SysManager/Services/TracerouteService.cs
@@ -76,7 +76,11 @@ public sealed class TracerouteService
                 {
                     using var dnsCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
                     dnsCts.CancelAfter(800); // 800ms max for reverse DNS
-                    var entry = await Dns.GetHostEntryAsync(addr.ToString()).WaitAsync(dnsCts.Token).ConfigureAwait(false);
+                    // Pass the token INTO GetHostEntryAsync rather than wrapping it in
+                    // WaitAsync: WaitAsync only abandons the await, leaving the lookup
+                    // running in the background (an orphaned task). The cancellation-aware
+                    // overload actually cancels the lookup when the 800ms budget elapses.
+                    var entry = await Dns.GetHostEntryAsync(addr.ToString(), dnsCts.Token).ConfigureAwait(false);
                     hop.HostName = entry.HostName;
                 }
                 catch (OperationCanceledException) { /* DNS too slow — leave as null */ }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.49</Version>
-    <FileVersion>1.20.49.0</FileVersion>
-    <AssemblyVersion>1.20.49.0</AssemblyVersion>
+    <Version>1.20.50</Version>
+    <FileVersion>1.20.50.0</FileVersion>
+    <AssemblyVersion>1.20.50.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary
Reverse-DNS host-name lookups during a traceroute now stop when their 800 ms budget elapses, instead of leaking into the background.

## Root cause
Each hop awaited `Dns.GetHostEntryAsync(addr).WaitAsync(dnsCts.Token)` with an 800 ms `CancelAfter`. `WaitAsync` only abandons the *await* on timeout — the underlying `GetHostEntryAsync` (the overload with no token) keeps running to completion in the background. On a route with several unresolvable hops, those orphaned lookups pile up and hold sockets/threads until the OS resolver finally gives up.

## Fix
- Pass the timeout token straight into the cancellation-aware overload `Dns.GetHostEntryAsync(host, cancellationToken)` (available since .NET 8). When the 800 ms budget elapses the lookup is genuinely cancelled, freeing the resource immediately.
- Same observable behavior (`hop.HostName` populated within the budget, left null otherwise); only the orphaned-task leak is gone.

## Tests
- No behavioral change for callers, and the path needs a live slow-DNS responder to exercise — not reproducible in a unit test. Existing traceroute tests remain green.

## Verification
- `dotnet build` (app + tests): 0 warnings, 0 errors.