### PR TITLE
fix: expand 8.3 short paths before the shredder system-folder guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.51] - 2026-06-22
+
+### Security
+- **The file shredder now expands 8.3 short paths before its system-folder safety check.** The guard that blocks shredding inside Windows/System32/Program Files compared full paths, but a short-name alias (e.g. `C:\PROGRA~1`) isn't expanded by the framework, so it could slip past the check. Short paths are now expanded to their long form first, closing that bypass.
+
 ## [1.20.50] - 2026-06-22
 
 ### Fixed

--- a/SysManager/SysManager.Tests/FileShredderServiceTests.cs
+++ b/SysManager/SysManager.Tests/FileShredderServiceTests.cs
@@ -270,4 +270,44 @@ public class FileShredderServiceTests
             () => svc.ShredFileAsync(Path.Combine(sibling, "x.dat"), ShredMethod.Quick, null, CancellationToken.None));
         Assert.IsNotType<SecurityException>(ex);
     }
+
+    // ---------- 8.3 short-path bypass regression ----------
+
+    [Fact]
+    public void ExpandShortPath_PathWithoutTilde_ReturnsUnchanged()
+    {
+        // Fast path: no '~' component means nothing to expand.
+        const string p = @"C:\Program Files\SomeApp\file.dat";
+        Assert.Equal(p, FileShredderService.ExpandShortPath(p));
+    }
+
+    [Fact]
+    public void ExpandShortPath_NonexistentShortPath_ReturnsLiteral()
+    {
+        // A '~' path that doesn't resolve must fall back to the literal input rather
+        // than throw, so ValidatePath still checks the path it was given.
+        var p = @"C:\NOEXIS~1\nothing.dat";
+        Assert.Equal(p, FileShredderService.ExpandShortPath(p));
+    }
+
+    [Fact]
+    public void ExpandShortPath_ProgramFilesShortName_ExpandsToLongForm()
+    {
+        // Regression: C:\PROGRA~1 must expand to the real "Program Files" path so a
+        // short-name alias of a protected directory can't slip past the denylist.
+        var progFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        var root = Path.GetPathRoot(progFiles); // e.g. "C:\"
+        if (string.IsNullOrEmpty(root)) return;
+        var shortForm = Path.Combine(root, "PROGRA~1");
+
+        var expanded = FileShredderService.ExpandShortPath(shortForm);
+
+        // On volumes with 8.3 generation enabled this expands to "Program Files";
+        // where 8.3 is disabled GetLongPathName returns the literal — accept either,
+        // but it must never be left as a different protected-looking alias.
+        Assert.True(
+            expanded.Equals(progFiles, StringComparison.OrdinalIgnoreCase) ||
+            expanded.Equals(shortForm, StringComparison.OrdinalIgnoreCase),
+            $"Unexpected expansion: {expanded}");
+    }
 }

--- a/SysManager/SysManager/Services/FileShredderService.cs
+++ b/SysManager/SysManager/Services/FileShredderService.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Cryptography;
 using Serilog;
@@ -28,7 +29,7 @@ public enum ShredMethod
 /// Securely deletes files by overwriting their contents with specified patterns
 /// before removing them from the file system.
 /// </summary>
-public sealed class FileShredderService
+public sealed partial class FileShredderService
 {
     private const int BufferSize = 65_536; // 64 KB
 
@@ -245,6 +246,11 @@ public sealed class FileShredderService
         catch (IOException) { /* not a link or cannot resolve — validate the literal path */ }
         catch (UnauthorizedAccessException) { /* cannot probe — validate the literal path */ }
 
+        // Expand any 8.3 short components (e.g. C:\PROGRA~1 -> C:\Program Files).
+        // Path.GetFullPath does NOT expand short names, so without this a short-name
+        // alias of a protected directory would slip past the prefix check below.
+        fullPath = ExpandShortPath(fullPath);
+
         foreach (var prefix in ProtectedPrefixes)
         {
             // Match on a directory boundary, not a raw prefix: the path must equal the
@@ -269,4 +275,34 @@ public sealed class FileShredderService
         ShredMethod.Thorough => [0x00, 0xFF, 0x00, 0xFF, 0xAA, 0x55, null],
         _ => [0x00]
     };
+
+    /// <summary>
+    /// Expands any 8.3 short path components to their long form via GetLongPathName.
+    /// Returns the input unchanged if the path doesn't exist or the API fails — the
+    /// caller still validates the (possibly short) literal path in that case.
+    /// </summary>
+    internal static string ExpandShortPath(string path)
+    {
+        // Fast path: no '~' means there can't be an 8.3 alias component.
+        if (!path.Contains('~')) return path;
+
+        // First call with a zero-length buffer returns the required length (incl. NUL).
+        uint needed = NativeMethods.GetLongPathName(path, [], 0);
+        if (needed == 0) return path; // not found / no permission — keep literal
+
+        var buffer = new char[needed];
+        uint written = NativeMethods.GetLongPathName(path, buffer, needed);
+        if (written == 0 || written >= needed) return path; // failed / race — keep literal
+
+        return new string(buffer, 0, (int)written);
+    }
+
+    private static partial class NativeMethods
+    {
+        [LibraryImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16, EntryPoint = "GetLongPathNameW")]
+        internal static partial uint GetLongPathName(
+            string lpszShortPath,
+            [Out] char[] lpszLongPath,
+            uint cchBuffer);
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.50</Version>
-    <FileVersion>1.20.50.0</FileVersion>
-    <AssemblyVersion>1.20.50.0</AssemblyVersion>
+    <Version>1.20.51</Version>
+    <FileVersion>1.20.51.0</FileVersion>
+    <AssemblyVersion>1.20.51.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary
Closes an 8.3 short-path bypass in the file shredder's protected-folder safety check.

## Root cause
`ValidatePath` blocks shredding inside Windows / System32 / Program Files by comparing the resolved full path against those roots. It already resolves symlinks/junctions, but `Path.GetFullPath` does **not** expand 8.3 short names. So a short-name alias of a protected directory — e.g. `C:\PROGRA~1\...` for `C:\Program Files\...` — would not match the long-form prefix and could slip past the guard.

## Fix
- Added `ExpandShortPath` (backed by `GetLongPathNameW` via `LibraryImport`) that expands short components to their long form, called right before the denylist comparison.
- Fast-paths paths with no `~` (no possible 8.3 component) and falls back to the literal path if the API can't resolve it (so the guard still validates what it was given).
- Uses a `char[]` buffer (source-generated `LibraryImport` doesn't support `StringBuilder`), sizing via the standard zero-length probe call.

## Tests
- New `ExpandShortPath` tests: no-`~` returns unchanged, nonexistent short path returns literal, and `C:\PROGRA~1` expands to the real Program Files path (accepting the literal where the volume has 8.3 generation disabled).

## Verification
- `dotnet build` (app + tests): 0 warnings, 0 errors.