### PR TITLE
fix: honor cancellation during the speed-test ping phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.52] - 2026-06-22
+
+### Fixed
+- **Cancelling a speed test now stops the ping phase immediately.** The initial latency measurement ran four 2-second probes without honoring the cancellation token, so pressing Cancel during the ping phase could wait up to 8 seconds before stopping. The probes now observe cancellation and stop right away.
+
 ## [1.20.51] - 2026-06-22
 
 ### Security

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -40,7 +40,7 @@ public sealed class SpeedTestService
         IProgress<(int Percent, string Message)>? progress, CancellationToken ct)
     {
         progress?.Report((0, "Pinging test server…"));
-        var pingMs = await MeasurePingAsync(CfPingHost).ConfigureAwait(false);
+        var pingMs = await MeasurePingAsync(CfPingHost, ct).ConfigureAwait(false);
 
         progress?.Report((5, "Measuring download…"));
         var downloadMbps = await MeasureDownloadAsync(progress, ct).ConfigureAwait(false);
@@ -52,7 +52,7 @@ public sealed class SpeedTestService
         return new SpeedTestResult("HTTP", downloadMbps, uploadMbps, pingMs, CfPingHost, DateTime.Now);
     }
 
-    private static async Task<double> MeasurePingAsync(string host)
+    private static async Task<double> MeasurePingAsync(string host, CancellationToken ct)
     {
         try
         {
@@ -60,7 +60,9 @@ public sealed class SpeedTestService
             List<long> samples = [];
             for (int i = 0; i < 4; i++)
             {
-                var r = await p.SendPingAsync(host, 2000).ConfigureAwait(false);
+                // Pass the token so cancelling the speed test interrupts the ping phase
+                // immediately, instead of running all four 2 s probes (up to 8 s) first.
+                var r = await p.SendPingAsync(host, TimeSpan.FromMilliseconds(2000), cancellationToken: ct).ConfigureAwait(false);
                 if (r.Status == IPStatus.Success) samples.Add(r.RoundtripTime);
             }
             return samples.Count > 0 ? samples.Average() : 0;

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.51</Version>
-    <FileVersion>1.20.51.0</FileVersion>
-    <AssemblyVersion>1.20.51.0</AssemblyVersion>
+    <Version>1.20.52</Version>
+    <FileVersion>1.20.52.0</FileVersion>
+    <AssemblyVersion>1.20.52.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary
Cancelling a speed test now interrupts the initial ping phase immediately instead of running up to 8 seconds of probes first.

## Root cause
`RunHttpAsync` receives a `CancellationToken`, but `MeasurePingAsync(CfPingHost)` was called without it and used the `SendPingAsync(host, timeout)` overload that takes no token. The ping phase fires four sequential 2-second probes, so pressing Cancel during it could wait up to ~8 s before the test actually stopped.

## Fix
- Thread `ct` into `MeasurePingAsync` and switch to the `SendPingAsync(host, TimeSpan, cancellationToken)` overload (available since .NET 8).
- Each probe now observes cancellation, so the ping phase stops promptly. The download/upload phases already honored the token.

## Tests
- No behavioral change for a completed run; the cancellation path needs a live ping responder and a precisely-timed cancel, which isn't unit-testable here. Existing speed-test tests remain green.

## Verification
- `dotnet build` (app + tests): 0 warnings, 0 errors.