### PR TITLE
test: uniformize VM test helper naming and boolean assertions

### DIFF
--- a/SysManager/SysManager.Tests/BulkInstallerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/BulkInstallerViewModelTests.cs
@@ -14,27 +14,27 @@ namespace SysManager.Tests;
 /// </summary>
 public class BulkInstallerViewModelTests
 {
-    private static BulkInstallerViewModel CreateVm() =>
+    private static BulkInstallerViewModel NewVm() =>
         new(new BulkInstallerService(new PowerShellRunner()), new AppIconService());
 
     [Fact]
     public void Constructor_PopulatesAppsWithCuratedList()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Equal(46, vm.Apps.Count);
     }
 
     [Fact]
     public void Constructor_FilteredAppsMatchesAllApps()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Equal(vm.Apps.Count, vm.FilteredApps.Count);
     }
 
     [Fact]
     public void SelectAll_SelectsAllFilteredApps()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         vm.SelectAllCommand.Execute(null);
         Assert.All(vm.FilteredApps, app => Assert.True(app.IsSelected));
     }
@@ -42,7 +42,7 @@ public class BulkInstallerViewModelTests
     [Fact]
     public void DeselectAll_DeselectsAllApps()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         // First select all, then deselect
         vm.SelectAllCommand.Execute(null);
         vm.DeselectAllCommand.Execute(null);
@@ -63,7 +63,7 @@ public class BulkInstallerViewModelTests
     [InlineData("Runtimes & Frameworks", 4)]
     public void FilterByCategory_ShowsOnlyMatchingCategory(string category, int expectedCount)
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         vm.SelectedCategory = category;
         Assert.Equal(expectedCount, vm.FilteredApps.Count);
         Assert.All(vm.FilteredApps, app => Assert.Equal(category, app.Category));
@@ -75,7 +75,7 @@ public class BulkInstallerViewModelTests
     [InlineData("zzz_nonexistent", 0)]
     public void FilterByText_ShowsMatchingName(string text, int expectedCount)
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         vm.FilterText = text;
         Assert.Equal(expectedCount, vm.FilteredApps.Count);
     }
@@ -83,7 +83,7 @@ public class BulkInstallerViewModelTests
     [Fact]
     public void CombinedFilter_CategoryAndText_Works()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         vm.SelectedCategory = "Development";
         vm.FilterText = "Git";
         Assert.Single(vm.FilteredApps);
@@ -93,7 +93,7 @@ public class BulkInstallerViewModelTests
     [Fact]
     public void Categories_ContainsAllAndElevenSpecificPlusCustom()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Contains("All", vm.Categories);
         Assert.Contains("Custom", vm.Categories);
         Assert.Equal(13, vm.Categories.Count);
@@ -104,7 +104,7 @@ public class BulkInstallerViewModelTests
     [Fact]
     public void InstallSelectedCommand_DisabledWhileBusy()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.True(vm.InstallSelectedCommand.CanExecute(null));   // idle → clickable
 
         vm.IsBusy = true;

--- a/SysManager/SysManager.Tests/ContextMenuViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ContextMenuViewModelTests.cs
@@ -14,12 +14,12 @@ namespace SysManager.Tests;
 /// </summary>
 public class ContextMenuViewModelTests
 {
-    private static ContextMenuViewModel CreateVm() => new(new ContextMenuService());
+    private static ContextMenuViewModel NewVm() => new(new ContextMenuService());
 
     [Fact]
     public void Constructor_LocationFilters_ContainsAllPlusSpecific()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Contains("All", vm.LocationFilters);
         Assert.Contains("Files", vm.LocationFilters);
         Assert.Contains("Folders", vm.LocationFilters);
@@ -31,21 +31,21 @@ public class ContextMenuViewModelTests
     [Fact]
     public void Constructor_SelectedLocation_DefaultsToAll()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Equal("All", vm.SelectedLocation);
     }
 
     [Fact]
     public void Constructor_FilterText_DefaultsEmpty()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Equal("", vm.FilterText);
     }
 
     [Fact]
     public void Constructor_Entries_StartsEmpty()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         // Before scan, entries should be empty
         Assert.Empty(vm.Entries);
     }
@@ -53,28 +53,28 @@ public class ContextMenuViewModelTests
     [Fact]
     public void Constructor_TotalCount_DefaultsToZero()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Equal(0, vm.TotalCount);
     }
 
     [Fact]
     public void Constructor_EnabledCount_DefaultsToZero()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Equal(0, vm.EnabledCount);
     }
 
     [Fact]
     public void Constructor_DisabledCount_DefaultsToZero()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Equal(0, vm.DisabledCount);
     }
 
     [Fact]
     public void Commands_NotNull()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.NotNull(vm.ScanCommand);
         Assert.NotNull(vm.ToggleEntryCommand);
         Assert.NotNull(vm.RefreshCommand);
@@ -84,7 +84,7 @@ public class ContextMenuViewModelTests
     [Fact]
     public void Constructor_ActivePresetId_DefaultsToMenuStyle()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Contains(vm.ActivePresetId, new[] { "win10", "win11" });
     }
 }

--- a/SysManager/SysManager.Tests/DnsHostsViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DnsHostsViewModelTests.cs
@@ -18,27 +18,27 @@ namespace SysManager.Tests;
 /// </summary>
 public class DnsHostsViewModelTests
 {
-    private static DnsHostsViewModel CreateVm() =>
+    private static DnsHostsViewModel NewVm() =>
         new(new DnsService(new PowerShellRunner()), new HostsFileService());
 
     [StaFact]
     public void Constructor_PresetsListPopulated_With5Presets()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Equal(5, vm.Presets.Count);
     }
 
     [StaFact]
     public void Constructor_HostEntries_IsNotNull()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.NotNull(vm.HostEntries);
     }
 
     [StaFact]
     public void Presets_ContainsExpectedNames()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         var names = vm.Presets.Select(p => p.Name).ToList();
         Assert.Contains("Google", names);
         Assert.Contains("Cloudflare", names);
@@ -80,7 +80,7 @@ public class DnsHostsViewModelTests
     [StaFact]
     public void RemoveEntry_RemovesFromCollection()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         var entry = new HostsEntry { IpAddress = "10.0.0.1", Hostname = "test.local" };
         vm.HostEntries.Add(entry);
 

--- a/SysManager/SysManager.Tests/EqualityConverterTests.cs
+++ b/SysManager/SysManager.Tests/EqualityConverterTests.cs
@@ -32,21 +32,21 @@ public class EqualityConverterTests
     public void Convert_NullValue_ReturnsFalse()
     {
         var result = _sut.Convert(null, typeof(bool), "balanced", CultureInfo.InvariantCulture);
-        Assert.Equal(false, result);
+        Assert.False((bool)result!);
     }
 
     [Fact]
     public void Convert_NullParameter_ReturnsFalse()
     {
         var result = _sut.Convert("balanced", typeof(bool), null, CultureInfo.InvariantCulture);
-        Assert.Equal(false, result);
+        Assert.False((bool)result!);
     }
 
     [Fact]
     public void Convert_BothNull_ReturnsFalse()
     {
         var result = _sut.Convert(null, typeof(bool), null, CultureInfo.InvariantCulture);
-        Assert.Equal(false, result);
+        Assert.False((bool)result!);
     }
 
     [Theory]
@@ -77,6 +77,6 @@ public class EqualityConverterTests
     public void Convert_IsCaseSensitive()
     {
         var result = _sut.Convert("Balanced", typeof(bool), "balanced", CultureInfo.InvariantCulture);
-        Assert.Equal(false, result);
+        Assert.False((bool)result!);
     }
 }

--- a/SysManager/SysManager.Tests/FileShredderViewModelTests.cs
+++ b/SysManager/SysManager.Tests/FileShredderViewModelTests.cs
@@ -20,34 +20,34 @@ namespace SysManager.Tests;
 [Collection("DialogService")]
 public class FileShredderViewModelTests
 {
-    private static FileShredderViewModel CreateVm() =>
+    private static FileShredderViewModel NewVm() =>
         new(new FileShredderService());
 
     [Fact]
     public void Constructor_ItemsStartsEmpty()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Empty(vm.Items);
     }
 
     [Fact]
     public void Constructor_SelectedMethodDefaultsToStandard()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Equal(ShredMethod.Standard, vm.SelectedMethod);
     }
 
     [Fact]
     public void Constructor_SelectedMethodValueIs3()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Equal(3, (int)vm.SelectedMethod);
     }
 
     [Fact]
     public void RemoveItem_RemovesFromList()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         var item = new ShredItem
         {
             Path = @"C:\temp\test.txt",
@@ -65,7 +65,7 @@ public class FileShredderViewModelTests
     [Fact]
     public void RemoveItem_WithNull_DoesNotCrash()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         // Should not throw when passing null
         vm.RemoveItemCommand.Execute(null);
         Assert.Empty(vm.Items);
@@ -74,21 +74,21 @@ public class FileShredderViewModelTests
     [Fact]
     public void IsShredding_DefaultsFalse()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.False(vm.IsShredding);
     }
 
     [Fact]
     public void IsBusy_DefaultsFalse()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.False(vm.IsBusy);
     }
 
     [Fact]
     public void Items_CanAddMultiple()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         vm.Items.Add(new ShredItem { Path = @"C:\a.txt", Name = "a.txt", SizeBytes = 100, IsFolder = false });
         vm.Items.Add(new ShredItem { Path = @"C:\b.txt", Name = "b.txt", SizeBytes = 200, IsFolder = false });
         vm.Items.Add(new ShredItem { Path = @"C:\folder", Name = "folder", SizeBytes = 5000, IsFolder = true });
@@ -109,7 +109,7 @@ public class FileShredderViewModelTests
         DialogService.Instance = dialog;
         try
         {
-            var vm = CreateVm();
+            var vm = NewVm();
             vm.Items.Add(new ShredItem
             {
                 Path = file, Name = Path.GetFileName(file), SizeBytes = 1, IsFolder = false
@@ -140,7 +140,7 @@ public class FileShredderViewModelTests
         DialogService.Instance = dialog;
         try
         {
-            var vm = CreateVm();
+            var vm = NewVm();
             vm.Items.Add(new ShredItem
             {
                 Path = file, Name = Path.GetFileName(file), SizeBytes = 1, IsFolder = false
@@ -166,7 +166,7 @@ public class FileShredderViewModelTests
         DialogService.Instance = dialog;
         try
         {
-            var vm = CreateVm(); // Items empty
+            var vm = NewVm(); // Items empty
 
             await vm.ShredAllCommand.ExecuteAsync(null);
 

--- a/SysManager/SysManager.Tests/IntGreaterThanZeroConverterTests.cs
+++ b/SysManager/SysManager.Tests/IntGreaterThanZeroConverterTests.cs
@@ -31,14 +31,14 @@ public class IntGreaterThanZeroConverterTests
     public void Convert_NonInt_ReturnsFalse()
     {
         var result = _sut.Convert("hello", typeof(bool), null!, CultureInfo.InvariantCulture);
-        Assert.Equal(false, result);
+        Assert.False((bool)result!);
     }
 
     [Fact]
     public void Convert_Null_ReturnsFalse()
     {
         var result = _sut.Convert(null!, typeof(bool), null!, CultureInfo.InvariantCulture);
-        Assert.Equal(false, result);
+        Assert.False((bool)result!);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
@@ -13,14 +13,14 @@ namespace SysManager.Tests;
 /// </summary>
 public class PerformanceViewModelTests
 {
-    private static PerformanceViewModel CreateVm() => new(new PerformanceService(new PowerShellRunner()));
+    private static PerformanceViewModel NewVm() => new(new PerformanceService(new PowerShellRunner()));
 
     // ── Commands exist ──
 
     [Fact]
     public void Constructor_GlobalCommands_Exist()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.NotNull(vm.RefreshCommand);
         Assert.NotNull(vm.RestoreAllCommand);
     }
@@ -28,7 +28,7 @@ public class PerformanceViewModelTests
     [Fact]
     public void Constructor_PerSectionCommands_Exist()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.NotNull(vm.ApplyPowerPlanCommand);
         Assert.NotNull(vm.ApplyVisualEffectsCommand);
         Assert.NotNull(vm.ApplyGameModeCommand);
@@ -42,42 +42,42 @@ public class PerformanceViewModelTests
     [Fact]
     public void Constructor_Profile_NotNull()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.NotNull(vm.Profile);
     }
 
     [Fact]
     public void Constructor_Summary_HasDefaultValue()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.False(string.IsNullOrEmpty(vm.Summary));
     }
 
     [Fact]
     public void Constructor_SelectedPlan_DefaultBalanced()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Equal("balanced", vm.SelectedPlan);
     }
 
     [Fact]
     public void Constructor_HasSnapshot_DefaultFalse()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.False(vm.HasSnapshot);
     }
 
     [Fact]
     public void Constructor_NeedsReboot_DefaultFalse()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.False(vm.NeedsReboot);
     }
 
     [Fact]
     public void Constructor_WantToggles_DefaultFalse()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.False(vm.WantVisualEffectsReduced);
         Assert.False(vm.WantGameModeOff);
         Assert.False(vm.WantXboxGameBarOff);
@@ -90,7 +90,7 @@ public class PerformanceViewModelTests
     [Fact]
     public void SelectedPlan_CanBeChanged()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         vm.SelectedPlan = "ultimate";
         Assert.Equal("ultimate", vm.SelectedPlan);
     }
@@ -98,7 +98,7 @@ public class PerformanceViewModelTests
     [Fact]
     public void WantVisualEffectsReduced_CanBeToggled()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         vm.WantVisualEffectsReduced = true;
         Assert.True(vm.WantVisualEffectsReduced);
         vm.WantVisualEffectsReduced = false;
@@ -108,7 +108,7 @@ public class PerformanceViewModelTests
     [Fact]
     public void WantGameModeOff_CanBeToggled()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         vm.WantGameModeOff = true;
         Assert.True(vm.WantGameModeOff);
     }
@@ -116,7 +116,7 @@ public class PerformanceViewModelTests
     [Fact]
     public void WantXboxGameBarOff_CanBeToggled()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         vm.WantXboxGameBarOff = true;
         Assert.True(vm.WantXboxGameBarOff);
     }
@@ -124,7 +124,7 @@ public class PerformanceViewModelTests
     [Fact]
     public void WantGpuMaxPerformance_CanBeToggled()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         vm.WantGpuMaxPerformance = true;
         Assert.True(vm.WantGpuMaxPerformance);
     }
@@ -132,7 +132,7 @@ public class PerformanceViewModelTests
     [Fact]
     public void WantProcessorMaxState_CanBeToggled()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         vm.WantProcessorMaxState = true;
         Assert.True(vm.WantProcessorMaxState);
     }
@@ -140,21 +140,21 @@ public class PerformanceViewModelTests
     [Fact]
     public void NvidiaGpuName_DefaultEmpty()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Equal("", vm.NvidiaGpuName);
     }
 
     [Fact]
     public void HasNvidiaGpu_DefaultFalse()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.False(vm.HasNvidiaGpu);
     }
 
     [Fact]
     public void SelectedPlan_NotifiesPropertyChanged()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         var changed = new List<string>();
         vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
         vm.SelectedPlan = "high";
@@ -166,14 +166,14 @@ public class PerformanceViewModelTests
     [Fact]
     public void IsProcessorStateLocked_DefaultFalse()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.False(vm.IsProcessorStateLocked);
     }
 
     [Fact]
     public void IsProcessorStateEditable_InverseOfLocked()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.True(vm.IsProcessorStateEditable);
         vm.IsProcessorStateLocked = true;
         Assert.False(vm.IsProcessorStateEditable);
@@ -182,7 +182,7 @@ public class PerformanceViewModelTests
     [Fact]
     public void IsProcessorStateLocked_NotifiesEditable()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         var changed = new List<string>();
         vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
         vm.IsProcessorStateLocked = true;

--- a/SysManager/SysManager.Tests/PrivacyViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PrivacyViewModelTests.cs
@@ -16,19 +16,19 @@ namespace SysManager.Tests;
 [Collection("DialogService")]
 public class PrivacyViewModelTests
 {
-    private static PrivacyViewModel CreateVm() => new(new PrivacyService());
+    private static PrivacyViewModel NewVm() => new(new PrivacyService());
 
     [Fact]
     public void Constructor_Toggles_Populated_With12Items()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Equal(12, vm.Toggles.Count);
     }
 
     [Fact]
     public void Constructor_Categories_ContainsAllPlusSpecific()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Contains("All", vm.Categories);
         Assert.Contains("Telemetry", vm.Categories);
         Assert.Contains("UI Declutter", vm.Categories);
@@ -39,7 +39,7 @@ public class PrivacyViewModelTests
     [Fact]
     public void Constructor_SelectedCategory_DefaultsToAll()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Equal("All", vm.SelectedCategory);
     }
 
@@ -49,7 +49,7 @@ public class PrivacyViewModelTests
     [InlineData("Features", 4)]
     public void FilterByCategory_ShowsOnlyMatchingToggles(string category, int expectedCount)
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         vm.SelectedCategory = category;
         Assert.Equal(expectedCount, vm.FilteredToggles.Count);
         Assert.All(vm.FilteredToggles, t => Assert.Equal(category, t.Category));
@@ -58,7 +58,7 @@ public class PrivacyViewModelTests
     [Fact]
     public void FilterByAll_ShowsAllToggles()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         vm.SelectedCategory = "Telemetry"; // Filter first
         vm.SelectedCategory = "All";       // Then reset
         Assert.Equal(12, vm.FilteredToggles.Count);
@@ -67,14 +67,14 @@ public class PrivacyViewModelTests
     [Fact]
     public void FilteredToggles_InitiallyMatchesAll()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Equal(vm.Toggles.Count, vm.FilteredToggles.Count);
     }
 
     [Fact]
     public void Constructor_NoPendingChanges_AfterLoad()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Equal(0, vm.PendingChangeCount);
         Assert.False(vm.HasPendingChanges);
     }
@@ -82,7 +82,7 @@ public class PrivacyViewModelTests
     [Fact]
     public void TogglingValue_IncrementsPendingChangeCount()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         var first = vm.Toggles[0];
         first.IsEnabled = !first.IsEnabled;
 
@@ -93,7 +93,7 @@ public class PrivacyViewModelTests
     [Fact]
     public void TogglingValueBackToBaseline_ResetsPendingCount()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         var first = vm.Toggles[0];
         var original = first.IsEnabled;
 
@@ -106,7 +106,7 @@ public class PrivacyViewModelTests
     [Fact]
     public void DiscardChanges_RestoresAllTogglesToBaseline()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         var baseline = vm.Toggles.Select(t => t.IsEnabled).ToList();
 
         // Flip every toggle.
@@ -123,7 +123,7 @@ public class PrivacyViewModelTests
     [Fact]
     public void StatusMessage_MentionsPending_WhenChangesQueued()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         vm.Toggles[0].IsEnabled = !vm.Toggles[0].IsEnabled;
 
         Assert.Contains("pending", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
@@ -132,7 +132,7 @@ public class PrivacyViewModelTests
     [Fact]
     public void ApplyChanges_WithNoPending_SetsNoChangesMessage()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         vm.ApplyChangesCommand.Execute(null);
 
         Assert.Contains("no changes", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
@@ -147,7 +147,7 @@ public class PrivacyViewModelTests
         DialogService.Instance = dialog;
         try
         {
-            var vm = CreateVm();
+            var vm = NewVm();
             vm.Toggles[0].IsEnabled = !vm.Toggles[0].IsEnabled; // create a pending change
             var pendingBefore = vm.PendingChangeCount;
 

--- a/SysManager/SysManager.Tests/UninstallerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/UninstallerViewModelTests.cs
@@ -15,12 +15,12 @@ namespace SysManager.Tests;
 /// </summary>
 public class UninstallerViewModelTests
 {
-    private static UninstallerViewModel CreateVm() => new(new UninstallerService(new PowerShellRunner()));
+    private static UninstallerViewModel NewVm() => new(new UninstallerService(new PowerShellRunner()));
 
     [Fact]
     public void Constructor_Commands_Exist()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.NotNull(vm.ScanCommand);
         Assert.NotNull(vm.UninstallSelectedCommand);
         Assert.NotNull(vm.CancelCommand);
@@ -31,7 +31,7 @@ public class UninstallerViewModelTests
     [Fact]
     public void Constructor_Collections_NotNull()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.NotNull(vm.AllApps);
         Assert.NotNull(vm.FilteredApps);
         Assert.NotNull(vm.Console);
@@ -40,21 +40,21 @@ public class UninstallerViewModelTests
     [Fact]
     public void FilterText_DefaultEmpty()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Equal("", vm.FilterText);
     }
 
     [Fact]
     public void Summary_HasDefaultValue()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.False(string.IsNullOrEmpty(vm.Summary));
     }
 
     [Fact]
     public void FilterText_CanBeChanged()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         vm.FilterText = "chrome";
         Assert.Equal("chrome", vm.FilterText);
     }
@@ -62,7 +62,7 @@ public class UninstallerViewModelTests
     [Fact]
     public void AppCount_DefaultZero()
     {
-        var vm = CreateVm();
+        var vm = NewVm();
         Assert.Equal(0, vm.AppCount);
     }
 


### PR DESCRIPTION
## Summary
First batch of the modernization+uniformity sweep (test-project uniformity). No production code touched; `test:` so no release.

## Changes
- **`CreateVm()` -> `NewVm()`** in 7 test files (BulkInstaller, ContextMenu, DnsHosts, FileShredder, Performance, Privacy, Uninstaller). The majority of the suite (10 files) already used `NewVm()`; these 7 were the outliers. Now uniform across all ViewModel tests.
- **`Assert.Equal(false, result)` -> `Assert.False((bool)result!)`** in EqualityConverterTests and IntGreaterThanZeroConverterTests, matching the boolean-assertion style used everywhere else. (The cast is needed because IValueConverter.Convert returns object.)

## Verification
- `dotnet build` (tests project): 0 warnings, 0 errors (TreatWarningsAsErrors=true).
- Pure rename + assertion-style change; no test logic or coverage changed.