### PR TITLE
docs: align README and CONTRIBUTING with actual Dashboard, Deep Cleanup and test layout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,11 +124,13 @@ Full run:
 
 ```powershell
 dotnet test SysManager/SysManager.Tests/SysManager.Tests.csproj -c Release
+dotnet test SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj -c Release
 dotnet test SysManager/SysManager.UITests/SysManager.UITests.csproj -c Release
 ```
 
-UI tests require an interactive desktop session. Run them locally, not
-over SSH/Remote PowerShell.
+The integration and UI tests touch the live system / require an interactive
+desktop session, so they run locally only (not in CI) — run them locally,
+not over SSH/Remote PowerShell. CI runs the unit tests.
 
 Filter to one class while iterating:
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ deleting anything (uses the standard `LegacyDisable` registry mechanism):
 - Safe by design: never touches browsers, passwords, the registry, active
   drivers, or actual game files. Locked files are skipped, never forced.
 
-### Large files finder
+#### Large files finder (part of Deep Cleanup)
 - Scan Downloads, Documents, Desktop, Videos, Pictures, Music, Program
   Files, or a whole drive.
 - Configurable min-size (default 500 MB) and top-N (default 100).
@@ -339,6 +339,11 @@ deleting anything (uses the standard `LegacyDisable` registry mechanism):
 ### Dashboard
 - One-line OS / CPU / RAM / disk summary
 - Live uptime counter
+- **Real-time vitals** — CPU, RAM, and GPU usage refreshed at 300 ms while
+  the tab is visible (polling pauses automatically when it isn't), with live
+  indicator dots.
+- **Recent Activity** — the last few actions you ran (Quick Cleanup, Update
+  All Apps, Check Updates, …) with timestamps.
 - **Quick Tune-Up** — one-click wizard that cleans temp files, optionally
   empties the Recycle Bin, scans for broken shortcuts, checks disk SMART
   health, flags high uptime (14+ days) and high RAM usage (85%+). Displays


### PR DESCRIPTION
## Summary
Documentation accuracy pass from the modernization audit. Brings user-facing docs in line with what the code actually does. `docs:` so no release.

## Changes
- **README — Dashboard**: added the **Real-time vitals** (CPU/RAM/GPU at 300 ms while visible, polling auto-pauses) and **Recent Activity** features. Both exist in DashboardViewModel but were undocumented.
- **README — Large files finder**: demoted from a top-level `###` section to a `####` sub-item of Deep Cleanup, since it has no separate tab/ViewModel — it is driven by DeepCleanupViewModel via LargeFileScanner. The old heading implied a standalone tab.
- **CONTRIBUTING — Running tests**: added `SysManager.IntegrationTests` to the full-run commands and clarified that integration + UI tests run locally only (CI runs the unit tests).

## Notes
- Verified the README "55 tabs / 30 implemented / 25 WIP" claim against the code (25 `Wip*` placeholder ViewModels) — accurate, left unchanged.
- The historical CHANGELOG "2281 tests" line (v1.7.20) was left intact — it is an immutable historical entry that was true at that release, not a current claim.

## Verification
- Docs-only; internal links unaffected (the changed heading was not a link target).