### PR TITLE
refactor: modernize single-element JSON handling and log previously-silent catches

### DIFF
--- a/SysManager/SysManager/Services/FileShredderService.cs
+++ b/SysManager/SysManager/Services/FileShredderService.cs
@@ -205,8 +205,8 @@ public sealed partial class FileShredderService
 
             FileInfo[] files;
             try { files = dir.GetFiles(); }
-            catch (UnauthorizedAccessException) { continue; }
-            catch (IOException) { continue; }
+            catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Shredder: access denied enumerating {Dir}", dir.FullName); continue; }
+            catch (IOException ex) { Log.Debug(ex, "Shredder: I/O error enumerating {Dir}", dir.FullName); continue; }
 
             foreach (var file in files)
                 results.Add(file.FullName);

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -632,8 +632,8 @@ public sealed partial class AboutViewModel : ViewModelBase
             if (File.Exists(dll))
                 return File.GetLastWriteTime(dll).ToString("dd MMM yyyy");
         }
-        catch (IOException) { }
-        catch (UnauthorizedAccessException) { }
+        catch (IOException ex) { Log.Debug(ex, "About: could not read build date from disk"); }
+        catch (UnauthorizedAccessException ex) { Log.Debug(ex, "About: access denied reading build date"); }
         return string.Empty;
     }
 }

--- a/SysManager/SysManager/ViewModels/DriversViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DriversViewModel.cs
@@ -97,9 +97,9 @@ public sealed partial class DriversViewModel : ViewModelBase
             var root = doc.RootElement;
 
             // PS returns an array if multiple, or a single object if only one.
-            var items = root.ValueKind == JsonValueKind.Array
+            IEnumerable<JsonElement> items = root.ValueKind == JsonValueKind.Array
                 ? root.EnumerateArray()
-                : new[] { root }.AsEnumerable();
+                : [root];
 
             foreach (var entry in items.Select(el => new DriverEntry
             {

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -389,9 +389,9 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
             using var doc = JsonDocument.Parse(raw);
             var root = doc.RootElement;
 
-            var items = root.ValueKind == JsonValueKind.Array
+            IEnumerable<JsonElement> items = root.ValueKind == JsonValueKind.Array
                 ? root.EnumerateArray()
-                : new[] { root }.AsEnumerable();
+                : [root];
 
             foreach (var entry in items.Select(el => new UpdateEntry
             {


### PR DESCRIPTION
## Summary
Modernization sweep — code idiom + exception-handling uniformity. `refactor:`, behavior-preserving, no release.

## Changes
- **Collection expression for single-element JSON** (DriversViewModel, WindowsUpdateViewModel): `new[] { root }.AsEnumerable()` -> `[root]` with an explicit `IEnumerable<JsonElement>` target type. Same result, idiomatic .NET 10.
- **Log previously-silent catches**: `FileShredderService.EnumerateFilesSafe` and `AboutViewModel`'s build-date reader had empty `catch (IOException)/(UnauthorizedAccessException)` blocks. They now `Log.Debug(...)` like the rest of the codebase (Protocol I: empty catches must log at Debug minimum). Both run once per directory / once per call, so no log flooding.

## Notes from the audit (deliberately NOT applied)
- Many `.Where(...).ToList()` -> `[.. ...]` suggestions were skipped: they force a `var` -> explicit-type rewrite for no real gain and `.ToList()` is already fine.
- `LatencySeries.ToList().FindIndex(...)` was left as-is: `ObservableCollection<T>` has no `FindIndex`, so the audit's proposed `.FindIndex` would not compile, and the `.ToList()` is on a cold path.
- `LargeFileScanner`'s per-directory empty catches were left silent intentionally — that loop walks an entire drive and logging every access-denied would flood the log.

## Verification
- `dotnet build` (app + tests): 0 warnings, 0 errors.