### PR TITLE
refactor: uniform ConfigureAwait(false) on service-layer Task.Run calls

### DIFF
--- a/SysManager/SysManager/Services/MemoryTestService.cs
+++ b/SysManager/SysManager/Services/MemoryTestService.cs
@@ -81,7 +81,7 @@ public sealed class MemoryTestService
             catch (UnauthorizedAccessException) { /* EventLog access denied */ }
 
             return new MemoryErrorSummary(wheaCount, diagCount, lastError);
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -142,6 +142,6 @@ public sealed class MemoryTestService
             catch (FormatException) { /* malformed WMI value */ }
             catch (OverflowException) { /* WMI value out of range */ }
             return list;
-        });
+        }).ConfigureAwait(false);
     }
 }

--- a/SysManager/SysManager/Services/SystemReportService.cs
+++ b/SysManager/SysManager/Services/SystemReportService.cs
@@ -33,7 +33,7 @@ public sealed class SystemReportService
         var snapshot = await _sysInfo.CaptureAsync(ct).ConfigureAwait(false);
         var diskHealth = await _diskHealth.CollectAsync(ct).ConfigureAwait(false);
 
-        return await Task.Run(() => BuildReport(snapshot, diskHealth), ct);
+        return await Task.Run(() => BuildReport(snapshot, diskHealth), ct).ConfigureAwait(false);
     }
 
     private static string BuildReport(SystemSnapshot snapshot, IReadOnlyList<DiskHealthReport> diskHealth)

--- a/SysManager/SysManager/Services/TemperatureService.cs
+++ b/SysManager/SysManager/Services/TemperatureService.cs
@@ -35,15 +35,15 @@ public sealed class TemperatureService
 
         if (isAdmin)
         {
-            await Task.Run(() => ReadViaLibreHardwareMonitor(readings));
+            await Task.Run(() => ReadViaLibreHardwareMonitor(readings)).ConfigureAwait(false);
 
             // LHM storage often has bad names — enrich from DiskHealthService
-            await EnrichStorageNamesAsync(readings);
+            await EnrichStorageNamesAsync(readings).ConfigureAwait(false);
         }
         else
         {
-            await Task.Run(() => ReadNvidiaGpuTemperatures(readings));
-            await ReadDiskTemperaturesAsync(readings);
+            await Task.Run(() => ReadNvidiaGpuTemperatures(readings)).ConfigureAwait(false);
+            await ReadDiskTemperaturesAsync(readings).ConfigureAwait(false);
 
             readings.Add(new TemperatureReading("CPU", "CPU Package", null, RequiresAdmin: true));
         }


### PR DESCRIPTION
## Summary
Async uniformity from the modernization audit. Library/service code should not capture the synchronization context; most services already use `ConfigureAwait(false)` on their `Task.Run` calls, these three were the outliers. `refactor:`, behavior-preserving, no release.

## Changes
- **SystemReportService** (line 36): `Task.Run(...)` -> `.ConfigureAwait(false)` — the rest of the same method already used it.
- **TemperatureService** (lines 38, 45 + the two awaits after them): added `ConfigureAwait(false)`. Service mutates a local list and returns it; no UI access on the continuation.
- **MemoryTestService** (both `CheckErrorLogsAsync` and `GetModulesAsync`): added `ConfigureAwait(false)` to the `Task.Run` blocks.

## Why uniform, not blanket
Matches the existing convention (EventLogService, PowerShellRunner, ServiceManagerService, SpeedTestService all use `ConfigureAwait(false)` on `Task.Run`). ViewModel continuations that touch the UI keep `ConfigureAwait(true)` — those were left alone.

## Verification
- `dotnet build` (app + tests): 0 warnings, 0 errors (TreatWarningsAsErrors=true).