### PR TITLE
refactor: final modernization stragglers (seal, ConfigureAwait, ToArray)

### DIFF
--- a/SysManager/SysManager/Helpers/ObservableCollectionExtensions.cs
+++ b/SysManager/SysManager/Helpers/ObservableCollectionExtensions.cs
@@ -12,7 +12,7 @@ namespace SysManager.Helpers;
 /// An <see cref="ObservableCollection{T}"/> that supports bulk replacement
 /// with a single <see cref="NotifyCollectionChangedAction.Reset"/> notification.
 /// </summary>
-public class BulkObservableCollection<T> : ObservableCollection<T>
+public sealed class BulkObservableCollection<T> : ObservableCollection<T>
 {
     private bool _suppressNotifications;
 

--- a/SysManager/SysManager/Services/ActivityLogService.cs
+++ b/SysManager/SysManager/Services/ActivityLogService.cs
@@ -26,7 +26,7 @@ public sealed class ActivityLogService
     public IReadOnlyList<ActivityEntry> GetRecent(int count = 5)
     {
         lock (_lock)
-            return _entries.Take(count).ToList();
+            return _entries.Take(count).ToArray();
     }
 
     public void Log(string action, string detail)

--- a/SysManager/SysManager/Services/DnsService.cs
+++ b/SysManager/SysManager/Services/DnsService.cs
@@ -114,7 +114,7 @@ public sealed class DnsService : IDisposable
                 .Select(r => r?.ToString())
                 .Where(s => !string.IsNullOrWhiteSpace(s) && IPAddress.TryParse(s, out _))
                 .Select(s => s!)
-                .ToList();
+                .ToArray();
         }
         finally { _gate.Release(); }
     }

--- a/SysManager/SysManager/Services/LargeFileScanner.cs
+++ b/SysManager/SysManager/Services/LargeFileScanner.cs
@@ -133,7 +133,7 @@ public sealed class LargeFileScanner
         }
 
         progress?.Report(new LargeFileProgress(scanned, bytesScanned, "Done"));
-        return heap.Reverse().Select(h => meta[h.Path]).ToList();
+        return heap.Reverse().Select(h => meta[h.Path]).ToArray();
     }
 
     private static bool ShouldSkip(string path)

--- a/SysManager/SysManager/Services/PingMonitorService.cs
+++ b/SysManager/SysManager/Services/PingMonitorService.cs
@@ -91,7 +91,7 @@ public sealed class PingMonitorService : IDisposable
             foreach (var target in active)
                 _ = PingOnceAsync(target, ct);
 
-            try { await Task.Delay(Clamp(Interval), ct); }
+            try { await Task.Delay(Clamp(Interval), ct).ConfigureAwait(false); }
             catch (OperationCanceledException) { return; }
         }
     }

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -95,7 +95,7 @@ public sealed class SpeedTestService
             }
         });
 
-        await Task.WhenAll(tasks);
+        await Task.WhenAll(tasks).ConfigureAwait(false);
         sw.Stop();
 
         var downloaded = Interlocked.Read(ref totalBytes);

--- a/SysManager/SysManager/Services/TracerouteMonitorService.cs
+++ b/SysManager/SysManager/Services/TracerouteMonitorService.cs
@@ -100,7 +100,7 @@ public sealed class TracerouteMonitorService : IDisposable
                 catch (InvalidOperationException) { /* traceroute failed for this target — skip */ }
             }
 
-            try { await Task.Delay(Interval, ct); }
+            try { await Task.Delay(Interval, ct).ConfigureAwait(false); }
             catch (OperationCanceledException) { return; }
         }
     }


### PR DESCRIPTION
## Summary
Closes out the last verified modernization stragglers from the completeness audit. refactor:, behavior-preserving, no release.

## Changes
- **seal BulkObservableCollection** — no subclasses exist; sealing matches the rest of the codebase and allows JIT devirtualization.
- **ConfigureAwait(false)** on the three service awaits that actually await (SpeedTestService Task.WhenAll, PingMonitorService + TracerouteMonitorService background Task.Delay). These continuations do not touch the UI (monitors emit via events).
- **.ToList() -> .ToArray()** on three methods whose return type is IReadOnlyList<T> (ActivityLogService.GetRecent, LargeFileScanner.Scan, DnsService.CaptureCurrentServersAsync) — array satisfies the interface without keeping a List's spare capacity.

## Audit false-positives deliberately NOT applied (verified against real code)
- ConfigureAwait on the expression-bodied => Task.Run(...) services: they RETURN the task without awaiting; all 13 such services use this exact uniform pattern, so adding it would force them async for zero benefit.
- new List<FileInfo>(2) -> []: the capacity hint is intentional; left as-is.
- ServiceManagerService CancellationToken: WaitForStatus already has a 30s timeout and no caller has a token to pass.

## Verification
- dotnet build (app + tests): 0 warnings, 0 errors.