### PR TITLE
chore: make release build path-deterministic

### DIFF
--- a/publish.ps1
+++ b/publish.ps1
@@ -35,6 +35,15 @@ $publishArgs = @(
     '-p:IncludeNativeLibrariesForSelfExtract=true',
     '-p:EnableCompressionInSingleFile=true',
     '-p:DebugType=embedded',
+    # Reproducible, path-normalized release build. ContinuousIntegrationBuild
+    # turns on DeterministicSourcePaths, which (with SourceLink, already
+    # referenced in Directory.Build.props) rewrites the local source root in the
+    # embedded PDB to a '/_/' prefix — so the shipped single-file binary never
+    # carries an absolute build path. publish.ps1 produces release artifacts only
+    # (release.yml invokes it), so this is correctly scoped to release builds and
+    # does not affect local IDE/dev debugging.
+    '-p:ContinuousIntegrationBuild=true',
+    '-p:Deterministic=true',
     '-o', $Output
 )
 


### PR DESCRIPTION
## What

Add `-p:ContinuousIntegrationBuild=true` and `-p:Deterministic=true` to the release publish in `publish.ps1`.

## Why

The single-file release build used `-p:DebugType=embedded`, which embeds the PDB — including the **absolute compile-time source path** — into the shipped `.exe`. SourceLink is already referenced in `Directory.Build.props`; turning on `ContinuousIntegrationBuild` enables DeterministicSourcePaths, so SourceLink rewrites the local source root to a normalized `/_/` prefix. The shipped binary no longer carries any absolute build path.

## Verification

- Built before/after via `publish.ps1` (Release, win-x64, 77.9 MB self-contained single-file).
- **Before:** the embedded document map contained the absolute source root.
- **After:** 0 occurrences of the source root in the rebuilt `.exe`; the map uses the deterministic `/_/` prefix.
- Scope: `publish.ps1` only invokes release artifacts (called from `release.yml`); local IDE/dev debugging is unaffected.

## Notes

`chore:` — build hygiene, no runtime behavior change, no release.