### PR TITLE
fix: require confirmation before Dashboard quick actions, Windows Update install, and lock shortcut delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.53] - 2026-06-23
+
+### Fixed
+- **Dashboard quick actions now ask before changing your system.** "Quick Cleanup" deleted temporary files and "Update All Apps" ran a winget upgrade of every installed app with no confirmation — unlike the equivalent actions on their dedicated tabs. Both now show a confirmation dialog first, matching the rest of the app.
+- **Installing Windows updates now asks for confirmation.** Selecting updates and clicking install applied them (including drivers and feature updates that can force a restart) without a prompt. A confirmation dialog now precedes the install.
+- **Deleting broken shortcuts no longer races other disk operations.** The shortcut cleaner's delete now holds the shared disk operation lock for its duration, so it can't run at the same time as a cleanup or tune-up.
+
 ## [1.20.52] - 2026-06-22
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DashboardViewModelTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using NSubstitute;
 using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
@@ -12,6 +13,9 @@ namespace SysManager.Tests;
 /// Pure unit tests for <see cref="DashboardViewModel"/>.
 /// RefreshAsync hits real WMI so it lives in IntegrationTests.
 /// </summary>
+// Serialized: the confirm-gate tests swap the static DialogService.Instance,
+// which is process-wide shared state.
+[Collection("DialogService")]
 public class DashboardViewModelTests
 {
     private static DashboardViewModel NewVm()
@@ -234,5 +238,54 @@ public class DashboardViewModelTests
         var (title, severity) = DashboardViewModel.ClassifyPendingReboot(false);
         Assert.Equal("No pending reboots", title);
         Assert.Equal(AlertSeverity.Green, severity);
+    }
+
+    // ── Confirmation-gate tests (destructive quick actions must route through Confirm) ──
+
+    [Fact]
+    public void QuickCleanup_WhenUserDeclinesConfirm_DoesNotRun()
+    {
+        var vm = NewVm();
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false); // user clicks "No"
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.QuickCleanupCommand.Execute(null);
+
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            // Declining returns before RunQuickActionAsync, so no action ran.
+            Assert.False(vm.IsQuickActionRunning);
+            Assert.False(vm.IsQuickActionDone);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public void QuickUpdateApps_WhenUserDeclinesConfirm_DoesNotRun()
+    {
+        var vm = NewVm();
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false); // user clicks "No"
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.QuickUpdateAppsCommand.Execute(null);
+
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            Assert.False(vm.IsQuickActionRunning);
+            Assert.False(vm.IsQuickActionDone);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
     }
 }

--- a/SysManager/SysManager.Tests/ShortcutCleanerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ShortcutCleanerViewModelTests.cs
@@ -121,4 +121,33 @@ public class ShortcutCleanerViewModelTests
             DialogService.Instance = prevDialog;
         }
     }
+
+    [Fact]
+    public void DeleteSelected_WhenDiskLocked_DoesNotDelete()
+    {
+        var vm = new ShortcutCleanerViewModel(new ShortcutCleanerService());
+        vm.BrokenShortcuts.Add(new BrokenShortcut { Name = "A", ShortcutPath = @"C:\nope\a.lnk", IsSelected = true });
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true); // user clicks "Yes"
+        DialogService.Instance = dialog;
+
+        // Hold the Disk lock so the delete must bail rather than race a disk op.
+        using var held = OperationLockService.Instance.TryAcquire(OperationCategory.Disk, "Test Holder");
+        Assert.NotNull(held);
+        try
+        {
+            vm.DeleteSelectedCommand.Execute(null);
+
+            // Confirm was shown, but the lock was unavailable → nothing deleted.
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            Assert.Single(vm.BrokenShortcuts);
+            Assert.Contains("already running", vm.ScanStatus);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
 }

--- a/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
+++ b/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Reflection;
+using NSubstitute;
 using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
@@ -13,6 +14,8 @@ namespace SysManager.Tests;
 /// Pure unit tests for <see cref="WindowsUpdateViewModel"/>.
 /// Tests that require PSWindowsUpdate module are in IntegrationTests.
 /// </summary>
+// Serialized: the confirm-gate test swaps the static DialogService.Instance.
+[Collection("DialogService")]
 public class WindowsUpdateViewModelTests
 {
     private static WindowsUpdateViewModel NewVm() => new(new PowerShellRunner(), new WindowsUpdateService());
@@ -312,6 +315,32 @@ public class WindowsUpdateViewModelTests
 
         vm.IsBusy = false;
         Assert.True(vm.ListUpdatesCommand.CanExecute(null));
+    }
+
+    // ── Confirmation-gate test (installing updates must route through Confirm) ──
+
+    [Fact]
+    public void InstallUpdates_WhenUserDeclinesConfirm_DoesNotInstall()
+    {
+        var vm = NewVm();
+        vm.Updates.Add(new UpdateEntry { Title = "KB123", IsSelected = true });
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false); // user clicks "No"
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.InstallUpdatesCommand.Execute(null);
+
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            // Declining returns before the elevation/install path, so nothing started.
+            Assert.False(vm.IsBusy);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
     }
 }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.52</Version>
-    <FileVersion>1.20.52.0</FileVersion>
-    <AssemblyVersion>1.20.52.0</AssemblyVersion>
+    <Version>1.20.53</Version>
+    <FileVersion>1.20.53.0</FileVersion>
+    <AssemblyVersion>1.20.53.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -562,6 +562,12 @@ public sealed partial class DashboardViewModel : ViewModelBase
     [RelayCommand(CanExecute = nameof(CanRunQuickAction))]
     private async Task QuickCleanupAsync()
     {
+        if (!DialogService.Instance.Confirm(
+                "Delete temporary files from your user and Windows Temp folders?\n\n" +
+                "Files in use may be skipped. This cannot be undone.",
+                "Confirm Quick Cleanup"))
+            return;
+
         await RunQuickActionAsync("Quick Cleanup", "Cleanup", "nav-cleanup", async () =>
         {
             QuickActionDetail = "Scanning temp folders...";
@@ -606,6 +612,12 @@ public sealed partial class DashboardViewModel : ViewModelBase
     [RelayCommand(CanExecute = nameof(CanRunQuickAction))]
     private async Task QuickUpdateAppsAsync()
     {
+        if (!DialogService.Instance.Confirm(
+                "Upgrade all installed apps that have updates available via winget?\n\n" +
+                "Apps may restart during the upgrade.",
+                "Confirm Update All Apps"))
+            return;
+
         await RunQuickActionAsync("Update All Apps", "App Updates", "nav-app-updates", async () =>
         {
             QuickActionDetail = "Checking for upgrades...";

--- a/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
@@ -104,6 +104,15 @@ public sealed partial class ShortcutCleanerViewModel : ViewModelBase
             $"Are you sure you want to {action} {selected.Count} broken shortcut{(selected.Count == 1 ? "" : "s")}?",
             "Delete Broken Shortcuts — Confirm")) return;
 
+        // Hold the Disk operation lock across the delete so it can't race a
+        // concurrent disk operation (cleanup / tune-up), mirroring ScanAsync.
+        using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.Disk, "Shortcut Delete");
+        if (opLock is null)
+        {
+            ScanStatus = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.Disk)} is already running.";
+            return;
+        }
+
         // The shell delete (SHFileOperation) is synchronous and can take a while for
         // many items — run it off the UI thread so the window stays responsive.
         var deleted = await Task.Run(() => ShortcutCleanerService.DeleteShortcuts(selected, MoveToRecycleBin));

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -300,6 +300,13 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
             return;
         }
 
+        if (!DialogService.Instance.Confirm(
+                $"Install {selected.Count} selected Windows update(s)?\n\n" +
+                "This may install drivers or feature updates and can require a restart. " +
+                "Do not reboot while the install is in progress.",
+                "Confirm Windows Update"))
+            return;
+
         if (!AdminHelper.IsElevated())
         {
             StatusMessage = "Admin required. Relaunching elevated...";


### PR DESCRIPTION
## What

Adds missing confirmation gates to three destructive/system-changing actions, and a disk operation lock to a fourth — closing audit findings F8/F28 (Dashboard), the Windows Update install gap, and the ShortcutCleaner race.

## Changes

- **DashboardViewModel** — `QuickCleanupAsync` (deletes temp files) and `QuickUpdateAppsAsync` (runs `winget upgrade --all`) now show a `DialogService.Confirm` before running, matching the existing `RunTuneUpAsync` gate and the dedicated Cleanup/App-Updates tabs.
- **WindowsUpdateViewModel** — `InstallUpdatesAsync` now confirms before installing selected updates (which can include drivers/feature updates and force a restart).
- **ShortcutCleanerViewModel** — `DeleteSelectedAsync` now holds the shared `OperationCategory.Disk` lock for the delete, mirroring `ScanAsync`, so it can't race a concurrent cleanup/tune-up.

## Why

These were the cheapest, highest-value safety gaps from the audit: the same destructive operations are gated on their dedicated tabs but were one-click-unconfirmed elsewhere, violating the project's 'destructive op = confirm + reversible' rule.

## Tests (regression)

- `DashboardViewModelTests`: declining Confirm leaves `QuickCleanup`/`QuickUpdateApps` un-run.
- `WindowsUpdateViewModelTests`: declining Confirm does not start the install.
- `ShortcutCleanerViewModelTests`: delete bails (nothing removed) when the Disk lock is already held.

All routed through the existing `IDialogService` test seam (NSubstitute), serialized via the `DialogService` collection. Both main + test projects build clean (0/0).