### PR TITLE
fix: cancelled scans throw instead of returning partial results; traceroute tracks destination across probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.54] - 2026-06-23
+
+### Fixed
+- **Cancelling a disk-usage or large-files scan no longer shows partial results as if complete.** Both scanners stopped mid-traversal on cancel but still returned what they had gathered, so a cancelled scan looked like a finished one with incomplete data. They now stop cleanly and report the scan as cancelled.
+- **Traceroute now stops correctly when the destination replies on any probe.** The hop status and the stop-at-destination check used only the last probe's result, so if an earlier probe reached the destination but a later one timed out, the trace could mislabel the hop and keep probing past the target. It now tracks the destination-reached result across all probes of each hop.
+
 ## [1.20.53] - 2026-06-23
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DiskAnalyzerServiceTests.cs
+++ b/SysManager/SysManager.Tests/DiskAnalyzerServiceTests.cs
@@ -55,6 +55,22 @@ public class DiskAnalyzerServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task Analyze_WhenCancelledMidScan_Throws_NotPartialResults()
+    {
+        // Several top-level folders so the traversal reports progress per folder.
+        for (int i = 0; i < 5; i++) CreateFile(Path.Combine("dir" + i, "f.txt"), 1024);
+
+        // Cancel from inside the progress callback (mid-scan) — this exercises the
+        // post-loop ThrowIfCancellationRequested guard, proving a cancelled scan
+        // throws instead of returning the partial results gathered so far.
+        using var cts = new CancellationTokenSource();
+        var progress = new SyncProgress<DiskAnalyzerService.AnalysisProgress>(_ => cts.Cancel());
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => _service.AnalyzeAsync(_root, progress, cts.Token));
+    }
+
+    [Fact]
     public async Task Analyze_SingleSubfolder_ReturnsOne()
     {
         CreateFile(Path.Combine("docs", "readme.txt"), 2048);

--- a/SysManager/SysManager.Tests/SyncProgress.cs
+++ b/SysManager/SysManager.Tests/SyncProgress.cs
@@ -13,6 +13,14 @@ namespace SysManager.Tests;
 /// </summary>
 public sealed class SyncProgress<T> : IProgress<T>
 {
+    private readonly Action<T>? _onReport;
+
+    public SyncProgress() { }
+
+    /// <summary>Also invoke <paramref name="onReport"/> synchronously per report —
+    /// e.g. to cancel a token mid-operation in a deterministic test.</summary>
+    public SyncProgress(Action<T> onReport) => _onReport = onReport;
+
     public List<T> Reports { get; } = [];
-    public void Report(T value) => Reports.Add(value);
+    public void Report(T value) { Reports.Add(value); _onReport?.Invoke(value); }
 }

--- a/SysManager/SysManager/Services/DiskAnalyzerService.cs
+++ b/SysManager/SysManager/Services/DiskAnalyzerService.cs
@@ -97,6 +97,11 @@ public sealed class DiskAnalyzerService
             });
         }
 
+        // If the scan was cancelled mid-traversal, the loop `break`s leave partial
+        // results — surfacing them as a completed analysis would mislead the user.
+        // Throw so the caller's OperationCanceledException branch handles it.
+        ct.ThrowIfCancellationRequested();
+
         if (rootFileCount > 0)
         {
             results.Add(new DiskUsageEntry

--- a/SysManager/SysManager/Services/LargeFileScanner.cs
+++ b/SysManager/SysManager/Services/LargeFileScanner.cs
@@ -132,6 +132,10 @@ public sealed class LargeFileScanner
             }
         }
 
+        // A cancelled scan exits the loop with partial results; surfacing them as
+        // "Done" would mislead the user. Throw so the caller's cancel branch handles it.
+        ct.ThrowIfCancellationRequested();
+
         progress?.Report(new LargeFileProgress(scanned, bytesScanned, "Done"));
         return heap.Reverse().Select(h => meta[h.Path]).ToArray();
     }

--- a/SysManager/SysManager/Services/TracerouteService.cs
+++ b/SysManager/SysManager/Services/TracerouteService.cs
@@ -34,7 +34,12 @@ public sealed class TracerouteService
             var options = new PingOptions(ttl, true);
             List<double> latencies = [];
             IPAddress? replyAddress = null;
-            IPStatus lastStatus = IPStatus.Unknown;
+            // Track the destination-reached status across ALL probes of this hop, not
+            // just the last one: if probe 1 reaches the destination (Success) but a
+            // later probe times out, the last-probe status would otherwise mislabel
+            // the hop and fail to stop the traceroute at the destination.
+            bool reachedDestination = false;
+            IPStatus replyStatus = IPStatus.Unknown;
 
             for (int probe = 0; probe < ProbesPerHop; probe++)
             {
@@ -45,12 +50,15 @@ public sealed class TracerouteService
                     var effectiveTimeout = TimeoutMs > 0 ? TimeoutMs : 3000;
                     var reply = await ping.SendPingAsync(host, effectiveTimeout, payload, options).WaitAsync(ct).ConfigureAwait(false);
                     sw.Stop();
-                    lastStatus = reply.Status;
 
                     if (reply.Status is IPStatus.Success or IPStatus.TtlExpired)
                     {
                         replyAddress ??= reply.Address;
                         latencies.Add(sw.Elapsed.TotalMilliseconds);
+                        // Prefer Success (destination) over TtlExpired (intermediate hop)
+                        // when summarizing the hop's status.
+                        if (replyStatus != IPStatus.Success) replyStatus = reply.Status;
+                        if (reply.Status == IPStatus.Success) reachedDestination = true;
                     }
                 }
                 catch (OperationCanceledException) { throw; }
@@ -64,7 +72,7 @@ public sealed class TracerouteService
                 HopNumber = ttl,
                 Address = replyAddress?.ToString() ?? "*",
                 LatencyMs = latencies.Count > 0 ? latencies.Average() : null,
-                Status = latencies.Count > 0 ? lastStatus.ToString() : "Timeout"
+                Status = latencies.Count > 0 ? replyStatus.ToString() : "Timeout"
             };
 
             // Await reverse DNS with a short timeout before emitting the hop.
@@ -90,7 +98,7 @@ public sealed class TracerouteService
             results.Add(hop);
             RaiseHopCompleted(hop);
 
-            if (lastStatus == IPStatus.Success) break; // reached destination
+            if (reachedDestination) break; // any probe reached the destination
         }
 
         return results;

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.53</Version>
-    <FileVersion>1.20.53.0</FileVersion>
-    <AssemblyVersion>1.20.53.0</AssemblyVersion>
+    <Version>1.20.54</Version>
+    <FileVersion>1.20.54.0</FileVersion>
+    <AssemblyVersion>1.20.54.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## What

Three correctness fixes for cancellation and probe-status handling (audit findings F8-cancel cluster + F9).

## Changes

- **DiskAnalyzerService** — `Analyze` broke out of its traversal loop on cancel but then sorted and returned the partial results with a "Done" progress report. It now calls `ThrowIfCancellationRequested()` after the loop, so a cancelled scan throws `OperationCanceledException` (which `DiskAnalyzerViewModel` already handles as "Scan cancelled.") instead of rendering partial data as complete.
- **LargeFileScanner** — same pattern: `Scan` now throws on cancel before its final "Done" report rather than returning the partial heap.
- **TracerouteService** — the hop `Status` and the stop-at-destination `break` used `lastStatus`, overwritten by every probe. If probe 1 reached the destination (Success) but probe 2 timed out, the hop was mislabeled and the trace kept going. Now tracked with a `reachedDestination` flag and a `replyStatus` that prefers Success across all probes of the hop.

## Why

A cancelled scan reported as a completed scan with partial data is misleading and makes the ViewModel's cancel branch dead code. The traceroute last-probe bug could make a trace overshoot its destination.

## Tests (regression)

- `DiskAnalyzerServiceTests` / `LargeFileScannerTests`: cancelling **mid-scan** (via a synchronous `SyncProgress` callback that cancels on first report) now throws `OperationCanceledException` — exercising the new post-loop guard, not just the `Task.Run(ct)` short-circuit.
- Extended the shared `SyncProgress<T>` test helper with an optional per-report callback (single source of truth — no duplicate helper).
- Traceroute's real-network path isn't unit-testable without a ping seam; the logic change is small and the reachedDestination flag is self-evident. Noted honestly rather than adding a flaky live-network test.

Both projects build clean (0/0).