### PR TITLE
fix: guard Deep Cleanup traversal root against reparse points to prevent data loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.55] - 2026-06-23
+
+### Security
+- **Deep Cleanup can no longer delete data outside a cache folder via a junction at its root.** The reparse-point guard that stops cleanup from following junctions/symlinks only covered sub-folders, not the cleanup root itself. A junction planted at a cleanup-root path (which a normal user can create without admin) was traversed directly, so the linked target's files could be deleted. The traversal now checks the root for being a reparse point first, and the per-file delete catches only the expected I/O/access exceptions instead of all exceptions.
+
 ## [1.20.54] - 2026-06-23
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DeepCleanupServiceTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupServiceTests.cs
@@ -466,4 +466,67 @@ public class DeepCleanupServiceTests
             catch { return false; }
         }
     }
+
+    [Fact]
+    public async Task CleanAsync_DoesNotFollowJunctionAtCleanupRoot()
+    {
+        // Regression for the ROOT-as-junction gap: the reparse guard previously only
+        // covered CHILD directories, so a junction planted AT a cleanup-root path
+        // (writable without admin, e.g. %LOCALAPPDATA%\NVIDIA\GLCache) was enumerated
+        // directly and the link TARGET's files were deleted — data loss outside the tree.
+        var baseDir = Path.Combine(Path.GetTempPath(), "smtest_juncroot_" + Guid.NewGuid().ToString("N"));
+        var target = Path.Combine(baseDir, "outside");   // simulates real user data
+        Directory.CreateDirectory(target);
+
+        var precious = Path.Combine(target, "precious.dat");
+        File.WriteAllText(precious, "do not delete me");
+
+        // The cleanup ROOT itself is the junction (points at the target).
+        var cleanRoot = Path.Combine(baseDir, "cacheLink");
+        var psi = new System.Diagnostics.ProcessStartInfo("cmd.exe", $"/c mklink /J \"{cleanRoot}\" \"{target}\"")
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+        try
+        {
+            using (var proc = System.Diagnostics.Process.Start(psi)!)
+            {
+                proc.WaitForExit(10_000);
+                if (proc.ExitCode != 0 || !IsReparse(cleanRoot))
+                {
+                    // Environment can't create junctions (rare) — nothing to assert.
+                    return;
+                }
+            }
+
+            var cat = new CleanupCategory
+            {
+                Name = "Cache",
+                Description = "Cleanup root that IS a junction",
+                Paths = new[] { cleanRoot },
+                TotalSizeBytes = 1,
+                FileCount = 1,
+                IsSelected = true
+            };
+            var s = new DeepCleanupService();
+            await s.CleanAsync(new[] { cat });
+
+            // The file behind the junction-root must survive: the root reparse guard
+            // stops the traversal before any file is enumerated for deletion.
+            Assert.True(File.Exists(precious), "Cleanup followed a junction at the cleanup root and deleted data outside the target tree");
+        }
+        finally
+        {
+            try { Directory.Delete(baseDir, recursive: true); } catch { }
+        }
+
+        static bool IsReparse(string p)
+        {
+            try { return (File.GetAttributes(p) & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint; }
+            catch { return false; }
+        }
+    }
 }

--- a/SysManager/SysManager/Services/DeepCleanupService.cs
+++ b/SysManager/SysManager/Services/DeepCleanupService.cs
@@ -378,7 +378,7 @@ public sealed partial class DeepCleanupService
                             freed += len;
                             filesDeleted++;
                         }
-                        catch (Exception ex)
+                        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
                         {
                             errors.Add($"{file}: {ex.Message}");
                             Log.Debug(ex, "Deep cleanup: failed to delete file {File}", file);
@@ -391,7 +391,7 @@ public sealed partial class DeepCleanupService
                         catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Deep cleanup: access denied deleting directory {Dir}", dir); }
                     }
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
                 {
                     errors.Add($"{path}: {ex.Message}");
                     Log.Debug(ex, "Deep cleanup: failed to enumerate path {Path}", path);
@@ -410,6 +410,12 @@ public sealed partial class DeepCleanupService
 
     private static IEnumerable<string> EnumerateFiles(string root, CancellationToken ct)
     {
+        // Guard the traversal ROOT itself, not just its children: if a cleanup-root
+        // cache path is replaced by a junction/symlink (writable without admin, e.g.
+        // %LOCALAPPDATA%\NVIDIA\GLCache), EnumerateFiles(root) would yield the LINK
+        // TARGET's files and the caller would delete them — data loss outside the
+        // target tree. IsReparsePoint fails safe (returns true on access error).
+        if (IsReparsePoint(root)) yield break;
         var stack = new Stack<string>();
         stack.Push(root);
         while (stack.Count > 0 && !ct.IsCancellationRequested)
@@ -445,6 +451,9 @@ public sealed partial class DeepCleanupService
     private static IEnumerable<string> EnumerateDirectoriesDepthFirst(string root, CancellationToken ct)
     {
         List<string> all = [];
+        // Guard the root (see EnumerateFiles): a junction at the root must not be
+        // traversed, or its target's subdirectories could be reached for deletion.
+        if (IsReparsePoint(root)) return all;
         var stack = new Stack<string>();
         stack.Push(root);
         while (stack.Count > 0 && !ct.IsCancellationRequested)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.54</Version>
-    <FileVersion>1.20.54.0</FileVersion>
-    <AssemblyVersion>1.20.54.0</AssemblyVersion>
+    <Version>1.20.55</Version>
+    <FileVersion>1.20.55.0</FileVersion>
+    <AssemblyVersion>1.20.55.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## What

Closes the audit's highest data-loss finding (F1): Deep Cleanup could delete files **outside** a cache folder when that folder is a junction/symlink.

## Root cause

`EnumerateFiles` and `EnumerateDirectoriesDepthFirst` applied the `IsReparsePoint` guard only to **child** directories discovered during traversal — the traversal **root** was pushed unconditionally. `Clean`'s per-path check used only `Directory.Exists`, which returns true for a junction. So a junction planted at a cleanup-root cache path (e.g. `%LOCALAPPDATA%\NVIDIA\GLCache` — creatable without admin via `mklink /J`) was enumerated directly, and the link target's files were passed to `File.Delete`.

## Fix

- `EnumerateFiles`: `if (IsReparsePoint(root)) yield break;` before pushing the root.
- `EnumerateDirectoriesDepthFirst`: `if (IsReparsePoint(root)) return all;` likewise.
- Both `Scan` and `Clean` route through `EnumerateFiles`, so reported sizes and deletions are both protected by the single centralized guard. `IsReparsePoint` fails safe (returns true on access error).
- Narrowed the two over-broad `catch (Exception)` blocks in the delete/enumerate loop to `when (ex is IOException or UnauthorizedAccessException or SecurityException)`, preserving the error-collection behavior while no longer swallowing unexpected exceptions.

## Test (regression)

- `CleanAsync_DoesNotFollowJunctionAtCleanupRoot`: the cleanup root **itself** is a junction pointing at a folder with a `precious.dat` file; after `CleanAsync`, the file must still exist. The existing `CleanAsync_DoesNotFollowJunctionOutsideTarget` only covered a junction as a *child*, which the old child-only guard already caught — this new test pins the root case the fix addresses. Skips gracefully if the environment can't create junctions.

Both projects build clean (0/0).