### PR TITLE
fix: make SFC and DISM mutually exclusive via the system-modification lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.56] - 2026-06-23
+
+### Fixed
+- **SFC and DISM repairs can no longer run at the same time and corrupt each other's output.** Both share a single PowerShell runner whose output event was subscribed by each command independently, so starting one while the other ran cross-contaminated their captured results and progress. They now acquire a shared system-modification lock, making them mutually exclusive (and blocked against other system-repair operations), with a clear "already running" message instead.
+
 ## [1.20.55] - 2026-06-23
 
 ### Security

--- a/SysManager/SysManager.Tests/CleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/CleanupViewModelTests.cs
@@ -491,4 +491,26 @@ public class DismResultParsingTests
         Assert.Contains("exit code 87", verdict);
         Assert.Equal("#F59E0B", color);
     }
+
+    // RunSfcAsync/RunDismAsync now both acquire the SystemModification operation lock
+    // (after the elevation gate) so they are mutually exclusive — concurrent runs would
+    // cross-contaminate the shared _runner's captured output. The full VM path is gated
+    // behind elevation (skipped in non-admin CI, like the tests above), so this pins the
+    // mutual-exclusion contract the fix relies on at the service level.
+    [Fact]
+    public void SystemModificationLock_IsMutuallyExclusive()
+    {
+        using var first = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "SFC scan");
+        Assert.NotNull(first);
+
+        // A second acquire for the same category (e.g. DISM while SFC holds it) must fail.
+        var second = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "DISM RestoreHealth");
+        Assert.Null(second);
+        Assert.Equal("SFC scan", OperationLockService.Instance.GetActiveOperationName(OperationCategory.SystemModification));
+
+        first!.Dispose();
+        // Once released, the category is free again.
+        using var third = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "DISM RestoreHealth");
+        Assert.NotNull(third);
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.55</Version>
-    <FileVersion>1.20.55.0</FileVersion>
-    <AssemblyVersion>1.20.55.0</AssemblyVersion>
+    <Version>1.20.56</Version>
+    <FileVersion>1.20.56.0</FileVersion>
+    <AssemblyVersion>1.20.56.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -273,6 +273,17 @@ public sealed partial class CleanupViewModel : ViewModelBase
             return;
         }
 
+        // SFC and DISM share the single _runner (and its LineReceived event), so they
+        // must be mutually exclusive — running both at once cross-contaminates their
+        // captured output and progress. The SystemModification lock enforces that and
+        // also blocks against the other system-repair operations.
+        using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "SFC scan");
+        if (opLock is null)
+        {
+            StatusMessage = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.SystemModification)} is already running.";
+            return;
+        }
+
         IsSfcRunning = true;
         IsProgressIndeterminate = true;
         SfcStatus = "Running — can take 5–15 minutes";
@@ -359,6 +370,16 @@ public sealed partial class CleanupViewModel : ViewModelBase
                 return;
             }
             if (AdminHelper.RelaunchAsAdmin()) System.Windows.Application.Current?.Shutdown();
+            return;
+        }
+
+        // Mutually exclusive with SFC (and the other system-repair ops): both share the
+        // single _runner and its LineReceived event, so concurrent runs would cross-
+        // contaminate captured output and progress.
+        using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "DISM RestoreHealth");
+        if (opLock is null)
+        {
+            StatusMessage = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.SystemModification)} is already running.";
             return;
         }
 


### PR DESCRIPTION
## What

Closes audit finding B03: the Cleanup tab's SFC and DISM repairs could run concurrently and cross-contaminate each other's output.

## Root cause

`RunSfcAsync` and `RunDismAsync` each subscribe a local `Collect` handler to the **shared** `_runner.LineReceived` event. The SFC button is disabled only while `IsSfcRunning` and the DISM button only while `IsDismRunning` (separate flags), so a user can start one while the other runs. Both `Collect` handlers then fire for every output line, cross-contaminating each command's `captured` list, clobbering `Progress`/`IsProgressIndeterminate`, and mutating the non-thread-safe `EtaCalculator` from two flows.

## Fix

Both commands now acquire `OperationCategory.SystemModification` via the existing `OperationLockService` (after the elevation gate), mirroring how `RunTempAsync` uses the `Disk` lock. This makes SFC and DISM mutually exclusive — and also blocked against the other system-repair operations — with a clear "already running" status instead of silent corruption. The `using var opLock` is held across the awaited run.

## Test

- `SystemModificationLock_IsMutuallyExclusive`: acquiring the lock for SFC blocks a second acquire (DISM), reports the active name, and frees on dispose. The full VM path is gated behind `AdminHelper.IsElevated()` (skipped in non-admin CI, exactly like the existing `RunSfc_WhenNotElevated` tests), so this pins the mutual-exclusion contract the fix relies on at the service level. The existing non-elevated VM tests remain the no-regression guard.

Both projects build clean (0/0).