### PR TITLE
docs: sync ARCHITECTURE/SECURITY/CONTRIBUTING/TESTING with current code

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,12 +87,16 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `DnsHostsViewModel` — DNS server configuration and hosts file editor in one tab.
 - `PrivacyViewModel` — Windows privacy and telemetry toggles via registry.
 - `ContextMenuViewModel` — scan and manage Explorer right-click context menu entries.
+- `ConsoleViewModel` — shared, per-tab scrollable console (each tab gets its own
+  instance; lines capped at 5000 to bound memory) backing the in-app Console mirror
+  used by Cleanup, Windows Update, System Health, App Updates, and Uninstaller.
 
 ## Services
 
 Thin wrappers around the underlying platform. Each service is designed to be
-unit-testable — where possible, they depend on interfaces or accept seams for
-swapping the underlying process runner.
+unit-testable. The key seam interfaces are `IPowerShellRunner` (PowerShellRunner),
+`IAppBlockerService` (AppBlockerService), and `IDialogService` (DialogService) —
+substitutable in tests (see `ServiceRegistration.cs`).
 
 Key services:
 - `PingMonitorService` / `TracerouteService` / `TracerouteMonitorService` —
@@ -155,8 +159,10 @@ Key services:
   direct MessageBox calls for testability).
 - `IconExtractorService` — extracts application icons from executables
   for display in process/app lists; caches results.
-- `OperationLockService` — prevents concurrent destructive operations
-  via named semaphore acquisition with timeout.
+- `OperationLockService` — prevents concurrent conflicting operations by
+  category (Disk / Network / SystemModification) via a thread-safe
+  `ConcurrentDictionary` try-acquire. Returns a disposable handle, or `null`
+  immediately if that category is already locked (non-blocking; no timeout).
 - `ProcessDescriptionService` — enriches process entries with friendly
   descriptions from file version info and known-process database.
 - `SpeedTestHistoryService` — persists speed test results to JSON for
@@ -211,8 +217,11 @@ Utility classes that don't fit neatly into Services or ViewModels:
 
 `ServiceRegistration.cs` configures `Microsoft.Extensions.DependencyInjection`.
 `App.OnStartup` builds the `IServiceProvider` and exposes it as `App.Services`.
-Core services and ViewModels are registered as singletons — one shared instance
-per app lifetime. `MainWindowViewModel` resolves child VMs from
+Most core services and ViewModels are registered as singletons — one shared
+instance per app lifetime. The exception is `PowerShellRunner` /
+`IPowerShellRunner`, registered **transient** so each consumer gets its own
+instance, avoiding `LineReceived` event cross-talk between tabs (see
+`ServiceRegistration.cs:24-25`). `MainWindowViewModel` resolves child VMs from
 the container at runtime; falls back to manual creation in tests (no DI
 dependency in the test project).
 
@@ -229,8 +238,11 @@ which restarts the process with `runas` and the current command-line args.
   scans) runs on background tasks.
 - View-model observable properties are updated on the UI thread via the
   dispatcher captured in `ViewModelBase`.
-- SFC and DISM each have their own `IsSfcRunning` / `IsDismRunning`
-  flags so they don't block unrelated UI or each other.
+- SFC and DISM each have their own `IsSfcRunning` / `IsDismRunning` flags for
+  UI state, but they are **mutually exclusive**: both share a single PowerShell
+  runner, so a `SystemModification` `OperationLockService` lock prevents running
+  them (or other system-repair operations) concurrently — starting one while the
+  other runs is refused with a status message.
 
 ## Safety guardrails (Deep Cleanup)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,8 @@ follows, and what to expect when you open a pull request.
 ```powershell
 git clone https://github.com/laurentiu021/SystemManager.git
 cd SystemManager
-dotnet build -c Debug
+# There is no solution file — build the project explicitly (matches CI).
+dotnet build SysManager/SysManager/SysManager.csproj -c Debug
 ```
 
 **Run the app**
@@ -61,7 +62,7 @@ dotnet run --project SysManager/SysManager/SysManager.csproj
 **Run the tests** (see [Running tests](#running-tests) for more)
 
 ```powershell
-dotnet test -c Release
+dotnet test SysManager/SysManager.Tests/SysManager.Tests.csproj -c Release
 ```
 
 ## Project layout
@@ -132,16 +133,17 @@ The integration and UI tests touch the live system / require an interactive
 desktop session, so they run locally only (not in CI) — run them locally,
 not over SSH/Remote PowerShell. CI runs the unit tests.
 
-Filter to one class while iterating:
+Filter to one class while iterating (pass the project the class lives in —
+`PingMonitorServiceTests` is an integration test):
 
 ```powershell
-dotnet test --filter "FullyQualifiedName~PingMonitorServiceTests"
+dotnet test SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj --filter "FullyQualifiedName~PingMonitorServiceTests"
 ```
 
 Generate a coverage report:
 
 ```powershell
-dotnet test -c Release --collect:"XPlat Code Coverage"
+dotnet test SysManager/SysManager.Tests/SysManager.Tests.csproj -c Release --collect:"XPlat Code Coverage"
 ```
 
 **Every non-trivial PR should include at least one test.** If you're

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,10 +72,13 @@ What the app can and cannot do by design:
 
 - Touching browser caches, cookies, or password stores.
 - Touching the Windows registry for cleanup.
-- Deleting files inside `steamapps\common`, `Program Files\*`, or any
-  active driver folder.
-- Deleting from the Large Files Finder — it is intentionally read-only,
-  even with admin rights.
+- Deleting game files, installed binaries, or any active driver folder. The
+  cleanup engine never touches `steamapps\common` or installed game/program
+  executables; it does remove specific launcher cache and log subfolders that
+  happen to live under `Program Files` (e.g. Steam `appcache` / `htmlcache` /
+  `depotcache` / `shadercache`, Riot/League logs) — but never the games themselves.
+- Deleting from the Large Files scan (in the Deep Cleanup tab) — it is
+  intentionally read-only, even with admin rights.
 - Sending telemetry or contacting any server other than the ones needed
   for an explicit user action (ping targets, speed-test hosts, GitHub
   Releases).

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,9 +6,9 @@ SysManager has three test projects, each with a distinct scope and runner.
 
 | Project | What it tests | Runs on CI |
 |---|---|---|
-| `SysManager.Tests` | Unit tests — mostly pure logic, but some tests touch lightweight OS APIs (registry reads, process enumeration, Task Scheduler queries). No WPF dispatcher, no WMI, no network I/O, no admin required. | ✅ Every push / PR |
+| `SysManager.Tests` | Unit tests — mostly pure logic, but some tests touch lightweight OS APIs (registry reads, process enumeration, Task Scheduler queries) and a few exercise STA/UI-thread code via `Xunit.StaFact` (`[StaFact]` / `[UIFact]`). No WMI, no network I/O, no admin required. | ✅ Every push / PR |
 | `SysManager.IntegrationTests` | Integration tests — real Windows APIs (Event Log, WMI, PowerShell, ICMP, WPF dispatcher) | ❌ Local only |
-| `SysManager.UITests` | End-to-end UI automation via FlaUI | ✅ CI (headless, limited) |
+| `SysManager.UITests` | End-to-end UI automation via FlaUI — needs an interactive desktop session; runs in CI on a desktop-enabled runner, non-blocking (`continue-on-error`) and skipped on fork PRs | ⚠️ CI (non-blocking) |
 
 ## Running unit tests (CI-equivalent)
 
@@ -64,9 +64,13 @@ Coverage is collected automatically on CI via `coverlet` and uploaded to
 
 Unit tests run in parallel by default (`parallelizeTestCollections: true`).
 Tests that share state or touch OS resources are isolated via xUnit
-collection definitions:
+collection definitions (all defined in `TestCollections.cs`, each with
+`DisableParallelization = true`):
 
-- `[Collection("Network")]` — tests using ICMP sockets run sequentially.
+- `[Collection("Network")]` — tests using ICMP sockets.
+- `[Collection("OperationLock")]` — tests that acquire the shared `OperationLockService`.
+- `[Collection("IconCache")]` — tests touching the shared icon cache.
+- `[Collection("DialogService")]` — tests that swap the static `DialogService.Instance`.
 
 ### Conventions
 


### PR DESCRIPTION
## What

Fixes documentation that drifted from the current code (found by a full doc/config audit, each item re-verified against source).

## ARCHITECTURE.md
- DI section said *all* singletons; `PowerShellRunner`/`IPowerShellRunner` are **transient** (ServiceRegistration.cs:24-25) to avoid `LineReceived` cross-talk. Corrected + explained.
- `OperationLockService` described as 'named semaphore with timeout'; it's a non-blocking `ConcurrentDictionary` try-acquire that returns `null` immediately if the category is busy. Corrected.
- Said SFC/DISM 'don't block each other'; PR #978 made them mutually exclusive via the SystemModification lock. Corrected.
- Added `ConsoleViewModel` to the inventory (was absent) and named the three seam interfaces (`IPowerShellRunner`/`IAppBlockerService`/`IDialogService`).

## SECURITY.md
- The 'forbidden' list claimed deleting under `Program Files\*` never happens, but Deep Cleanup removes launcher **cache/log** subfolders there (Steam appcache/htmlcache/depotcache/shadercache, Riot logs). Reworded to forbid game files/binaries/drivers while accurately noting the launcher cache/log dirs — the games themselves are never touched.
- Renamed 'Large Files Finder' → 'Large Files scan (Deep Cleanup tab)' to match the UI.

## CONTRIBUTING.md
- The quick-start `dotnet build` / `dotnet test` and the `--filter`/`--collect` commands ran bare (no project arg), which **fails from the repo root** — there is no solution file. Fixed all four to explicit `.csproj` paths matching ci.yml. `PingMonitorServiceTests` is in IntegrationTests (corrected the filter example's project).

## TESTING.md
- Removed the false 'No WPF dispatcher' claim (the unit project uses `Xunit.StaFact` `[StaFact]`/`[UIFact]`).
- Documented all four xUnit collections (Network, OperationLock, IconCache, DialogService), not just Network.
- Corrected the UITests row: desktop-session, non-blocking (`continue-on-error`), fork-skipped — not plain headless CI.

`docs:` — no code change, no release.