### PR TITLE
ci: harden release pipeline and build config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+    # Group minor+patch bumps into one PR; keep majors separate for careful review.
+    groups:
+      nuget-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "nuget"
     directory: "/SysManager/SysManager.Tests"
@@ -24,6 +30,12 @@ updates:
       - "tests"
     commit-message:
       prefix: "deps(tests)"
+      include: "scope"
+    groups:
+      nuget-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "nuget"
     directory: "/SysManager/SysManager.UITests"
@@ -36,6 +48,12 @@ updates:
       - "tests"
     commit-message:
       prefix: "deps(uitests)"
+      include: "scope"
+    groups:
+      nuget-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "nuget"
     directory: "/SysManager/SysManager.IntegrationTests"
@@ -48,6 +66,12 @@ updates:
       - "tests"
     commit-message:
       prefix: "deps(integration)"
+      include: "scope"
+    groups:
+      nuget-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # Keep GitHub Actions current.
   - package-ecosystem: "github-actions"
@@ -55,8 +79,16 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "github-actions"
     commit-message:
       prefix: "ci"
+      include: "scope"
+    # Group all action bumps into one PR — they're low-risk and SHA-pinned.
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,6 +10,14 @@ permissions:
   contents: write
   actions: write
 
+# Serialize version bump+tag across rapid merges to main. Without this, two close
+# merges both read the same latest tag, compute the same next version, and collide
+# (or drop a release). cancel-in-progress:false — let each merge tag in turn rather
+# than cancelling a bump mid-flight.
+concurrency:
+  group: auto-release-main
+  cancel-in-progress: false
+
 jobs:
   bump-and-tag:
     name: Bump version & tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,15 @@ jobs:
           dotnet restore SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj
           dotnet restore SysManager/SysManager.UITests/SysManager.UITests.csproj
 
+      # Format-check every C# project the workflow builds, not just the main one —
+      # the same .editorconfig governs the test projects, so otherwise their style
+      # could drift past CI silently.
       - name: Check formatting
-        run: dotnet format SysManager/SysManager/SysManager.csproj --verify-no-changes --verbosity diagnostic
+        run: |
+          dotnet format SysManager/SysManager/SysManager.csproj --verify-no-changes --verbosity diagnostic
+          dotnet format SysManager/SysManager.Tests/SysManager.Tests.csproj --verify-no-changes --verbosity diagnostic
+          dotnet format SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj --verify-no-changes --verbosity diagnostic
+          dotnet format SysManager/SysManager.UITests/SysManager.UITests.csproj --verify-no-changes --verbosity diagnostic
 
       - name: Build (Release)
         run: dotnet build SysManager/SysManager/SysManager.csproj -c Release --no-restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,13 @@ permissions:
   contents: write
   discussions: write
 
+# Serialize releases per tag so two pushes (or a tag push racing a manual dispatch)
+# can't run two release jobs that race the winget publish and Discussions post.
+# Never cancel an in-flight release — a half-published release is worse than a wait.
+concurrency:
+  group: release-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   guard:
     name: Skip if release already exists (tag move / re-push)
@@ -75,8 +82,10 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           $tag = if ($env:EVENT_NAME -eq "workflow_dispatch") { $env:INPUT_TAG } else { $env:REF_NAME }
-          # Validate the tag shape (vMAJOR.MINOR.PATCH[...]) before using it anywhere.
-          if ($tag -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+') {
+          # Validate the tag shape (vMAJOR.MINOR.PATCH) before using it anywhere.
+          # End-anchored ($) so a crafted tag can't append trailing content that
+          # slips past the guard on this privileged (contents/discussions: write) workflow.
+          if ($tag -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+$') {
             Write-Error "Invalid release tag '$tag' — expected a semver tag like v1.2.3."
             exit 1
           }

--- a/SysManager/Directory.Build.props
+++ b/SysManager/Directory.Build.props
@@ -12,6 +12,16 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
+  <!-- Reproducible, path-normalized RELEASE builds. With SourceLink, this rewrites the
+       local source root in the PDB to a '/_/' prefix so the shipped binary never carries
+       an absolute build path (e.g. the OS profile name). Previously these lived only in
+       publish.ps1 args, so a plain `dotnet build -c Release` still leaked the path; now
+       every Release build is clean. Debug builds keep local paths for normal debugging. -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>

--- a/SysManager/SysManager.IntegrationTests/AllViewModelsSweepTests.cs
+++ b/SysManager/SysManager.IntegrationTests/AllViewModelsSweepTests.cs
@@ -27,16 +27,19 @@ public class AllViewModelsSweepTests
     [Fact] public void About_Constructs() => Assert.NotNull(new AboutViewModel());
     [Fact] public void MainWindow_Constructs() => Assert.NotNull(new MainWindowViewModel());
 
-    [Fact] public void Dashboard_HasNonEmptySummaryOrEmpty()
+    [Fact]
+    public void Dashboard_HasNonEmptySummaryOrEmpty()
         => Assert.NotNull(new DashboardViewModel(new SystemInfoService(), new TuneUpService(new ShortcutCleanerService(), new DiskHealthService(), new SystemInfoService()), new HealthScoreService(new SystemInfoService(), new DiskHealthService(), new BatteryService()), new TemperatureService(new DiskHealthService(), skipHardwareInit: true)));
 
-    [Fact] public void AppUpdates_HasCollections()
+    [Fact]
+    public void AppUpdates_HasCollections()
     {
         var vm = new AppUpdatesViewModel(new WingetService(new PowerShellRunner()));
         Assert.NotNull(vm.Packages);
     }
 
-    [Fact] public void SystemHealth_HasCollections()
+    [Fact]
+    public void SystemHealth_HasCollections()
     {
         var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner());
         Assert.NotNull(vm.Modules);
@@ -45,19 +48,22 @@ public class AllViewModelsSweepTests
         Assert.NotNull(vm.ChkdskDrives);
     }
 
-    [Fact] public void Logs_HasCollection()
+    [Fact]
+    public void Logs_HasCollection()
     {
         var vm = new LogsViewModel(new EventLogService());
         Assert.NotNull(vm.Entries);
     }
 
-    [Fact] public void Drivers_HasDriversCollection()
+    [Fact]
+    public void Drivers_HasDriversCollection()
     {
         var vm = new DriversViewModel(new PowerShellRunner());
         Assert.NotNull(vm.Drivers);
     }
 
-    [Fact] public void DeepCleanup_HasCollections()
+    [Fact]
+    public void DeepCleanup_HasCollections()
     {
         var vm = new DeepCleanupViewModel(new DeepCleanupService(), new LargeFileScanner(), new FixedDriveService());
         Assert.NotNull(vm.Categories);
@@ -65,7 +71,8 @@ public class AllViewModelsSweepTests
         Assert.NotNull(vm.ScanLocations);
     }
 
-    [Fact] public void About_HasCollection()
+    [Fact]
+    public void About_HasCollection()
     {
         var vm = new AboutViewModel();
         Assert.NotNull(vm.ReleaseHistory);

--- a/SysManager/SysManager.IntegrationTests/CleanupCategoryTests.cs
+++ b/SysManager/SysManager.IntegrationTests/CleanupCategoryTests.cs
@@ -58,7 +58,9 @@ public class CleanupCategoryTests
     {
         var c = new CleanupCategory
         {
-            Name = "X", Description = "Y", Paths = Array.Empty<string>(),
+            Name = "X",
+            Description = "Y",
+            Paths = Array.Empty<string>(),
             FileCount = 12345
         };
         Assert.Equal("12,345 files", c.CountDisplay);
@@ -69,7 +71,9 @@ public class CleanupCategoryTests
     {
         var c = new CleanupCategory
         {
-            Name = "X", Description = "Y", Paths = Array.Empty<string>(),
+            Name = "X",
+            Description = "Y",
+            Paths = Array.Empty<string>(),
             TotalSizeBytes = 2048
         };
         Assert.Equal("2.0 KB", c.SizeDisplay);
@@ -80,7 +84,9 @@ public class CleanupCategoryTests
     {
         var c = new CleanupCategory
         {
-            Name = "X", Description = "Y", Paths = Array.Empty<string>()
+            Name = "X",
+            Description = "Y",
+            Paths = Array.Empty<string>()
         };
         c.IsSelected = true;
         Assert.True(c.IsSelected);
@@ -104,7 +110,9 @@ public class CleanupCategoryTests
     {
         var c = new CleanupCategory
         {
-            Name = "X", Description = "Y", Paths = Array.Empty<string>(),
+            Name = "X",
+            Description = "Y",
+            Paths = Array.Empty<string>(),
             OlderThan = TimeSpan.FromDays(30)
         };
         Assert.Equal(TimeSpan.FromDays(30), c.OlderThan);

--- a/SysManager/SysManager.IntegrationTests/LargeFileScannerTests.cs
+++ b/SysManager/SysManager.IntegrationTests/LargeFileScannerTests.cs
@@ -68,9 +68,9 @@ public class LargeFileScannerTests
         var root = Path.Combine(Path.GetTempPath(), "SysManagerLfTest_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
         var small = Path.Combine(root, "small.bin");
-        var big   = Path.Combine(root, "big.bin");
+        var big = Path.Combine(root, "big.bin");
         File.WriteAllBytes(small, new byte[100]);
-        File.WriteAllBytes(big,   new byte[2 * 1024 * 1024]); // 2 MB
+        File.WriteAllBytes(big, new byte[2 * 1024 * 1024]); // 2 MB
         try
         {
             var s = new LargeFileScanner();

--- a/SysManager/SysManager.IntegrationTests/UpdateServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/UpdateServiceTests.cs
@@ -11,13 +11,13 @@ public class UpdateServiceTests
     // -------- ParseVersion: happy paths ----------
 
     [Theory]
-    [InlineData("v0.5.0",   0, 5, 0)]
-    [InlineData("0.5.0",    0, 5, 0)]
-    [InlineData("V1.2.3",   1, 2, 3)]
-    [InlineData("v10.20.30",10,20,30)]
-    [InlineData("v0.0.1",   0, 0, 1)]
-    [InlineData("v99.0.0",  99, 0, 0)]
-    [InlineData("0.0.0",    0, 0, 0)]
+    [InlineData("v0.5.0", 0, 5, 0)]
+    [InlineData("0.5.0", 0, 5, 0)]
+    [InlineData("V1.2.3", 1, 2, 3)]
+    [InlineData("v10.20.30", 10, 20, 30)]
+    [InlineData("v0.0.1", 0, 0, 1)]
+    [InlineData("v99.0.0", 99, 0, 0)]
+    [InlineData("0.0.0", 0, 0, 0)]
     public void ParseVersion_AcceptsStandardTags(string tag, int major, int minor, int build)
     {
         var v = UpdateService.ParseVersion(tag);

--- a/SysManager/SysManager.Tests/BulkInstallerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/BulkInstallerViewModelTests.cs
@@ -2,9 +2,9 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
 using SysManager.Services;
 using SysManager.ViewModels;
-using SysManager.Helpers;
 
 namespace SysManager.Tests;
 

--- a/SysManager/SysManager.Tests/ContextMenuViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ContextMenuViewModelTests.cs
@@ -2,9 +2,9 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
 using SysManager.Services;
 using SysManager.ViewModels;
-using SysManager.Helpers;
 
 namespace SysManager.Tests;
 

--- a/SysManager/SysManager.Tests/DeepCleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupViewModelTests.cs
@@ -199,13 +199,21 @@ public class DeepCleanupViewModelTests
         var vm = NewVm();
         var c1 = new CleanupCategory
         {
-            Name = "A", Description = "a", Paths = [],
-            TotalSizeBytes = 1000, FileCount = 1, IsSelected = true
+            Name = "A",
+            Description = "a",
+            Paths = [],
+            TotalSizeBytes = 1000,
+            FileCount = 1,
+            IsSelected = true
         };
         var c2 = new CleanupCategory
         {
-            Name = "B", Description = "b", Paths = [],
-            TotalSizeBytes = 2000, FileCount = 2, IsSelected = false
+            Name = "B",
+            Description = "b",
+            Paths = [],
+            TotalSizeBytes = 2000,
+            FileCount = 2,
+            IsSelected = false
         };
         vm.Categories.Add(c1);
         vm.Categories.Add(c2);
@@ -276,13 +284,21 @@ public class DeepCleanupViewModelTests
         var vm = NewVm();
         vm.Categories.Add(new CleanupCategory
         {
-            Name = "Safe", Description = "d", Paths = [],
-            TotalSizeBytes = 100, FileCount = 1, IsDestructiveHint = false
+            Name = "Safe",
+            Description = "d",
+            Paths = [],
+            TotalSizeBytes = 100,
+            FileCount = 1,
+            IsDestructiveHint = false
         });
         vm.Categories.Add(new CleanupCategory
         {
-            Name = "Dangerous", Description = "d", Paths = [],
-            TotalSizeBytes = 200, FileCount = 1, IsDestructiveHint = true
+            Name = "Dangerous",
+            Description = "d",
+            Paths = [],
+            TotalSizeBytes = 200,
+            FileCount = 1,
+            IsDestructiveHint = true
         });
 
         vm.SelectAllCommand.Execute(true);
@@ -297,8 +313,12 @@ public class DeepCleanupViewModelTests
         var vm = NewVm();
         var c = new CleanupCategory
         {
-            Name = "X", Description = "d", Paths = [],
-            TotalSizeBytes = 100, FileCount = 1, IsSelected = true
+            Name = "X",
+            Description = "d",
+            Paths = [],
+            TotalSizeBytes = 100,
+            FileCount = 1,
+            IsSelected = true
         };
         vm.Categories.Add(c);
 
@@ -313,8 +333,12 @@ public class DeepCleanupViewModelTests
         var vm = NewVm();
         vm.Categories.Add(new CleanupCategory
         {
-            Name = "X", Description = "d", Paths = [],
-            TotalSizeBytes = 100, FileCount = 1, IsDestructiveHint = false
+            Name = "X",
+            Description = "d",
+            Paths = [],
+            TotalSizeBytes = 100,
+            FileCount = 1,
+            IsDestructiveHint = false
         });
 
         vm.SelectAllCommand.Execute(null);
@@ -540,8 +564,12 @@ public class DeepCleanupViewModelTests
             var vm = NewVm();
             vm.Categories.Add(new CleanupCategory
             {
-                Name = "Temp", Description = "test", Paths = new[] { dir },
-                TotalSizeBytes = 1, FileCount = 1, IsSelected = true
+                Name = "Temp",
+                Description = "test",
+                Paths = new[] { dir },
+                TotalSizeBytes = 1,
+                FileCount = 1,
+                IsSelected = true
             });
 
             await vm.CleanCommand.ExecuteAsync(null);
@@ -573,8 +601,12 @@ public class DeepCleanupViewModelTests
             var vm = NewVm();
             vm.Categories.Add(new CleanupCategory
             {
-                Name = "Temp", Description = "test", Paths = new[] { dir },
-                TotalSizeBytes = 1, FileCount = 1, IsSelected = true
+                Name = "Temp",
+                Description = "test",
+                Paths = new[] { dir },
+                TotalSizeBytes = 1,
+                FileCount = 1,
+                IsSelected = true
             });
 
             await vm.CleanCommand.ExecuteAsync(null);

--- a/SysManager/SysManager.Tests/DnsHostsViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DnsHostsViewModelTests.cs
@@ -4,10 +4,10 @@
 
 using System.IO;
 using NSubstitute;
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
-using SysManager.Helpers;
 
 namespace SysManager.Tests;
 

--- a/SysManager/SysManager.Tests/EventExplainerExtendedTests.cs
+++ b/SysManager/SysManager.Tests/EventExplainerExtendedTests.cs
@@ -75,8 +75,13 @@ public class EventExplainerExtendedTests
     }
 
     [Theory]
-    [InlineData(7000)] [InlineData(7001)] [InlineData(7009)]
-    [InlineData(7011)] [InlineData(7023)] [InlineData(7031)] [InlineData(7034)]
+    [InlineData(7000)]
+    [InlineData(7001)]
+    [InlineData(7009)]
+    [InlineData(7011)]
+    [InlineData(7023)]
+    [InlineData(7031)]
+    [InlineData(7034)]
     public void ServiceControlManager_AllEvents_AreExplained(int id)
     {
         var e = Make("Service Control Manager", id);

--- a/SysManager/SysManager.Tests/FileShredderViewModelTests.cs
+++ b/SysManager/SysManager.Tests/FileShredderViewModelTests.cs
@@ -4,10 +4,10 @@
 
 using System.IO;
 using NSubstitute;
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
-using SysManager.Helpers;
 
 namespace SysManager.Tests;
 
@@ -112,7 +112,10 @@ public class FileShredderViewModelTests
             var vm = NewVm();
             vm.Items.Add(new ShredItem
             {
-                Path = file, Name = Path.GetFileName(file), SizeBytes = 1, IsFolder = false
+                Path = file,
+                Name = Path.GetFileName(file),
+                SizeBytes = 1,
+                IsFolder = false
             });
 
             await vm.ShredAllCommand.ExecuteAsync(null);
@@ -143,7 +146,10 @@ public class FileShredderViewModelTests
             var vm = NewVm();
             vm.Items.Add(new ShredItem
             {
-                Path = file, Name = Path.GetFileName(file), SizeBytes = 1, IsFolder = false
+                Path = file,
+                Name = Path.GetFileName(file),
+                SizeBytes = 1,
+                IsFolder = false
             });
 
             await vm.ShredAllCommand.ExecuteAsync(null);

--- a/SysManager/SysManager.Tests/LogsViewModelExtendedTests.cs
+++ b/SysManager/SysManager.Tests/LogsViewModelExtendedTests.cs
@@ -165,8 +165,11 @@ public class LogsViewModelExtendedTests
     {
         var vm = new LogsViewModel(new Services.EventLogService())
         {
-            ShowCritical = true, ShowError = true, ShowWarning = true,
-            ShowInfo = true, ShowVerbose = true
+            ShowCritical = true,
+            ShowError = true,
+            ShowWarning = true,
+            ShowInfo = true,
+            ShowVerbose = true
         };
         Assert.Equal(5, BuildSev(vm).Count);
     }
@@ -176,8 +179,11 @@ public class LogsViewModelExtendedTests
     {
         var vm = new LogsViewModel(new Services.EventLogService())
         {
-            ShowCritical = false, ShowError = false, ShowWarning = false,
-            ShowInfo = false, ShowVerbose = false
+            ShowCritical = false,
+            ShowError = false,
+            ShowWarning = false,
+            ShowInfo = false,
+            ShowVerbose = false
         };
         Assert.Empty(BuildSev(vm));
     }
@@ -291,8 +297,11 @@ public class LogsViewModelExtendedTests
     {
         var vm = new LogsViewModel(new Services.EventLogService())
         {
-            ShowCritical = false, ShowError = false, ShowWarning = false,
-            ShowInfo = false, ShowVerbose = false
+            ShowCritical = false,
+            ShowError = false,
+            ShowWarning = false,
+            ShowInfo = false,
+            ShowVerbose = false
         };
         Assert.False(Filter(vm, Make(EventSeverity.Critical)));
         Assert.False(Filter(vm, Make(EventSeverity.Error)));

--- a/SysManager/SysManager.Tests/NavGroupTests.cs
+++ b/SysManager/SysManager.Tests/NavGroupTests.cs
@@ -32,16 +32,26 @@ public class NavGroupTests
     [Fact]
     public void Subtitle_CanBeSet()
     {
-        var g = new NavGroup { Id = "test", Label = "Test", Glyph = "T",
-            Subtitle = "A · B · C" };
+        var g = new NavGroup
+        {
+            Id = "test",
+            Label = "Test",
+            Glyph = "T",
+            Subtitle = "A · B · C"
+        };
         Assert.Equal("A · B · C", g.Subtitle);
     }
 
     [Fact]
     public void Tooltip_CanBeSet()
     {
-        var g = new NavGroup { Id = "test", Label = "Test", Glyph = "T",
-            Tooltip = "Alpha\nBeta\nGamma" };
+        var g = new NavGroup
+        {
+            Id = "test",
+            Label = "Test",
+            Glyph = "T",
+            Tooltip = "Alpha\nBeta\nGamma"
+        };
         Assert.Contains("Alpha", g.Tooltip);
         Assert.Contains("Beta", g.Tooltip);
     }
@@ -49,12 +59,18 @@ public class NavGroupTests
     [Fact]
     public void IsSingleItem_FalseWhenMultipleChildren()
     {
-        var g = new NavGroup { Id = "test", Label = "Test", Glyph = "T", Children = {
+        var g = new NavGroup
+        {
+            Id = "test",
+            Label = "Test",
+            Glyph = "T",
+            Children = {
             new NavItem { Id = "a", Label = "A", Glyph = "A",
                 Content = new object(), ViewType = typeof(object) },
             new NavItem { Id = "b", Label = "B", Glyph = "B",
                 Content = new object(), ViewType = typeof(object) },
-        }};
+        }
+        };
         Assert.False(g.IsSingleItem);
         Assert.Equal(2, g.ChildCount);
     }

--- a/SysManager/SysManager.Tests/ServicesViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ServicesViewModelTests.cs
@@ -250,8 +250,10 @@ public class ServicesViewModelTests
         // message before any elevation/confirm/PowerShell call.
         var critical = new ServiceEntry
         {
-            Name = "RpcSs", DisplayName = "Remote Procedure Call (RPC)",
-            Status = "Running", StartType = "Automatic",
+            Name = "RpcSs",
+            DisplayName = "Remote Procedure Call (RPC)",
+            Status = "Running",
+            StartType = "Automatic",
             SafetyLevel = Models.SafetyLevel.Critical,
             SafetyDescription = "Core Windows IPC. System will not function without it."
         };

--- a/SysManager/SysManager.Tests/UpdateServiceParseVersionBulkTests.cs
+++ b/SysManager/SysManager.Tests/UpdateServiceParseVersionBulkTests.cs
@@ -19,7 +19,7 @@ public class UpdateServiceParseVersionBulkTests
                 for (var patch = 0; patch <= 5; patch++)
                 {
                     yield return new object[] { $"v{major}.{minor}.{patch}", major, minor, patch };
-                    yield return new object[] { $"{major}.{minor}.{patch}",  major, minor, patch };
+                    yield return new object[] { $"{major}.{minor}.{patch}", major, minor, patch };
                 }
     }
 

--- a/SysManager/SysManager.UITests/SmokeUiTests.cs
+++ b/SysManager/SysManager.UITests/SmokeUiTests.cs
@@ -39,14 +39,14 @@ public class SmokeUiTests
     }
 
     [Theory]
-    [InlineData("nav-dashboard",      "Scan system")]
-    [InlineData("nav-app-updates",    "Scan for updates")]
+    [InlineData("nav-dashboard", "Scan system")]
+    [InlineData("nav-app-updates", "Scan for updates")]
     [InlineData("nav-windows-update", "Check module")]
-    [InlineData("nav-system-health",  "Overview")]
-    [InlineData("nav-cleanup",        "Clean TEMP")]
-    [InlineData("nav-network",        "Targets")]
-    [InlineData("nav-drivers",        "List installed drivers")]
-    [InlineData("nav-logs",           "System logs")]
+    [InlineData("nav-system-health", "Overview")]
+    [InlineData("nav-cleanup", "Clean TEMP")]
+    [InlineData("nav-network", "Targets")]
+    [InlineData("nav-drivers", "List installed drivers")]
+    [InlineData("nav-logs", "System logs")]
     public void EachTab_ShowsSignatureElement(string navId, string expectedText)
     {
         _fx.GoToTab(navId);

--- a/SysManager/SysManager/app.manifest
+++ b/SysManager/SysManager/app.manifest
@@ -11,9 +11,8 @@
   </trustInfo>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <!-- Windows 10 / 11 -->
+      <!-- Windows 10 / 11 (the only targets; .NET 10 cannot run on Windows 8.1) -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
-      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
     </application>
   </compatibility>
   <application xmlns="urn:schemas-microsoft-com:asm.v3">


### PR DESCRIPTION
## What

Pipeline + build-config hardening from the doc/config audit (no app behavior change).

## Workflows
- **release.yml** — tag-validation regex end-anchored (`...$`) so a crafted tag can't append content past the guard on this privileged workflow. Added a per-tag `concurrency` group (`cancel-in-progress: false`) so two pushes (or a push racing a manual dispatch) can't run two release jobs racing the winget publish + Discussions post.
- **auto-release.yml** — added a `concurrency` group (`cancel-in-progress: false`) so rapid merges to main can't both read the same latest tag and collide/drop a release.
- **ci.yml** — `dotnet format --verify-no-changes` now runs over all four C# projects (was main only).

## Build config
- **Directory.Build.props** — moved `ContinuousIntegrationBuild`/`Deterministic` here (Release-guarded) instead of only in publish.ps1, so **any** `dotnet build -c Release` produces a path-normalized PDB (verified: 0 occurrences of the source root, `/_/` prefix present). Debug keeps local paths.
- **app.manifest** — removed the dead Windows 8.1 `supportedOS` GUID.

## dependabot.yml
- Added `groups` (minor+patch grouped, majors individual) to all five entries + limit/scope on the actions entry.

## Formatting normalization (surfaced by this PR)
Expanding the CI format check to all four projects revealed **pre-existing** whitespace / object-initializer drift in the three test projects that the old main-only check was hiding. Normalized via `dotnet format`. **Whitespace/layout only — zero semantic change** (verified: object-initializer one-line→multi-line reformatting), all projects build 0/0.

`ci:` — config + formatting only, no code change, no release.