### PR TITLE
fix: don't run per-user uninstaller from a user-writable folder when elevated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.57] - 2026-06-24
+
+### Security
+- **The Uninstaller no longer runs a per-user app's uninstaller from a user-writable folder while elevated.** When SysManager ran as Administrator, uninstalling a local app executed the path from its registry `UninstallString` (and any DLL a `rundll32` command would load). That path was trusted even when it pointed inside `%LocalAppData%`, which a standard user can write to — and the uninstall key in `HKCU` is also user-writable. An unprivileged attacker could therefore plant a binary there plus a fake uninstall entry, then have an elevated SysManager run it with admin rights (local privilege escalation). Admin-protected locations (Program Files, Windows, ProgramData) stay trusted as before; the per-user location is now trusted only when SysManager is *not* elevated, so normal per-user uninstalls (e.g. VS Code, Discord) are unaffected.
+
 ## [1.20.56] - 2026-06-23
 
 ### Fixed

--- a/SysManager/SysManager.Tests/UninstallerServiceTests.cs
+++ b/SysManager/SysManager.Tests/UninstallerServiceTests.cs
@@ -19,7 +19,9 @@ public class UninstallerServiceTests
     public void IsUnderTrustedDirectory_PathInsideProgramFiles_IsTrusted()
     {
         var pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-        Assert.True(UninstallerService.IsUnderTrustedDirectory(System.IO.Path.Combine(pf, "Vendor", "app.exe")));
+        // Program Files is admin-protected, so it is trusted regardless of elevation.
+        Assert.True(UninstallerService.IsUnderTrustedDirectory(System.IO.Path.Combine(pf, "Vendor", "app.exe"), isElevated: false));
+        Assert.True(UninstallerService.IsUnderTrustedDirectory(System.IO.Path.Combine(pf, "Vendor", "app.exe"), isElevated: true));
     }
 
     [Fact]
@@ -28,12 +30,35 @@ public class UninstallerServiceTests
         // "C:\Program Files Evil\..." must NOT pass the "C:\Program Files" check.
         var pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
         var evil = pf + " Evil\\malware.exe";
-        Assert.False(UninstallerService.IsUnderTrustedDirectory(evil));
+        Assert.False(UninstallerService.IsUnderTrustedDirectory(evil, isElevated: false));
     }
 
     [Fact]
     public void IsUnderTrustedDirectory_UntrustedLocation_IsNotTrusted()
-        => Assert.False(UninstallerService.IsUnderTrustedDirectory(@"C:\Temp\random\app.exe"));
+        => Assert.False(UninstallerService.IsUnderTrustedDirectory(@"C:\Temp\random\app.exe", isElevated: false));
+
+    // ── SEC-LPE: user-writable per-user location is trusted only when NOT elevated ──
+
+    [Fact]
+    public void IsUnderTrustedDirectory_LocalAppData_TrustedWhenNotElevated()
+    {
+        // A per-user install (VS Code, Discord) lives under %LocalAppData% and must
+        // still uninstall normally when SysManager runs without elevation.
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var perUserApp = System.IO.Path.Combine(localAppData, "Programs", "VendorApp", "uninstall.exe");
+        Assert.True(UninstallerService.IsUnderTrustedDirectory(perUserApp, isElevated: false));
+    }
+
+    [Fact]
+    public void IsUnderTrustedDirectory_LocalAppData_NotTrustedWhenElevated()
+    {
+        // %LocalAppData% is writable by a standard user. When SysManager is elevated,
+        // executing a binary there would let an unprivileged attacker who planted it
+        // run with our elevation (local privilege escalation) — so it must NOT be trusted.
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var plantedBinary = System.IO.Path.Combine(localAppData, "Programs", "VendorApp", "uninstall.exe");
+        Assert.False(UninstallerService.IsUnderTrustedDirectory(plantedBinary, isElevated: true));
+    }
 
     // ── ValidateTrustedBinaryArgs (regression: LPE via HKCU UninstallString) ──
 
@@ -43,7 +68,7 @@ public class UninstallerServiceTests
         // rundll32 would load an attacker-controlled DLL from a writable temp path
         // with our elevation — must be rejected.
         var ex = Record.Exception(() =>
-            UninstallerService.ValidateTrustedBinaryArgs("rundll32.exe", @"C:\Temp\evil.dll,EntryPoint"));
+            UninstallerService.ValidateTrustedBinaryArgs("rundll32.exe", @"C:\Temp\evil.dll,EntryPoint", isElevated: false));
         Assert.IsType<InvalidOperationException>(ex);
     }
 
@@ -53,15 +78,27 @@ public class UninstallerServiceTests
         var sys = Environment.GetFolderPath(Environment.SpecialFolder.System);
         var dll = System.IO.Path.Combine(sys, "shell32.dll");
         var ex = Record.Exception(() =>
-            UninstallerService.ValidateTrustedBinaryArgs("rundll32.exe", $"\"{dll}\",Control_RunDLL"));
+            UninstallerService.ValidateTrustedBinaryArgs("rundll32.exe", $"\"{dll}\",Control_RunDLL", isElevated: false));
         Assert.Null(ex);
+    }
+
+    [Fact]
+    public void ValidateTrustedBinaryArgs_Rundll32_DllInLocalAppData_NotTrustedWhenElevated_Throws()
+    {
+        // SEC-LPE: a rundll32 DLL planted in user-writable %LocalAppData% must be
+        // rejected when elevated, even though it would be allowed un-elevated.
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var dll = System.IO.Path.Combine(localAppData, "evil.dll");
+        var ex = Record.Exception(() =>
+            UninstallerService.ValidateTrustedBinaryArgs("rundll32.exe", $"\"{dll}\",EntryPoint", isElevated: true));
+        Assert.IsType<InvalidOperationException>(ex);
     }
 
     [Fact]
     public void ValidateTrustedBinaryArgs_Rundll32_NoDllPath_Throws()
     {
         var ex = Record.Exception(() =>
-            UninstallerService.ValidateTrustedBinaryArgs("rundll32.exe", "   "));
+            UninstallerService.ValidateTrustedBinaryArgs("rundll32.exe", "   ", isElevated: false));
         Assert.IsType<InvalidOperationException>(ex);
     }
 
@@ -70,7 +107,7 @@ public class UninstallerServiceTests
     {
         var ex = Record.Exception(() =>
             UninstallerService.ValidateTrustedBinaryArgs(
-                "MsiExec.exe", "/X{0F2C3A4B-1234-5678-9ABC-DEF012345678} /quiet /norestart"));
+                "MsiExec.exe", "/X{0F2C3A4B-1234-5678-9ABC-DEF012345678} /quiet /norestart", isElevated: false));
         Assert.Null(ex);
     }
 
@@ -81,7 +118,7 @@ public class UninstallerServiceTests
     public void ValidateTrustedBinaryArgs_MsiExec_NonProductCode_Throws(string args)
     {
         var ex = Record.Exception(() =>
-            UninstallerService.ValidateTrustedBinaryArgs("MsiExec.exe", args));
+            UninstallerService.ValidateTrustedBinaryArgs("MsiExec.exe", args, isElevated: false));
         Assert.IsType<InvalidOperationException>(ex);
     }
 

--- a/SysManager/SysManager/Services/UninstallerService.cs
+++ b/SysManager/SysManager/Services/UninstallerService.cs
@@ -225,6 +225,14 @@ public sealed partial class UninstallerService
         // Handles both quoted paths ("C:\path\uninstall.exe" /S) and unquoted.
         var (exe, args) = ParseUninstallCommand(command);
 
+        // SEC-LPE: capture our own elevation up front. The UninstallString (and any
+        // rundll32 DLL path it carries) comes from a registry key that a standard user
+        // can write — HKCU especially. When SysManager itself runs elevated, executing
+        // a binary from a user-writable location would let an unprivileged attacker who
+        // planted it gain our elevation (local privilege escalation). The trusted-path
+        // checks below therefore tighten when elevated.
+        var isElevated = Helpers.AdminHelper.IsElevated();
+
         // SEC-002: Validate the executable exists and is a real file (not a
         // script or arbitrary command). HKCU uninstall keys can be modified
         // without admin, so we must not blindly execute whatever is there.
@@ -250,7 +258,7 @@ public sealed partial class UninstallerService
             // MsiExec take their payload from the (HKCU-writable) arguments. rundll32
             // will load ANY DLL at ANY entry point, and MsiExec will run an arbitrary
             // package; both inherit our elevation. Validate the payload before launch.
-            ValidateTrustedBinaryArgs(resolvedName, args);
+            ValidateTrustedBinaryArgs(resolvedName, args, isElevated);
         }
         else
         {
@@ -263,12 +271,14 @@ public sealed partial class UninstallerService
                 throw new InvalidOperationException(
                     $"Uninstall target is not an executable (.exe): '{exe}'. Refusing to run for security.");
 
-            // SEC-H2: Validate the executable resides under a trusted directory.
+            // SEC-H2 / SEC-LPE: Validate the executable resides under a trusted directory.
             // Registry uninstall keys (especially HKCU) can be modified without admin,
-            // so we must not execute arbitrary paths. Allow: Program Files, Windows,
-            // ProgramData, and LocalApplicationData (per-user installs like VS Code).
+            // so we must not execute arbitrary paths. Admin-protected dirs (Program Files,
+            // Windows, ProgramData) are always trusted; the user-writable per-user location
+            // (LocalApplicationData) is trusted ONLY when we are not elevated — otherwise an
+            // unprivileged attacker who dropped a binary there would gain our elevation.
             var fullPath = System.IO.Path.GetFullPath(exe);
-            if (!IsUnderTrustedDirectory(fullPath))
+            if (!IsUnderTrustedDirectory(fullPath, isElevated))
                 throw new InvalidOperationException(
                     $"Uninstall executable is outside trusted directories: '{exe}'. Refusing to run for security.");
         }
@@ -367,19 +377,28 @@ public sealed partial class UninstallerService
     }
 
     /// <summary>
-    /// Checks whether the given absolute path resides under a trusted system directory
-    /// (Program Files, Windows, ProgramData, or LocalApplicationData).
+    /// Checks whether the given absolute path resides under a trusted directory.
+    /// Admin-protected directories (Program Files, Windows, ProgramData) are always
+    /// trusted. The user-writable per-user location (LocalApplicationData) is trusted
+    /// ONLY when <paramref name="isElevated"/> is false — when we run elevated, a binary
+    /// there could have been planted by an unprivileged attacker, so trusting it would
+    /// be a local privilege-escalation vector (SEC-LPE).
     /// </summary>
-    internal static bool IsUnderTrustedDirectory(string fullPath)
+    internal static bool IsUnderTrustedDirectory(string fullPath, bool isElevated)
     {
-        var trustedDirs = new[]
+        var trustedDirs = new List<string>
         {
             Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
             Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
             Environment.GetFolderPath(Environment.SpecialFolder.Windows),
-            Environment.GetEnvironmentVariable("ProgramData") ?? @"C:\ProgramData",
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
+            Environment.GetEnvironmentVariable("ProgramData") ?? @"C:\ProgramData"
         };
+
+        // Per-user install locations (e.g. VS Code, Discord) are writable without admin.
+        // Trust them only when we are NOT elevated, so an elevated uninstall can never
+        // execute an attacker-planted binary from a user-writable directory.
+        if (!isElevated)
+            trustedDirs.Add(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
 
         // Compare on a directory boundary, not a raw prefix. A bare StartsWith lets
         // "C:\Program Files Evil\x.exe" pass the "C:\Program Files" check — so append
@@ -404,7 +423,7 @@ public sealed partial class UninstallerService
     /// must be a product-code uninstall (/X{GUID}); anything else (e.g. an arbitrary
     /// package path or /I install) is rejected.
     /// </remarks>
-    internal static void ValidateTrustedBinaryArgs(string resolvedExeName, string args)
+    internal static void ValidateTrustedBinaryArgs(string resolvedExeName, string args, bool isElevated)
     {
         if (resolvedExeName.Equals("rundll32.exe", StringComparison.OrdinalIgnoreCase))
         {
@@ -414,8 +433,11 @@ public sealed partial class UninstallerService
                 throw new InvalidOperationException(
                     "rundll32 uninstall command has no DLL path — refusing to run for security.");
 
+            // Same SEC-LPE rule as the executable check: a user-writable DLL path is only
+            // trusted when not elevated, so rundll32 can't load attacker-planted DLLs with
+            // our elevation.
             var dllFullPath = System.IO.Path.GetFullPath(dll);
-            if (!IsUnderTrustedDirectory(dllFullPath))
+            if (!IsUnderTrustedDirectory(dllFullPath, isElevated))
                 throw new InvalidOperationException(
                     $"rundll32 would load a DLL outside trusted directories: '{dll}'. Refusing to run for security.");
         }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.56</Version>
-    <FileVersion>1.20.56.0</FileVersion>
-    <AssemblyVersion>1.20.56.0</AssemblyVersion>
+    <Version>1.20.57</Version>
+    <FileVersion>1.20.57.0</FileVersion>
+    <AssemblyVersion>1.20.57.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Closes a **local privilege-escalation (LPE)** vector in the Uninstaller.

When SysManager runs **elevated**, `UninstallLocalAsync` executes the path taken from an app's registry `UninstallString` (and, for `rundll32` commands, the DLL it loads). The trusted-directory allowlist trusted `%LocalAppData%` unconditionally. That folder is **writable by a standard user**, and the `HKCU` uninstall key the path is read from is **also user-writable**. So an unprivileged attacker could:

1. drop `evil.exe` (or `evil.dll`) under `%LocalAppData%`, and
2. write a matching `UninstallString` to an `HKCU\...\Uninstall\<app>` key,

then, when the user runs SysManager **as Administrator** and uninstalls that entry, SysManager would execute the planted binary **with admin rights**.

## Fix

`IsUnderTrustedDirectory` now splits its allowlist:

- **Always trusted** (admin-protected): Program Files, Program Files (x86), Windows, ProgramData.
- **Trusted only when NOT elevated** (user-writable): `LocalApplicationData`.

A per-user app (VS Code, Discord) never needs admin to uninstall, so refusing the user-writable location *only when elevated* loses no legitimate behavior while removing the escalation path. The same rule is applied to the `rundll32` DLL-path check in `ValidateTrustedBinaryArgs`.

Elevation is **injected as a parameter** into both static helpers (rather than read from the environment inside them) so the guard stays deterministically unit-testable.

## Tests (regression)

- `IsUnderTrustedDirectory_LocalAppData_TrustedWhenNotElevated` — per-user uninstall still works un-elevated.
- `IsUnderTrustedDirectory_LocalAppData_NotTrustedWhenElevated` — the escalation path is refused when elevated.
- `IsUnderTrustedDirectory_PathInsideProgramFiles_IsTrusted` — admin-protected dirs trusted in **both** elevation states.
- `ValidateTrustedBinaryArgs_Rundll32_DllInLocalAppData_NotTrustedWhenElevated_Throws` — rundll32 DLL planted in `%LocalAppData%` rejected when elevated.
- Existing boundary/injection/MsiExec tests updated to the new signature.

## Verification

- `dotnet build` (main + tests): **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes` (main + tests): clean.
- Propagate check: `IsUnderTrustedDirectory` / `ValidateTrustedBinaryArgs` are referenced only in `UninstallerService.cs` — no other callers.

## Reviewers (standing)
R8 Security (lead), R3 Debug — diff touches the elevated execution path.