### PR TITLE
fix: shredder follows mid-path junctions before its system-folder check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.58] - 2026-06-24
+
+### Security
+- **The file shredder can no longer be tricked into destroying a system file through a junction in the middle of the path.** Its safety check resolved a link only at the end of the path (and expanded short `8.3` names), but a junction or symlink in a *parent* folder — which a standard user can create without admin — was not followed during validation. A path such as `C:\Temp\link\notepad.exe`, where `C:\Temp\link` pointed into `System32`, slipped past the system-folder denylist and the real protected file behind it was overwritten and deleted. The shredder now asks Windows for the fully-resolved canonical path (collapsing every junction/symlink anywhere in the chain) and re-checks that against the protected-folder list before touching anything.
+
 ## [1.20.57] - 2026-06-24
 
 ### Security

--- a/SysManager/SysManager.Tests/FileShredderServiceTests.cs
+++ b/SysManager/SysManager.Tests/FileShredderServiceTests.cs
@@ -271,6 +271,95 @@ public class FileShredderServiceTests
         Assert.IsNotType<SecurityException>(ex);
     }
 
+    // ---------- mid-path junction bypass regression (P0) ----------
+
+    [Fact]
+    public async Task ShredFileAsync_FileBehindMidPathJunctionToProtected_ThrowsSecurityException()
+    {
+        // Regression: ValidatePath resolved only a LEAF link and expanded 8.3 names, but
+        // neither follows a junction in a PARENT component. A junction at an unprotected
+        // path pointing into System32 (creatable without admin via `mklink /J`) let a
+        // path like <temp>\link\notepad.exe pass the denylist, and the real protected
+        // file behind it was shredded through. The guard must canonicalize the full path.
+        var svc = NewService();
+        var sys32 = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "System32");
+
+        var baseDir = Path.Combine(Path.GetTempPath(), "smtest_midjunc_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(baseDir);
+        var link = Path.Combine(baseDir, "sys32link");
+
+        try
+        {
+            // mklink /J creates a directory junction; no admin rights required.
+            var psi = new System.Diagnostics.ProcessStartInfo("cmd.exe", $"/c mklink /J \"{link}\" \"{sys32}\"")
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+            using (var proc = System.Diagnostics.Process.Start(psi)!)
+            {
+                proc.WaitForExit(10_000);
+                if (proc.ExitCode != 0 || !IsReparse(link))
+                    return; // environment can't create junctions (rare) — nothing to assert
+            }
+
+            // A file that reliably exists under System32, reached THROUGH the junction.
+            var throughJunction = Path.Combine(link, "notepad.exe");
+            if (!File.Exists(throughJunction))
+                throughJunction = Path.Combine(link, "drivers", "etc", "hosts");
+
+            await Assert.ThrowsAsync<SecurityException>(
+                () => svc.ShredFileAsync(throughJunction, ShredMethod.Quick, null, CancellationToken.None));
+        }
+        finally
+        {
+            // Delete the junction itself (Directory.Delete on a junction removes the link,
+            // not its target), then the base dir.
+            try { Directory.Delete(link); } catch { /* ignore */ }
+            try { Directory.Delete(baseDir, recursive: true); } catch { /* ignore */ }
+        }
+
+        static bool IsReparse(string p)
+        {
+            try { return (File.GetAttributes(p) & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint; }
+            catch { return false; }
+        }
+    }
+
+    [Fact]
+    public void ResolveFinalPath_MissingPath_ReturnsNull()
+    {
+        // A path that can't be opened must return null so ValidatePath falls back to the
+        // already-validated literal form rather than throwing.
+        var missing = Path.Combine(Path.GetTempPath(), "smtest_nofinal_" + Guid.NewGuid().ToString("N") + ".dat");
+        Assert.Null(FileShredderService.ResolveFinalPath(missing));
+    }
+
+    [Fact]
+    public void ResolveFinalPath_RealTempFile_ResolvesToItself()
+    {
+        // For a normal (non-link) file the canonical path equals the input, confirming the
+        // handle-based resolver and \\?\ prefix stripping work. Compare against the EXPANDED
+        // long form, not the raw input: GetFinalPathNameByHandle always returns the long
+        // form, while %TEMP% on a CI runner can contain an 8.3 component (e.g. RUNNER~1),
+        // so a raw comparison would be environment-dependent and flaky.
+        var file = Path.Combine(Path.GetTempPath(), "smtest_final_" + Guid.NewGuid().ToString("N") + ".dat");
+        File.WriteAllText(file, "x");
+        try
+        {
+            var resolved = FileShredderService.ResolveFinalPath(file);
+            Assert.NotNull(resolved);
+            var expectedLong = FileShredderService.ExpandShortPath(Path.GetFullPath(file));
+            Assert.Equal(expectedLong, resolved, ignoreCase: true);
+        }
+        finally
+        {
+            if (File.Exists(file)) File.Delete(file);
+        }
+    }
+
     // ---------- 8.3 short-path bypass regression ----------
 
     [Fact]

--- a/SysManager/SysManager/Services/FileShredderService.cs
+++ b/SysManager/SysManager/Services/FileShredderService.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Cryptography;
+using Microsoft.Win32.SafeHandles;
 using Serilog;
 
 namespace SysManager.Services;
@@ -250,12 +251,30 @@ public sealed partial class FileShredderService
         // Path.GetFullPath does NOT expand short names, so without this a short-name
         // alias of a protected directory would slip past the prefix check below.
         fullPath = ExpandShortPath(fullPath);
+        ThrowIfProtected(fullPath);
 
+        // ResolveLinkTarget above only follows a reparse point that sits at the LEAF of
+        // the path — it does not collapse a junction/symlink in a PARENT component. So a
+        // path like C:\temp\j\notepad.exe, where C:\temp\j is a junction to System32
+        // (a junction a standard user can create without admin), still slips past the
+        // leaf check above and would be shredded through to the real System32 file.
+        // Ask the OS for the fully-resolved canonical path, which collapses EVERY reparse
+        // point anywhere in the chain, and validate that too. Best-effort: when the path
+        // can't be opened (missing, locked) we keep the already-validated literal form.
+        var canonical = ResolveFinalPath(fullPath);
+        if (canonical is not null && !canonical.Equals(fullPath, StringComparison.OrdinalIgnoreCase))
+            ThrowIfProtected(ExpandShortPath(canonical));
+    }
+
+    /// <summary>
+    /// Throws <see cref="SecurityException"/> if <paramref name="fullPath"/> equals or
+    /// sits under any system-protected root. Matches on a directory boundary so an
+    /// unrelated sibling (e.g. "C:\WindowsApps") is not blocked by "C:\Windows".
+    /// </summary>
+    private static void ThrowIfProtected(string fullPath)
+    {
         foreach (var prefix in ProtectedPrefixes)
         {
-            // Match on a directory boundary, not a raw prefix: the path must equal the
-            // protected root or sit beneath it (prefix + separator). Without this,
-            // "C:\Windows" would also block an unrelated sibling like "C:\WindowsApps".
             if (fullPath.Equals(prefix, StringComparison.OrdinalIgnoreCase) ||
                 fullPath.StartsWith(prefix + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
             {
@@ -263,6 +282,51 @@ public sealed partial class FileShredderService
                     $"Shredding system-protected paths is not allowed: {fullPath}");
             }
         }
+    }
+
+    /// <summary>
+    /// Returns the fully-resolved canonical path for <paramref name="path"/> with every
+    /// reparse point (junction/symlink) in the chain collapsed, via
+    /// <c>GetFinalPathNameByHandle</c>. Returns null when the path can't be opened
+    /// (missing, locked, access denied) so the caller falls back to the literal path.
+    /// </summary>
+    internal static string? ResolveFinalPath(string path)
+    {
+        // FILE_FLAG_BACKUP_SEMANTICS lets us open a directory handle too, not just files.
+        using SafeFileHandle handle = NativeMethods.CreateFile(
+            path,
+            0, // no access rights needed — we only resolve the name
+            FileShare.ReadWrite | FileShare.Delete,
+            IntPtr.Zero,
+            FileMode.Open,
+            NativeMethods.FILE_FLAG_BACKUP_SEMANTICS,
+            IntPtr.Zero);
+
+        if (handle.IsInvalid)
+            return null;
+
+        // First call with a zero-length buffer returns the required length (incl. NUL).
+        uint needed = NativeMethods.GetFinalPathNameByHandle(handle, [], 0, 0);
+        if (needed == 0)
+            return null;
+
+        var buffer = new char[needed];
+        uint written = NativeMethods.GetFinalPathNameByHandle(handle, buffer, needed, 0);
+        if (written == 0 || written >= needed)
+            return null;
+
+        var result = new string(buffer, 0, (int)written);
+
+        // GetFinalPathNameByHandle returns the \\?\ (or \\?\UNC\) extended-length prefix.
+        // Strip it so the result compares against the plain protected-prefix strings.
+        const string dosPrefix = @"\\?\";
+        const string uncPrefix = @"\\?\UNC\";
+        if (result.StartsWith(uncPrefix, StringComparison.Ordinal))
+            result = @"\\" + result[uncPrefix.Length..];
+        else if (result.StartsWith(dosPrefix, StringComparison.Ordinal))
+            result = result[dosPrefix.Length..];
+
+        return result;
     }
 
     /// <summary>
@@ -299,10 +363,29 @@ public sealed partial class FileShredderService
 
     private static partial class NativeMethods
     {
+        internal const uint FILE_FLAG_BACKUP_SEMANTICS = 0x0200_0000;
+
         [LibraryImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16, EntryPoint = "GetLongPathNameW")]
         internal static partial uint GetLongPathName(
             string lpszShortPath,
             [Out] char[] lpszLongPath,
             uint cchBuffer);
+
+        [LibraryImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16, EntryPoint = "CreateFileW", SetLastError = true)]
+        internal static partial SafeFileHandle CreateFile(
+            string lpFileName,
+            uint dwDesiredAccess,
+            FileShare dwShareMode,
+            IntPtr lpSecurityAttributes,
+            FileMode dwCreationDisposition,
+            uint dwFlagsAndAttributes,
+            IntPtr hTemplateFile);
+
+        [LibraryImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16, EntryPoint = "GetFinalPathNameByHandleW", SetLastError = true)]
+        internal static partial uint GetFinalPathNameByHandle(
+            SafeFileHandle hFile,
+            [Out] char[] lpszFilePath,
+            uint cchFilePath,
+            uint dwFlags);
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.57</Version>
-    <FileVersion>1.20.57.0</FileVersion>
-    <AssemblyVersion>1.20.57.0</AssemblyVersion>
+    <Version>1.20.58</Version>
+    <FileVersion>1.20.58.0</FileVersion>
+    <AssemblyVersion>1.20.58.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Closes a **data-loss / system-file-destruction** vector in the file shredder — the app's most data-loss-sensitive guard.

`FileShredderService.ValidatePath` resolved a reparse point only at the **leaf** of the path (`FileInfo.ResolveLinkTarget`) and expanded 8.3 short names, but it did **not** follow a junction or symlink in a **parent** component. A standard user can create a directory junction without admin (`mklink /J`), so:

```
C:\Temp\link  ->  C:\Windows\System32       (junction, no admin needed)
shred  C:\Temp\link\notepad.exe
```

passed the system-folder denylist (the literal `C:\Temp\...` is not protected), then the OS resolved the junction and the **real `System32\notepad.exe`** was overwritten and deleted.

## Fix

`ValidatePath` now performs a second check against the **fully-resolved canonical path**:

1. Existing leaf-link + 8.3 expansion check (unchanged) → `ThrowIfProtected`.
2. **New:** `ResolveFinalPath` opens a handle (`CreateFileW` + `FILE_FLAG_BACKUP_SEMANTICS`, no access rights requested) and calls `GetFinalPathNameByHandleW`, which collapses **every** reparse point anywhere in the chain. The `\?\` / `\?\UNC\` prefix is stripped, the result re-expanded, and `ThrowIfProtected` runs against it.

`ResolveFinalPath` is **best-effort**: if the path can't be opened (missing/locked/denied) it returns `null` and validation falls back to the already-checked literal form — so legitimate shredding of normal files is unaffected.

The protected-prefix comparison is factored into a shared `ThrowIfProtected` helper (single source of truth) so the leaf-resolved and fully-canonical paths are validated identically.

## Tests (regression)

- `ShredFileAsync_FileBehindMidPathJunctionToProtected_ThrowsSecurityException` — `mklink /J` into System32, shred a file *through* the junction → must throw `SecurityException`. Skips cleanly where the environment can't create junctions.
- `ResolveFinalPath_MissingPath_ReturnsNull` — unopenable path → null (fallback path).
- `ResolveFinalPath_RealTempFile_ResolvesToItself` — non-link file resolves to its long form (compared against the expanded long form, not the raw input, so it's not flaky on a runner whose `%TEMP%` has an 8.3 component).

## Verification

- `dotnet build` (main + tests): **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes` (main + tests): clean.
- New P/Invoke follows the existing `LibraryImport` + `...W` EntryPoint idiom in this file.

## Reviewers (standing)
R8 Security (lead), R3 Debug — diff touches the file-deletion safety guard.