### PR TITLE
fix: gate App Updates and Context Menu actions while one is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.59] - 2026-06-24
+
+### Fixed
+- **The App Updates and Context Menu tabs no longer risk a crash when their actions overlap.** On both tabs the long-running actions shared one cancellation source that each action re-created. Starting a second action while the first was still running (e.g. clicking Scan again mid-upgrade, or applying a context-menu preset while a scan ran) could dispose the cancellation source the first was still using and throw. Those actions are now disabled while one of them is running — matching how the Windows Update and Bulk Installer tabs already behave — while Cancel stays available. On the Context Menu tab this also prevents two overlapping runs from corrupting the entry list or triggering two Explorer restarts at once.
+
 ## [1.20.58] - 2026-06-24
 
 ### Security

--- a/SysManager/SysManager.Tests/AppUpdatesViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppUpdatesViewModelTests.cs
@@ -143,6 +143,28 @@ public class AppUpdatesViewModelTests
         Assert.Contains("No packages", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
     }
 
+    // ---------- re-entrancy guard (regression: shared CTS disposed mid-flight) ----------
+
+    [Fact]
+    public void LongRunningCommands_DisabledWhileBusy()
+    {
+        // Scan and UpgradeSelected both recreate the shared _cts. Without the NotBusy gate,
+        // triggering one while the other runs would dispose the CTS still being awaited
+        // (ObjectDisposedException). Cancel must stay enabled so an in-flight run can stop.
+        var vm = NewVm();
+        Assert.True(vm.ScanCommand.CanExecute(null));
+        Assert.True(vm.UpgradeSelectedCommand.CanExecute(null));
+
+        vm.IsBusy = true;
+        Assert.False(vm.ScanCommand.CanExecute(null));
+        Assert.False(vm.UpgradeSelectedCommand.CanExecute(null));
+        Assert.True(vm.CancelCommand.CanExecute(null));
+
+        vm.IsBusy = false;
+        Assert.True(vm.ScanCommand.CanExecute(null));
+        Assert.True(vm.UpgradeSelectedCommand.CanExecute(null));
+    }
+
     // ---------- runner plumbing ----------
 
     [Fact]

--- a/SysManager/SysManager.Tests/ContextMenuViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ContextMenuViewModelTests.cs
@@ -87,4 +87,27 @@ public class ContextMenuViewModelTests
         var vm = NewVm();
         Assert.Contains(vm.ActivePresetId, new[] { "win10", "win11" });
     }
+
+    // ---------- re-entrancy guard (regression: overlapping scan/preset runs) ----------
+
+    [Fact]
+    public void LongRunningCommands_DisabledWhileBusy()
+    {
+        // Scan, Refresh and ApplyPreset all mutate the shared _allEntries list off the UI
+        // thread (ApplyPreset also restarts Explorer). The NotBusy gate disables them while
+        // one runs so overlapping runs can't corrupt that list or race two restarts.
+        // Drive IsBusy explicitly rather than asserting the post-construction baseline:
+        // the constructor kicks off an async scan that briefly sets IsBusy itself.
+        var vm = NewVm();
+
+        vm.IsBusy = true;
+        Assert.False(vm.ScanCommand.CanExecute(null));
+        Assert.False(vm.RefreshCommand.CanExecute(null));
+        Assert.False(vm.ApplyPresetCommand.CanExecute(null));
+
+        vm.IsBusy = false;
+        Assert.True(vm.ScanCommand.CanExecute(null));
+        Assert.True(vm.RefreshCommand.CanExecute(null));
+        Assert.True(vm.ApplyPresetCommand.CanExecute(null));
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.58</Version>
-    <FileVersion>1.20.58.0</FileVersion>
-    <AssemblyVersion>1.20.58.0</AssemblyVersion>
+    <Version>1.20.59</Version>
+    <FileVersion>1.20.59.0</FileVersion>
+    <AssemblyVersion>1.20.59.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
@@ -31,7 +31,26 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
         _winget = winget;
         _lineHandler = line => Console.Append(line);
         _winget.LineReceived += _lineHandler;
+        // Re-evaluate the long-running commands' CanExecute when IsBusy flips. Scan and
+        // UpgradeSelected both recreate the shared _cts; without this gate a second
+        // command could dispose the CTS the first is still awaiting (ObjectDisposedException).
+        PropertyChanged += OnVmPropertyChanged;
         IsElevated = SysManager.Helpers.AdminHelper.IsElevated();
+    }
+
+    /// <summary>
+    /// Gate for the long-running commands. Scan and UpgradeSelected share <see cref="_cts"/>
+    /// and each recreates it, so disabling both while one runs prevents a second command
+    /// from disposing the CTS mid-flight. Cancel is intentionally NOT gated — it must stay
+    /// enabled while an operation runs. Mirrors WindowsUpdateViewModel.
+    /// </summary>
+    private bool NotBusy => !IsBusy;
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(IsBusy)) return;
+        ScanCommand.NotifyCanExecuteChanged();
+        UpgradeSelectedCommand.NotifyCanExecuteChanged();
     }
 
     [RelayCommand]
@@ -47,7 +66,7 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
         foreach (var p in Packages) p.IsSelected = value;
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task ScanAsync()
     {
         IsBusy = true;
@@ -67,7 +86,7 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
         finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task UpgradeSelectedAsync()
     {
         var toUpgrade = Packages.Where(p => p.IsSelected).ToList();
@@ -113,6 +132,7 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
         if (disposing)
         {
             _winget.LineReceived -= _lineHandler;
+            PropertyChanged -= OnVmPropertyChanged;
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/ContextMenuViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ContextMenuViewModel.cs
@@ -52,7 +52,35 @@ public sealed partial class ContextMenuViewModel : ViewModelBase
         PresetDescription = IsClassicMenuEnabled
             ? ContextMenuPreset.All["win10"].Description
             : ContextMenuPreset.All["win11"].Description;
+        // Re-evaluate the long-running commands' CanExecute when IsBusy flips. Scan,
+        // Refresh and ApplyPreset all mutate the shared _allEntries list off the UI thread
+        // (ApplyPreset also restarts Explorer); disabling them while one runs prevents
+        // overlapping runs from corrupting that list or racing two Explorer restarts.
+        PropertyChanged += OnVmPropertyChanged;
         InitializeAsync(InitAsync);
+    }
+
+    /// <summary>
+    /// Gate for the long-running commands so overlapping Scan/Refresh/ApplyPreset runs
+    /// can't mutate <see cref="_allEntries"/> concurrently or race two Explorer restarts.
+    /// The startup scan calls <see cref="ScanAsync"/> directly (not via the command) so it
+    /// is unaffected by this gate.
+    /// </summary>
+    private bool NotBusy => !IsBusy;
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(IsBusy)) return;
+        ScanCommand.NotifyCanExecuteChanged();
+        RefreshCommand.NotifyCanExecuteChanged();
+        ApplyPresetCommand.NotifyCanExecuteChanged();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+            PropertyChanged -= OnVmPropertyChanged;
+        base.Dispose(disposing);
     }
 
     partial void OnFilterTextChanged(string value) => ApplyFilter();
@@ -66,7 +94,7 @@ public sealed partial class ContextMenuViewModel : ViewModelBase
         catch (UnauthorizedAccessException ex) { Log.Warning("Context menu auto-scan failed: {Error}", ex.Message); }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task ScanAsync()
     {
         IsBusy = true;
@@ -143,7 +171,7 @@ public sealed partial class ContextMenuViewModel : ViewModelBase
         }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task ApplyPresetAsync(object? parameter)
     {
         if (parameter is not string presetId) return;
@@ -229,7 +257,7 @@ public sealed partial class ContextMenuViewModel : ViewModelBase
         finally { IsBusy = false; }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private Task RefreshAsync() => ScanAsync();
 
     private void ApplyFilter()


### PR DESCRIPTION
## Summary

Fixes a re-entrancy crash class on two tabs — the same bug already fixed on Windows Update and Bulk Installer.

On both the **App Updates** and **Context Menu** tabs, the long-running commands shared a single `CancellationTokenSource` that each command re-created on entry. Triggering a second command while the first was still awaiting disposed the CTS the first was using → `ObjectDisposedException`:

- **App Updates:** `Scan` and `UpgradeSelected` both do `_cts?.Dispose(); _cts = new(...)`. Clicking Scan again mid-upgrade (or vice versa) crashes.
- **Context Menu:** `Scan` / `Refresh` / `ApplyPreset` all mutate the shared `_allEntries` list off the UI thread, and `ApplyPreset` restarts Explorer. Overlapping runs could corrupt the list or race two restarts.

## Fix

Each view model now:
- exposes a `private bool NotBusy => !IsBusy;` gate,
- subscribes to its own `PropertyChanged` and calls `NotifyCanExecuteChanged()` on the long-running commands when `IsBusy` flips (mirroring `WindowsUpdateViewModel`),
- marks those commands `[RelayCommand(CanExecute = nameof(NotBusy))]`.

`Cancel` is intentionally **not** gated — it must stay enabled to stop an in-flight run. `ContextMenuViewModel` gains a `Dispose` override to unsubscribe the handler. The Context Menu startup auto-scan calls `ScanAsync()` directly (not through the command), so it is unaffected by the gate.

## Tests (regression)

- `AppUpdatesViewModelTests.LongRunningCommands_DisabledWhileBusy` — Scan/UpgradeSelected disabled while busy, Cancel stays enabled, re-enabled after.
- `ContextMenuViewModelTests.LongRunningCommands_DisabledWhileBusy` — Scan/Refresh/ApplyPreset disabled while busy, re-enabled after (drives `IsBusy` explicitly since the constructor briefly auto-scans).

## Verification

- `dotnet build` (main + tests): **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes` (main + tests): clean.

## Reviewers (standing)
R3 Debug (lead — crash class), R5 Architect (binding/CanExecute seam).