### PR TITLE
fix: make Windows Features scan and toggle mutually exclusive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.60] - 2026-06-24
+
+### Fixed
+- **Scanning Windows optional features while a feature toggle is running no longer mixes up their output.** The Scan and enable/disable actions share one PowerShell runner, and each subscribes to its output independently. Toggling was already blocked while busy, but Scan was not — so starting a scan mid-toggle let both read the same output stream and cross-contaminate results. Scan is now disabled while a toggle runs (and vice versa), making the two mutually exclusive.
+
 ## [1.20.59] - 2026-06-24
 
 ### Fixed

--- a/SysManager/SysManager.Tests/WindowsFeaturesTests.cs
+++ b/SysManager/SysManager.Tests/WindowsFeaturesTests.cs
@@ -133,4 +133,27 @@ public class WindowsFeaturesTests
         Assert.Equal(0, vm.FeatureCount);
         Assert.False(vm.PendingReboot);
     }
+
+    // ── re-entrancy guard (regression: shared runner cross-contamination) ──
+
+    [Fact]
+    public void ViewModel_ScanAndToggle_DisabledWhileBusy()
+    {
+        // Scan and ToggleFeature both drive the shared WindowsFeaturesService PowerShell
+        // runner. Running them concurrently would let both LineReceived handlers capture
+        // the same output. The NotBusy/CanToggle gates make them mutually exclusive.
+        var vm = new WindowsFeaturesViewModel(new WindowsFeaturesService(new PowerShellRunner()));
+        var feature = new WindowsFeature { Name = "TelnetClient", DisplayName = "Telnet Client" };
+
+        Assert.True(vm.ScanCommand.CanExecute(null));
+        Assert.True(vm.ToggleFeatureCommand.CanExecute(feature));
+
+        vm.IsBusy = true;
+        Assert.False(vm.ScanCommand.CanExecute(null));
+        Assert.False(vm.ToggleFeatureCommand.CanExecute(feature));
+
+        vm.IsBusy = false;
+        Assert.True(vm.ScanCommand.CanExecute(null));
+        Assert.True(vm.ToggleFeatureCommand.CanExecute(feature));
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.59</Version>
-    <FileVersion>1.20.59.0</FileVersion>
-    <AssemblyVersion>1.20.59.0</AssemblyVersion>
+    <Version>1.20.60</Version>
+    <FileVersion>1.20.60.0</FileVersion>
+    <AssemblyVersion>1.20.60.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
@@ -36,7 +36,19 @@ public sealed partial class WindowsFeaturesViewModel : ViewModelBase
     public WindowsFeaturesViewModel(WindowsFeaturesService service)
     {
         _service = service;
+        // Scan and ToggleFeature both drive the shared WindowsFeaturesService PowerShell
+        // runner (each subscribes its own LineReceived handler). Running them concurrently
+        // would cross-contaminate the captured output (the SFC/DISM bug class). Re-evaluate
+        // both commands' CanExecute when IsBusy flips so they are mutually exclusive.
+        PropertyChanged += OnVmPropertyChanged;
         IsElevated = AdminHelper.IsElevated();
+    }
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(IsBusy)) return;
+        ScanCommand.NotifyCanExecuteChanged();
+        ToggleFeatureCommand.NotifyCanExecuteChanged();
     }
 
     [RelayCommand]
@@ -46,7 +58,7 @@ public sealed partial class WindowsFeaturesViewModel : ViewModelBase
             System.Windows.Application.Current?.Shutdown();
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task ScanAsync()
     {
         IsBusy = true;
@@ -101,7 +113,6 @@ public sealed partial class WindowsFeaturesViewModel : ViewModelBase
             return;
 
         IsBusy = true;
-        ToggleFeatureCommand.NotifyCanExecuteChanged();
         feature.Status = feature.IsEnabled ? "Disabling…" : "Enabling…";
         StatusMessage = $"{(feature.IsEnabled ? "Disabling" : "Enabling")} {feature.DisplayName}…";
         _toggleCts?.Cancel();
@@ -147,7 +158,6 @@ public sealed partial class WindowsFeaturesViewModel : ViewModelBase
         finally
         {
             IsBusy = false;
-            ToggleFeatureCommand.NotifyCanExecuteChanged();
         }
     }
 
@@ -160,10 +170,16 @@ public sealed partial class WindowsFeaturesViewModel : ViewModelBase
 
     private bool CanToggle(WindowsFeature? _) => !IsBusy;
 
+    /// <summary>Gate for Scan so it can't run while a feature toggle is in flight (and vice
+    /// versa) — both share one PowerShell runner whose LineReceived output would otherwise
+    /// be captured by both operations at once.</summary>
+    private bool NotBusy => !IsBusy;
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)
         {
+            PropertyChanged -= OnVmPropertyChanged;
             _scanCts?.Cancel(); _scanCts?.Dispose();
             _toggleCts?.Cancel(); _toggleCts?.Dispose();
         }


### PR DESCRIPTION
## Summary

Same re-entrancy / shared-runner bug class as the SFC/DISM and App Updates fixes.

`WindowsFeaturesViewModel`'s `Scan` and `ToggleFeature` commands both drive the **shared** `WindowsFeaturesService` `PowerShellRunner`, and each subscribes its own `LineReceived` handler for the duration of its call. `ToggleFeature` was already gated on `!IsBusy` (`CanToggle`), but **`Scan` was not** — so starting a scan while a toggle was still running let both handlers capture the same runner output and cross-contaminate results.

## Fix

- `Scan` now carries `[RelayCommand(CanExecute = nameof(NotBusy))]`.
- A single `PropertyChanged` hook re-evaluates **both** commands when `IsBusy` flips, replacing the two manual `ToggleFeatureCommand.NotifyCanExecuteChanged()` calls (cleaner, and now covers Scan too) — mirroring the pattern just landed for App Updates / Context Menu.
- `Dispose` unsubscribes the hook.

The two operations are now mutually exclusive; `Cancel` is unaffected (cancels both CTSes).

## Tests (regression)

- `WindowsFeaturesTests.ViewModel_ScanAndToggle_DisabledWhileBusy` — both commands enabled when idle, both disabled while `IsBusy`, both re-enabled after.

## Verification

- `dotnet build` (main + tests): **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes` (main + tests): clean.

## Reviewers (standing)
R3 Debug (lead — re-entrancy), R8 Security (shared elevated PowerShell runner).