### PR TITLE
fix: gate Uninstaller scan and uninstall while one is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.61] - 2026-06-24
+
+### Fixed
+- **Starting a scan or uninstall on the Uninstaller tab while another is running no longer risks a crash.** Both the Scan and Uninstall actions re-create one shared cancellation source, so triggering a second action while the first was still running could dispose the cancellation source the first was using and throw. Those two actions are now disabled while one of them runs — matching the App Updates, Windows Update and Bulk Installer tabs — while Cancel stays available.
+
 ## [1.20.60] - 2026-06-24
 
 ### Fixed

--- a/SysManager/SysManager.Tests/UninstallerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/UninstallerViewModelTests.cs
@@ -229,4 +229,26 @@ public class UninstallerViewModelGateTests
             DialogService.Instance = prevDialog;
         }
     }
+
+    // ── re-entrancy guard (regression: shared CTS disposed mid-flight) ──
+
+    [Fact]
+    public void LongRunningCommands_DisabledWhileBusy()
+    {
+        // Scan and UninstallSelected both recreate the shared _cts. Without the NotBusy gate,
+        // triggering one while the other runs would dispose the CTS still being awaited
+        // (ObjectDisposedException). Cancel must stay enabled so an in-flight run can stop.
+        var vm = NewVm();
+        Assert.True(vm.ScanCommand.CanExecute(null));
+        Assert.True(vm.UninstallSelectedCommand.CanExecute(null));
+
+        vm.IsBusy = true;
+        Assert.False(vm.ScanCommand.CanExecute(null));
+        Assert.False(vm.UninstallSelectedCommand.CanExecute(null));
+        Assert.True(vm.CancelCommand.CanExecute(null));
+
+        vm.IsBusy = false;
+        Assert.True(vm.ScanCommand.CanExecute(null));
+        Assert.True(vm.UninstallSelectedCommand.CanExecute(null));
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.60</Version>
-    <FileVersion>1.20.60.0</FileVersion>
-    <AssemblyVersion>1.20.60.0</AssemblyVersion>
+    <Version>1.20.61</Version>
+    <FileVersion>1.20.61.0</FileVersion>
+    <AssemblyVersion>1.20.61.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
@@ -38,7 +38,26 @@ public sealed partial class UninstallerViewModel : ViewModelBase
         _service = service;
         _lineHandler = line => Console.Append(line);
         _service.LineReceived += _lineHandler;
+        // Scan and UninstallSelected both recreate the shared _cts; without this gate a
+        // second command could dispose the CTS the first is still awaiting
+        // (ObjectDisposedException). Re-evaluate both commands' CanExecute when IsBusy flips.
+        PropertyChanged += OnVmPropertyChanged;
         IsElevated = AdminHelper.IsElevated();
+    }
+
+    /// <summary>
+    /// Gate for the long-running commands. Scan and UninstallSelected share <see cref="_cts"/>
+    /// and each recreates it, so disabling both while one runs prevents a second command from
+    /// disposing the CTS mid-flight. Cancel is intentionally NOT gated. Mirrors the App Updates
+    /// and Windows Update tabs.
+    /// </summary>
+    private bool NotBusy => !IsBusy;
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(IsBusy)) return;
+        ScanCommand.NotifyCanExecuteChanged();
+        UninstallSelectedCommand.NotifyCanExecuteChanged();
     }
 
     [RelayCommand]
@@ -48,7 +67,7 @@ public sealed partial class UninstallerViewModel : ViewModelBase
             System.Windows.Application.Current?.Shutdown();
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task ScanAsync()
     {
         IsBusy = true;
@@ -84,7 +103,7 @@ public sealed partial class UninstallerViewModel : ViewModelBase
         }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task UninstallSelectedAsync()
     {
         var toRemove = FilteredApps.Where(a => a.IsSelected).ToList();
@@ -164,6 +183,7 @@ public sealed partial class UninstallerViewModel : ViewModelBase
         if (disposing)
         {
             _service.LineReceived -= _lineHandler;
+            PropertyChanged -= OnVmPropertyChanged;
             _cts?.Dispose();
         }
         base.Dispose(disposing);


### PR DESCRIPTION
## Summary

Same re-entrancy crash class fixed on Windows Update, App Updates, Bulk Installer and (just now) Context Menu / Windows Features.

`UninstallerViewModel`'s `Scan` and `UninstallSelected` commands both do `_cts?.Dispose(); _cts = new(...)` on entry. Triggering one while the other is still awaiting disposes the `CancellationTokenSource` the first command is using → `ObjectDisposedException`.

## Fix

- Both commands now carry `[RelayCommand(CanExecute = nameof(NotBusy))]`.
- A `PropertyChanged` hook re-evaluates both when `IsBusy` flips (mirroring the App Updates / Windows Update pattern).
- `Cancel` is intentionally **not** gated so an in-flight batch can still be stopped.
- `Dispose` unsubscribes the hook.
- The existing per-row recovery in the uninstall loop (each row's failure caught, loop continues) is unchanged.

## Tests (regression)

- `UninstallerViewModelTests.LongRunningCommands_DisabledWhileBusy` — Scan/UninstallSelected disabled while busy, Cancel stays enabled, both re-enabled after.

## Verification

- `dotnet build` (main + tests): **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes`: clean.

## Reviewers (standing)
R3 Debug (lead — re-entrancy crash class).