### PR TITLE
fix: Startup Enable All reports failures and actions no longer overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.62] - 2026-06-24
+
+### Fixed
+- **"Enable All" on the Startup tab now reports honestly when some items can't be enabled.** It used to always say "All items enabled" even if a registry write failed (for example, an item that needs administrator rights), hiding the failure. It now counts the results and reports how many were enabled and how many could not be — and says so when everything was already enabled.
+- **Startup actions can no longer overlap.** Scan, Enable All and the per-item toggle all read or write the same startup registry/task state; running two at once could interleave their writes and produce inconsistent counts. They are now disabled while one of them is running.
+
 ## [1.20.61] - 2026-06-24
 
 ### Fixed

--- a/SysManager/SysManager.Tests/StartupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/StartupViewModelTests.cs
@@ -122,4 +122,26 @@ public class StartupViewModelTests
         var ex = Record.Exception(() => vm.OpenFileLocationCommand.Execute(42));
         Assert.Null(ex);
     }
+
+    // ── re-entrancy guard (regression: overlapping registry writes) ──
+
+    [Fact]
+    public void StateChangingCommands_DisabledWhileBusy()
+    {
+        // Scan, EnableAll and ToggleEntry all read or write the same startup registry/task
+        // state; the NotBusy gate stops them overlapping and interleaving registry writes.
+        // Drive IsBusy explicitly rather than asserting the post-construction baseline: the
+        // constructor kicks off an async auto-scan that briefly sets IsBusy itself.
+        var vm = new StartupViewModel(new Services.StartupService());
+
+        vm.IsBusy = true;
+        Assert.False(vm.ScanCommand.CanExecute(null));
+        Assert.False(vm.EnableAllCommand.CanExecute(null));
+        Assert.False(vm.ToggleEntryCommand.CanExecute(null));
+
+        vm.IsBusy = false;
+        Assert.True(vm.ScanCommand.CanExecute(null));
+        Assert.True(vm.EnableAllCommand.CanExecute(null));
+        Assert.True(vm.ToggleEntryCommand.CanExecute(null));
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.61</Version>
-    <FileVersion>1.20.61.0</FileVersion>
-    <AssemblyVersion>1.20.61.0</AssemblyVersion>
+    <Version>1.20.62</Version>
+    <FileVersion>1.20.62.0</FileVersion>
+    <AssemblyVersion>1.20.62.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/StartupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StartupViewModel.cs
@@ -32,7 +32,32 @@ public sealed partial class StartupViewModel : ViewModelBase
     public StartupViewModel(StartupService service)
     {
         _service = service;
+        // Scan, EnableAll and ToggleEntry all read or write the same startup registry/task
+        // state; running them concurrently could interleave registry writes and produce
+        // inconsistent counts. Re-evaluate their CanExecute when IsBusy flips so only one
+        // runs at a time. The startup auto-scan calls ScanAsync directly (not via the
+        // command), so it is unaffected by the gate.
+        PropertyChanged += OnVmPropertyChanged;
         InitializeAsync(InitAsync);
+    }
+
+    /// <summary>Gate so Scan / EnableAll / ToggleEntry can't overlap and interleave their
+    /// registry writes.</summary>
+    private bool NotBusy => !IsBusy;
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(IsBusy)) return;
+        ScanCommand.NotifyCanExecuteChanged();
+        EnableAllCommand.NotifyCanExecuteChanged();
+        ToggleEntryCommand.NotifyCanExecuteChanged();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+            PropertyChanged -= OnVmPropertyChanged;
+        base.Dispose(disposing);
     }
 
     partial void OnHideWindowsEntriesChanged(bool value) => ApplyFilter();
@@ -44,7 +69,7 @@ public sealed partial class StartupViewModel : ViewModelBase
         catch (UnauthorizedAccessException ex) { Log.Warning("Startup auto-scan failed: {Error}", ex.Message); }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task ScanAsync()
     {
         IsBusy = true;
@@ -89,7 +114,7 @@ public sealed partial class StartupViewModel : ViewModelBase
         finally { IsBusy = false; }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task ToggleEntryAsync(object? parameter)
     {
         if (parameter is not StartupEntry entry) return;
@@ -113,13 +138,42 @@ public sealed partial class StartupViewModel : ViewModelBase
         }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task EnableAllAsync()
     {
-        foreach (var entry in Entries.Where(e => !e.IsEnabled))
-            await StartupService.SetEnabledAsync(entry, true).ConfigureAwait(false);
-        UpdateCounts();
-        StatusMessage = "All items enabled.";
+        IsBusy = true;
+        try
+        {
+            var toEnable = Entries.Where(e => !e.IsEnabled).ToList();
+            if (toEnable.Count == 0)
+            {
+                StatusMessage = "All startup items are already enabled.";
+                return;
+            }
+
+            // Report the outcome honestly: SetEnabledAsync returns false (and sets the
+            // entry's StatusText) when a registry/task write fails, e.g. an item that
+            // needs elevation. Previously every failure was swallowed and the status
+            // still claimed "All items enabled."
+            var enabled = 0;
+            var failed = 0;
+            foreach (var entry in toEnable)
+            {
+                if (await StartupService.SetEnabledAsync(entry, true).ConfigureAwait(false))
+                    enabled++;
+                else
+                    failed++;
+            }
+
+            UpdateCounts();
+            StatusMessage = failed == 0
+                ? $"Enabled {enabled} startup item(s)."
+                : $"Enabled {enabled} of {toEnable.Count} — {failed} could not be enabled (may require administrator).";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary

Two correctness fixes on the Startup tab.

**1. "Enable All" hid failures.** `EnableAllAsync` ignored the `bool` returned by each `StartupService.SetEnabledAsync` call and always reported *"All items enabled"* — even when a registry/task write failed (e.g. an item that needs administrator rights, where the service sets the entry's `StatusText` to an error). The failure was invisible to the user.

**2. Startup actions could overlap.** `Scan`, `EnableAll` and the per-item `ToggleEntry` all read or write the same startup registry/task state. Running two concurrently could interleave their writes and produce inconsistent counts.

## Fix

- `EnableAllAsync` now counts successes/failures and reports honestly: *"Enabled N startup item(s)."*, or *"Enabled N of M — K could not be enabled (may require administrator)."*, or *"All startup items are already enabled."* when there's nothing to do. It also sets `IsBusy` for its duration.
- All three commands carry `[RelayCommand(CanExecute = nameof(NotBusy))]`, re-evaluated via a `PropertyChanged` hook when `IsBusy` flips (the established pattern). The constructor auto-scan calls `ScanAsync()` directly, so it's unaffected by the gate.
- `Dispose` unsubscribes the hook.

## Tests (regression)

- `StartupViewModelTests.StateChangingCommands_DisabledWhileBusy` — Scan/EnableAll/ToggleEntry disabled while busy, re-enabled after (drives `IsBusy` explicitly because the constructor briefly auto-scans).

## Verification

- `dotnet build` (main + tests): **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes` (main + tests): clean.

## Reviewers (standing)
R3 Debug (re-entrancy), R1 Product (honest status reporting is user-facing).