### PR TITLE
fix: Process Manager refresh preserves row selection instead of rebuilding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.63] - 2026-06-24
+
+### Fixed
+- **The Process Manager no longer loses your selected row every second.** The list auto-refreshes once a second, and each refresh rebuilt the whole collection — which cleared the row you had selected (and your scroll position) and re-extracted every process icon each time. The refresh now updates the existing rows in place: surviving processes keep their row (and your selection), new processes are added, exited ones are removed, and icons are only fetched for newly-appeared processes.
+
 ## [1.20.62] - 2026-06-24
 
 ### Fixed

--- a/SysManager/SysManager.Tests/ProcessManagerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ProcessManagerViewModelTests.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
+using SysManager.Models;
 using SysManager.ViewModels;
 
 namespace SysManager.Tests;
@@ -49,5 +51,88 @@ public class ProcessManagerViewModelTests
     {
         var vm = new ProcessManagerViewModel(new Services.ProcessManagerService());
         Assert.False(string.IsNullOrEmpty(vm.Summary));
+    }
+
+    // ── ReconcileInto (regression: 1 Hz refresh preserves instances/selection) ──
+
+    private static ProcessEntry Proc(int pid, long mem = 0, double cpu = 0) =>
+        new() { Pid = pid, Name = $"p{pid}", MemoryBytes = mem, CpuPercent = cpu };
+
+    [Fact]
+    public void ReconcileInto_SurvivingPid_KeepsSameInstanceAndUpdatesMetrics()
+    {
+        var target = new BulkObservableCollection<ProcessEntry>();
+        var original = Proc(100, mem: 10, cpu: 1);
+        original.Icon = null; // identity field set once; must not be touched on update
+        target.Add(original);
+
+        // A fresh snapshot for the same PID with new metrics.
+        var snapshot = new List<ProcessEntry> { Proc(100, mem: 999, cpu: 42) };
+
+        ProcessManagerViewModel.ReconcileInto(target, snapshot);
+
+        Assert.Single(target);
+        // Same instance is reused — this is what lets the DataGrid keep selection.
+        Assert.Same(original, target[0]);
+        // Volatile metrics updated in place.
+        Assert.Equal(999, target[0].MemoryBytes);
+        Assert.Equal(42, target[0].CpuPercent);
+    }
+
+    [Fact]
+    public void ReconcileInto_AddsNewAndRemovesDeadPids()
+    {
+        var target = new BulkObservableCollection<ProcessEntry>();
+        var keep = Proc(1);
+        var dead = Proc(2);
+        target.Add(keep);
+        target.Add(dead);
+
+        // PID 2 exited, PID 3 is new.
+        var snapshot = new List<ProcessEntry> { Proc(1), Proc(3) };
+
+        ProcessManagerViewModel.ReconcileInto(target, snapshot);
+
+        var pids = target.Select(p => p.Pid).OrderBy(x => x).ToList();
+        Assert.Equal(new[] { 1, 3 }, pids);
+        Assert.Same(keep, target.First(p => p.Pid == 1)); // survivor instance preserved
+        Assert.DoesNotContain(dead, target);
+    }
+
+    // ── SyncOrdered (regression: filtered view reorders without a Reset) ──
+
+    [Fact]
+    public void SyncOrdered_ReordersInPlacePreservingInstances()
+    {
+        var target = new BulkObservableCollection<ProcessEntry>();
+        var a = Proc(1);
+        var b = Proc(2);
+        var c = Proc(3);
+        target.Add(a);
+        target.Add(b);
+        target.Add(c);
+
+        // Desired order c, a (b dropped by filter).
+        ProcessManagerViewModel.SyncOrdered(target, new List<ProcessEntry> { c, a });
+
+        Assert.Equal(2, target.Count);
+        Assert.Same(c, target[0]);
+        Assert.Same(a, target[1]);
+        Assert.DoesNotContain(b, target);
+    }
+
+    [Fact]
+    public void SyncOrdered_AddsMissingAtDesiredPosition()
+    {
+        var target = new BulkObservableCollection<ProcessEntry>();
+        var a = Proc(1);
+        target.Add(a);
+        var b = Proc(2);
+
+        // b should be inserted before a.
+        ProcessManagerViewModel.SyncOrdered(target, new List<ProcessEntry> { b, a });
+
+        Assert.Same(b, target[0]);
+        Assert.Same(a, target[1]);
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.62</Version>
-    <FileVersion>1.20.62.0</FileVersion>
-    <AssemblyVersion>1.20.62.0</AssemblyVersion>
+    <Version>1.20.63</Version>
+    <FileVersion>1.20.63.0</FileVersion>
+    <AssemblyVersion>1.20.63.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
@@ -73,32 +73,43 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
 
         try
         {
-            // PERF-007: Perform snapshot, icon extraction, and description lookup
-            // on a background thread to avoid UI freezes on slow processes.
+            // PERF-007: snapshot + enrichment on a background thread to avoid UI freezes.
+            // Icon extraction (the expensive part) is done ONLY for processes not already
+            // shown — see ReconcileInto, which is handed the set of PIDs we already track.
+            var existingPids = Processes.Select(p => p.Pid).ToHashSet();
             var enriched = await Task.Run(async () =>
             {
                 var snapshot = await _service.SnapshotAsync();
                 foreach (var p in snapshot)
                 {
-                    p.Icon = IconExtractorService.GetProcessIcon(p.FilePath, p.Name);
-                    var dbEntry = ProcessDescriptionService.Instance.Lookup(p.Name);
-                    if (dbEntry is not null)
+                    // Only the volatile metrics change per tick; identity/description are
+                    // stable, so enrich (and extract icons) just for newly-seen PIDs.
+                    if (!existingPids.Contains(p.Pid))
                     {
-                        p.PlainDescription = dbEntry.Description;
-                        p.Category = dbEntry.Category;
-                        p.SafetyLevel = dbEntry.Safety.ToString();
-                    }
-                    else
-                    {
-                        p.PlainDescription = p.Description;
-                        p.Category = "Unknown";
-                        p.SafetyLevel = "Unknown";
+                        p.Icon = IconExtractorService.GetProcessIcon(p.FilePath, p.Name);
+                        var dbEntry = ProcessDescriptionService.Instance.Lookup(p.Name);
+                        if (dbEntry is not null)
+                        {
+                            p.PlainDescription = dbEntry.Description;
+                            p.Category = dbEntry.Category;
+                            p.SafetyLevel = dbEntry.Safety.ToString();
+                        }
+                        else
+                        {
+                            p.PlainDescription = p.Description;
+                            p.Category = "Unknown";
+                            p.SafetyLevel = "Unknown";
+                        }
                     }
                 }
                 return snapshot;
             });
 
-            Processes.ReplaceWith(enriched);
+            // Merge into the existing collection in place instead of replacing it. A
+            // wholesale ReplaceWith raises a Reset that makes the DataGrid drop the user's
+            // selection and scroll position every second; ReconcileInto keeps the surviving
+            // ProcessEntry instances (so selection survives) and only adds/removes/updates.
+            ReconcileInto(Processes, enriched);
 
             ApplyFilter();
             StatusMessage = $"Loaded {ProcessCount} processes.";
@@ -115,6 +126,50 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
         {
             IsBusy = false;
             IsProgressIndeterminate = false;
+        }
+    }
+
+    /// <summary>
+    /// Merges <paramref name="snapshot"/> into <paramref name="target"/> in place, keyed by
+    /// PID: surviving processes keep their existing <see cref="ProcessEntry"/> instance (with
+    /// volatile metrics updated), new processes are added, and exited processes are removed.
+    /// Preserving the instances is what lets the DataGrid keep the user's selection across a
+    /// refresh. Newly-added entries from <paramref name="snapshot"/> are already enriched
+    /// (icon/description) by the caller; surviving entries keep their existing icon/description.
+    /// </summary>
+    internal static void ReconcileInto(
+        BulkObservableCollection<ProcessEntry> target,
+        IReadOnlyList<ProcessEntry> snapshot)
+    {
+        var existing = target.ToDictionary(p => p.Pid);
+        var seen = new HashSet<int>(snapshot.Count);
+
+        foreach (var fresh in snapshot)
+        {
+            seen.Add(fresh.Pid);
+            if (existing.TryGetValue(fresh.Pid, out var current))
+            {
+                // Update only the volatile metrics on the existing instance; identity fields
+                // (Name, FilePath, Icon, PlainDescription, Category, SafetyLevel, StartTime)
+                // are stable for a given PID and stay as they were.
+                current.CpuPercent = fresh.CpuPercent;
+                current.MemoryBytes = fresh.MemoryBytes;
+                current.ThreadCount = fresh.ThreadCount;
+                current.Status = fresh.Status;
+                current.HasMainWindow = fresh.HasMainWindow;
+            }
+            else
+            {
+                target.Add(fresh);
+            }
+        }
+
+        // Remove processes that no longer exist. Iterate a snapshot of the indices so we can
+        // mutate target safely.
+        for (var i = target.Count - 1; i >= 0; i--)
+        {
+            if (!seen.Contains(target[i].Pid))
+                target.RemoveAt(i);
         }
     }
 
@@ -164,11 +219,47 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
         }
 
         // Default order by memory descending; DataGrid column headers handle user sorting.
-        FilteredProcesses.ReplaceWith(source.OrderByDescending(p => p.MemoryBytes));
+        var desired = source.OrderByDescending(p => p.MemoryBytes).ToList();
+
+        // Sync the bound collection in place (Insert/Move/Remove) instead of ReplaceWith,
+        // which raises a Reset. A Reset on the 1 Hz auto-refresh would drop the user's row
+        // selection every second; an in-place sync keeps the surviving instances and their
+        // selection intact.
+        SyncOrdered(FilteredProcesses, desired);
 
         ProcessCount = FilteredProcesses.Count;
         TotalMemory = FilteredProcesses.Sum(p => p.MemoryBytes);
         Summary = $"{ProcessCount} processes · {FormatSize(TotalMemory)} total memory";
+    }
+
+    /// <summary>
+    /// Makes <paramref name="target"/> match <paramref name="desired"/> in both membership
+    /// and order using in-place Insert/Move/Remove operations (never a Reset), so a
+    /// DataGrid bound to it keeps the user's selection and scroll position. Items are matched
+    /// by reference, so surviving <see cref="ProcessEntry"/> instances are reused.
+    /// </summary>
+    internal static void SyncOrdered(
+        BulkObservableCollection<ProcessEntry> target,
+        IReadOnlyList<ProcessEntry> desired)
+    {
+        // Remove items that are no longer desired (walk backwards so indices stay valid).
+        var desiredSet = new HashSet<ProcessEntry>(desired);
+        for (var i = target.Count - 1; i >= 0; i--)
+        {
+            if (!desiredSet.Contains(target[i]))
+                target.RemoveAt(i);
+        }
+
+        // Insert/move each desired item into its target position.
+        for (var i = 0; i < desired.Count; i++)
+        {
+            var item = desired[i];
+            var currentIndex = target.IndexOf(item);
+            if (currentIndex < 0)
+                target.Insert(i, item);
+            else if (currentIndex != i)
+                target.Move(currentIndex, i);
+        }
     }
 
     private static string FormatSize(long bytes) => Helpers.FormatHelper.FormatSize(bytes);


### PR DESCRIPTION
## Summary

Fixes the highest-impact correctness/UX bug on the Process Manager tab (audit F4, HIGH).

The list auto-refreshes **once a second**. Each refresh did `Processes.ReplaceWith(snapshot)` then `FilteredProcesses.ReplaceWith(...)`. `ReplaceWith` raises a `Reset`, which makes the bound DataGrid **drop the user's selected row and scroll position every second** — and every process icon was re-extracted on every tick (wasteful on a 1 Hz loop).

## Fix

**`RefreshAsync` — merge in place, keyed by PID (`ReconcileInto`):**
- surviving processes keep their existing `ProcessEntry` instance; only the volatile metrics (CPU, memory, threads, status, window state) are updated,
- new PIDs are added, exited PIDs are removed,
- icon extraction + description-DB lookup now run **only for newly-appeared PIDs** (the caller passes the set of already-tracked PIDs), not for every process every tick.

**`ApplyFilter` — ordered in-place sync (`SyncOrdered`):**
- the bound `FilteredProcesses` is updated with `Insert`/`Move`/`Remove` (never `Reset`), so the per-tick re-sort by memory doesn't blow away selection either.

Because survivors are the **same instances** in both `Processes` and `FilteredProcesses`, their `[ObservableProperty]` metric updates flow to the grid live, and `SelectedItem` (a reference) survives.

## Tests (regression)

- `ReconcileInto_SurvivingPid_KeepsSameInstanceAndUpdatesMetrics` — `Assert.Same` proves instance reuse + metrics updated.
- `ReconcileInto_AddsNewAndRemovesDeadPids`.
- `SyncOrdered_ReordersInPlacePreservingInstances`.
- `SyncOrdered_AddsMissingAtDesiredPosition`.

## Verification

- `dotnet build` (main + tests): **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes` (main + tests): clean.

## Reviewers (standing)
R3 Debug (lead), R4 Performance (1 Hz poll-loop allocation/icon cost), R7 Frontend (DataGrid selection behaviour).