### PR TITLE
fix: broken-shortcut scan tolerates unreadable folders and long targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.64] - 2026-06-24
+
+### Fixed
+- **The broken-shortcut scan no longer stops early at the first unreadable folder, and no longer mislabels long-target shortcuts as broken.** The scan used a recursive enumerator that threw the moment it reached a folder it couldn't read (e.g. a protected Start Menu subfolder), which aborted the rest of that location and silently skipped every shortcut after it. It now walks folder-by-folder and skips only the unreadable ones (and skips junction/symlink folders so it can't be redirected out of the tree). Separately, shortcut targets were read into a 260-character buffer, so a target longer than that was truncated and the shortcut wrongly reported as broken — the buffer is now large enough to hold extended-length paths.
+
 ## [1.20.63] - 2026-06-24
 
 ### Fixed

--- a/SysManager/SysManager.Tests/ShortcutCleanerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ShortcutCleanerViewModelTests.cs
@@ -150,4 +150,45 @@ public class ShortcutCleanerViewModelTests
             DialogService.Instance = prevDialog;
         }
     }
+
+    // ── EnumerateLnkFilesSafe (regression: nested scan must not abort on one bad folder) ──
+
+    [Fact]
+    public void EnumerateLnkFilesSafe_FindsLnkFilesAtAllDepths()
+    {
+        // Regression: the old SearchOption.AllDirectories enumerator threw the first time it
+        // hit an unreadable subfolder, aborting the whole location and dropping every later
+        // shortcut. The tolerant walk must find .lnk files at every depth and ignore non-.lnk.
+        var root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "smtest_lnkscan_" + System.Guid.NewGuid().ToString("N"));
+        var deep = System.IO.Path.Combine(root, "a", "b", "c");
+        System.IO.Directory.CreateDirectory(deep);
+        try
+        {
+            System.IO.File.WriteAllText(System.IO.Path.Combine(root, "top.lnk"), "");
+            System.IO.File.WriteAllText(System.IO.Path.Combine(root, "a", "mid.lnk"), "");
+            System.IO.File.WriteAllText(System.IO.Path.Combine(deep, "deep.lnk"), "");
+            System.IO.File.WriteAllText(System.IO.Path.Combine(deep, "not-a-shortcut.txt"), "");
+
+            var found = ShortcutCleanerService.EnumerateLnkFilesSafe(root, CancellationToken.None)
+                .Select(System.IO.Path.GetFileName)
+                .OrderBy(n => n)
+                .ToList();
+
+            Assert.Equal(new[] { "deep.lnk", "mid.lnk", "top.lnk" }, found);
+        }
+        finally
+        {
+            try { System.IO.Directory.Delete(root, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void EnumerateLnkFilesSafe_MissingRoot_ReturnsEmptyWithoutThrowing()
+    {
+        // A root that doesn't exist must yield nothing rather than throw (the per-directory
+        // try/catch swallows the access error).
+        var missing = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "smtest_noroot_" + System.Guid.NewGuid().ToString("N"));
+        var found = ShortcutCleanerService.EnumerateLnkFilesSafe(missing, CancellationToken.None).ToList();
+        Assert.Empty(found);
+    }
 }

--- a/SysManager/SysManager/Services/ShortcutCleanerService.cs
+++ b/SysManager/SysManager/Services/ShortcutCleanerService.cs
@@ -37,43 +37,85 @@ public sealed partial class ShortcutCleanerService
 
             progress?.Report($"Scanning {label}...");
 
-            try
+            foreach (var lnk in EnumerateLnkFilesSafe(path, ct))
             {
-                foreach (var lnk in Directory.EnumerateFiles(path, "*.lnk", SearchOption.AllDirectories))
+                if (ct.IsCancellationRequested) break;
+
+                try
                 {
-                    if (ct.IsCancellationRequested) break;
+                    var target = ResolveShortcutTarget(lnk);
+                    if (string.IsNullOrWhiteSpace(target)) continue;
 
-                    try
+                    // Skip URLs, shell objects, and special targets
+                    if (target.StartsWith("::") || target.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    // Check if target exists (file or directory)
+                    if (!File.Exists(target) && !Directory.Exists(target))
                     {
-                        var target = ResolveShortcutTarget(lnk);
-                        if (string.IsNullOrWhiteSpace(target)) continue;
-
-                        // Skip URLs, shell objects, and special targets
-                        if (target.StartsWith("::") || target.StartsWith("http", StringComparison.OrdinalIgnoreCase))
-                            continue;
-
-                        // Check if target exists (file or directory)
-                        if (!File.Exists(target) && !Directory.Exists(target))
+                        results.Add(new BrokenShortcut
                         {
-                            results.Add(new BrokenShortcut
-                            {
-                                Name = Path.GetFileNameWithoutExtension(lnk),
-                                ShortcutPath = lnk,
-                                TargetPath = target,
-                                Location = label
-                            });
-                        }
+                            Name = Path.GetFileNameWithoutExtension(lnk),
+                            ShortcutPath = lnk,
+                            TargetPath = target,
+                            Location = label
+                        });
                     }
-                    catch (IOException) { /* skip inaccessible shortcut */ }
-                    catch (UnauthorizedAccessException) { /* skip protected shortcut */ }
-                    catch (COMException) { /* skip corrupted shortcut */ }
                 }
+                catch (IOException) { /* skip inaccessible shortcut */ }
+                catch (UnauthorizedAccessException) { /* skip protected shortcut */ }
+                catch (COMException) { /* skip corrupted shortcut */ }
             }
-            catch (IOException ex) { Log.Debug(ex, "Failed to scan {Location}", label); }
-            catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Access denied scanning {Location}", label); }
         }
 
         return results;
+    }
+
+    /// <summary>
+    /// Recursively enumerates <c>*.lnk</c> files under <paramref name="root"/>, tolerating
+    /// per-directory access errors. <see cref="Directory.EnumerateFiles(string, string, SearchOption)"/>
+    /// with <see cref="SearchOption.AllDirectories"/> throws mid-iteration the first time it hits
+    /// a folder it can't read (e.g. a protected Start-Menu subfolder), which previously aborted
+    /// the entire scan for that location and silently dropped every shortcut after it. This walks
+    /// the tree directory-by-directory so one unreadable folder is skipped, not the whole scan.
+    /// Reparse points (junctions/symlinks) are skipped to avoid following links out of the tree.
+    /// </summary>
+    internal static IEnumerable<string> EnumerateLnkFilesSafe(string root, CancellationToken ct)
+    {
+        Stack<string> stack = [];
+        stack.Push(root);
+
+        while (stack.Count > 0)
+        {
+            if (ct.IsCancellationRequested) yield break;
+            var dir = stack.Pop();
+
+            string[] files;
+            try { files = Directory.GetFiles(dir, "*.lnk"); }
+            catch (IOException) { continue; }
+            catch (UnauthorizedAccessException) { continue; }
+
+            foreach (var f in files)
+                yield return f;
+
+            string[] subDirs;
+            try { subDirs = Directory.GetDirectories(dir); }
+            catch (IOException) { continue; }
+            catch (UnauthorizedAccessException) { continue; }
+
+            foreach (var sub in subDirs)
+            {
+                // Skip reparse points so a junction can't redirect the walk outside the tree.
+                try
+                {
+                    if ((File.GetAttributes(sub) & FileAttributes.ReparsePoint) != 0) continue;
+                }
+                catch (IOException) { continue; }
+                catch (UnauthorizedAccessException) { continue; }
+
+                stack.Push(sub);
+            }
+        }
     }
 
     /// <summary>
@@ -146,7 +188,11 @@ public sealed partial class ShortcutCleanerService
         {
             file.Load(lnkPath, 0);
 
-            var sb = new char[260];
+            // Use an extended-length buffer rather than the legacy MAX_PATH (260). A target
+            // longer than 260 chars would otherwise be truncated, fail the existence check,
+            // and the shortcut would be wrongly reported as broken (a destructive false
+            // positive — the user could delete a perfectly valid shortcut).
+            var sb = new char[short.MaxValue];
             link.GetPath(sb, sb.Length, IntPtr.Zero, 0);
             var target = new string(sb).TrimEnd('\0');
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.63</Version>
-    <FileVersion>1.20.63.0</FileVersion>
-    <AssemblyVersion>1.20.63.0</AssemblyVersion>
+    <Version>1.20.64</Version>
+    <FileVersion>1.20.64.0</FileVersion>
+    <AssemblyVersion>1.20.64.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Two correctness bugs in the broken-shortcut scan (audit B10).

**1. The scan aborted at the first unreadable folder.** It used `Directory.EnumerateFiles(path, "*.lnk", SearchOption.AllDirectories)` with a single `try/catch` around the whole loop. That lazy enumerator **throws mid-iteration** the first time it reaches a subfolder it can't read (e.g. a protected Start Menu subfolder) — so the `catch` aborted the entire location and **every shortcut after the bad folder was silently skipped**.

**2. Long shortcut targets were mislabeled as broken.** `ResolveShortcutTarget` read the target into a 260-char (MAX_PATH) buffer. A target longer than that was truncated, failed the `File/Directory.Exists` check, and the shortcut was reported as **broken** — a destructive false positive the user could act on (deleting a valid shortcut).

## Fix

- New `EnumerateLnkFilesSafe`: walks the tree **directory-by-directory** with a per-directory `try/catch`, so an unreadable folder is skipped (not the whole scan). It also skips **reparse points** (junctions/symlinks) so a junction can't redirect the walk out of the tree.
- `ResolveShortcutTarget` now uses an extended-length buffer instead of `char[260]`.

## Tests (regression)

- `EnumerateLnkFilesSafe_FindsLnkFilesAtAllDepths` — finds `.lnk` at top/mid/deep levels, ignores non-`.lnk`.
- `EnumerateLnkFilesSafe_MissingRoot_ReturnsEmptyWithoutThrowing`.

## Verification

- `dotnet build` (main + tests): **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes` (main + tests): clean.

(Note: the two informational CodeQL `cs/unmanaged-code` notes in this file are the `IShellLink` COM + `SHFileOperation` P/Invoke, inherent to shortcut resolution — unchanged by this PR.)

## Reviewers (standing)
R3 Debug (lead — silent data loss in results), R8 Security (reparse-point traversal).