### PR TITLE
fix: Run-as-admin reliably lands in the elevated instance (single-instance race)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.65] - 2026-06-24
+
+### Changed
+- **Added detailed administrator-state logging at startup** to help diagnose a report of some tabs still showing the "needs administrator" notice after elevating. On launch the app now records, to its local log file only, the process elevation state (including the Windows token elevation type and process ID) and each affected tab's administrator status. This is written only to the local log under `%LocalAppData%\SysManager\logs` with usernames scrubbed — nothing is sent anywhere.
+
 ## [1.20.64] - 2026-06-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.20.65] - 2026-06-24
 
+### Fixed
+- **"Run as administrator" now reliably lands you in the elevated window instead of leaving the tabs still asking for admin.** The app allows only one instance at a time, enforced by a system-wide lock. When you clicked "Run as administrator", the elevated copy started while the original (non-elevated) window was still closing and had not yet released that lock — so the elevated copy saw "another instance is already running", brought the *old* non-elevated window back to the foreground, and exited. You were left on the non-elevated instance, where the tabs that need admin still showed the "needs administrator" notice. The elevated relaunch now hands the single-instance lock over to the new instance (it waits briefly for the old one to release it), so you end up in the actually-elevated window.
+
 ### Changed
-- **Added detailed administrator-state logging at startup** to help diagnose a report of some tabs still showing the "needs administrator" notice after elevating. On launch the app now records, to its local log file only, the process elevation state (including the Windows token elevation type and process ID) and each affected tab's administrator status. This is written only to the local log under `%LocalAppData%\SysManager\logs` with usernames scrubbed — nothing is sent anywhere.
+- **Added administrator-state logging at startup** to confirm the fix above and catch any residual case. On launch the app records, to its local log file only, the process elevation state (Windows token elevation type + process ID) and each affected tab's administrator status, under `%LocalAppData%\SysManager\logs` with usernames scrubbed — nothing is sent anywhere.
 
 ## [1.20.64] - 2026-06-24
 

--- a/SysManager/SysManager.Tests/AdminHelperTests.cs
+++ b/SysManager/SysManager.Tests/AdminHelperTests.cs
@@ -25,6 +25,16 @@ public class AdminHelperTests
     }
 
     [Fact]
+    public void LogElevationDiagnostics_DoesNotThrow()
+    {
+        // The diagnostic opens the process token via P/Invoke and writes one log line;
+        // it must never throw regardless of elevation state or whether a logger sink is
+        // configured (it catches the security/access/win32 cases internally).
+        var ex = Record.Exception(() => AdminHelper.LogElevationDiagnostics("test"));
+        Assert.Null(ex);
+    }
+
+    [Fact]
     public void RelaunchAsAdmin_DoesNotThrow()
     {
         // On CI / non-interactive hosts this will fail to launch (no UAC)

--- a/SysManager/SysManager.Tests/AdminHelperTests.cs
+++ b/SysManager/SysManager.Tests/AdminHelperTests.cs
@@ -35,6 +35,17 @@ public class AdminHelperTests
     }
 
     [Fact]
+    public void RelaunchedElevatedArg_IsAStableNonEmptySwitch()
+    {
+        // App.OnStartup matches this exact token in the elevated child's command line to
+        // decide whether to wait for the single-instance mutex handover. It must stay a
+        // non-empty, whitespace-free switch so it survives argument splitting intact.
+        Assert.False(string.IsNullOrWhiteSpace(AdminHelper.RelaunchedElevatedArg));
+        Assert.DoesNotContain(' ', AdminHelper.RelaunchedElevatedArg);
+        Assert.StartsWith("--", AdminHelper.RelaunchedElevatedArg);
+    }
+
+    [Fact]
     public void RelaunchAsAdmin_DoesNotThrow()
     {
         // On CI / non-interactive hosts this will fail to launch (no UAC)

--- a/SysManager/SysManager/App.xaml.cs
+++ b/SysManager/SysManager/App.xaml.cs
@@ -53,9 +53,21 @@ public partial class App : Application
         _instanceMutex = new Mutex(true, MutexName, out bool createdNew);
         if (!createdNew)
         {
-            ActivateExistingInstance();
-            Shutdown();
-            return;
+            // When this instance was started by "Run as administrator", the outgoing
+            // non-elevated instance is shutting down but may not have released the mutex
+            // yet. Wait briefly for it to hand over instead of treating ourselves as a
+            // duplicate — otherwise the elevated copy exits and the user is left on the
+            // non-elevated window with the admin banners still showing.
+            if (WasRelaunchedElevated(e.Args) && TryWaitForMutexHandover())
+            {
+                createdNew = true; // acquired after the old instance released it
+            }
+            else
+            {
+                ActivateExistingInstance();
+                Shutdown();
+                return;
+            }
         }
 
         LogService.Init();
@@ -82,6 +94,34 @@ public partial class App : Application
         // Fire-and-forget is intentional — the listener loop runs for the app
         // lifetime and is cancelled via _pipeCts on OnExit.
         _ = StartPipeListenerAsync();
+    }
+
+    /// <summary>
+    /// True when this instance was started by <see cref="Helpers.AdminHelper.RelaunchAsAdmin"/>
+    /// (carries the elevation sentinel argument).
+    /// </summary>
+    private static bool WasRelaunchedElevated(string[] args)
+        => args.Any(a => string.Equals(a, Helpers.AdminHelper.RelaunchedElevatedArg, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Waits up to a few seconds for the outgoing instance to release the single-instance
+    /// mutex, then takes ownership. Returns true if the mutex was acquired. The wait covers
+    /// the brief window between the old instance calling Shutdown() and its OnExit releasing
+    /// the mutex. An <see cref="AbandonedMutexException"/> still means we own it (the previous
+    /// owner exited without releasing) — that is success, not failure.
+    /// </summary>
+    private bool TryWaitForMutexHandover()
+    {
+        if (_instanceMutex is null) return false;
+        try
+        {
+            return _instanceMutex.WaitOne(TimeSpan.FromSeconds(5));
+        }
+        catch (AbandonedMutexException)
+        {
+            // Previous owner exited without releasing — ownership has passed to us.
+            return true;
+        }
     }
 
     protected override void OnExit(ExitEventArgs e)

--- a/SysManager/SysManager/Helpers/AdminHelper.cs
+++ b/SysManager/SysManager/Helpers/AdminHelper.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Security.Principal;
 using Serilog;
 
@@ -11,13 +12,93 @@ namespace SysManager.Helpers;
 /// <summary>
 /// Utilities for detecting current elevation and relaunching the app elevated on demand.
 /// </summary>
-public static class AdminHelper
+public static partial class AdminHelper
 {
     public static bool IsElevated()
     {
         using var identity = WindowsIdentity.GetCurrent();
         var principal = new WindowsPrincipal(identity);
         return principal.IsInRole(WindowsBuiltInRole.Administrator);
+    }
+
+    /// <summary>
+    /// DIAGNOSTIC (issue: some tabs show the "needs admin" banner even after elevating):
+    /// writes a one-line snapshot of this process's elevation state to the local log so a
+    /// real divergence can be told apart from a two-instance situation. Logs the PID, the
+    /// <see cref="IsElevated"/> result, the token's elevation type, and whether the identity
+    /// is in the Administrators role. Local log only — no telemetry. Safe to remove once the
+    /// admin-banner issue is root-caused.
+    /// </summary>
+    public static void LogElevationDiagnostics(string context)
+    {
+        try
+        {
+            using var identity = WindowsIdentity.GetCurrent();
+            var principal = new WindowsPrincipal(identity);
+            var inAdminRole = principal.IsInRole(WindowsBuiltInRole.Administrator);
+
+            using var process = Process.GetCurrentProcess();
+            var pid = process.Id;
+
+            Log.Information(
+                "ELEVATION-DIAG [{Context}] pid={Pid} isElevated={IsElevated} inAdminRole={InAdminRole} " +
+                "tokenElevationType={ElevationType} owner={Owner}",
+                context, pid, IsElevated(), inAdminRole, GetTokenElevationType(), identity.Owner?.Value ?? "?");
+        }
+        catch (System.Security.SecurityException ex) { Log.Debug(ex, "Elevation diagnostics unavailable (security)"); }
+        catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Elevation diagnostics unavailable (access)"); }
+        catch (System.ComponentModel.Win32Exception ex) { Log.Debug(ex, "Elevation diagnostics unavailable (win32)"); }
+    }
+
+    /// <summary>
+    /// Returns the process token's elevation type: "Full" (running elevated), "Limited"
+    /// (UAC split-token, not elevated), "Default" (UAC off or built-in admin), or "Unknown".
+    /// This distinguishes a genuinely-elevated process from a non-elevated one more precisely
+    /// than the admin-role check alone.
+    /// </summary>
+    private static string GetTokenElevationType()
+    {
+        const int TokenElevationType = 18; // TOKEN_INFORMATION_CLASS.TokenElevationType
+        using var process = Process.GetCurrentProcess();
+        if (!NativeMethods.OpenProcessToken(process.Handle, NativeMethods.TOKEN_QUERY, out var token))
+            return "Unknown";
+        try
+        {
+            if (NativeMethods.GetTokenInformation(token, TokenElevationType, out var type, sizeof(int), out _))
+            {
+                return type switch
+                {
+                    1 => "Default",
+                    2 => "Full",
+                    3 => "Limited",
+                    _ => "Unknown"
+                };
+            }
+            return "Unknown";
+        }
+        finally
+        {
+            NativeMethods.CloseHandle(token);
+        }
+    }
+
+    private static partial class NativeMethods
+    {
+        internal const uint TOKEN_QUERY = 0x0008;
+
+        [LibraryImport("advapi32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool OpenProcessToken(IntPtr processHandle, uint desiredAccess, out IntPtr tokenHandle);
+
+        [LibraryImport("advapi32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool GetTokenInformation(
+            IntPtr tokenHandle, int tokenInformationClass, out int tokenInformation,
+            int tokenInformationLength, out int returnLength);
+
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool CloseHandle(IntPtr handle);
     }
 
     /// <summary>

--- a/SysManager/SysManager/Helpers/AdminHelper.cs
+++ b/SysManager/SysManager/Helpers/AdminHelper.cs
@@ -102,6 +102,16 @@ public static partial class AdminHelper
     }
 
     /// <summary>
+    /// Command-line sentinel passed to the elevated instance started by
+    /// <see cref="RelaunchAsAdmin"/>. The single-instance guard in App.OnStartup recognizes
+    /// it and WAITS for the outgoing instance's mutex to be released instead of treating the
+    /// elevated copy as a duplicate and exiting — otherwise the elevated instance loses the
+    /// single-instance race against the still-closing original and the user is left on the
+    /// non-elevated window (the "tabs still ask for admin after elevating" bug).
+    /// </summary>
+    public const string RelaunchedElevatedArg = "--relaunched-elevated";
+
+    /// <summary>
     /// Relaunch the current process with UAC elevation and exit the current instance.
     /// Pass an optional argument hint so the new instance can jump back to the right tab.
     /// </summary>
@@ -114,12 +124,18 @@ public static partial class AdminHelper
             var exePath = Environment.ProcessPath ?? currentProc.MainModule?.FileName;
             if (string.IsNullOrWhiteSpace(exePath)) return false;
 
+            // Always tag the elevated child so its single-instance guard waits for this
+            // instance to release the mutex rather than bailing as a "duplicate".
+            var arguments = string.IsNullOrWhiteSpace(argumentHint)
+                ? RelaunchedElevatedArg
+                : $"{RelaunchedElevatedArg} {argumentHint}";
+
             var psi = new ProcessStartInfo
             {
                 FileName = exePath,
                 UseShellExecute = true,
                 Verb = "runas",
-                Arguments = argumentHint ?? string.Empty
+                Arguments = arguments
             };
             // Dispose the returned Process handle — we don't track the elevated instance.
             Process.Start(psi)?.Dispose();

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.64</Version>
-    <FileVersion>1.20.64.0</FileVersion>
-    <AssemblyVersion>1.20.64.0</AssemblyVersion>
+    <Version>1.20.65</Version>
+    <FileVersion>1.20.65.0</FileVersion>
+    <AssemblyVersion>1.20.65.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -258,6 +258,21 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         Title = IsElevated ? "SysManager — Administrator" : "SysManager";
         Log.Information("MainWindow initialized. Elevated: {IsElevated}", IsElevated);
 
+        // DIAGNOSTIC (admin-banner issue): record the process elevation snapshot, plus each
+        // admin-banner VM's own IsElevated, so we can tell whether the tabs genuinely diverge
+        // from the process (a real bug) or the window is the non-elevated instance. The VMs
+        // all read AdminHelper.IsElevated() at construction, so any mismatch here is the bug.
+        // Local log only; removed once root-caused.
+        AdminHelper.LogElevationDiagnostics("MainWindowViewModel");
+        Log.Information(
+            "ELEVATION-DIAG [tabs] dashboard={D} appBlocker={AB} privacy={Pv} services={Sv} " +
+            "windowsFeatures={WF} cleanup={Cl} contextMenu={CM} dnsHosts={DH} uninstaller={Un} " +
+            "windowsUpdate={WU} appUpdates={AU} bulkInstaller={BI} performance={Pf} networkRepair={NR} systemHealth={SH}",
+            Dashboard?.IsElevated, AppBlocker?.IsElevated, Privacy?.IsElevated, Services?.IsElevated,
+            WindowsFeatures?.IsElevated, Cleanup?.IsElevated, ContextMenu?.IsElevated, DnsHosts?.IsElevated,
+            Uninstaller?.IsElevated, WindowsUpdate?.IsElevated, AppUpdates?.IsElevated, BulkInstaller?.IsElevated,
+            Performance?.IsElevated, NetworkRepair?.IsElevated, SystemHealth?.IsElevated);
+
         foreach (var g in BuildNavGroups())
         {
             NavGroups.Add(g);


### PR DESCRIPTION
## Summary

Fixes the user report: after clicking **Run as administrator**, some tabs still showed the "needs administrator" banner although the app appeared elevated.

## Root cause (found in code, deterministic race)

The app enforces single-instance via a system mutex (`Global\SysManager_SingleInstance_*`).

1. `RelaunchAsAdmin` starts the elevated child, then the original instance calls `Application.Current.Shutdown()`.
2. WPF `Shutdown()` is **asynchronous** — the original releases the mutex only in `OnExit`, which runs after the message pump unwinds.
3. The **elevated child starts first**, hits `new Mutex(true, …, out createdNew)` → `createdNew == false` (original still owns it) → it runs `ActivateExistingInstance()` (brings the **non-elevated original's** window to the foreground) and **exits** as a "duplicate".
4. The user is left on the **non-elevated** instance → admin-requiring tabs still show the banner.

This is a timing race, so it presented inconsistently ("some tabs", "looked like Dashboard was admin").

## Fix

- `RelaunchAsAdmin` tags the elevated child with a sentinel arg (`--relaunched-elevated`).
- `App.OnStartup`: when `createdNew == false` **and** the sentinel is present, it **waits up to 5s** for the outgoing instance to release the mutex (`WaitOne`, treating `AbandonedMutexException` as success) and takes ownership — instead of bailing as a duplicate.
- The sentinel is added **only** on relaunch, so an ordinary second launch still activates the existing window exactly as before. No caller ever passed `argumentHint`, and nothing else parses `e.Args`, so existing behaviour is unchanged.

## Plus: confirmation diagnostics (local log only)

`AdminHelper.LogElevationDiagnostics` logs one line at startup — process id, `IsElevated`, admin-role, and the **token elevation type** (`Full`/`Limited`/`Default`) via `OpenProcessToken`+`GetTokenInformation` — and `MainWindow` logs each admin-banner tab's `IsElevated`. Written only to `%LocalAppData%\SysManager\logs` (usernames scrubbed). No telemetry. This confirms the fix in the field; can be removed once verified.

## Tests
- `LogElevationDiagnostics_DoesNotThrow`, `RelaunchedElevatedArg_IsAStableNonEmptySwitch`.
- `dotnet build` + `dotnet format --verify-no-changes` (main + tests): clean.

## Reviewers (standing)
R3 Debug (lead — process-lifecycle race), R8 Security (token P/Invoke, single-instance integrity, no-telemetry), R6 Systems (single-instance + local-log model).