### PR TITLE
fix: System Logs tab no longer blank; remove duplicate admin banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.66] - 2026-06-24
+
+### Fixed
+- **The System Logs tab is no longer blank.** One of the severity summary cards (Warnings) set a glow effect's colour from a brush resource instead of a colour value, which threw when the tab's view was first built and left the whole tab empty. The glow now uses the colour directly, matching the other cards, so the tab renders normally.
+- **The Privacy and Windows Features tabs no longer show two "running as administrator" notices at once.** When elevated, each of those tabs displayed both the standard full-width administrator banner and a small redundant "Administrator" chip in the toolbar. The redundant chip has been removed; the standard banner remains (and the Windows Features "Reboot pending" chip is unaffected).
+
 ## [1.20.65] - 2026-06-24
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.65</Version>
-    <FileVersion>1.20.65.0</FileVersion>
-    <AssemblyVersion>1.20.65.0</AssemblyVersion>
+    <Version>1.20.66</Version>
+    <FileVersion>1.20.66.0</FileVersion>
+    <AssemblyVersion>1.20.66.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -95,7 +95,11 @@
                     <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
                         <Ellipse Style="{StaticResource SevDot}" Fill="{DynamicResource WarningStripe}">
                             <Ellipse.Effect>
-                                <DropShadowEffect Color="{DynamicResource WarningStripe}" BlurRadius="8" ShadowDepth="0" Opacity="0.6"/>
+                                <!-- DropShadowEffect.Color is a Color, not a Brush — binding the
+                                     WarningStripe brush resource here threw at view-load time and
+                                     left the whole System Logs tab blank. Use the literal color
+                                     (WarningStripe = #FBBF24), matching the other severity cards. -->
+                                <DropShadowEffect Color="#FBBF24" BlurRadius="8" ShadowDepth="0" Opacity="0.6"/>
                             </Ellipse.Effect>
                         </Ellipse>
                         <TextBlock Text="{Binding WarningCount}" FontSize="20" FontWeight="Bold"

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -81,20 +81,6 @@
                           SelectedItem="{Binding SelectedCategory}"
                           AutomationProperties.Name="Filter toggles by category"
                           Width="140" Margin="0,0,12,0"/>
-
-                <Border CornerRadius="10" Padding="10,4" Margin="4,0"
-                        Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                        Visibility="{Binding IsElevated, Converter={StaticResource BoolToVis}}">
-                    <Grid>
-                        <Border Background="{DynamicResource WarningStripe}" Width="3" HorizontalAlignment="Left" CornerRadius="2"
-                                Margin="-10,-4,0,-4"/>
-                        <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
-                            <TextBlock Text="&#x1F6E1;" FontSize="11" VerticalAlignment="Center"/>
-                            <TextBlock Text="Administrator" FontSize="11" Foreground="{DynamicResource WarningText}"
-                                       FontWeight="SemiBold" Margin="6,0,0,0" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </Grid>
-                </Border>
             </WrapPanel>
         </Border>
 

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -48,19 +48,6 @@
                         Visibility="{Binding PendingReboot, Converter={StaticResource BoolToVis}}">
                     <TextBlock Text="⚠ Reboot pending" FontSize="11" Foreground="{DynamicResource Warning}"/>
                 </Border>
-                <Border CornerRadius="10" Padding="10,5" Margin="4,0"
-                        Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                        Visibility="{Binding IsElevated, Converter={StaticResource BoolToVis}}">
-                    <Grid>
-                        <Border Background="{DynamicResource WarningStripe}" Width="3" HorizontalAlignment="Left" CornerRadius="2"
-                                Margin="-10,-5,0,-5"/>
-                        <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
-                            <TextBlock Text="&#x1F6E1;" FontSize="11" VerticalAlignment="Center"/>
-                            <TextBlock Text="Administrator" Foreground="{DynamicResource WarningText}" FontSize="11"
-                                       FontWeight="SemiBold" Margin="6,0,0,0" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </Grid>
-                </Border>
             </WrapPanel>
         </Border>
 


### PR DESCRIPTION
Two UI bugs reported on the downloaded release.

## 1. System Logs tab was completely blank

**Root cause:** the Warnings severity card bound a `DropShadowEffect`'s **`Color`** to the `WarningStripe` resource, which is a `SolidColorBrush` — but `DropShadowEffect.Color` is a `System.Windows.Media.Color`, not a `Brush`. The type mismatch threw when `LogsView` was instantiated on first navigation (`NavItem.View` calls `Activator.CreateInstance(typeof(LogsView))`), so the whole tab's content failed to load and rendered empty.

```xml
<!-- before (threw) -->
<DropShadowEffect Color="{DynamicResource WarningStripe}" .../>
<!-- after (matches the Critical/Error/Info cards, which use literals) -->
<DropShadowEffect Color="#FBBF24" .../>   <!-- #FBBF24 == WarningStripe -->
```

The Ellipse `Fill="{DynamicResource WarningStripe}"` on the same card is correct (Fill is a Brush) and unchanged.

## 2. Two "running as administrator" notices on Privacy + Windows Features

When elevated, both tabs showed the standard full-width admin banner **and** a small redundant "Administrator" chip in the toolbar (next to the search/category controls — "the one near the search bar"). Removed the redundant chip from both views; the standard banner remains the single indicator. The Windows Features **"Reboot pending"** chip is distinct and left intact.

## Propagate check
- `grep` confirms **no other** view binds a `Color=` property to a brush resource (the LogsView Warnings card was the only one).
- `grep` confirms **no other** `Text="Administrator"` toolbar chip remains.

## Why CI didn't catch it
`LogsTabUiTests` (FlaUI) already assert the tab's header + buttons render and would have flagged the blank tab — but the `ui-tests` job is `continue-on-error: true` (non-blocking), so its failure surfaced only as a warning annotation, not a merge block. Those tests now pass with the fix.

## Verification
- `dotnet build -c Release`: 0 warnings, 0 errors.
- `dotnet format --verify-no-changes`: clean.

## Reviewers (standing)
R7 Frontend (lead — WPF resource typing, banner uniformity), R3 Debug (view-load crash).