### PR TITLE
fix: remove temporary elevation diagnostics from retail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.20.67] - 2026-06-24
+
+### Changed
+- **Removed the temporary administrator-state startup logging.** The diagnostic added while investigating the "tabs still ask for admin after elevating" report has done its job and is no longer written. The underlying fix (the elevated relaunch now reliably lands in the elevated window) stays in place.
+
 ## [1.20.66] - 2026-06-24
 
 ### Fixed

--- a/SysManager/SysManager.Tests/AdminHelperTests.cs
+++ b/SysManager/SysManager.Tests/AdminHelperTests.cs
@@ -25,16 +25,6 @@ public class AdminHelperTests
     }
 
     [Fact]
-    public void LogElevationDiagnostics_DoesNotThrow()
-    {
-        // The diagnostic opens the process token via P/Invoke and writes one log line;
-        // it must never throw regardless of elevation state or whether a logger sink is
-        // configured (it catches the security/access/win32 cases internally).
-        var ex = Record.Exception(() => AdminHelper.LogElevationDiagnostics("test"));
-        Assert.Null(ex);
-    }
-
-    [Fact]
     public void RelaunchedElevatedArg_IsAStableNonEmptySwitch()
     {
         // App.OnStartup matches this exact token in the elevated child's command line to

--- a/SysManager/SysManager/Helpers/AdminHelper.cs
+++ b/SysManager/SysManager/Helpers/AdminHelper.cs
@@ -3,7 +3,6 @@
 // License: MIT
 
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Security.Principal;
 using Serilog;
 
@@ -12,93 +11,13 @@ namespace SysManager.Helpers;
 /// <summary>
 /// Utilities for detecting current elevation and relaunching the app elevated on demand.
 /// </summary>
-public static partial class AdminHelper
+public static class AdminHelper
 {
     public static bool IsElevated()
     {
         using var identity = WindowsIdentity.GetCurrent();
         var principal = new WindowsPrincipal(identity);
         return principal.IsInRole(WindowsBuiltInRole.Administrator);
-    }
-
-    /// <summary>
-    /// DIAGNOSTIC (issue: some tabs show the "needs admin" banner even after elevating):
-    /// writes a one-line snapshot of this process's elevation state to the local log so a
-    /// real divergence can be told apart from a two-instance situation. Logs the PID, the
-    /// <see cref="IsElevated"/> result, the token's elevation type, and whether the identity
-    /// is in the Administrators role. Local log only — no telemetry. Safe to remove once the
-    /// admin-banner issue is root-caused.
-    /// </summary>
-    public static void LogElevationDiagnostics(string context)
-    {
-        try
-        {
-            using var identity = WindowsIdentity.GetCurrent();
-            var principal = new WindowsPrincipal(identity);
-            var inAdminRole = principal.IsInRole(WindowsBuiltInRole.Administrator);
-
-            using var process = Process.GetCurrentProcess();
-            var pid = process.Id;
-
-            Log.Information(
-                "ELEVATION-DIAG [{Context}] pid={Pid} isElevated={IsElevated} inAdminRole={InAdminRole} " +
-                "tokenElevationType={ElevationType} owner={Owner}",
-                context, pid, IsElevated(), inAdminRole, GetTokenElevationType(), identity.Owner?.Value ?? "?");
-        }
-        catch (System.Security.SecurityException ex) { Log.Debug(ex, "Elevation diagnostics unavailable (security)"); }
-        catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Elevation diagnostics unavailable (access)"); }
-        catch (System.ComponentModel.Win32Exception ex) { Log.Debug(ex, "Elevation diagnostics unavailable (win32)"); }
-    }
-
-    /// <summary>
-    /// Returns the process token's elevation type: "Full" (running elevated), "Limited"
-    /// (UAC split-token, not elevated), "Default" (UAC off or built-in admin), or "Unknown".
-    /// This distinguishes a genuinely-elevated process from a non-elevated one more precisely
-    /// than the admin-role check alone.
-    /// </summary>
-    private static string GetTokenElevationType()
-    {
-        const int TokenElevationType = 18; // TOKEN_INFORMATION_CLASS.TokenElevationType
-        using var process = Process.GetCurrentProcess();
-        if (!NativeMethods.OpenProcessToken(process.Handle, NativeMethods.TOKEN_QUERY, out var token))
-            return "Unknown";
-        try
-        {
-            if (NativeMethods.GetTokenInformation(token, TokenElevationType, out var type, sizeof(int), out _))
-            {
-                return type switch
-                {
-                    1 => "Default",
-                    2 => "Full",
-                    3 => "Limited",
-                    _ => "Unknown"
-                };
-            }
-            return "Unknown";
-        }
-        finally
-        {
-            NativeMethods.CloseHandle(token);
-        }
-    }
-
-    private static partial class NativeMethods
-    {
-        internal const uint TOKEN_QUERY = 0x0008;
-
-        [LibraryImport("advapi32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static partial bool OpenProcessToken(IntPtr processHandle, uint desiredAccess, out IntPtr tokenHandle);
-
-        [LibraryImport("advapi32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static partial bool GetTokenInformation(
-            IntPtr tokenHandle, int tokenInformationClass, out int tokenInformation,
-            int tokenInformationLength, out int returnLength);
-
-        [LibraryImport("kernel32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static partial bool CloseHandle(IntPtr handle);
     }
 
     /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.66</Version>
-    <FileVersion>1.20.66.0</FileVersion>
-    <AssemblyVersion>1.20.66.0</AssemblyVersion>
+    <Version>1.20.67</Version>
+    <FileVersion>1.20.67.0</FileVersion>
+    <AssemblyVersion>1.20.67.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -258,21 +258,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         Title = IsElevated ? "SysManager — Administrator" : "SysManager";
         Log.Information("MainWindow initialized. Elevated: {IsElevated}", IsElevated);
 
-        // DIAGNOSTIC (admin-banner issue): record the process elevation snapshot, plus each
-        // admin-banner VM's own IsElevated, so we can tell whether the tabs genuinely diverge
-        // from the process (a real bug) or the window is the non-elevated instance. The VMs
-        // all read AdminHelper.IsElevated() at construction, so any mismatch here is the bug.
-        // Local log only; removed once root-caused.
-        AdminHelper.LogElevationDiagnostics("MainWindowViewModel");
-        Log.Information(
-            "ELEVATION-DIAG [tabs] dashboard={D} appBlocker={AB} privacy={Pv} services={Sv} " +
-            "windowsFeatures={WF} cleanup={Cl} contextMenu={CM} dnsHosts={DH} uninstaller={Un} " +
-            "windowsUpdate={WU} appUpdates={AU} bulkInstaller={BI} performance={Pf} networkRepair={NR} systemHealth={SH}",
-            Dashboard?.IsElevated, AppBlocker?.IsElevated, Privacy?.IsElevated, Services?.IsElevated,
-            WindowsFeatures?.IsElevated, Cleanup?.IsElevated, ContextMenu?.IsElevated, DnsHosts?.IsElevated,
-            Uninstaller?.IsElevated, WindowsUpdate?.IsElevated, AppUpdates?.IsElevated, BulkInstaller?.IsElevated,
-            Performance?.IsElevated, NetworkRepair?.IsElevated, SystemHealth?.IsElevated);
-
         foreach (var g in BuildNavGroups())
         {
             NavGroups.Add(g);


### PR DESCRIPTION
## Summary

Removes the temporary administrator-state startup logging that was added to investigate the "tabs still ask for admin after elevating" report. The root cause was found and fixed (single-instance mutex handover on elevated relaunch), so the diagnostic has done its job and must not ship in a retail build.

## Changes
- Removed `AdminHelper.LogElevationDiagnostics`, `GetTokenElevationType`, and the `OpenProcessToken`/`GetTokenInformation`/`CloseHandle` P/Invoke block.
- Reverted `AdminHelper` from `partial` back to plain `static` and dropped the now-unused `System.Runtime.InteropServices` using.
- Removed the `ELEVATION-DIAG` lines from `MainWindowViewModel.InitNavigation` (kept the normal `"MainWindow initialized. Elevated: {IsElevated}"` log).
- Removed the diagnostic's `LogElevationDiagnostics_DoesNotThrow` test.

## Unchanged (the actual fix stays)
- `RelaunchAsAdmin` still tags the elevated child with `--relaunched-elevated`.
- `App.OnStartup` still waits for the single-instance mutex handover on relaunch.
- `RelaunchedElevatedArg_IsAStableNonEmptySwitch` test retained.

## Verification
- `dotnet build` (main + tests): **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes` (main + tests): clean.
- `grep` confirms zero remaining `ELEVATION-DIAG` / `LogElevationDiagnostics` references.

## Reviewers (standing)
R3 Debug, R8 Security (confirm no diagnostic/token P/Invoke remains in retail).