### PR TITLE
feat: Environment Variables tab — edit User/System vars with a PATH editor

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,7 +49,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Network | `PingViewModel` · `TracerouteViewModel` · `SpeedTestViewModel` · `NetworkRepairViewModel` (shared: `NetworkSharedState`) · `DnsHostsViewModel` |
 | Apps | `AppUpdatesViewModel` · `BulkInstallerViewModel` · `UninstallerViewModel` |
 | Privacy & Security | `PrivacyViewModel` · `FileShredderViewModel` · `AppBlockerViewModel` · `AppAlertsViewModel` · `PlaceholderViewModel` (Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover · Defender Tweaks · Notification Blocker) |
-| Customization | `ContextMenuViewModel` · `PlaceholderViewModel` (Dark Mode Scheduler · Volume Control · Environment Variables) |
+| Customization | `ContextMenuViewModel` · `EnvironmentVariablesViewModel` · `PlaceholderViewModel` (Dark Mode Scheduler · Volume Control) |
 | Info | `DriversViewModel` · `BatteryHealthViewModel` · `LogsViewModel` · `SystemReportViewModel` · `AboutViewModel` |
 | Advanced | `PlaceholderViewModel` (Profile Export/Import · CLI Interface) |
 
@@ -88,6 +88,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `PrivacyViewModel` — Windows privacy and telemetry toggles via registry.
 - `ContextMenuViewModel` — scan and manage Explorer right-click context menu entries.
 - `SystemReportViewModel` — generate a read-only full-system snapshot and export it as text, HTML, or JSON.
+- `EnvironmentVariablesViewModel` — view/edit User and System environment variables with a dedicated PATH editor (reorder, dedupe, missing-folder detection); staged edits with a one-time backup.
 - `ConsoleViewModel` — shared, per-tab scrollable console (each tab gets its own
   instance; lines capped at 5000 to bound memory) backing the in-app Console mirror
   used by Cleanup, Windows Update, System Health, App Updates, and Uninstaller.
@@ -187,6 +188,10 @@ Key services:
   (OS, CPU, memory, GPU, motherboard, storage health, network) into a
   `SystemReportData` payload, then renders it to plain text, self-contained
   HTML, or JSON so all three exports share a single source of truth.
+- `EnvironmentVariableService` — reads/writes User and Machine environment
+  variables via `Environment.SetEnvironmentVariable` (which broadcasts
+  WM_SETTINGCHANGE), with name validation, pure PATH split/join/dedupe helpers,
+  and a one-time JSON backup of the original environment before the first write.
 - `AppIconService` — downloads and caches application favicons for UI display.
 - `TemperatureService` — aggregates CPU, GPU, and disk temperatures from
   LibreHardwareMonitor (admin) and NvAPIWrapper (non-admin NVIDIA). Real-time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.22.0] - 2026-06-24
+
+### Added
+- **Environment Variables tab.** The Customization group's "Environment Variables" placeholder is now a working tab. View and edit both User and System (machine-wide) variables in one grid, filter by scope, and search by name or value. A dedicated PATH editor opens for PATH-like variables: reorder directories, remove entries, strip duplicates in one click, and see missing folders highlighted. Add or remove variables too. Edits stay local until you press *Apply*; a one-time JSON backup of every variable is written first so the original environment can be restored. System-scope changes require administrator rights (the tab shows the standard elevation banner); User-scope changes do not. Changes broadcast to Windows so new terminals pick them up without a reboot.
+
 ## [1.21.0] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ fully open source.
 
 ### Sidebar navigation
 The sidebar organises 55 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 31 tabs are fully
-implemented; 24 are work-in-progress placeholders marked with ⚙️:
+find what you need without scrolling through a flat list. 32 tabs are fully
+implemented; 23 are work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |
 |-------|------|
@@ -88,7 +88,7 @@ implemented; 24 are work-in-progress placeholders marked with ⚙️:
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS & Hosts |
 | 📦 Apps | App Updates · Bulk Installer · Uninstaller |
 | 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · App Alerts · Debloater & Ads ⚙️ · Browser Cleaner ⚙️ · Edge/OneDrive Remover ⚙️ · Defender Tweaks ⚙️ · Notification Blocker ⚙️ |
-| 🎨 Customization | Context Menu · Dark Mode Scheduler ⚙️ · Volume Control ⚙️ · Environment Variables ⚙️ |
+| 🎨 Customization | Context Menu · Dark Mode Scheduler ⚙️ · Volume Control ⚙️ · Environment Variables |
 | ℹ️ Info | Drivers · Battery Health · System Logs · System Report · About |
 | ⚙️ Advanced | Profile Export/Import ⚙️ · CLI Interface ⚙️ |
 
@@ -119,6 +119,19 @@ deleting anything (uses the standard `LegacyDisable` registry mechanism):
 - **"Applies to" column** — shows whether entry affects Files, Folders, Desktop, or Directory Background
 - **HKCU fallback** — system-protected entries can be toggled via user-level registry override
 - Admin elevation banner with one-click restart as administrator
+
+### Environment Variables
+Edit Windows environment variables without the cramped built-in dialog:
+- **User and System scopes in one grid** — filter by scope, search by name or value
+- **In-place value editing**, plus add and remove variables
+- **Dedicated PATH editor** for PATH-like variables — reorder directories, remove
+  entries, and strip duplicates in one click
+- **Missing folders highlighted** so you can spot dead PATH entries at a glance
+- **Local until Apply** — changes are staged; a one-time JSON backup of every
+  variable is written before the first write so the original environment is recoverable
+- Changes broadcast to Windows, so new terminals pick them up without a reboot
+- System-scope edits need administrator rights (standard elevation banner); user
+  variables can be edited without it
 
 ### Network monitor
 - Live ping across multiple targets overlaid on a single latency chart

--- a/SysManager/SysManager.Tests/EnvironmentVariableServiceTests.cs
+++ b/SysManager/SysManager.Tests/EnvironmentVariableServiceTests.cs
@@ -1,0 +1,180 @@
+// SysManager · EnvironmentVariableServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="EnvironmentVariableService"/>. The pure helpers (name validation,
+/// PATH split/join/dedup) and the file-backed backup/restore are exercised deterministically;
+/// the live registry read/write path is intentionally not unit-tested (it touches the machine
+/// environment and needs admin for the System scope).
+/// </summary>
+public class EnvironmentVariableServiceTests
+{
+    // ---------- ValidateName ----------
+
+    [Theory]
+    [InlineData("PATH")]
+    [InlineData("JAVA_HOME")]
+    [InlineData("_underscore")]
+    [InlineData("My.Var")]
+    [InlineData("Var-1")]
+    public void ValidateName_AcceptsValidNames(string name)
+        => Assert.Equal(name, EnvironmentVariableService.ValidateName(name));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("has space")]
+    [InlineData("has=equals")]
+    [InlineData("1startsWithDigit")]
+    [InlineData("=hiddenDriveVar")]
+    [InlineData("semi;colon")]
+    [InlineData("per%cent")]
+    public void ValidateName_RejectsInvalidNames(string name)
+        => Assert.Throws<ArgumentException>(() => EnvironmentVariableService.ValidateName(name));
+
+    [Fact]
+    public void ValidateName_RejectsOverlongName()
+        => Assert.Throws<ArgumentException>(() => EnvironmentVariableService.ValidateName(new string('A', 256)));
+
+    // ---------- SplitPath / JoinPath ----------
+
+    [Fact]
+    public void SplitPath_TrimsAndDropsEmptySegments()
+    {
+        var result = EnvironmentVariableService.SplitPath(@"C:\a ; ;C:\b;");
+        Assert.Equal([@"C:\a", @"C:\b"], result);
+    }
+
+    [Fact]
+    public void SplitPath_NullOrEmpty_ReturnsEmpty()
+    {
+        Assert.Empty(EnvironmentVariableService.SplitPath(null));
+        Assert.Empty(EnvironmentVariableService.SplitPath(""));
+    }
+
+    [Fact]
+    public void JoinPath_JoinsWithSemicolons_AndDropsBlanks()
+    {
+        var result = EnvironmentVariableService.JoinPath([@"C:\a", "  ", @"C:\b"]);
+        Assert.Equal(@"C:\a;C:\b", result);
+    }
+
+    [Fact]
+    public void SplitThenJoin_RoundTrips()
+    {
+        const string path = @"C:\Windows;C:\Windows\System32;C:\Tools";
+        Assert.Equal(path, EnvironmentVariableService.JoinPath(EnvironmentVariableService.SplitPath(path)));
+    }
+
+    // ---------- Deduplicate ----------
+
+    [Fact]
+    public void Deduplicate_RemovesCaseInsensitiveDuplicates_KeepsFirst()
+    {
+        var result = EnvironmentVariableService.Deduplicate([@"C:\A", @"c:\a", @"C:\B"]);
+        Assert.Equal([@"C:\A", @"C:\B"], result);
+    }
+
+    [Fact]
+    public void Deduplicate_IgnoresTrailingSlashDifference()
+    {
+        var result = EnvironmentVariableService.Deduplicate([@"C:\A\", @"C:\A", @"C:\A\\"]);
+        Assert.Single(result);
+        Assert.Equal(@"C:\A\", result[0]);
+    }
+
+    [Fact]
+    public void Deduplicate_NoDuplicates_PreservesAll()
+    {
+        var input = new[] { @"C:\A", @"C:\B", @"C:\C" };
+        Assert.Equal(input, EnvironmentVariableService.Deduplicate(input));
+    }
+
+    // ---------- Backup / restore ----------
+
+    private static (EnvironmentVariableService svc, string dir) NewServiceWithTempBackup()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "SysManagerEnvTest_" + Guid.NewGuid().ToString("N"));
+        return (new EnvironmentVariableService(dir), dir);
+    }
+
+    [Fact]
+    public void HasBackup_FalseBeforeEnsure_TrueAfter()
+    {
+        var (svc, dir) = NewServiceWithTempBackup();
+        try
+        {
+            Assert.False(svc.HasBackup);
+            svc.EnsureBackup();
+            Assert.True(svc.HasBackup);
+            Assert.True(File.Exists(svc.BackupPath));
+        }
+        finally { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void EnsureBackup_DoesNotOverwriteExistingBackup()
+    {
+        var (svc, dir) = NewServiceWithTempBackup();
+        try
+        {
+            svc.EnsureBackup();
+            var firstWrite = File.GetLastWriteTimeUtc(svc.BackupPath);
+            File.WriteAllText(svc.BackupPath, "{\"User\":{\"SENTINEL\":\"keep\"},\"Machine\":{}}");
+
+            svc.EnsureBackup(); // must be a no-op since a backup already exists
+
+            var restored = svc.ReadBackup();
+            Assert.NotNull(restored);
+            Assert.True(restored!.User.ContainsKey("SENTINEL"));
+            Assert.Equal("keep", restored.User["SENTINEL"]);
+        }
+        finally { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void ReadBackup_NoBackup_ReturnsNull()
+    {
+        var (svc, dir) = NewServiceWithTempBackup();
+        try { Assert.Null(svc.ReadBackup()); }
+        finally { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void ReadBackup_CorruptFile_ReturnsNull()
+    {
+        var (svc, dir) = NewServiceWithTempBackup();
+        try
+        {
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(svc.BackupPath, "{ this is not valid json ");
+            Assert.Null(svc.ReadBackup());
+        }
+        finally { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Read_UserScope_ReturnsSortedNonEmpty()
+    {
+        // The User environment always contains at least TEMP/Path on a real Windows box,
+        // but we only assert structural invariants so the test is robust on CI runners.
+        var (svc, dir) = NewServiceWithTempBackup();
+        try
+        {
+            var vars = svc.Read(EnvVarScope.User);
+            Assert.All(vars, v => Assert.Equal(EnvVarScope.User, v.Scope));
+            Assert.All(vars, v => Assert.False(string.IsNullOrEmpty(v.Name)));
+            // sorted, case-insensitive
+            var names = vars.Select(v => v.Name).ToList();
+            Assert.Equal(names.OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList(), names);
+        }
+        finally { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+    }
+}

--- a/SysManager/SysManager/Models/EnvVariable.cs
+++ b/SysManager/SysManager/Models/EnvVariable.cs
@@ -1,0 +1,39 @@
+// SysManager · EnvVariable
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SysManager.Models;
+
+/// <summary>The registry scope an environment variable lives in.</summary>
+public enum EnvVarScope
+{
+    /// <summary>Per-user variables (HKCU\Environment) — editable without elevation.</summary>
+    User,
+
+    /// <summary>System-wide variables (HKLM ...\Session Manager\Environment) — require administrator.</summary>
+    Machine
+}
+
+/// <summary>
+/// A single Windows environment variable. <see cref="Value"/> is observable so the
+/// grid can edit it in place; <see cref="Name"/> and <see cref="Scope"/> identify it
+/// and never change once loaded.
+/// </summary>
+public sealed partial class EnvVariable : ObservableObject
+{
+    [ObservableProperty] private string _value = "";
+
+    public required string Name { get; init; }
+    public required EnvVarScope Scope { get; init; }
+
+    /// <summary>True for PATH-like variables whose value is a ';'-separated directory list.</summary>
+    public bool IsPathLike =>
+        Name.Equals("Path", StringComparison.OrdinalIgnoreCase) ||
+        Name.Equals("PATHEXT", StringComparison.OrdinalIgnoreCase) ||
+        Name.EndsWith("PATH", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Human-readable scope label for the grid ("User" / "System").</summary>
+    public string ScopeLabel => Scope == EnvVarScope.Machine ? "System" : "User";
+}

--- a/SysManager/SysManager/Models/PathEntry.cs
+++ b/SysManager/SysManager/Models/PathEntry.cs
@@ -1,0 +1,21 @@
+// SysManager · PathEntry
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SysManager.Models;
+
+/// <summary>
+/// One directory inside a PATH-like variable's ';'-separated list. Observable flags
+/// drive the editor's highlighting: <see cref="IsMissing"/> (directory does not exist)
+/// and <see cref="IsDuplicate"/> (same directory appears earlier in the list).
+/// </summary>
+public sealed partial class PathEntry : ObservableObject
+{
+    [ObservableProperty] private string _directory = "";
+    [ObservableProperty] private bool _isMissing;
+    [ObservableProperty] private bool _isDuplicate;
+
+    public PathEntry(string directory) => _directory = directory;
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -60,6 +60,7 @@ public static class ServiceRegistration
         services.AddSingleton<DnsService>();
         services.AddSingleton<HostsFileService>();
         services.AddSingleton<ContextMenuService>();
+        services.AddSingleton<EnvironmentVariableService>();
         services.AddSingleton<WindowsUpdateService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
@@ -96,6 +97,7 @@ public static class ServiceRegistration
         services.AddSingleton<DnsHostsViewModel>();
         services.AddSingleton<ContextMenuViewModel>();
         services.AddSingleton<SystemReportViewModel>();
+        services.AddSingleton<EnvironmentVariablesViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/EnvironmentVariableService.cs
+++ b/SysManager/SysManager/Services/EnvironmentVariableService.cs
@@ -1,0 +1,231 @@
+// SysManager · EnvironmentVariableService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Win32;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Reads and writes Windows environment variables for both the User
+/// (HKCU\Environment) and Machine (HKLM ...\Session Manager\Environment) scopes.
+///
+/// Writes go through <see cref="Environment.SetEnvironmentVariable(string,string,EnvironmentVariableTarget)"/>,
+/// which updates the registry AND broadcasts WM_SETTINGCHANGE so already-running
+/// processes (Explorer, new shells) pick up the change without a reboot.
+///
+/// Machine-scope writes require administrator rights; <see cref="SetVariable"/> returns
+/// <c>false</c> (rather than throwing) when the write is denied, mirroring
+/// <see cref="PrivacyService"/>. A timestamped JSON backup of every variable is written
+/// before the first mutation so the user can fully restore the original environment.
+/// </summary>
+public sealed partial class EnvironmentVariableService
+{
+    private readonly string _backupDir;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
+    /// <summary>
+    /// Creates the service. The optional <paramref name="backupDir"/> override exists
+    /// for testing so the backup/restore logic can run without touching the real
+    /// %LOCALAPPDATA% backup location.
+    /// </summary>
+    public EnvironmentVariableService(string? backupDir = null)
+    {
+        _backupDir = backupDir ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "SysManager", "Backups", "Environment");
+    }
+
+    // Variable names: letters, digits, underscore and a few shell-safe punctuation
+    // characters; no '=', no whitespace, no control chars. Rejects the leading '='
+    // used by hidden drive-current-directory pseudo-variables (=C:, =ExitCode).
+    [GeneratedRegex(@"^[A-Za-z_][A-Za-z0-9_.()\-]*$")]
+    private static partial Regex VariableNameRegex();
+
+    /// <summary>Validates an environment-variable name. Throws <see cref="ArgumentException"/> on invalid input.</summary>
+    public static string ValidateName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Variable name cannot be empty.", nameof(name));
+        if (name.Length > 255)
+            throw new ArgumentException("Variable name is too long (max 255 characters).", nameof(name));
+        if (!VariableNameRegex().IsMatch(name))
+            throw new ArgumentException(
+                $"Invalid variable name: '{name}'. Use letters, digits and underscores; no spaces or '='.", nameof(name));
+        return name.Trim();
+    }
+
+    // ── Reading ──────────────────────────────────────────────────────────────
+
+    /// <summary>Reads all variables for the given scope, sorted by name.</summary>
+    public List<EnvVariable> Read(EnvVarScope scope)
+    {
+        List<EnvVariable> result = [];
+        var target = scope == EnvVarScope.Machine
+            ? EnvironmentVariableTarget.Machine
+            : EnvironmentVariableTarget.User;
+        try
+        {
+            var vars = Environment.GetEnvironmentVariables(target);
+            foreach (System.Collections.DictionaryEntry kv in vars)
+            {
+                var name = kv.Key?.ToString();
+                if (string.IsNullOrEmpty(name)) continue;
+                result.Add(new EnvVariable
+                {
+                    Name = name,
+                    Scope = scope,
+                    Value = kv.Value?.ToString() ?? ""
+                });
+            }
+        }
+        catch (System.Security.SecurityException ex)
+        {
+            Log.Warning(ex, "Environment: reading {Scope} scope denied", scope);
+        }
+        return [.. result.OrderBy(v => v.Name, StringComparer.OrdinalIgnoreCase)];
+    }
+
+    /// <summary>Reads both scopes into one list (User first, then Machine).</summary>
+    public List<EnvVariable> ReadAll()
+    {
+        List<EnvVariable> all = [.. Read(EnvVarScope.User)];
+        all.AddRange(Read(EnvVarScope.Machine));
+        return all;
+    }
+
+    // ── Writing ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Sets (or, when <paramref name="value"/> is null, deletes) a variable. Validates
+    /// the name at the trust boundary. Returns <c>false</c> if the write is denied
+    /// (typically a Machine-scope write without elevation) instead of throwing.
+    /// </summary>
+    public bool SetVariable(string name, string? value, EnvVarScope scope)
+    {
+        var validName = ValidateName(name);
+        var target = scope == EnvVarScope.Machine
+            ? EnvironmentVariableTarget.Machine
+            : EnvironmentVariableTarget.User;
+        try
+        {
+            Environment.SetEnvironmentVariable(validName, value, target);
+            Log.Information("Environment: {Action} {Scope} variable {Name}",
+                value is null ? "deleted" : "set", scope, validName);
+            return true;
+        }
+        catch (System.Security.SecurityException ex)
+        {
+            Log.Warning(ex, "Environment: write to {Scope} variable {Name} denied (elevation required)", scope, validName);
+            return false;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Log.Warning(ex, "Environment: write to {Scope} variable {Name} denied (elevation required)", scope, validName);
+            return false;
+        }
+    }
+
+    /// <summary>Deletes a variable. Returns false if the write is denied.</summary>
+    public bool DeleteVariable(string name, EnvVarScope scope) => SetVariable(name, null, scope);
+
+    // ── PATH helpers (pure, testable) ──────────────────────────────────────────
+
+    /// <summary>
+    /// Splits a ';'-separated PATH value into trimmed, non-empty directory tokens,
+    /// preserving order. (Windows ignores empty PATH segments.)
+    /// </summary>
+    public static List<string> SplitPath(string? value) =>
+        string.IsNullOrEmpty(value)
+            ? []
+            : [.. value.Split(';').Select(p => p.Trim()).Where(p => p.Length > 0)];
+
+    /// <summary>Joins directories back into a ';'-separated PATH value.</summary>
+    public static string JoinPath(IEnumerable<string> directories) =>
+        string.Join(';', directories.Select(d => d.Trim()).Where(d => d.Length > 0));
+
+    /// <summary>
+    /// Removes duplicate directories (case-insensitive, ignoring a trailing '\'),
+    /// keeping the first occurrence and preserving order. Returns the deduplicated list.
+    /// </summary>
+    public static List<string> Deduplicate(IEnumerable<string> directories)
+    {
+        List<string> result = [];
+        HashSet<string> seen = new(StringComparer.OrdinalIgnoreCase);
+        foreach (var dir in directories)
+        {
+            var key = dir.TrimEnd('\\', '/');
+            if (seen.Add(key)) result.Add(dir);
+        }
+        return result;
+    }
+
+    // ── Backup / restore ───────────────────────────────────────────────────────
+
+    /// <summary>Path of the pristine pre-SysManager backup (created before the first write).</summary>
+    public string BackupPath => Path.Combine(_backupDir, "environment-backup.json");
+
+    /// <summary>True if a pristine backup already exists.</summary>
+    public bool HasBackup => File.Exists(BackupPath);
+
+    /// <summary>
+    /// Writes a one-time pristine backup of every User and Machine variable, so the
+    /// original environment can be restored later. No-op if a backup already exists
+    /// (preserving the truly-original snapshot, like <see cref="HostsFileService"/>).
+    /// </summary>
+    public void EnsureBackup()
+    {
+        if (HasBackup) return;
+        Directory.CreateDirectory(_backupDir);
+        var snapshot = new EnvBackup(
+            User: ToDict(Read(EnvVarScope.User)),
+            Machine: ToDict(Read(EnvVarScope.Machine)));
+        File.WriteAllText(BackupPath, JsonSerializer.Serialize(snapshot, JsonOptions),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        Log.Information("Environment: pristine backup written to {Path}", BackupPath);
+    }
+
+    private static Dictionary<string, string> ToDict(IEnumerable<EnvVariable> vars)
+    {
+        Dictionary<string, string> dict = new(StringComparer.OrdinalIgnoreCase);
+        foreach (var v in vars) dict[v.Name] = v.Value;
+        return dict;
+    }
+
+    /// <summary>A point-in-time snapshot of both environment scopes.</summary>
+    public sealed record EnvBackup(
+        Dictionary<string, string> User,
+        Dictionary<string, string> Machine);
+
+    /// <summary>Reads the backup snapshot, or null if there is none / it cannot be parsed.</summary>
+    public EnvBackup? ReadBackup()
+    {
+        if (!HasBackup) return null;
+        try
+        {
+            return JsonSerializer.Deserialize<EnvBackup>(File.ReadAllText(BackupPath), JsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            Log.Warning(ex, "Environment: backup file is corrupt and will be ignored");
+            return null;
+        }
+        catch (IOException ex)
+        {
+            Log.Warning(ex, "Environment: backup file could not be read");
+            return null;
+        }
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.21.0</Version>
-    <FileVersion>1.21.0.0</FileVersion>
-    <AssemblyVersion>1.21.0.0</AssemblyVersion>
+    <Version>1.22.0</Version>
+    <FileVersion>1.22.0.0</FileVersion>
+    <AssemblyVersion>1.22.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
@@ -1,0 +1,411 @@
+// SysManager · EnvironmentVariablesViewModel — view and edit Windows environment variables
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.Specialized;
+using System.IO;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the Environment Variables tab. Lists User and Machine (System)
+/// variables, edits values in place, adds and removes variables, and offers a
+/// dedicated PATH editor (reorder, remove duplicates, flag missing folders).
+/// Edits are local until the user presses Apply; Machine-scope writes need admin.
+/// </summary>
+public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
+{
+    private readonly EnvironmentVariableService _service;
+
+    // Baseline of the on-disk state, keyed "scope\0NAME" → value. Used to compute the
+    // pending-change count (edits + additions + deletions) the same way PrivacyViewModel does.
+    private readonly Dictionary<string, string> _baseline = new(StringComparer.Ordinal);
+
+    // Original (scope, name) pairs captured at load — lets us delete a removed variable by
+    // its real name/scope even after its working item is gone from the list.
+    private readonly Dictionary<string, (EnvVarScope scope, string name)> _originals = new(StringComparer.Ordinal);
+
+    // True while the PATH editor writes back SelectedVariable.Value, so the resulting
+    // PropertyChanged does not rebuild (and discard) the entries currently being edited.
+    private bool _committingPath;
+
+    public BulkObservableCollection<EnvVariable> Variables { get; } = new();
+    public BulkObservableCollection<EnvVariable> FilteredVariables { get; } = new();
+
+    /// <summary>Directories of the selected PATH-like variable, with missing/duplicate flags.</summary>
+    public BulkObservableCollection<PathEntry> PathEntries { get; } = new();
+
+    public List<string> ScopeFilters { get; } = ["All", "User", "System"];
+
+    [ObservableProperty] private string _searchText = "";
+    [ObservableProperty] private string _selectedScopeFilter = "All";
+    [ObservableProperty] private bool _isElevated;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasPendingChanges))]
+    private int _pendingChangeCount;
+
+    public bool HasPendingChanges => PendingChangeCount > 0;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsPathSelected))]
+    private EnvVariable? _selectedVariable;
+
+    public bool IsPathSelected => SelectedVariable?.IsPathLike == true;
+
+    // Add-new row.
+    [ObservableProperty] private string _newName = "";
+    [ObservableProperty] private string _newValue = "";
+    [ObservableProperty] private string _newScope = "User";
+
+    // Add-directory row (PATH editor).
+    [ObservableProperty] private string _newDirectory = "";
+
+    public EnvironmentVariablesViewModel(EnvironmentVariableService service)
+    {
+        _service = service;
+        IsElevated = AdminHelper.IsElevated();
+        Load();
+    }
+
+    private static string Key(EnvVariable v) => Key(v.Scope, v.Name);
+    private static string Key(EnvVarScope scope, string name) => $"{(int)scope}\0{name.ToUpperInvariant()}";
+
+    private void Load()
+    {
+        foreach (var v in Variables)
+            v.PropertyChanged -= OnVariablePropertyChanged;
+
+        var loaded = _service.ReadAll();
+        Variables.ReplaceWith(loaded);
+
+        _baseline.Clear();
+        _originals.Clear();
+        foreach (var v in Variables)
+        {
+            _baseline[Key(v)] = v.Value;
+            _originals[Key(v)] = (v.Scope, v.Name);
+            v.PropertyChanged += OnVariablePropertyChanged;
+        }
+
+        ApplyFilter();
+        RecomputePending();
+        UpdateStatus();
+    }
+
+    partial void OnSearchTextChanged(string value) => ApplyFilter();
+    partial void OnSelectedScopeFilterChanged(string value) => ApplyFilter();
+
+    partial void OnSelectedVariableChanged(EnvVariable? oldValue, EnvVariable? newValue)
+    {
+        if (oldValue is not null)
+            PathEntries.CollectionChanged -= OnPathEntriesChanged;
+        RebuildPathEntries();
+        if (IsPathSelected)
+            PathEntries.CollectionChanged += OnPathEntriesChanged;
+    }
+
+    private void ApplyFilter()
+    {
+        IEnumerable<EnvVariable> source = Variables;
+
+        if (SelectedScopeFilter == "User")
+            source = source.Where(v => v.Scope == EnvVarScope.User);
+        else if (SelectedScopeFilter == "System")
+            source = source.Where(v => v.Scope == EnvVarScope.Machine);
+
+        if (!string.IsNullOrWhiteSpace(SearchText))
+        {
+            var term = SearchText.Trim();
+            source = source.Where(v =>
+                v.Name.Contains(term, StringComparison.OrdinalIgnoreCase) ||
+                v.Value.Contains(term, StringComparison.OrdinalIgnoreCase));
+        }
+
+        FilteredVariables.ReplaceWith(source);
+    }
+
+    private void OnVariablePropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(EnvVariable.Value)) return;
+        RecomputePending();
+        UpdateStatus();
+        // Rebuild the PATH editor only for an external edit (e.g. typing in the grid),
+        // never for the editor's own write-back — that would discard the live entries.
+        if (!_committingPath && ReferenceEquals(sender, SelectedVariable) && IsPathSelected)
+            RebuildPathEntries();
+    }
+
+    private void RecomputePending()
+    {
+        var pending = 0;
+        var live = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var v in Variables)
+        {
+            live.Add(Key(v));
+            if (!_baseline.TryGetValue(Key(v), out var baseValue)) pending++;        // added
+            else if (!string.Equals(baseValue, v.Value, StringComparison.Ordinal)) pending++; // edited
+        }
+        foreach (var key in _baseline.Keys)
+            if (!live.Contains(key)) pending++;                                       // deleted
+
+        PendingChangeCount = pending;
+    }
+
+    // ── PATH editor ────────────────────────────────────────────────────────────
+
+    private void RebuildPathEntries()
+    {
+        if (!IsPathSelected || SelectedVariable is null)
+        {
+            PathEntries.Clear();
+            return;
+        }
+
+        var dirs = EnvironmentVariableService.SplitPath(SelectedVariable.Value);
+        PathEntries.ReplaceWith(dirs.Select(d => new PathEntry(d)));
+        AnnotatePathEntries();
+    }
+
+    private void AnnotatePathEntries()
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in PathEntries)
+        {
+            var key = entry.Directory.TrimEnd('\\', '/');
+            entry.IsDuplicate = !seen.Add(key);
+            try { entry.IsMissing = !string.IsNullOrWhiteSpace(entry.Directory) && !Directory.Exists(entry.Directory); }
+            catch (ArgumentException) { entry.IsMissing = true; } // malformed path characters
+        }
+    }
+
+    private void OnPathEntriesChanged(object? sender, NotifyCollectionChangedEventArgs e) => CommitPathEntries();
+
+    /// <summary>Writes the current PATH-entry order back into the selected variable's value.</summary>
+    private void CommitPathEntries()
+    {
+        if (!IsPathSelected || SelectedVariable is null) return;
+        _committingPath = true;
+        try { SelectedVariable.Value = EnvironmentVariableService.JoinPath(PathEntries.Select(p => p.Directory)); }
+        finally { _committingPath = false; }
+        AnnotatePathEntries();
+    }
+
+    [RelayCommand]
+    private void AddDirectory()
+    {
+        var dir = NewDirectory.Trim();
+        if (dir.Length == 0 || SelectedVariable is null) return;
+        PathEntries.Add(new PathEntry(dir)); // triggers CommitPathEntries via CollectionChanged
+        NewDirectory = "";
+    }
+
+    [RelayCommand]
+    private void RemoveDirectory(PathEntry? entry)
+    {
+        if (entry is null) return;
+        PathEntries.Remove(entry);
+    }
+
+    [RelayCommand]
+    private void MoveDirectoryUp(PathEntry? entry)
+    {
+        if (entry is null) return;
+        var i = PathEntries.IndexOf(entry);
+        if (i > 0) PathEntries.Move(i, i - 1);
+    }
+
+    [RelayCommand]
+    private void MoveDirectoryDown(PathEntry? entry)
+    {
+        if (entry is null) return;
+        var i = PathEntries.IndexOf(entry);
+        if (i >= 0 && i < PathEntries.Count - 1) PathEntries.Move(i, i + 1);
+    }
+
+    [RelayCommand]
+    private void RemoveDuplicateDirectories()
+    {
+        if (!IsPathSelected || SelectedVariable is null) return;
+        var deduped = EnvironmentVariableService.Deduplicate(PathEntries.Select(p => p.Directory));
+        if (deduped.Count == PathEntries.Count)
+        {
+            StatusMessage = "No duplicate directories found.";
+            return;
+        }
+        var removed = PathEntries.Count - deduped.Count;
+        PathEntries.ReplaceWith(deduped.Select(d => new PathEntry(d)));
+        CommitPathEntries();
+        StatusMessage = $"Removed {removed} duplicate director{(removed == 1 ? "y" : "ies")} — press Apply to save.";
+    }
+
+    // ── Add / delete variables ───────────────────────────────────────────────────
+
+    [RelayCommand]
+    private void AddVariable()
+    {
+        string name;
+        try { name = EnvironmentVariableService.ValidateName(NewName); }
+        catch (ArgumentException ex) { StatusMessage = ex.Message; return; }
+
+        var scope = NewScope == "System" ? EnvVarScope.Machine : EnvVarScope.User;
+        if (Variables.Any(v => v.Scope == scope && v.Name.Equals(name, StringComparison.OrdinalIgnoreCase)))
+        {
+            StatusMessage = $"A {NewScope} variable named '{name}' already exists.";
+            return;
+        }
+
+        var added = new EnvVariable { Name = name, Scope = scope, Value = NewValue };
+        added.PropertyChanged += OnVariablePropertyChanged;
+        Variables.Add(added);
+        ApplyFilter();
+        RecomputePending();
+        NewName = "";
+        NewValue = "";
+        StatusMessage = $"Added {NewScope} variable '{name}' — press Apply to save.";
+    }
+
+    [RelayCommand]
+    private void DeleteVariable(EnvVariable? variable)
+    {
+        if (variable is null) return;
+        if (!DialogService.Instance.Confirm(
+                $"Remove the {variable.ScopeLabel} variable '{variable.Name}'?\n\n" +
+                "It is removed locally now and deleted for real when you press Apply.",
+                "Remove Environment Variable"))
+            return;
+
+        variable.PropertyChanged -= OnVariablePropertyChanged;
+        Variables.Remove(variable);
+        if (ReferenceEquals(variable, SelectedVariable)) SelectedVariable = null;
+        ApplyFilter();
+        RecomputePending();
+        StatusMessage = $"Removed '{variable.Name}' locally — press Apply to delete it.";
+    }
+
+    // ── Apply / discard / refresh / restore ──────────────────────────────────────
+
+    [RelayCommand]
+    private void RelaunchAsAdmin()
+    {
+        if (AdminHelper.RelaunchAsAdmin())
+            System.Windows.Application.Current?.Shutdown();
+    }
+
+    [RelayCommand]
+    private void ApplyChanges()
+    {
+        if (PendingChangeCount == 0)
+        {
+            StatusMessage = "No changes to apply.";
+            return;
+        }
+
+        var touchesMachine = ChangedVariables().Any(v => v.Scope == EnvVarScope.Machine)
+            || DeletedEntries().Any(e => e.scope == EnvVarScope.Machine);
+        if (touchesMachine && !IsElevated)
+        {
+            StatusMessage = "Some changes affect System variables — relaunch as administrator first.";
+            return;
+        }
+
+        if (!DialogService.Instance.Confirm(
+                $"Apply {PendingChangeCount} environment change{(PendingChangeCount == 1 ? "" : "s")}?\n\n" +
+                "A one-time backup of all variables is saved first so you can restore the original environment.",
+                "Confirm Environment Changes"))
+        {
+            StatusMessage = "Apply cancelled.";
+            return;
+        }
+
+        _service.EnsureBackup();
+
+        var failures = 0;
+        var applied = 0;
+
+        // Deletions: original variables no longer present in the working set.
+        foreach (var (scope, name) in DeletedEntries().ToList())
+        {
+            if (_service.DeleteVariable(name, scope))
+            {
+                applied++;
+                _baseline.Remove(Key(scope, name));
+                _originals.Remove(Key(scope, name));
+            }
+            else failures++;
+        }
+
+        // Adds + edits.
+        foreach (var v in ChangedVariables().ToList())
+        {
+            if (_service.SetVariable(v.Name, v.Value, v.Scope)) { applied++; _baseline[Key(v)] = v.Value; }
+            else failures++;
+        }
+
+        RecomputePending();
+
+        if (failures == 0)
+        {
+            StatusMessage = $"Applied {applied} change{(applied == 1 ? "" : "s")}. Open a new terminal to see them.";
+            Log.Information("Environment: applied {Count} changes", applied);
+        }
+        else
+        {
+            StatusMessage = $"Applied {applied} change{(applied == 1 ? "" : "s")}; {failures} need administrator rights.";
+            Log.Warning("Environment: {Applied} applied, {Failed} failed (likely elevation required)", applied, failures);
+        }
+    }
+
+    private IEnumerable<EnvVariable> ChangedVariables() => Variables.Where(v =>
+        !_baseline.TryGetValue(Key(v), out var baseValue) ||
+        !string.Equals(baseValue, v.Value, StringComparison.Ordinal));
+
+    private IEnumerable<(EnvVarScope scope, string name)> DeletedEntries()
+    {
+        var live = Variables.Select(Key).ToHashSet(StringComparer.Ordinal);
+        return _originals.Where(kv => !live.Contains(kv.Key)).Select(kv => kv.Value);
+    }
+
+    [RelayCommand]
+    private void DiscardChanges()
+    {
+        Load();
+        StatusMessage = "Pending changes discarded.";
+    }
+
+    [RelayCommand]
+    private void Refresh()
+    {
+        Load();
+        StatusMessage = "Variables refreshed.";
+        Log.Information("Environment: refreshed variable list");
+    }
+
+    private void UpdateStatus()
+    {
+        var userCount = Variables.Count(v => v.Scope == EnvVarScope.User);
+        var sysCount = Variables.Count(v => v.Scope == EnvVarScope.Machine);
+        var summary = $"{userCount} user · {sysCount} system variables.";
+        if (PendingChangeCount > 0)
+            summary += $" {PendingChangeCount} pending change{(PendingChangeCount == 1 ? "" : "s")} — press Apply.";
+        StatusMessage = summary;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            if (IsPathSelected)
+                PathEntries.CollectionChanged -= OnPathEntriesChanged;
+            foreach (var v in Variables)
+                v.PropertyChanged -= OnVariablePropertyChanged;
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -48,6 +48,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public DnsHostsViewModel DnsHosts { get; }
     public ContextMenuViewModel ContextMenu { get; }
     public SystemReportViewModel SystemReport { get; }
+    public EnvironmentVariablesViewModel EnvironmentVariables { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -81,7 +82,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     // Customization group (Context Menu is now fully implemented)
     public PlaceholderViewModel WipDarkModeScheduler { get; private set; } = null!;
     public PlaceholderViewModel WipVolumeControl { get; private set; } = null!;
-    public PlaceholderViewModel WipEnvVariableEditor { get; private set; } = null!;
 
     // System group (additions)
     public PlaceholderViewModel WipTaskScheduler { get; private set; } = null!;
@@ -148,6 +148,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Privacy = sp.GetRequiredService<PrivacyViewModel>();
             ContextMenu = sp.GetRequiredService<ContextMenuViewModel>();
             SystemReport = sp.GetRequiredService<SystemReportViewModel>();
+            EnvironmentVariables = sp.GetRequiredService<EnvironmentVariablesViewModel>();
         }
         else
         {
@@ -199,6 +200,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Privacy = new PrivacyViewModel(new PrivacyService());
             ContextMenu = new ContextMenuViewModel(new ContextMenuService());
             SystemReport = new SystemReportViewModel(new SystemReportService(sysInfo, diskHealth));
+            EnvironmentVariables = new EnvironmentVariablesViewModel(new EnvironmentVariableService());
         }
 
         InitPlaceholders();
@@ -240,7 +242,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         // Customization group (Context Menu is now fully implemented)
         WipDarkModeScheduler = new PlaceholderViewModel("Dark Mode Scheduler", "Auto light/dark theme + color temperature (f.lux-style) on schedule or sunset.", "#329");
         WipVolumeControl = new PlaceholderViewModel("Volume Control", "Per-app volume mixer with output device routing and profile presets.", "#332");
-        WipEnvVariableEditor = new PlaceholderViewModel("Environment Variables", "GUI PATH editor with drag-reorder, duplicate detection, and path validation.", "#331");
 
         // System group (additions)
         WipTaskScheduler = new PlaceholderViewModel("Task Scheduler", "Browse and toggle scheduled tasks with color-coded safety indicators.", "#334");
@@ -340,7 +341,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-context-menu",   "Context Menu",          "", ContextMenu,          typeof(Views.ContextMenuView)),
             Item("nav-dark-mode",      "Dark Mode Scheduler",   "", WipDarkModeScheduler, typeof(Views.PlaceholderView)),
             Item("nav-volume-control", "Volume Control",        "", WipVolumeControl,     typeof(Views.PlaceholderView)),
-            Item("nav-env-variables",  "Environment Variables", "", WipEnvVariableEditor, typeof(Views.PlaceholderView))),
+            Item("nav-env-variables",  "Environment Variables", "", EnvironmentVariables, typeof(Views.EnvironmentVariablesView))),
 
         Group("grp-info", "Info", "",
             Item("nav-drivers",       "Drivers",        "", Drivers,        typeof(Views.DriversView)),
@@ -462,6 +463,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         Privacy?.Dispose();
         ContextMenu?.Dispose();
         SystemReport?.Dispose();
+        EnvironmentVariables?.Dispose();
         WipDebloater?.Dispose();
         WipBrowserCleaner?.Dispose();
         WipEdgeOneDriveRemover?.Dispose();
@@ -469,7 +471,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         WipNotificationBlocker?.Dispose();
         WipDarkModeScheduler?.Dispose();
         WipVolumeControl?.Dispose();
-        WipEnvVariableEditor?.Dispose();
         WipTaskScheduler?.Dispose();
         WipBootAnalyzer?.Dispose();
         WipRestorePoints?.Dispose();

--- a/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
+++ b/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
@@ -1,0 +1,223 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.EnvironmentVariablesView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             d:DataContext="{d:DesignInstance vm:EnvironmentVariablesViewModel}"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             Background="{DynamicResource Surface0}">
+
+    <Grid Margin="28,24,28,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,16">
+            <TextBlock Text="Environment Variables" Style="{StaticResource Display}"/>
+            <TextBlock Text="View and edit User and System environment variables, with a dedicated PATH editor (reorder, remove duplicates, flag missing folders). Changes are local until you press Apply; a one-time backup is saved first."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <!-- Elevation banner: not elevated -->
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        AutomationProperties.Name="Restart SysManager as administrator"
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
+                    <TextBlock Text="Editing System variables writes to machine-wide registry keys and requires administrator privileges. User variables can be edited without it."
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- Elevation banner: elevated -->
+        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — both User and System variables are editable."
+                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Toolbar -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+            <StackPanel>
+                <WrapPanel>
+                    <Button Content="Apply" Command="{Binding ApplyChangesCommand}"
+                            IsEnabled="{Binding HasPendingChanges}"
+                            AutomationProperties.Name="Apply pending environment changes"
+                            Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"
+                            ToolTip="Write pending changes to the registry (a backup is saved first)."/>
+                    <Button Content="Discard" Command="{Binding DiscardChangesCommand}"
+                            IsEnabled="{Binding HasPendingChanges}"
+                            AutomationProperties.Name="Discard pending environment changes"
+                            Style="{StaticResource GhostButton}" Margin="0,0,8,0"
+                            ToolTip="Revert all pending changes."/>
+                    <Button Content="Refresh" Command="{Binding RefreshCommand}"
+                            AutomationProperties.Name="Refresh variable list"
+                            Style="{StaticResource GhostButton}" Margin="0,0,16,0"
+                            ToolTip="Re-read all variables from the registry."/>
+
+                    <TextBlock Text="Scope:" VerticalAlignment="Center" Margin="0,0,8,0" Style="{StaticResource Subtle}"/>
+                    <ComboBox ItemsSource="{Binding ScopeFilters}" SelectedItem="{Binding SelectedScopeFilter}"
+                              AutomationProperties.Name="Filter by scope" Width="100" Margin="0,0,12,0"/>
+                    <TextBox Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                             AutomationProperties.Name="Search variables" Width="220"
+                             VerticalContentAlignment="Center"
+                             ToolTip="Filter by name or value."/>
+                </WrapPanel>
+
+                <!-- Add-new-variable row -->
+                <WrapPanel Margin="0,10,0,0">
+                    <TextBlock Text="New:" VerticalAlignment="Center" Margin="0,0,8,0" Style="{StaticResource Subtle}"/>
+                    <TextBox Text="{Binding NewName, UpdateSourceTrigger=PropertyChanged}"
+                             AutomationProperties.Name="New variable name" Width="160" Margin="0,0,8,0"
+                             VerticalContentAlignment="Center" ToolTip="Variable name (letters, digits, underscore)."/>
+                    <TextBox Text="{Binding NewValue, UpdateSourceTrigger=PropertyChanged}"
+                             AutomationProperties.Name="New variable value" Width="240" Margin="0,0,8,0"
+                             VerticalContentAlignment="Center" ToolTip="Value."/>
+                    <ComboBox ItemsSource="{Binding ScopeFilters}" SelectedItem="{Binding NewScope}"
+                              AutomationProperties.Name="New variable scope" Width="100" Margin="0,0,8,0"/>
+                    <Button Content="Add variable" Command="{Binding AddVariableCommand}"
+                            AutomationProperties.Name="Add new variable"
+                            Style="{StaticResource SecondaryButton}"/>
+                </WrapPanel>
+            </StackPanel>
+        </Border>
+
+        <!-- Content: variables list (left) + PATH editor (right when a PATH variable is selected) -->
+        <Grid Grid.Row="3">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- Variables grid -->
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+                <DataGrid ItemsSource="{Binding FilteredVariables}"
+                          SelectedItem="{Binding SelectedVariable}"
+                          AutomationProperties.Name="Environment variables"
+                          AutoGenerateColumns="False" HeadersVisibility="Column"
+                          CanUserAddRows="False" SelectionMode="Single"
+                          Background="Transparent" BorderThickness="0"
+                          GridLinesVisibility="None"
+                          VirtualizingPanel.IsVirtualizing="True"
+                          VirtualizingPanel.VirtualizationMode="Recycling">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Name" Binding="{Binding Name}" IsReadOnly="True" Width="180"/>
+                        <DataGridTextColumn Header="Scope" Binding="{Binding ScopeLabel}" IsReadOnly="True" Width="70"/>
+                        <DataGridTextColumn Header="Value" Binding="{Binding Value, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                        <DataGridTemplateColumn Header="" Width="Auto">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Button Content="Remove" Command="{Binding DataContext.DeleteVariableCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                            CommandParameter="{Binding}"
+                                            AutomationProperties.Name="{Binding Name, StringFormat='Remove variable {0}'}"
+                                            Style="{StaticResource GhostButton}" Padding="8,4" Margin="4,2"/>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Border>
+
+            <!-- PATH editor -->
+            <Border Grid.Column="1" Style="{StaticResource Card}" Padding="14" Margin="12,0,0,0" Width="380"
+                    Visibility="{Binding IsPathSelected, Converter={StaticResource FlexVis}}">
+                <DockPanel>
+                    <StackPanel DockPanel.Dock="Top">
+                        <TextBlock Text="{Binding SelectedVariable.Name, StringFormat='PATH editor — {0}'}"
+                                   FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource TextPrimary}"/>
+                        <TextBlock Text="Reorder with the arrows, remove entries, or strip duplicates. Missing folders are highlighted."
+                                   Style="{StaticResource Subtle}" Margin="0,2,0,8" TextWrapping="Wrap"/>
+                        <Button Content="Remove duplicates" Command="{Binding RemoveDuplicateDirectoriesCommand}"
+                                AutomationProperties.Name="Remove duplicate PATH directories"
+                                Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left" Margin="0,0,0,8"/>
+                    </StackPanel>
+
+                    <!-- Add directory row -->
+                    <Grid DockPanel.Dock="Bottom" Margin="0,8,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBox Grid.Column="0" Text="{Binding NewDirectory, UpdateSourceTrigger=PropertyChanged}"
+                                 AutomationProperties.Name="New PATH directory" VerticalContentAlignment="Center"
+                                 ToolTip="Directory to append to PATH."/>
+                        <Button Grid.Column="1" Content="Add" Command="{Binding AddDirectoryCommand}"
+                                AutomationProperties.Name="Add PATH directory"
+                                Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"/>
+                    </Grid>
+
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <ItemsControl ItemsSource="{Binding PathEntries}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border Margin="0,2" Padding="8,6" CornerRadius="6" BorderThickness="1"
+                                            Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+                                            <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                                <TextBlock Text="{Binding Directory}" FontSize="12" TextWrapping="Wrap"
+                                                           Foreground="{DynamicResource TextPrimary}"/>
+                                                <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
+                                                    <TextBlock Text="missing folder" FontSize="10" Foreground="#F87171" Margin="0,0,10,0"
+                                                               Visibility="{Binding IsMissing, Converter={StaticResource FlexVis}}"/>
+                                                    <TextBlock Text="duplicate" FontSize="10" Foreground="#FBBF24"
+                                                               Visibility="{Binding IsDuplicate, Converter={StaticResource FlexVis}}"/>
+                                                </StackPanel>
+                                            </StackPanel>
+                                            <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                                <Button Content="&#xE74A;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                                                        Command="{Binding DataContext.MoveDirectoryUpCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                        CommandParameter="{Binding}"
+                                                        AutomationProperties.Name="Move directory up"
+                                                        Style="{StaticResource GhostButton}" Padding="6,2"/>
+                                                <Button Content="&#xE74B;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                                                        Command="{Binding DataContext.MoveDirectoryDownCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                        CommandParameter="{Binding}"
+                                                        AutomationProperties.Name="Move directory down"
+                                                        Style="{StaticResource GhostButton}" Padding="6,2"/>
+                                                <Button Content="&#xE711;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                                                        Command="{Binding DataContext.RemoveDirectoryCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                        CommandParameter="{Binding}"
+                                                        AutomationProperties.Name="Remove directory"
+                                                        Style="{StaticResource GhostButton}" Padding="6,2"/>
+                                            </StackPanel>
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                </DockPanel>
+            </Border>
+        </Grid>
+
+        <!-- Status bar -->
+        <DockPanel Grid.Row="4" Margin="0,8,0,0">
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/EnvironmentVariablesView.xaml.cs
+++ b/SysManager/SysManager/Views/EnvironmentVariablesView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · EnvironmentVariablesView — environment variable editor UI
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class EnvironmentVariablesView : UserControl
+{
+    public EnvironmentVariablesView() => InitializeComponent();
+}


### PR DESCRIPTION
## Summary
Turns the Customization group's **Environment Variables** placeholder into a fully working tab.

- **User + System scopes in one grid** — filter by scope, search by name or value, edit values in place, add and remove variables.
- **Dedicated PATH editor** for PATH-like variables — reorder directories (up/down), remove entries, strip duplicates in one click, and see **missing folders highlighted**.
- **Staged edits** — nothing is written until *Apply*; a one-time JSON backup of every variable is saved first so the original environment can be restored.
- Writes go through `Environment.SetEnvironmentVariable` (broadcasts `WM_SETTINGCHANGE`), so new terminals pick up changes without a reboot.
- System-scope writes require administrator (standard elevation banner); User-scope writes don't.

Closes #331

## Design (matches existing architecture)
- **Service** `EnvironmentVariableService` mirrors `HostsFileService` (one-time pristine backup, `HasBackup`/`ReadBackup`, constructor-injectable backup dir for tests) and `PrivacyService` (write returns `false` on access-denied instead of throwing). Name validation is a `[GeneratedRegex]` trust-boundary check; PATH split/join/dedupe are pure static helpers.
- **ViewModel** `EnvironmentVariablesViewModel` follows `PrivacyViewModel`: baseline/pending-change tracking, `BulkObservableCollection`, `DialogService.Instance.Confirm` before destructive actions, `AdminHelper` elevation, `Dispose` unsubscribes. PATH-editor write-back is guarded against a re-entrant rebuild.
- **View** Strategy-1 layout identical to PrivacyView (root gutter 28,24,28,16; both admin-banner states; toolbar Card; DataGrid with GridLinesVisibility=None/virtualization). `AutomationProperties.Name` on every control. No `DropShadowEffect` (avoids the view-load trap).
- Wired into DI + both `MainWindowViewModel` construction paths; nav glyph U+E943 (unique).

## Safety / security
- Variable names validated at the boundary (no `=`, no whitespace, no leading digit, no shell metacharacters); rejects hidden `=Drive` pseudo-vars and overlong names — covered by negative tests.
- Backup written before the first mutation; System writes need elevation (checked before Apply, and the service degrades gracefully if denied).
- No network anywhere in the path.

## Tests
- 20 tests in `EnvironmentVariableServiceTests`: name validation (accept/reject incl. injection-ish inputs + overlong), PATH split/join round-trip + blank handling, dedupe (case-insensitive, trailing-slash, no-op), backup create/no-overwrite/corrupt-file/missing, and a structural read invariant. Deterministic (temp backup dir, no registry writes).

## Docs
- README (32 implemented / 23 WIP, new feature section, Customization row), ARCHITECTURE (VM + service descriptions, Customization row), CHANGELOG (1.20.69 Added), version bump 1.20.68 → 1.20.69.