### PR TITLE
chore: align version to 1.21.0 (feat: minor bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.20.68] - 2026-06-24
+## [1.21.0] - 2026-06-24
 
 ### Added
 - **System Report tab.** The Info group's "System Report" placeholder is now a working tab. Click *Generate* to gather a full, read-only snapshot of this PC — operating system, CPU, memory (with per-slot detail), GPU, motherboard, storage health (including SMART temperature, wear, and power-on time when available), and active network adapters. Export the report as plain text, a styled self-contained HTML page, or structured JSON, or copy it to the clipboard. The report is read-only: nothing on the system is changed, and the file is written only where you choose — nothing leaves the machine.

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.20.68</Version>
-    <FileVersion>1.20.68.0</FileVersion>
-    <AssemblyVersion>1.20.68.0</AssemblyVersion>
+    <Version>1.21.0</Version>
+    <FileVersion>1.21.0.0</FileVersion>
+    <AssemblyVersion>1.21.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
The System Report feature (#1008) merged as a `feat:`, which auto-release correctly bumped to **1.21.0** (minor). The CHANGELOG header and csproj were mistakenly set to 1.20.68 (patch), so the Release workflow could not find a `## [1.21.0]` section and failed loud — no release was published (users remain on 1.20.67).

This aligns the CHANGELOG header and all three csproj version fields to **1.21.0** so the release for the existing `v1.21.0` tag can publish. No code or behavior change.

`chore:` — does not trigger a new auto-release tag.