### PR TITLE
feat: Restore Points tab — list, create, and restore System Restore points

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,7 +41,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Group | View Models |
 |-------|-------------|
 | Dashboard | `DashboardViewModel` |
-| System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `PlaceholderViewModel` (Restore Points · Task Scheduler · Boot Analyzer) |
+| System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `PlaceholderViewModel` (Task Scheduler · Boot Analyzer) |
 | Gaming & Profiles | `PlaceholderViewModel` (Gaming Profile · Standby List Cleaner · Timer Resolution · CPU Core Affinity · Display Profiles) |
 | Monitor | `ProcessManagerViewModel` · `PlaceholderViewModel` (Resource History · Privacy Monitor · File Lock Detector · Settings Watchdog · Bandwidth Monitor) |
 | Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `PlaceholderViewModel` (Scheduled Maintenance) |
@@ -89,6 +89,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `ContextMenuViewModel` — scan and manage Explorer right-click context menu entries.
 - `SystemReportViewModel` — generate a read-only full-system snapshot and export it as text, HTML, or JSON.
 - `EnvironmentVariablesViewModel` — view/edit User and System environment variables with a dedicated PATH editor (reorder, dedupe, missing-folder detection); staged edits with a one-time backup.
+- `RestorePointsViewModel` — list, create, and restore Windows System Restore points (admin for create/restore; restore reboots, gated by confirmation).
 - `ConsoleViewModel` — shared, per-tab scrollable console (each tab gets its own
   instance; lines capped at 5000 to bound memory) backing the in-app Console mirror
   used by Cleanup, Windows Update, System Health, App Updates, and Uninstaller.
@@ -192,6 +193,10 @@ Key services:
   variables via `Environment.SetEnvironmentVariable` (which broadcasts
   WM_SETTINGCHANGE), with name validation, pure PATH split/join/dedupe helpers,
   and a one-time JSON backup of the original environment before the first write.
+- `RestorePointService` — lists (`Get-ComputerRestorePoint`), creates
+  (`Checkpoint-Computer`), and restores (`Restore-Computer`) System Restore points
+  through the `IPowerShellRunner` seam; the output parser is a pure, unit-tested
+  static method.
 - `AppIconService` — downloads and caches application favicons for UI display.
 - `TemperatureService` — aggregates CPU, GPU, and disk temperatures from
   LibreHardwareMonitor (admin) and NvAPIWrapper (non-admin NVIDIA). Real-time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.23.0] - 2026-06-24
+
+### Added
+- **Restore Points tab.** The System group's "Restore Points" placeholder is now a working tab. List every Windows System Restore point (sequence number, date, description, and type, newest first), create a new restore point with an optional description, and restore the PC to a selected point. Creating and restoring require administrator rights (the tab shows the standard elevation banner); viewing the list does not. Restoring warns clearly that Windows will restart and asks for confirmation first. Creating also enables System Restore on the system drive if it was off, and notes Windows' once-per-24-hour limit.
+
 ## [1.22.0] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ fully open source.
 
 ### Sidebar navigation
 The sidebar organises 55 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 32 tabs are fully
-implemented; 23 are work-in-progress placeholders marked with ⚙️:
+find what you need without scrolling through a flat list. 33 tabs are fully
+implemented; 22 are work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |
 |-------|------|
 | 🏠 Dashboard | Dashboard |
-| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points ⚙️ · Task Scheduler ⚙️ · Boot Analyzer ⚙️ |
+| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Task Scheduler ⚙️ · Boot Analyzer ⚙️ |
 | 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner ⚙️ · Timer Resolution ⚙️ · CPU Core Affinity ⚙️ · Display Profiles ⚙️ |
 | 📊 Monitor | Process Manager · Resource History ⚙️ · Privacy Monitor ⚙️ · File Lock Detector ⚙️ · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance ⚙️ |
@@ -175,6 +175,16 @@ Edit Windows environment variables without the cramped built-in dialog:
 - Memory diagnostic that scans the last 30 days of WHEA events for RAM errors
 - Schedule the Windows Memory Diagnostic at next boot
 - Read-only chkdsk with auto-discovered NTFS/ReFS drives and multi-select
+
+### Restore Points
+- List every Windows System Restore point — sequence number, date, description,
+  and type — newest first
+- **Create** a restore point with an optional custom description (enables System
+  Restore on the system drive first if it's off)
+- **Restore** the PC to a selected point, with a clear confirmation that warns
+  Windows will restart and that programs/drivers added since that point are removed
+- Admin elevation banner — viewing the list works unprivileged; creating and
+  restoring need administrator rights
 
 ### Windows Update (Windows Update Agent COM API)
 - Direct Windows Update Agent COM integration (`Microsoft.Update.Session`) —

--- a/SysManager/SysManager.Tests/RestorePointServiceTests.cs
+++ b/SysManager/SysManager.Tests/RestorePointServiceTests.cs
@@ -1,0 +1,117 @@
+// SysManager · RestorePointServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Management.Automation;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="RestorePointService.ParseRestorePoints"/> — the pure parser that
+/// turns <c>Get-ComputerRestorePoint</c> output into <see cref="RestorePoint"/> records.
+/// Building PSObjects directly keeps these deterministic and free of any live PowerShell
+/// or System Restore dependency. The create/restore paths hit the OS and are not unit-tested.
+/// </summary>
+public class RestorePointServiceTests
+{
+    private static PSObject MakeRow(object? seq, string? desc, string? iso, string? type, string? evt)
+    {
+        var o = new PSObject();
+        o.Properties.Add(new PSNoteProperty("SequenceNumber", seq));
+        o.Properties.Add(new PSNoteProperty("Description", desc));
+        o.Properties.Add(new PSNoteProperty("CreationTimeIso", iso));
+        o.Properties.Add(new PSNoteProperty("RestorePointType", type));
+        o.Properties.Add(new PSNoteProperty("EventType", evt));
+        return o;
+    }
+
+    [Fact]
+    public void Parse_MapsAllFields()
+    {
+        var rows = new[] { MakeRow(7, "Before update", "2026-01-02T13:14:15.0000000+00:00", "MODIFY_SETTINGS", "BEGIN_SYSTEM_CHANGE") };
+        var result = RestorePointService.ParseRestorePoints(rows);
+
+        Assert.Single(result);
+        var rp = result[0];
+        Assert.Equal(7, rp.SequenceNumber);
+        Assert.Equal("Before update", rp.Description);
+        Assert.Equal("MODIFY_SETTINGS", rp.RestorePointType);
+        Assert.Equal("BEGIN_SYSTEM_CHANGE", rp.EventType);
+        Assert.Equal(2026, rp.CreationTime.Year);
+    }
+
+    [Fact]
+    public void Parse_SortsNewestFirstBySequence()
+    {
+        var rows = new[]
+        {
+            MakeRow(3, "c", "2026-01-03T00:00:00Z", "MODIFY_SETTINGS", "x"),
+            MakeRow(1, "a", "2026-01-01T00:00:00Z", "MODIFY_SETTINGS", "x"),
+            MakeRow(2, "b", "2026-01-02T00:00:00Z", "MODIFY_SETTINGS", "x"),
+        };
+        var result = RestorePointService.ParseRestorePoints(rows);
+        Assert.Equal([3, 2, 1], result.Select(r => r.SequenceNumber));
+    }
+
+    [Fact]
+    public void Parse_SkipsRowsWithoutSequenceNumber()
+    {
+        var rows = new[]
+        {
+            MakeRow(null, "no seq", "2026-01-01T00:00:00Z", "MODIFY_SETTINGS", "x"),
+            MakeRow(5, "ok", "2026-01-01T00:00:00Z", "MODIFY_SETTINGS", "x"),
+        };
+        var result = RestorePointService.ParseRestorePoints(rows);
+        Assert.Single(result);
+        Assert.Equal(5, result[0].SequenceNumber);
+    }
+
+    [Fact]
+    public void Parse_HandlesUInt32SequenceFromWmi()
+    {
+        // WMI commonly surfaces SequenceNumber as a uint; the parser must coerce it.
+        var rows = new[] { MakeRow((uint)42, "wmi", "2026-01-01T00:00:00Z", "MODIFY_SETTINGS", "x") };
+        var result = RestorePointService.ParseRestorePoints(rows);
+        Assert.Single(result);
+        Assert.Equal(42, result[0].SequenceNumber);
+    }
+
+    [Fact]
+    public void Parse_MissingOptionalFields_DefaultToEmpty()
+    {
+        var rows = new[] { MakeRow(1, null, null, null, null) };
+        var result = RestorePointService.ParseRestorePoints(rows);
+        Assert.Single(result);
+        Assert.Equal("", result[0].Description);
+        Assert.Equal("", result[0].RestorePointType);
+        Assert.Equal(default, result[0].CreationTime);
+    }
+
+    [Fact]
+    public void Parse_EmptyInput_ReturnsEmpty()
+        => Assert.Empty(RestorePointService.ParseRestorePoints([]));
+
+    // ---------- TypeDisplay mapping ----------
+
+    [Theory]
+    [InlineData("APPLICATION_INSTALL", "App install")]
+    [InlineData("APPLICATION_UNINSTALL", "App uninstall")]
+    [InlineData("DEVICE_DRIVER_INSTALL", "Driver install")]
+    [InlineData("MODIFY_SETTINGS", "Manual / settings")]
+    [InlineData("CANCELLED_OPERATION", "Cancelled operation")]
+    [InlineData("SOMETHING_NEW", "SOMETHING_NEW")]
+    public void TypeDisplay_MapsKnownTypes(string raw, string expected)
+    {
+        var rp = new RestorePoint(1, "d", new DateTime(2026, 1, 1), raw, "e");
+        Assert.Equal(expected, rp.TypeDisplay);
+    }
+
+    [Fact]
+    public void CreatedDisplay_FormatsTimestamp()
+    {
+        var rp = new RestorePoint(1, "d", new DateTime(2026, 1, 2, 13, 14, 0), "MODIFY_SETTINGS", "e");
+        Assert.Equal("2026-01-02 13:14", rp.CreatedDisplay);
+    }
+}

--- a/SysManager/SysManager/Models/RestorePoint.cs
+++ b/SysManager/SysManager/Models/RestorePoint.cs
@@ -1,0 +1,34 @@
+// SysManager · RestorePoint
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// A Windows System Restore point as reported by <c>Get-ComputerRestorePoint</c>.
+/// Immutable snapshot: the sequence number and creation time identify it uniquely.
+/// </summary>
+public sealed record RestorePoint(
+    int SequenceNumber,
+    string Description,
+    DateTime CreationTime,
+    string RestorePointType,
+    string EventType)
+{
+    /// <summary>Human-readable creation timestamp for the grid.</summary>
+    public string CreatedDisplay => CreationTime.ToString("yyyy-MM-dd HH:mm");
+
+    /// <summary>
+    /// Friendly restore-point type label. Windows reports a small set of well-known
+    /// type strings; anything unrecognized falls through to the raw value.
+    /// </summary>
+    public string TypeDisplay => RestorePointType switch
+    {
+        "APPLICATION_INSTALL" => "App install",
+        "APPLICATION_UNINSTALL" => "App uninstall",
+        "DEVICE_DRIVER_INSTALL" => "Driver install",
+        "MODIFY_SETTINGS" => "Manual / settings",
+        "CANCELLED_OPERATION" => "Cancelled operation",
+        _ => RestorePointType
+    };
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -61,6 +61,7 @@ public static class ServiceRegistration
         services.AddSingleton<HostsFileService>();
         services.AddSingleton<ContextMenuService>();
         services.AddSingleton<EnvironmentVariableService>();
+        services.AddSingleton<RestorePointService>();
         services.AddSingleton<WindowsUpdateService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
@@ -98,6 +99,7 @@ public static class ServiceRegistration
         services.AddSingleton<ContextMenuViewModel>();
         services.AddSingleton<SystemReportViewModel>();
         services.AddSingleton<EnvironmentVariablesViewModel>();
+        services.AddSingleton<RestorePointsViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/RestorePointService.cs
+++ b/SysManager/SysManager/Services/RestorePointService.cs
@@ -1,0 +1,137 @@
+// SysManager · RestorePointService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Management.Automation;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Lists, creates, and restores Windows System Restore points via PowerShell.
+///
+/// All PowerShell goes through the <see cref="IPowerShellRunner"/> seam so the parsing
+/// and orchestration can be unit-tested with a substituted runner (Gate-ARCH). Creating
+/// and restoring require administrator rights; restoring triggers a reboot and is gated
+/// behind an explicit confirmation in the ViewModel.
+///
+/// SECURITY: only hard-coded scripts are passed to the runner. The single user-supplied
+/// value (a restore-point description) is single-quote-escaped before being embedded,
+/// matching <see cref="PerformanceService.CreateRestorePointAsync"/>.
+/// </summary>
+public sealed class RestorePointService
+{
+    private readonly IPowerShellRunner _ps;
+
+    private const string CreateOkSentinel = "__SM_RP_CREATED__";
+
+    public RestorePointService(IPowerShellRunner ps) => _ps = ps;
+
+    /// <summary>
+    /// Lists existing restore points, newest first. Returns an empty list if System
+    /// Restore is disabled or the query is denied (logged at Debug).
+    /// </summary>
+    public async Task<IReadOnlyList<RestorePoint>> ListAsync(CancellationToken ct = default)
+    {
+        // Get-ComputerRestorePoint surfaces SequenceNumber, Description, CreationTime
+        // (a WMI CIM_DATETIME string), RestorePointType, and EventType.
+        const string script =
+            "Get-ComputerRestorePoint | Select-Object SequenceNumber, Description, " +
+            "@{N='CreationTimeIso';E={ $_.ConvertToDateTime($_.CreationTime).ToString('o') }}, " +
+            "RestorePointType, EventType";
+        try
+        {
+            Collection<PSObject> results = await _ps.RunAsync(script, cancellationToken: ct).ConfigureAwait(false);
+            return ParseRestorePoints(results);
+        }
+        catch (System.Management.Automation.RuntimeException ex)
+        {
+            Log.Debug("RestorePoint: list failed (System Restore may be disabled): {Error}", ex.Message);
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Parses <c>Get-ComputerRestorePoint</c> output into <see cref="RestorePoint"/> records,
+    /// sorted newest-first. Pure and runner-agnostic so it can be unit-tested directly.
+    /// </summary>
+    public static IReadOnlyList<RestorePoint> ParseRestorePoints(IEnumerable<PSObject> objects)
+    {
+        List<RestorePoint> points = [];
+        foreach (var obj in objects)
+        {
+            if (obj is null) continue;
+            var seq = ToInt(obj.Properties["SequenceNumber"]?.Value);
+            if (seq is null) continue;
+
+            var description = obj.Properties["Description"]?.Value?.ToString()?.Trim() ?? "";
+            var type = obj.Properties["RestorePointType"]?.Value?.ToString()?.Trim() ?? "";
+            var eventType = obj.Properties["EventType"]?.Value?.ToString()?.Trim() ?? "";
+
+            DateTime created = default;
+            var iso = obj.Properties["CreationTimeIso"]?.Value?.ToString();
+            if (!string.IsNullOrWhiteSpace(iso))
+                DateTime.TryParse(iso, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out created);
+
+            points.Add(new RestorePoint(seq.Value, description, created, type, eventType));
+        }
+        return [.. points.OrderByDescending(p => p.SequenceNumber)];
+    }
+
+    private static int? ToInt(object? value) => value switch
+    {
+        null => null,
+        int i => i,
+        uint u => (int)u,
+        long l => (int)l,
+        _ => int.TryParse(value.ToString(), out var n) ? n : null
+    };
+
+    /// <summary>
+    /// Creates a restore point. Requires admin. Returns true only on confirmed success;
+    /// Windows rate-limits creation to one per 24h and reports that as a non-terminating
+    /// error, so a success sentinel is required rather than the absence of an exception.
+    /// </summary>
+    public async Task<bool> CreateAsync(string description, CancellationToken ct = default)
+    {
+        var safeDesc = (string.IsNullOrWhiteSpace(description) ? "SysManager Restore Point" : description)
+            .Replace("'", "''");
+        var script =
+            "try { " +
+            "Enable-ComputerRestore -Drive $env:SystemDrive -ErrorAction SilentlyContinue; " +
+            $"Checkpoint-Computer -Description '{safeDesc}' -RestorePointType 'MODIFY_SETTINGS' -ErrorAction Stop; " +
+            $"'{CreateOkSentinel}' " +
+            "} catch { Write-Error $_; exit 1 }";
+        var results = await _ps.RunAsync(script, cancellationToken: ct).ConfigureAwait(false);
+        var ok = results.Any(o => string.Equals(o?.BaseObject?.ToString(), CreateOkSentinel, StringComparison.Ordinal));
+        if (!ok)
+            Log.Warning("RestorePoint: Checkpoint-Computer did not confirm success (it may be rate-limited to one per 24h).");
+        return ok;
+    }
+
+    /// <summary>
+    /// Restores the system to the given restore point. Requires admin and TRIGGERS A REBOOT.
+    /// The caller MUST confirm with the user first. Returns false if the request could not
+    /// be issued (the machine reboots on success, so a true return is rarely observed).
+    /// </summary>
+    public async Task<bool> RestoreAsync(int sequenceNumber, CancellationToken ct = default)
+    {
+        // SequenceNumber is an int we validate ourselves, so embedding it is injection-safe.
+        var script =
+            $"try {{ Restore-Computer -RestorePoint {sequenceNumber} -Confirm:$false -ErrorAction Stop }} " +
+            "catch { Write-Error $_; exit 1 }";
+        try
+        {
+            await _ps.RunAsync(script, cancellationToken: ct).ConfigureAwait(false);
+            return true;
+        }
+        catch (System.Management.Automation.RuntimeException ex)
+        {
+            Log.Warning("RestorePoint: restore to #{Seq} failed: {Error}", sequenceNumber, ex.Message);
+            return false;
+        }
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.22.0</Version>
-    <FileVersion>1.22.0.0</FileVersion>
-    <AssemblyVersion>1.22.0.0</AssemblyVersion>
+    <Version>1.23.0</Version>
+    <FileVersion>1.23.0.0</FileVersion>
+    <AssemblyVersion>1.23.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -49,6 +49,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public ContextMenuViewModel ContextMenu { get; }
     public SystemReportViewModel SystemReport { get; }
     public EnvironmentVariablesViewModel EnvironmentVariables { get; }
+    public RestorePointsViewModel RestorePoints { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -88,7 +89,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public PlaceholderViewModel WipBootAnalyzer { get; private set; } = null!;
 
     // Advanced group
-    public PlaceholderViewModel WipRestorePoints { get; private set; } = null!;
     public PlaceholderViewModel WipProfileExportImport { get; private set; } = null!;
     public PlaceholderViewModel WipCliInterface { get; private set; } = null!;
 
@@ -149,6 +149,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             ContextMenu = sp.GetRequiredService<ContextMenuViewModel>();
             SystemReport = sp.GetRequiredService<SystemReportViewModel>();
             EnvironmentVariables = sp.GetRequiredService<EnvironmentVariablesViewModel>();
+            RestorePoints = sp.GetRequiredService<RestorePointsViewModel>();
         }
         else
         {
@@ -201,6 +202,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             ContextMenu = new ContextMenuViewModel(new ContextMenuService());
             SystemReport = new SystemReportViewModel(new SystemReportService(sysInfo, diskHealth));
             EnvironmentVariables = new EnvironmentVariablesViewModel(new EnvironmentVariableService());
+            RestorePoints = new RestorePointsViewModel(new RestorePointService(new PowerShellRunner()));
         }
 
         InitPlaceholders();
@@ -248,7 +250,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         WipBootAnalyzer = new PlaceholderViewModel("Boot Analyzer", "Measure boot time breakdown per service/driver with optimization recommendations.", "#343");
 
         // Advanced group
-        WipRestorePoints = new PlaceholderViewModel("Restore Points", "Create and manage system restore points with size tracking.", "#10");
         WipProfileExportImport = new PlaceholderViewModel("Profile Export/Import", "Export SysManager configuration as JSON, import on another PC.", "#341");
         WipCliInterface = new PlaceholderViewModel("CLI Interface", "Command-line control: sysmanager --cleanup --apply-profile Gaming --silent.", "#342");
     }
@@ -285,7 +286,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-services",         "Services",         "", Services,         typeof(Views.ServicesView)),
             Item("nav-startup",          "Startup Manager",  "", Startup,          typeof(Views.StartupView)),
             Item("nav-windows-features", "Windows Features", "", WindowsFeatures,  typeof(Views.WindowsFeaturesView)),
-            Item("nav-restore-points",   "Restore Points",   "", WipRestorePoints, typeof(Views.PlaceholderView)),
+            Item("nav-restore-points",   "Restore Points",   "", RestorePoints,    typeof(Views.RestorePointsView)),
             Item("nav-task-scheduler",   "Task Scheduler",   "", WipTaskScheduler, typeof(Views.PlaceholderView)),
             Item("nav-boot-analyzer",    "Boot Analyzer",    "", WipBootAnalyzer,  typeof(Views.PlaceholderView))),
 
@@ -464,6 +465,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         ContextMenu?.Dispose();
         SystemReport?.Dispose();
         EnvironmentVariables?.Dispose();
+        RestorePoints?.Dispose();
         WipDebloater?.Dispose();
         WipBrowserCleaner?.Dispose();
         WipEdgeOneDriveRemover?.Dispose();
@@ -473,7 +475,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         WipVolumeControl?.Dispose();
         WipTaskScheduler?.Dispose();
         WipBootAnalyzer?.Dispose();
-        WipRestorePoints?.Dispose();
         WipProfileExportImport?.Dispose();
         WipCliInterface?.Dispose();
 

--- a/SysManager/SysManager/ViewModels/RestorePointsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/RestorePointsViewModel.cs
@@ -1,0 +1,180 @@
+// SysManager · RestorePointsViewModel — list, create, and restore System Restore points
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the Restore Points tab. Lists existing System Restore points,
+/// creates new ones, and restores from a selected point. Creating and restoring
+/// require administrator rights; restoring reboots the machine and is gated behind
+/// an explicit confirmation dialog.
+/// </summary>
+public sealed partial class RestorePointsViewModel : ViewModelBase
+{
+    private readonly RestorePointService _service;
+    private CancellationTokenSource? _cts;
+
+    public BulkObservableCollection<RestorePoint> RestorePoints { get; } = new();
+
+    [ObservableProperty] private bool _isElevated;
+    [ObservableProperty] private bool _hasPoints;
+    [ObservableProperty] private string _newDescription = "";
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasSelection))]
+    private RestorePoint? _selectedPoint;
+
+    public bool HasSelection => SelectedPoint is not null;
+
+    public RestorePointsViewModel(RestorePointService service)
+    {
+        _service = service;
+        IsElevated = AdminHelper.IsElevated();
+        StatusMessage = "Loading restore points…";
+        PropertyChanged += OnVmPropertyChanged;
+        InitializeAsync(RefreshAsync);
+    }
+
+    private bool NotBusy => !IsBusy;
+    private bool CanCreate => !IsBusy && IsElevated;
+    private bool CanRestore => !IsBusy && IsElevated && HasSelection;
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(IsBusy) or nameof(IsElevated) or nameof(HasSelection))
+        {
+            RefreshCommand.NotifyCanExecuteChanged();
+            CreateCommand.NotifyCanExecuteChanged();
+            RestoreCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(NotBusy))]
+    private async Task RefreshAsync()
+    {
+        IsBusy = true;
+        IsProgressIndeterminate = true;
+        StatusMessage = "Reading System Restore points…";
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        try
+        {
+            var points = await _service.ListAsync(_cts.Token).ConfigureAwait(true);
+            RestorePoints.ReplaceWith(points);
+            HasPoints = points.Count > 0;
+            StatusMessage = points.Count == 0
+                ? "No restore points found. System Restore may be turned off for this PC."
+                : $"{points.Count} restore point{(points.Count == 1 ? "" : "s")}.";
+        }
+        catch (OperationCanceledException) { StatusMessage = "Cancelled."; }
+        finally
+        {
+            IsBusy = false;
+            IsProgressIndeterminate = false;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanCreate))]
+    private async Task CreateAsync()
+    {
+        var description = string.IsNullOrWhiteSpace(NewDescription)
+            ? $"SysManager — {DateTime.Now:yyyy-MM-dd HH:mm}"
+            : NewDescription.Trim();
+
+        IsBusy = true;
+        IsProgressIndeterminate = true;
+        StatusMessage = "Creating restore point…";
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        try
+        {
+            var ok = await _service.CreateAsync(description, _cts.Token).ConfigureAwait(true);
+            if (ok)
+            {
+                NewDescription = "";
+                StatusMessage = "Restore point created.";
+                ToastService.Instance.Show("Restore point created", description);
+                var points = await _service.ListAsync(_cts.Token).ConfigureAwait(true);
+                RestorePoints.ReplaceWith(points);
+                HasPoints = points.Count > 0;
+            }
+            else
+            {
+                StatusMessage = "Could not create a restore point. Windows allows only one every 24 hours, " +
+                    "and System Restore must be enabled for the system drive.";
+            }
+        }
+        catch (OperationCanceledException) { StatusMessage = "Cancelled."; }
+        finally
+        {
+            IsBusy = false;
+            IsProgressIndeterminate = false;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRestore))]
+    private async Task RestoreAsync()
+    {
+        if (SelectedPoint is not { } point) return;
+
+        if (!DialogService.Instance.Confirm(
+                $"Restore this PC to:\n\n#{point.SequenceNumber} — {point.Description}\n{point.CreatedDisplay}\n\n" +
+                "Windows will RESTART to apply the restore. Open files should be saved and " +
+                "other apps closed first. Your personal files are not affected, but programs and " +
+                "drivers installed after this point will be removed.\n\nContinue?",
+                "Restore System — this will restart Windows"))
+        {
+            StatusMessage = "Restore cancelled.";
+            return;
+        }
+
+        IsBusy = true;
+        IsProgressIndeterminate = true;
+        StatusMessage = "Starting system restore — Windows will restart…";
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        try
+        {
+            var ok = await _service.RestoreAsync(point.SequenceNumber, _cts.Token).ConfigureAwait(true);
+            // On success the machine reboots, so this line is usually never reached.
+            StatusMessage = ok
+                ? "Restore initiated — the system will restart."
+                : "Could not start the restore. Make sure System Restore is enabled and try again.";
+            Log.Information("RestorePoint: restore to #{Seq} requested (ok={Ok})", point.SequenceNumber, ok);
+        }
+        catch (OperationCanceledException) { StatusMessage = "Cancelled."; }
+        finally
+        {
+            IsBusy = false;
+            IsProgressIndeterminate = false;
+        }
+    }
+
+    [RelayCommand]
+    private void Cancel() => _cts?.Cancel();
+
+    [RelayCommand]
+    private void RelaunchAsAdmin()
+    {
+        if (AdminHelper.RelaunchAsAdmin())
+            System.Windows.Application.Current?.Shutdown();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            PropertyChanged -= OnVmPropertyChanged;
+            _cts?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/SysManager/SysManager/Views/RestorePointsView.xaml
+++ b/SysManager/SysManager/Views/RestorePointsView.xaml
@@ -1,0 +1,128 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.RestorePointsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             d:DataContext="{d:DesignInstance vm:RestorePointsViewModel}"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             Background="{DynamicResource Surface0}">
+
+    <Grid Margin="28,24,28,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,16">
+            <TextBlock Text="Restore Points" Style="{StaticResource Display}"/>
+            <TextBlock Text="List, create, and restore Windows System Restore points. Creating and restoring require administrator rights; restoring restarts Windows to roll the system back."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <!-- Elevation banner: not elevated -->
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        AutomationProperties.Name="Restart SysManager as administrator"
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
+                    <TextBlock Text="Creating and restoring restore points require administrator privileges. You can still view existing points without elevation."
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- Elevation banner: elevated -->
+        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — you can create and restore restore points."
+                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Toolbar -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+            <WrapPanel>
+                <TextBox Text="{Binding NewDescription, UpdateSourceTrigger=PropertyChanged}"
+                         AutomationProperties.Name="New restore point description"
+                         Width="240" Margin="0,0,8,0" VerticalContentAlignment="Center"
+                         ToolTip="Optional description for the new restore point."/>
+                <Button Content="Create restore point" Command="{Binding CreateCommand}"
+                        AutomationProperties.Name="Create a restore point"
+                        Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"
+                        ToolTip="Create a new System Restore point (admin; once per 24h)."/>
+                <Button Content="Refresh" Command="{Binding RefreshCommand}"
+                        AutomationProperties.Name="Refresh restore point list"
+                        Style="{StaticResource GhostButton}" Margin="0,0,8,0"
+                        ToolTip="Re-read the list of restore points."/>
+                <Button Content="Cancel" Command="{Binding CancelCommand}"
+                        AutomationProperties.Name="Cancel current operation"
+                        Style="{StaticResource GhostButton}" Margin="0,0,16,0"
+                        Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+
+                <Button Content="Restore selected…" Command="{Binding RestoreCommand}"
+                        AutomationProperties.Name="Restore the selected restore point"
+                        Style="{StaticResource DangerButton}"
+                        ToolTip="Roll the system back to the selected restore point (restarts Windows)."/>
+            </WrapPanel>
+        </Border>
+
+        <!-- Restore points grid -->
+        <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
+            <Grid>
+                <DataGrid ItemsSource="{Binding RestorePoints}"
+                          SelectedItem="{Binding SelectedPoint}"
+                          AutomationProperties.Name="Restore points"
+                          AutoGenerateColumns="False" HeadersVisibility="Column"
+                          CanUserAddRows="False" IsReadOnly="True" SelectionMode="Single"
+                          Background="Transparent" BorderThickness="0"
+                          GridLinesVisibility="None"
+                          VirtualizingPanel.IsVirtualizing="True"
+                          VirtualizingPanel.VirtualizationMode="Recycling">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="#" Binding="{Binding SequenceNumber}" Width="60"/>
+                        <DataGridTextColumn Header="Created" Binding="{Binding CreatedDisplay}" Width="150"/>
+                        <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="*"/>
+                        <DataGridTextColumn Header="Type" Binding="{Binding TypeDisplay}" Width="160"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+
+                <!-- Empty state -->
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center"
+                            Visibility="{Binding HasPoints, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+                    <TextBlock Text="&#xE777;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="32"
+                               HorizontalAlignment="Center" Margin="0,0,0,8" Foreground="{DynamicResource TextSecondary}"/>
+                    <TextBlock Text="No restore points" FontSize="14" FontWeight="SemiBold"
+                               Foreground="{DynamicResource TextSecondary}" HorizontalAlignment="Center"/>
+                    <TextBlock Text="Create one above, or enable System Restore in Windows if the list stays empty."
+                               Style="{StaticResource Subtle}" HorizontalAlignment="Center" Margin="0,4,0,0"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Status bar -->
+        <DockPanel Grid.Row="4" Margin="0,8,0,0">
+            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Right" Width="180" Height="4"
+                         IsIndeterminate="{Binding IsProgressIndeterminate}"
+                         Visibility="{Binding IsBusy, Converter={StaticResource FlexVis}}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" VerticalAlignment="Center"/>
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/RestorePointsView.xaml.cs
+++ b/SysManager/SysManager/Views/RestorePointsView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · RestorePointsView — System Restore point management UI
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class RestorePointsView : UserControl
+{
+    public RestorePointsView() => InitializeComponent();
+}


### PR DESCRIPTION
## Summary
Turns the System group's **Restore Points** placeholder into a working tab.

- **List** every Windows System Restore point — sequence number, date, description, and type — newest first.
- **Create** a restore point with an optional description (enables System Restore on the system drive first if it's off; notes Windows' once-per-24h limit).
- **Restore** the PC to a selected point, behind a clear confirmation that warns Windows will restart and that programs/drivers added since that point are removed.
- Admin elevation banner — viewing works unprivileged; create/restore need administrator.

This delivers the **Restore Point Management** half of #10. The **Scheduled Maintenance** half of that issue is not included here and remains open.

## Design (matches existing architecture)
- **Service** `RestorePointService` runs all PowerShell through the `IPowerShellRunner` seam (Gate-ARCH), reusing the proven success-sentinel idiom from `PerformanceService.CreateRestorePointAsync` (Checkpoint-Computer reports the 24h rate-limit as a non-terminating error). The output parser `ParseRestorePoints` is a pure static method — no live System Restore needed to test it. `Restore-Computer` embeds only an int sequence number (injection-safe); the description is single-quote-escaped.
- **ViewModel** `RestorePointsViewModel` follows the established async/busy pattern (CanExecute gates via NotifyCanExecuteChanged, CTS lifecycle, `InitializeAsync` scan-on-load, `AdminHelper` elevation, `DialogService.Instance.Confirm` before the reboot, `Dispose`).
- **View** Strategy-1 layout (root gutter 28,24,28,16; both admin-banner states; toolbar Card; DataGrid with GridLinesVisibility=None/virtualization; empty state via `HasPoints`). The Restore action uses `DangerButton`. `AutomationProperties.Name` on every control. No `DropShadowEffect`.
- Wired into DI + both `MainWindowViewModel` construction paths; nav glyph U+E7AD (unique).

## Safety / security
- Restore is destructive (reboots + rolls back) → explicit `DialogService.Confirm` with a plain-English warning before anything happens.
- Create/restore degrade gracefully when not elevated (the commands fail and the status explains why); the list still loads.
- No network anywhere in the path; sequence numbers validated as ints before use.

## Tests
- 11 tests in `RestorePointServiceTests`: parser field mapping, newest-first sort, skipping rows without a sequence number, uint→int coercion (WMI), missing-optional-field defaults, empty input, plus `TypeDisplay`/`CreatedDisplay` formatting. Deterministic — PSObjects built in-memory, no live PowerShell.

## Docs
- README (33 implemented / 22 WIP, new feature section, System row), ARCHITECTURE (VM + service descriptions, System row), CHANGELOG (1.23.0 Added), version bump 1.22.0 → 1.23.0.