### PR TITLE
feat: Debloater & Ads tab — remove preinstalled Store apps safely

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,7 +48,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Storage | `DiskAnalyzerViewModel` · `DuplicateFileViewModel` |
 | Network | `PingViewModel` · `TracerouteViewModel` · `SpeedTestViewModel` · `NetworkRepairViewModel` (shared: `NetworkSharedState`) · `DnsHostsViewModel` |
 | Apps | `AppUpdatesViewModel` · `BulkInstallerViewModel` · `UninstallerViewModel` |
-| Privacy & Security | `PrivacyViewModel` · `FileShredderViewModel` · `AppBlockerViewModel` · `AppAlertsViewModel` · `PlaceholderViewModel` (Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover · Defender Tweaks · Notification Blocker) |
+| Privacy & Security | `PrivacyViewModel` · `FileShredderViewModel` · `AppBlockerViewModel` · `AppAlertsViewModel` · `DebloaterViewModel` · `PlaceholderViewModel` (Browser Cleaner · Edge/OneDrive Remover · Defender Tweaks · Notification Blocker) |
 | Customization | `ContextMenuViewModel` · `EnvironmentVariablesViewModel` · `PlaceholderViewModel` (Dark Mode Scheduler · Volume Control) |
 | Info | `DriversViewModel` · `BatteryHealthViewModel` · `LogsViewModel` · `SystemReportViewModel` · `AboutViewModel` |
 | Advanced | `PlaceholderViewModel` (Profile Export/Import · CLI Interface) |
@@ -90,6 +90,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `SystemReportViewModel` — generate a read-only full-system snapshot and export it as text, HTML, or JSON.
 - `EnvironmentVariablesViewModel` — view/edit User and System environment variables with a dedicated PATH editor (reorder, dedupe, missing-folder detection); staged edits with a one-time backup.
 - `RestorePointsViewModel` — list, create, and restore Windows System Restore points (admin for create/restore; restore reboots, gated by confirmation).
+- `DebloaterViewModel` — list and remove preinstalled Store apps with a curated bloat preset; system-critical packages are denylisted; removal is per-user and reversible via the Store.
 - `ConsoleViewModel` — shared, per-tab scrollable console (each tab gets its own
   instance; lines capped at 5000 to bound memory) backing the in-app Console mirror
   used by Cleanup, Windows Update, System Health, App Updates, and Uninstaller.
@@ -197,6 +198,10 @@ Key services:
   (`Checkpoint-Computer`), and restores (`Restore-Computer`) System Restore points
   through the `IPowerShellRunner` seam; the output parser is a pure, unit-tested
   static method.
+- `DebloaterService` — lists (`Get-AppxPackage`) and removes (`Remove-AppxPackage`,
+  per-user) Windows Store apps through the `IPowerShellRunner` seam. A hard-coded
+  denylist of system-critical package families is enforced in code; the parser and
+  denylist check are pure, unit-tested static methods.
 - `AppIconService` — downloads and caches application favicons for UI display.
 - `TemperatureService` — aggregates CPU, GPU, and disk temperatures from
   LibreHardwareMonitor (admin) and NvAPIWrapper (non-admin NVIDIA). Real-time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.24.0] - 2026-06-24
+
+### Added
+- **Debloater & Ads tab.** The Privacy & Security group's "Debloater & Ads" placeholder is now a working tab. Scan installed Windows Store apps and remove the ones you don't use — with a curated "common bloat" preset that pre-selects safe, frequently-removed apps (Bing News/Weather, Clipchamp, Solitaire, Xbox apps, Teams consumer, and more). System-critical packages (the Store itself, frameworks, security and shell components) are denylisted: they're shown but can never be selected or removed. Removal runs per-user with an impact summary and confirmation first, and is reversible — any removed app can be reinstalled from the Microsoft Store. Search and per-app descriptions help you decide what each app is before removing it.
+
 ## [1.23.0] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ fully open source.
 
 ### Sidebar navigation
 The sidebar organises 55 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 33 tabs are fully
-implemented; 22 are work-in-progress placeholders marked with ⚙️:
+find what you need without scrolling through a flat list. 34 tabs are fully
+implemented; 21 are work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |
 |-------|------|
@@ -87,7 +87,7 @@ implemented; 22 are work-in-progress placeholders marked with ⚙️:
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS & Hosts |
 | 📦 Apps | App Updates · Bulk Installer · Uninstaller |
-| 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · App Alerts · Debloater & Ads ⚙️ · Browser Cleaner ⚙️ · Edge/OneDrive Remover ⚙️ · Defender Tweaks ⚙️ · Notification Blocker ⚙️ |
+| 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · App Alerts · Debloater & Ads · Browser Cleaner ⚙️ · Edge/OneDrive Remover ⚙️ · Defender Tweaks ⚙️ · Notification Blocker ⚙️ |
 | 🎨 Customization | Context Menu · Dark Mode Scheduler ⚙️ · Volume Control ⚙️ · Environment Variables |
 | ℹ️ Info | Drivers · Battery Health · System Logs · System Report · About |
 | ⚙️ Advanced | Profile Export/Import ⚙️ · CLI Interface ⚙️ |
@@ -357,6 +357,17 @@ Edit Windows environment variables without the cramped built-in dialog:
 - Fully reversible — unblock restores normal execution
 - Shows list of currently blocked apps with select/deselect and batch unblock
 - Requires admin privileges for registry modifications
+
+### Debloater & Ads
+Remove preinstalled Windows Store apps you don't use:
+- **Scan** all installed Store apps with name, publisher, and a short description
+- **Curated "common bloat" preset** pre-selects safe, frequently-removed apps
+  (Bing News/Weather, Clipchamp, Solitaire, Xbox apps, consumer Teams, and more)
+- **System-critical apps are protected** — the Store, frameworks, and security/shell
+  components are denylisted and can never be selected or removed
+- **Impact summary + confirmation** before anything is uninstalled
+- **Reversible** — removal is per-user, so any app can be reinstalled from the Store
+- Search and per-app descriptions help you decide before removing
 
 ### Battery Health
 - Charge %, health %, wear level, cycle count, chemistry

--- a/SysManager/SysManager.Tests/DebloaterServiceTests.cs
+++ b/SysManager/SysManager.Tests/DebloaterServiceTests.cs
@@ -1,0 +1,125 @@
+// SysManager · DebloaterServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Management.Automation;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="DebloaterService"/>'s pure logic — the denylist
+/// (<see cref="DebloaterService.IsProtected"/>) and the <c>Get-AppxPackage</c> parser
+/// (<see cref="DebloaterService.ParsePackages"/>). PSObjects are built in memory so the
+/// tests need no live Appx subsystem. The actual Remove-AppxPackage path touches the OS
+/// and is not unit-tested.
+/// </summary>
+public class DebloaterServiceTests
+{
+    private static PSObject MakePkg(string? name, string? full, string? family, string? publisher = "CN=Microsoft", string? version = "1.0.0.0")
+    {
+        var o = new PSObject();
+        o.Properties.Add(new PSNoteProperty("Name", name));
+        o.Properties.Add(new PSNoteProperty("PackageFullName", full));
+        o.Properties.Add(new PSNoteProperty("PackageFamilyName", family));
+        o.Properties.Add(new PSNoteProperty("Publisher", publisher));
+        o.Properties.Add(new PSNoteProperty("Version", version));
+        return o;
+    }
+
+    // ---------- IsProtected (denylist) ----------
+
+    [Theory]
+    [InlineData("Microsoft.WindowsStore")]
+    [InlineData("Microsoft.WindowsStore_22210.1402.7.0_x64__8wekyb3d8bbwe")]
+    [InlineData("Microsoft.DesktopAppInstaller")]
+    [InlineData("Microsoft.VCLibs.140.00")]
+    [InlineData("Microsoft.NET.Native.Framework.2.2")]
+    [InlineData("Microsoft.UI.Xaml.2.8")]
+    [InlineData("Microsoft.Windows.ShellExperienceHost")]
+    [InlineData("Microsoft.SecHealthUI")]
+    public void IsProtected_TrueForSystemCriticalPackages(string name)
+        => Assert.True(DebloaterService.IsProtected(name));
+
+    [Theory]
+    [InlineData("Microsoft.BingNews")]
+    [InlineData("Microsoft.MicrosoftSolitaireCollection")]
+    [InlineData("Clipchamp.Clipchamp")]
+    [InlineData("SpotifyAB.SpotifyMusic")]
+    public void IsProtected_FalseForRemovableApps(string name)
+        => Assert.False(DebloaterService.IsProtected(name));
+
+    [Fact]
+    public void IsProtected_IsCaseInsensitive()
+        => Assert.True(DebloaterService.IsProtected("microsoft.windowsstore_x64"));
+
+    // ---------- ParsePackages ----------
+
+    [Fact]
+    public void Parse_MapsFieldsAndFlags()
+    {
+        var rows = new[] { MakePkg("Microsoft.BingNews", "Microsoft.BingNews_1.2_x64__abc", "Microsoft.BingNews_abc") };
+        var result = DebloaterService.ParsePackages(rows);
+
+        Assert.Single(result);
+        var app = result[0];
+        Assert.Equal("Microsoft.BingNews", app.Name);
+        Assert.Equal("Microsoft News", app.DisplayName);   // from catalog
+        Assert.True(app.IsCommonBloat);
+        Assert.False(app.IsProtected);
+        Assert.NotEqual("", app.Description);
+    }
+
+    [Fact]
+    public void Parse_FlagsProtectedPackages()
+    {
+        var rows = new[] { MakePkg("Microsoft.WindowsStore", "Microsoft.WindowsStore_1_x64__abc", "Microsoft.WindowsStore_abc") };
+        var result = DebloaterService.ParsePackages(rows);
+        Assert.Single(result);
+        Assert.True(result[0].IsProtected);
+        Assert.False(result[0].IsCommonBloat); // never both
+    }
+
+    [Fact]
+    public void Parse_SkipsRowsMissingIdentity()
+    {
+        var rows = new[]
+        {
+            MakePkg(null, "full", "family"),
+            MakePkg("Name", null, "family"),
+            MakePkg("Name", "full", null),
+            MakePkg("Microsoft.BingWeather", "Microsoft.BingWeather_1_x64__abc", "Microsoft.BingWeather_abc"),
+        };
+        var result = DebloaterService.ParsePackages(rows);
+        Assert.Single(result);
+        Assert.Equal("Microsoft.BingWeather", result[0].Name);
+    }
+
+    [Fact]
+    public void Parse_OrdersCommonBloatFirst()
+    {
+        var rows = new[]
+        {
+            MakePkg("Contoso.RandomApp", "Contoso.RandomApp_1_x64__abc", "Contoso.RandomApp_abc"),
+            MakePkg("Microsoft.BingNews", "Microsoft.BingNews_1_x64__abc", "Microsoft.BingNews_abc"),
+        };
+        var result = DebloaterService.ParsePackages(rows);
+        Assert.Equal("Microsoft.BingNews", result[0].Name); // common bloat sorts first
+        Assert.Equal("Contoso.RandomApp", result[1].Name);
+    }
+
+    [Fact]
+    public void Parse_UnknownApp_GetsPrettifiedDisplayName()
+    {
+        var rows = new[] { MakePkg("Contoso.SuperWidgetApp", "Contoso.SuperWidgetApp_1_x64__abc", "Contoso.SuperWidgetApp_abc") };
+        var result = DebloaterService.ParsePackages(rows);
+        Assert.Single(result);
+        // "SuperWidgetApp" -> "Super Widget App"
+        Assert.Equal("Super Widget App", result[0].DisplayName);
+        Assert.False(result[0].IsCommonBloat);
+    }
+
+    [Fact]
+    public void Parse_EmptyInput_ReturnsEmpty()
+        => Assert.Empty(DebloaterService.ParsePackages([]));
+}

--- a/SysManager/SysManager/Models/StoreApp.cs
+++ b/SysManager/SysManager/Models/StoreApp.cs
@@ -1,0 +1,42 @@
+// SysManager · StoreApp
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SysManager.Models;
+
+/// <summary>
+/// A removable Windows Store (Appx/MSIX) app, as reported by <c>Get-AppxPackage</c>.
+/// <see cref="IsSelected"/> drives bulk removal; <see cref="IsProtected"/> marks
+/// system-critical packages the denylist refuses to remove (shown disabled in the UI).
+/// </summary>
+public sealed partial class StoreApp : ObservableObject
+{
+    [ObservableProperty] private bool _isSelected;
+    [ObservableProperty] private string _status = "";
+
+    /// <summary>The PackageFullName — the exact identifier passed to Remove-AppxPackage.</summary>
+    public required string PackageFullName { get; init; }
+
+    /// <summary>The PackageFamilyName (stable across versions) — used for matching/denylist.</summary>
+    public required string PackageFamilyName { get; init; }
+
+    /// <summary>The bare package name (e.g. "Microsoft.WindowsCalculator").</summary>
+    public required string Name { get; init; }
+
+    /// <summary>A friendly display name when the curated catalog knows one, else <see cref="Name"/>.</summary>
+    public required string DisplayName { get; init; }
+
+    public required string Publisher { get; init; }
+    public required string Version { get; init; }
+
+    /// <summary>One-line description of what the app is and what removing it affects.</summary>
+    public string Description { get; init; } = "";
+
+    /// <summary>True for system-critical packages that must never be removed (denylisted).</summary>
+    public bool IsProtected { get; init; }
+
+    /// <summary>True for items in the curated "commonly removed bloat" preset.</summary>
+    public bool IsCommonBloat { get; init; }
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -62,6 +62,7 @@ public static class ServiceRegistration
         services.AddSingleton<ContextMenuService>();
         services.AddSingleton<EnvironmentVariableService>();
         services.AddSingleton<RestorePointService>();
+        services.AddSingleton<DebloaterService>();
         services.AddSingleton<WindowsUpdateService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
@@ -100,6 +101,7 @@ public static class ServiceRegistration
         services.AddSingleton<SystemReportViewModel>();
         services.AddSingleton<EnvironmentVariablesViewModel>();
         services.AddSingleton<RestorePointsViewModel>();
+        services.AddSingleton<DebloaterViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/DebloaterService.cs
+++ b/SysManager/SysManager/Services/DebloaterService.cs
@@ -1,0 +1,235 @@
+// SysManager · DebloaterService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+using System.Text.RegularExpressions;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Lists and removes Windows Store (Appx) apps for the current user. All PowerShell
+/// runs through the <see cref="IPowerShellRunner"/> seam so listing/parsing can be
+/// unit-tested with a substituted runner (Gate-ARCH).
+///
+/// SAFETY: a hard-coded denylist of system-critical package families (Store, frameworks,
+/// security/shell components) is enforced in <see cref="IsProtected"/> — those packages
+/// are never offered for removal, even if the catalog or the user selects them. Removal
+/// uses the per-user <c>Remove-AppxPackage</c> (no provisioning/-AllUsers), so it is
+/// reversible: the user can reinstall any removed app from the Microsoft Store.
+/// </summary>
+public sealed partial class DebloaterService
+{
+    private readonly IPowerShellRunner _ps;
+
+    public DebloaterService(IPowerShellRunner ps) => _ps = ps;
+
+    // PackageFullName shape: letters/digits/dot/dash/underscore/tilde, plus we accept the
+    // version and publisher-hash segments. Validated before being embedded in a script.
+    [GeneratedRegex(@"^[A-Za-z0-9][A-Za-z0-9._~-]{0,255}$")]
+    private static partial Regex PackageFullNameRegex();
+
+    /// <summary>
+    /// System-critical package families that must never be removed. Matched by a
+    /// case-insensitive prefix on the family/name so version-specific suffixes still match.
+    /// </summary>
+    private static readonly string[] ProtectedPrefixes =
+    [
+        "Microsoft.WindowsStore",
+        "Microsoft.StorePurchaseApp",
+        "Microsoft.DesktopAppInstaller",       // winget / App Installer
+        "Microsoft.VCLibs",                    // C++ runtime frameworks
+        "Microsoft.NET.Native",                // .NET native frameworks
+        "Microsoft.UI.Xaml",                   // WinUI framework
+        "Microsoft.Services.Store.Engagement",
+        "Microsoft.Windows.ShellExperienceHost",
+        "Microsoft.Windows.StartMenuExperienceHost",
+        "Microsoft.Windows.Search",            // search host
+        "Microsoft.Windows.SecHealthUI",       // Windows Security UI
+        "Microsoft.SecHealthUI",
+        "Microsoft.AAD.BrokerPlugin",
+        "Microsoft.AccountsControl",
+        "Microsoft.LockApp",
+        "Microsoft.CredDialogHost",
+        "Microsoft.Win32WebViewHost",
+        "Microsoft.Windows.CloudExperienceHost",
+        "Microsoft.Windows.ContentDeliveryManager",
+        "Microsoft.Windows.PeopleExperienceHost",
+        "Microsoft.Windows.Photos.Settings",
+        "Microsoft.WindowsAppRuntime",
+        "MicrosoftWindows.Client",             // client framework family
+        "Windows.CBSPreview",
+        "Microsoft.Windows.NarratorQuickStart",
+        "Microsoft.XboxGameCallableUI",
+    ];
+
+    /// <summary>
+    /// Curated "commonly removed bloat" families — pre-checked safe items the preset selects.
+    /// Each entry maps a name prefix to a friendly label + one-line description.
+    /// </summary>
+    private static readonly Dictionary<string, (string Display, string Description)> Catalog =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Microsoft.BingNews"] = ("Microsoft News", "Bing-powered news app."),
+            ["Microsoft.BingWeather"] = ("Weather", "Bing-powered weather app."),
+            ["Microsoft.BingSearch"] = ("Bing Search", "Web search integration."),
+            ["Clipchamp.Clipchamp"] = ("Clipchamp", "Video editor bundled with Windows 11."),
+            ["Microsoft.GamingApp"] = ("Xbox", "Xbox app and Game Pass storefront."),
+            ["Microsoft.XboxGamingOverlay"] = ("Xbox Game Bar", "In-game overlay (Win+G)."),
+            ["Microsoft.XboxIdentityProvider"] = ("Xbox Identity Provider", "Xbox sign-in helper."),
+            ["Microsoft.XboxSpeechToTextOverlay"] = ("Xbox Speech-to-Text", "Game chat captions overlay."),
+            ["Microsoft.ZuneMusic"] = ("Media Player / Groove", "Music & media player."),
+            ["Microsoft.ZuneVideo"] = ("Movies & TV", "Video store and player."),
+            ["Microsoft.MicrosoftSolitaireCollection"] = ("Solitaire Collection", "Bundled solitaire games (with ads)."),
+            ["Microsoft.People"] = ("People", "Contacts aggregator app."),
+            ["Microsoft.windowscommunicationsapps"] = ("Mail & Calendar", "Legacy Mail and Calendar apps."),
+            ["Microsoft.YourPhone"] = ("Phone Link", "Android/iPhone companion."),
+            ["Microsoft.Todos"] = ("Microsoft To Do", "Task list app."),
+            ["Microsoft.PowerAutomateDesktop"] = ("Power Automate", "Desktop automation tool."),
+            ["MicrosoftCorporationII.MicrosoftFamily"] = ("Family", "Family safety app."),
+            ["MicrosoftTeams"] = ("Teams (personal)", "Consumer Teams chat."),
+            ["MicrosoftCorporationII.QuickAssist"] = ("Quick Assist", "Remote assistance tool."),
+            ["Microsoft.Getstarted"] = ("Tips", "Windows tips and getting-started app."),
+            ["Microsoft.MicrosoftOfficeHub"] = ("Office Hub", "Office app launcher/upsell."),
+            ["Microsoft.3DBuilder"] = ("3D Builder", "Legacy 3D model viewer."),
+            ["Microsoft.MixedReality.Portal"] = ("Mixed Reality Portal", "Windows Mixed Reality."),
+            ["Microsoft.SkypeApp"] = ("Skype", "Bundled Skype app."),
+            ["Microsoft.WindowsMaps"] = ("Maps", "Offline maps app."),
+            ["Microsoft.WindowsFeedbackHub"] = ("Feedback Hub", "Sends feedback to Microsoft."),
+        };
+
+    /// <summary>
+    /// Lists installed Store apps for the current user, newest catalog matches first.
+    /// Protected packages are included but flagged <see cref="StoreApp.IsProtected"/>.
+    /// Returns an empty list if the query fails (logged at Debug).
+    /// </summary>
+    public async Task<IReadOnlyList<StoreApp>> ListAsync(CancellationToken ct = default)
+    {
+        // Non-framework, non-resource packages for the current user.
+        const string script =
+            "Get-AppxPackage | Where-Object { -not $_.IsFramework -and -not $_.IsResourcePackage } | " +
+            "Select-Object Name, PackageFullName, PackageFamilyName, Publisher, Version";
+        try
+        {
+            Collection<PSObject> results = await _ps.RunAsync(script, cancellationToken: ct).ConfigureAwait(false);
+            return ParsePackages(results);
+        }
+        catch (System.Management.Automation.RuntimeException ex)
+        {
+            Log.Debug("Debloater: list failed: {Error}", ex.Message);
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Parses <c>Get-AppxPackage</c> output into <see cref="StoreApp"/> records, applying the
+    /// denylist and curated catalog. Pure and runner-agnostic for unit testing.
+    /// </summary>
+    public static IReadOnlyList<StoreApp> ParsePackages(IEnumerable<PSObject> objects)
+    {
+        List<StoreApp> apps = [];
+        foreach (var obj in objects)
+        {
+            if (obj is null) continue;
+            var name = obj.Properties["Name"]?.Value?.ToString()?.Trim();
+            var fullName = obj.Properties["PackageFullName"]?.Value?.ToString()?.Trim();
+            var familyName = obj.Properties["PackageFamilyName"]?.Value?.ToString()?.Trim();
+            if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(fullName) || string.IsNullOrEmpty(familyName))
+                continue;
+
+            var publisher = obj.Properties["Publisher"]?.Value?.ToString()?.Trim() ?? "";
+            var version = obj.Properties["Version"]?.Value?.ToString()?.Trim() ?? "";
+
+            var isProtected = IsProtected(name);
+            var inCatalog = TryGetCatalog(name, out var display, out var description);
+
+            apps.Add(new StoreApp
+            {
+                Name = name,
+                PackageFullName = fullName,
+                PackageFamilyName = familyName,
+                DisplayName = inCatalog ? display : PrettyName(name),
+                Publisher = publisher,
+                Version = version,
+                Description = description,
+                IsProtected = isProtected,
+                IsCommonBloat = inCatalog && !isProtected
+            });
+        }
+        // Curated bloat first, then the rest; alphabetical within each band.
+        return [.. apps
+            .OrderByDescending(a => a.IsCommonBloat)
+            .ThenBy(a => a.DisplayName, StringComparer.OrdinalIgnoreCase)];
+    }
+
+    /// <summary>True if the package name matches a system-critical denylist prefix.</summary>
+    public static bool IsProtected(string packageName) =>
+        ProtectedPrefixes.Any(p => packageName.StartsWith(p, StringComparison.OrdinalIgnoreCase));
+
+    private static bool TryGetCatalog(string name, out string display, out string description)
+    {
+        foreach (var (prefix, entry) in Catalog)
+        {
+            if (name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                display = entry.Display;
+                description = entry.Description;
+                return true;
+            }
+        }
+        display = "";
+        description = "";
+        return false;
+    }
+
+    /// <summary>Turns "Microsoft.WindowsCalculator" into "Windows Calculator" for unknown apps.</summary>
+    private static string PrettyName(string name)
+    {
+        var tail = name.Contains('.') ? name[(name.LastIndexOf('.') + 1)..] : name;
+        return SpaceCamelCase().Replace(tail, "$1 $2").Trim();
+    }
+
+    [GeneratedRegex(@"([a-z0-9])([A-Z])")]
+    private static partial Regex SpaceCamelCase();
+
+    /// <summary>
+    /// Removes a Store app for the current user. Refuses protected packages and validates
+    /// the package full name before use. Returns true on success.
+    /// </summary>
+    public async Task<bool> RemoveAsync(StoreApp app, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        if (app.IsProtected || IsProtected(app.Name))
+        {
+            Log.Warning("Debloater: refusing to remove protected package {Name}", app.Name);
+            return false;
+        }
+        if (!PackageFullNameRegex().IsMatch(app.PackageFullName))
+        {
+            Log.Warning("Debloater: rejected invalid package full name {Full}", app.PackageFullName);
+            return false;
+        }
+
+        var safeFull = app.PackageFullName.Replace("'", "''");
+        var script =
+            "try { " +
+            $"Remove-AppxPackage -Package '{safeFull}' -ErrorAction Stop; '__SM_RM_OK__' " +
+            "} catch { Write-Error $_; exit 1 }";
+        try
+        {
+            var results = await _ps.RunAsync(script, cancellationToken: ct).ConfigureAwait(false);
+            var ok = results.Any(o => string.Equals(o?.BaseObject?.ToString(), "__SM_RM_OK__", StringComparison.Ordinal));
+            if (!ok) Log.Warning("Debloater: removal of {Name} did not confirm success", app.Name);
+            return ok;
+        }
+        catch (System.Management.Automation.RuntimeException ex)
+        {
+            Log.Warning("Debloater: removal of {Name} failed: {Error}", app.Name, ex.Message);
+            return false;
+        }
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.23.0</Version>
-    <FileVersion>1.23.0.0</FileVersion>
-    <AssemblyVersion>1.23.0.0</AssemblyVersion>
+    <Version>1.24.0</Version>
+    <FileVersion>1.24.0.0</FileVersion>
+    <AssemblyVersion>1.24.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DebloaterViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DebloaterViewModel.cs
@@ -1,0 +1,197 @@
+// SysManager · DebloaterViewModel — list and remove preinstalled Store apps safely
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the Debloater &amp; Ads tab. Lists removable Windows Store apps, lets the
+/// user select them (with a curated "common bloat" preset), and removes the selection
+/// per-user after an impact confirmation. System-critical packages are denylisted by the
+/// service and shown disabled. Removal is reversible — apps can be reinstalled from the Store.
+/// </summary>
+public sealed partial class DebloaterViewModel : ViewModelBase
+{
+    private readonly DebloaterService _service;
+    private CancellationTokenSource? _cts;
+
+    public BulkObservableCollection<StoreApp> Apps { get; } = new();
+    public BulkObservableCollection<StoreApp> FilteredApps { get; } = new();
+
+    [ObservableProperty] private string _searchText = "";
+    [ObservableProperty] private bool _hasApps;
+
+    public DebloaterViewModel(DebloaterService service)
+    {
+        _service = service;
+        StatusMessage = "Loading installed apps…";
+        PropertyChanged += OnVmPropertyChanged;
+        InitializeAsync(RefreshAsync);
+    }
+
+    private bool NotBusy => !IsBusy;
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(IsBusy))
+        {
+            RefreshCommand.NotifyCanExecuteChanged();
+            RemoveSelectedCommand.NotifyCanExecuteChanged();
+            SelectCommonBloatCommand.NotifyCanExecuteChanged();
+            ClearSelectionCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    partial void OnSearchTextChanged(string value) => ApplyFilter();
+
+    private void ApplyFilter()
+    {
+        IEnumerable<StoreApp> source = Apps;
+        if (!string.IsNullOrWhiteSpace(SearchText))
+        {
+            var term = SearchText.Trim();
+            source = source.Where(a =>
+                a.DisplayName.Contains(term, StringComparison.OrdinalIgnoreCase) ||
+                a.Name.Contains(term, StringComparison.OrdinalIgnoreCase) ||
+                a.Publisher.Contains(term, StringComparison.OrdinalIgnoreCase));
+        }
+        FilteredApps.ReplaceWith(source);
+    }
+
+    [RelayCommand(CanExecute = nameof(NotBusy))]
+    private async Task RefreshAsync()
+    {
+        IsBusy = true;
+        IsProgressIndeterminate = true;
+        StatusMessage = "Reading installed Store apps…";
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        try
+        {
+            var apps = await _service.ListAsync(_cts.Token).ConfigureAwait(true);
+            Apps.ReplaceWith(apps);
+            HasApps = apps.Count > 0;
+            ApplyFilter();
+            var removable = apps.Count(a => !a.IsProtected);
+            StatusMessage = apps.Count == 0
+                ? "No Store apps found."
+                : $"{apps.Count} apps ({removable} removable, {apps.Count - removable} protected).";
+        }
+        catch (OperationCanceledException) { StatusMessage = "Cancelled."; }
+        finally
+        {
+            IsBusy = false;
+            IsProgressIndeterminate = false;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(NotBusy))]
+    private void SelectCommonBloat()
+    {
+        var n = 0;
+        foreach (var app in Apps)
+        {
+            app.IsSelected = app.IsCommonBloat;
+            if (app.IsSelected) n++;
+        }
+        StatusMessage = $"Selected {n} commonly-removed app{(n == 1 ? "" : "s")}. Review, then Remove selected.";
+    }
+
+    [RelayCommand(CanExecute = nameof(NotBusy))]
+    private void ClearSelection()
+    {
+        foreach (var app in Apps) app.IsSelected = false;
+        StatusMessage = "Selection cleared.";
+    }
+
+    [RelayCommand(CanExecute = nameof(NotBusy))]
+    private async Task RemoveSelectedAsync()
+    {
+        // Protected packages can never be selected for removal, even if a binding tries.
+        var targets = Apps.Where(a => a.IsSelected && !a.IsProtected).ToList();
+        if (targets.Count == 0)
+        {
+            StatusMessage = "Nothing selected. Tick the apps to remove, or use the preset.";
+            return;
+        }
+
+        var preview = string.Join("\n", targets.Take(15).Select(a => $"  • {a.DisplayName}"));
+        if (targets.Count > 15) preview += $"\n  …and {targets.Count - 15} more";
+
+        if (!DialogService.Instance.Confirm(
+                $"Remove {targets.Count} app{(targets.Count == 1 ? "" : "s")} for the current user?\n\n{preview}\n\n" +
+                "This uninstalls them for your account only. You can reinstall any of them later " +
+                "from the Microsoft Store. Continue?",
+                "Remove selected apps"))
+        {
+            StatusMessage = "Removal cancelled.";
+            return;
+        }
+
+        IsBusy = true;
+        IsProgressIndeterminate = false;
+        Progress = 0;
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        var removed = 0;
+        var failed = 0;
+        try
+        {
+            for (var i = 0; i < targets.Count; i++)
+            {
+                _cts.Token.ThrowIfCancellationRequested();
+                var app = targets[i];
+                app.Status = "Removing…";
+                StatusMessage = $"Removing {app.DisplayName} ({i + 1} of {targets.Count})…";
+                var ok = await _service.RemoveAsync(app, _cts.Token).ConfigureAwait(true);
+                if (ok)
+                {
+                    removed++;
+                    app.Status = "Removed";
+                    Apps.Remove(app);
+                }
+                else
+                {
+                    failed++;
+                    app.Status = "Failed";
+                }
+                Progress = (int)((i + 1) * 100.0 / targets.Count);
+            }
+            HasApps = Apps.Count > 0;
+            ApplyFilter();
+            StatusMessage = failed == 0
+                ? $"Removed {removed} app{(removed == 1 ? "" : "s")}. Reinstall any from the Microsoft Store if needed."
+                : $"Removed {removed}; {failed} could not be removed.";
+            Log.Information("Debloater: removed {Removed}, failed {Failed}", removed, failed);
+        }
+        catch (OperationCanceledException)
+        {
+            StatusMessage = $"Cancelled after removing {removed} app{(removed == 1 ? "" : "s")}.";
+        }
+        finally
+        {
+            IsBusy = false;
+            Progress = 0;
+        }
+    }
+
+    [RelayCommand]
+    private void Cancel() => _cts?.Cancel();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            PropertyChanged -= OnVmPropertyChanged;
+            _cts?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -50,6 +50,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public SystemReportViewModel SystemReport { get; }
     public EnvironmentVariablesViewModel EnvironmentVariables { get; }
     public RestorePointsViewModel RestorePoints { get; }
+    public DebloaterViewModel Debloater { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -73,8 +74,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
     // Apps group (Bulk Installer is now fully implemented)
 
-    // Privacy & Security group (Privacy & Telemetry is now fully implemented)
-    public PlaceholderViewModel WipDebloater { get; private set; } = null!;
+    // Privacy & Security group (Privacy & Telemetry + Debloater now fully implemented)
     public PlaceholderViewModel WipBrowserCleaner { get; private set; } = null!;
     public PlaceholderViewModel WipEdgeOneDriveRemover { get; private set; } = null!;
     public PlaceholderViewModel WipDefenderTweaks { get; private set; } = null!;
@@ -150,6 +150,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             SystemReport = sp.GetRequiredService<SystemReportViewModel>();
             EnvironmentVariables = sp.GetRequiredService<EnvironmentVariablesViewModel>();
             RestorePoints = sp.GetRequiredService<RestorePointsViewModel>();
+            Debloater = sp.GetRequiredService<DebloaterViewModel>();
         }
         else
         {
@@ -203,6 +204,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             SystemReport = new SystemReportViewModel(new SystemReportService(sysInfo, diskHealth));
             EnvironmentVariables = new EnvironmentVariablesViewModel(new EnvironmentVariableService());
             RestorePoints = new RestorePointsViewModel(new RestorePointService(new PowerShellRunner()));
+            Debloater = new DebloaterViewModel(new DebloaterService(new PowerShellRunner()));
         }
 
         InitPlaceholders();
@@ -235,7 +237,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         // Apps group — Bulk Installer is now fully implemented (no placeholder needed)
 
         // Privacy & Security group (Privacy & Telemetry is now fully implemented)
-        WipDebloater = new PlaceholderViewModel("Debloater & Ads", "Remove UWP bloatware, disable all Windows ads, remove Copilot/Recall/AI features.", "#9");
         WipBrowserCleaner = new PlaceholderViewModel("Browser Cleaner", "Per-browser cache/cookies/history cleanup with keep-list for important cookies.", "#336");
         WipEdgeOneDriveRemover = new PlaceholderViewModel("Edge/OneDrive Remover", "Safely remove or disable Edge and OneDrive with full restore capability.", "#339");
         WipDefenderTweaks = new PlaceholderViewModel("Defender Tweaks", "Toggle SmartScreen, manage exclusions, configure PUA and cloud protection.", "#344");
@@ -332,7 +333,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-file-shredder",        "File Shredder",         "", FileShredder,           typeof(Views.FileShredderView)),
             Item("nav-app-blocker",          "App Blocker",           "", AppBlocker,             typeof(Views.AppBlockerView)),
             Item("nav-app-alerts",           "App Alerts",            "", AppAlerts,              typeof(Views.AppAlertsView)),
-            Item("nav-debloater",            "Debloater & Ads",       "", WipDebloater,           typeof(Views.PlaceholderView)),
+            Item("nav-debloater",            "Debloater & Ads",       "", Debloater,             typeof(Views.DebloaterView)),
             Item("nav-browser-cleaner",      "Browser Cleaner",       "", WipBrowserCleaner,      typeof(Views.PlaceholderView)),
             Item("nav-edge-onedrive",        "Edge/OneDrive Remover", "", WipEdgeOneDriveRemover, typeof(Views.PlaceholderView)),
             Item("nav-defender-tweaks",      "Defender Tweaks",       "", WipDefenderTweaks,      typeof(Views.PlaceholderView)),
@@ -466,7 +467,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         SystemReport?.Dispose();
         EnvironmentVariables?.Dispose();
         RestorePoints?.Dispose();
-        WipDebloater?.Dispose();
+        Debloater?.Dispose();
         WipBrowserCleaner?.Dispose();
         WipEdgeOneDriveRemover?.Dispose();
         WipDefenderTweaks?.Dispose();

--- a/SysManager/SysManager/Views/DebloaterView.xaml
+++ b/SysManager/SysManager/Views/DebloaterView.xaml
@@ -1,0 +1,132 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.DebloaterView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             d:DataContext="{d:DesignInstance vm:DebloaterViewModel}"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             Background="{DynamicResource Surface0}">
+
+    <Grid Margin="28,24,28,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,16">
+            <TextBlock Text="Debloater &amp; Ads" Style="{StaticResource Display}"/>
+            <TextBlock Text="Remove preinstalled Store apps you don't use. A curated preset pre-selects commonly-removed bloat; system-critical apps are protected and can't be removed. Everything is uninstalled for your account only and can be reinstalled from the Microsoft Store."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <!-- Toolbar -->
+        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+            <WrapPanel>
+                <Button Content="Select common bloat" Command="{Binding SelectCommonBloatCommand}"
+                        AutomationProperties.Name="Select commonly removed apps"
+                        Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"
+                        ToolTip="Pre-select the curated set of commonly-removed apps."/>
+                <Button Content="Clear selection" Command="{Binding ClearSelectionCommand}"
+                        AutomationProperties.Name="Clear selection"
+                        Style="{StaticResource GhostButton}" Margin="0,0,8,0"/>
+                <Button Content="Refresh" Command="{Binding RefreshCommand}"
+                        AutomationProperties.Name="Refresh app list"
+                        Style="{StaticResource GhostButton}" Margin="0,0,8,0"/>
+                <Button Content="Cancel" Command="{Binding CancelCommand}"
+                        AutomationProperties.Name="Cancel current operation"
+                        Style="{StaticResource GhostButton}" Margin="0,0,16,0"
+                        Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+
+                <Button Content="Remove selected…" Command="{Binding RemoveSelectedCommand}"
+                        AutomationProperties.Name="Remove selected apps"
+                        Style="{StaticResource DangerButton}" Margin="0,0,16,0"
+                        ToolTip="Uninstall the ticked apps for the current user (reversible via the Store)."/>
+
+                <TextBox Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                         AutomationProperties.Name="Search apps" Width="220"
+                         VerticalContentAlignment="Center" VerticalAlignment="Center"
+                         ToolTip="Filter by name or publisher."/>
+            </WrapPanel>
+        </Border>
+
+        <!-- Apps grid -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
+            <Grid>
+                <DataGrid ItemsSource="{Binding FilteredApps}"
+                          AutomationProperties.Name="Installed Store apps"
+                          AutoGenerateColumns="False" HeadersVisibility="Column"
+                          CanUserAddRows="False" SelectionMode="Single"
+                          Background="Transparent" BorderThickness="0"
+                          GridLinesVisibility="None"
+                          VirtualizingPanel.IsVirtualizing="True"
+                          VirtualizingPanel.VirtualizationMode="Recycling">
+                    <DataGrid.Columns>
+                        <DataGridTemplateColumn Header="" Width="44">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <CheckBox IsChecked="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}"
+                                              IsEnabled="{Binding IsProtected, Converter={StaticResource BoolInvert}}"
+                                              AutomationProperties.Name="{Binding DisplayName, StringFormat='Select {0} for removal'}"
+                                              HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTemplateColumn Header="App" Width="*">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <StackPanel Margin="0,4">
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" FontSize="13"
+                                                       Foreground="{DynamicResource TextPrimary}"/>
+                                            <Border Background="{DynamicResource Surface3}" CornerRadius="4" Padding="6,1" Margin="8,0,0,0"
+                                                    VerticalAlignment="Center"
+                                                    Visibility="{Binding IsProtected, Converter={StaticResource FlexVis}}">
+                                                <TextBlock Text="Protected" FontSize="10" Foreground="{DynamicResource TextMuted}"/>
+                                            </Border>
+                                            <Border Background="{DynamicResource Surface3}" CornerRadius="4" Padding="6,1" Margin="8,0,0,0"
+                                                    VerticalAlignment="Center"
+                                                    Visibility="{Binding IsCommonBloat, Converter={StaticResource FlexVis}}">
+                                                <TextBlock Text="Common bloat" FontSize="10" Foreground="{DynamicResource TextMuted}"/>
+                                            </Border>
+                                        </StackPanel>
+                                        <TextBlock Text="{Binding Description}" FontSize="11" Foreground="{DynamicResource TextMuted}"
+                                                   TextWrapping="Wrap" Margin="0,2,16,0"
+                                                   Visibility="{Binding Description, Converter={StaticResource FlexVis}}"/>
+                                        <TextBlock Text="{Binding Name}" FontSize="10" Foreground="{DynamicResource TextMuted}"
+                                                   Opacity="0.6" Margin="0,2,0,0"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTextColumn Header="Publisher" Binding="{Binding Publisher}" IsReadOnly="True" Width="200"/>
+                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" IsReadOnly="True" Width="100"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+
+                <!-- Empty state -->
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center"
+                            Visibility="{Binding HasApps, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+                    <TextBlock Text="&#xECAA;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="32"
+                               HorizontalAlignment="Center" Margin="0,0,0,8" Foreground="{DynamicResource TextSecondary}"/>
+                    <TextBlock Text="No apps loaded" FontSize="14" FontWeight="SemiBold"
+                               Foreground="{DynamicResource TextSecondary}" HorizontalAlignment="Center"/>
+                    <TextBlock Text="Press Refresh to scan installed Store apps."
+                               Style="{StaticResource Subtle}" HorizontalAlignment="Center" Margin="0,4,0,0"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Status bar -->
+        <DockPanel Grid.Row="3" Margin="0,8,0,0">
+            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Right" Width="180" Height="4"
+                         IsIndeterminate="{Binding IsProgressIndeterminate}" Value="{Binding Progress}" Maximum="100"
+                         Visibility="{Binding IsBusy, Converter={StaticResource FlexVis}}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" VerticalAlignment="Center"/>
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/DebloaterView.xaml.cs
+++ b/SysManager/SysManager/Views/DebloaterView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · DebloaterView — Store app debloater UI
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class DebloaterView : UserControl
+{
+    public DebloaterView() => InitializeComponent();
+}


### PR DESCRIPTION
## Summary
Turns the Privacy & Security group's **Debloater & Ads** placeholder into a working tab.

- **Scan** installed Windows Store apps with name, publisher, and a short description.
- **Curated "common bloat" preset** pre-selects safe, frequently-removed apps (Bing News/Weather, Clipchamp, Solitaire, Xbox apps, consumer Teams, and more).
- **System-critical apps are denylisted** — the Store, frameworks, and security/shell components are shown but can never be selected or removed.
- **Impact summary + confirmation** before anything is uninstalled.
- **Reversible** — removal is per-user (`Remove-AppxPackage`, no provisioning), so any app can be reinstalled from the Microsoft Store.
- Search + per-app descriptions to decide before removing.

Closes #908

## Design (matches existing architecture)
- **Service** `DebloaterService` runs `Get-AppxPackage` / `Remove-AppxPackage` through the `IPowerShellRunner` seam (Gate-ARCH). The denylist (system-critical package families) and the parser are pure static methods, mirroring `AppBlockerService`'s `BootCriticalExecutables` HashSet guard and `UninstallerService`'s `[GeneratedRegex]` validation. PackageFullName is regex-validated and single-quote-escaped before use.
- **ViewModel** `DebloaterViewModel` follows the established async/busy + `DialogService.Confirm` + `InitializeAsync` + `Dispose` pattern; protected apps can never be removed even if a binding tries.
- **View** Strategy-1 layout; checkbox column disabled for protected items (via `BoolInvert`), `DangerButton` for the destructive action, empty state via `HasApps`, per-item Protected/Common-bloat tags. `AutomationProperties.Name` on every control. No `DropShadowEffect`.
- Wired into DI + both `MainWindowViewModel` construction paths; nav glyph U+EC61 (was a 3-way duplicate of the trash glyph as a placeholder).

## Safety / security
- Hard-coded denylist enforced in BOTH the service (`RemoveAsync` refuses protected packages) and the UI (checkbox disabled) — defense in depth.
- Per-user removal only — never `-AllUsers` / provisioning, so it can't break the machine image and is always reinstallable.
- Impact summary + confirmation before removal; no network in the path.

## Tests
- 16 tests in `DebloaterServiceTests`: denylist (protected vs removable, case-insensitive, version-suffixed family names), parser field mapping + flags, skip-rows-missing-identity, common-bloat-first ordering, prettified display names for unknown apps, empty input. Deterministic — PSObjects built in memory.

## Docs
- README (34 implemented / 21 WIP, new feature section, Privacy & Security row), ARCHITECTURE (VM + service descriptions, Privacy row), CHANGELOG (1.24.0 Added), version bump → 1.24.0.