### PR TITLE
feat: Legacy Panels tab — one-click launcher for classic Windows applets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,7 +41,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Group | View Models |
 |-------|-------------|
 | Dashboard | `DashboardViewModel` |
-| System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `PlaceholderViewModel` (Task Scheduler · Boot Analyzer) |
+| System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `LegacyPanelsViewModel` · `PlaceholderViewModel` (Task Scheduler · Boot Analyzer) |
 | Gaming & Profiles | `PlaceholderViewModel` (Gaming Profile · Standby List Cleaner · Timer Resolution · CPU Core Affinity · Display Profiles) |
 | Monitor | `ProcessManagerViewModel` · `PlaceholderViewModel` (Resource History · Privacy Monitor · File Lock Detector · Settings Watchdog · Bandwidth Monitor) |
 | Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `PlaceholderViewModel` (Scheduled Maintenance) |
@@ -90,6 +90,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `SystemReportViewModel` — generate a read-only full-system snapshot and export it as text, HTML, or JSON.
 - `EnvironmentVariablesViewModel` — view/edit User and System environment variables with a dedicated PATH editor (reorder, dedupe, missing-folder detection); staged edits with a one-time backup.
 - `RestorePointsViewModel` — list, create, and restore Windows System Restore points (admin for create/restore; restore reboots, gated by confirmation).
+- `LegacyPanelsViewModel` — one-click launcher for the fixed catalog of classic Windows applets (pure launchers, no system modification).
 - `DebloaterViewModel` — list and remove preinstalled Store apps with a curated bloat preset; system-critical packages are denylisted; removal is per-user and reversible via the Store.
 - `ConsoleViewModel` — shared, per-tab scrollable console (each tab gets its own
   instance; lines capped at 5000 to bound memory) backing the in-app Console mirror
@@ -202,6 +203,10 @@ Key services:
   per-user) Windows Store apps through the `IPowerShellRunner` seam. A hard-coded
   denylist of system-critical package families is enforced in code; the parser and
   denylist check are pure, unit-tested static methods.
+- `LegacyPanelService` — opens classic Windows applets (Control Panel, Sound,
+  Device Manager, …) via their `control`/`*.cpl`/`*.msc` commands. The catalog is
+  hard-coded and `Launch` re-validates catalog membership, so no input reaches
+  `Process.Start`; pure launchers, no system modification.
 - `AppIconService` — downloads and caches application favicons for UI display.
 - `TemperatureService` — aggregates CPU, GPU, and disk temperatures from
   LibreHardwareMonitor (admin) and NvAPIWrapper (non-admin NVIDIA). Real-time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.25.0] - 2026-06-24
+
+### Added
+- **Legacy Panels tab** (System group). A one-click launcher for the classic Windows applets that newer releases keep burying — Control Panel, Sound, Power Options, Network Connections, Region, System Properties, User Accounts, Device Manager, Computer Management, Programs and Features, Mouse, and Date and Time. Each is a pure launcher that just opens the built-in panel; nothing is modified, so no elevation or confirmation is needed. The applet list is hard-coded, so no input ever reaches the process launcher.
+
 ## [1.24.0] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ fully open source.
 ## Features
 
 ### Sidebar navigation
-The sidebar organises 55 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 34 tabs are fully
+The sidebar organises 56 feature tabs into 12 collapsible groups so you can
+find what you need without scrolling through a flat list. 35 tabs are fully
 implemented; 21 are work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |
 |-------|------|
 | 🏠 Dashboard | Dashboard |
-| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Task Scheduler ⚙️ · Boot Analyzer ⚙️ |
+| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Legacy Panels · Task Scheduler ⚙️ · Boot Analyzer ⚙️ |
 | 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner ⚙️ · Timer Resolution ⚙️ · CPU Core Affinity ⚙️ · Display Profiles ⚙️ |
 | 📊 Monitor | Process Manager · Resource History ⚙️ · Privacy Monitor ⚙️ · File Lock Detector ⚙️ · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance ⚙️ |
@@ -185,6 +185,15 @@ Edit Windows environment variables without the cramped built-in dialog:
   Windows will restart and that programs/drivers added since that point are removed
 - Admin elevation banner — viewing the list works unprivileged; creating and
   restoring need administrator rights
+
+### Legacy Panels
+- One-click launcher for the classic Windows applets that newer releases keep
+  hiding: Control Panel, Sound, Power Options, Network Connections, Region,
+  System Properties, User Accounts, Device Manager, Computer Management,
+  Programs and Features, Mouse, and Date and Time
+- **Pure launchers** — each just opens the built-in panel; nothing is modified,
+  so no elevation or confirmation is needed
+- The applet list is fixed in code, so no typed input ever reaches the launcher
 
 ### Windows Update (Windows Update Agent COM API)
 - Direct Windows Update Agent COM integration (`Microsoft.Update.Session`) —

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -75,16 +75,16 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
-    public void NavItems_ContainAll55()
+    public void NavItems_ContainAll56()
     {
         var vm = new MainWindowViewModel();
-        Assert.Equal(55, vm.NavItems.Count);
+        Assert.Equal(56, vm.NavItems.Count);
         var ids = vm.NavItems.Select(n => n.Id).ToList();
 
         // Dashboard
         Assert.Contains("nav-dashboard", ids);
 
-        // System (9)
+        // System (10)
         Assert.Contains("nav-system-health", ids);
         Assert.Contains("nav-windows-update", ids);
         Assert.Contains("nav-performance", ids);
@@ -94,6 +94,7 @@ public class MainWindowViewModelTests
         Assert.Contains("nav-restore-points", ids);
         Assert.Contains("nav-task-scheduler", ids);
         Assert.Contains("nav-boot-analyzer", ids);
+        Assert.Contains("nav-legacy-panels", ids);
 
         // Gaming & Profiles (5)
         Assert.Contains("nav-gaming-profile", ids);
@@ -238,11 +239,11 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
-    public void NavGroups_SystemGroup_Contains9Items()
+    public void NavGroups_SystemGroup_Contains10Items()
     {
         var vm = new MainWindowViewModel();
         var sys = vm.NavGroups.First(g => g.Id == "grp-system");
-        Assert.Equal(9, sys.Children.Count);
+        Assert.Equal(10, sys.Children.Count);
         var ids = sys.Children.Select(c => c.Id).ToList();
         Assert.Contains("nav-system-health", ids);
         Assert.Contains("nav-windows-update", ids);
@@ -253,6 +254,7 @@ public class MainWindowViewModelTests
         Assert.Contains("nav-restore-points", ids);
         Assert.Contains("nav-task-scheduler", ids);
         Assert.Contains("nav-boot-analyzer", ids);
+        Assert.Contains("nav-legacy-panels", ids);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/LegacyPanelServiceTests.cs
+++ b/SysManager/SysManager.Tests/LegacyPanelServiceTests.cs
@@ -1,0 +1,63 @@
+// SysManager · LegacyPanelServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="LegacyPanelService"/>. The catalog is asserted for integrity
+/// (every entry well-formed, names unique) and <see cref="LegacyPanelService.Launch"/>
+/// is verified to reject panels that are not part of the hard-coded catalog (the
+/// security boundary). Actually launching an applet is a side effect and not unit-tested.
+/// </summary>
+public class LegacyPanelServiceTests
+{
+    [Fact]
+    public void Panels_CatalogIsNotEmpty()
+        => Assert.NotEmpty(LegacyPanelService.Panels);
+
+    [Fact]
+    public void Panels_EveryEntryHasNameAndLauncher()
+    {
+        Assert.All(LegacyPanelService.Panels, p =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(p.Name));
+            Assert.False(string.IsNullOrWhiteSpace(p.Description));
+            Assert.False(string.IsNullOrWhiteSpace(p.FileName));
+            Assert.NotNull(p.Arguments); // may be empty, never null
+        });
+    }
+
+    [Fact]
+    public void Panels_NamesAreUnique()
+    {
+        var names = LegacyPanelService.Panels.Select(p => p.Name).ToList();
+        Assert.Equal(names.Count, names.Distinct().Count());
+    }
+
+    [Fact]
+    public void Panels_LaunchersUseKnownHosts()
+    {
+        var allowedHosts = new[] { "control.exe", "mmc.exe", "netplwiz.exe", "SystemPropertiesAdvanced.exe" };
+        Assert.All(LegacyPanelService.Panels, p => Assert.Contains(p.FileName, allowedHosts));
+    }
+
+    [Fact]
+    public void Launch_RejectsPanelNotInCatalog()
+    {
+        var svc = new LegacyPanelService();
+        // A panel that looks plausible but is not the same instance as any catalog entry.
+        var rogue = new LegacyPanel("Rogue", "not in catalog", "", "cmd.exe", "/c calc");
+        Assert.False(svc.Launch(rogue));
+    }
+
+    [Fact]
+    public void Launch_NullPanel_Throws()
+    {
+        var svc = new LegacyPanelService();
+        Assert.Throws<ArgumentNullException>(() => svc.Launch(null!));
+    }
+}

--- a/SysManager/SysManager/Models/LegacyPanel.cs
+++ b/SysManager/SysManager/Models/LegacyPanel.cs
@@ -1,0 +1,18 @@
+// SysManager · LegacyPanel
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// A classic Windows applet that the Legacy Panels launcher can open. Pure launch
+/// metadata — <see cref="FileName"/> + <see cref="Arguments"/> are passed verbatim to
+/// <c>Process.Start</c> (UseShellExecute). The catalog is hard-coded, so no user input
+/// ever reaches the process launcher.
+/// </summary>
+public sealed record LegacyPanel(
+    string Name,
+    string Description,
+    string Glyph,
+    string FileName,
+    string Arguments);

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -63,6 +63,7 @@ public static class ServiceRegistration
         services.AddSingleton<EnvironmentVariableService>();
         services.AddSingleton<RestorePointService>();
         services.AddSingleton<DebloaterService>();
+        services.AddSingleton<LegacyPanelService>();
         services.AddSingleton<WindowsUpdateService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
@@ -102,6 +103,7 @@ public static class ServiceRegistration
         services.AddSingleton<EnvironmentVariablesViewModel>();
         services.AddSingleton<RestorePointsViewModel>();
         services.AddSingleton<DebloaterViewModel>();
+        services.AddSingleton<LegacyPanelsViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/LegacyPanelService.cs
+++ b/SysManager/SysManager/Services/LegacyPanelService.cs
@@ -1,0 +1,78 @@
+// SysManager · LegacyPanelService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Diagnostics;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Opens classic Windows applets (Control Panel, Sound, Power Options, Device Manager,
+/// etc.) via their well-known <c>control</c>/<c>*.cpl</c>/<c>*.msc</c> commands.
+///
+/// SECURITY: the catalog is hard-coded — no user input ever reaches <c>Process.Start</c>.
+/// <see cref="Launch"/> only accepts a <see cref="LegacyPanel"/> from <see cref="Panels"/>,
+/// and re-validates membership before launching. These are pure launchers; none modify the
+/// system, so no elevation or confirmation is needed (the applets themselves prompt for UAC
+/// when an action inside them requires it).
+/// </summary>
+public sealed class LegacyPanelService
+{
+    /// <summary>The fixed catalog of classic applets, grouped logically by order.</summary>
+    public static IReadOnlyList<LegacyPanel> Panels { get; } =
+    [
+        new("Control Panel", "The classic Control Panel home.", "", "control.exe", ""),
+        new("Sound", "Playback, recording, and sound device settings.", "", "control.exe", "mmsys.cpl"),
+        new("Power Options", "Power plans and sleep/battery behavior.", "", "control.exe", "powercfg.cpl"),
+        new("Network Connections", "Adapter list (ncpa.cpl) — enable, disable, properties.", "", "control.exe", "ncpa.cpl"),
+        new("Region", "Date, time, and regional formats.", "", "control.exe", "intl.cpl"),
+        new("System Properties", "Advanced system settings, performance, environment vars.", "", "SystemPropertiesAdvanced.exe", ""),
+        new("User Accounts", "Classic user account management (netplwiz).", "", "netplwiz.exe", ""),
+        new("Device Manager", "Hardware devices and driver management.", "", "mmc.exe", "devmgmt.msc"),
+        new("Computer Management", "Disks, services, event viewer, and more in one console.", "", "mmc.exe", "compmgmt.msc"),
+        new("Programs and Features", "Classic installed-programs uninstaller (appwiz.cpl).", "", "control.exe", "appwiz.cpl"),
+        new("Mouse", "Pointer, buttons, and wheel settings.", "", "control.exe", "main.cpl"),
+        new("Date and Time", "System clock and time-zone settings.", "", "control.exe", "timedate.cpl"),
+    ];
+
+    /// <summary>
+    /// Launches the given applet. Returns false if the panel is not from the known catalog
+    /// or the process could not start (logged). Never throws on a launch failure.
+    /// </summary>
+    public bool Launch(LegacyPanel panel)
+    {
+        ArgumentNullException.ThrowIfNull(panel);
+
+        // Defense in depth: only ever launch a catalog entry, never arbitrary input.
+        if (!Panels.Contains(panel))
+        {
+            Log.Warning("LegacyPanel: refusing to launch unknown panel {Name}", panel.Name);
+            return false;
+        }
+
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = panel.FileName,
+                Arguments = panel.Arguments,
+                UseShellExecute = true
+            };
+            Process.Start(psi)?.Dispose();
+            Log.Information("LegacyPanel: opened {Name}", panel.Name);
+            return true;
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            Log.Warning("LegacyPanel: could not open {Name}: {Error}", panel.Name, ex.Message);
+            return false;
+        }
+        catch (InvalidOperationException ex)
+        {
+            Log.Warning("LegacyPanel: could not open {Name}: {Error}", panel.Name, ex.Message);
+            return false;
+        }
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.24.0</Version>
-    <FileVersion>1.24.0.0</FileVersion>
-    <AssemblyVersion>1.24.0.0</AssemblyVersion>
+    <Version>1.25.0</Version>
+    <FileVersion>1.25.0.0</FileVersion>
+    <AssemblyVersion>1.25.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/LegacyPanelsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LegacyPanelsViewModel.cs
@@ -1,0 +1,35 @@
+// SysManager · LegacyPanelsViewModel — one-click launcher for classic Windows applets
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.Input;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the Legacy Panels tab. Exposes the fixed catalog of classic Windows
+/// applets and a command to open one. Pure launchers — no system modification, no admin.
+/// </summary>
+public sealed partial class LegacyPanelsViewModel : ViewModelBase
+{
+    private readonly LegacyPanelService _service;
+
+    public IReadOnlyList<LegacyPanel> Panels => LegacyPanelService.Panels;
+
+    public LegacyPanelsViewModel(LegacyPanelService service)
+    {
+        _service = service;
+        StatusMessage = "Click any panel to open the classic Windows applet.";
+    }
+
+    [RelayCommand]
+    private void Open(LegacyPanel? panel)
+    {
+        if (panel is null) return;
+        StatusMessage = _service.Launch(panel)
+            ? $"Opened {panel.Name}."
+            : $"Couldn't open {panel.Name} — it may not be available on this edition of Windows.";
+    }
+}

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -51,6 +51,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public EnvironmentVariablesViewModel EnvironmentVariables { get; }
     public RestorePointsViewModel RestorePoints { get; }
     public DebloaterViewModel Debloater { get; }
+    public LegacyPanelsViewModel LegacyPanels { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -151,6 +152,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             EnvironmentVariables = sp.GetRequiredService<EnvironmentVariablesViewModel>();
             RestorePoints = sp.GetRequiredService<RestorePointsViewModel>();
             Debloater = sp.GetRequiredService<DebloaterViewModel>();
+            LegacyPanels = sp.GetRequiredService<LegacyPanelsViewModel>();
         }
         else
         {
@@ -205,6 +207,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             EnvironmentVariables = new EnvironmentVariablesViewModel(new EnvironmentVariableService());
             RestorePoints = new RestorePointsViewModel(new RestorePointService(new PowerShellRunner()));
             Debloater = new DebloaterViewModel(new DebloaterService(new PowerShellRunner()));
+            LegacyPanels = new LegacyPanelsViewModel(new LegacyPanelService());
         }
 
         InitPlaceholders();
@@ -289,7 +292,8 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-windows-features", "Windows Features", "", WindowsFeatures,  typeof(Views.WindowsFeaturesView)),
             Item("nav-restore-points",   "Restore Points",   "", RestorePoints,    typeof(Views.RestorePointsView)),
             Item("nav-task-scheduler",   "Task Scheduler",   "", WipTaskScheduler, typeof(Views.PlaceholderView)),
-            Item("nav-boot-analyzer",    "Boot Analyzer",    "", WipBootAnalyzer,  typeof(Views.PlaceholderView))),
+            Item("nav-boot-analyzer",    "Boot Analyzer",    "", WipBootAnalyzer,  typeof(Views.PlaceholderView)),
+            Item("nav-legacy-panels",    "Legacy Panels",    "", LegacyPanels,     typeof(Views.LegacyPanelsView))),
 
         Group("grp-gaming", "Gaming & Profiles", "",
             Item("nav-gaming-profile",   "Gaming Profile",       "", WipGamingProfile,      typeof(Views.PlaceholderView)),
@@ -468,6 +472,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         EnvironmentVariables?.Dispose();
         RestorePoints?.Dispose();
         Debloater?.Dispose();
+        LegacyPanels?.Dispose();
         WipBrowserCleaner?.Dispose();
         WipEdgeOneDriveRemover?.Dispose();
         WipDefenderTweaks?.Dispose();

--- a/SysManager/SysManager/Views/LegacyPanelsView.xaml
+++ b/SysManager/SysManager/Views/LegacyPanelsView.xaml
@@ -1,0 +1,79 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.LegacyPanelsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             d:DataContext="{d:DesignInstance vm:LegacyPanelsViewModel}"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             Background="{DynamicResource Surface0}">
+
+    <Grid Margin="28,24,28,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,16">
+            <TextBlock Text="Legacy Panels" Style="{StaticResource Display}"/>
+            <TextBlock Text="Open the classic Windows applets that newer releases keep hiding — one click each. These just open the built-in panel; they don't change anything themselves."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <!-- Panel cards -->
+        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="8">
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <ItemsControl ItemsSource="{Binding Panels}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <WrapPanel/>
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Button Command="{Binding DataContext.OpenCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                    CommandParameter="{Binding}"
+                                    AutomationProperties.Name="{Binding Name, StringFormat='Open {0}'}"
+                                    ToolTip="{Binding Description}"
+                                    Width="260" Margin="8" Padding="0"
+                                    HorizontalContentAlignment="Stretch" Cursor="Hand">
+                                <Button.Template>
+                                    <ControlTemplate TargetType="Button">
+                                        <Border x:Name="Bd" Background="{DynamicResource Surface2}"
+                                                BorderBrush="{DynamicResource Border1}" BorderThickness="1"
+                                                CornerRadius="8" Padding="14,12">
+                                            <StackPanel>
+                                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13"
+                                                           Foreground="{DynamicResource TextPrimary}"/>
+                                                <TextBlock Text="{Binding Description}" FontSize="11"
+                                                           Foreground="{DynamicResource TextMuted}"
+                                                           TextWrapping="Wrap" Margin="0,4,0,0" Height="48"/>
+                                            </StackPanel>
+                                        </Border>
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Surface3}"/>
+                                                <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Border2}"/>
+                                            </Trigger>
+                                            <Trigger Property="IsPressed" Value="True">
+                                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Surface4}"/>
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
+                                    </ControlTemplate>
+                                </Button.Template>
+                            </Button>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </Border>
+
+        <!-- Status bar -->
+        <DockPanel Grid.Row="2" Margin="0,8,0,0">
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" VerticalAlignment="Center"/>
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/LegacyPanelsView.xaml.cs
+++ b/SysManager/SysManager/Views/LegacyPanelsView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · LegacyPanelsView — classic Windows applet launcher UI
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class LegacyPanelsView : UserControl
+{
+    public LegacyPanelsView() => InitializeComponent();
+}


### PR DESCRIPTION
## Summary
Adds a new **Legacy Panels** tab to the System group: a one-click launcher for the classic Windows applets that newer releases keep burying.

- Control Panel, Sound, Power Options, Network Connections, Region, System Properties, User Accounts, Device Manager, Computer Management, Programs and Features, Mouse, Date and Time.
- **Pure launchers** — each just opens the built-in applet; nothing is modified, so no elevation or confirmation is needed.

Closes #911

## Design (matches existing architecture)
- **Service** `LegacyPanelService` holds a hard-coded `Panels` catalog and a `Launch` method that re-validates catalog membership before `Process.Start(... UseShellExecute=true)` — so no typed/user input ever reaches the launcher (defense in depth). Launch failures are caught (`Win32Exception`/`InvalidOperationException`) and logged, never thrown.
- **ViewModel** `LegacyPanelsViewModel` exposes the catalog + an `Open` `[RelayCommand]`; trivial, no async/admin.
- **View** Strategy-1 layout; a scrollable `WrapPanel` of templated card-buttons (hover/press states from theme brushes), `AutomationProperties.Name` + tooltip per card. No `DropShadowEffect`.
- New System-group nav item (glyph U+E713, unique); wired into DI + both `MainWindowViewModel` construction paths + dispose.

## Tests
- 6 unit tests in `LegacyPanelServiceTests`: catalog non-empty, every entry well-formed, unique names, launchers restricted to known hosts (`control.exe`/`mmc.exe`/`netplwiz.exe`/`SystemPropertiesAdvanced.exe`), `Launch` rejects a panel not in the catalog (the security boundary), and null-throws.
- Integration tests updated: nav count 55 → 56, System group 9 → 10 items.

## Docs
- README (56 tabs / 35 implemented, new feature section, System row), ARCHITECTURE (VM + service descriptions, System row), CHANGELOG (1.25.0 Added), version bump → 1.25.0.