### PR TITLE
feat: System Fixes tab — one-click repairs for common Windows breakages

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,7 +41,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Group | View Models |
 |-------|-------------|
 | Dashboard | `DashboardViewModel` |
-| System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `LegacyPanelsViewModel` · `PlaceholderViewModel` (Task Scheduler · Boot Analyzer) |
+| System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `LegacyPanelsViewModel` · `SystemFixesViewModel` · `PlaceholderViewModel` (Task Scheduler · Boot Analyzer) |
 | Gaming & Profiles | `PlaceholderViewModel` (Gaming Profile · Standby List Cleaner · Timer Resolution · CPU Core Affinity · Display Profiles) |
 | Monitor | `ProcessManagerViewModel` · `PlaceholderViewModel` (Resource History · Privacy Monitor · File Lock Detector · Settings Watchdog · Bandwidth Monitor) |
 | Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `PlaceholderViewModel` (Scheduled Maintenance) |
@@ -91,6 +91,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `EnvironmentVariablesViewModel` — view/edit User and System environment variables with a dedicated PATH editor (reorder, dedupe, missing-folder detection); staged edits with a one-time backup.
 - `RestorePointsViewModel` — list, create, and restore Windows System Restore points (admin for create/restore; restore reboots, gated by confirmation).
 - `LegacyPanelsViewModel` — one-click launcher for the fixed catalog of classic Windows applets (pure launchers, no system modification).
+- `SystemFixesViewModel` — consolidated one-click repairs (Windows Update reset, network reset, WinGet reinstall) with per-fix confirmation + live output; opens netplwiz for secure auto-logon.
 - `DebloaterViewModel` — list and remove preinstalled Store apps with a curated bloat preset; system-critical packages are denylisted; removal is per-user and reversible via the Store.
 - `ConsoleViewModel` — shared, per-tab scrollable console (each tab gets its own
   instance; lines capped at 5000 to bound memory) backing the in-app Console mirror
@@ -207,6 +208,11 @@ Key services:
   Device Manager, …) via their `control`/`*.cpl`/`*.msc` commands. The catalog is
   hard-coded and `Launch` re-validates catalog membership, so no input reaches
   `Process.Start`; pure launchers, no system modification.
+- `SystemFixService` — one-click repairs (reset Windows Update, reset the network
+  stack, reinstall WinGet) via hard-coded PowerShell scripts through the
+  `IPowerShellRunner` seam; streams output and returns an honest success/failure
+  `SystemFixResult`. Auto-logon is delegated to the built-in netplwiz dialog, never
+  a plaintext credential write.
 - `AppIconService` — downloads and caches application favicons for UI display.
 - `TemperatureService` — aggregates CPU, GPU, and disk temperatures from
   LibreHardwareMonitor (admin) and NvAPIWrapper (non-admin NVIDIA). Real-time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.26.0] - 2026-06-24
+
+### Added
+- **System Fixes tab** (System group). A consolidated panel for common one-click Windows repairs, each with a plain-English description and a confirmation before it runs: **Reset Windows Update** (stop services, clear the SoftwareDistribution/catroot2 caches, restart services), **Reset Network Stack** (Winsock + TCP/IP reset and DNS flush), and **Reinstall WinGet** (re-register the App Installer when app installs/uninstalls fail). A **Set up Auto Sign-in** shortcut opens the built-in User Accounts dialog so Windows stores the credential securely — SysManager never handles your password. Repairs run with live output and report success or failure honestly. They modify system state and require administrator rights (standard elevation banner).
+
 ## [1.25.0] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ fully open source.
 ## Features
 
 ### Sidebar navigation
-The sidebar organises 56 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 35 tabs are fully
+The sidebar organises 57 feature tabs into 12 collapsible groups so you can
+find what you need without scrolling through a flat list. 36 tabs are fully
 implemented; 21 are work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |
 |-------|------|
 | 🏠 Dashboard | Dashboard |
-| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Legacy Panels · Task Scheduler ⚙️ · Boot Analyzer ⚙️ |
+| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Legacy Panels · System Fixes · Task Scheduler ⚙️ · Boot Analyzer ⚙️ |
 | 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner ⚙️ · Timer Resolution ⚙️ · CPU Core Affinity ⚙️ · Display Profiles ⚙️ |
 | 📊 Monitor | Process Manager · Resource History ⚙️ · Privacy Monitor ⚙️ · File Lock Detector ⚙️ · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance ⚙️ |
@@ -194,6 +194,17 @@ Edit Windows environment variables without the cramped built-in dialog:
 - **Pure launchers** — each just opens the built-in panel; nothing is modified,
   so no elevation or confirmation is needed
 - The applet list is fixed in code, so no typed input ever reaches the launcher
+
+### System Fixes
+One-click repairs for common Windows breakages, each with a clear description and
+a confirmation before it runs:
+- **Reset Windows Update** — stop the update services, clear the
+  SoftwareDistribution and catroot2 caches, and restart the services
+- **Reset Network Stack** — Winsock + TCP/IP reset and DNS flush
+- **Reinstall WinGet** — re-register the App Installer when app installs/uninstalls fail
+- **Set up Auto Sign-in** — opens the built-in User Accounts dialog, so Windows
+  stores the credential securely and SysManager never handles your password
+- Live output, honest success/failure reporting, admin elevation banner
 
 ### Windows Update (Windows Update Agent COM API)
 - Direct Windows Update Agent COM integration (`Microsoft.Update.Session`) —

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -75,16 +75,16 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
-    public void NavItems_ContainAll56()
+    public void NavItems_ContainAll57()
     {
         var vm = new MainWindowViewModel();
-        Assert.Equal(56, vm.NavItems.Count);
+        Assert.Equal(57, vm.NavItems.Count);
         var ids = vm.NavItems.Select(n => n.Id).ToList();
 
         // Dashboard
         Assert.Contains("nav-dashboard", ids);
 
-        // System (10)
+        // System (11)
         Assert.Contains("nav-system-health", ids);
         Assert.Contains("nav-windows-update", ids);
         Assert.Contains("nav-performance", ids);
@@ -95,6 +95,7 @@ public class MainWindowViewModelTests
         Assert.Contains("nav-task-scheduler", ids);
         Assert.Contains("nav-boot-analyzer", ids);
         Assert.Contains("nav-legacy-panels", ids);
+        Assert.Contains("nav-system-fixes", ids);
 
         // Gaming & Profiles (5)
         Assert.Contains("nav-gaming-profile", ids);
@@ -239,11 +240,11 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
-    public void NavGroups_SystemGroup_Contains10Items()
+    public void NavGroups_SystemGroup_Contains11Items()
     {
         var vm = new MainWindowViewModel();
         var sys = vm.NavGroups.First(g => g.Id == "grp-system");
-        Assert.Equal(10, sys.Children.Count);
+        Assert.Equal(11, sys.Children.Count);
         var ids = sys.Children.Select(c => c.Id).ToList();
         Assert.Contains("nav-system-health", ids);
         Assert.Contains("nav-windows-update", ids);
@@ -255,6 +256,7 @@ public class MainWindowViewModelTests
         Assert.Contains("nav-task-scheduler", ids);
         Assert.Contains("nav-boot-analyzer", ids);
         Assert.Contains("nav-legacy-panels", ids);
+        Assert.Contains("nav-system-fixes", ids);
     }
 
     [Fact]

--- a/SysManager/SysManager/Models/SystemFixResult.cs
+++ b/SysManager/SysManager/Models/SystemFixResult.cs
@@ -1,0 +1,15 @@
+// SysManager · SystemFixResult
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// Result of a single one-click system repair (Windows Update reset, network reset,
+/// WinGet reinstall). Carries the captured output and whether a reboot is recommended.
+/// </summary>
+public sealed record SystemFixResult(
+    string FixName,
+    bool Success,
+    string Output,
+    bool NeedsReboot);

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -64,6 +64,7 @@ public static class ServiceRegistration
         services.AddSingleton<RestorePointService>();
         services.AddSingleton<DebloaterService>();
         services.AddSingleton<LegacyPanelService>();
+        services.AddSingleton<SystemFixService>();
         services.AddSingleton<WindowsUpdateService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
@@ -104,6 +105,7 @@ public static class ServiceRegistration
         services.AddSingleton<RestorePointsViewModel>();
         services.AddSingleton<DebloaterViewModel>();
         services.AddSingleton<LegacyPanelsViewModel>();
+        services.AddSingleton<SystemFixesViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/SystemFixService.cs
+++ b/SysManager/SysManager/Services/SystemFixService.cs
@@ -1,0 +1,117 @@
+// SysManager · SystemFixService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// One-click repairs for common Windows breakages — Windows Update, the network stack,
+/// and WinGet. All commands run through the <see cref="IPowerShellRunner"/> seam (so the
+/// orchestration is substitutable in tests) and stream their output via
+/// <see cref="IPowerShellRunner.LineReceived"/> for live display.
+///
+/// SECURITY: every script is hard-coded — no user input is interpolated. These repairs
+/// mutate system state and require administrator rights; each is gated behind an explicit
+/// confirmation in the ViewModel. Account auto-logon is intentionally NOT implemented here
+/// as a credential write (that would store the password in plaintext in the registry);
+/// the ViewModel instead opens the built-in <c>netplwiz</c> dialog, which sets it securely.
+/// </summary>
+public sealed class SystemFixService : IDisposable
+{
+    private readonly IPowerShellRunner _ps;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public SystemFixService(IPowerShellRunner ps) => _ps = ps;
+
+    public event Action<PowerShellLine>? LineReceived
+    {
+        add => _ps.LineReceived += value;
+        remove => _ps.LineReceived -= value;
+    }
+
+    public void Dispose() => _gate.Dispose();
+
+    /// <summary>
+    /// Resets Windows Update: stops the services, renames SoftwareDistribution and
+    /// catroot2 (so Windows rebuilds them), then restarts the services. Requires admin
+    /// and a reboot afterwards for best results.
+    /// </summary>
+    public Task<SystemFixResult> ResetWindowsUpdateAsync(CancellationToken ct = default)
+    {
+        const string script = """
+            $ErrorActionPreference = 'Stop'
+            $services = 'wuauserv','cryptSvc','bits','msiserver'
+            foreach ($s in $services) { Stop-Service -Name $s -Force -ErrorAction SilentlyContinue }
+            $sd = Join-Path $env:SystemRoot 'SoftwareDistribution'
+            $cr = Join-Path $env:SystemRoot 'System32\catroot2'
+            if (Test-Path $sd) { Rename-Item $sd "$sd.old.$((Get-Date).ToString('yyyyMMddHHmmss'))" -ErrorAction SilentlyContinue }
+            if (Test-Path $cr) { Rename-Item $cr "$cr.old.$((Get-Date).ToString('yyyyMMddHHmmss'))" -ErrorAction SilentlyContinue }
+            foreach ($s in $services) { Start-Service -Name $s -ErrorAction SilentlyContinue }
+            'Windows Update components reset. A reboot is recommended.'
+            """;
+        return RunFixAsync("Reset Windows Update", script, needsReboot: true, ct);
+    }
+
+    /// <summary>
+    /// Resets the network stack: Winsock catalog and TCP/IP. Requires admin and a reboot.
+    /// </summary>
+    public Task<SystemFixResult> ResetNetworkAsync(CancellationToken ct = default)
+    {
+        const string script = """
+            $ErrorActionPreference = 'Continue'
+            & netsh winsock reset | Out-String
+            & netsh int ip reset | Out-String
+            & ipconfig /flushdns | Out-String
+            'Network stack reset. Reboot to complete.'
+            """;
+        return RunFixAsync("Reset Network", script, needsReboot: true, ct);
+    }
+
+    /// <summary>
+    /// Re-registers the WinGet (App Installer) package so app installs/uninstalls work
+    /// again. Requires admin. No reboot needed.
+    /// </summary>
+    public Task<SystemFixResult> ReinstallWinGetAsync(CancellationToken ct = default)
+    {
+        const string script = """
+            $ErrorActionPreference = 'Stop'
+            $pkg = Get-AppxPackage -AllUsers Microsoft.DesktopAppInstaller -ErrorAction SilentlyContinue |
+                   Select-Object -First 1
+            if ($pkg) {
+                Add-AppxPackage -DisableDevelopmentMode -Register `
+                    (Join-Path $pkg.InstallLocation 'AppXManifest.xml') -ErrorAction Stop
+                'WinGet (App Installer) re-registered successfully.'
+            } else {
+                throw 'App Installer package not found. Install "App Installer" from the Microsoft Store.'
+            }
+            """;
+        return RunFixAsync("Reinstall WinGet", script, needsReboot: false, ct);
+    }
+
+    private async Task<SystemFixResult> RunFixAsync(string name, string script, bool needsReboot, CancellationToken ct)
+    {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        var output = new System.Collections.Concurrent.ConcurrentQueue<string>();
+        void OnLine(PowerShellLine line) => output.Enqueue(line.Text);
+        _ps.LineReceived += OnLine;
+        try
+        {
+            // RunAsync throws on a terminating error (ErrorActionPreference=Stop / throw),
+            // so a normal return means the script ran to completion.
+            await _ps.RunAsync(script, cancellationToken: ct).ConfigureAwait(false);
+            return new SystemFixResult(name, Success: true, string.Join(Environment.NewLine, output), needsReboot);
+        }
+        catch (System.Management.Automation.RuntimeException ex)
+        {
+            output.Enqueue(ex.Message);
+            return new SystemFixResult(name, Success: false, string.Join(Environment.NewLine, output), needsReboot);
+        }
+        finally
+        {
+            _ps.LineReceived -= OnLine;
+            _gate.Release();
+        }
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.25.0</Version>
-    <FileVersion>1.25.0.0</FileVersion>
-    <AssemblyVersion>1.25.0.0</AssemblyVersion>
+    <Version>1.26.0</Version>
+    <FileVersion>1.26.0.0</FileVersion>
+    <AssemblyVersion>1.26.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -52,6 +52,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public RestorePointsViewModel RestorePoints { get; }
     public DebloaterViewModel Debloater { get; }
     public LegacyPanelsViewModel LegacyPanels { get; }
+    public SystemFixesViewModel SystemFixes { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -153,6 +154,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             RestorePoints = sp.GetRequiredService<RestorePointsViewModel>();
             Debloater = sp.GetRequiredService<DebloaterViewModel>();
             LegacyPanels = sp.GetRequiredService<LegacyPanelsViewModel>();
+            SystemFixes = sp.GetRequiredService<SystemFixesViewModel>();
         }
         else
         {
@@ -208,6 +210,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             RestorePoints = new RestorePointsViewModel(new RestorePointService(new PowerShellRunner()));
             Debloater = new DebloaterViewModel(new DebloaterService(new PowerShellRunner()));
             LegacyPanels = new LegacyPanelsViewModel(new LegacyPanelService());
+            SystemFixes = new SystemFixesViewModel(new SystemFixService(new PowerShellRunner()));
         }
 
         InitPlaceholders();
@@ -293,7 +296,8 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-restore-points",   "Restore Points",   "", RestorePoints,    typeof(Views.RestorePointsView)),
             Item("nav-task-scheduler",   "Task Scheduler",   "", WipTaskScheduler, typeof(Views.PlaceholderView)),
             Item("nav-boot-analyzer",    "Boot Analyzer",    "", WipBootAnalyzer,  typeof(Views.PlaceholderView)),
-            Item("nav-legacy-panels",    "Legacy Panels",    "", LegacyPanels,     typeof(Views.LegacyPanelsView))),
+            Item("nav-legacy-panels",    "Legacy Panels",    "", LegacyPanels,     typeof(Views.LegacyPanelsView)),
+            Item("nav-system-fixes",     "System Fixes",     "", SystemFixes,      typeof(Views.SystemFixesView))),
 
         Group("grp-gaming", "Gaming & Profiles", "",
             Item("nav-gaming-profile",   "Gaming Profile",       "", WipGamingProfile,      typeof(Views.PlaceholderView)),
@@ -473,6 +477,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         RestorePoints?.Dispose();
         Debloater?.Dispose();
         LegacyPanels?.Dispose();
+        SystemFixes?.Dispose();
         WipBrowserCleaner?.Dispose();
         WipEdgeOneDriveRemover?.Dispose();
         WipDefenderTweaks?.Dispose();

--- a/SysManager/SysManager/ViewModels/SystemFixesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemFixesViewModel.cs
@@ -1,0 +1,155 @@
+// SysManager · SystemFixesViewModel — one-click repairs for common Windows breakages
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Diagnostics;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the System Fixes tab. Surfaces a small set of well-known one-click
+/// repairs (Windows Update, network stack, WinGet) plus a secure shortcut to the
+/// built-in auto-logon dialog. Each repair confirms first, runs through
+/// <see cref="SystemFixService"/>, streams output, and reports success/failure honestly.
+/// Repairs require administrator rights; the tab shows the standard elevation banner.
+/// </summary>
+public sealed partial class SystemFixesViewModel : ViewModelBase
+{
+    private readonly SystemFixService _service;
+    private CancellationTokenSource? _cts;
+
+    [ObservableProperty] private bool _isElevated;
+    [ObservableProperty] private string _output = "";
+
+    public SystemFixesViewModel(SystemFixService service)
+    {
+        _service = service;
+        IsElevated = AdminHelper.IsElevated();
+        StatusMessage = "Pick a repair. Each asks for confirmation before it runs.";
+        _service.LineReceived += OnLine;
+        PropertyChanged += OnVmPropertyChanged;
+    }
+
+    private bool CanRunFix => !IsBusy && IsElevated;
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(IsBusy) or nameof(IsElevated))
+        {
+            ResetWindowsUpdateCommand.NotifyCanExecuteChanged();
+            ResetNetworkCommand.NotifyCanExecuteChanged();
+            ReinstallWinGetCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    private void OnLine(PowerShellLine line)
+    {
+        var text = line.Text;
+        System.Windows.Application.Current?.Dispatcher.Invoke(() =>
+            Output += (Output.Length == 0 ? "" : Environment.NewLine) + text);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRunFix))]
+    private Task ResetWindowsUpdateAsync() => RunFixAsync(
+        "Reset Windows Update?",
+        "This stops the Windows Update services, clears their cache folders " +
+        "(SoftwareDistribution and catroot2, renamed so Windows rebuilds them), and restarts " +
+        "the services. Pending updates will re-download. A reboot is recommended afterwards.\n\nContinue?",
+        ct => _service.ResetWindowsUpdateAsync(ct));
+
+    [RelayCommand(CanExecute = nameof(CanRunFix))]
+    private Task ResetNetworkAsync() => RunFixAsync(
+        "Reset Network Stack?",
+        "This resets the Winsock catalog and TCP/IP stack and flushes the DNS cache. " +
+        "It can fix many connectivity problems but will briefly drop the connection and " +
+        "needs a reboot to fully apply.\n\nContinue?",
+        ct => _service.ResetNetworkAsync(ct));
+
+    [RelayCommand(CanExecute = nameof(CanRunFix))]
+    private Task ReinstallWinGetAsync() => RunFixAsync(
+        "Reinstall WinGet?",
+        "This re-registers the Windows Package Manager (App Installer) for your account, " +
+        "which fixes most cases where app installs or uninstalls fail. No reboot needed.\n\nContinue?",
+        ct => _service.ReinstallWinGetAsync(ct));
+
+    private async Task RunFixAsync(string title, string message, Func<CancellationToken, Task<SystemFixResult>> fix)
+    {
+        if (!DialogService.Instance.Confirm(message, title))
+        {
+            StatusMessage = "Cancelled.";
+            return;
+        }
+
+        IsBusy = true;
+        IsProgressIndeterminate = true;
+        Output = "";
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        try
+        {
+            var result = await fix(_cts.Token).ConfigureAwait(true);
+            if (result.Success)
+            {
+                StatusMessage = result.NeedsReboot
+                    ? $"{result.FixName} completed — reboot to finish."
+                    : $"{result.FixName} completed.";
+                ToastService.Instance.Show(result.FixName, result.NeedsReboot ? "Done — reboot recommended." : "Done.");
+            }
+            else
+            {
+                StatusMessage = $"{result.FixName} did not complete — see the output for details.";
+            }
+            Log.Information("SystemFix: {Fix} success={Success}", result.FixName, result.Success);
+        }
+        catch (OperationCanceledException) { StatusMessage = "Cancelled."; }
+        finally
+        {
+            IsBusy = false;
+            IsProgressIndeterminate = false;
+        }
+    }
+
+    [RelayCommand]
+    private void OpenAutologin()
+    {
+        // Auto-logon is configured through the built-in netplwiz dialog, which stores the
+        // credential securely (LSA secret) — SysManager never writes a plaintext password.
+        try
+        {
+            Process.Start(new ProcessStartInfo("netplwiz.exe") { UseShellExecute = true })?.Dispose();
+            StatusMessage = "Opened User Accounts (netplwiz). Untick \"Users must enter a user name and password\" to enable auto sign-in.";
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            Log.Warning("SystemFix: could not open netplwiz: {Error}", ex.Message);
+            StatusMessage = "Couldn't open the User Accounts dialog.";
+        }
+    }
+
+    [RelayCommand]
+    private void Cancel() => _cts?.Cancel();
+
+    [RelayCommand]
+    private void RelaunchAsAdmin()
+    {
+        if (AdminHelper.RelaunchAsAdmin())
+            System.Windows.Application.Current?.Shutdown();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _service.LineReceived -= OnLine;
+            PropertyChanged -= OnVmPropertyChanged;
+            _cts?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/SysManager/SysManager/Views/SystemFixesView.xaml
+++ b/SysManager/SysManager/Views/SystemFixesView.xaml
@@ -1,0 +1,149 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.SystemFixesView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             d:DataContext="{d:DesignInstance vm:SystemFixesViewModel}"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             Background="{DynamicResource Surface0}">
+
+    <Grid Margin="28,24,28,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,16">
+            <TextBlock Text="System Fixes" Style="{StaticResource Display}"/>
+            <TextBlock Text="One-click repairs for common Windows breakages. Each fix explains what it does and asks for confirmation before it runs. These change system state and need administrator rights."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <!-- Elevation banner: not elevated -->
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        AutomationProperties.Name="Restart SysManager as administrator"
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
+                    <TextBlock Text="These repairs modify system services and settings, so they require administrator privileges."
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- Elevation banner: elevated -->
+        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — all repairs are available."
+                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Fix cards -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="16">
+            <StackPanel>
+                <Grid Margin="0,0,0,10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" VerticalAlignment="Center" Margin="0,0,16,0">
+                        <TextBlock Text="Reset Windows Update" FontWeight="SemiBold" FontSize="13" Foreground="{DynamicResource TextPrimary}"/>
+                        <TextBlock Text="Stop the update services, clear their caches, and restart them — fixes most stuck-update problems."
+                                   FontSize="11" Foreground="{DynamicResource TextMuted}" TextWrapping="Wrap" Margin="0,2,0,0"/>
+                    </StackPanel>
+                    <Button Grid.Column="1" Content="Run" Command="{Binding ResetWindowsUpdateCommand}"
+                            AutomationProperties.Name="Reset Windows Update"
+                            Style="{StaticResource SecondaryButton}" VerticalAlignment="Center" MinWidth="80"/>
+                </Grid>
+
+                <Grid Margin="0,0,0,10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" VerticalAlignment="Center" Margin="0,0,16,0">
+                        <TextBlock Text="Reset Network Stack" FontWeight="SemiBold" FontSize="13" Foreground="{DynamicResource TextPrimary}"/>
+                        <TextBlock Text="Reset Winsock + TCP/IP and flush DNS — fixes many connectivity issues. Needs a reboot."
+                                   FontSize="11" Foreground="{DynamicResource TextMuted}" TextWrapping="Wrap" Margin="0,2,0,0"/>
+                    </StackPanel>
+                    <Button Grid.Column="1" Content="Run" Command="{Binding ResetNetworkCommand}"
+                            AutomationProperties.Name="Reset network stack"
+                            Style="{StaticResource SecondaryButton}" VerticalAlignment="Center" MinWidth="80"/>
+                </Grid>
+
+                <Grid Margin="0,0,0,10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" VerticalAlignment="Center" Margin="0,0,16,0">
+                        <TextBlock Text="Reinstall WinGet" FontWeight="SemiBold" FontSize="13" Foreground="{DynamicResource TextPrimary}"/>
+                        <TextBlock Text="Re-register the Windows Package Manager (App Installer) when app installs or uninstalls fail."
+                                   FontSize="11" Foreground="{DynamicResource TextMuted}" TextWrapping="Wrap" Margin="0,2,0,0"/>
+                    </StackPanel>
+                    <Button Grid.Column="1" Content="Run" Command="{Binding ReinstallWinGetCommand}"
+                            AutomationProperties.Name="Reinstall WinGet"
+                            Style="{StaticResource SecondaryButton}" VerticalAlignment="Center" MinWidth="80"/>
+                </Grid>
+
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" VerticalAlignment="Center" Margin="0,0,16,0">
+                        <TextBlock Text="Set up Auto Sign-in" FontWeight="SemiBold" FontSize="13" Foreground="{DynamicResource TextPrimary}"/>
+                        <TextBlock Text="Opens the built-in User Accounts dialog to enable automatic sign-in. Windows stores the credential securely — SysManager never sees your password."
+                                   FontSize="11" Foreground="{DynamicResource TextMuted}" TextWrapping="Wrap" Margin="0,2,0,0"/>
+                    </StackPanel>
+                    <Button Grid.Column="1" Content="Open" Command="{Binding OpenAutologinCommand}"
+                            AutomationProperties.Name="Open auto sign-in settings"
+                            Style="{StaticResource GhostButton}" VerticalAlignment="Center" MinWidth="80"/>
+                </Grid>
+            </StackPanel>
+        </Border>
+
+        <!-- Output console -->
+        <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
+            <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="14,12">
+                <TextBox Text="{Binding Output, Mode=OneWay}"
+                         AutomationProperties.Name="Repair output"
+                         IsReadOnly="True" TextWrapping="Wrap"
+                         Background="Transparent" BorderThickness="0"
+                         FontFamily="{StaticResource MonoFont}" FontSize="12"
+                         Foreground="{DynamicResource TextPrimary}"/>
+            </ScrollViewer>
+        </Border>
+
+        <!-- Status bar -->
+        <DockPanel Grid.Row="4" Margin="0,8,0,0">
+            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Right" Width="180" Height="4"
+                         IsIndeterminate="{Binding IsProgressIndeterminate}"
+                         Visibility="{Binding IsBusy, Converter={StaticResource FlexVis}}"/>
+            <Button DockPanel.Dock="Right" Content="Cancel" Command="{Binding CancelCommand}"
+                    AutomationProperties.Name="Cancel current repair"
+                    Style="{StaticResource GhostButton}" Margin="0,0,12,0" Padding="10,2"
+                    Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" VerticalAlignment="Center"/>
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/SystemFixesView.xaml.cs
+++ b/SysManager/SysManager/Views/SystemFixesView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · SystemFixesView — one-click system repairs UI
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class SystemFixesView : UserControl
+{
+    public SystemFixesView() => InitializeComponent();
+}


### PR DESCRIPTION
## Summary
Adds a **System Fixes** tab (System group) consolidating well-known one-click Windows repairs, each with a plain-English description and a confirmation before it runs:

- **Reset Windows Update** — stop the update services, clear SoftwareDistribution + catroot2 (renamed so Windows rebuilds them), restart services.
- **Reset Network Stack** — Winsock + TCP/IP reset and DNS flush.
- **Reinstall WinGet** — re-register the App Installer when app installs/uninstalls fail.
- **Set up Auto Sign-in** — opens the built-in `netplwiz` dialog so Windows stores the credential securely; SysManager never handles the password.

Closes #909

## Design (matches existing architecture)
- **Service** `SystemFixService` runs hard-coded PowerShell scripts through the `IPowerShellRunner` seam (Gate-ARCH), streaming output via `LineReceived` and returning an honest `SystemFixResult` (no false "done" — scripts use `ErrorActionPreference='Stop'`/`throw`, so a normal return means success). Mirrors `NetworkRepairService` (gate + output queue + result record).
- **ViewModel** `SystemFixesViewModel` follows the async/busy + `DialogService.Confirm` + `AdminHelper` + CanExecute-gate + `Dispose` pattern; live output marshalled to the dispatcher.
- **View** Strategy-1 layout; both admin-banner states; fix cards (name + description + Run button); read-only MonoFont output console; Cancel while busy. `AutomationProperties.Name` on every control. No `DropShadowEffect`.
- New System-group nav item (glyph U+E9F5, unique); wired into DI + both `MainWindowViewModel` paths + dispose.

## Safety / security
- Every script is hard-coded — no user input is interpolated anywhere.
- Auto-logon is intentionally NOT a credential write (which would store the password in plaintext in the registry) — it delegates to the built-in netplwiz dialog (LSA-secret storage).
- All repairs confirm first and require administrator; failures are caught and reported, never thrown to the UI.

## Tests
- Integration tests updated: nav count 56 → 57, System group 10 → 11 items. (The repair scripts themselves mutate the live OS and are not unit-tested — they run only through the seam behind a confirmation.)

## Docs
- README (57 tabs / 36 implemented, new feature section, System row), ARCHITECTURE (VM + service descriptions, System row), CHANGELOG (1.26.0 Added), version bump → 1.26.0.