### PR TITLE
feat: DNS filtering presets and IPv6 support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -182,7 +182,8 @@ Key services:
 - `PrivacyService` — reads and writes Windows privacy and telemetry
   registry toggles (activity history, advertising ID, diagnostics, etc.).
 - `DnsService` — manages DNS server configuration via PowerShell
-  `Set-DnsClientServerAddress` with preset support (Google, Cloudflare, etc.).
+  `Set-DnsClientServerAddress` with preset support (plain resolvers plus
+  ad/malware/family-blocking variants), IPv4 + IPv6, and reversible snapshots.
 - `HostsFileService` — parses and edits the Windows hosts file with
   add/remove/toggle operations; keeps a one-time pristine backup and can
   restore it (`HasBackup` / `RestoreBackup`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.27.0] - 2026-06-24
+
+### Added
+- **DNS filtering presets and IPv6** (DNS & Hosts tab). The DNS preset switcher now includes ad/malware/family-blocking variants — Cloudflare Malware-blocking (1.1.1.2) and Family (1.1.1.3), AdGuard DNS (ad/tracker blocking, plus a Family variant), and OpenDNS FamilyShield — each with a short description of what it blocks. Every preset now also configures IPv6 resolvers automatically alongside IPv4. The existing "Reset to automatic (DHCP)" undo continues to work for all variants.
+
 ## [1.26.0] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -339,9 +339,13 @@ a confirmation before it runs:
 - Confirmation dialog before irreversible shred
 
 ### DNS & Hosts
-- **DNS Preset Switching** — one-click DNS change: Google, Cloudflare, Quad9,
-  OpenDNS, or reset to automatic (DHCP). Shows current active DNS. An **Undo**
-  button restores the exact DNS configuration in effect before the last change.
+- **DNS Preset Switching** — one-click DNS change: plain resolvers (Google,
+  Cloudflare, Quad9, OpenDNS) plus **ad/malware/family-blocking variants**
+  (Cloudflare 1.1.1.2 malware / 1.1.1.3 family, AdGuard DNS ad-blocking + family,
+  OpenDNS FamilyShield), each with a description of what it blocks. **IPv6
+  resolvers** are configured automatically alongside IPv4. Reset to automatic
+  (DHCP) any time; shows current active DNS. An **Undo** button restores the exact
+  DNS configuration in effect before the last change.
 - **Hosts File Editor** — view, add, and remove entries from the Windows
   hosts file with a clean table UI. Add IP + hostname pairs, toggle entries,
   or remove them. Backs up hosts file before modifications.

--- a/SysManager/SysManager.Tests/DnsHostsViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DnsHostsViewModelTests.cs
@@ -22,10 +22,11 @@ public class DnsHostsViewModelTests
         new(new DnsService(new PowerShellRunner()), new HostsFileService());
 
     [StaFact]
-    public void Constructor_PresetsListPopulated_With5Presets()
+    public void Constructor_PresetsListPopulated_WithFilteringVariants()
     {
         var vm = NewVm();
-        Assert.Equal(5, vm.Presets.Count);
+        // 4 plain resolvers + 5 filtering variants + Automatic (DHCP).
+        Assert.Equal(10, vm.Presets.Count);
     }
 
     [StaFact]

--- a/SysManager/SysManager.Tests/DnsServiceTests.cs
+++ b/SysManager/SysManager.Tests/DnsServiceTests.cs
@@ -313,6 +313,86 @@ public class DnsServiceTests
         await Assert.ThrowsAsync<ArgumentNullException>(() => svc.RestoreServersAsync(null!));
     }
 
+    // ---------- filtering variants + IPv6 (#910) ----------
+
+    [Fact]
+    public void GetPresets_IncludesFilteringVariants()
+    {
+        using var svc = new DnsService(Substitute.For<IPowerShellRunner>());
+        var names = svc.GetPresets().Select(p => p.Name).ToList();
+
+        Assert.Contains(names, n => n.Contains("Malware", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(names, n => n.Contains("AdGuard", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(names, n => n.Contains("Family", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(names, n => n.Contains("FamilyShield", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void GetPresets_PlainResolversCarryIpv6()
+    {
+        using var svc = new DnsService(Substitute.For<IPowerShellRunner>());
+        var cloudflare = svc.GetPresets().First(p => p.Name == "Cloudflare");
+
+        Assert.True(cloudflare.HasIpv6);
+        Assert.Equal("2606:4700:4700::1111", cloudflare.PrimaryV6);
+    }
+
+    [Fact]
+    public void GetPresets_AutomaticHasNoIpv6()
+    {
+        using var svc = new DnsService(Substitute.For<IPowerShellRunner>());
+        var auto = svc.GetPresets().First(p => p.Name.Contains("Automatic", StringComparison.OrdinalIgnoreCase));
+        Assert.False(auto.HasIpv6);
+    }
+
+    [Fact]
+    public async Task SetDnsAsync_WithIpv6_SetsBothFamiliesInSeparateCalls()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+              .Returns(Result("7"));
+        using var svc = new DnsService(runner);
+
+        await svc.SetDnsAsync("1.1.1.2", "1.0.0.2", "2606:4700:4700::1112", "2606:4700:4700::1002");
+
+        // One script issues two Set-DnsClientServerAddress calls: one IPv4, one IPv6.
+        await runner.Received(1).RunAsync(
+            Arg.Is<string>(s =>
+                s.Contains("-InterfaceIndex 7") &&
+                s.Contains("1.1.1.2") && s.Contains("1.0.0.2") &&
+                s.Contains("2606:4700:4700::1112") && s.Contains("2606:4700:4700::1002")),
+            Arg.Any<IDictionary<string, object?>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SetDnsAsync_WithoutIpv6_OnlySetsIpv4()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+              .Returns(Result("7"));
+        using var svc = new DnsService(runner);
+
+        await svc.SetDnsAsync("8.8.8.8", "8.8.4.4", "", "");
+
+        await runner.Received(1).RunAsync(
+            Arg.Is<string>(s => s.Contains("8.8.8.8") && !s.Contains("::")),
+            Arg.Any<IDictionary<string, object?>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("not-an-ip")]
+    [InlineData("zzzz::1")]
+    public async Task SetDnsAsync_InvalidIpv6_ThrowsAndNeverRunsScript(string badV6)
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        using var svc = new DnsService(runner);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.SetDnsAsync("1.1.1.1", "1.0.0.1", badV6, ""));
+        await runner.DidNotReceiveWithAnyArgs().RunAsync(default!, default, default);
+    }
+
     [Fact]
     public async Task RestoreServersAsync_InvalidAddressInSnapshot_Throws()
     {

--- a/SysManager/SysManager/Models/DnsPreset.cs
+++ b/SysManager/SysManager/Models/DnsPreset.cs
@@ -5,7 +5,9 @@
 namespace SysManager.Models;
 
 /// <summary>
-/// Represents a DNS server preset (e.g. Google, Cloudflare, Quad9).
+/// Represents a DNS server preset (e.g. Google, Cloudflare, Quad9), including optional
+/// filtering variants (ad/malware/family blocking) and IPv6 resolvers configured
+/// alongside the IPv4 pair when the provider offers them.
 /// </summary>
 public sealed class DnsPreset
 {
@@ -13,6 +15,15 @@ public sealed class DnsPreset
     public required string Primary { get; init; }
     public required string Secondary { get; init; }
     public string Description { get; init; } = "";
+
+    /// <summary>Optional primary IPv6 resolver, set alongside IPv4 when non-empty.</summary>
+    public string PrimaryV6 { get; init; } = "";
+
+    /// <summary>Optional secondary IPv6 resolver.</summary>
+    public string SecondaryV6 { get; init; } = "";
+
+    /// <summary>True when this preset configures IPv6 resolvers in addition to IPv4.</summary>
+    public bool HasIpv6 => !string.IsNullOrEmpty(PrimaryV6);
 
     public override string ToString() => Name;
 }

--- a/SysManager/SysManager/Services/DnsService.cs
+++ b/SysManager/SysManager/Services/DnsService.cs
@@ -26,10 +26,28 @@ public sealed class DnsService : IDisposable
     /// </summary>
     public List<DnsPreset> GetPresets() =>
     [
-        new DnsPreset { Name = "Google",      Primary = "8.8.8.8",         Secondary = "8.8.4.4",         Description = "Google Public DNS" },
-        new DnsPreset { Name = "Cloudflare",  Primary = "1.1.1.1",         Secondary = "1.0.0.1",         Description = "Cloudflare DNS — privacy-focused" },
-        new DnsPreset { Name = "Quad9",       Primary = "9.9.9.9",         Secondary = "149.112.112.112", Description = "Quad9 — malware blocking" },
-        new DnsPreset { Name = "OpenDNS",     Primary = "208.67.222.222",  Secondary = "208.67.220.220",  Description = "Cisco OpenDNS" },
+        // Plain resolvers (IPv4 + IPv6).
+        new DnsPreset { Name = "Google",      Primary = "8.8.8.8",         Secondary = "8.8.4.4",
+            PrimaryV6 = "2001:4860:4860::8888", SecondaryV6 = "2001:4860:4860::8844", Description = "Google Public DNS — fast, no filtering" },
+        new DnsPreset { Name = "Cloudflare",  Primary = "1.1.1.1",         Secondary = "1.0.0.1",
+            PrimaryV6 = "2606:4700:4700::1111", SecondaryV6 = "2606:4700:4700::1001", Description = "Cloudflare — privacy-focused, no filtering" },
+        new DnsPreset { Name = "Quad9",       Primary = "9.9.9.9",         Secondary = "149.112.112.112",
+            PrimaryV6 = "2620:fe::fe", SecondaryV6 = "2620:fe::9", Description = "Quad9 — blocks known malware domains (secure by default)" },
+        new DnsPreset { Name = "OpenDNS",     Primary = "208.67.222.222",  Secondary = "208.67.220.220",
+            PrimaryV6 = "2620:119:35::35", SecondaryV6 = "2620:119:53::53", Description = "Cisco OpenDNS — standard resolver" },
+
+        // Filtering variants.
+        new DnsPreset { Name = "Cloudflare — Malware blocking", Primary = "1.1.1.2", Secondary = "1.0.0.2",
+            PrimaryV6 = "2606:4700:4700::1112", SecondaryV6 = "2606:4700:4700::1002", Description = "Cloudflare 1.1.1.2 — blocks malware" },
+        new DnsPreset { Name = "Cloudflare — Family (malware + adult)", Primary = "1.1.1.3", Secondary = "1.0.0.3",
+            PrimaryV6 = "2606:4700:4700::1113", SecondaryV6 = "2606:4700:4700::1003", Description = "Cloudflare 1.1.1.3 — blocks malware and adult content" },
+        new DnsPreset { Name = "AdGuard DNS — Ad blocking", Primary = "94.140.14.14", Secondary = "94.140.15.15",
+            PrimaryV6 = "2a10:50c0::ad1:ff", SecondaryV6 = "2a10:50c0::ad2:ff", Description = "AdGuard — blocks ads and trackers" },
+        new DnsPreset { Name = "AdGuard DNS — Family", Primary = "94.140.14.15", Secondary = "94.140.15.16",
+            PrimaryV6 = "2a10:50c0::bad1:ff", SecondaryV6 = "2a10:50c0::bad2:ff", Description = "AdGuard — ads, trackers, and adult content" },
+        new DnsPreset { Name = "OpenDNS FamilyShield", Primary = "208.67.222.123", Secondary = "208.67.220.123",
+            PrimaryV6 = "2620:119:35::123", SecondaryV6 = "2620:119:53::123", Description = "OpenDNS FamilyShield — blocks adult content" },
+
         new DnsPreset { Name = "Automatic (DHCP)", Primary = "",           Secondary = "",                Description = "Use DHCP-assigned DNS" },
     ];
 
@@ -179,6 +197,48 @@ public sealed class DnsService : IDisposable
                 """;
 
             await _ps.RunAsync(script, cancellationToken: ct).ConfigureAwait(false);
+        }
+        finally { _gate.Release(); }
+    }
+
+    /// <summary>
+    /// Sets the IPv4 DNS pair and, when supplied, the IPv6 pair on the active adapter.
+    /// IPv6 is set as a separate address family so a v4-only preset leaves IPv6 untouched.
+    /// All addresses are validated before any script runs.
+    /// </summary>
+    public async Task SetDnsAsync(string primary, string secondary, string primaryV6, string secondaryV6, CancellationToken ct = default)
+    {
+        if (!IPAddress.TryParse(primary, out _))
+            throw new ArgumentException($"Invalid primary DNS address: '{primary}'", nameof(primary));
+        if (!IPAddress.TryParse(secondary, out _))
+            throw new ArgumentException($"Invalid secondary DNS address: '{secondary}'", nameof(secondary));
+
+        var hasV6 = !string.IsNullOrEmpty(primaryV6);
+        if (hasV6)
+        {
+            if (!IPAddress.TryParse(primaryV6, out _))
+                throw new ArgumentException($"Invalid primary IPv6 DNS address: '{primaryV6}'", nameof(primaryV6));
+            if (!string.IsNullOrEmpty(secondaryV6) && !IPAddress.TryParse(secondaryV6, out _))
+                throw new ArgumentException($"Invalid secondary IPv6 DNS address: '{secondaryV6}'", nameof(secondaryV6));
+        }
+
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            int ifIndex = await GetActiveInterfaceIndexAsync(ct).ConfigureAwait(false);
+            // Set the IPv4 family explicitly so it cannot clobber the IPv6 entries set below.
+            var script = new System.Text.StringBuilder();
+            script.AppendLine("$ErrorActionPreference = 'Stop'");
+            script.AppendLine($"Set-DnsClientServerAddress -InterfaceIndex {ifIndex} -ServerAddresses @(\"{primary}\",\"{secondary}\") -ErrorAction Stop");
+            if (hasV6)
+            {
+                var v6List = string.IsNullOrEmpty(secondaryV6) ? $"\"{primaryV6}\"" : $"\"{primaryV6}\",\"{secondaryV6}\"";
+                // -AddressFamily is implied by the address shape, but listing both families in
+                // one call replaces all of them — so issue IPv6 as its own call to be additive.
+                script.AppendLine($"Set-DnsClientServerAddress -InterfaceIndex {ifIndex} -ServerAddresses @({v6List}) -ErrorAction Stop");
+            }
+
+            await _ps.RunAsync(script.ToString(), cancellationToken: ct).ConfigureAwait(false);
         }
         finally { _gate.Release(); }
     }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.26.0</Version>
-    <FileVersion>1.26.0.0</FileVersion>
-    <AssemblyVersion>1.26.0.0</AssemblyVersion>
+    <Version>1.27.0</Version>
+    <FileVersion>1.27.0.0</FileVersion>
+    <AssemblyVersion>1.27.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
@@ -139,9 +139,10 @@ public sealed partial class DnsHostsViewModel : ViewModelBase
             return;
         }
 
+        var v6Note = SelectedPreset.HasIpv6 ? " + IPv6" : "";
         if (!DialogService.Instance.Confirm(
                 $"Change this PC's DNS servers to {SelectedPreset.Name} " +
-                $"({SelectedPreset.Primary}, {SelectedPreset.Secondary})?\n\n" +
+                $"({SelectedPreset.Primary}, {SelectedPreset.Secondary}{v6Note})?\n\n" +
                 "You can revert any time with \"Reset to automatic (DHCP)\".",
                 "Confirm DNS Change"))
         {
@@ -157,7 +158,8 @@ public sealed partial class DnsHostsViewModel : ViewModelBase
             // exact previous configuration, not just a generic DHCP reset.
             var snapshot = await _dnsService.CaptureCurrentServersAsync(_cts.Token).ConfigureAwait(false);
 
-            await _dnsService.SetDnsAsync(SelectedPreset.Primary, SelectedPreset.Secondary, _cts.Token)
+            await _dnsService.SetDnsAsync(SelectedPreset.Primary, SelectedPreset.Secondary,
+                    SelectedPreset.PrimaryV6, SelectedPreset.SecondaryV6, _cts.Token)
                 .ConfigureAwait(false);
 
             _previousServers = snapshot;


### PR DESCRIPTION
## Summary
Extends the existing **DNS & Hosts** preset switcher (no new tab) with filtering variants and IPv6.

- **Filtering variants**, each with a description of what it blocks: Cloudflare Malware-blocking (1.1.1.2) and Family (1.1.1.3), AdGuard DNS ad/tracker blocking + Family, OpenDNS FamilyShield.
- **IPv6 resolvers** configured automatically alongside IPv4 for every preset.
- The existing **Undo** (restore previous DNS) and DHCP reset continue to work for all variants.

Closes #910

## Design (matches existing architecture)
- `DnsPreset` gains optional `PrimaryV6`/`SecondaryV6` + a `HasIpv6` flag — purely additive, no breaking change.
- `DnsService.GetPresets()` adds the filtering entries and IPv6 addresses for all real resolvers.
- New `SetDnsAsync(primary, secondary, primaryV6, secondaryV6, ct)` overload validates every address and sets IPv6 in a **separate, additive** `Set-DnsClientServerAddress` call so a v4-only preset never clobbers IPv6 (and vice-versa). The original two-arg overload is untouched (back-compat + existing tests).
- `DnsHostsViewModel.ApplyDnsAsync` calls the new overload and notes IPv6 in the confirmation/status; snapshot-based undo unchanged.

## Safety
- Every address (v4 and v6) is validated with `IPAddress.TryParse` before any script runs; invalid input throws before the seam is touched.
- No user free-text reaches PowerShell — presets are hard-coded.

## Tests
- 7 new tests in `DnsServiceTests`: filtering variants present, plain resolvers carry IPv6, Automatic has none, the 4-arg overload sets both families in one script, v4-only path emits no `::` addresses, and invalid IPv6 throws without running a script. Existing DNS tests unchanged and still pass.

## Docs
- README (DNS & Hosts feature section), ARCHITECTURE (DnsService description), CHANGELOG (1.27.0 Added), version bump → 1.27.0. (No tab-count change — this extends an existing tab.)