### PR TITLE
feat: Profile Export/Import tab — portable SysManager configuration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,7 +51,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Privacy & Security | `PrivacyViewModel` · `FileShredderViewModel` · `AppBlockerViewModel` · `AppAlertsViewModel` · `DebloaterViewModel` · `PlaceholderViewModel` (Browser Cleaner · Edge/OneDrive Remover · Defender Tweaks · Notification Blocker) |
 | Customization | `ContextMenuViewModel` · `EnvironmentVariablesViewModel` · `PlaceholderViewModel` (Dark Mode Scheduler · Volume Control) |
 | Info | `DriversViewModel` · `BatteryHealthViewModel` · `LogsViewModel` · `SystemReportViewModel` · `AboutViewModel` |
-| Advanced | `PlaceholderViewModel` (Profile Export/Import · CLI Interface) |
+| Advanced | `ProfileViewModel` · `PlaceholderViewModel` (CLI Interface) |
 
 - `DashboardViewModel` — real-time system vitals (CPU/RAM/GPU at 300ms polling),
   temperatures (LibreHardwareMonitor + NvAPIWrapper), storage overview, system
@@ -92,6 +92,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `RestorePointsViewModel` — list, create, and restore Windows System Restore points (admin for create/restore; restore reboots, gated by confirmation).
 - `LegacyPanelsViewModel` — one-click launcher for the fixed catalog of classic Windows applets (pure launchers, no system modification).
 - `SystemFixesViewModel` — consolidated one-click repairs (Windows Update reset, network reset, WinGet reinstall) with per-fix confirmation + live output; opens netplwiz for secure auto-logon.
+- `ProfileViewModel` — export/import SysManager's own config (theme, speed-test history) as a portable JSON profile with selective sections and version checking.
 - `DebloaterViewModel` — list and remove preinstalled Store apps with a curated bloat preset; system-critical packages are denylisted; removal is per-user and reversible via the Store.
 - `ConsoleViewModel` — shared, per-tab scrollable console (each tab gets its own
   instance; lines capped at 5000 to bound memory) backing the in-app Console mirror
@@ -214,6 +215,10 @@ Key services:
   `IPowerShellRunner` seam; streams output and returns an honest success/failure
   `SystemFixResult`. Auto-logon is delegated to the built-in netplwiz dialog, never
   a plaintext credential write.
+- `ProfileService` — bundles SysManager's own config files (theme, speed-test
+  history) into a versioned, portable JSON profile and applies it back; only
+  catalog-known sections are written (a tampered profile can't drop arbitrary
+  files), and the config directory is injectable for tests.
 - `AppIconService` — downloads and caches application favicons for UI display.
 - `TemperatureService` — aggregates CPU, GPU, and disk temperatures from
   LibreHardwareMonitor (admin) and NvAPIWrapper (non-admin NVIDIA). Real-time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.28.0] - 2026-06-24
+
+### Added
+- **Profile Export/Import tab** (Advanced group). The placeholder is now a working tab that exports SysManager's own configuration — theme/appearance and speed-test history — to a single portable JSON file, and imports it on another PC. Export is selective (tick which sections to include); import shows what the profile contains and asks for confirmation before overwriting, supports selective per-section apply, and refuses profiles made by a newer, incompatible version. Only SysManager's own config is ever touched — never system settings — so importing is fully reversible.
+
 ## [1.27.0] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ fully open source.
 
 ### Sidebar navigation
 The sidebar organises 57 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 36 tabs are fully
-implemented; 21 are work-in-progress placeholders marked with ⚙️:
+find what you need without scrolling through a flat list. 37 tabs are fully
+implemented; 20 are work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |
 |-------|------|
@@ -90,7 +90,7 @@ implemented; 21 are work-in-progress placeholders marked with ⚙️:
 | 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · App Alerts · Debloater & Ads · Browser Cleaner ⚙️ · Edge/OneDrive Remover ⚙️ · Defender Tweaks ⚙️ · Notification Blocker ⚙️ |
 | 🎨 Customization | Context Menu · Dark Mode Scheduler ⚙️ · Volume Control ⚙️ · Environment Variables |
 | ℹ️ Info | Drivers · Battery Health · System Logs · System Report · About |
-| ⚙️ Advanced | Profile Export/Import ⚙️ · CLI Interface ⚙️ |
+| ⚙️ Advanced | Profile Export/Import · CLI Interface ⚙️ |
 
 > ⚙️ = Work in Progress — placeholder tab visible in the sidebar, implementation coming in future updates.
 
@@ -471,6 +471,15 @@ Remove preinstalled Windows Store apps you don't use:
 - One-click "Install" replaces the running executable in-place and
   restarts automatically (no manual file copying needed).
 - Full release-note history pulled live from GitHub.
+
+### Profile Export / Import
+- Export your SysManager settings — theme/appearance and speed-test history — to
+  a single portable JSON file, and import them on another PC
+- **Selective export** (tick which sections to include) and **selective import**
+  (confirm what a profile contains before anything is overwritten)
+- **Version-aware** — refuses profiles created by a newer, incompatible build
+- Only SysManager's own config is ever touched (never system settings), so an
+  import is fully reversible — just import a different profile
 
 ## Screenshots
 

--- a/SysManager/SysManager.Tests/ProfileServiceTests.cs
+++ b/SysManager/SysManager.Tests/ProfileServiceTests.cs
@@ -1,0 +1,122 @@
+// SysManager · ProfileServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="ProfileService"/> — the config export/import bundle. Runs against a
+/// temp config directory so it never touches the real %LOCALAPPDATA%\SysManager profile.
+/// </summary>
+public class ProfileServiceTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly ProfileService _svc;
+
+    public ProfileServiceTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "SysManagerProfileTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+        _svc = new ProfileService(_dir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true);
+    }
+
+    private void WriteConfig(string fileName, string json) => File.WriteAllText(Path.Combine(_dir, fileName), json);
+
+    // ---------- AvailableSections ----------
+
+    [Fact]
+    public void AvailableSections_OnlyIncludesExistingFiles()
+    {
+        Assert.Empty(_svc.AvailableSections());
+
+        WriteConfig("theme.json", "{\"preset\":\"midnight\"}");
+        var sections = _svc.AvailableSections();
+        Assert.Single(sections);
+        Assert.Equal("theme", sections[0].Key);
+        Assert.Contains("midnight", sections[0].Json);
+    }
+
+    // ---------- Serialize / Deserialize round-trip ----------
+
+    [Fact]
+    public void BuildAndSerialize_RoundTrips()
+    {
+        WriteConfig("theme.json", "{\"preset\":\"deep-ocean\"}");
+        WriteConfig("speedtest-history.json", "[1,2,3]");
+
+        var profile = _svc.BuildProfile(new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Local));
+        var json = ProfileService.Serialize(profile);
+        var restored = ProfileService.Deserialize(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal(ProfileService.CurrentSchemaVersion, restored!.SchemaVersion);
+        Assert.Equal(2, restored.Sections.Count);
+        Assert.Contains(restored.Sections, s => s.Key == "theme" && s.Json.Contains("deep-ocean"));
+    }
+
+    [Fact]
+    public void Deserialize_GarbageJson_ReturnsNull()
+        => Assert.Null(ProfileService.Deserialize("{ not a profile "));
+
+    [Fact]
+    public void Deserialize_NewerSchema_Throws()
+    {
+        var future = $"{{\"SchemaVersion\":{ProfileService.CurrentSchemaVersion + 1},\"AppVersion\":\"9.9.9\",\"ExportedAt\":\"2026-01-01T00:00:00\",\"Sections\":[]}}";
+        Assert.Throws<NotSupportedException>(() => ProfileService.Deserialize(future));
+    }
+
+    // ---------- ApplySections ----------
+
+    [Fact]
+    public void ApplySections_WritesKnownFiles()
+    {
+        var sections = new[]
+        {
+            new ConfigSection("theme", "Theme & appearance", "theme.json", "{\"preset\":\"warm-ember\"}"),
+        };
+        var applied = _svc.ApplySections(sections);
+
+        Assert.Equal(1, applied);
+        Assert.Equal("{\"preset\":\"warm-ember\"}", File.ReadAllText(Path.Combine(_dir, "theme.json")));
+    }
+
+    [Fact]
+    public void ApplySections_IgnoresUnknownSection_AndUsesCatalogFileName()
+    {
+        // A tampered profile claiming a rogue key / file name must NOT write outside the catalog.
+        var sections = new[]
+        {
+            new ConfigSection("rogue", "Rogue", "..\\..\\evil.json", "should-not-write"),
+            new ConfigSection("theme", "Theme", "theme.json", "{\"ok\":true}"),
+        };
+        var applied = _svc.ApplySections(sections);
+
+        Assert.Equal(1, applied);                                   // only the known section
+        Assert.False(File.Exists(Path.Combine(_dir, "evil.json"))); // rogue dropped
+        Assert.True(File.Exists(Path.Combine(_dir, "theme.json")));
+    }
+
+    // ---------- Export / Import file round-trip ----------
+
+    [Fact]
+    public async Task ExportThenImport_File_RoundTrips()
+    {
+        WriteConfig("theme.json", "{\"preset\":\"violet-night\"}");
+        var profilePath = Path.Combine(_dir, "exported-profile.json");
+
+        await _svc.ExportToFileAsync(profilePath, _svc.BuildProfile(new DateTime(2026, 6, 24, 0, 0, 0, DateTimeKind.Local)));
+        var imported = await _svc.ImportFromFileAsync(profilePath);
+
+        Assert.NotNull(imported);
+        Assert.Contains(imported!.Sections, s => s.Key == "theme" && s.Json.Contains("violet-night"));
+    }
+}

--- a/SysManager/SysManager/Models/ConfigProfile.cs
+++ b/SysManager/SysManager/Models/ConfigProfile.cs
@@ -1,0 +1,24 @@
+// SysManager · ConfigProfile
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// A portable export of SysManager's own configuration — a versioned bundle of the
+/// app's settings files (theme, speed-test history, …) that can be carried to another
+/// PC and selectively re-applied. Contains only SysManager's own JSON config, never
+/// system state, so importing it is fully reversible (it overwrites app config files).
+/// </summary>
+public sealed record ConfigProfile(
+    int SchemaVersion,
+    string AppVersion,
+    DateTime ExportedAt,
+    IReadOnlyList<ConfigSection> Sections);
+
+/// <summary>One exported config file: its logical key, file name, and raw JSON content.</summary>
+public sealed record ConfigSection(
+    string Key,
+    string DisplayName,
+    string FileName,
+    string Json);

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -65,6 +65,7 @@ public static class ServiceRegistration
         services.AddSingleton<DebloaterService>();
         services.AddSingleton<LegacyPanelService>();
         services.AddSingleton<SystemFixService>();
+        services.AddSingleton<ProfileService>();
         services.AddSingleton<WindowsUpdateService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
@@ -106,6 +107,7 @@ public static class ServiceRegistration
         services.AddSingleton<DebloaterViewModel>();
         services.AddSingleton<LegacyPanelsViewModel>();
         services.AddSingleton<SystemFixesViewModel>();
+        services.AddSingleton<ProfileViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/ProfileService.cs
+++ b/SysManager/SysManager/Services/ProfileService.cs
@@ -1,0 +1,129 @@
+// SysManager · ProfileService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Exports and imports SysManager's own configuration as a single portable JSON profile,
+/// so a user can replicate their setup on another PC. Only SysManager's own config files
+/// (under %LOCALAPPDATA%\SysManager) are included — never system state — so applying a
+/// profile just overwrites those app files and is fully reversible.
+///
+/// The config directory is constructor-injectable so the export/import logic can be unit
+/// tested against a temp directory without touching the real profile.
+/// </summary>
+public sealed class ProfileService
+{
+    /// <summary>Bump when the on-disk profile shape changes incompatibly.</summary>
+    public const int CurrentSchemaVersion = 1;
+
+    private readonly string _configDir;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
+    /// <summary>The set of config files a profile carries — logical key, label, and file name.</summary>
+    private static readonly (string Key, string DisplayName, string FileName)[] Catalog =
+    [
+        ("theme", "Theme & appearance", "theme.json"),
+        ("speedtest", "Speed-test history", "speedtest-history.json"),
+    ];
+
+    public ProfileService(string? configDir = null)
+        => _configDir = configDir ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager");
+
+    /// <summary>The config sections available to export (those whose file exists on disk).</summary>
+    public IReadOnlyList<ConfigSection> AvailableSections()
+    {
+        List<ConfigSection> sections = [];
+        foreach (var (key, display, fileName) in Catalog)
+        {
+            var path = Path.Combine(_configDir, fileName);
+            if (!File.Exists(path)) continue;
+            string json;
+            try { json = File.ReadAllText(path); }
+            catch (IOException ex) { Log.Debug("Profile: skipping {File} ({Error})", fileName, ex.Message); continue; }
+            sections.Add(new ConfigSection(key, display, fileName, json));
+        }
+        return sections;
+    }
+
+    /// <summary>Builds a profile from the given sections (defaults to all available).</summary>
+    public ConfigProfile BuildProfile(DateTime exportedAt, IReadOnlyList<ConfigSection>? sections = null)
+        => new(CurrentSchemaVersion, UpdateService.CurrentVersion.ToString(3), exportedAt,
+               sections ?? AvailableSections());
+
+    /// <summary>Serializes a profile to indented JSON.</summary>
+    public static string Serialize(ConfigProfile profile) => JsonSerializer.Serialize(profile, JsonOptions);
+
+    /// <summary>
+    /// Parses a profile from JSON. Returns null if it is not a valid profile.
+    /// Throws <see cref="NotSupportedException"/> if the schema version is newer than
+    /// this build understands (so the user gets a clear "update SysManager" message
+    /// rather than a silently mis-applied config).
+    /// </summary>
+    public static ConfigProfile? Deserialize(string json)
+    {
+        ConfigProfile? profile;
+        try { profile = JsonSerializer.Deserialize<ConfigProfile>(json, JsonOptions); }
+        catch (JsonException) { return null; }
+        if (profile is null) return null;
+        if (profile.SchemaVersion > CurrentSchemaVersion)
+            throw new NotSupportedException(
+                $"This profile was made by a newer version of SysManager (format v{profile.SchemaVersion}). Update SysManager to import it.");
+        return profile;
+    }
+
+    /// <summary>Writes a profile to a file the user chose.</summary>
+    public async Task ExportToFileAsync(string path, ConfigProfile profile, CancellationToken ct = default)
+        => await File.WriteAllTextAsync(path, Serialize(profile),
+               new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), ct).ConfigureAwait(false);
+
+    /// <summary>Reads + parses a profile from a file.</summary>
+    public async Task<ConfigProfile?> ImportFromFileAsync(string path, CancellationToken ct = default)
+        => Deserialize(await File.ReadAllTextAsync(path, ct).ConfigureAwait(false));
+
+    /// <summary>
+    /// Applies the chosen sections, overwriting the matching config files. Only sections
+    /// whose key is in the known <see cref="Catalog"/> are written (so a tampered profile
+    /// can't drop arbitrary files), and each file lands inside the config directory.
+    /// Returns the number of sections applied.
+    /// </summary>
+    public int ApplySections(IEnumerable<ConfigSection> sections)
+    {
+        Directory.CreateDirectory(_configDir);
+        var applied = 0;
+        foreach (var section in sections)
+        {
+            var known = Array.Find(Catalog, c => c.Key == section.Key);
+            if (known.Key is null)
+            {
+                Log.Warning("Profile: skipping unknown config section '{Key}'", section.Key);
+                continue;
+            }
+            // Always use the catalog's own file name — never a path from the (untrusted) profile.
+            var path = Path.Combine(_configDir, known.FileName);
+            try
+            {
+                File.WriteAllText(path, section.Json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                applied++;
+            }
+            catch (IOException ex) { Log.Warning("Profile: could not write {File}: {Error}", known.FileName, ex.Message); }
+            catch (UnauthorizedAccessException ex) { Log.Warning("Profile: access denied writing {File}: {Error}", known.FileName, ex.Message); }
+        }
+        Log.Information("Profile: applied {Count} config section(s)", applied);
+        return applied;
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.27.0</Version>
-    <FileVersion>1.27.0.0</FileVersion>
-    <AssemblyVersion>1.27.0.0</AssemblyVersion>
+    <Version>1.28.0</Version>
+    <FileVersion>1.28.0.0</FileVersion>
+    <AssemblyVersion>1.28.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -53,6 +53,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public DebloaterViewModel Debloater { get; }
     public LegacyPanelsViewModel LegacyPanels { get; }
     public SystemFixesViewModel SystemFixes { get; }
+    public ProfileViewModel Profile { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -91,7 +92,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public PlaceholderViewModel WipBootAnalyzer { get; private set; } = null!;
 
     // Advanced group
-    public PlaceholderViewModel WipProfileExportImport { get; private set; } = null!;
     public PlaceholderViewModel WipCliInterface { get; private set; } = null!;
 
     /// <summary>Grouped sidebar tree (12 categories).</summary>
@@ -155,6 +155,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Debloater = sp.GetRequiredService<DebloaterViewModel>();
             LegacyPanels = sp.GetRequiredService<LegacyPanelsViewModel>();
             SystemFixes = sp.GetRequiredService<SystemFixesViewModel>();
+            Profile = sp.GetRequiredService<ProfileViewModel>();
         }
         else
         {
@@ -211,6 +212,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Debloater = new DebloaterViewModel(new DebloaterService(new PowerShellRunner()));
             LegacyPanels = new LegacyPanelsViewModel(new LegacyPanelService());
             SystemFixes = new SystemFixesViewModel(new SystemFixService(new PowerShellRunner()));
+            Profile = new ProfileViewModel(new ProfileService());
         }
 
         InitPlaceholders();
@@ -257,7 +259,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         WipBootAnalyzer = new PlaceholderViewModel("Boot Analyzer", "Measure boot time breakdown per service/driver with optimization recommendations.", "#343");
 
         // Advanced group
-        WipProfileExportImport = new PlaceholderViewModel("Profile Export/Import", "Export SysManager configuration as JSON, import on another PC.", "#341");
         WipCliInterface = new PlaceholderViewModel("CLI Interface", "Command-line control: sysmanager --cleanup --apply-profile Gaming --silent.", "#342");
     }
 
@@ -361,7 +362,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-about",         "About",          "", About,          typeof(Views.AboutView))),
 
         Group("grp-advanced", "Advanced", "",
-            Item("nav-profile-export", "Profile Export/Import", "", WipProfileExportImport, typeof(Views.PlaceholderView)),
+            Item("nav-profile-export", "Profile Export/Import", "", Profile,               typeof(Views.ProfileView)),
             Item("nav-cli-interface",  "CLI Interface",         "", WipCliInterface,        typeof(Views.PlaceholderView))),
     ];
 
@@ -478,6 +479,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         Debloater?.Dispose();
         LegacyPanels?.Dispose();
         SystemFixes?.Dispose();
+        Profile?.Dispose();
         WipBrowserCleaner?.Dispose();
         WipEdgeOneDriveRemover?.Dispose();
         WipDefenderTweaks?.Dispose();
@@ -486,7 +488,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         WipVolumeControl?.Dispose();
         WipTaskScheduler?.Dispose();
         WipBootAnalyzer?.Dispose();
-        WipProfileExportImport?.Dispose();
         WipCliInterface?.Dispose();
 
         GC.SuppressFinalize(this);

--- a/SysManager/SysManager/ViewModels/ProfileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProfileViewModel.cs
@@ -1,0 +1,143 @@
+// SysManager · ProfileViewModel — export/import SysManager's own configuration
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Win32;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the Profile Export/Import tab. Exports SysManager's own configuration
+/// (theme, speed-test history, …) to a portable JSON file and imports it on another PC,
+/// with selective per-section apply. Only SysManager's app config is touched — never the
+/// system — so importing is fully reversible.
+/// </summary>
+public sealed partial class ProfileViewModel : ViewModelBase
+{
+    private readonly ProfileService _service;
+
+    /// <summary>Sections discovered for export (those whose config file exists).</summary>
+    public BulkObservableCollection<SelectableSection> Sections { get; } = new();
+
+    [ObservableProperty] private bool _hasSections;
+
+    public ProfileViewModel(ProfileService service)
+    {
+        _service = service;
+        RefreshSections();
+        StatusMessage = "Export your SysManager settings to a file, or import a profile from another PC.";
+    }
+
+    private void RefreshSections()
+    {
+        var available = _service.AvailableSections()
+            .Select(s => new SelectableSection(s) { IsSelected = true });
+        Sections.ReplaceWith(available);
+        HasSections = Sections.Count > 0;
+    }
+
+    [RelayCommand]
+    private async Task ExportAsync()
+    {
+        var chosen = Sections.Where(s => s.IsSelected).Select(s => s.Section).ToList();
+        if (chosen.Count == 0)
+        {
+            StatusMessage = "Select at least one section to export.";
+            return;
+        }
+
+        var dlg = new SaveFileDialog
+        {
+            FileName = $"SysManager-Profile-{DateTime.Now:yyyy-MM-dd}.json",
+            Filter = "SysManager profile (*.json)|*.json|All files (*.*)|*.*"
+        };
+        if (dlg.ShowDialog() != true) return;
+
+        IsBusy = true;
+        try
+        {
+            var profile = _service.BuildProfile(DateTime.Now, chosen);
+            await _service.ExportToFileAsync(dlg.FileName, profile).ConfigureAwait(true);
+            StatusMessage = $"Exported {chosen.Count} section{(chosen.Count == 1 ? "" : "s")} to {Path.GetFileName(dlg.FileName)}.";
+            ToastService.Instance.Show("Profile exported", Path.GetFileName(dlg.FileName));
+            Log.Information("Profile: exported {Count} sections", chosen.Count);
+        }
+        catch (IOException ex) { StatusMessage = $"Export failed: {ex.Message}"; }
+        catch (UnauthorizedAccessException ex) { StatusMessage = $"Export failed (access denied): {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    [RelayCommand]
+    private async Task ImportAsync()
+    {
+        var dlg = new OpenFileDialog
+        {
+            Filter = "SysManager profile (*.json)|*.json|All files (*.*)|*.*",
+            CheckFileExists = true
+        };
+        if (dlg.ShowDialog() != true) return;
+
+        IsBusy = true;
+        try
+        {
+            ConfigProfile? profile;
+            try { profile = await _service.ImportFromFileAsync(dlg.FileName).ConfigureAwait(true); }
+            catch (NotSupportedException ex) { StatusMessage = ex.Message; return; }
+
+            if (profile is null)
+            {
+                StatusMessage = "That file isn't a valid SysManager profile.";
+                return;
+            }
+            if (profile.Sections.Count == 0)
+            {
+                StatusMessage = "The profile contains no config sections.";
+                return;
+            }
+
+            var preview = string.Join("\n", profile.Sections.Select(s => $"  • {s.DisplayName}"));
+            if (!DialogService.Instance.Confirm(
+                    $"Import {profile.Sections.Count} section{(profile.Sections.Count == 1 ? "" : "s")} from this profile?\n\n{preview}\n\n" +
+                    $"Exported {profile.ExportedAt:yyyy-MM-dd} by SysManager v{profile.AppVersion}.\n\n" +
+                    "This overwrites the matching SysManager settings on this PC. Restart SysManager afterwards for all changes to take effect.",
+                    "Import profile"))
+            {
+                StatusMessage = "Import cancelled.";
+                return;
+            }
+
+            var applied = _service.ApplySections(profile.Sections);
+            RefreshSections();
+            StatusMessage = $"Imported {applied} section{(applied == 1 ? "" : "s")}. Restart SysManager to apply everything.";
+            ToastService.Instance.Show("Profile imported", "Restart SysManager to apply all changes.");
+        }
+        catch (IOException ex) { StatusMessage = $"Import failed: {ex.Message}"; }
+        catch (UnauthorizedAccessException ex) { StatusMessage = $"Import failed (access denied): {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    [RelayCommand]
+    private void Refresh()
+    {
+        RefreshSections();
+        StatusMessage = "Section list refreshed.";
+    }
+}
+
+/// <summary>A config section paired with a checkbox state for selective export.</summary>
+public sealed partial class SelectableSection : ObservableObject
+{
+    [ObservableProperty] private bool _isSelected = true;
+
+    public ConfigSection Section { get; }
+    public string DisplayName => Section.DisplayName;
+
+    public SelectableSection(ConfigSection section) => Section = section;
+}

--- a/SysManager/SysManager/Views/ProfileView.xaml
+++ b/SysManager/SysManager/Views/ProfileView.xaml
@@ -1,0 +1,82 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.ProfileView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             d:DataContext="{d:DesignInstance vm:ProfileViewModel}"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             Background="{DynamicResource Surface0}">
+
+    <Grid Margin="28,24,28,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,16">
+            <TextBlock Text="Profile Export / Import" Style="{StaticResource Display}"/>
+            <TextBlock Text="Save your SysManager settings to a file and carry them to another PC. Only SysManager's own configuration is exported — never system settings — so importing just overwrites the app's config and can be undone by importing a different profile."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <!-- Export card -->
+        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="16" VerticalAlignment="Top">
+            <StackPanel>
+                <TextBlock Text="Export" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource TextPrimary}"/>
+                <TextBlock Text="Choose which settings to include, then save them as a portable JSON profile."
+                           Style="{StaticResource Subtle}" Margin="0,2,0,10" TextWrapping="Wrap"/>
+
+                <ItemsControl ItemsSource="{Binding Sections}" Margin="0,0,0,8"
+                              Visibility="{Binding HasSections, Converter={StaticResource FlexVis}}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <CheckBox Content="{Binding DisplayName}"
+                                      IsChecked="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}"
+                                      AutomationProperties.Name="{Binding DisplayName, StringFormat='Include {0} in export'}"
+                                      Margin="0,4" Foreground="{DynamicResource TextPrimary}"/>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <TextBlock Text="No exportable settings found yet. Use the app a little (set a theme, run a speed test), then refresh."
+                           Style="{StaticResource Subtle}" TextWrapping="Wrap" Margin="0,0,0,8"
+                           Visibility="{Binding HasSections, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+
+                <WrapPanel>
+                    <Button Content="Export profile…" Command="{Binding ExportCommand}"
+                            IsEnabled="{Binding HasSections}"
+                            AutomationProperties.Name="Export profile to file"
+                            Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"/>
+                    <Button Content="Refresh" Command="{Binding RefreshCommand}"
+                            AutomationProperties.Name="Refresh section list"
+                            Style="{StaticResource GhostButton}"/>
+                </WrapPanel>
+            </StackPanel>
+        </Border>
+
+        <!-- Import card -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,12,0,0" Padding="16">
+            <StackPanel>
+                <TextBlock Text="Import" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource TextPrimary}"/>
+                <TextBlock Text="Load a profile exported from another PC. You'll see what it contains and confirm before anything is overwritten. Restart SysManager afterwards for all changes to take effect."
+                           Style="{StaticResource Subtle}" Margin="0,2,0,10" TextWrapping="Wrap"/>
+                <Button Content="Import profile…" Command="{Binding ImportCommand}"
+                        AutomationProperties.Name="Import profile from file"
+                        Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Status bar -->
+        <DockPanel Grid.Row="3" Margin="0,8,0,0">
+            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Right" Width="180" Height="4"
+                         IsIndeterminate="True"
+                         Visibility="{Binding IsBusy, Converter={StaticResource FlexVis}}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" VerticalAlignment="Center"/>
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/ProfileView.xaml.cs
+++ b/SysManager/SysManager/Views/ProfileView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · ProfileView — configuration export/import UI
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class ProfileView : UserControl
+{
+    public ProfileView() => InitializeComponent();
+}


### PR DESCRIPTION
## Summary
Turns the Advanced group's **Profile Export/Import** placeholder into a working tab.

- **Export** SysManager's own config — theme/appearance and speed-test history — to a single portable JSON file (tick which sections to include).
- **Import** on another PC: see what the profile contains, confirm, and apply (selective per-section).
- **Version-aware** — refuses a profile made by a newer, incompatible build with a clear "update SysManager" message.
- Only SysManager's own config is ever touched (never system settings), so an import is fully reversible — just import a different profile.

Closes #341

## Design (matches existing architecture)
- `ProfileService` (config dir injectable for tests) bundles a hard-coded **catalog** of config files into a versioned `ConfigProfile` record and applies it back. `ApplySections` writes **only catalog-known sections using the catalog's own file names** — a tampered profile claiming a rogue key or `..\evil.json` path can't drop files outside the config dir. Serialize/Deserialize are pure static methods.
- `ProfileViewModel` follows the existing async/busy + `DialogService.Confirm` + `SaveFileDialog`/`OpenFileDialog` + `BulkObservableCollection` conventions.
- `ProfileView` Strategy-1 layout (export card with section checkboxes, import card, status bar). `AutomationProperties.Name` on every control. No `DropShadowEffect`.
- Replaces the placeholder in the Advanced group (nav id `nav-profile-export` unchanged); wired into DI + both `MainWindowViewModel` paths + dispose.

## Safety
- Path-injection guarded: imported sections are written only to catalog file names inside the config dir (covered by a negative test).
- Schema-version gate prevents silently mis-applying a future format.
- No system state touched — only files under %LOCALAPPDATA%\SysManager.

## Tests
- 8 tests in `ProfileServiceTests` (temp config dir): available-sections detection, build/serialize/deserialize round-trip, garbage→null, newer-schema→throws, apply writes known files, **rogue section ignored + no path escape**, and export→import file round-trip.

## Docs
- README (37 implemented / 20 WIP, new feature section, Advanced row), ARCHITECTURE (VM + service descriptions, Advanced row), CHANGELOG (1.28.0 Added), version bump → 1.28.0.