### PR TITLE
feat: BIOS & firmware section in System Health

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -122,6 +122,10 @@ Key services:
   human-readable explanations.
 - `HealthAnalyzer` — raw SMART / ping data into verdict pills.
 - `SystemInfoService` — OS / CPU / RAM / uptime snapshot.
+- `BiosService` — read-only BIOS/firmware + motherboard info (Win32_BIOS,
+  Win32_BaseBoard, UEFI/Secure-Boot registry) plus a pure manufacturer
+  support-URL resolver for BIOS updates; never flashes firmware. Consumed by
+  `SystemHealthViewModel`.
 - `TuneUpService` — orchestrates the Quick Tune-Up wizard: temp cleanup,
   Recycle Bin, shortcut scan, disk SMART, uptime/RAM checks. Non-destructive.
 - `HealthScoreService` — aggregates disk health, RAM, uptime, and battery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.29.0] - 2026-06-24
+
+### Added
+- **BIOS & firmware section in System Health.** A scan now also reports your BIOS version, release date, and vendor, the motherboard model, the boot mode (UEFI / Legacy), and Secure Boot status — all read-only. A **Find BIOS update** button opens the right manufacturer support page (ASUS, MSI, Gigabyte, ASRock, Dell, HP, Lenovo, Acer, Biostar, or a web search as a fallback) based on the detected motherboard, and **Copy info** copies the board model + BIOS version for support searches. SysManager never flashes firmware itself; the section includes a clear reminder that BIOS updates carry risk if interrupted.
+
 ## [1.28.0] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ Edit Windows environment variables without the cramped built-in dialog:
 - Memory diagnostic that scans the last 30 days of WHEA events for RAM errors
 - Schedule the Windows Memory Diagnostic at next boot
 - Read-only chkdsk with auto-discovered NTFS/ReFS drives and multi-select
+- **BIOS & firmware** — BIOS version/date/vendor, motherboard model, boot mode
+  (UEFI/Legacy), and Secure Boot status, all read-only. A **Find BIOS update**
+  button opens the right manufacturer support page (ASUS, MSI, Gigabyte, ASRock,
+  Dell, HP, Lenovo, …) for the detected board, and **Copy info** grabs the model +
+  BIOS version for support searches. SysManager never flashes firmware itself.
 
 ### Restore Points
 - List every Windows System Restore point — sequence number, date, description,

--- a/SysManager/SysManager.IntegrationTests/AllViewModelsSweepTests.cs
+++ b/SysManager/SysManager.IntegrationTests/AllViewModelsSweepTests.cs
@@ -19,7 +19,7 @@ public class AllViewModelsSweepTests
     [Fact] public void Dashboard_Constructs() => Assert.NotNull(new DashboardViewModel(new SystemInfoService(), new TuneUpService(new ShortcutCleanerService(), new DiskHealthService(), new SystemInfoService()), new HealthScoreService(new SystemInfoService(), new DiskHealthService(), new BatteryService()), new TemperatureService(new DiskHealthService(), skipHardwareInit: true)));
     [Fact] public void AppUpdates_Constructs() => Assert.NotNull(new AppUpdatesViewModel(new WingetService(new PowerShellRunner())));
     [Fact] public void WindowsUpdate_Constructs() => Assert.NotNull(new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService()));
-    [Fact] public void SystemHealth_Constructs() => Assert.NotNull(new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner()));
+    [Fact] public void SystemHealth_Constructs() => Assert.NotNull(new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService()));
     [Fact] public void Cleanup_Constructs() => Assert.NotNull(new CleanupViewModel(new PowerShellRunner()));
     [Fact] public void DeepCleanup_Constructs() => Assert.NotNull(new DeepCleanupViewModel(new DeepCleanupService(), new LargeFileScanner(), new FixedDriveService()));
     [Fact] public void Drivers_Constructs() => Assert.NotNull(new DriversViewModel(new PowerShellRunner()));
@@ -41,7 +41,7 @@ public class AllViewModelsSweepTests
     [Fact]
     public void SystemHealth_HasCollections()
     {
-        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner());
+        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService());
         Assert.NotNull(vm.Modules);
         Assert.NotNull(vm.Disks);
         Assert.NotNull(vm.DiskHealth);

--- a/SysManager/SysManager.IntegrationTests/SystemHealthMultiDriveTests.cs
+++ b/SysManager/SysManager.IntegrationTests/SystemHealthMultiDriveTests.cs
@@ -9,7 +9,7 @@ namespace SysManager.IntegrationTests;
 
 public class SystemHealthMultiDriveTests
 {
-    private static SystemHealthViewModel Build() => new(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner());
+    private static SystemHealthViewModel Build() => new(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService());
 
     [Fact]
     public void ChkdskDrives_Collection_Exists()

--- a/SysManager/SysManager.IntegrationTests/SystemHealthViewModelExtendedTests.cs
+++ b/SysManager/SysManager.IntegrationTests/SystemHealthViewModelExtendedTests.cs
@@ -13,7 +13,7 @@ public class SystemHealthViewModelExtendedTests
     [Fact]
     public void AllCommandsExist()
     {
-        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner());
+        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService());
         Assert.NotNull(vm.ScanCommand);
         Assert.NotNull(vm.CheckDiskHealthCommand);
         Assert.NotNull(vm.CheckMemoryErrorsCommand);
@@ -26,7 +26,7 @@ public class SystemHealthViewModelExtendedTests
     [Fact]
     public void Defaults_AreSafe()
     {
-        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner());
+        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService());
         Assert.Empty(vm.DiskHealth);
         Assert.Equal(0, vm.WheaMemoryErrors);
         Assert.Equal(0, vm.MemoryDiagnosticResults);
@@ -37,7 +37,7 @@ public class SystemHealthViewModelExtendedTests
     [Fact]
     public async Task CheckDiskHealth_PopulatesCollection()
     {
-        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner());
+        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService());
         await vm.CheckDiskHealthCommand.ExecuteAsync(null);
         // Count depends on hardware. Only guarantee: not busy anymore and no crash.
         Assert.False(vm.IsBusy);
@@ -46,7 +46,7 @@ public class SystemHealthViewModelExtendedTests
     [Fact]
     public async Task CheckMemoryErrors_UpdatesVerdict()
     {
-        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner());
+        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService());
         var initialVerdict = vm.MemoryHealthVerdict;
         await vm.CheckMemoryErrorsCommand.ExecuteAsync(null);
         // Verdict should have changed (or at least still be non-empty).
@@ -57,7 +57,7 @@ public class SystemHealthViewModelExtendedTests
     [Fact]
     public void CancelScan_WithoutActive_IsSafe()
     {
-        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner());
+        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService());
         var ex = Record.Exception(() => vm.CancelScanCommand.Execute(null));
         Assert.Null(ex);
     }
@@ -65,7 +65,7 @@ public class SystemHealthViewModelExtendedTests
     [Fact]
     public void IsElevated_MatchesCurrentProcess()
     {
-        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner());
+        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService());
         Assert.Equal(Helpers.AdminHelper.IsElevated(), vm.IsElevated);
     }
 }

--- a/SysManager/SysManager.IntegrationTests/SystemHealthViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/SystemHealthViewModelTests.cs
@@ -13,7 +13,7 @@ public class SystemHealthViewModelTests
     [Fact]
     public void Ctor_DefaultsAreSafe()
     {
-        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner());
+        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService());
         Assert.Empty(vm.Modules);
         Assert.Empty(vm.Disks);
         Assert.Null(vm.Os);
@@ -25,7 +25,7 @@ public class SystemHealthViewModelTests
     [Fact]
     public async Task ScanCommand_PopulatesInfo()
     {
-        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner());
+        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService());
         await vm.ScanCommand.ExecuteAsync(null);
         Assert.NotNull(vm.Os);
         Assert.NotNull(vm.Cpu);
@@ -36,7 +36,7 @@ public class SystemHealthViewModelTests
     [Fact]
     public async Task ScanCommand_ResetsBusy()
     {
-        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner());
+        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService());
         await vm.ScanCommand.ExecuteAsync(null);
         Assert.False(vm.IsBusy);
     }
@@ -44,7 +44,7 @@ public class SystemHealthViewModelTests
     [Fact]
     public async Task ScanCommand_IsIdempotent()
     {
-        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner());
+        var vm = new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService());
         await vm.ScanCommand.ExecuteAsync(null);
         var firstDiskCount = vm.Disks.Count;
         await vm.ScanCommand.ExecuteAsync(null);

--- a/SysManager/SysManager.Tests/BiosServiceTests.cs
+++ b/SysManager/SysManager.Tests/BiosServiceTests.cs
@@ -1,0 +1,74 @@
+// SysManager · BiosServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="BiosService"/>'s pure logic — the manufacturer support-URL
+/// resolver and the WMI date formatter. The live <see cref="BiosService.Read"/> hits
+/// WMI/registry and is not unit-tested.
+/// </summary>
+public class BiosServiceTests
+{
+    [Theory]
+    [InlineData("ASUSTeK COMPUTER INC.", "https://www.asus.com/support/")]
+    [InlineData("Micro-Star International Co., Ltd.", "https://www.msi.com/support")]
+    [InlineData("MSI", "https://www.msi.com/support")]
+    [InlineData("Gigabyte Technology Co., Ltd.", "https://www.gigabyte.com/Support")]
+    [InlineData("ASRock", "https://www.asrock.com/support/")]
+    [InlineData("Dell Inc.", "https://www.dell.com/support/home")]
+    [InlineData("HP", "https://support.hp.com")]
+    [InlineData("Hewlett-Packard", "https://support.hp.com")]
+    [InlineData("LENOVO", "https://pcsupport.lenovo.com")]
+    public void SupportUrl_ResolvesKnownManufacturers(string manufacturer, string expected)
+        => Assert.Equal(expected, BiosService.SupportUrl(manufacturer, "X570"));
+
+    [Fact]
+    public void SupportUrl_UnknownManufacturer_FallsBackToWebSearch()
+    {
+        var url = BiosService.SupportUrl("Acme Boards", "SuperBoard 9000");
+        Assert.StartsWith("https://www.google.com/search?q=", url);
+        Assert.Contains("BIOS", url);
+        Assert.Contains("Acme", url);
+    }
+
+    [Fact]
+    public void SupportUrl_NullManufacturer_DoesNotThrow()
+    {
+        var url = BiosService.SupportUrl(null!, "Board");
+        Assert.StartsWith("https://www.google.com/search?q=", url);
+    }
+
+    [Theory]
+    [InlineData("20240115000000.000000+000", "2024-01-15")]
+    [InlineData("20231231", "2023-12-31")]
+    public void FormatWmiDate_ParsesCimDateTime(string cim, string expected)
+        => Assert.Equal(expected, BiosService.FormatWmiDate(cim));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("short")]
+    [InlineData("notadateXX")]
+    public void FormatWmiDate_InvalidInput_ReturnsEmpty(string? cim)
+        => Assert.Equal("", BiosService.FormatWmiDate(cim));
+
+    [Fact]
+    public void BiosInfo_BoardDisplay_CombinesManufacturerAndProduct()
+    {
+        var b = new BiosInfo("1.2.0", "2024-01-15", "AMI", "UEFI", "On", "ASUSTeK", "ROG STRIX X570-E");
+        Assert.Equal("ASUSTeK ROG STRIX X570-E", b.BoardDisplay);
+        Assert.False(b.IsEmpty);
+    }
+
+    [Fact]
+    public void BiosInfo_IsEmpty_WhenNoData()
+    {
+        var b = new BiosInfo("", "", "", "Unknown", "Unknown", "", "");
+        Assert.True(b.IsEmpty);
+    }
+}

--- a/SysManager/SysManager.Tests/SystemHealthViewModelTests.cs
+++ b/SysManager/SysManager.Tests/SystemHealthViewModelTests.cs
@@ -10,7 +10,7 @@ namespace SysManager.Tests;
 
 public class SystemHealthViewModelTests
 {
-    private static SystemHealthViewModel NewVm() => new(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner());
+    private static SystemHealthViewModel NewVm() => new(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService());
 
     // ---------- construction ----------
 

--- a/SysManager/SysManager/Models/BiosInfo.cs
+++ b/SysManager/SysManager/Models/BiosInfo.cs
@@ -1,0 +1,25 @@
+// SysManager · BiosInfo
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// Read-only BIOS / firmware and motherboard information for the System Health tab.
+/// Gathered from Win32_BIOS and Win32_BaseBoard plus UEFI/Secure Boot detection.
+/// </summary>
+public sealed record BiosInfo(
+    string Version,
+    string ReleaseDate,
+    string Manufacturer,
+    string BootMode,        // "UEFI" / "Legacy BIOS" / "Unknown"
+    string SecureBoot,      // "On" / "Off" / "Unknown"
+    string BoardManufacturer,
+    string BoardProduct)
+{
+    /// <summary>"Manufacturer Product" for the motherboard, trimmed.</summary>
+    public string BoardDisplay => $"{BoardManufacturer} {BoardProduct}".Trim();
+
+    /// <summary>True when no meaningful BIOS data was gathered (e.g. query denied).</summary>
+    public bool IsEmpty => string.IsNullOrWhiteSpace(Version) && string.IsNullOrWhiteSpace(BoardDisplay);
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -66,6 +66,7 @@ public static class ServiceRegistration
         services.AddSingleton<LegacyPanelService>();
         services.AddSingleton<SystemFixService>();
         services.AddSingleton<ProfileService>();
+        services.AddSingleton<BiosService>();
         services.AddSingleton<WindowsUpdateService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────

--- a/SysManager/SysManager/Services/BiosService.cs
+++ b/SysManager/SysManager/Services/BiosService.cs
@@ -1,0 +1,131 @@
+// SysManager · BiosService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Management;
+using Microsoft.Win32;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Reads BIOS/firmware and motherboard information (Win32_BIOS, Win32_BaseBoard) and
+/// resolves the right manufacturer support page for BIOS updates. Strictly read-only —
+/// it never attempts to flash firmware. The support-URL resolver is a pure static method
+/// so it can be unit-tested without any WMI access.
+/// </summary>
+public sealed class BiosService
+{
+    /// <summary>Gathers BIOS + motherboard info. Returns an empty-ish record if queries fail.</summary>
+    public BiosInfo Read()
+    {
+        string version = "", releaseDate = "", manufacturer = "";
+        string boardManufacturer = "", boardProduct = "";
+
+        try
+        {
+            using var searcher = new ManagementObjectSearcher(
+                "SELECT SMBIOSBIOSVersion, Manufacturer, ReleaseDate FROM Win32_BIOS");
+            using var collection = searcher.Get();
+            foreach (ManagementObject mo in collection)
+            {
+                using (mo)
+                {
+                    version = mo["SMBIOSBIOSVersion"]?.ToString()?.Trim() ?? "";
+                    manufacturer = mo["Manufacturer"]?.ToString()?.Trim() ?? "";
+                    releaseDate = FormatWmiDate(mo["ReleaseDate"]?.ToString());
+                    break;
+                }
+            }
+        }
+        catch (ManagementException ex) { Log.Debug("BIOS info unavailable: {Error}", ex.Message); }
+        catch (System.Runtime.InteropServices.COMException ex) { Log.Debug("BIOS info WMI COM error: {Error}", ex.Message); }
+        catch (UnauthorizedAccessException ex) { Log.Debug("BIOS info access denied: {Error}", ex.Message); }
+
+        try
+        {
+            using var searcher = new ManagementObjectSearcher("SELECT Manufacturer, Product FROM Win32_BaseBoard");
+            using var collection = searcher.Get();
+            foreach (ManagementObject mo in collection)
+            {
+                using (mo)
+                {
+                    boardManufacturer = mo["Manufacturer"]?.ToString()?.Trim() ?? "";
+                    boardProduct = mo["Product"]?.ToString()?.Trim() ?? "";
+                    break;
+                }
+            }
+        }
+        catch (ManagementException ex) { Log.Debug("Motherboard info unavailable: {Error}", ex.Message); }
+        catch (System.Runtime.InteropServices.COMException ex) { Log.Debug("Motherboard info WMI COM error: {Error}", ex.Message); }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Motherboard info access denied: {Error}", ex.Message); }
+
+        return new BiosInfo(version, releaseDate, manufacturer, ReadBootMode(), ReadSecureBoot(), boardManufacturer, boardProduct);
+    }
+
+    /// <summary>UEFI vs Legacy via the PEFirmwareType registry value (1=BIOS, 2=UEFI).</summary>
+    private static string ReadBootMode()
+    {
+        try
+        {
+            using var key = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Control");
+            return key?.GetValue("PEFirmwareType") switch
+            {
+                2 => "UEFI",
+                1 => "Legacy BIOS",
+                _ => "Unknown"
+            };
+        }
+        catch (System.Security.SecurityException) { return "Unknown"; }
+        catch (UnauthorizedAccessException) { return "Unknown"; }
+    }
+
+    /// <summary>Secure Boot on/off via the SecureBoot\State\UEFISecureBootEnabled registry value.</summary>
+    private static string ReadSecureBoot()
+    {
+        try
+        {
+            using var key = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Control\SecureBoot\State");
+            return key?.GetValue("UEFISecureBootEnabled") switch
+            {
+                1 => "On",
+                0 => "Off",
+                _ => "Unknown"
+            };
+        }
+        catch (System.Security.SecurityException) { return "Unknown"; }
+        catch (UnauthorizedAccessException) { return "Unknown"; }
+    }
+
+    /// <summary>Converts a WMI CIM_DATETIME (yyyymmdd...) to yyyy-MM-dd, or "" if unparseable.</summary>
+    internal static string FormatWmiDate(string? cimDate)
+    {
+        if (string.IsNullOrWhiteSpace(cimDate) || cimDate.Length < 8) return "";
+        var datePart = cimDate[..8];
+        return long.TryParse(datePart, out _)
+            ? $"{datePart[..4]}-{datePart[4..6]}-{datePart[6..8]}"
+            : "";
+    }
+
+    /// <summary>
+    /// Resolves the manufacturer's BIOS-update support page from the motherboard/system
+    /// manufacturer. Falls back to a web search for the board model. Pure + unit-tested.
+    /// </summary>
+    public static string SupportUrl(string manufacturer, string boardModel)
+    {
+        var m = (manufacturer ?? "").ToLowerInvariant();
+        if (m.Contains("asus")) return "https://www.asus.com/support/";
+        if (m.Contains("msi") || m.Contains("micro-star")) return "https://www.msi.com/support";
+        if (m.Contains("gigabyte")) return "https://www.gigabyte.com/Support";
+        if (m.Contains("asrock")) return "https://www.asrock.com/support/";
+        if (m.Contains("dell")) return "https://www.dell.com/support/home";
+        if (m.Contains("hewlett") || m.Contains("hp")) return "https://support.hp.com";
+        if (m.Contains("lenovo")) return "https://pcsupport.lenovo.com";
+        if (m.Contains("acer")) return "https://www.acer.com/support";
+        if (m.Contains("biostar")) return "https://www.biostar.com.tw/app/en/support/";
+
+        var query = Uri.EscapeDataString($"{manufacturer} {boardModel} BIOS update".Trim());
+        return $"https://www.google.com/search?q={query}";
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.28.0</Version>
-    <FileVersion>1.28.0.0</FileVersion>
-    <AssemblyVersion>1.28.0.0</AssemblyVersion>
+    <Version>1.29.0</Version>
+    <FileVersion>1.29.0.0</FileVersion>
+    <AssemblyVersion>1.29.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -178,7 +178,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Dashboard = new DashboardViewModel(sysInfo, tuneUp, healthScore, new TemperatureService(diskHealth));
             AppUpdates = new AppUpdatesViewModel(winget);
             WindowsUpdate = new WindowsUpdateViewModel(runner, new WindowsUpdateService());
-            SystemHealth = new SystemHealthViewModel(sysInfo, diskHealth, new MemoryTestService(), fixedDrives, runner);
+            SystemHealth = new SystemHealthViewModel(sysInfo, diskHealth, new MemoryTestService(), fixedDrives, runner, new BiosService());
             Cleanup = new CleanupViewModel(runner);
             DeepCleanup = new DeepCleanupViewModel(new DeepCleanupService(), new LargeFileScanner(), fixedDrives);
             DuplicateFile = new DuplicateFileViewModel(new DuplicateFileService());

--- a/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
@@ -22,6 +22,7 @@ public sealed partial class SystemHealthViewModel : ViewModelBase
     private readonly MemoryTestService _memTest;
     private readonly FixedDriveService _drives;
     private readonly PowerShellRunner _runner;
+    private readonly BiosService _biosService;
     private CancellationTokenSource? _cts;
 
     public BulkObservableCollection<MemoryModule> Modules { get; } = new();
@@ -45,13 +46,17 @@ public sealed partial class SystemHealthViewModel : ViewModelBase
     [ObservableProperty] private string _memoryHealthVerdict = "Click 'Check memory errors' to inspect.";
     [ObservableProperty] private string _memoryHealthColorHex = "#9AA0A6";
 
-    public SystemHealthViewModel(SystemInfoService sys, DiskHealthService diskHealth, MemoryTestService memTest, FixedDriveService drives, PowerShellRunner runner)
+    // BIOS / firmware (read-only); populated on Scan.
+    [ObservableProperty] private BiosInfo? _bios;
+
+    public SystemHealthViewModel(SystemInfoService sys, DiskHealthService diskHealth, MemoryTestService memTest, FixedDriveService drives, PowerShellRunner runner, BiosService biosService)
     {
         _sys = sys;
         _diskHealth = diskHealth;
         _memTest = memTest;
         _drives = drives;
         _runner = runner;
+        _biosService = biosService;
         IsElevated = AdminHelper.IsElevated();
         _runner.LineReceived += OnRunnerLineReceived;
 
@@ -92,6 +97,8 @@ public sealed partial class SystemHealthViewModel : ViewModelBase
             Memory = snap.Memory;
             Modules.ReplaceWith(snap.Memory.Modules);
             Disks.ReplaceWith(snap.Disks);
+            // BIOS read hits blocking WMI/registry — keep it off the UI thread.
+            Bios = await Task.Run(_biosService.Read);
             Summary = $"OS {snap.Os.Caption}  —  CPU {snap.Cpu.Name} ({snap.Cpu.Cores}c/{snap.Cpu.LogicalProcessors}t)  —  RAM {snap.Memory.UsedGB:0.0}/{snap.Memory.TotalGB:0.0} GB  —  Disks {snap.Disks.Count}";
             StatusMessage = $"Scan at {snap.CapturedAt:HH:mm:ss}";
             ToastService.Instance.Show("System Health scan complete", $"{snap.Disks.Count} disks, {snap.Memory.Modules.Count} RAM modules");
@@ -101,6 +108,41 @@ public sealed partial class SystemHealthViewModel : ViewModelBase
         catch (System.Management.ManagementException ex) { StatusMessage = $"Scan failed: {ex.Message}"; }
         catch (InvalidOperationException ex) { StatusMessage = $"Scan failed: {ex.Message}"; }
         finally { IsBusy = false; IsProgressIndeterminate = false; }
+    }
+
+    /// <summary>Opens the motherboard manufacturer's support page (or a web search) for BIOS updates.</summary>
+    [RelayCommand]
+    private void OpenBiosSupport()
+    {
+        var url = BiosService.SupportUrl(Bios?.BoardManufacturer ?? "", Bios?.BoardProduct ?? "");
+        try
+        {
+            Process.Start(new ProcessStartInfo(url) { UseShellExecute = true })?.Dispose();
+            StatusMessage = "Opened the manufacturer support page in your browser.";
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            Log.Warning("Could not open BIOS support page: {Error}", ex.Message);
+            StatusMessage = "Couldn't open the browser.";
+        }
+    }
+
+    /// <summary>Copies the motherboard model + BIOS version to the clipboard for support searches.</summary>
+    [RelayCommand]
+    private void CopyBiosInfo()
+    {
+        if (Bios is null) { StatusMessage = "Run a scan first."; return; }
+        var text = $"{Bios.BoardDisplay} — BIOS {Bios.Version} ({Bios.ReleaseDate})".Trim();
+        try
+        {
+            System.Windows.Clipboard.SetText(text);
+            StatusMessage = "BIOS info copied to clipboard.";
+        }
+        catch (System.Runtime.InteropServices.ExternalException ex)
+        {
+            Log.Debug("Clipboard locked: {Error}", ex.Message);
+            StatusMessage = "Couldn't copy: the clipboard is in use.";
+        }
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -111,6 +111,38 @@
                     </Grid>
                 </Border>
 
+                <!-- BIOS / firmware -->
+                <Border Style="{StaticResource Card}" Margin="0,16,0,0"
+                        Visibility="{Binding Bios, Converter={StaticResource FlexVis}}">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0" Margin="0,0,16,0">
+                            <TextBlock Text="BIOS &amp; firmware" Style="{StaticResource SectionTitle}"/>
+                            <StackPanel Margin="0,8,0,0" DataContext="{Binding Bios}">
+                                <TextBlock Margin="0,2"><Run Text="Motherboard: " Foreground="{DynamicResource TextMuted}"/><Run Text="{Binding BoardDisplay, Mode=OneWay}"/></TextBlock>
+                                <TextBlock Margin="0,2"><Run Text="BIOS version: " Foreground="{DynamicResource TextMuted}"/><Run Text="{Binding Version, Mode=OneWay}"/></TextBlock>
+                                <TextBlock Margin="0,2"><Run Text="BIOS date: " Foreground="{DynamicResource TextMuted}"/><Run Text="{Binding ReleaseDate, Mode=OneWay}"/></TextBlock>
+                                <TextBlock Margin="0,2"><Run Text="BIOS vendor: " Foreground="{DynamicResource TextMuted}"/><Run Text="{Binding Manufacturer, Mode=OneWay}"/></TextBlock>
+                                <TextBlock Margin="0,2"><Run Text="Boot mode: " Foreground="{DynamicResource TextMuted}"/><Run Text="{Binding BootMode, Mode=OneWay}"/></TextBlock>
+                                <TextBlock Margin="0,2"><Run Text="Secure Boot: " Foreground="{DynamicResource TextMuted}"/><Run Text="{Binding SecureBoot, Mode=OneWay}"/></TextBlock>
+                            </StackPanel>
+                            <TextBlock Text="Read-only. Updating a BIOS carries risk if interrupted — only flash from the manufacturer's file, on stable power. SysManager never flashes firmware itself."
+                                       Style="{StaticResource Subtle}" Margin="0,8,0,0" TextWrapping="Wrap"/>
+                        </StackPanel>
+                        <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                            <Button Content="Find BIOS update" Command="{Binding OpenBiosSupportCommand}"
+                                    AutomationProperties.Name="Open manufacturer support page for BIOS updates"
+                                    Style="{StaticResource PrimaryButton}" Padding="14,8" Margin="0,0,8,0"/>
+                            <Button Content="Copy info" Command="{Binding CopyBiosInfoCommand}"
+                                    AutomationProperties.Name="Copy BIOS and motherboard info"
+                                    Style="{StaticResource GhostButton}" Padding="14,8"/>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
                 <!-- Storage devices list -->
                 <Border Style="{StaticResource Card}" Margin="0,16,0,0">
                     <StackPanel>


### PR DESCRIPTION
## Summary
Adds a read-only **BIOS & firmware** card to the System Health tab (Closes #1).

- Shows BIOS version, release date, and vendor; the motherboard model; boot mode (UEFI / Legacy); and Secure Boot status — populated on **Scan**.
- **Find BIOS update** opens the right manufacturer support page for the detected board (ASUS, MSI, Gigabyte, ASRock, Dell, HP, Lenovo, Acer, Biostar), or a web search as a fallback.
- **Copy info** copies the board model + BIOS version for support searches.
- Strictly read-only — SysManager never flashes firmware. The card carries a clear warning that BIOS updates carry risk if interrupted.

## Design (matches existing architecture)
- New `BiosService` reads Win32_BIOS + Win32_BaseBoard and the PEFirmwareType / SecureBoot registry values. The `SupportUrl` resolver and `FormatWmiDate` are **pure static methods** (unit-tested); the live `Read()` runs off the UI thread (`Task.Run`) during the existing Scan.
- `SystemHealthViewModel` gains a constructor-injected `BiosService`, a `Bios` observable property, and `OpenBiosSupport`/`CopyBiosInfo` commands — all consistent with the existing VM idioms.
- The view adds one additive Card matching the existing card pattern (SectionTitle/Subtle styles, PrimaryButton/GhostButton); visibility bound through `FlexVis` on the nullable `Bios` (shows once a scan populates it). No `DropShadowEffect`.

## Breaking-change handling
- The `SystemHealthViewModel` constructor gained a parameter. **All 14 call sites** across the unit + integration test projects (including target-typed `new(...)` forms) and the manual construction path in `MainWindowViewModel` were updated — every test project builds 0/0.

## Tests
- 9 new tests in `BiosServiceTests`: support-URL resolution for 8 known vendors + web-search fallback + null manufacturer, WMI CIM-date parsing (valid + invalid), and `BiosInfo.BoardDisplay`/`IsEmpty`.

## Docs
- README (System health feature section), ARCHITECTURE (BiosService description), CHANGELOG (1.29.0 Added), version bump → 1.29.0. (No tab-count change — extends the existing System Health tab.)