### PR TITLE
feat: Windows Update timing & deferral controls

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -116,6 +116,10 @@ Key services:
 - `WingetService` — shells out to `winget` and parses its table output.
 - `WindowsUpdateService` — drives Windows Update through the WUA COM API
   (scan, select, install) with progress reporting; backs `WindowsUpdateViewModel`.
+- `WindowsUpdatePolicyService` — reads/writes the documented Windows Update
+  deferral policy keys (defer feature updates, bounded pause, restore default).
+  Injectable registry root for tests; deliberately offers no permanent
+  disable-updates option, only a bounded pause.
 - `DiskHealthService` — pulls SMART data through WMI.
 - `MemoryTestService` — scans WHEA / MemoryDiagnostics events.
 - `EventLogService` + `EventExplainer` — read Windows Event Log and attach

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.30.0] - 2026-06-24
+
+### Added
+- **Windows Update timing & deferral controls** (Windows Update tab). A new "Update timing & deferral" section lets you **defer feature updates** by a configurable number of days while security and quality updates keep installing, **pause all updates** for a bounded window (up to 35 days, after which Windows auto-resumes), and **Restore default** to return to standard behavior. It uses the documented Windows Update policy registry keys and is fully reversible. There is deliberately no "disable updates forever" option — the strongest action is a clearly-bounded pause, so a machine is never left permanently unpatched. Requires administrator.
+
 ## [1.29.0] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -232,6 +232,12 @@ a confirmation before it runs:
 - Pending-reboot check, update history (last 30 — via PSWindowsUpdate)
 - Admin banner with a one-click "Run as Administrator" relaunch
 - PSWindowsUpdate is optional now (used only for the History view)
+- **Update timing & deferral** — defer feature updates by N days while security
+  patches keep flowing, pause all updates for a bounded window (max 35 days, then
+  Windows auto-resumes), or restore defaults. Uses the documented Windows Update
+  policy keys and is fully reversible. No "disable updates forever" option by
+  design — the strongest action is a bounded pause, so the machine is never left
+  permanently unpatched.
 
 ### App updates (winget)
 - Scan for upgradable packages

--- a/SysManager/SysManager.IntegrationTests/AdminElevationVmTests.cs
+++ b/SysManager/SysManager.IntegrationTests/AdminElevationVmTests.cs
@@ -16,7 +16,7 @@ public class AdminElevationVmTests
     [Fact]
     public void WindowsUpdateVm_ExposesIsElevated()
     {
-        var vm = new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService());
+        var vm = new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService(), new WindowsUpdatePolicyService());
         // Must equal the current process' elevation state.
         Assert.Equal(Helpers.AdminHelper.IsElevated(), vm.IsElevated);
     }
@@ -24,7 +24,7 @@ public class AdminElevationVmTests
     [Fact]
     public void WindowsUpdateVm_HasRelaunchCommand()
     {
-        var vm = new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService());
+        var vm = new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService(), new WindowsUpdatePolicyService());
         Assert.NotNull(vm.RelaunchAsAdminCommand);
     }
 
@@ -59,7 +59,7 @@ public class AdminElevationVmTests
     [Fact]
     public void AllElevationVms_Report_SameElevationFlag()
     {
-        var a = new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService()).IsElevated;
+        var a = new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService(), new WindowsUpdatePolicyService()).IsElevated;
         var b = new CleanupViewModel(new PowerShellRunner()).IsElevated;
         var c = new AppUpdatesViewModel(new WingetService(new PowerShellRunner())).IsElevated;
         Assert.Equal(a, b);

--- a/SysManager/SysManager.IntegrationTests/AllViewModelsSweepTests.cs
+++ b/SysManager/SysManager.IntegrationTests/AllViewModelsSweepTests.cs
@@ -18,7 +18,7 @@ public class AllViewModelsSweepTests
 {
     [Fact] public void Dashboard_Constructs() => Assert.NotNull(new DashboardViewModel(new SystemInfoService(), new TuneUpService(new ShortcutCleanerService(), new DiskHealthService(), new SystemInfoService()), new HealthScoreService(new SystemInfoService(), new DiskHealthService(), new BatteryService()), new TemperatureService(new DiskHealthService(), skipHardwareInit: true)));
     [Fact] public void AppUpdates_Constructs() => Assert.NotNull(new AppUpdatesViewModel(new WingetService(new PowerShellRunner())));
-    [Fact] public void WindowsUpdate_Constructs() => Assert.NotNull(new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService()));
+    [Fact] public void WindowsUpdate_Constructs() => Assert.NotNull(new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService(), new WindowsUpdatePolicyService()));
     [Fact] public void SystemHealth_Constructs() => Assert.NotNull(new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService()));
     [Fact] public void Cleanup_Constructs() => Assert.NotNull(new CleanupViewModel(new PowerShellRunner()));
     [Fact] public void DeepCleanup_Constructs() => Assert.NotNull(new DeepCleanupViewModel(new DeepCleanupService(), new LargeFileScanner(), new FixedDriveService()));

--- a/SysManager/SysManager.IntegrationTests/LightTouchViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/LightTouchViewModelTests.cs
@@ -73,7 +73,7 @@ public class LightTouchViewModelTests
     [Fact]
     public void WindowsUpdateVm_Ctor_IsSafe()
     {
-        var vm = new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService());
+        var vm = new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService(), new WindowsUpdatePolicyService());
         Assert.NotNull(vm.Console);
         Assert.False(vm.ModuleAvailable);
     }
@@ -81,7 +81,7 @@ public class LightTouchViewModelTests
     [Fact]
     public void WindowsUpdateVm_AllCommandsExist()
     {
-        var vm = new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService());
+        var vm = new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService(), new WindowsUpdatePolicyService());
         Assert.NotNull(vm.CheckModuleCommand);
         Assert.NotNull(vm.InstallModuleCommand);
         Assert.NotNull(vm.ListUpdatesCommand);
@@ -94,7 +94,7 @@ public class LightTouchViewModelTests
     [Fact]
     public void WindowsUpdateVm_ModuleStatusDefault_IsSet()
     {
-        var vm = new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService());
+        var vm = new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService(), new WindowsUpdatePolicyService());
         // Since the WUA COM migration, updates use the COM API directly and
         // PSWindowsUpdate backs only the History view; the default status reflects that.
         Assert.False(string.IsNullOrWhiteSpace(vm.ModuleStatus));

--- a/SysManager/SysManager.IntegrationTests/WindowsUpdateAutoCheckTests.cs
+++ b/SysManager/SysManager.IntegrationTests/WindowsUpdateAutoCheckTests.cs
@@ -9,7 +9,7 @@ namespace SysManager.IntegrationTests;
 
 public class WindowsUpdateAutoCheckTests
 {
-    private static WindowsUpdateViewModel Build() => new(new PowerShellRunner(), new WindowsUpdateService());
+    private static WindowsUpdateViewModel Build() => new(new PowerShellRunner(), new WindowsUpdateService(), new WindowsUpdatePolicyService());
 
     [Fact]
     public void ModuleStatus_HasInitialMessage()

--- a/SysManager/SysManager.IntegrationTests/WindowsUpdateViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/WindowsUpdateViewModelTests.cs
@@ -10,7 +10,7 @@ namespace SysManager.IntegrationTests;
 
 public class WindowsUpdateViewModelTests
 {
-    private static WindowsUpdateViewModel NewVm() => new(new PowerShellRunner(), new WindowsUpdateService());
+    private static WindowsUpdateViewModel NewVm() => new(new PowerShellRunner(), new WindowsUpdateService(), new WindowsUpdatePolicyService());
 
     // ---------- construction ----------
 
@@ -117,7 +117,7 @@ public class WindowsUpdateViewModelTests
     public void RunnerLineReceived_AppendsToConsole()
     {
         var runner = new PowerShellRunner();
-        var vm = new WindowsUpdateViewModel(runner, new WindowsUpdateService());
+        var vm = new WindowsUpdateViewModel(runner, new WindowsUpdateService(), new WindowsUpdatePolicyService());
 
         var ev = typeof(PowerShellRunner)
             .GetField(nameof(PowerShellRunner.LineReceived),
@@ -134,7 +134,7 @@ public class WindowsUpdateViewModelTests
     public void RunnerProgressChanged_UpdatesProgress()
     {
         var runner = new PowerShellRunner();
-        var vm = new WindowsUpdateViewModel(runner, new WindowsUpdateService());
+        var vm = new WindowsUpdateViewModel(runner, new WindowsUpdateService(), new WindowsUpdatePolicyService());
 
         var ev = typeof(PowerShellRunner)
             .GetField(nameof(PowerShellRunner.ProgressChanged),

--- a/SysManager/SysManager.Tests/WindowsUpdatePolicyServiceTests.cs
+++ b/SysManager/SysManager.Tests/WindowsUpdatePolicyServiceTests.cs
@@ -1,0 +1,107 @@
+// SysManager · WindowsUpdatePolicyServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using Microsoft.Win32;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Round-trip tests for <see cref="WindowsUpdatePolicyService"/>. The service takes an
+/// injectable registry root; here we point it at a disposable HKCU subkey so defer/pause/
+/// restore can be verified against a real hive without administrator rights and without
+/// touching the machine's real Windows Update policy.
+/// </summary>
+public sealed class WindowsUpdatePolicyServiceTests : IDisposable
+{
+    private readonly string _rootName = @"Software\SysManagerTests\WUPolicy_" + Guid.NewGuid().ToString("N");
+    private readonly RegistryKey _root;
+    private readonly WindowsUpdatePolicyService _svc;
+    private static readonly DateTime Now = new(2026, 6, 24, 12, 0, 0, DateTimeKind.Local);
+
+    public WindowsUpdatePolicyServiceTests()
+    {
+        _root = Registry.CurrentUser.CreateSubKey(_rootName, writable: true)!;
+        _svc = new WindowsUpdatePolicyService(_root);
+    }
+
+    public void Dispose()
+    {
+        _root.Dispose();
+        try { Registry.CurrentUser.DeleteSubKeyTree(_rootName, throwOnMissingSubKey: false); } catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public void Read_NoPolicy_ReturnsDefaults()
+    {
+        var p = _svc.Read(Now);
+        Assert.False(p.DeferFeatureUpdates);
+        Assert.False(p.PauseActive);
+        Assert.Contains("Default", p.Summary);
+    }
+
+    [Fact]
+    public void DeferFeatureUpdates_WritesAndReadsBack()
+    {
+        Assert.True(_svc.DeferFeatureUpdates(45));
+        var p = _svc.Read(Now);
+        Assert.True(p.DeferFeatureUpdates);
+        Assert.Equal(45, p.FeatureDeferDays);
+        Assert.Contains("deferred 45", p.Summary);
+    }
+
+    [Fact]
+    public void PauseUpdates_SetsBoundedEndTimeInFuture()
+    {
+        Assert.True(_svc.PauseUpdates(7, Now));
+        var p = _svc.Read(Now);
+        Assert.True(p.PauseActive);
+        Assert.Equal(Now.AddDays(7), p.PauseUntil);
+        Assert.Contains("paused until", p.Summary);
+    }
+
+    [Fact]
+    public void PauseUpdates_IsClampedToMax()
+    {
+        Assert.True(_svc.PauseUpdates(999, Now));
+        var p = _svc.Read(Now);
+        Assert.Equal(Now.AddDays(WindowsUpdatePolicyService.MaxPauseDays), p.PauseUntil);
+    }
+
+    [Fact]
+    public void Read_ExpiredPause_IsNotActive()
+    {
+        _svc.PauseUpdates(7, Now);
+        // 10 days later the pause has lapsed.
+        var p = _svc.Read(Now.AddDays(10));
+        Assert.False(p.PauseActive);
+    }
+
+    [Fact]
+    public void RestoreDefault_ClearsAllPolicy()
+    {
+        _svc.DeferFeatureUpdates(30);
+        _svc.PauseUpdates(14, Now);
+        Assert.True(_svc.RestoreDefault());
+
+        var p = _svc.Read(Now);
+        Assert.False(p.DeferFeatureUpdates);
+        Assert.False(p.PauseActive);
+        Assert.Equal(0, p.FeatureDeferDays);
+    }
+
+    [Theory]
+    [InlineData(-5, 0)]
+    [InlineData(30, 30)]
+    [InlineData(9999, 365)]
+    public void ClampDeferDays_BoundsTo0To365(int input, int expected)
+        => Assert.Equal(expected, WindowsUpdatePolicyService.ClampDeferDays(input));
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(7, 7)]
+    [InlineData(999, 35)]
+    public void ClampPauseDays_BoundsTo1To35(int input, int expected)
+        => Assert.Equal(expected, WindowsUpdatePolicyService.ClampPauseDays(input));
+}

--- a/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
+++ b/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
@@ -18,7 +18,7 @@ namespace SysManager.Tests;
 [Collection("DialogService")]
 public class WindowsUpdateViewModelTests
 {
-    private static WindowsUpdateViewModel NewVm() => new(new PowerShellRunner(), new WindowsUpdateService());
+    private static WindowsUpdateViewModel NewVm() => new(new PowerShellRunner(), new WindowsUpdateService(), new WindowsUpdatePolicyService());
 
     // ---------- construction & defaults ----------
 

--- a/SysManager/SysManager/Models/WindowsUpdatePolicy.cs
+++ b/SysManager/SysManager/Models/WindowsUpdatePolicy.cs
@@ -1,0 +1,25 @@
+// SysManager · WindowsUpdatePolicy
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// A snapshot of the Windows Update deferral policy currently in effect, read from the
+/// documented WindowsUpdate policy registry keys. All fields are reversible — clearing
+/// them returns Windows to its out-of-box update behavior.
+/// </summary>
+public sealed record WindowsUpdatePolicy(
+    bool DeferFeatureUpdates,
+    int FeatureDeferDays,
+    bool PauseActive,
+    DateTime? PauseUntil)
+{
+    /// <summary>Plain-English summary of the active policy for the status line.</summary>
+    public string Summary =>
+        PauseActive && PauseUntil is { } until
+            ? $"Updates paused until {until:yyyy-MM-dd}."
+            : DeferFeatureUpdates
+                ? $"Feature updates deferred {FeatureDeferDays} day(s); security updates still install."
+                : "Default — Windows manages update timing.";
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -67,6 +67,7 @@ public static class ServiceRegistration
         services.AddSingleton<SystemFixService>();
         services.AddSingleton<ProfileService>();
         services.AddSingleton<BiosService>();
+        services.AddSingleton<WindowsUpdatePolicyService>();
         services.AddSingleton<WindowsUpdateService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────

--- a/SysManager/SysManager/Services/WindowsUpdatePolicyService.cs
+++ b/SysManager/SysManager/Services/WindowsUpdatePolicyService.cs
@@ -1,0 +1,138 @@
+// SysManager · WindowsUpdatePolicyService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Globalization;
+using Microsoft.Win32;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Reads and writes the documented Windows Update deferral policy keys
+/// (HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate). Lets the user defer feature
+/// updates, pause updates for a bounded window, and restore defaults — every change is
+/// fully reversible by clearing the policy values. There is intentionally NO "disable all
+/// updates" option: the strongest action is a clearly-bounded pause, so a machine is never
+/// left permanently unpatched.
+///
+/// The registry root is injectable so the logic can be unit-tested against a redirected
+/// HKCU subkey without administrator rights or touching real machine policy (mirrors
+/// <see cref="AppBlockerService"/>).
+/// </summary>
+public sealed class WindowsUpdatePolicyService
+{
+    // Relative path under the base key. Under HKLM this is the real Group Policy location
+    // the Windows Update client honors.
+    private const string PolicyPath = @"SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate";
+
+    // Max bounded pause Windows itself honors (~35 days); we never exceed it.
+    public const int MaxPauseDays = 35;
+
+    private readonly RegistryKey _baseKey;
+
+    /// <summary>
+    /// Creates the service over a registry root. Defaults to
+    /// <see cref="Registry.LocalMachine"/> (real machine policy, needs admin); tests pass a
+    /// redirected root (an HKCU subkey) to avoid admin and machine writes.
+    /// </summary>
+    public WindowsUpdatePolicyService(RegistryKey? baseKey = null)
+        => _baseKey = baseKey ?? Registry.LocalMachine;
+
+    /// <summary>Reads the current deferral policy. Never throws — returns defaults on failure.</summary>
+    public WindowsUpdatePolicy Read(DateTime now)
+    {
+        try
+        {
+            using var key = _baseKey.OpenSubKey(PolicyPath);
+            if (key is null) return new WindowsUpdatePolicy(false, 0, false, null);
+
+            var defer = key.GetValue("DeferFeatureUpdates") is int d && d == 1;
+            var days = key.GetValue("DeferFeatureUpdatesPeriodInDays") is int n ? n : 0;
+
+            DateTime? pauseUntil = null;
+            if (key.GetValue("PauseFeatureUpdatesEndTime") is string s &&
+                DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var until))
+                pauseUntil = until;
+            var paused = pauseUntil is { } u && u > now;
+
+            return new WindowsUpdatePolicy(defer, days, paused, paused ? pauseUntil : null);
+        }
+        catch (System.Security.SecurityException ex) { Log.Debug("WU policy read denied: {Error}", ex.Message); }
+        catch (UnauthorizedAccessException ex) { Log.Debug("WU policy read denied: {Error}", ex.Message); }
+        return new WindowsUpdatePolicy(false, 0, false, null);
+    }
+
+    /// <summary>Clamps a requested defer-days value into the range Windows accepts (0–365).</summary>
+    public static int ClampDeferDays(int days) => Math.Clamp(days, 0, 365);
+
+    /// <summary>Clamps a requested pause window into 1–<see cref="MaxPauseDays"/> days.</summary>
+    public static int ClampPauseDays(int days) => Math.Clamp(days, 1, MaxPauseDays);
+
+    /// <summary>
+    /// Defers feature updates by the given number of days (quality/security updates keep
+    /// flowing). Returns false if the write was denied (no elevation).
+    /// </summary>
+    public bool DeferFeatureUpdates(int days)
+    {
+        var clamped = ClampDeferDays(days);
+        return Write(key =>
+        {
+            key.SetValue("DeferFeatureUpdates", 1, RegistryValueKind.DWord);
+            key.SetValue("DeferFeatureUpdatesPeriodInDays", clamped, RegistryValueKind.DWord);
+        }, $"defer feature updates {clamped}d");
+    }
+
+    /// <summary>
+    /// Pauses updates for a bounded window (clamped to <see cref="MaxPauseDays"/>), after
+    /// which Windows auto-resumes. Returns false if the write was denied.
+    /// </summary>
+    public bool PauseUpdates(int days, DateTime now)
+    {
+        var until = now.AddDays(ClampPauseDays(days));
+        var iso = until.ToString("o", CultureInfo.InvariantCulture);
+        return Write(key =>
+        {
+            key.SetValue("PauseFeatureUpdatesStartTime", now.ToString("o", CultureInfo.InvariantCulture), RegistryValueKind.String);
+            key.SetValue("PauseFeatureUpdatesEndTime", iso, RegistryValueKind.String);
+            key.SetValue("PauseQualityUpdatesStartTime", now.ToString("o", CultureInfo.InvariantCulture), RegistryValueKind.String);
+            key.SetValue("PauseQualityUpdatesEndTime", iso, RegistryValueKind.String);
+        }, $"pause updates until {until:yyyy-MM-dd}");
+    }
+
+    /// <summary>
+    /// Restores default behavior by removing all the policy values SysManager sets.
+    /// Returns false if the write was denied.
+    /// </summary>
+    public bool RestoreDefault()
+    {
+        return Write(key =>
+        {
+            foreach (var name in new[]
+            {
+                "DeferFeatureUpdates", "DeferFeatureUpdatesPeriodInDays",
+                "PauseFeatureUpdatesStartTime", "PauseFeatureUpdatesEndTime",
+                "PauseQualityUpdatesStartTime", "PauseQualityUpdatesEndTime"
+            })
+            {
+                try { key.DeleteValue(name, throwOnMissingValue: false); }
+                catch (System.Security.SecurityException) { /* best-effort per-value */ }
+            }
+        }, "restore default update policy");
+    }
+
+    private bool Write(Action<RegistryKey> mutate, string what)
+    {
+        try
+        {
+            using var key = _baseKey.CreateSubKey(PolicyPath, writable: true);
+            if (key is null) return false;
+            mutate(key);
+            Log.Information("WU policy: {What}", what);
+            return true;
+        }
+        catch (System.Security.SecurityException ex) { Log.Warning("WU policy write denied ({What}): {Error}", what, ex.Message); return false; }
+        catch (UnauthorizedAccessException ex) { Log.Warning("WU policy write denied ({What}): {Error}", what, ex.Message); return false; }
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.29.0</Version>
-    <FileVersion>1.29.0.0</FileVersion>
-    <AssemblyVersion>1.29.0.0</AssemblyVersion>
+    <Version>1.30.0</Version>
+    <FileVersion>1.30.0.0</FileVersion>
+    <AssemblyVersion>1.30.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -177,7 +177,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
             Dashboard = new DashboardViewModel(sysInfo, tuneUp, healthScore, new TemperatureService(diskHealth));
             AppUpdates = new AppUpdatesViewModel(winget);
-            WindowsUpdate = new WindowsUpdateViewModel(runner, new WindowsUpdateService());
+            WindowsUpdate = new WindowsUpdateViewModel(runner, new WindowsUpdateService(), new WindowsUpdatePolicyService());
             SystemHealth = new SystemHealthViewModel(sysInfo, diskHealth, new MemoryTestService(), fixedDrives, runner, new BiosService());
             Cleanup = new CleanupViewModel(runner);
             DeepCleanup = new DeepCleanupViewModel(new DeepCleanupService(), new LargeFileScanner(), fixedDrives);

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -17,6 +17,7 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
 {
     private readonly PowerShellRunner _runner;
     private readonly WindowsUpdateService _wu;
+    private readonly WindowsUpdatePolicyService _policy;
     private CancellationTokenSource? _cts;
 
     public BulkObservableCollection<UpdateEntry> Updates { get; } = new();
@@ -37,10 +38,16 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
     [ObservableProperty] private bool _allSelected;
     private bool _suppressAllSelected;
 
-    public WindowsUpdateViewModel(PowerShellRunner runner, WindowsUpdateService wu)
+    // Update deferral policy (registry-backed, reversible).
+    [ObservableProperty] private string _policySummary = "";
+    [ObservableProperty] private int _deferDays = 30;
+    [ObservableProperty] private int _pauseDays = 7;
+
+    public WindowsUpdateViewModel(PowerShellRunner runner, WindowsUpdateService wu, WindowsUpdatePolicyService policy)
     {
         _runner = runner;
         _wu = wu;
+        _policy = policy;
         _runner.LineReceived += OnRunnerLineReceived;
         _runner.ProgressChanged += OnRunnerProgressChanged;
         _wu.Log += OnWuLog;
@@ -55,6 +62,56 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
         // and IsBusy stays false until the user triggers an action.
         ModuleAvailable = true;
         ModuleStatus = "PSWindowsUpdate is used for the History view only.";
+        RefreshPolicy();
+    }
+
+    private void RefreshPolicy() => PolicySummary = _policy.Read(DateTime.Now).Summary;
+
+    [RelayCommand]
+    private void DeferFeatureUpdates()
+    {
+        if (!RequireAdminForPolicy()) return;
+        if (!DialogService.Instance.Confirm(
+                $"Defer Windows feature updates by {WindowsUpdatePolicyService.ClampDeferDays(DeferDays)} days?\n\n" +
+                "Security and quality updates keep installing normally — only large feature upgrades are held back. " +
+                "Reversible any time with \"Restore default\".",
+                "Defer feature updates"))
+            return;
+        PolicySummary = _policy.DeferFeatureUpdates(DeferDays)
+            ? _policy.Read(DateTime.Now).Summary
+            : "Couldn't apply the policy — administrator rights are required.";
+    }
+
+    [RelayCommand]
+    private void PauseUpdates()
+    {
+        if (!RequireAdminForPolicy()) return;
+        var clamped = WindowsUpdatePolicyService.ClampPauseDays(PauseDays);
+        if (!DialogService.Instance.Confirm(
+                $"Pause all Windows updates for {clamped} days?\n\n" +
+                "Windows will automatically resume updates when the pause ends. This is a bounded pause — " +
+                "SysManager never disables updates permanently.",
+                "Pause updates"))
+            return;
+        PolicySummary = _policy.PauseUpdates(PauseDays, DateTime.Now)
+            ? _policy.Read(DateTime.Now).Summary
+            : "Couldn't apply the policy — administrator rights are required.";
+    }
+
+    [RelayCommand]
+    private void RestoreUpdatePolicy()
+    {
+        if (!RequireAdminForPolicy()) return;
+        PolicySummary = _policy.RestoreDefault()
+            ? _policy.Read(DateTime.Now).Summary
+            : "Couldn't restore the policy — administrator rights are required.";
+    }
+
+    private bool RequireAdminForPolicy()
+    {
+        if (IsElevated) return true;
+        PolicySummary = "Changing update policy requires administrator rights — use \"Run as administrator\".";
+        return false;
     }
 
     private void OnRunnerLineReceived(PowerShellLine l) => Console.Append(l);

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -109,6 +109,39 @@
                             Visibility="{Binding IsShowingHistory, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                     <Button Content="Cancel" Command="{Binding CancelCommand}" Style="{StaticResource GhostButton}" Margin="0,0,8,8"/>
                 </WrapPanel>
+
+                <!-- Update deferral policy (registry-backed, fully reversible) -->
+                <Expander Header="Update timing &amp; deferral" Margin="0,8,0,0" Foreground="{DynamicResource TextPrimary}">
+                    <StackPanel Margin="0,10,0,0">
+                        <TextBlock Text="{Binding PolicySummary}" Style="{StaticResource Subtle}" TextWrapping="Wrap" Margin="0,0,0,10"/>
+
+                        <WrapPanel VerticalAlignment="Center" Margin="0,0,0,6">
+                            <TextBlock Text="Defer feature updates by" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                            <TextBox Text="{Binding DeferDays}" Width="60" VerticalContentAlignment="Center"
+                                     AutomationProperties.Name="Days to defer feature updates" Margin="0,0,6,0"/>
+                            <TextBlock Text="days" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                            <Button Content="Apply deferral" Command="{Binding DeferFeatureUpdatesCommand}"
+                                    AutomationProperties.Name="Defer feature updates"
+                                    Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
+                        </WrapPanel>
+
+                        <WrapPanel VerticalAlignment="Center" Margin="0,0,0,6">
+                            <TextBlock Text="Pause all updates for" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                            <TextBox Text="{Binding PauseDays}" Width="60" VerticalContentAlignment="Center"
+                                     AutomationProperties.Name="Days to pause updates" Margin="0,0,6,0"/>
+                            <TextBlock Text="days (max 35)" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                            <Button Content="Pause updates" Command="{Binding PauseUpdatesCommand}"
+                                    AutomationProperties.Name="Pause updates"
+                                    Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
+                            <Button Content="Restore default" Command="{Binding RestoreUpdatePolicyCommand}"
+                                    AutomationProperties.Name="Restore default update policy"
+                                    Style="{StaticResource GhostButton}"/>
+                        </WrapPanel>
+
+                        <TextBlock Text="Security and quality updates keep installing while feature updates are deferred. A pause is always bounded — SysManager never disables updates permanently. Requires administrator; reversible with Restore default."
+                                   Style="{StaticResource Subtle}" TextWrapping="Wrap" Margin="0,4,0,0"/>
+                    </StackPanel>
+                </Expander>
             </StackPanel>
         </Border>
 


### PR DESCRIPTION
## Summary
Adds an **Update timing & deferral** section to the Windows Update tab (Closes #912).

- **Defer feature updates** by a configurable number of days — security and quality updates keep installing.
- **Pause all updates** for a bounded window (max 35 days; Windows auto-resumes after).
- **Restore default** to return to standard out-of-box behavior.
- Deliberately **no permanent "disable updates" option** — the strongest action is a clearly-bounded pause, so a machine is never left unpatched.

## Design (matches existing architecture)
- New `WindowsUpdatePolicyService` reads/writes the documented `SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate` keys. It mirrors `AppBlockerService`'s **injectable registry root**, so the round-trip logic is unit-tested against a redirected HKCU subkey without admin or touching real machine policy. Values are clamped (defer 0–365, pause 1–35) and writes return `false` (never throw) when denied.
- `WindowsUpdateViewModel` gains a constructor-injected `WindowsUpdatePolicyService`, a `PolicySummary` + defer/pause-day properties, and Defer/Pause/Restore commands — each confirms first and checks elevation.
- The view adds the controls as an **Expander inside the existing Actions card** — no grid-row renumbering, minimal surface change. `AutomationProperties.Name` on every control. No `DropShadowEffect`.

## Breaking-change handling
- The `WindowsUpdateViewModel` constructor gained a parameter; **all 12 call sites** (incl. target-typed `new(...)`) across the unit + integration projects and the manual path in `MainWindowViewModel` were updated — all projects build 0/0.

## Safety
- Fully reversible (Restore default clears every value SysManager sets).
- Bounded pause only; no permanent disable.
- Requires admin; denied writes degrade gracefully with a clear message.

## Tests
- 11 tests in `WindowsUpdatePolicyServiceTests` (HKCU-redirected root): defaults, defer round-trip, bounded pause + clamp, expired-pause detection, restore-clears-all, and the clamp helpers.

## Docs
- README (Windows Update feature section), ARCHITECTURE (service description), CHANGELOG (1.30.0 Added), version bump → 1.30.0. (No tab-count change — extends the existing Windows Update tab.)