### PR TITLE
feat: Browser Cleaner tab — per-browser cache/cookies/history cleanup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,7 +48,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Storage | `DiskAnalyzerViewModel` · `DuplicateFileViewModel` |
 | Network | `PingViewModel` · `TracerouteViewModel` · `SpeedTestViewModel` · `NetworkRepairViewModel` (shared: `NetworkSharedState`) · `DnsHostsViewModel` |
 | Apps | `AppUpdatesViewModel` · `BulkInstallerViewModel` · `UninstallerViewModel` |
-| Privacy & Security | `PrivacyViewModel` · `FileShredderViewModel` · `AppBlockerViewModel` · `AppAlertsViewModel` · `DebloaterViewModel` · `PlaceholderViewModel` (Browser Cleaner · Edge/OneDrive Remover · Defender Tweaks · Notification Blocker) |
+| Privacy & Security | `PrivacyViewModel` · `FileShredderViewModel` · `AppBlockerViewModel` · `AppAlertsViewModel` · `DebloaterViewModel` · `BrowserCleanerViewModel` · `PlaceholderViewModel` (Edge/OneDrive Remover · Defender Tweaks · Notification Blocker) |
 | Customization | `ContextMenuViewModel` · `EnvironmentVariablesViewModel` · `PlaceholderViewModel` (Dark Mode Scheduler · Volume Control) |
 | Info | `DriversViewModel` · `BatteryHealthViewModel` · `LogsViewModel` · `SystemReportViewModel` · `AboutViewModel` |
 | Advanced | `ProfileViewModel` · `PlaceholderViewModel` (CLI Interface) |
@@ -94,6 +94,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `SystemFixesViewModel` — consolidated one-click repairs (Windows Update reset, network reset, WinGet reinstall) with per-fix confirmation + live output; opens netplwiz for secure auto-logon.
 - `ProfileViewModel` — export/import SysManager's own config (theme, speed-test history) as a portable JSON profile with selective sections and version checking.
 - `DebloaterViewModel` — list and remove preinstalled Store apps with a curated bloat preset; system-critical packages are denylisted; removal is per-user and reversible via the Store.
+- `BrowserCleanerViewModel` — scan per-browser cache/history/cookies/sessions with sizes and clean the selected categories; cookies/sessions default unticked.
 - `ConsoleViewModel` — shared, per-tab scrollable console (each tab gets its own
   instance; lines capped at 5000 to bound memory) backing the in-app Console mirror
   used by Cleanup, Windows Update, System Health, App Updates, and Uninstaller.
@@ -214,6 +215,10 @@ Key services:
   per-user) Windows Store apps through the `IPowerShellRunner` seam. A hard-coded
   denylist of system-critical package families is enforced in code; the parser and
   denylist check are pure, unit-tested static methods.
+- `BrowserCleanerService` — scans + cleans per-browser data (Chromium family +
+  Firefox) under injectable LOCALAPPDATA/APPDATA roots. Scan is read-only (sizes);
+  Clean deletes only discovered files, skips locked files, and never follows
+  reparse points. Cookies/sessions are flagged sensitive.
 - `LegacyPanelService` — opens classic Windows applets (Control Panel, Sound,
   Device Manager, …) via their `control`/`*.cpl`/`*.msc` commands. The catalog is
   hard-coded and `Launch` re-validates catalog membership, so no input reaches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.31.0] - 2026-06-24
+
+### Added
+- **Browser Cleaner tab** (Privacy & Security). The placeholder is now a working tab that scans installed browsers — Chrome, Edge, Brave, Opera, and Firefox — and shows the on-disk size of each cleanable category (cache, history, cookies, sessions). Tick what to remove and clean it after a confirmation. Cookies and sessions are flagged "signs you out" and left **unticked by default**, so a clean never logs you out by accident. Cache and history are pre-selected. Cleaning is per-user (no admin); locked files (browser open) are skipped rather than forced, and reparse points are never followed.
+
 ## [1.30.0] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ fully open source.
 
 ### Sidebar navigation
 The sidebar organises 57 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 37 tabs are fully
-implemented; 20 are work-in-progress placeholders marked with ⚙️:
+find what you need without scrolling through a flat list. 38 tabs are fully
+implemented; 19 are work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |
 |-------|------|
@@ -87,7 +87,7 @@ implemented; 20 are work-in-progress placeholders marked with ⚙️:
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS & Hosts |
 | 📦 Apps | App Updates · Bulk Installer · Uninstaller |
-| 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · App Alerts · Debloater & Ads · Browser Cleaner ⚙️ · Edge/OneDrive Remover ⚙️ · Defender Tweaks ⚙️ · Notification Blocker ⚙️ |
+| 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · App Alerts · Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover ⚙️ · Defender Tweaks ⚙️ · Notification Blocker ⚙️ |
 | 🎨 Customization | Context Menu · Dark Mode Scheduler ⚙️ · Volume Control ⚙️ · Environment Variables |
 | ℹ️ Info | Drivers · Battery Health · System Logs · System Report · About |
 | ⚙️ Advanced | Profile Export/Import · CLI Interface ⚙️ |
@@ -403,6 +403,16 @@ Remove preinstalled Windows Store apps you don't use:
 - **Impact summary + confirmation** before anything is uninstalled
 - **Reversible** — removal is per-user, so any app can be reinstalled from the Store
 - Search and per-app descriptions help you decide before removing
+
+### Browser Cleaner
+Reclaim space and clear browsing traces, per browser:
+- **Auto-detects** Chrome, Edge, Brave, Opera, and Firefox
+- **Per-category** with size shown: Cache, History, Cookies, Sessions
+- **Cookies/sessions are flagged and left unticked** by default — cleaning them
+  signs you out, so it's always an explicit choice; cache and history are pre-selected
+- **Confirmation with an impact summary** before anything is deleted
+- Per-user (no admin); locked files (browser open) are skipped, not forced, and
+  symlinks/junctions are never followed
 
 ### Battery Health
 - Charge %, health %, wear level, cycle count, chemistry

--- a/SysManager/SysManager.Tests/BrowserCleanerServiceTests.cs
+++ b/SysManager/SysManager.Tests/BrowserCleanerServiceTests.cs
@@ -1,0 +1,101 @@
+// SysManager · BrowserCleanerServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="BrowserCleanerService"/>. Runs against temp LOCALAPPDATA/APPDATA
+/// trees so scan + clean can be exercised deterministically without touching real browser
+/// profiles. Verifies that only existing categories surface, sizes are measured, cookies are
+/// flagged sensitive + unselected, and Clean actually removes files.
+/// </summary>
+public sealed class BrowserCleanerServiceTests : IDisposable
+{
+    private readonly string _local;
+    private readonly string _roaming;
+    private readonly BrowserCleanerService _svc;
+
+    public BrowserCleanerServiceTests()
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), "SysManagerBrowserTest_" + Guid.NewGuid().ToString("N"));
+        _local = Path.Combine(baseDir, "Local");
+        _roaming = Path.Combine(baseDir, "Roaming");
+        Directory.CreateDirectory(_local);
+        Directory.CreateDirectory(_roaming);
+        _svc = new BrowserCleanerService(_local, _roaming);
+    }
+
+    public void Dispose()
+    {
+        var parent = Directory.GetParent(_local)!.FullName;
+        if (Directory.Exists(parent)) Directory.Delete(parent, recursive: true);
+    }
+
+    private void WriteFile(string relUnderLocal, int bytes)
+    {
+        var full = Path.Combine(_local, relUnderLocal);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllBytes(full, new byte[bytes]);
+    }
+
+    [Fact]
+    public async Task Scan_NoBrowsers_ReturnsEmpty()
+        => Assert.Empty(await _svc.ScanAsync());
+
+    [Fact]
+    public async Task Scan_FindsChromeCache_WithSize()
+    {
+        WriteFile(@"Google\Chrome\User Data\Default\Cache\data_0", 1024);
+        WriteFile(@"Google\Chrome\User Data\Default\Cache\data_1", 2048);
+
+        var items = await _svc.ScanAsync();
+        var cache = items.FirstOrDefault(i => i.Browser == "Google Chrome" && i.Category == "Cache");
+        Assert.NotNull(cache);
+        Assert.Equal(3072, cache!.SizeBytes);
+        Assert.Equal(2, cache.FileCount);
+        Assert.True(cache.IsSelected);      // cache is pre-selected
+        Assert.False(cache.IsSensitive);
+    }
+
+    [Fact]
+    public async Task Scan_CookiesAreSensitive_AndUnselected()
+    {
+        WriteFile(@"Google\Chrome\User Data\Default\Network\Cookies", 512);
+
+        var items = await _svc.ScanAsync();
+        var cookies = items.FirstOrDefault(i => i.Category == "Cookies");
+        Assert.NotNull(cookies);
+        Assert.True(cookies!.IsSensitive);
+        Assert.False(cookies.IsSelected);   // never auto-selected — would sign the user out
+    }
+
+    [Fact]
+    public async Task Scan_OmitsEmptyOrMissingCategories()
+    {
+        // Only Edge cache exists; nothing else should surface.
+        WriteFile(@"Microsoft\Edge\User Data\Default\Cache\f", 10);
+        var items = await _svc.ScanAsync();
+        Assert.All(items, i => Assert.Equal("Microsoft Edge", i.Browser));
+        Assert.Contains(items, i => i.Category == "Cache");
+        Assert.DoesNotContain(items, i => i.Category == "Cookies");
+    }
+
+    [Fact]
+    public async Task Clean_DeletesSelectedFiles()
+    {
+        WriteFile(@"Google\Chrome\User Data\Default\Cache\data_0", 1024);
+        WriteFile(@"Google\Chrome\User Data\Default\Cache\sub\data_1", 2048);
+
+        var items = await _svc.ScanAsync();
+        var cache = items.First(i => i.Category == "Cache");
+        var deleted = await _svc.CleanAsync([cache]);
+
+        Assert.Equal(2, deleted);
+        Assert.Empty(Directory.GetFiles(
+            Path.Combine(_local, @"Google\Chrome\User Data\Default\Cache"), "*", SearchOption.AllDirectories));
+    }
+}

--- a/SysManager/SysManager/Models/BrowserCleanupItem.cs
+++ b/SysManager/SysManager/Models/BrowserCleanupItem.cs
@@ -1,0 +1,32 @@
+// SysManager · BrowserCleanupItem
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using SysManager.Helpers;
+
+namespace SysManager.Models;
+
+/// <summary>
+/// One cleanable browser-data category (a browser + a data type such as Cache or History),
+/// with the on-disk size discovered by a scan. <see cref="IsSelected"/> drives which items
+/// a clean removes; cookies default to unselected so logins aren't dropped by accident.
+/// </summary>
+public sealed partial class BrowserCleanupItem : ObservableObject
+{
+    [ObservableProperty] private bool _isSelected;
+    [ObservableProperty] private long _sizeBytes;
+    [ObservableProperty] private int _fileCount;
+
+    public required string Browser { get; init; }
+    public required string Category { get; init; }
+    public required string Description { get; init; }
+
+    /// <summary>Absolute paths (files and/or directories) this item covers.</summary>
+    public required IReadOnlyList<string> Paths { get; init; }
+
+    /// <summary>True for cookie/session data — cleaning it signs you out of sites.</summary>
+    public bool IsSensitive { get; init; }
+
+    public string SizeDisplay => FormatHelper.FormatSize(SizeBytes);
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -68,6 +68,7 @@ public static class ServiceRegistration
         services.AddSingleton<ProfileService>();
         services.AddSingleton<BiosService>();
         services.AddSingleton<WindowsUpdatePolicyService>();
+        services.AddSingleton<BrowserCleanerService>();
         services.AddSingleton<WindowsUpdateService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
@@ -110,6 +111,7 @@ public static class ServiceRegistration
         services.AddSingleton<LegacyPanelsViewModel>();
         services.AddSingleton<SystemFixesViewModel>();
         services.AddSingleton<ProfileViewModel>();
+        services.AddSingleton<BrowserCleanerViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/BrowserCleanerService.cs
+++ b/SysManager/SysManager/Services/BrowserCleanerService.cs
@@ -1,0 +1,209 @@
+// SysManager · BrowserCleanerService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Scans and cleans per-browser cache / cookies / history / sessions for the Chromium
+/// family (Chrome, Edge, Brave, Opera) and Firefox. Scan is read-only (sizes only); Clean
+/// deletes only the discovered files. Cookies/sessions are flagged sensitive and default to
+/// unselected so a clean never silently signs the user out.
+///
+/// The base data directories are injectable so the catalog/scan logic can be unit-tested
+/// against a temp directory tree without touching the real browser profiles.
+/// </summary>
+public sealed class BrowserCleanerService
+{
+    private readonly string _localAppData;
+    private readonly string _roamingAppData;
+
+    public BrowserCleanerService(string? localAppData = null, string? roamingAppData = null)
+    {
+        _localAppData = localAppData ?? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        _roamingAppData = roamingAppData ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+    }
+
+    private sealed record Def(string Browser, string Category, string Description, bool Sensitive, string[] RelativePaths, bool Roaming = false);
+
+    // Chromium "Default" profile layout is shared by Chrome/Edge/Brave/Opera.
+    private static Def[] ChromiumDefs(string browser, string userDataRel) =>
+    [
+        new(browser, "Cache", "Cached images and files.", false,
+            [$@"{userDataRel}\Default\Cache", $@"{userDataRel}\Default\Code Cache", $@"{userDataRel}\Default\GPUCache"]),
+        new(browser, "History", "Browsing and download history.", false,
+            [$@"{userDataRel}\Default\History", $@"{userDataRel}\Default\History-journal"]),
+        new(browser, "Cookies", "Cookies — clearing these signs you out of websites.", true,
+            [$@"{userDataRel}\Default\Network\Cookies", $@"{userDataRel}\Default\Network\Cookies-journal"]),
+        new(browser, "Sessions", "Open tabs / session restore data.", true,
+            [$@"{userDataRel}\Default\Sessions", $@"{userDataRel}\Default\Session Storage"]),
+    ];
+
+    private List<Def> BuildDefs()
+    {
+        List<Def> defs = [];
+        defs.AddRange(ChromiumDefs("Google Chrome", @"Google\Chrome\User Data"));
+        defs.AddRange(ChromiumDefs("Microsoft Edge", @"Microsoft\Edge\User Data"));
+        defs.AddRange(ChromiumDefs("Brave", @"BraveSoftware\Brave-Browser\User Data"));
+        defs.AddRange(ChromiumDefs("Opera", @"Opera Software\Opera Stable"));
+        // Firefox keeps profiles in roaming AppData; cache lives in local.
+        defs.Add(new("Firefox", "Cache", "Cached images and files.", false, [@"Mozilla\Firefox\Profiles"]) );
+        return defs;
+    }
+
+    private string Root(bool roaming) => roaming ? _roamingAppData : _localAppData;
+
+    /// <summary>
+    /// Discovers cleanable items with their on-disk size. Read-only. Items whose paths don't
+    /// exist (browser not installed / category empty) are omitted.
+    /// </summary>
+    public Task<IReadOnlyList<BrowserCleanupItem>> ScanAsync(CancellationToken ct = default)
+        => Task.Run<IReadOnlyList<BrowserCleanupItem>>(() =>
+        {
+            List<BrowserCleanupItem> items = [];
+            foreach (var d in BuildDefs())
+            {
+                if (ct.IsCancellationRequested) break;
+                var abs = d.RelativePaths
+                    .Select(r => Path.Combine(Root(d.Roaming), r))
+                    .Where(PathExists)
+                    .ToArray();
+                if (abs.Length == 0) continue;
+
+                long size = 0; var files = 0;
+                foreach (var p in abs)
+                {
+                    if (ct.IsCancellationRequested) break;
+                    var (s, f) = MeasurePath(p, ct);
+                    size += s; files += f;
+                }
+                if (size == 0 && files == 0) continue;
+
+                items.Add(new BrowserCleanupItem
+                {
+                    Browser = d.Browser,
+                    Category = d.Category,
+                    Description = d.Description,
+                    Paths = abs,
+                    IsSensitive = d.Sensitive,
+                    SizeBytes = size,
+                    FileCount = files,
+                    IsSelected = !d.Sensitive   // cache/history pre-selected; cookies/sessions opt-in
+                });
+            }
+            return items;
+        }, ct);
+
+    /// <summary>
+    /// Deletes the files for the given items. Returns the number of files deleted. Best-effort:
+    /// locked files (browser running) are skipped, not fatal. Reparse points are never followed.
+    /// </summary>
+    public Task<int> CleanAsync(IReadOnlyList<BrowserCleanupItem> items, CancellationToken ct = default)
+        => Task.Run(() =>
+        {
+            var deleted = 0;
+            foreach (var item in items)
+            {
+                if (ct.IsCancellationRequested) break;
+                foreach (var path in item.Paths)
+                {
+                    if (ct.IsCancellationRequested) break;
+                    deleted += DeletePath(path, ct);
+                }
+            }
+            Log.Information("BrowserCleaner: deleted {Count} files across {Items} items", deleted, items.Count);
+            return deleted;
+        }, ct);
+
+    private static bool PathExists(string p) => File.Exists(p) || Directory.Exists(p);
+
+    private static (long size, int files) MeasurePath(string path, CancellationToken ct)
+    {
+        try
+        {
+            if (File.Exists(path)) return (SafeLength(path), 1);
+            if (!Directory.Exists(path) || IsReparsePoint(path)) return (0, 0);
+            long size = 0; var files = 0;
+            foreach (var file in SafeEnumerateFiles(path, ct))
+            {
+                if (ct.IsCancellationRequested) break;
+                size += SafeLength(file);
+                files++;
+            }
+            return (size, files);
+        }
+        catch (IOException) { return (0, 0); }
+        catch (UnauthorizedAccessException) { return (0, 0); }
+    }
+
+    private static int DeletePath(string path, CancellationToken ct)
+    {
+        var deleted = 0;
+        try
+        {
+            if (File.Exists(path))
+            {
+                if (TryDeleteFile(path)) deleted++;
+                return deleted;
+            }
+            if (!Directory.Exists(path) || IsReparsePoint(path)) return 0;
+            foreach (var file in SafeEnumerateFiles(path, ct))
+            {
+                if (ct.IsCancellationRequested) break;
+                if (TryDeleteFile(file)) deleted++;
+            }
+        }
+        catch (IOException) { /* best-effort */ }
+        catch (UnauthorizedAccessException) { /* best-effort */ }
+        return deleted;
+    }
+
+    private static bool TryDeleteFile(string file)
+    {
+        try { File.Delete(file); return true; }
+        catch (IOException) { return false; }                 // file locked (browser open)
+        catch (UnauthorizedAccessException) { return false; }
+    }
+
+    private static long SafeLength(string path)
+    {
+        try { return new FileInfo(path).Length; }
+        catch (IOException) { return 0; }
+        catch (UnauthorizedAccessException) { return 0; }
+    }
+
+    private static bool IsReparsePoint(string path)
+    {
+        try { return (File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0; }
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+    }
+
+    private static IEnumerable<string> SafeEnumerateFiles(string root, CancellationToken ct)
+    {
+        var stack = new Stack<string>();
+        stack.Push(root);
+        while (stack.Count > 0)
+        {
+            if (ct.IsCancellationRequested) yield break;
+            var cur = stack.Pop();
+            if (IsReparsePoint(cur)) continue;
+
+            string[] subDirs;
+            try { subDirs = Directory.GetDirectories(cur); }
+            catch (IOException) { continue; }
+            catch (UnauthorizedAccessException) { continue; }
+            foreach (var d in subDirs) stack.Push(d);
+
+            string[] files;
+            try { files = Directory.GetFiles(cur); }
+            catch (IOException) { continue; }
+            catch (UnauthorizedAccessException) { continue; }
+            foreach (var f in files) yield return f;
+        }
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.30.0</Version>
-    <FileVersion>1.30.0.0</FileVersion>
-    <AssemblyVersion>1.30.0.0</AssemblyVersion>
+    <Version>1.31.0</Version>
+    <FileVersion>1.31.0.0</FileVersion>
+    <AssemblyVersion>1.31.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/BrowserCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BrowserCleanerViewModel.cs
@@ -1,0 +1,149 @@
+// SysManager · BrowserCleanerViewModel — per-browser cache/cookies/history cleanup
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the Browser Cleaner tab. Scans installed browsers for cleanable data
+/// (cache, history, cookies, sessions), shows the size of each, and removes the selected
+/// items after confirmation. Cookies/sessions are flagged and unselected by default so a
+/// clean never signs the user out by accident. Operates on per-user data — no admin needed.
+/// </summary>
+public sealed partial class BrowserCleanerViewModel : ViewModelBase
+{
+    private readonly BrowserCleanerService _service;
+    private CancellationTokenSource? _cts;
+
+    public BulkObservableCollection<BrowserCleanupItem> Items { get; } = new();
+
+    [ObservableProperty] private bool _hasItems;
+    [ObservableProperty] private string _totalSelectedDisplay = "";
+
+    public BrowserCleanerViewModel(BrowserCleanerService service)
+    {
+        _service = service;
+        StatusMessage = "Scanning installed browsers…";
+        PropertyChanged += OnVmPropertyChanged;
+        InitializeAsync(ScanAsync);
+    }
+
+    private bool NotBusy => !IsBusy;
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(IsBusy))
+        {
+            ScanCommand.NotifyCanExecuteChanged();
+            CleanCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    private void OnItemSelectionChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(BrowserCleanupItem.IsSelected)) UpdateSelectedTotal();
+    }
+
+    private void UpdateSelectedTotal()
+    {
+        var bytes = Items.Where(i => i.IsSelected).Sum(i => i.SizeBytes);
+        TotalSelectedDisplay = FormatHelper.FormatSize(bytes);
+    }
+
+    [RelayCommand(CanExecute = nameof(NotBusy))]
+    private async Task ScanAsync()
+    {
+        IsBusy = true;
+        IsProgressIndeterminate = true;
+        StatusMessage = "Scanning installed browsers…";
+        foreach (var old in Items) old.PropertyChanged -= OnItemSelectionChanged;
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        try
+        {
+            var items = await _service.ScanAsync(_cts.Token).ConfigureAwait(true);
+            Items.ReplaceWith(items);
+            foreach (var i in Items) i.PropertyChanged += OnItemSelectionChanged;
+            HasItems = Items.Count > 0;
+            UpdateSelectedTotal();
+            var total = FormatHelper.FormatSize(Items.Sum(i => i.SizeBytes));
+            StatusMessage = Items.Count == 0
+                ? "No cleanable browser data found."
+                : $"Found {Items.Count} categories across your browsers — {total} total. Cookies and sessions are left unticked to keep you signed in.";
+        }
+        catch (OperationCanceledException) { StatusMessage = "Cancelled."; }
+        finally
+        {
+            IsBusy = false;
+            IsProgressIndeterminate = false;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(NotBusy))]
+    private async Task CleanAsync()
+    {
+        var selected = Items.Where(i => i.IsSelected).ToList();
+        if (selected.Count == 0)
+        {
+            StatusMessage = "Nothing selected. Tick the categories to clean.";
+            return;
+        }
+
+        var sensitive = selected.Where(i => i.IsSensitive).ToList();
+        var sensitiveNote = sensitive.Count > 0
+            ? $"\n\nNote: this includes {sensitive.Count} cookie/session item(s) — clearing them will sign you out of websites and close saved sessions."
+            : "";
+        var sizeNote = FormatHelper.FormatSize(selected.Sum(i => i.SizeBytes));
+
+        if (!DialogService.Instance.Confirm(
+                $"Clean {selected.Count} selected categor{(selected.Count == 1 ? "y" : "ies")} (~{sizeNote})?\n\n" +
+                "Close the affected browsers first so locked files can be removed. Open files are skipped, not forced." +
+                sensitiveNote,
+                "Clean browser data"))
+        {
+            StatusMessage = "Clean cancelled.";
+            return;
+        }
+
+        IsBusy = true;
+        IsProgressIndeterminate = true;
+        StatusMessage = "Cleaning…";
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        try
+        {
+            var deleted = await _service.CleanAsync(selected, _cts.Token).ConfigureAwait(true);
+            StatusMessage = $"Removed {deleted} file(s). Re-scanning…";
+            ToastService.Instance.Show("Browser data cleaned", $"{deleted} files removed.");
+            Log.Information("BrowserCleaner: cleaned {Count} categories, {Deleted} files", selected.Count, deleted);
+            await ScanAsync().ConfigureAwait(true);
+        }
+        catch (OperationCanceledException) { StatusMessage = "Cancelled."; }
+        finally
+        {
+            IsBusy = false;
+            IsProgressIndeterminate = false;
+        }
+    }
+
+    [RelayCommand]
+    private void Cancel() => _cts?.Cancel();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            PropertyChanged -= OnVmPropertyChanged;
+            foreach (var i in Items) i.PropertyChanged -= OnItemSelectionChanged;
+            _cts?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -54,6 +54,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public LegacyPanelsViewModel LegacyPanels { get; }
     public SystemFixesViewModel SystemFixes { get; }
     public ProfileViewModel Profile { get; }
+    public BrowserCleanerViewModel BrowserCleaner { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -77,8 +78,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
     // Apps group (Bulk Installer is now fully implemented)
 
-    // Privacy & Security group (Privacy & Telemetry + Debloater now fully implemented)
-    public PlaceholderViewModel WipBrowserCleaner { get; private set; } = null!;
+    // Privacy & Security group (Privacy & Telemetry + Debloater + Browser Cleaner now fully implemented)
     public PlaceholderViewModel WipEdgeOneDriveRemover { get; private set; } = null!;
     public PlaceholderViewModel WipDefenderTweaks { get; private set; } = null!;
     public PlaceholderViewModel WipNotificationBlocker { get; private set; } = null!;
@@ -156,6 +156,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             LegacyPanels = sp.GetRequiredService<LegacyPanelsViewModel>();
             SystemFixes = sp.GetRequiredService<SystemFixesViewModel>();
             Profile = sp.GetRequiredService<ProfileViewModel>();
+            BrowserCleaner = sp.GetRequiredService<BrowserCleanerViewModel>();
         }
         else
         {
@@ -213,6 +214,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             LegacyPanels = new LegacyPanelsViewModel(new LegacyPanelService());
             SystemFixes = new SystemFixesViewModel(new SystemFixService(new PowerShellRunner()));
             Profile = new ProfileViewModel(new ProfileService());
+            BrowserCleaner = new BrowserCleanerViewModel(new BrowserCleanerService());
         }
 
         InitPlaceholders();
@@ -245,7 +247,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         // Apps group — Bulk Installer is now fully implemented (no placeholder needed)
 
         // Privacy & Security group (Privacy & Telemetry is now fully implemented)
-        WipBrowserCleaner = new PlaceholderViewModel("Browser Cleaner", "Per-browser cache/cookies/history cleanup with keep-list for important cookies.", "#336");
         WipEdgeOneDriveRemover = new PlaceholderViewModel("Edge/OneDrive Remover", "Safely remove or disable Edge and OneDrive with full restore capability.", "#339");
         WipDefenderTweaks = new PlaceholderViewModel("Defender Tweaks", "Toggle SmartScreen, manage exclusions, configure PUA and cloud protection.", "#344");
         WipNotificationBlocker = new PlaceholderViewModel("Notification Blocker", "Suppress annoying app pop-ups (update nags, trial reminders) with allowlist.", "#340");
@@ -343,7 +344,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-app-blocker",          "App Blocker",           "", AppBlocker,             typeof(Views.AppBlockerView)),
             Item("nav-app-alerts",           "App Alerts",            "", AppAlerts,              typeof(Views.AppAlertsView)),
             Item("nav-debloater",            "Debloater & Ads",       "", Debloater,             typeof(Views.DebloaterView)),
-            Item("nav-browser-cleaner",      "Browser Cleaner",       "", WipBrowserCleaner,      typeof(Views.PlaceholderView)),
+            Item("nav-browser-cleaner",      "Browser Cleaner",       "", BrowserCleaner,         typeof(Views.BrowserCleanerView)),
             Item("nav-edge-onedrive",        "Edge/OneDrive Remover", "", WipEdgeOneDriveRemover, typeof(Views.PlaceholderView)),
             Item("nav-defender-tweaks",      "Defender Tweaks",       "", WipDefenderTweaks,      typeof(Views.PlaceholderView)),
             Item("nav-notification-blocker", "Notification Blocker",  "", WipNotificationBlocker, typeof(Views.PlaceholderView))),
@@ -480,7 +481,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         LegacyPanels?.Dispose();
         SystemFixes?.Dispose();
         Profile?.Dispose();
-        WipBrowserCleaner?.Dispose();
+        BrowserCleaner?.Dispose();
         WipEdgeOneDriveRemover?.Dispose();
         WipDefenderTweaks?.Dispose();
         WipNotificationBlocker?.Dispose();

--- a/SysManager/SysManager/Views/BrowserCleanerView.xaml
+++ b/SysManager/SysManager/Views/BrowserCleanerView.xaml
@@ -1,0 +1,112 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.BrowserCleanerView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             d:DataContext="{d:DesignInstance vm:BrowserCleanerViewModel}"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             Background="{DynamicResource Surface0}">
+
+    <Grid Margin="28,24,28,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,16">
+            <TextBlock Text="Browser Cleaner" Style="{StaticResource Display}"/>
+            <TextBlock Text="Reclaim space and clear browsing traces across Chrome, Edge, Brave, Opera, and Firefox. Scan first to see the size of each category; cookies and sessions are left unticked so cleaning doesn't sign you out. Close the browser first so its files aren't locked."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <!-- Toolbar -->
+        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+            <WrapPanel>
+                <Button Content="Scan" Command="{Binding ScanCommand}"
+                        AutomationProperties.Name="Scan browsers"
+                        Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
+                <Button Content="Clean selected" Command="{Binding CleanCommand}"
+                        AutomationProperties.Name="Clean selected browser data"
+                        Style="{StaticResource DangerButton}" Margin="0,0,8,0"/>
+                <Button Content="Cancel" Command="{Binding CancelCommand}"
+                        AutomationProperties.Name="Cancel current operation"
+                        Style="{StaticResource GhostButton}" Margin="0,0,16,0"
+                        Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+                <TextBlock VerticalAlignment="Center" Style="{StaticResource Subtle}"
+                           Text="{Binding TotalSelectedDisplay, StringFormat='Selected: {0}'}"
+                           Visibility="{Binding HasItems, Converter={StaticResource FlexVis}}"/>
+            </WrapPanel>
+        </Border>
+
+        <!-- Items grid -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
+            <Grid>
+                <DataGrid ItemsSource="{Binding Items}"
+                          AutomationProperties.Name="Browser data categories"
+                          AutoGenerateColumns="False" HeadersVisibility="Column"
+                          CanUserAddRows="False" SelectionMode="Single"
+                          Background="Transparent" BorderThickness="0"
+                          GridLinesVisibility="None"
+                          VirtualizingPanel.IsVirtualizing="True"
+                          VirtualizingPanel.VirtualizationMode="Recycling">
+                    <DataGrid.Columns>
+                        <DataGridTemplateColumn Header="" Width="44">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <CheckBox IsChecked="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}"
+                                              AutomationProperties.Name="{Binding Category, StringFormat='Select {0}'}"
+                                              HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTextColumn Header="Browser" Binding="{Binding Browser}" IsReadOnly="True" Width="160"/>
+                        <DataGridTemplateColumn Header="Category" Width="*">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <StackPanel Margin="0,4">
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="{Binding Category}" FontWeight="SemiBold" FontSize="13"
+                                                       Foreground="{DynamicResource TextPrimary}"/>
+                                            <Border Background="{DynamicResource Surface3}" CornerRadius="4" Padding="6,1" Margin="8,0,0,0"
+                                                    VerticalAlignment="Center"
+                                                    Visibility="{Binding IsSensitive, Converter={StaticResource FlexVis}}">
+                                                <TextBlock Text="signs you out" FontSize="10" Foreground="#FBBF24"/>
+                                            </Border>
+                                        </StackPanel>
+                                        <TextBlock Text="{Binding Description}" FontSize="11" Foreground="{DynamicResource TextMuted}"
+                                                   TextWrapping="Wrap" Margin="0,2,16,0"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTextColumn Header="Size" Binding="{Binding SizeDisplay}" IsReadOnly="True" Width="110"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+
+                <!-- Empty state -->
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center"
+                            Visibility="{Binding HasItems, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+                    <TextBlock Text="&#xE774;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="32"
+                               HorizontalAlignment="Center" Margin="0,0,0,8" Foreground="{DynamicResource TextSecondary}"/>
+                    <TextBlock Text="No browser data found" FontSize="14" FontWeight="SemiBold"
+                               Foreground="{DynamicResource TextSecondary}" HorizontalAlignment="Center"/>
+                    <TextBlock Text="Press Scan to look for cleanable cache, history, and cookies."
+                               Style="{StaticResource Subtle}" HorizontalAlignment="Center" Margin="0,4,0,0"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Status bar -->
+        <DockPanel Grid.Row="3" Margin="0,8,0,0">
+            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Right" Width="180" Height="4"
+                         IsIndeterminate="{Binding IsProgressIndeterminate}"
+                         Visibility="{Binding IsBusy, Converter={StaticResource FlexVis}}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" VerticalAlignment="Center"/>
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/BrowserCleanerView.xaml.cs
+++ b/SysManager/SysManager/Views/BrowserCleanerView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · BrowserCleanerView — per-browser data cleanup UI
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class BrowserCleanerView : UserControl
+{
+    public BrowserCleanerView() => InitializeComponent();
+}


### PR DESCRIPTION
## Summary
Turns the Privacy & Security group's **Browser Cleaner** placeholder into a working tab.

- **Auto-detects** Chrome, Edge, Brave, Opera, and Firefox.
- **Per-category with sizes**: Cache, History, Cookies, Sessions — scan first to see what's there.
- **Cookies/sessions are flagged "signs you out" and left unticked by default**; cache and history are pre-selected. Cleaning is always an explicit, confirmed choice.
- **Confirmation with impact summary** (size + a note when sensitive items are included) before deletion.
- Per-user (no admin); locked files (browser open) are skipped rather than forced; reparse points are never followed.

Closes #336

## Design (matches existing architecture)
- `BrowserCleanerService` takes **injectable LOCALAPPDATA/APPDATA roots** (like the testable services), so scan + clean are unit-tested against a temp tree. Scan is read-only (sizes only); Clean deletes only discovered files and reuses the same reparse-point-safe enumeration approach as `DeepCleanupService`.
- `BrowserCleanerViewModel` follows the scan-first + `DialogService.Confirm` + `BulkObservableCollection` + `InitializeAsync` + `Dispose` conventions; tracks a live selected-size total.
- `BrowserCleanerView` Strategy-1 layout; checkbox column, sensitive-item tag, `DangerButton` for clean, empty state via `HasItems`. `AutomationProperties.Name` on every control. No `DropShadowEffect`.
- Replaces the placeholder (nav id `nav-browser-cleaner` unchanged); wired into DI + both `MainWindowViewModel` paths + dispose.

## Safety
- Cookies/sessions never auto-selected — no silent sign-out.
- Locked-file-tolerant (skips, never forces); reparse points skipped (no symlink traversal out of the profile).
- Confirmation required; per-user only.

## Tests
- 6 tests in `BrowserCleanerServiceTests` (temp roots): empty scan, Chrome cache discovery + size, cookies flagged sensitive + unselected, empty/missing categories omitted, and Clean deletes selected files recursively.

## Docs
- README (38 implemented / 19 WIP, new feature section, Privacy row), ARCHITECTURE (VM + service descriptions, Privacy row), CHANGELOG (1.31.0 Added), version bump → 1.31.0.