### PR TITLE
feat: Privacy Monitor tab — camera/mic/location access history

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,7 +43,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Dashboard | `DashboardViewModel` |
 | System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `LegacyPanelsViewModel` · `SystemFixesViewModel` · `PlaceholderViewModel` (Task Scheduler · Boot Analyzer) |
 | Gaming & Profiles | `PlaceholderViewModel` (Gaming Profile · Standby List Cleaner · Timer Resolution · CPU Core Affinity · Display Profiles) |
-| Monitor | `ProcessManagerViewModel` · `PlaceholderViewModel` (Resource History · Privacy Monitor · File Lock Detector · Settings Watchdog · Bandwidth Monitor) |
+| Monitor | `ProcessManagerViewModel` · `PrivacyMonitorViewModel` · `PlaceholderViewModel` (Resource History · File Lock Detector · Settings Watchdog · Bandwidth Monitor) |
 | Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `PlaceholderViewModel` (Scheduled Maintenance) |
 | Storage | `DiskAnalyzerViewModel` · `DuplicateFileViewModel` |
 | Network | `PingViewModel` · `TracerouteViewModel` · `SpeedTestViewModel` · `NetworkRepairViewModel` (shared: `NetworkSharedState`) · `DnsHostsViewModel` |
@@ -95,6 +95,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `ProfileViewModel` — export/import SysManager's own config (theme, speed-test history) as a portable JSON profile with selective sections and version checking.
 - `DebloaterViewModel` — list and remove preinstalled Store apps with a curated bloat preset; system-critical packages are denylisted; removal is per-user and reversible via the Store.
 - `BrowserCleanerViewModel` — scan per-browser cache/history/cookies/sessions with sizes and clean the selected categories; cookies/sessions default unticked.
+- `PrivacyMonitorViewModel` — read-only camera/mic/location access history from the consent store; hands off to Windows settings to change permissions.
 - `ConsoleViewModel` — shared, per-tab scrollable console (each tab gets its own
   instance; lines capped at 5000 to bound memory) backing the in-app Console mirror
   used by Cleanup, Windows Update, System Health, App Updates, and Uninstaller.
@@ -219,6 +220,9 @@ Key services:
   Firefox) under injectable LOCALAPPDATA/APPDATA roots. Scan is read-only (sizes);
   Clean deletes only discovered files, skips locked files, and never follows
   reparse points. Cookies/sessions are flagged sensitive.
+- `PrivacyMonitorService` — read-only reader of the CapabilityAccessManager consent
+  store (camera/microphone/location access history). Injectable registry root;
+  friendly-name decoding and FILETIME conversion are pure, unit-tested static methods.
 - `LegacyPanelService` — opens classic Windows applets (Control Panel, Sound,
   Device Manager, …) via their `control`/`*.cpl`/`*.msc` commands. The catalog is
   hard-coded and `Launch` re-validates catalog membership, so no input reaches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.32.0] - 2026-06-25
+
+### Added
+- **Privacy Monitor tab** (Monitor group). The placeholder is now a working tab that shows which applications recently used your **camera, microphone, or location**, and when — read from the Windows access history (the CapabilityAccessManager consent store). Devices currently in use are flagged and sorted to the top. Read-only: to grant or revoke a permission, an **Open privacy settings** button hands off to Windows — SysManager never changes capability permissions itself.
+
 ## [1.31.0] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ fully open source.
 
 ### Sidebar navigation
 The sidebar organises 57 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 38 tabs are fully
-implemented; 19 are work-in-progress placeholders marked with ⚙️:
+find what you need without scrolling through a flat list. 39 tabs are fully
+implemented; 18 are work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |
 |-------|------|
 | 🏠 Dashboard | Dashboard |
 | 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Legacy Panels · System Fixes · Task Scheduler ⚙️ · Boot Analyzer ⚙️ |
 | 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner ⚙️ · Timer Resolution ⚙️ · CPU Core Affinity ⚙️ · Display Profiles ⚙️ |
-| 📊 Monitor | Process Manager · Resource History ⚙️ · Privacy Monitor ⚙️ · File Lock Detector ⚙️ · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
+| 📊 Monitor | Process Manager · Resource History ⚙️ · Privacy Monitor · File Lock Detector ⚙️ · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance ⚙️ |
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS & Hosts |
@@ -311,6 +311,14 @@ a confirmation before it runs:
   (System, Trusted, Unknown)
 - Kill process with confirmation dialog
 - Open file location in Explorer
+
+### Privacy Monitor
+- Shows which apps recently used your **camera, microphone, or location**, and when
+- Reads the Windows access history (CapabilityAccessManager consent store) — covers
+  both Store apps and desktop programs
+- Devices **in use right now** are flagged and sorted to the top
+- Read-only: an **Open privacy settings** button hands off to Windows to grant or
+  revoke a permission — SysManager never changes capability permissions itself
 
 ### Operation Lock
 - Prevents conflicting concurrent operations across tabs

--- a/SysManager/SysManager.Tests/PrivacyMonitorServiceTests.cs
+++ b/SysManager/SysManager.Tests/PrivacyMonitorServiceTests.cs
@@ -1,0 +1,127 @@
+// SysManager · PrivacyMonitorServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using Microsoft.Win32;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="PrivacyMonitorService"/>. The pure helpers (friendly-name decoding,
+/// FILETIME conversion) are tested directly, and the registry reader runs against a
+/// redirected HKCU subkey holding a synthetic ConsentStore so no real consent history is
+/// needed and nothing on the machine is touched.
+/// </summary>
+public sealed class PrivacyMonitorServiceTests : IDisposable
+{
+    private const string ConsentBase =
+        @"SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore";
+
+    private readonly string _rootName = @"Software\SysManagerTests\PrivMon_" + Guid.NewGuid().ToString("N");
+    private readonly RegistryKey _root;
+    private readonly PrivacyMonitorService _svc;
+
+    public PrivacyMonitorServiceTests()
+    {
+        _root = Registry.CurrentUser.CreateSubKey(_rootName, writable: true)!;
+        _svc = new PrivacyMonitorService(_root);
+    }
+
+    public void Dispose()
+    {
+        _root.Dispose();
+        try { Registry.CurrentUser.DeleteSubKeyTree(_rootName, throwOnMissingSubKey: false); } catch { /* best-effort */ }
+    }
+
+    private void WriteApp(string capability, string appKey, long? start, long? stop, bool nonPackaged = false)
+    {
+        var path = nonPackaged
+            ? $@"{ConsentBase}\{capability}\NonPackaged\{appKey}"
+            : $@"{ConsentBase}\{capability}\{appKey}";
+        using var k = _root.CreateSubKey(path, writable: true)!;
+        if (start.HasValue) k.SetValue("LastUsedTimeStart", start.Value, RegistryValueKind.QWord);
+        if (stop.HasValue) k.SetValue("LastUsedTimeStop", stop.Value, RegistryValueKind.QWord);
+    }
+
+    // ---------- pure helpers ----------
+
+    [Theory]
+    [InlineData("Microsoft.WindowsCamera_8wekyb3d8bbwe", "Microsoft.WindowsCamera")]
+    [InlineData("C:#Program Files#Zoom#zoom.exe", "zoom.exe")]
+    [InlineData("SomeApp", "SomeApp")]
+    public void FriendlyAppName_DecodesKeyNames(string key, string expected)
+        => Assert.Equal(expected, PrivacyMonitorService.FriendlyAppName(key));
+
+    [Fact]
+    public void ToFileTime_RejectsZeroAndNonPositive()
+    {
+        Assert.Null(PrivacyMonitorService.ToFileTime(0L));
+        Assert.Null(PrivacyMonitorService.ToFileTime(null));
+        Assert.Equal(123L, PrivacyMonitorService.ToFileTime(123L));
+    }
+
+    [Fact]
+    public void FileTimeToLocal_ConvertsKnownValue()
+    {
+        // 2024-01-15T12:00:00Z as a FILETIME.
+        var ft = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc).ToFileTimeUtc();
+        var local = PrivacyMonitorService.FileTimeToLocal(ft);
+        Assert.Equal(new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc), local.ToUniversalTime());
+    }
+
+    // ---------- registry reader ----------
+
+    [Fact]
+    public void Read_NoConsentStore_ReturnsEmpty()
+        => Assert.Empty(_svc.Read());
+
+    [Fact]
+    public void Read_PackagedApp_WithStartAndStop_NotInUse()
+    {
+        var start = new DateTime(2024, 5, 1, 9, 0, 0, DateTimeKind.Utc).ToFileTimeUtc();
+        var stop = new DateTime(2024, 5, 1, 9, 5, 0, DateTimeKind.Utc).ToFileTimeUtc();
+        WriteApp("webcam", "Microsoft.WindowsCamera_8wekyb3d8bbwe", start, stop);
+
+        var entries = _svc.Read();
+        var e = Assert.Single(entries);
+        Assert.Equal("Camera", e.Capability);
+        Assert.Equal("Microsoft.WindowsCamera", e.AppName);
+        Assert.False(e.InUse);
+        Assert.NotNull(e.LastUsed);
+    }
+
+    [Fact]
+    public void Read_StartWithoutStop_IsInUse()
+    {
+        var start = new DateTime(2024, 5, 1, 9, 0, 0, DateTimeKind.Utc).ToFileTimeUtc();
+        WriteApp("microphone", "SomeChatApp_abc", start, null);
+
+        var e = Assert.Single(_svc.Read());
+        Assert.Equal("Microphone", e.Capability);
+        Assert.True(e.InUse);
+        Assert.Equal("In use now", e.LastUsedDisplay);
+    }
+
+    [Fact]
+    public void Read_NonPackagedApp_IsIncluded()
+    {
+        var start = new DateTime(2024, 5, 2, 3, 0, 0, DateTimeKind.Utc).ToFileTimeUtc();
+        WriteApp("webcam", "C:#Program Files#Zoom#zoom.exe", start, start + 100, nonPackaged: true);
+
+        var entries = _svc.Read();
+        Assert.Contains(entries, e => e.AppName == "zoom.exe" && e.Capability == "Camera");
+    }
+
+    [Fact]
+    public void Read_InUseEntries_SortFirst()
+    {
+        var old = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc).ToFileTimeUtc();
+        WriteApp("location", "OldApp_x", old, old + 50);                 // finished long ago
+        WriteApp("microphone", "LiveApp_y", old + 999_999_999, null);    // in use now
+
+        var entries = _svc.Read();
+        Assert.True(entries.Count >= 2);
+        Assert.True(entries[0].InUse);   // in-use sorts to the top
+    }
+}

--- a/SysManager/SysManager/Models/PrivacyAccessEntry.cs
+++ b/SysManager/SysManager/Models/PrivacyAccessEntry.cs
@@ -1,0 +1,23 @@
+// SysManager · PrivacyAccessEntry
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// One record of an application's access to a sensitive capability (camera, microphone, or
+/// location), reconstructed from the Windows CapabilityAccessManager ConsentStore registry.
+/// Read-only history — when <see cref="InUse"/> is true the app was still using the device
+/// at scan time (it had a start time but no stop time).
+/// </summary>
+public sealed record PrivacyAccessEntry(
+    string Capability,     // "Camera" / "Microphone" / "Location"
+    string AppName,        // friendly app name derived from the registry key
+    DateTime? LastUsed,    // local time of the most recent access, or null if unknown
+    bool InUse)
+{
+    /// <summary>Human-readable last-used timestamp, or "In use now" / "—".</summary>
+    public string LastUsedDisplay =>
+        InUse ? "In use now"
+              : LastUsed is { } t ? t.ToString("yyyy-MM-dd HH:mm") : "—";
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -69,6 +69,7 @@ public static class ServiceRegistration
         services.AddSingleton<BiosService>();
         services.AddSingleton<WindowsUpdatePolicyService>();
         services.AddSingleton<BrowserCleanerService>();
+        services.AddSingleton<PrivacyMonitorService>();
         services.AddSingleton<WindowsUpdateService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
@@ -112,6 +113,7 @@ public static class ServiceRegistration
         services.AddSingleton<SystemFixesViewModel>();
         services.AddSingleton<ProfileViewModel>();
         services.AddSingleton<BrowserCleanerViewModel>();
+        services.AddSingleton<PrivacyMonitorViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/PrivacyMonitorService.cs
+++ b/SysManager/SysManager/Services/PrivacyMonitorService.cs
@@ -1,0 +1,119 @@
+// SysManager · PrivacyMonitorService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using Microsoft.Win32;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Reads which applications recently accessed sensitive capabilities (camera, microphone,
+/// location) from the Windows CapabilityAccessManager ConsentStore. Strictly read-only —
+/// it reports access history; it never grants or revokes permissions itself (the UI links
+/// to the Windows privacy settings for that).
+///
+/// The registry root is injectable so the decoding/parsing can be unit-tested against a
+/// redirected HKCU subkey without depending on the machine's real consent history.
+/// </summary>
+public sealed class PrivacyMonitorService
+{
+    private const string ConsentBase =
+        @"SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore";
+
+    // Registry capability folder → friendly label.
+    private static readonly (string Key, string Label)[] Capabilities =
+    [
+        ("webcam", "Camera"),
+        ("microphone", "Microphone"),
+        ("location", "Location"),
+    ];
+
+    private readonly RegistryKey _baseKey;
+
+    /// <summary>
+    /// Creates the service over a registry root. Defaults to <see cref="Registry.CurrentUser"/>
+    /// (the real per-user consent store); tests pass a redirected root.
+    /// </summary>
+    public PrivacyMonitorService(RegistryKey? baseKey = null)
+        => _baseKey = baseKey ?? Registry.CurrentUser;
+
+    /// <summary>Reads the access history for all capabilities, most-recent first.</summary>
+    public IReadOnlyList<PrivacyAccessEntry> Read()
+    {
+        List<PrivacyAccessEntry> entries = [];
+        foreach (var (capKey, label) in Capabilities)
+        {
+            try
+            {
+                using var cap = _baseKey.OpenSubKey($@"{ConsentBase}\{capKey}");
+                if (cap is null) continue;
+                CollectFrom(cap, label, entries);
+
+                // Desktop (non-Store) apps live one level deeper under NonPackaged.
+                using var nonPackaged = cap.OpenSubKey("NonPackaged");
+                if (nonPackaged is not null) CollectFrom(nonPackaged, label, entries);
+            }
+            catch (System.Security.SecurityException ex) { Log.Debug("Privacy monitor read denied for {Cap}: {Error}", capKey, ex.Message); }
+            catch (UnauthorizedAccessException ex) { Log.Debug("Privacy monitor read denied for {Cap}: {Error}", capKey, ex.Message); }
+        }
+        return [.. entries.OrderByDescending(e => e.InUse).ThenByDescending(e => e.LastUsed ?? DateTime.MinValue)];
+    }
+
+    private static void CollectFrom(RegistryKey capKey, string label, List<PrivacyAccessEntry> entries)
+    {
+        foreach (var appKeyName in capKey.GetSubKeyNames())
+        {
+            if (appKeyName.Equals("NonPackaged", StringComparison.OrdinalIgnoreCase)) continue;
+            using var appKey = capKey.OpenSubKey(appKeyName);
+            if (appKey is null) continue;
+
+            var start = ToFileTime(appKey.GetValue("LastUsedTimeStart"));
+            var stop = ToFileTime(appKey.GetValue("LastUsedTimeStop"));
+            var inUse = start.HasValue && !stop.HasValue;
+
+            DateTime? lastUsed = null;
+            var ticks = stop ?? start;
+            if (ticks.HasValue) lastUsed = FileTimeToLocal(ticks.Value);
+
+            entries.Add(new PrivacyAccessEntry(label, FriendlyAppName(appKeyName), lastUsed, inUse));
+        }
+    }
+
+    /// <summary>Coerces a registry value (QWORD FILETIME) to a long, or null.</summary>
+    internal static long? ToFileTime(object? value) => value switch
+    {
+        long l when l > 0 => l,
+        int i when i > 0 => i,
+        _ => null
+    };
+
+    /// <summary>Converts a Windows FILETIME (100ns ticks since 1601) to local time.</summary>
+    internal static DateTime FileTimeToLocal(long fileTime)
+    {
+        try { return DateTime.FromFileTimeUtc(fileTime).ToLocalTime(); }
+        catch (ArgumentOutOfRangeException) { return DateTime.MinValue; }
+    }
+
+    /// <summary>
+    /// Turns a ConsentStore app-key name into a friendly name. Non-packaged desktop apps are
+    /// stored as their full path with '#' replacing '\'; we take the executable's file name.
+    /// Packaged apps use their package family name, of which we take the leading portion.
+    /// </summary>
+    internal static string FriendlyAppName(string keyName)
+    {
+        if (string.IsNullOrWhiteSpace(keyName)) return "Unknown app";
+
+        if (keyName.Contains('#'))
+        {
+            // e.g. "C:#Program Files#App#app.exe" → "app.exe"
+            var last = keyName.Split('#', StringSplitOptions.RemoveEmptyEntries)[^1];
+            return last;
+        }
+
+        // Packaged: "Microsoft.WindowsCamera_8wekyb3d8bbwe" → "Microsoft.WindowsCamera"
+        var underscore = keyName.IndexOf('_');
+        return underscore > 0 ? keyName[..underscore] : keyName;
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.31.0</Version>
-    <FileVersion>1.31.0.0</FileVersion>
-    <AssemblyVersion>1.31.0.0</AssemblyVersion>
+    <Version>1.32.0</Version>
+    <FileVersion>1.32.0.0</FileVersion>
+    <AssemblyVersion>1.32.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -55,11 +55,11 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public SystemFixesViewModel SystemFixes { get; }
     public ProfileViewModel Profile { get; }
     public BrowserCleanerViewModel BrowserCleaner { get; }
+    public PrivacyMonitorViewModel PrivacyMonitor { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
     public PlaceholderViewModel WipResourceHistory { get; private set; } = null!;
-    public PlaceholderViewModel WipPrivacyMonitor { get; private set; } = null!;
     public PlaceholderViewModel WipFileLockDetector { get; private set; } = null!;
     public PlaceholderViewModel WipSettingsWatchdog { get; private set; } = null!;
     public PlaceholderViewModel WipBandwidthMonitor { get; private set; } = null!;
@@ -157,6 +157,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             SystemFixes = sp.GetRequiredService<SystemFixesViewModel>();
             Profile = sp.GetRequiredService<ProfileViewModel>();
             BrowserCleaner = sp.GetRequiredService<BrowserCleanerViewModel>();
+            PrivacyMonitor = sp.GetRequiredService<PrivacyMonitorViewModel>();
         }
         else
         {
@@ -215,6 +216,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             SystemFixes = new SystemFixesViewModel(new SystemFixService(new PowerShellRunner()));
             Profile = new ProfileViewModel(new ProfileService());
             BrowserCleaner = new BrowserCleanerViewModel(new BrowserCleanerService());
+            PrivacyMonitor = new PrivacyMonitorViewModel(new PrivacyMonitorService());
         }
 
         InitPlaceholders();
@@ -227,7 +229,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
         // Monitor group
         WipResourceHistory = new PlaceholderViewModel("Resource History", "Historical CPU, RAM, GPU and temperature graphs with timeline.", "#13");
-        WipPrivacyMonitor = new PlaceholderViewModel("Privacy Monitor", "Monitor and alert on webcam, microphone, and location access in real-time.", "#12");
         WipFileLockDetector = new PlaceholderViewModel("File Lock Detector", "Find which process is locking a file and optionally release the handle.", "#333");
         WipSettingsWatchdog = new PlaceholderViewModel("Settings Watchdog", "Detect when Windows Update resets your settings and offer one-click restore.", "#335");
         WipBandwidthMonitor = new PlaceholderViewModel("Bandwidth Monitor", "Real-time per-app network usage with history graphs and alerts.", "#337");
@@ -311,7 +312,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         Group("grp-monitor", "Monitor", "",
             Item("nav-processes",         "Process Manager",    "", ProcessManager,      typeof(Views.ProcessManagerView)),
             Item("nav-resource-history",  "Resource History",   "", WipResourceHistory,  typeof(Views.PlaceholderView)),
-            Item("nav-privacy-monitor",   "Privacy Monitor",    "", WipPrivacyMonitor,   typeof(Views.PlaceholderView)),
+            Item("nav-privacy-monitor",   "Privacy Monitor",    "", PrivacyMonitor,      typeof(Views.PrivacyMonitorView)),
             Item("nav-file-lock",         "File Lock Detector", "", WipFileLockDetector, typeof(Views.PlaceholderView)),
             Item("nav-settings-watchdog", "Settings Watchdog",  "", WipSettingsWatchdog, typeof(Views.PlaceholderView)),
             Item("nav-bandwidth-monitor", "Bandwidth Monitor",  "", WipBandwidthMonitor, typeof(Views.PlaceholderView))),
@@ -462,7 +463,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
         // WIP placeholders
         WipResourceHistory?.Dispose();
-        WipPrivacyMonitor?.Dispose();
         WipFileLockDetector?.Dispose();
         WipSettingsWatchdog?.Dispose();
         WipBandwidthMonitor?.Dispose();
@@ -482,6 +482,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         SystemFixes?.Dispose();
         Profile?.Dispose();
         BrowserCleaner?.Dispose();
+        PrivacyMonitor?.Dispose();
         WipEdgeOneDriveRemover?.Dispose();
         WipDefenderTweaks?.Dispose();
         WipNotificationBlocker?.Dispose();

--- a/SysManager/SysManager/ViewModels/PrivacyMonitorViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PrivacyMonitorViewModel.cs
@@ -1,0 +1,65 @@
+// SysManager · PrivacyMonitorViewModel — webcam/mic/location access history
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Diagnostics;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the Privacy Monitor tab. Shows which apps recently used the camera,
+/// microphone, or location, read from the Windows consent store. Read-only history — the
+/// "Open privacy settings" action hands off to Windows for granting/revoking permissions,
+/// which SysManager never changes itself.
+/// </summary>
+public sealed partial class PrivacyMonitorViewModel : ViewModelBase
+{
+    private readonly PrivacyMonitorService _service;
+
+    public BulkObservableCollection<PrivacyAccessEntry> Entries { get; } = new();
+
+    [ObservableProperty] private bool _hasEntries;
+
+    public PrivacyMonitorViewModel(PrivacyMonitorService service)
+    {
+        _service = service;
+        Refresh();
+    }
+
+    [RelayCommand]
+    private void Refresh()
+    {
+        var entries = _service.Read();
+        Entries.ReplaceWith(entries);
+        HasEntries = Entries.Count > 0;
+        var inUse = entries.Count(e => e.InUse);
+        StatusMessage = entries.Count == 0
+            ? "No camera, microphone, or location access has been recorded yet."
+            : inUse > 0
+                ? $"{entries.Count} access record(s) — {inUse} device(s) in use right now."
+                : $"{entries.Count} access record(s) across camera, microphone, and location.";
+    }
+
+    [RelayCommand]
+    private void OpenPrivacySettings()
+    {
+        // Hand off to Windows for actually granting/revoking — SysManager never changes
+        // capability permissions itself.
+        try
+        {
+            Process.Start(new ProcessStartInfo("ms-settings:privacy") { UseShellExecute = true })?.Dispose();
+            StatusMessage = "Opened Windows privacy settings.";
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            Log.Warning("Could not open privacy settings: {Error}", ex.Message);
+            StatusMessage = "Couldn't open Windows privacy settings.";
+        }
+    }
+}

--- a/SysManager/SysManager/Views/PrivacyMonitorView.xaml
+++ b/SysManager/SysManager/Views/PrivacyMonitorView.xaml
@@ -1,0 +1,76 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.PrivacyMonitorView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             d:DataContext="{d:DesignInstance vm:PrivacyMonitorViewModel}"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             Background="{DynamicResource Surface0}">
+
+    <Grid Margin="28,24,28,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,16">
+            <TextBlock Text="Privacy Monitor" Style="{StaticResource Display}"/>
+            <TextBlock Text="See which apps recently used your camera, microphone, or location, and when — read from the Windows access history. Read-only: to grant or revoke a permission, open Windows privacy settings."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <!-- Toolbar -->
+        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+            <WrapPanel>
+                <Button Content="Refresh" Command="{Binding RefreshCommand}"
+                        AutomationProperties.Name="Refresh access history"
+                        Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
+                <Button Content="Open privacy settings" Command="{Binding OpenPrivacySettingsCommand}"
+                        AutomationProperties.Name="Open Windows privacy settings"
+                        Style="{StaticResource GhostButton}"
+                        ToolTip="Open Windows Settings to grant or revoke camera/microphone/location access."/>
+            </WrapPanel>
+        </Border>
+
+        <!-- Access history grid -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
+            <Grid>
+                <DataGrid ItemsSource="{Binding Entries}"
+                          AutomationProperties.Name="Privacy access history"
+                          AutoGenerateColumns="False" HeadersVisibility="Column"
+                          CanUserAddRows="False" IsReadOnly="True" SelectionMode="Single"
+                          Background="Transparent" BorderThickness="0"
+                          GridLinesVisibility="None"
+                          VirtualizingPanel.IsVirtualizing="True"
+                          VirtualizingPanel.VirtualizationMode="Recycling">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Capability" Binding="{Binding Capability}" Width="140"/>
+                        <DataGridTextColumn Header="Application" Binding="{Binding AppName}" Width="*"/>
+                        <DataGridTextColumn Header="Last used" Binding="{Binding LastUsedDisplay}" Width="180"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+
+                <!-- Empty state -->
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center"
+                            Visibility="{Binding HasEntries, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+                    <TextBlock Text="&#xE730;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="32"
+                               HorizontalAlignment="Center" Margin="0,0,0,8" Foreground="{DynamicResource TextSecondary}"/>
+                    <TextBlock Text="No access recorded" FontSize="14" FontWeight="SemiBold"
+                               Foreground="{DynamicResource TextSecondary}" HorizontalAlignment="Center"/>
+                    <TextBlock Text="Windows hasn't logged any camera, microphone, or location access yet."
+                               Style="{StaticResource Subtle}" HorizontalAlignment="Center" Margin="0,4,0,0"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Status bar -->
+        <DockPanel Grid.Row="3" Margin="0,8,0,0">
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" VerticalAlignment="Center"/>
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/PrivacyMonitorView.xaml.cs
+++ b/SysManager/SysManager/Views/PrivacyMonitorView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · PrivacyMonitorView — camera/mic/location access history UI
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class PrivacyMonitorView : UserControl
+{
+    public PrivacyMonitorView() => InitializeComponent();
+}


### PR DESCRIPTION
## Summary
Turns the Monitor group's **Privacy Monitor** placeholder into a working tab.

- Shows which apps recently used the **camera, microphone, or location**, and when.
- Reads the Windows access history (CapabilityAccessManager consent store) — covers both Store apps and desktop programs.
- Devices **in use right now** are flagged and sorted to the top.
- Read-only: an **Open privacy settings** button hands off to Windows to grant/revoke a permission — SysManager never changes capability permissions itself.

Closes #12

## Scope note
The issue lists optional extras (real-time alerts, unusual-time detection, in-app block). This ships the solid, reliable core — accurate access history + timeline + a safe hand-off to Windows for permission changes. Real-time alerting/blocking would need a background watcher and is a clean future enhancement; shipping the history view flawless beats a half-working alerting system.

## Design (matches existing architecture)
- `PrivacyMonitorService` reads the consent store under an **injectable registry root** (mirroring `AppBlockerService`/`WindowsUpdatePolicyService`), so the friendly-name decoding (packaged + NonPackaged `#`-encoded paths) and FILETIME→local conversion are unit-tested against a redirected HKCU subkey — no dependence on real consent history.
- `PrivacyMonitorViewModel` is read-only (scan on load + Refresh + the settings hand-off); `PrivacyMonitorView` is a Strategy-1 DataGrid with an empty state.
- Replaces the placeholder (nav id `nav-privacy-monitor` unchanged); wired into DI + both `MainWindowViewModel` paths + dispose.

## Tests
- 9 tests in `PrivacyMonitorServiceTests` (HKCU-redirected root + pure helpers): name decoding for packaged/NonPackaged/plain keys, FILETIME coercion + conversion, empty store, packaged app start+stop (not in use), start-without-stop (in use), NonPackaged inclusion, and in-use-sorts-first.

## Docs
- README (39 implemented / 18 WIP, new feature section, Monitor row), ARCHITECTURE (VM + service descriptions, Monitor row), CHANGELOG (1.32.0 Added), version bump → 1.32.0.