### PR TITLE
feat: Boot Analyzer tab — boot time history and slow-component breakdown

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,7 +41,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Group | View Models |
 |-------|-------------|
 | Dashboard | `DashboardViewModel` |
-| System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `LegacyPanelsViewModel` · `SystemFixesViewModel` · `PlaceholderViewModel` (Task Scheduler · Boot Analyzer) |
+| System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `LegacyPanelsViewModel` · `SystemFixesViewModel` · `BootAnalyzerViewModel` · `PlaceholderViewModel` (Task Scheduler) |
 | Gaming & Profiles | `PlaceholderViewModel` (Gaming Profile · Standby List Cleaner · Timer Resolution · CPU Core Affinity · Display Profiles) |
 | Monitor | `ProcessManagerViewModel` · `PrivacyMonitorViewModel` · `PlaceholderViewModel` (Resource History · File Lock Detector · Settings Watchdog · Bandwidth Monitor) |
 | Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `PlaceholderViewModel` (Scheduled Maintenance) |
@@ -92,6 +92,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `RestorePointsViewModel` — list, create, and restore Windows System Restore points (admin for create/restore; restore reboots, gated by confirmation).
 - `LegacyPanelsViewModel` — one-click launcher for the fixed catalog of classic Windows applets (pure launchers, no system modification).
 - `SystemFixesViewModel` — consolidated one-click repairs (Windows Update reset, network reset, WinGet reinstall) with per-fix confirmation + live output; opens netplwiz for secure auto-logon.
+- `BootAnalyzerViewModel` — read-only boot-time history + slow-component breakdown from the Diagnostics-Performance log, with a trend vs recent average; needs admin to read the log.
 - `ProfileViewModel` — export/import SysManager's own config (theme, speed-test history) as a portable JSON profile with selective sections and version checking.
 - `DebloaterViewModel` — list and remove preinstalled Store apps with a curated bloat preset; system-critical packages are denylisted; removal is per-user and reversible via the Store.
 - `BrowserCleanerViewModel` — scan per-browser cache/history/cookies/sessions with sizes and clean the selected categories; cookies/sessions default unticked.
@@ -223,6 +224,10 @@ Key services:
 - `PrivacyMonitorService` — read-only reader of the CapabilityAccessManager consent
   store (camera/microphone/location access history). Injectable registry root;
   friendly-name decoding and FILETIME conversion are pure, unit-tested static methods.
+- `BootAnalyzerService` — read-only reader of the Diagnostics-Performance log
+  (event 100 boot durations; 101–110 slow-component events). Event-ID→kind mapping
+  and event-XML field parsing are pure, unit-tested static methods; reading the log
+  needs admin.
 - `LegacyPanelService` — opens classic Windows applets (Control Panel, Sound,
   Device Manager, …) via their `control`/`*.cpl`/`*.msc` commands. The catalog is
   hard-coded and `Launch` re-validates catalog membership, so no input reaches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.33.0] - 2026-06-25
+
+### Added
+- **Boot Analyzer tab** (System group). The placeholder is now a working tab that reads the Windows boot-performance history (the Diagnostics-Performance log) and shows how long your PC takes to boot — total, core (main path), and desktop ready-up time — across recent boots, with a trend versus your recent average. A second list shows the apps, drivers, services, and devices Windows flagged as slowing boot, with the delay attributed to each. Read-only; reading the log requires administrator (the tab shows the standard elevation banner).
+
 ## [1.32.0] - 2026-06-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ fully open source.
 
 ### Sidebar navigation
 The sidebar organises 57 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 39 tabs are fully
-implemented; 18 are work-in-progress placeholders marked with ⚙️:
+find what you need without scrolling through a flat list. 40 tabs are fully
+implemented; 17 are work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |
 |-------|------|
 | 🏠 Dashboard | Dashboard |
-| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Legacy Panels · System Fixes · Task Scheduler ⚙️ · Boot Analyzer ⚙️ |
+| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Legacy Panels · System Fixes · Boot Analyzer · Task Scheduler ⚙️ |
 | 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner ⚙️ · Timer Resolution ⚙️ · CPU Core Affinity ⚙️ · Display Profiles ⚙️ |
 | 📊 Monitor | Process Manager · Resource History ⚙️ · Privacy Monitor · File Lock Detector ⚙️ · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance ⚙️ |
@@ -210,6 +210,16 @@ a confirmation before it runs:
 - **Set up Auto Sign-in** — opens the built-in User Accounts dialog, so Windows
   stores the credential securely and SysManager never handles your password
 - Live output, honest success/failure reporting, admin elevation banner
+
+### Boot Analyzer
+- Shows how long your PC takes to boot — total, core (main path), and
+  desktop ready-up time — across recent boots, read from the Windows
+  boot-performance history (Diagnostics-Performance log)
+- A trend line tells you whether the last boot was faster or slower than your
+  recent average
+- Lists the apps, drivers, services, and devices Windows flagged as slowing boot,
+  with the delay attributed to each
+- Read-only; reading the log requires administrator (elevation banner shown)
 
 ### Windows Update (Windows Update Agent COM API)
 - Direct Windows Update Agent COM integration (`Microsoft.Update.Session`) —

--- a/SysManager/SysManager.Tests/BootAnalyzerServiceTests.cs
+++ b/SysManager/SysManager.Tests/BootAnalyzerServiceTests.cs
@@ -1,0 +1,108 @@
+// SysManager · BootAnalyzerServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Xml.Linq;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="BootAnalyzerService"/>'s pure event-XML parsing. Synthetic
+/// Diagnostics-Performance event payloads are fed in directly, so no live event log (or
+/// admin) is needed. The live reader path is not unit-tested.
+/// </summary>
+public class BootAnalyzerServiceTests
+{
+    private const string Ns = "http://schemas.microsoft.com/win/2004/08/events/event";
+
+    private static XElement Event(int eventId, params (string Name, string Value)[] data)
+    {
+        XNamespace ns = Ns;
+        var ev = new XElement(ns + "Event",
+            new XElement(ns + "System", new XElement(ns + "EventID", eventId)));
+        var dataEl = new XElement(ns + "EventData");
+        foreach (var (name, value) in data)
+            dataEl.Add(new XElement(ns + "Data", new XAttribute("Name", name), value));
+        ev.Add(dataEl);
+        return ev;
+    }
+
+    // ---------- DataValue ----------
+
+    [Fact]
+    public void DataValue_ReadsNamedData()
+    {
+        var ev = Event(100, ("BootTime", "42000"), ("MainPathBootTime", "30000"));
+        Assert.Equal("42000", BootAnalyzerService.DataValue(ev, "BootTime"));
+        Assert.Equal("30000", BootAnalyzerService.DataValue(ev, "MainPathBootTime"));
+        Assert.Null(BootAnalyzerService.DataValue(ev, "Missing"));
+    }
+
+    [Fact]
+    public void DataValue_NullXml_ReturnsNull()
+        => Assert.Null(BootAnalyzerService.DataValue(null, "BootTime"));
+
+    // ---------- KindForEventId ----------
+
+    [Theory]
+    [InlineData(101, "Application")]
+    [InlineData(102, "Driver")]
+    [InlineData(103, "Service")]
+    [InlineData(104, "Device")]
+    [InlineData(109, "Background")]
+    [InlineData(999, "Component")]
+    public void KindForEventId_MapsKnownIds(int id, string expected)
+        => Assert.Equal(expected, BootAnalyzerService.KindForEventId(id));
+
+    // ---------- ParseBoot ----------
+
+    [Fact]
+    public void ParseBoot_ReadsDurations()
+    {
+        var when = new DateTime(2026, 6, 24, 8, 0, 0, DateTimeKind.Local);
+        var ev = Event(100, ("BootTime", "42000"), ("MainPathBootTime", "30000"), ("BootPostBootTime", "12000"));
+        var b = BootAnalyzerService.ParseBoot(when, ev);
+
+        Assert.NotNull(b);
+        Assert.Equal(42000, b!.BootTimeMs);
+        Assert.Equal(30000, b.MainPathBootTimeMs);
+        Assert.Equal(12000, b.PostBootTimeMs);
+        Assert.Equal("42.0 s", b.BootSecondsDisplay);
+    }
+
+    [Fact]
+    public void ParseBoot_NoBootTime_ReturnsNull()
+        => Assert.Null(BootAnalyzerService.ParseBoot(DateTime.Now, Event(100, ("MainPathBootTime", "30000"))));
+
+    // ---------- ParseDegradation ----------
+
+    [Fact]
+    public void ParseDegradation_ReadsNameAndTime()
+    {
+        var when = new DateTime(2026, 6, 24, 8, 0, 0, DateTimeKind.Local);
+        var ev = Event(102, ("Name", "slowdriver.sys"), ("TotalTime", "5200"));
+        var d = BootAnalyzerService.ParseDegradation(when, 102, ev);
+
+        Assert.NotNull(d);
+        Assert.Equal("Driver", d!.Kind);
+        Assert.Equal("slowdriver.sys", d.Name);
+        Assert.Equal(5200, d.DurationMs);
+        Assert.Equal("5.2 s", d.DurationDisplay);
+    }
+
+    [Fact]
+    public void ParseDegradation_FallsBackToFriendlyName()
+    {
+        var ev = Event(101, ("FriendlyName", "Some App"), ("Time", "800"));
+        var d = BootAnalyzerService.ParseDegradation(DateTime.Now, 101, ev);
+        Assert.NotNull(d);
+        Assert.Equal("Some App", d!.Name);
+        Assert.Equal(800, d.DurationMs);
+        Assert.Equal("800 ms", d.DurationDisplay);
+    }
+
+    [Fact]
+    public void ParseDegradation_NoName_ReturnsNull()
+        => Assert.Null(BootAnalyzerService.ParseDegradation(DateTime.Now, 101, Event(101, ("TotalTime", "500"))));
+}

--- a/SysManager/SysManager/Models/BootRecord.cs
+++ b/SysManager/SysManager/Models/BootRecord.cs
@@ -1,0 +1,39 @@
+// SysManager · BootRecord
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// A single boot's performance summary, parsed from a Diagnostics-Performance event 100.
+/// Times are in milliseconds as Windows reports them. <see cref="BootTimeMs"/> is the total
+/// time to a usable desktop.
+/// </summary>
+public sealed record BootRecord(
+    DateTime BootTime,
+    long BootTimeMs,
+    long MainPathBootTimeMs,
+    long PostBootTimeMs)
+{
+    /// <summary>Total boot time as whole seconds, one decimal.</summary>
+    public string BootSecondsDisplay => $"{BootTimeMs / 1000.0:F1} s";
+
+    public string MainPathDisplay => $"{MainPathBootTimeMs / 1000.0:F1} s";
+    public string PostBootDisplay => $"{PostBootTimeMs / 1000.0:F1} s";
+    public string WhenDisplay => BootTime.ToString("yyyy-MM-dd HH:mm");
+}
+
+/// <summary>
+/// A component (app, driver, service, or device) that Windows flagged as slowing boot,
+/// parsed from a Diagnostics-Performance degradation event (101–110). <see cref="DurationMs"/>
+/// is the delay attributed to it.
+/// </summary>
+public sealed record BootDegradation(
+    DateTime When,
+    string Kind,       // "Application" / "Driver" / "Service" / "Device" / "Background"
+    string Name,
+    long DurationMs)
+{
+    public string DurationDisplay => DurationMs >= 1000 ? $"{DurationMs / 1000.0:F1} s" : $"{DurationMs} ms";
+    public string WhenDisplay => When.ToString("yyyy-MM-dd HH:mm");
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -70,6 +70,7 @@ public static class ServiceRegistration
         services.AddSingleton<WindowsUpdatePolicyService>();
         services.AddSingleton<BrowserCleanerService>();
         services.AddSingleton<PrivacyMonitorService>();
+        services.AddSingleton<BootAnalyzerService>();
         services.AddSingleton<WindowsUpdateService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
@@ -114,6 +115,7 @@ public static class ServiceRegistration
         services.AddSingleton<ProfileViewModel>();
         services.AddSingleton<BrowserCleanerViewModel>();
         services.AddSingleton<PrivacyMonitorViewModel>();
+        services.AddSingleton<BootAnalyzerViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/BootAnalyzerService.cs
+++ b/SysManager/SysManager/Services/BootAnalyzerService.cs
@@ -1,0 +1,135 @@
+// SysManager · BootAnalyzerService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Diagnostics.Eventing.Reader;
+using System.Globalization;
+using System.Xml.Linq;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Reads boot-performance history from the Microsoft-Windows-Diagnostics-Performance
+/// operational log. Event 100 carries each boot's total/main-path/post-boot durations;
+/// events 101–110 name components (apps, drivers, services, devices) that degraded boot.
+/// Strictly read-only — it surfaces what Windows already measured; it changes nothing.
+///
+/// Reading that log requires administrator; without elevation the queries yield nothing
+/// (handled gracefully). The event-ID→kind mapping and XML field parsing are pure static
+/// methods so they can be unit-tested without the live event log.
+/// </summary>
+public sealed class BootAnalyzerService
+{
+    private const string LogName = "Microsoft-Windows-Diagnostics-Performance/Operational";
+    private static readonly XNamespace EvtNs = "http://schemas.microsoft.com/win/2004/08/events/event";
+
+    /// <summary>Reads up to <paramref name="maxBoots"/> recent boot summaries, newest first.</summary>
+    public Task<IReadOnlyList<BootRecord>> ReadBootsAsync(int maxBoots = 20, CancellationToken ct = default)
+        => Task.Run<IReadOnlyList<BootRecord>>(() =>
+        {
+            List<BootRecord> boots = [];
+            foreach (var (rec, xml) in ReadEvents("*[System[(EventID=100)]]", maxBoots, ct))
+            {
+                using (rec)
+                {
+                    var b = ParseBoot(rec.TimeCreated ?? DateTime.MinValue, xml);
+                    if (b is not null) boots.Add(b);
+                }
+            }
+            return boots;
+        }, ct);
+
+    /// <summary>Reads recent boot-degradation events (slow apps/drivers/services), newest first.</summary>
+    public Task<IReadOnlyList<BootDegradation>> ReadDegradationsAsync(int max = 60, CancellationToken ct = default)
+        => Task.Run<IReadOnlyList<BootDegradation>>(() =>
+        {
+            List<BootDegradation> items = [];
+            foreach (var (rec, xml) in ReadEvents("*[System[(EventID>=101 and EventID<=110)]]", max, ct))
+            {
+                using (rec)
+                {
+                    var id = (int)(rec.Id);
+                    var d = ParseDegradation(rec.TimeCreated ?? DateTime.MinValue, id, xml);
+                    if (d is not null) items.Add(d);
+                }
+            }
+            return items;
+        }, ct);
+
+    private IEnumerable<(EventRecord rec, XElement? xml)> ReadEvents(string xpath, int max, CancellationToken ct)
+    {
+        EventLogReader? reader = null;
+        try
+        {
+            var q = new EventLogQuery(LogName, PathType.LogName, xpath) { ReverseDirection = true };
+            reader = new EventLogReader(q);
+        }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Boot analyzer: log access denied: {Error}", ex.Message); yield break; }
+        catch (EventLogNotFoundException ex) { Log.Debug("Boot analyzer: log not found: {Error}", ex.Message); yield break; }
+        catch (EventLogException ex) { Log.Debug("Boot analyzer: query failed: {Error}", ex.Message); yield break; }
+
+        using (reader)
+        {
+            var emitted = 0;
+            while (!ct.IsCancellationRequested && emitted < max)
+            {
+                EventRecord? rec;
+                try { rec = reader.ReadEvent(); }
+                catch (EventLogException) { continue; }
+                if (rec is null) yield break;
+
+                XElement? xml = null;
+                try { xml = XElement.Parse(rec.ToXml()); }
+                catch (System.Xml.XmlException) { /* emit with null xml */ }
+                emitted++;
+                yield return (rec, xml);
+            }
+        }
+    }
+
+    // ── Pure parsing (unit-tested) ─────────────────────────────────────────────
+
+    /// <summary>Reads a named &lt;Data Name="x"&gt; value from an event's XML payload.</summary>
+    internal static string? DataValue(XElement? eventXml, string name)
+    {
+        if (eventXml is null) return null;
+        var data = eventXml.Descendants(EvtNs + "Data")
+            .FirstOrDefault(d => (string?)d.Attribute("Name") == name);
+        return data?.Value;
+    }
+
+    private static long ParseLong(XElement? xml, string name)
+        => long.TryParse(DataValue(xml, name), NumberStyles.Integer, CultureInfo.InvariantCulture, out var v) ? v : 0;
+
+    /// <summary>Parses an event-100 payload into a <see cref="BootRecord"/>, or null if no boot time.</summary>
+    internal static BootRecord? ParseBoot(DateTime when, XElement? xml)
+    {
+        var boot = ParseLong(xml, "BootTime");
+        if (boot <= 0) return null;
+        return new BootRecord(when, boot, ParseLong(xml, "MainPathBootTime"), ParseLong(xml, "BootPostBootTime"));
+    }
+
+    /// <summary>Maps a Diagnostics-Performance degradation event ID to a component kind.</summary>
+    internal static string KindForEventId(int eventId) => eventId switch
+    {
+        101 or 105 => "Application",
+        102 or 106 => "Driver",
+        103 or 107 => "Service",
+        104 or 108 => "Device",
+        109 or 110 => "Background",
+        _ => "Component"
+    };
+
+    /// <summary>Parses a degradation event (101–110) into a <see cref="BootDegradation"/>, or null.</summary>
+    internal static BootDegradation? ParseDegradation(DateTime when, int eventId, XElement? xml)
+    {
+        var name = DataValue(xml, "Name") ?? DataValue(xml, "FriendlyName") ?? DataValue(xml, "FileName");
+        if (string.IsNullOrWhiteSpace(name)) return null;
+        var ms = ParseLong(xml, "TotalTime");
+        if (ms == 0) ms = ParseLong(xml, "Time");
+        if (ms == 0) ms = ParseLong(xml, "Degradation");
+        return new BootDegradation(when, KindForEventId(eventId), name.Trim(), ms);
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.32.0</Version>
-    <FileVersion>1.32.0.0</FileVersion>
-    <AssemblyVersion>1.32.0.0</AssemblyVersion>
+    <Version>1.33.0</Version>
+    <FileVersion>1.33.0.0</FileVersion>
+    <AssemblyVersion>1.33.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/BootAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BootAnalyzerViewModel.cs
@@ -1,0 +1,118 @@
+// SysManager · BootAnalyzerViewModel — boot-time history and slow-component breakdown
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the Boot Analyzer tab. Reads boot-performance history and slow-component
+/// events from the Windows Diagnostics-Performance log. Read-only; reading that log needs
+/// administrator, so the tab shows the standard elevation banner when not elevated.
+/// </summary>
+public sealed partial class BootAnalyzerViewModel : ViewModelBase
+{
+    private readonly BootAnalyzerService _service;
+    private CancellationTokenSource? _cts;
+
+    public BulkObservableCollection<BootRecord> Boots { get; } = new();
+    public BulkObservableCollection<BootDegradation> Degradations { get; } = new();
+
+    [ObservableProperty] private bool _isElevated;
+    [ObservableProperty] private bool _hasData;
+    [ObservableProperty] private BootRecord? _latestBoot;
+    [ObservableProperty] private string _trend = "";
+
+    public BootAnalyzerViewModel(BootAnalyzerService service)
+    {
+        _service = service;
+        IsElevated = AdminHelper.IsElevated();
+        StatusMessage = "Reading boot performance history…";
+        PropertyChanged += OnVmPropertyChanged;
+        InitializeAsync(RefreshAsync);
+    }
+
+    private bool NotBusy => !IsBusy;
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(IsBusy)) RefreshCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand(CanExecute = nameof(NotBusy))]
+    private async Task RefreshAsync()
+    {
+        IsBusy = true;
+        IsProgressIndeterminate = true;
+        StatusMessage = "Reading boot performance history…";
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        try
+        {
+            var boots = await _service.ReadBootsAsync(20, _cts.Token).ConfigureAwait(true);
+            var degr = await _service.ReadDegradationsAsync(60, _cts.Token).ConfigureAwait(true);
+
+            Boots.ReplaceWith(boots);
+            Degradations.ReplaceWith(degr);
+            LatestBoot = boots.Count > 0 ? boots[0] : null;
+            HasData = boots.Count > 0;
+            Trend = ComputeTrend(boots);
+
+            if (boots.Count == 0)
+                StatusMessage = IsElevated
+                    ? "No boot performance events found yet (a few reboots are needed to build history)."
+                    : "Reading boot history requires administrator — use \"Run as administrator\".";
+            else
+                StatusMessage = $"{boots.Count} boots analyzed; {degr.Count} slow-component events. Latest boot: {boots[0].BootSecondsDisplay}.";
+        }
+        catch (OperationCanceledException) { StatusMessage = "Cancelled."; }
+        finally
+        {
+            IsBusy = false;
+            IsProgressIndeterminate = false;
+        }
+    }
+
+    /// <summary>Compares the latest boot to the average of the rest to describe a trend.</summary>
+    private static string ComputeTrend(IReadOnlyList<BootRecord> boots)
+    {
+        if (boots.Count < 3) return "";
+        var latest = boots[0].BootTimeMs;
+        var rest = boots.Skip(1).ToList();
+        var avg = rest.Average(b => b.BootTimeMs);
+        if (avg <= 0) return "";
+        var pct = (latest - avg) / avg * 100.0;
+        return pct switch
+        {
+            > 15 => $"Last boot was {pct:F0}% slower than your recent average ({avg / 1000.0:F1} s).",
+            < -15 => $"Last boot was {-pct:F0}% faster than your recent average ({avg / 1000.0:F1} s).",
+            _ => $"Boot time is steady — recent average {avg / 1000.0:F1} s."
+        };
+    }
+
+    [RelayCommand]
+    private void Cancel() => _cts?.Cancel();
+
+    [RelayCommand]
+    private void RelaunchAsAdmin()
+    {
+        if (AdminHelper.RelaunchAsAdmin())
+            System.Windows.Application.Current?.Shutdown();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            PropertyChanged -= OnVmPropertyChanged;
+            _cts?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -56,6 +56,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public ProfileViewModel Profile { get; }
     public BrowserCleanerViewModel BrowserCleaner { get; }
     public PrivacyMonitorViewModel PrivacyMonitor { get; }
+    public BootAnalyzerViewModel BootAnalyzer { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -89,7 +90,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
     // System group (additions)
     public PlaceholderViewModel WipTaskScheduler { get; private set; } = null!;
-    public PlaceholderViewModel WipBootAnalyzer { get; private set; } = null!;
 
     // Advanced group
     public PlaceholderViewModel WipCliInterface { get; private set; } = null!;
@@ -158,6 +158,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Profile = sp.GetRequiredService<ProfileViewModel>();
             BrowserCleaner = sp.GetRequiredService<BrowserCleanerViewModel>();
             PrivacyMonitor = sp.GetRequiredService<PrivacyMonitorViewModel>();
+            BootAnalyzer = sp.GetRequiredService<BootAnalyzerViewModel>();
         }
         else
         {
@@ -217,6 +218,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Profile = new ProfileViewModel(new ProfileService());
             BrowserCleaner = new BrowserCleanerViewModel(new BrowserCleanerService());
             PrivacyMonitor = new PrivacyMonitorViewModel(new PrivacyMonitorService());
+            BootAnalyzer = new BootAnalyzerViewModel(new BootAnalyzerService());
         }
 
         InitPlaceholders();
@@ -258,7 +260,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
         // System group (additions)
         WipTaskScheduler = new PlaceholderViewModel("Task Scheduler", "Browse and toggle scheduled tasks with color-coded safety indicators.", "#334");
-        WipBootAnalyzer = new PlaceholderViewModel("Boot Analyzer", "Measure boot time breakdown per service/driver with optimization recommendations.", "#343");
 
         // Advanced group
         WipCliInterface = new PlaceholderViewModel("CLI Interface", "Command-line control: sysmanager --cleanup --apply-profile Gaming --silent.", "#342");
@@ -298,7 +299,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-windows-features", "Windows Features", "", WindowsFeatures,  typeof(Views.WindowsFeaturesView)),
             Item("nav-restore-points",   "Restore Points",   "", RestorePoints,    typeof(Views.RestorePointsView)),
             Item("nav-task-scheduler",   "Task Scheduler",   "", WipTaskScheduler, typeof(Views.PlaceholderView)),
-            Item("nav-boot-analyzer",    "Boot Analyzer",    "", WipBootAnalyzer,  typeof(Views.PlaceholderView)),
+            Item("nav-boot-analyzer",    "Boot Analyzer",    "", BootAnalyzer,     typeof(Views.BootAnalyzerView)),
             Item("nav-legacy-panels",    "Legacy Panels",    "", LegacyPanels,     typeof(Views.LegacyPanelsView)),
             Item("nav-system-fixes",     "System Fixes",     "", SystemFixes,      typeof(Views.SystemFixesView))),
 
@@ -483,13 +484,13 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         Profile?.Dispose();
         BrowserCleaner?.Dispose();
         PrivacyMonitor?.Dispose();
+        BootAnalyzer?.Dispose();
         WipEdgeOneDriveRemover?.Dispose();
         WipDefenderTweaks?.Dispose();
         WipNotificationBlocker?.Dispose();
         WipDarkModeScheduler?.Dispose();
         WipVolumeControl?.Dispose();
         WipTaskScheduler?.Dispose();
-        WipBootAnalyzer?.Dispose();
         WipCliInterface?.Dispose();
 
         GC.SuppressFinalize(this);

--- a/SysManager/SysManager/Views/BootAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/BootAnalyzerView.xaml
@@ -1,0 +1,121 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.BootAnalyzerView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             d:DataContext="{d:DesignInstance vm:BootAnalyzerViewModel}"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             Background="{DynamicResource Surface0}">
+
+    <Grid Margin="28,24,28,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,16">
+            <TextBlock Text="Boot Analyzer" Style="{StaticResource Display}"/>
+            <TextBlock Text="How long your PC takes to boot, and which apps, drivers, or services Windows flagged as slowing it down. Read from the Windows boot-performance history — reading it needs administrator."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <!-- Elevation banner: not elevated -->
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        AutomationProperties.Name="Restart SysManager as administrator"
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
+                    <TextBlock Text="Reading the Windows boot-performance log requires administrator privileges."
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- Summary -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="16"
+                Visibility="{Binding HasData, Converter={StaticResource FlexVis}}">
+            <StackPanel>
+                <TextBlock Text="Latest boot" Style="{StaticResource SectionTitle}"/>
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0" DataContext="{Binding LatestBoot}">
+                    <TextBlock Text="{Binding BootSecondsDisplay}" FontSize="26" FontWeight="Bold"
+                               Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
+                    <StackPanel Margin="20,0,0,0" VerticalAlignment="Center">
+                        <TextBlock Foreground="{DynamicResource TextMuted}" FontSize="12">
+                            <Run Text="Core (main path): "/><Run Text="{Binding MainPathDisplay, Mode=OneWay}"/>
+                        </TextBlock>
+                        <TextBlock Foreground="{DynamicResource TextMuted}" FontSize="12">
+                            <Run Text="Desktop ready-up: "/><Run Text="{Binding PostBootDisplay, Mode=OneWay}"/>
+                        </TextBlock>
+                    </StackPanel>
+                </StackPanel>
+                <TextBlock Text="{Binding Trend}" Style="{StaticResource Subtle}" Margin="0,8,0,0" TextWrapping="Wrap"
+                           Visibility="{Binding Trend, Converter={StaticResource FlexVis}}"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Boots + degradations -->
+        <Grid Grid.Row="3">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0" Margin="0,0,6,0">
+                <DockPanel>
+                    <TextBlock DockPanel.Dock="Top" Text="Boot history" Style="{StaticResource SectionTitle}" Margin="14,12,14,0"/>
+                    <DataGrid ItemsSource="{Binding Boots}" Margin="0,8,0,0"
+                              AutomationProperties.Name="Boot history"
+                              AutoGenerateColumns="False" HeadersVisibility="Column"
+                              CanUserAddRows="False" IsReadOnly="True" SelectionMode="Single"
+                              Background="Transparent" BorderThickness="0" GridLinesVisibility="None"
+                              VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="When" Binding="{Binding WhenDisplay}" Width="*"/>
+                            <DataGridTextColumn Header="Boot time" Binding="{Binding BootSecondsDisplay}" Width="100"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </DockPanel>
+            </Border>
+
+            <Border Grid.Column="1" Style="{StaticResource Card}" Padding="0" Margin="6,0,0,0">
+                <DockPanel>
+                    <TextBlock DockPanel.Dock="Top" Text="Slowed boot" Style="{StaticResource SectionTitle}" Margin="14,12,14,0"/>
+                    <DataGrid ItemsSource="{Binding Degradations}" Margin="0,8,0,0"
+                              AutomationProperties.Name="Components that slowed boot"
+                              AutoGenerateColumns="False" HeadersVisibility="Column"
+                              CanUserAddRows="False" IsReadOnly="True" SelectionMode="Single"
+                              Background="Transparent" BorderThickness="0" GridLinesVisibility="None"
+                              VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Kind" Binding="{Binding Kind}" Width="100"/>
+                            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
+                            <DataGridTextColumn Header="Delay" Binding="{Binding DurationDisplay}" Width="80"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </DockPanel>
+            </Border>
+        </Grid>
+
+        <!-- Status bar -->
+        <DockPanel Grid.Row="4" Margin="0,8,0,0">
+            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Right" Width="180" Height="4"
+                         IsIndeterminate="{Binding IsProgressIndeterminate}"
+                         Visibility="{Binding IsBusy, Converter={StaticResource FlexVis}}"/>
+            <Button DockPanel.Dock="Right" Content="Refresh" Command="{Binding RefreshCommand}"
+                    AutomationProperties.Name="Refresh boot history"
+                    Style="{StaticResource GhostButton}" Margin="0,0,12,0" Padding="10,2"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" VerticalAlignment="Center"/>
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/BootAnalyzerView.xaml.cs
+++ b/SysManager/SysManager/Views/BootAnalyzerView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · BootAnalyzerView — boot performance history UI
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class BootAnalyzerView : UserControl
+{
+    public BootAnalyzerView() => InitializeComponent();
+}


### PR DESCRIPTION
## Summary
Turns the System group's **Boot Analyzer** placeholder into a working tab.

- Shows how long your PC takes to boot — **total, core (main path), and desktop ready-up** time — across recent boots.
- A **trend** line compares the last boot to your recent average.
- Lists the **apps, drivers, services, and devices** Windows flagged as slowing boot, with the delay attributed to each.
- Read-only; reading the boot-performance log requires administrator (standard elevation banner).

Closes #343

## Design (matches existing architecture)
- `BootAnalyzerService` reads the Microsoft-Windows-Diagnostics-Performance/Operational log via `EventLogReader` (same API + thread-pool offload as `EventLogService`). It parses event 100 (boot durations) and events 101–110 (degradation), driving everything from the event XML's named `<Data>` fields. The event-ID→kind mapping and all field parsing are **pure static methods**, unit-tested against synthetic event XML — no live log or admin needed for the tests.
- `BootAnalyzerViewModel` follows the scan-on-load + admin-banner + `BulkObservableCollection` + `Dispose` conventions; computes a trend vs the recent average.
- `BootAnalyzerView` Strategy-1 layout (admin banner, latest-boot summary card, two side-by-side grids, status bar). `AutomationProperties.Name` on controls. No `DropShadowEffect`.
- Replaces the placeholder (nav id `nav-boot-analyzer` unchanged); wired into DI + both `MainWindowViewModel` paths + dispose.

## Tests
- 10 tests in `BootAnalyzerServiceTests`: `DataValue` named-field reads (+ null xml), event-ID→kind mapping, `ParseBoot` (durations + no-boot-time → null), `ParseDegradation` (name + time, FriendlyName fallback, no-name → null).

## Docs
- README (40 implemented / 17 WIP, new feature section, System row), ARCHITECTURE (VM + service descriptions, System row), CHANGELOG (1.33.0 Added), version bump → 1.33.0.