### PR TITLE
fix: Browser Cleaner refuses to follow junctions/symlinks out of browser folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.33.1] - 2026-06-25
+
+### Fixed
+- **Browser Cleaner now refuses to follow junctions or symbolic links out of a browser's own folders.** The reparse-point safety check failed *open* — if a folder's attributes couldn't be read it was treated as a normal folder and traversed — and the file-deletion path skipped the check entirely, so a junction or link placed inside a browser profile directory (something a standard user can create without administrator rights) could redirect a clean to measure or delete files outside the browser tree. The check now fails *safe* (an unreadable entry is treated as a link and skipped), runs before every measure and delete on both files and folders, and matches the behavior already used by Deep Cleanup and the File Shredder. The Firefox "Cache" entry now targets each profile's `cache2` cache folder specifically, instead of the whole profile directory — so a Firefox clean can never touch saved logins, bookmarks, or preferences.
+
 ## [1.33.0] - 2026-06-25
 
 ### Added

--- a/SysManager/SysManager.Tests/BrowserCleanerServiceTests.cs
+++ b/SysManager/SysManager.Tests/BrowserCleanerServiceTests.cs
@@ -32,7 +32,23 @@ public sealed class BrowserCleanerServiceTests : IDisposable
     public void Dispose()
     {
         var parent = Directory.GetParent(_local)!.FullName;
-        if (Directory.Exists(parent)) Directory.Delete(parent, recursive: true);
+        if (!Directory.Exists(parent)) return;
+        // Remove any junctions/symlinks as links first — Directory.Delete(recursive:true)
+        // throws "The parameter is incorrect" on reparse points (the junctions some tests
+        // create). Unlink them (non-recursively, so the target is untouched), then delete.
+        try { UnlinkReparsePoints(parent); } catch (IOException) { /* best-effort teardown */ }
+        try { Directory.Delete(parent, recursive: true); } catch (IOException) { /* best-effort teardown */ }
+    }
+
+    private static void UnlinkReparsePoints(string dir)
+    {
+        foreach (var sub in Directory.GetDirectories(dir))
+        {
+            if ((File.GetAttributes(sub) & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint)
+                Directory.Delete(sub);            // remove the link only, never its target
+            else
+                UnlinkReparsePoints(sub);
+        }
     }
 
     private void WriteFile(string relUnderLocal, int bytes)

--- a/SysManager/SysManager.Tests/BrowserCleanerServiceTests.cs
+++ b/SysManager/SysManager.Tests/BrowserCleanerServiceTests.cs
@@ -98,4 +98,93 @@ public sealed class BrowserCleanerServiceTests : IDisposable
         Assert.Empty(Directory.GetFiles(
             Path.Combine(_local, @"Google\Chrome\User Data\Default\Cache"), "*", SearchOption.AllDirectories));
     }
+
+    // --- Reparse-point safety: a standard user can drop a junction (mklink /J, no admin)
+    // inside a browser profile dir. The cleaner must NEVER follow it out of the tree to
+    // measure or delete unrelated user data. ---
+
+    /// <summary>Creates an NTFS junction at <paramref name="linkPath"/> → <paramref name="targetPath"/>.</summary>
+    private static bool TryCreateJunction(string linkPath, string targetPath)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(linkPath)!);
+        var psi = new System.Diagnostics.ProcessStartInfo("cmd.exe", $"/c mklink /J \"{linkPath}\" \"{targetPath}\"")
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+        using var p = System.Diagnostics.Process.Start(psi);
+        if (p is null) return false;
+        p.WaitForExit(10_000);
+        return p.ExitCode == 0 && Directory.Exists(linkPath);
+    }
+
+    [Fact]
+    public async Task Scan_DoesNotFollowJunction_OutOfBrowserTree()
+    {
+        // "victim" data living OUTSIDE the browser tree.
+        var victimDir = Path.Combine(Directory.GetParent(_local)!.FullName, "victim");
+        Directory.CreateDirectory(victimDir);
+        File.WriteAllBytes(Path.Combine(victimDir, "secret.dat"), new byte[4096]);
+
+        // Replace Chrome's Cache leaf with a junction pointing at the victim dir.
+        var cacheLink = Path.Combine(_local, @"Google\Chrome\User Data\Default\Cache");
+        if (!TryCreateJunction(cacheLink, victimDir)) return; // skip if junctions unavailable
+
+        var items = await _svc.ScanAsync();
+        var cache = items.FirstOrDefault(i => i.Browser == "Google Chrome" && i.Category == "Cache");
+        // The junctioned cache must not contribute the victim's bytes/files to the scan.
+        if (cache is not null)
+        {
+            Assert.Equal(0, cache.SizeBytes);
+            Assert.Equal(0, cache.FileCount);
+        }
+        Assert.True(File.Exists(Path.Combine(victimDir, "secret.dat")));
+    }
+
+    [Fact]
+    public async Task Clean_DoesNotDeleteThroughJunction_OutOfBrowserTree()
+    {
+        var victimDir = Path.Combine(Directory.GetParent(_local)!.FullName, "victim");
+        Directory.CreateDirectory(victimDir);
+        var secret = Path.Combine(victimDir, "secret.dat");
+        File.WriteAllBytes(secret, new byte[4096]);
+
+        var cacheLink = Path.Combine(_local, @"Google\Chrome\User Data\Default\Cache");
+        if (!TryCreateJunction(cacheLink, victimDir)) return; // skip if junctions unavailable
+
+        // Force the item through Clean directly (bypassing scan-time filtering) to prove
+        // the deletion path itself refuses to follow the junction.
+        var item = new Models.BrowserCleanupItem
+        {
+            Browser = "Google Chrome", Category = "Cache", Description = "",
+            Paths = [cacheLink], IsSensitive = false, IsSelected = true
+        };
+        var deleted = await _svc.CleanAsync([item]);
+
+        Assert.Equal(0, deleted);
+        Assert.True(File.Exists(secret), "Clean must not delete files through a junction.");
+    }
+
+    [Fact]
+    public async Task Scan_FirefoxCache_TargetsCache2_NotProfileRoot()
+    {
+        // A Firefox profile with both a cache and sensitive files at the profile root.
+        WriteFile(@"Mozilla\Firefox\Profiles\abc.default-release\cache2\entries\e0", 2048);
+        WriteFile(@"Mozilla\Firefox\Profiles\abc.default-release\logins.json", 256);
+        WriteFile(@"Mozilla\Firefox\Profiles\abc.default-release\key4.db", 256);
+
+        var items = await _svc.ScanAsync();
+        var ff = items.FirstOrDefault(i => i.Browser == "Firefox");
+        Assert.NotNull(ff);
+        // Only the cache2 bytes are counted — never the profile root's logins/keys.
+        Assert.Equal(2048, ff!.SizeBytes);
+        Assert.All(ff.Paths, p => Assert.EndsWith("cache2", p, StringComparison.OrdinalIgnoreCase));
+
+        // And a clean leaves the sensitive profile files intact.
+        await _svc.CleanAsync([ff]);
+        Assert.True(File.Exists(Path.Combine(_local, @"Mozilla\Firefox\Profiles\abc.default-release\logins.json")));
+        Assert.True(File.Exists(Path.Combine(_local, @"Mozilla\Firefox\Profiles\abc.default-release\key4.db")));
+    }
 }

--- a/SysManager/SysManager/Services/BrowserCleanerService.cs
+++ b/SysManager/SysManager/Services/BrowserCleanerService.cs
@@ -50,9 +50,35 @@ public sealed class BrowserCleanerService
         defs.AddRange(ChromiumDefs("Microsoft Edge", @"Microsoft\Edge\User Data"));
         defs.AddRange(ChromiumDefs("Brave", @"BraveSoftware\Brave-Browser\User Data"));
         defs.AddRange(ChromiumDefs("Opera", @"Opera Software\Opera Stable"));
-        // Firefox keeps profiles in roaming AppData; cache lives in local.
-        defs.Add(new("Firefox", "Cache", "Cached images and files.", false, [@"Mozilla\Firefox\Profiles"]) );
+        // Firefox keeps profiles in roaming AppData, but the cache lives under LocalAppData
+        // in per-profile "<profile>\cache2" folders. We target the cache2 subfolders only —
+        // never the Profiles root, which holds prefs.js, logins.json, key4.db and bookmarks.
+        // The exact profile folder name is machine-specific, so the per-profile cache2 paths
+        // are expanded at scan time (see ExpandFirefoxCachePaths).
+        foreach (var cachePath in ExpandFirefoxCachePaths())
+            defs.Add(new("Firefox", "Cache", "Cached images and files.", false, [cachePath]));
         return defs;
+    }
+
+    /// <summary>
+    /// Returns the relative paths of each Firefox profile's <c>cache2</c> folder under
+    /// LocalAppData (e.g. <c>Mozilla\Firefox\Profiles\abc.default-release\cache2</c>).
+    /// Returns an empty sequence when Firefox isn't installed. Never returns the Profiles
+    /// root, so a clean can only ever touch cache, never saved logins/bookmarks/prefs.
+    /// </summary>
+    private IEnumerable<string> ExpandFirefoxCachePaths()
+    {
+        const string profilesRel = @"Mozilla\Firefox\Profiles";
+        var profilesAbs = Path.Combine(_localAppData, profilesRel);
+        if (!Directory.Exists(profilesAbs) || IsReparsePoint(profilesAbs)) yield break;
+
+        string[] profileDirs;
+        try { profileDirs = Directory.GetDirectories(profilesAbs); }
+        catch (IOException) { yield break; }
+        catch (UnauthorizedAccessException) { yield break; }
+
+        foreach (var dir in profileDirs)
+            yield return Path.Combine(profilesRel, Path.GetFileName(dir), "cache2");
     }
 
     private string Root(bool roaming) => roaming ? _roamingAppData : _localAppData;
@@ -125,8 +151,11 @@ public sealed class BrowserCleanerService
     {
         try
         {
+            // Skip reparse-point leaves (a file/dir symlink or junction): following one
+            // could measure — and later delete — data outside the browser's own tree.
+            if (IsReparsePoint(path)) return (0, 0);
             if (File.Exists(path)) return (SafeLength(path), 1);
-            if (!Directory.Exists(path) || IsReparsePoint(path)) return (0, 0);
+            if (!Directory.Exists(path)) return (0, 0);
             long size = 0; var files = 0;
             foreach (var file in SafeEnumerateFiles(path, ct))
             {
@@ -145,12 +174,17 @@ public sealed class BrowserCleanerService
         var deleted = 0;
         try
         {
+            // Skip reparse-point leaves before any delete. File.Delete on a file symlink
+            // removes the link, but a junction standing in for an expected directory leaf
+            // would otherwise be recursed into and its target's files deleted — data loss
+            // outside the browser tree. Fail-closed IsReparsePoint is the gate (see below).
+            if (IsReparsePoint(path)) return 0;
             if (File.Exists(path))
             {
                 if (TryDeleteFile(path)) deleted++;
                 return deleted;
             }
-            if (!Directory.Exists(path) || IsReparsePoint(path)) return 0;
+            if (!Directory.Exists(path)) return 0;
             foreach (var file in SafeEnumerateFiles(path, ct))
             {
                 if (ct.IsCancellationRequested) break;
@@ -176,11 +210,17 @@ public sealed class BrowserCleanerService
         catch (UnauthorizedAccessException) { return 0; }
     }
 
+    /// <summary>
+    /// True when the path is a reparse point (junction or symbolic link). Fails SAFE:
+    /// returns true when the attributes can't be read, so an unreadable entry is treated
+    /// as a link and skipped rather than followed/deleted. Mirrors
+    /// <see cref="DeepCleanupService"/> and <see cref="FileShredderService"/>.
+    /// </summary>
     private static bool IsReparsePoint(string path)
     {
-        try { return (File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0; }
-        catch (IOException) { return false; }
-        catch (UnauthorizedAccessException) { return false; }
+        try { return (File.GetAttributes(path) & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint; }
+        catch (IOException) { return true; }
+        catch (UnauthorizedAccessException) { return true; }
     }
 
     private static IEnumerable<string> SafeEnumerateFiles(string root, CancellationToken ct)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.33.0</Version>
-    <FileVersion>1.33.0.0</FileVersion>
-    <AssemblyVersion>1.33.0.0</AssemblyVersion>
+    <Version>1.33.1</Version>
+    <FileVersion>1.33.1.0</FileVersion>
+    <AssemblyVersion>1.33.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem

A read of the Browser Cleaner service surfaced a data-loss class defect in its reparse-point (junction / symbolic-link) handling:

1. `IsReparsePoint` **failed open** — when a folder's attributes couldn't be read (`IOException`/`UnauthorizedAccessException`) it returned `false` ("not a link, safe to traverse"). Every other cleanup service in the codebase (Deep Cleanup, File Shredder) fails *closed* (`return true`).
2. The **file measure/delete branch had no reparse check at all** — only the directory branch was guarded.
3. The **Firefox "Cache" entry pointed at the whole `Mozilla\Firefox\Profiles` tree** (containing `logins.json`, `key4.db`, bookmarks, prefs), labelled non-sensitive and therefore pre-selected.

A standard user can create a junction (`mklink /J`, no admin) inside a browser profile directory. Combined, the above let a clean follow that junction out of the browser tree and measure/delete unrelated user data.

## Fix

- `IsReparsePoint` now **fails safe** (unreadable entry → treated as a link → skipped), matching `DeepCleanupService`/`FileShredderService`.
- The reparse check now runs **before every measure and delete**, on both files and directories.
- The Firefox cache entry now targets each profile's **`cache2`** folder specifically (expanded per-profile at scan time), never the profile root — a Firefox clean can no longer touch saved logins/bookmarks/preferences.

## Tests

Adds regression tests (junctions, which need no admin):
- `Scan_DoesNotFollowJunction_OutOfBrowserTree`
- `Clean_DoesNotDeleteThroughJunction_OutOfBrowserTree`
- `Scan_FirefoxCache_TargetsCache2_NotProfileRoot`

Main + Tests build 0 warnings / 0 errors.

## Docs / version

- CHANGELOG entry under 1.33.1
- csproj bumped 1.33.0 → 1.33.1 (patch, `fix:`)