### PR TITLE
fix: preserve REG_EXPAND_SZ on environment edits + add Restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.33.3] - 2026-06-25
+
+### Fixed
+- **Editing an environment variable no longer breaks `%VAR%` expansion in PATH and similar variables.** SysManager wrote every variable as a plain string (REG_SZ), which silently converted variables Windows stores as expandable (REG_EXPAND_SZ) — most importantly the system `Path` — and froze references like `%SystemRoot%` or `%JAVA_HOME%` to whatever they happened to expand to at edit time, so they stopped tracking their source variable. Variables are now written directly to the registry with their original type preserved (a variable that was expandable stays expandable, and a new value containing a `%token%` is created as expandable), and the editor now shows and round-trips the raw `%VAR%` tokens instead of their expanded form. A single `WM_SETTINGCHANGE` broadcast still notifies running programs after a batch of changes.
+
+### Added
+- **Restore button on the Environment Variables tab.** The one-time backup taken before your first change can now be restored from inside the app: every variable is rewritten to its original value (type preserved) and any variable added since is removed. The Apply confirmation already promised this was possible — now there's a button for it. (System-scope restore needs administrator rights; if the safety backup can't be written, Apply now stops without making any change instead of risking an unbacked edit.)
+
 ## [1.33.2] - 2026-06-25
 
 ### Fixed

--- a/SysManager/SysManager.Tests/EnvironmentVariableServiceTests.cs
+++ b/SysManager/SysManager.Tests/EnvironmentVariableServiceTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.IO;
+using Microsoft.Win32;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -42,6 +43,34 @@ public class EnvironmentVariableServiceTests
     [Fact]
     public void ValidateName_RejectsOverlongName()
         => Assert.Throws<ArgumentException>(() => EnvironmentVariableService.ValidateName(new string('A', 256)));
+
+    // ---------- ChooseKind (REG_EXPAND_SZ preservation) ----------
+
+    [Fact]
+    public void ChooseKind_PreservesExistingExpandString()
+    {
+        // The core regression: an existing PATH stored as REG_EXPAND_SZ must STAY expandable
+        // even when its new value no longer literally contains a '%' at edit time, so its
+        // %VAR% tokens keep expanding system-wide.
+        Assert.Equal(RegistryValueKind.ExpandString,
+            EnvironmentVariableService.ChooseKind(RegistryValueKind.ExpandString, @"C:\Tools;C:\Bin"));
+    }
+
+    [Fact]
+    public void ChooseKind_PreservesExistingString()
+    {
+        Assert.Equal(RegistryValueKind.String,
+            EnvironmentVariableService.ChooseKind(RegistryValueKind.String, @"%SystemRoot%\x"));
+    }
+
+    [Theory]
+    [InlineData(@"%SystemRoot%\System32", true)]   // new value with a token → expandable
+    [InlineData(@"C:\Plain\Path", false)]          // new value without a token → plain
+    public void ChooseKind_NewVariable_UsesExpandStringWhenTokenPresent(string value, bool expectExpand)
+    {
+        var expected = expectExpand ? RegistryValueKind.ExpandString : RegistryValueKind.String;
+        Assert.Equal(expected, EnvironmentVariableService.ChooseKind(null, value));
+    }
 
     // ---------- SplitPath / JoinPath ----------
 
@@ -158,6 +187,35 @@ public class EnvironmentVariableServiceTests
             Assert.Null(svc.ReadBackup());
         }
         finally { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void SetVariable_PreservesExpandSz_AndReadsRawTokens_EndToEnd()
+    {
+        // End-to-end regression for the REG_EXPAND_SZ flattening bug: write an expandable
+        // value to a throwaway User variable, then confirm via the service that the value
+        // KIND stayed REG_EXPAND_SZ and the RAW %VAR% token round-tripped (not expanded).
+        // Uses a unique name in the real HKCU\Environment and removes it in finally.
+        var svc = new EnvironmentVariableService();
+        var name = "SM_TEST_" + Guid.NewGuid().ToString("N");
+        const string rawValue = @"%SystemRoot%\System32;C:\SmTest";
+        try
+        {
+            Assert.True(svc.SetVariable(name, rawValue, EnvVarScope.User));
+
+            using var key = Registry.CurrentUser.OpenSubKey("Environment");
+            Assert.NotNull(key);
+            Assert.Equal(RegistryValueKind.ExpandString, key!.GetValueKind(name));
+
+            var roundTripped = svc.Read(EnvVarScope.User).Single(v => v.Name == name);
+            Assert.Equal(rawValue, roundTripped.Value);   // %SystemRoot% preserved, not expanded
+            Assert.True(roundTripped.IsExpandable);
+        }
+        finally
+        {
+            using var key = Registry.CurrentUser.OpenSubKey("Environment", writable: true);
+            key?.DeleteValue(name, throwOnMissingValue: false);
+        }
     }
 
     [Fact]

--- a/SysManager/SysManager/Models/EnvVariable.cs
+++ b/SysManager/SysManager/Models/EnvVariable.cs
@@ -28,6 +28,14 @@ public sealed partial class EnvVariable : ObservableObject
     public required string Name { get; init; }
     public required EnvVarScope Scope { get; init; }
 
+    /// <summary>
+    /// True when the variable is stored as REG_EXPAND_SZ (its value may contain %VAR%
+    /// tokens that Windows expands). Preserved on write so editing a PATH never flips it
+    /// to a plain REG_SZ and freezes its tokens. Defaults to false for new variables; the
+    /// service promotes a new value containing '%' to expandable automatically.
+    /// </summary>
+    public bool IsExpandable { get; init; }
+
     /// <summary>True for PATH-like variables whose value is a ';'-separated directory list.</summary>
     public bool IsPathLike =>
         Name.Equals("Path", StringComparison.OrdinalIgnoreCase) ||

--- a/SysManager/SysManager/Services/EnvironmentVariableService.cs
+++ b/SysManager/SysManager/Services/EnvironmentVariableService.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -17,9 +18,14 @@ namespace SysManager.Services;
 /// Reads and writes Windows environment variables for both the User
 /// (HKCU\Environment) and Machine (HKLM ...\Session Manager\Environment) scopes.
 ///
-/// Writes go through <see cref="Environment.SetEnvironmentVariable(string,string,EnvironmentVariableTarget)"/>,
-/// which updates the registry AND broadcasts WM_SETTINGCHANGE so already-running
-/// processes (Explorer, new shells) pick up the change without a reboot.
+/// Writes go directly to the registry so the value KIND is preserved: a variable
+/// stored as REG_EXPAND_SZ (e.g. a PATH containing %SystemRoot%) stays REG_EXPAND_SZ,
+/// and reads return the RAW value with %VAR% tokens intact (not the expansion). Using
+/// <see cref="Environment.SetEnvironmentVariable(string,string,EnvironmentVariableTarget)"/>
+/// would instead rewrite every variable as REG_SZ and freeze its tokens to their
+/// edit-time expansion — silently corrupting PATH. After a batch of writes the caller
+/// broadcasts WM_SETTINGCHANGE once (see <see cref="BroadcastSettingChange"/>) so
+/// already-running processes (Explorer, new shells) pick the change up without a reboot.
 ///
 /// Machine-scope writes require administrator rights; <see cref="SetVariable"/> returns
 /// <c>false</c> (rather than throwing) when the write is denied, mirroring
@@ -28,6 +34,10 @@ namespace SysManager.Services;
 /// </summary>
 public sealed partial class EnvironmentVariableService
 {
+    // Registry locations of the two environment scopes.
+    private const string UserEnvPath = @"Environment";
+    private const string MachineEnvPath = @"SYSTEM\CurrentControlSet\Control\Session Manager\Environment";
+
     private readonly string _backupDir;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -69,29 +79,44 @@ public sealed partial class EnvironmentVariableService
 
     // ── Reading ──────────────────────────────────────────────────────────────
 
-    /// <summary>Reads all variables for the given scope, sorted by name.</summary>
+    private static (RegistryKey hive, string path) Location(EnvVarScope scope) =>
+        scope == EnvVarScope.Machine
+            ? (Registry.LocalMachine, MachineEnvPath)
+            : (Registry.CurrentUser, UserEnvPath);
+
+    /// <summary>
+    /// Reads all variables for the given scope, sorted by name. Reads the RAW value
+    /// (<see cref="RegistryValueOptions.DoNotExpandEnvironmentNames"/>) so %VAR% tokens
+    /// are preserved for round-tripping, and records the value KIND so a write can keep
+    /// REG_EXPAND_SZ intact.
+    /// </summary>
     public List<EnvVariable> Read(EnvVarScope scope)
     {
         List<EnvVariable> result = [];
-        var target = scope == EnvVarScope.Machine
-            ? EnvironmentVariableTarget.Machine
-            : EnvironmentVariableTarget.User;
+        var (hive, path) = Location(scope);
         try
         {
-            var vars = Environment.GetEnvironmentVariables(target);
-            foreach (System.Collections.DictionaryEntry kv in vars)
+            using var key = hive.OpenSubKey(path);
+            if (key is null) return result;
+            foreach (var name in key.GetValueNames())
             {
-                var name = kv.Key?.ToString();
                 if (string.IsNullOrEmpty(name)) continue;
+                var raw = key.GetValue(name, "", RegistryValueOptions.DoNotExpandEnvironmentNames);
+                var expandable = key.GetValueKind(name) == RegistryValueKind.ExpandString;
                 result.Add(new EnvVariable
                 {
                     Name = name,
                     Scope = scope,
-                    Value = kv.Value?.ToString() ?? ""
+                    Value = raw?.ToString() ?? "",
+                    IsExpandable = expandable
                 });
             }
         }
         catch (System.Security.SecurityException ex)
+        {
+            Log.Warning(ex, "Environment: reading {Scope} scope denied", scope);
+        }
+        catch (UnauthorizedAccessException ex)
         {
             Log.Warning(ex, "Environment: reading {Scope} scope denied", scope);
         }
@@ -109,21 +134,42 @@ public sealed partial class EnvironmentVariableService
     // ── Writing ──────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Sets (or, when <paramref name="value"/> is null, deletes) a variable. Validates
-    /// the name at the trust boundary. Returns <c>false</c> if the write is denied
-    /// (typically a Machine-scope write without elevation) instead of throwing.
+    /// Sets (or, when <paramref name="value"/> is null, deletes) a variable, writing
+    /// directly to the registry so the value KIND is preserved. An existing variable
+    /// keeps its kind (REG_EXPAND_SZ stays expandable); a new variable is written as
+    /// REG_EXPAND_SZ when its value contains a %VAR% token, else REG_SZ. Validates the
+    /// name at the trust boundary. Returns <c>false</c> if the write is denied (typically
+    /// a Machine-scope write without elevation) instead of throwing.
+    ///
+    /// Does NOT broadcast WM_SETTINGCHANGE — the caller broadcasts once after a batch via
+    /// <see cref="BroadcastSettingChange"/>.
     /// </summary>
     public bool SetVariable(string name, string? value, EnvVarScope scope)
     {
         var validName = ValidateName(name);
-        var target = scope == EnvVarScope.Machine
-            ? EnvironmentVariableTarget.Machine
-            : EnvironmentVariableTarget.User;
+        var (hive, path) = Location(scope);
         try
         {
-            Environment.SetEnvironmentVariable(validName, value, target);
-            Log.Information("Environment: {Action} {Scope} variable {Name}",
-                value is null ? "deleted" : "set", scope, validName);
+            using var key = hive.OpenSubKey(path, writable: true);
+            if (key is null)
+            {
+                Log.Warning("Environment: {Scope} environment key not found", scope);
+                return false;
+            }
+
+            if (value is null)
+            {
+                key.DeleteValue(validName, throwOnMissingValue: false);
+                Log.Information("Environment: deleted {Scope} variable {Name}", scope, validName);
+                return true;
+            }
+
+            // Preserve the existing kind; for a new value, choose ExpandString when it
+            // references a %VAR% token so expansion keeps working (matches how Windows
+            // itself stores PATH and similar variables).
+            var kind = ChooseKind(ExistingKind(key, validName), value);
+            key.SetValue(validName, value, kind);
+            Log.Information("Environment: set {Scope} variable {Name} ({Kind})", scope, validName, kind);
             return true;
         }
         catch (System.Security.SecurityException ex)
@@ -138,8 +184,51 @@ public sealed partial class EnvironmentVariableService
         }
     }
 
+    private static RegistryValueKind? ExistingKind(RegistryKey key, string name)
+    {
+        try { return key.GetValueKind(name); }
+        catch (IOException) { return null; }   // value does not exist yet
+    }
+
+    /// <summary>
+    /// Decides the registry value kind for a write: keep an existing variable's kind so a
+    /// REG_EXPAND_SZ (e.g. PATH) is never flattened to REG_SZ; for a NEW variable use
+    /// REG_EXPAND_SZ when the value contains a %VAR% token, else REG_SZ. Pure for testing.
+    /// </summary>
+    public static RegistryValueKind ChooseKind(RegistryValueKind? existingKind, string value)
+        => existingKind ?? (value.Contains('%') ? RegistryValueKind.ExpandString : RegistryValueKind.String);
+
     /// <summary>Deletes a variable. Returns false if the write is denied.</summary>
     public bool DeleteVariable(string name, EnvVarScope scope) => SetVariable(name, null, scope);
+
+    /// <summary>
+    /// Broadcasts WM_SETTINGCHANGE("Environment") so already-running processes pick up
+    /// environment changes without a reboot. Bounded (SMTO_ABORTIFHUNG, 5 s) so a frozen
+    /// top-level window can't hang the caller. Call once after a batch of writes.
+    /// </summary>
+    public static void BroadcastSettingChange()
+    {
+        try
+        {
+            _ = NativeMethods.SendMessageTimeout(
+                NativeMethods.HWND_BROADCAST, NativeMethods.WM_SETTINGCHANGE,
+                IntPtr.Zero, "Environment",
+                NativeMethods.SMTO_ABORTIFHUNG, 5000, out _);
+        }
+        catch (EntryPointNotFoundException ex) { Log.Debug("Environment: WM_SETTINGCHANGE broadcast unavailable: {Error}", ex.Message); }
+    }
+
+    private static partial class NativeMethods
+    {
+        internal static readonly IntPtr HWND_BROADCAST = new(0xFFFF);
+        internal const uint WM_SETTINGCHANGE = 0x001A;
+        internal const uint SMTO_ABORTIFHUNG = 0x0002;
+
+        [LibraryImport("user32.dll", StringMarshalling = StringMarshalling.Utf16, EntryPoint = "SendMessageTimeoutW")]
+        internal static partial IntPtr SendMessageTimeout(
+            IntPtr hWnd, uint msg, IntPtr wParam, string lParam,
+            uint flags, uint timeout, out IntPtr result);
+    }
 
     // ── PATH helpers (pure, testable) ──────────────────────────────────────────
 
@@ -227,5 +316,44 @@ public sealed partial class EnvironmentVariableService
             Log.Warning(ex, "Environment: backup file could not be read");
             return null;
         }
+    }
+
+    /// <summary>The outcome of a <see cref="RestoreFromBackup"/> call.</summary>
+    public readonly record struct RestoreResult(bool HadBackup, int Restored, int Removed, int Failed);
+
+    /// <summary>
+    /// Restores the environment to the pristine backup: every backed-up variable is
+    /// written back (kind preserved for existing names), and any variable that did NOT
+    /// exist in the backup is removed. Returns counts. Machine-scope changes need admin —
+    /// those writes count as failures (not exceptions) when not elevated. The caller
+    /// should <see cref="BroadcastSettingChange"/> once afterwards.
+    /// </summary>
+    public RestoreResult RestoreFromBackup()
+    {
+        var backup = ReadBackup();
+        if (backup is null) return new RestoreResult(false, 0, 0, 0);
+
+        int restored = 0, removed = 0, failed = 0;
+        foreach (var scope in new[] { EnvVarScope.User, EnvVarScope.Machine })
+        {
+            var saved = scope == EnvVarScope.Machine ? backup.Machine : backup.User;
+
+            // Re-write every backed-up variable to its original value.
+            foreach (var (name, value) in saved)
+            {
+                if (SetVariable(name, value, scope)) restored++;
+                else failed++;
+            }
+
+            // Remove anything present now but absent from the backup (added since).
+            foreach (var current in Read(scope))
+            {
+                if (saved.ContainsKey(current.Name)) continue;
+                if (DeleteVariable(current.Name, scope)) removed++;
+                else failed++;
+            }
+        }
+        Log.Information("Environment: restored {Restored}, removed {Removed}, failed {Failed} from backup", restored, removed, failed);
+        return new RestoreResult(true, restored, removed, failed);
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.33.2</Version>
-    <FileVersion>1.33.2.0</FileVersion>
-    <AssemblyVersion>1.33.2.0</AssemblyVersion>
+    <Version>1.33.3</Version>
+    <FileVersion>1.33.3.0</FileVersion>
+    <AssemblyVersion>1.33.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
@@ -324,7 +324,20 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
             return;
         }
 
-        _service.EnsureBackup();
+        try { _service.EnsureBackup(); }
+        catch (IOException ex)
+        {
+            StatusMessage = "Could not write the safety backup — no changes were made.";
+            Log.Warning(ex, "Environment: backup write failed; aborting apply");
+            return;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            StatusMessage = "Could not write the safety backup — no changes were made.";
+            Log.Warning(ex, "Environment: backup write denied; aborting apply");
+            return;
+        }
+        OnPropertyChanged(nameof(HasBackup));
 
         var failures = 0;
         var applied = 0;
@@ -348,6 +361,9 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
             else failures++;
         }
 
+        // Broadcast once so running processes (Explorer, new shells) pick up the changes.
+        if (applied > 0) EnvironmentVariableService.BroadcastSettingChange();
+
         RecomputePending();
 
         if (failures == 0)
@@ -370,6 +386,53 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
     {
         var live = Variables.Select(Key).ToHashSet(StringComparer.Ordinal);
         return _originals.Where(kv => !live.Contains(kv.Key)).Select(kv => kv.Value);
+    }
+
+    /// <summary>True once a pristine backup exists (after the first Apply) — enables Restore.</summary>
+    public bool HasBackup => _service.HasBackup;
+
+    [RelayCommand]
+    private void RestoreBackup()
+    {
+        if (!_service.HasBackup)
+        {
+            StatusMessage = "There is no backup to restore yet — it is created the first time you apply changes.";
+            return;
+        }
+
+        // Restoring Machine-scope variables needs admin; warn early like Apply does.
+        if (!IsElevated && _service.ReadBackup() is { Machine.Count: > 0 })
+        {
+            // Still allow restoring User-scope vars, but tell the user System ones will be skipped.
+            if (!DialogService.Instance.Confirm(
+                    "Restore the original environment from the backup?\n\n" +
+                    "This rewrites every variable to its value from before your first change, and removes " +
+                    "variables added since. System variables can only be restored when running as administrator " +
+                    "and will be skipped now.",
+                    "Restore Environment"))
+            {
+                StatusMessage = "Restore cancelled.";
+                return;
+            }
+        }
+        else if (!DialogService.Instance.Confirm(
+                     "Restore the original environment from the backup?\n\n" +
+                     "This rewrites every variable to its value from before your first change, and removes " +
+                     "variables added since.",
+                     "Restore Environment"))
+        {
+            StatusMessage = "Restore cancelled.";
+            return;
+        }
+
+        var r = _service.RestoreFromBackup();
+        if (r.Restored > 0 || r.Removed > 0) EnvironmentVariableService.BroadcastSettingChange();
+        Load();
+
+        StatusMessage = r.Failed == 0
+            ? $"Restored {r.Restored} variable{(r.Restored == 1 ? "" : "s")}" +
+              (r.Removed > 0 ? $" and removed {r.Removed} added since." : ".")
+            : $"Restored {r.Restored}, removed {r.Removed}; {r.Failed} need administrator rights.";
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
+++ b/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
@@ -73,8 +73,13 @@
                             ToolTip="Revert all pending changes."/>
                     <Button Content="Refresh" Command="{Binding RefreshCommand}"
                             AutomationProperties.Name="Refresh variable list"
-                            Style="{StaticResource GhostButton}" Margin="0,0,16,0"
+                            Style="{StaticResource GhostButton}" Margin="0,0,8,0"
                             ToolTip="Re-read all variables from the registry."/>
+                    <Button Content="Restore backup" Command="{Binding RestoreBackupCommand}"
+                            IsEnabled="{Binding HasBackup}"
+                            AutomationProperties.Name="Restore the original environment from backup"
+                            Style="{StaticResource GhostButton}" Margin="0,0,16,0"
+                            ToolTip="Revert every variable to its value from before your first change (created on first Apply)."/>
 
                     <TextBlock Text="Scope:" VerticalAlignment="Center" Margin="0,0,8,0" Style="{StaticResource Subtle}"/>
                     <ComboBox ItemsSource="{Binding ScopeFilters}" SelectedItem="{Binding SelectedScopeFilter}"


### PR DESCRIPTION
## Problem

The Environment Variables tab wrote every variable through `Environment.SetEnvironmentVariable`, which on Windows stores the value as **REG_SZ** (it has no overload to specify the kind). Reads used `GetEnvironmentVariables`, which returns the **already-expanded** value. Two destructive effects on a variable Windows stores as **REG_EXPAND_SZ** (most importantly the machine `Path`):

1. The type silently flips REG_EXPAND_SZ → REG_SZ, so any remaining `%VAR%` tokens stop expanding system-wide.
2. Other entries get frozen to their edit-time expansion — `%JAVA_HOME%\bin` becomes a hard-coded path that no longer tracks `JAVA_HOME`.

*Empirically reproduced:* writing `%TEMP%\probe` via `SetEnvironmentVariable` to HKCU\Environment comes back as `KIND=String`.

Separately, the Apply confirmation promised *"a one-time backup … so you can restore the original environment"*, but there was **no in-app restore** (the `ReadBackup` API had no caller/UI), and `EnsureBackup` was unguarded so a failed backup write would crash Apply on the UI thread.

## Fix

- **Direct registry writes preserving the kind.** `SetVariable` opens the scope key and writes with the existing `RegistryValueKind` (so REG_EXPAND_SZ stays expandable); a *new* value containing a `%token%` is created as REG_EXPAND_SZ, else REG_SZ. Logic extracted to a pure `ChooseKind` for testing.
- **Raw reads.** `Read` uses `RegistryValueOptions.DoNotExpandEnvironmentNames` so the editor shows/round-trips raw `%VAR%` tokens, and records `IsExpandable`.
- **Single `WM_SETTINGCHANGE` broadcast** (bounded `SendMessageTimeout`, SMTO_ABORTIFHUNG/5s) after a batch of writes — replaces the per-write broadcast the BCL used to do.
- **Restore command + toolbar button** (gated on `HasBackup`): rewrites every variable to its backed-up value (kind preserved) and removes ones added since. System-scope restore needs admin.
- **Apply aborts cleanly** if the safety backup can't be written, instead of mutating without a backup.

## Tests

- `ChooseKind_PreservesExistingExpandString` / `PreservesExistingString` / new-variable token cases — pins the exact regression.
- `SetVariable_PreservesExpandSz_AndReadsRawTokens_EndToEnd` — writes a throwaway User variable, asserts the kind stayed REG_EXPAND_SZ and the raw `%SystemRoot%` token round-tripped, then deletes it.

Main + Tests + IntegrationTests build 0/0.

## Docs / version

- CHANGELOG under 1.33.3 (Fixed + Added); csproj 1.33.3 (patch, `fix:`).