### PR TITLE
fix: DNS Undo restores IPv6 too and survives a partial apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.33.4] - 2026-06-25
+
+### Fixed
+- **"Undo" on the DNS & Hosts tab now fully restores the previous setting, including IPv6.** Applying a filtering preset configures both IPv4 and IPv6 resolvers, but Undo only captured and restored IPv4 — so reverting an ad/family-blocking preset left its IPv6 resolvers active, and on a dual-stack network the "undone" filtering was often still in effect. Undo now snapshots both families before a change and, on restore, clears the adapter's DNS first (removing anything applied since) before re-applying exactly what was captured. Undo is also offered now even if a change only partially applied. Additionally, programming the IPv6 resolvers is treated as best-effort: on a machine with IPv6 disabled the IPv4 change still succeeds (and stays undoable) instead of the whole apply failing.
+
 ## [1.33.3] - 2026-06-25
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DnsServiceTests.cs
+++ b/SysManager/SysManager.Tests/DnsServiceTests.cs
@@ -225,11 +225,12 @@ public class DnsServiceTests
     public async Task CaptureCurrentServersAsync_ReturnsParsedAddresses()
     {
         var runner = Substitute.For<IPowerShellRunner>();
+        // Capture now tags each address with its family ("IPv4=" / "IPv6=").
         runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
               .Returns(new Collection<PSObject>
               {
-                  PSObject.AsPSObject("8.8.8.8"),
-                  PSObject.AsPSObject("8.8.4.4"),
+                  PSObject.AsPSObject("IPv4=8.8.8.8"),
+                  PSObject.AsPSObject("IPv4=8.8.4.4"),
               });
         using var svc = new DnsService(runner);
 
@@ -239,15 +240,33 @@ public class DnsServiceTests
     }
 
     [Fact]
+    public async Task CaptureSnapshotAsync_CapturesBothFamilies()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+              .Returns(new Collection<PSObject>
+              {
+                  PSObject.AsPSObject("IPv4=8.8.8.8"),
+                  PSObject.AsPSObject("IPv6=2001:4860:4860::8888"),
+              });
+        using var svc = new DnsService(runner);
+
+        var snap = await svc.CaptureSnapshotAsync();
+
+        Assert.Equal(["8.8.8.8"], snap.V4);
+        Assert.Equal(["2001:4860:4860::8888"], snap.V6);
+    }
+
+    [Fact]
     public async Task CaptureCurrentServersAsync_FiltersNonIpNoise()
     {
         var runner = Substitute.For<IPowerShellRunner>();
         runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
               .Returns(new Collection<PSObject>
               {
-                  PSObject.AsPSObject("1.1.1.1"),
-                  PSObject.AsPSObject(""),       // blank line
-                  PSObject.AsPSObject("garbage"),// non-IP noise
+                  PSObject.AsPSObject("IPv4=1.1.1.1"),
+                  PSObject.AsPSObject(""),            // blank line
+                  PSObject.AsPSObject("IPv4=garbage"),// non-IP noise
               });
         using var svc = new DnsService(runner);
 
@@ -301,6 +320,44 @@ public class DnsServiceTests
 
         await runner.Received(1).RunAsync(
             Arg.Is<string>(s => s.Contains("-ResetServerAddresses")),
+            Arg.Any<IDictionary<string, object?>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RestoreSnapshotAsync_ResetsThenReAppliesBothFamilies()
+    {
+        // The reversibility regression: restoring must CLEAR both families first (so any
+        // filtering IPv6 resolver applied since is removed) and then re-apply the captured
+        // v4 + v6 — not leave the IPv6 in place as the old IPv4-only restore did.
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+              .Returns(Result("7"));
+        using var svc = new DnsService(runner);
+
+        await svc.RestoreSnapshotAsync(new DnsService.DnsSnapshot(["9.9.9.9"], ["2620:fe::fe"]));
+
+        await runner.Received(1).RunAsync(
+            Arg.Is<string>(s =>
+                s.Contains("-ResetServerAddresses") &&        // clears whatever was applied since
+                s.Contains("9.9.9.9") &&                      // re-applies captured IPv4
+                s.Contains("2620:fe::fe")),                   // re-applies captured IPv6
+            Arg.Any<IDictionary<string, object?>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RestoreSnapshotAsync_EmptyBothFamilies_ResetsToDhcp()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+              .Returns(Result("7"));
+        using var svc = new DnsService(runner);
+
+        await svc.RestoreSnapshotAsync(DnsService.DnsSnapshot.Empty);
+
+        await runner.Received(1).RunAsync(
+            Arg.Is<string>(s => s.Contains("-ResetServerAddresses") && !s.Contains("@(\"")),
             Arg.Any<IDictionary<string, object?>?>(),
             Arg.Any<CancellationToken>());
     }

--- a/SysManager/SysManager/Services/DnsService.cs
+++ b/SysManager/SysManager/Services/DnsService.cs
@@ -107,72 +107,114 @@ public sealed class DnsService : IDisposable
     }
 
     /// <summary>
+    /// A point-in-time snapshot of an adapter's DNS configuration for BOTH families, so a
+    /// change can be reverted exactly. An empty list for a family means that family was on
+    /// automatic (DHCP) at capture time and is restored by clearing it back to DHCP.
+    /// </summary>
+    public sealed record DnsSnapshot(IReadOnlyList<string> V4, IReadOnlyList<string> V6)
+    {
+        public static readonly DnsSnapshot Empty = new([], []);
+    }
+
+    /// <summary>
     /// Captures the current IPv4 DNS server addresses of the active adapter so a
     /// change can be reverted to the exact previous configuration. Returns an empty
     /// list when the adapter is on automatic (DHCP) — restoring that snapshot resets
     /// to DHCP rather than re-applying static servers.
     /// </summary>
     public async Task<IReadOnlyList<string>> CaptureCurrentServersAsync(CancellationToken ct = default)
+        => (await CaptureSnapshotAsync(ct).ConfigureAwait(false)).V4;
+
+    /// <summary>
+    /// Captures the current DNS server addresses of the active adapter for BOTH IPv4 and
+    /// IPv6, so a change that programs both families can be fully reverted. An empty list
+    /// for a family means it was on automatic (DHCP).
+    /// </summary>
+    public async Task<DnsSnapshot> CaptureSnapshotAsync(CancellationToken ct = default)
     {
         await _gate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
+            // Tag each address with its family so one query returns both, in order.
             const string script = ActiveAdapterSelector + """
 
                 if ($adapter) {
-                    $dns = Get-DnsClientServerAddress -InterfaceIndex $adapter.ifIndex -AddressFamily IPv4
-                    $dns.ServerAddresses
+                    foreach ($fam in @('IPv4','IPv6')) {
+                        $dns = Get-DnsClientServerAddress -InterfaceIndex $adapter.ifIndex -AddressFamily $fam
+                        foreach ($a in $dns.ServerAddresses) { "$fam=$a" }
+                    }
                 }
                 """;
 
             Collection<PSObject> results = await _ps.RunAsync(script, cancellationToken: ct)
                 .ConfigureAwait(false);
 
-            return results
-                .Select(r => r?.ToString())
-                .Where(s => !string.IsNullOrWhiteSpace(s) && IPAddress.TryParse(s, out _))
-                .Select(s => s!)
-                .ToArray();
+            List<string> v4 = [], v6 = [];
+            foreach (var r in results)
+            {
+                var line = r?.ToString();
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                var eq = line.IndexOf('=');
+                if (eq <= 0) continue;
+                var fam = line[..eq];
+                var addr = line[(eq + 1)..];
+                if (!IPAddress.TryParse(addr, out _)) continue;
+                if (fam == "IPv4") v4.Add(addr);
+                else if (fam == "IPv6") v6.Add(addr);
+            }
+            return new DnsSnapshot(v4, v6);
         }
         finally { _gate.Release(); }
     }
 
     /// <summary>
-    /// Restores DNS to a previously captured set of server addresses. An empty
+    /// Restores DNS to a previously captured IPv4-only set of server addresses. An empty
     /// snapshot means the adapter was on DHCP, so this resets to automatic.
     /// </summary>
-    public async Task RestoreServersAsync(IReadOnlyList<string> servers, CancellationToken ct = default)
+    public Task RestoreServersAsync(IReadOnlyList<string> servers, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(servers);
+        return RestoreSnapshotAsync(new DnsSnapshot(servers, []), ct);
+    }
 
-        if (servers.Count == 0)
-        {
-            await ResetToDhcpAsync(ct).ConfigureAwait(false);
-            return;
-        }
+    /// <summary>
+    /// Restores DNS to a previously captured snapshot for BOTH families. Resets the adapter
+    /// to DHCP first (clearing anything that was applied since, including filtering IPv6
+    /// resolvers a v4-only restore would otherwise leave behind), then re-applies the
+    /// captured static servers per family. A fully-empty snapshot therefore restores DHCP.
+    /// </summary>
+    public async Task RestoreSnapshotAsync(DnsSnapshot snapshot, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
 
-        // Validate every captured address before applying — the snapshot should
-        // already be clean, but never interpolate an unvalidated value into a script.
-        foreach (var server in servers)
+        // Validate every captured address before applying — the snapshot should already be
+        // clean, but never interpolate an unvalidated value into a script.
+        foreach (var server in snapshot.V4.Concat(snapshot.V6))
         {
             if (!IPAddress.TryParse(server, out _))
-                throw new ArgumentException($"Invalid DNS address in snapshot: '{server}'", nameof(servers));
+                throw new ArgumentException($"Invalid DNS address in snapshot: '{server}'", nameof(snapshot));
         }
 
         await _gate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
             int ifIndex = await GetActiveInterfaceIndexAsync(ct).ConfigureAwait(false);
-            string joined = string.Join(",", servers.Select(s => $"\"{s}\""));
-            // -ErrorAction Stop makes a non-terminating cmdlet failure (denied
-            // privilege, adapter down, RPC failure) terminating, so RunAsync's
-            // EndInvoke throws instead of the call silently reporting success.
-            string script = $"""
-                $ErrorActionPreference = 'Stop'
-                Set-DnsClientServerAddress -InterfaceIndex {ifIndex} -ServerAddresses @({joined}) -ErrorAction Stop
-                """;
+            var script = new System.Text.StringBuilder();
+            script.AppendLine("$ErrorActionPreference = 'Stop'");
+            // Clear BOTH families first so any servers applied since (incl. IPv6) are removed.
+            script.AppendLine($"Set-DnsClientServerAddress -InterfaceIndex {ifIndex} -ResetServerAddresses -ErrorAction Stop");
+            if (snapshot.V4.Count > 0)
+            {
+                var v4 = string.Join(",", snapshot.V4.Select(s => $"\"{s}\""));
+                script.AppendLine($"Set-DnsClientServerAddress -InterfaceIndex {ifIndex} -ServerAddresses @({v4}) -ErrorAction Stop");
+            }
+            if (snapshot.V6.Count > 0)
+            {
+                var v6 = string.Join(",", snapshot.V6.Select(s => $"\"{s}\""));
+                script.AppendLine($"Set-DnsClientServerAddress -InterfaceIndex {ifIndex} -ServerAddresses @({v6}) -ErrorAction Stop");
+            }
 
-            await _ps.RunAsync(script, cancellationToken: ct).ConfigureAwait(false);
+            await _ps.RunAsync(script.ToString(), cancellationToken: ct).ConfigureAwait(false);
         }
         finally { _gate.Release(); }
     }
@@ -233,9 +275,14 @@ public sealed class DnsService : IDisposable
             if (hasV6)
             {
                 var v6List = string.IsNullOrEmpty(secondaryV6) ? $"\"{primaryV6}\"" : $"\"{primaryV6}\",\"{secondaryV6}\"";
-                // -AddressFamily is implied by the address shape, but listing both families in
-                // one call replaces all of them — so issue IPv6 as its own call to be additive.
-                script.AppendLine($"Set-DnsClientServerAddress -InterfaceIndex {ifIndex} -ServerAddresses @({v6List}) -ErrorAction Stop");
+                // IPv6 is BEST-EFFORT: on a machine with IPv6 disabled, setting an IPv6 DNS
+                // throws. We must NOT fail the whole apply (IPv4 already succeeded) or the UI
+                // would report failure while IPv4 silently changed, with Undo never offered.
+                // The address family is implied by the address shape; a separate call keeps it
+                // additive to the IPv4 set above. A warning is emitted but does not terminate.
+                script.AppendLine(
+                    $"try {{ Set-DnsClientServerAddress -InterfaceIndex {ifIndex} -ServerAddresses @({v6List}) -ErrorAction Stop }} " +
+                    "catch { Write-Warning \"IPv6 DNS not applied: $($_.Exception.Message)\" }");
             }
 
             await _ps.RunAsync(script.ToString(), cancellationToken: ct).ConfigureAwait(false);

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.33.3</Version>
-    <FileVersion>1.33.3.0</FileVersion>
-    <AssemblyVersion>1.33.3.0</AssemblyVersion>
+    <Version>1.33.4</Version>
+    <FileVersion>1.33.4.0</FileVersion>
+    <AssemblyVersion>1.33.4.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
@@ -36,7 +36,7 @@ public sealed partial class DnsHostsViewModel : ViewModelBase
     /// change, captured so the change can be reverted to the exact previous state.
     /// Null until a change is applied this session.
     /// </summary>
-    private IReadOnlyList<string>? _previousServers;
+    private DnsService.DnsSnapshot? _previousServers;
 
     [ObservableProperty] private bool _canRestorePreviousDns;
 
@@ -154,16 +154,17 @@ public sealed partial class DnsHostsViewModel : ViewModelBase
         StatusMessage = $"Applying {SelectedPreset.Name} DNS...";
         try
         {
-            // Snapshot the servers in effect now so the change is reversible to the
-            // exact previous configuration, not just a generic DHCP reset.
-            var snapshot = await _dnsService.CaptureCurrentServersAsync(_cts.Token).ConfigureAwait(false);
+            // Snapshot BOTH families in effect now so the change is reversible to the exact
+            // previous configuration, not just a generic DHCP reset. Record it (and enable
+            // Undo) BEFORE the Set: if the Set partially applies (e.g. IPv4 lands, IPv6
+            // fails), the user must still be offered an Undo for what did change.
+            var snapshot = await _dnsService.CaptureSnapshotAsync(_cts.Token).ConfigureAwait(false);
+            _previousServers = snapshot;
+            Application.Current?.Dispatcher?.Invoke(() => CanRestorePreviousDns = true);
 
             await _dnsService.SetDnsAsync(SelectedPreset.Primary, SelectedPreset.Secondary,
                     SelectedPreset.PrimaryV6, SelectedPreset.SecondaryV6, _cts.Token)
                 .ConfigureAwait(false);
-
-            _previousServers = snapshot;
-            Application.Current?.Dispatcher?.Invoke(() => CanRestorePreviousDns = true);
 
             await RefreshDnsAsync();
             Application.Current?.Dispatcher?.Invoke(() =>
@@ -231,9 +232,10 @@ public sealed partial class DnsHostsViewModel : ViewModelBase
             return;
         }
 
-        var label = _previousServers.Count == 0
+        var allPrev = _previousServers.V4.Concat(_previousServers.V6).ToList();
+        var label = allPrev.Count == 0
             ? "automatic (DHCP)"
-            : string.Join(", ", _previousServers);
+            : string.Join(", ", allPrev);
 
         if (!DialogService.Instance.Confirm(
                 $"Restore this PC's DNS to its previous setting ({label})?",
@@ -247,7 +249,7 @@ public sealed partial class DnsHostsViewModel : ViewModelBase
         StatusMessage = "Restoring previous DNS...";
         try
         {
-            await _dnsService.RestoreServersAsync(_previousServers, _cts.Token).ConfigureAwait(false);
+            await _dnsService.RestoreSnapshotAsync(_previousServers, _cts.Token).ConfigureAwait(false);
 
             _previousServers = null;
             Application.Current?.Dispatcher?.Invoke(() =>


### PR DESCRIPTION
## Problem

Applying a filtering DNS preset programs **both** IPv4 and IPv6 resolvers, but the Undo path only captured and restored **IPv4**:

- `CaptureCurrentServersAsync` read `-AddressFamily IPv4` only; `RestoreServersAsync` re-applied just those. `Set-DnsClientServerAddress` operates per-family, so an IPv4-only restore does **not** clear the IPv6 resolvers — reverting an ad/family-blocking preset left its filtering IPv6 DNS active. On a dual-stack network (IPv6 usually preferred) the "undone" filtering was still in effect, breaking the README/dialog "restores the exact previous configuration" promise.
- The snapshot was recorded **after** the Set, so if the Set partially applied (IPv4 lands, IPv6 throws on an IPv6-disabled machine) the method threw and Undo was never offered, even though IPv4 had changed.

## Fix

- **Capture both families** — new `CaptureSnapshotAsync` returns a `DnsSnapshot(V4, V6)` (one query tags each address `IPv4=`/`IPv6=`).
- **Restore both families** — new `RestoreSnapshotAsync` clears the adapter's DNS first (`-ResetServerAddresses`, removing anything applied since, incl. filtering IPv6) then re-applies exactly the captured v4 + v6. A fully-empty snapshot restores DHCP.
- **Undo offered before the Set** — the VM records the snapshot and enables Undo *before* applying, so a partial apply is still reversible.
- **IPv6 set is best-effort** — on an IPv6-disabled machine the IPv6 write is caught (`Write-Warning`, not terminating), so the IPv4 change still succeeds and stays undoable instead of failing the whole apply.

`CaptureCurrentServersAsync` / `RestoreServersAsync` are kept as IPv4 shims over the new snapshot methods (no caller churn elsewhere).

## Tests

- `CaptureSnapshotAsync_CapturesBothFamilies`
- `RestoreSnapshotAsync_ResetsThenReAppliesBothFamilies` (the exact reversibility regression)
- `RestoreSnapshotAsync_EmptyBothFamilies_ResetsToDhcp`
- existing capture/restore tests updated to the family-tagged format

Main + Tests build 0/0.

## Docs / version

- CHANGELOG under 1.33.4; csproj 1.33.4 (patch, `fix:`).