### PR TITLE
fix: Profile Export/Import reads/writes theme from the correct AppData folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.33.5] - 2026-06-25
+
+### Fixed
+- **Profile Export/Import now correctly handles the theme/appearance section.** The exporter looked for every config file under one folder (Local AppData), but the theme is saved under Roaming AppData — so exporting never picked up your theme, and importing a profile wrote the theme to a folder the app doesn't read on startup, making it a silent no-op. Each config file is now read from and written to the same folder its owning feature uses (theme under Roaming, speed-test history under Local), so theme export and import actually take effect.
+
 ## [1.33.4] - 2026-06-25
 
 ### Fixed

--- a/SysManager/SysManager.Tests/ProfileServiceTests.cs
+++ b/SysManager/SysManager.Tests/ProfileServiceTests.cs
@@ -105,6 +105,37 @@ public class ProfileServiceTests : IDisposable
         Assert.True(File.Exists(Path.Combine(_dir, "theme.json")));
     }
 
+    [Fact]
+    public void Theme_UsesRoamingBase_Speedtest_UsesLocalBase()
+    {
+        // Regression: theme.json lives under Roaming AppData (ThemeService) while
+        // speedtest-history.json lives under Local (SpeedTestHistoryService). The profiler
+        // must read/write each from its OWN base, not a single shared dir.
+        var local = Path.Combine(_dir, "Local");
+        var roaming = Path.Combine(_dir, "Roaming");
+        Directory.CreateDirectory(local);
+        Directory.CreateDirectory(roaming);
+        var svc = new ProfileService(local, roaming);
+
+        // Apply both sections.
+        svc.ApplySections(
+        [
+            new ConfigSection("theme", "Theme", "theme.json", "{\"preset\":\"midnight\"}"),
+            new ConfigSection("speedtest", "Speed-test history", "speedtest-history.json", "[1,2]"),
+        ]);
+
+        // theme.json must land in Roaming; speedtest-history.json in Local.
+        Assert.True(File.Exists(Path.Combine(roaming, "theme.json")));
+        Assert.False(File.Exists(Path.Combine(local, "theme.json")));
+        Assert.True(File.Exists(Path.Combine(local, "speedtest-history.json")));
+        Assert.False(File.Exists(Path.Combine(roaming, "speedtest-history.json")));
+
+        // And export reads them back from the correct bases.
+        var sections = svc.AvailableSections();
+        Assert.Contains(sections, s => s.Key == "theme" && s.Json.Contains("midnight"));
+        Assert.Contains(sections, s => s.Key == "speedtest");
+    }
+
     // ---------- Export / Import file round-trip ----------
 
     [Fact]

--- a/SysManager/SysManager/Services/ProfileService.cs
+++ b/SysManager/SysManager/Services/ProfileService.cs
@@ -14,10 +14,13 @@ namespace SysManager.Services;
 /// <summary>
 /// Exports and imports SysManager's own configuration as a single portable JSON profile,
 /// so a user can replicate their setup on another PC. Only SysManager's own config files
-/// (under %LOCALAPPDATA%\SysManager) are included — never system state — so applying a
-/// profile just overwrites those app files and is fully reversible.
+/// are included — never system state — so applying a profile just overwrites those app
+/// files and is fully reversible. Each config file is read from and written to the SAME
+/// folder its owning service uses: <c>theme.json</c> lives under Roaming AppData (matching
+/// <see cref="ThemeService"/>) while <c>speedtest-history.json</c> lives under Local AppData
+/// (matching <see cref="SpeedTestHistoryService"/>).
 ///
-/// The config directory is constructor-injectable so the export/import logic can be unit
+/// The base directories are constructor-injectable so the export/import logic can be unit
 /// tested against a temp directory without touching the real profile.
 /// </summary>
 public sealed class ProfileService
@@ -25,7 +28,8 @@ public sealed class ProfileService
     /// <summary>Bump when the on-disk profile shape changes incompatibly.</summary>
     public const int CurrentSchemaVersion = 1;
 
-    private readonly string _configDir;
+    private readonly string _localConfigDir;
+    private readonly string _roamingConfigDir;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -33,24 +37,49 @@ public sealed class ProfileService
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
     };
 
-    /// <summary>The set of config files a profile carries — logical key, label, and file name.</summary>
-    private static readonly (string Key, string DisplayName, string FileName)[] Catalog =
+    /// <summary>Whether a config file lives under Roaming (true) or Local (false) AppData.</summary>
+    private enum Base { Local, Roaming }
+
+    /// <summary>
+    /// The set of config files a profile carries — logical key, label, file name, and which
+    /// AppData base it lives under. The base MUST match the owning service or export/import
+    /// silently reads/writes the wrong location.
+    /// </summary>
+    private static readonly (string Key, string DisplayName, string FileName, Base Base)[] Catalog =
     [
-        ("theme", "Theme & appearance", "theme.json"),
-        ("speedtest", "Speed-test history", "speedtest-history.json"),
+        ("theme", "Theme & appearance", "theme.json", Base.Roaming),        // ThemeService → Roaming
+        ("speedtest", "Speed-test history", "speedtest-history.json", Base.Local), // SpeedTestHistoryService → Local
     ];
 
+    /// <summary>
+    /// Creates the service. When <paramref name="configDir"/> is given (tests), BOTH bases
+    /// resolve to it so the temp tree holds every section. In production the bases are the
+    /// real Roaming/Local <c>SysManager</c> folders.
+    /// </summary>
     public ProfileService(string? configDir = null)
-        => _configDir = configDir ?? Path.Combine(
+    {
+        _localConfigDir = configDir ?? Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager");
+        _roamingConfigDir = configDir ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "SysManager");
+    }
+
+    /// <summary>Test seam: distinct Local/Roaming bases to verify each section lands in the right one.</summary>
+    internal ProfileService(string localConfigDir, string roamingConfigDir)
+    {
+        _localConfigDir = localConfigDir;
+        _roamingConfigDir = roamingConfigDir;
+    }
+
+    private string DirFor(Base b) => b == Base.Roaming ? _roamingConfigDir : _localConfigDir;
 
     /// <summary>The config sections available to export (those whose file exists on disk).</summary>
     public IReadOnlyList<ConfigSection> AvailableSections()
     {
         List<ConfigSection> sections = [];
-        foreach (var (key, display, fileName) in Catalog)
+        foreach (var (key, display, fileName, baseDir) in Catalog)
         {
-            var path = Path.Combine(_configDir, fileName);
+            var path = Path.Combine(DirFor(baseDir), fileName);
             if (!File.Exists(path)) continue;
             string json;
             try { json = File.ReadAllText(path); }
@@ -103,7 +132,6 @@ public sealed class ProfileService
     /// </summary>
     public int ApplySections(IEnumerable<ConfigSection> sections)
     {
-        Directory.CreateDirectory(_configDir);
         var applied = 0;
         foreach (var section in sections)
         {
@@ -113,8 +141,11 @@ public sealed class ProfileService
                 Log.Warning("Profile: skipping unknown config section '{Key}'", section.Key);
                 continue;
             }
-            // Always use the catalog's own file name — never a path from the (untrusted) profile.
-            var path = Path.Combine(_configDir, known.FileName);
+            // Always use the catalog's own file name + base — never a path from the
+            // (untrusted) profile — and write to the SAME folder the owning service reads.
+            var dir = DirFor(known.Base);
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, known.FileName);
             try
             {
                 File.WriteAllText(path, section.Json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.33.4</Version>
-    <FileVersion>1.33.4.0</FileVersion>
-    <AssemblyVersion>1.33.4.0</AssemblyVersion>
+    <Version>1.33.5</Version>
+    <FileVersion>1.33.5.0</FileVersion>
+    <AssemblyVersion>1.33.5.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem

The Profile Export/Import service resolved **every** config file under a single folder (`%LOCALAPPDATA%\SysManager`). But the two config files live in different places:

- `theme.json` → **Roaming** AppData (`ThemeService`)
- `speedtest-history.json` → **Local** AppData (`SpeedTestHistoryService`)

So exporting never found the theme (the feature's headline section), and importing a profile wrote `theme.json` to Local AppData — a folder `ThemeService` never reads on startup — making theme import a **silent no-op**.

## Fix

Each catalog entry now carries which AppData base it belongs to, and `AvailableSections`/`ApplySections` read and write each file from/to the matching base (theme → Roaming, speed-test → Local). An internal two-dir constructor was added as a test seam.

## Tests

- `Theme_UsesRoamingBase_Speedtest_UsesLocalBase` — with distinct Local/Roaming temp dirs, asserts `theme.json` lands in Roaming and `speedtest-history.json` in Local, and export reads each back from the right base.
- Existing single-dir tests still pass (both bases collapse to the injected dir).

Main + Tests build 0/0.

## Docs / version

- CHANGELOG under 1.33.5; csproj 1.33.5 (patch, `fix:`).