### PR TITLE
fix: Debloater protects the Photos app (correct package family name)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.33.6] - 2026-06-25
+
+### Fixed
+- **The Debloater now correctly protects the Photos app from removal.** The system-critical denylist listed `Microsoft.Windows.Photos.Settings`, but the real package name is `Microsoft.Windows.Photos` — and because the match is a prefix check, the shorter real name never matched, so Photos was offered as removable. The entry is now the correct family name. A redundant, never-matching Windows Security entry was also removed (the correct one was already present). Added tests covering each critical package by its real name, plus tests confirming removal refuses a protected package and rejects an injection-shaped package name without ever invoking PowerShell.
+
 ## [1.33.5] - 2026-06-25
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DebloaterServiceTests.cs
+++ b/SysManager/SysManager.Tests/DebloaterServiceTests.cs
@@ -2,7 +2,10 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Collections.ObjectModel;
 using System.Management.Automation;
+using NSubstitute;
+using SysManager.Models;
 using SysManager.Services;
 
 namespace SysManager.Tests;
@@ -30,6 +33,8 @@ public class DebloaterServiceTests
     // ---------- IsProtected (denylist) ----------
 
     [Theory]
+    // Each entry is the REAL Get-AppxPackage .Name of a system-critical package; a too-specific
+    // or misspelled denylist prefix would make StartsWith fail and let it be removed.
     [InlineData("Microsoft.WindowsStore")]
     [InlineData("Microsoft.WindowsStore_22210.1402.7.0_x64__8wekyb3d8bbwe")]
     [InlineData("Microsoft.DesktopAppInstaller")]
@@ -37,7 +42,12 @@ public class DebloaterServiceTests
     [InlineData("Microsoft.NET.Native.Framework.2.2")]
     [InlineData("Microsoft.UI.Xaml.2.8")]
     [InlineData("Microsoft.Windows.ShellExperienceHost")]
+    [InlineData("Microsoft.Windows.StartMenuExperienceHost")]
     [InlineData("Microsoft.SecHealthUI")]
+    [InlineData("Microsoft.AccountsControl")]
+    [InlineData("Microsoft.Windows.Photos")]                 // regression: was ...Photos.Settings (too specific)
+    [InlineData("Microsoft.Windows.ContentDeliveryManager")]
+    [InlineData("Microsoft.StorePurchaseApp")]
     public void IsProtected_TrueForSystemCriticalPackages(string name)
         => Assert.True(DebloaterService.IsProtected(name));
 
@@ -122,4 +132,58 @@ public class DebloaterServiceTests
     [Fact]
     public void Parse_EmptyInput_ReturnsEmpty()
         => Assert.Empty(DebloaterService.ParsePackages([]));
+
+    // ---------- RemoveAsync safety gates ----------
+
+    private static StoreApp App(string name, string full, bool isProtected = false) => new()
+    {
+        Name = name, PackageFullName = full, PackageFamilyName = name + "_abc",
+        DisplayName = name, Publisher = "CN=Microsoft", Version = "1.0.0.0", IsProtected = isProtected
+    };
+
+    [Fact]
+    public async Task RemoveAsync_RefusesProtectedPackage_WithoutInvokingRunner()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        var svc = new DebloaterService(runner);
+
+        // Protected by name even if the flag was (somehow) cleared by a tampered binding.
+        var result = await svc.RemoveAsync(App("Microsoft.Windows.Photos", "Microsoft.Windows.Photos_1_x64__abc"));
+
+        Assert.False(result);
+        await runner.DidNotReceive().RunAsync(
+            Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("App.Name'; Remove-Item C:\\ -Recurse #")]
+    [InlineData("App Name with spaces")]
+    [InlineData("App$(rm)")]
+    public async Task RemoveAsync_RejectsInjectionInFullName_WithoutInvokingRunner(string badFull)
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        var svc = new DebloaterService(runner);
+
+        var result = await svc.RemoveAsync(App("Contoso.App", badFull));
+
+        Assert.False(result);
+        await runner.DidNotReceive().RunAsync(
+            Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RemoveAsync_ValidRemovableApp_InvokesRunner_AndConfirmsSuccess()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+              .Returns(new Collection<PSObject> { PSObject.AsPSObject("__SM_RM_OK__") });
+        var svc = new DebloaterService(runner);
+
+        var result = await svc.RemoveAsync(App("Contoso.RandomApp", "Contoso.RandomApp_1.0.0.0_x64__abc"));
+
+        Assert.True(result);
+        await runner.Received(1).RunAsync(
+            Arg.Is<string>(s => s.Contains("Remove-AppxPackage") && s.Contains("Contoso.RandomApp_1.0.0.0_x64__abc")),
+            Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>());
+    }
 }

--- a/SysManager/SysManager/Services/DebloaterService.cs
+++ b/SysManager/SysManager/Services/DebloaterService.cs
@@ -48,8 +48,7 @@ public sealed partial class DebloaterService
         "Microsoft.Windows.ShellExperienceHost",
         "Microsoft.Windows.StartMenuExperienceHost",
         "Microsoft.Windows.Search",            // search host
-        "Microsoft.Windows.SecHealthUI",       // Windows Security UI
-        "Microsoft.SecHealthUI",
+        "Microsoft.SecHealthUI",               // Windows Security UI (real package family name)
         "Microsoft.AAD.BrokerPlugin",
         "Microsoft.AccountsControl",
         "Microsoft.LockApp",
@@ -58,7 +57,7 @@ public sealed partial class DebloaterService
         "Microsoft.Windows.CloudExperienceHost",
         "Microsoft.Windows.ContentDeliveryManager",
         "Microsoft.Windows.PeopleExperienceHost",
-        "Microsoft.Windows.Photos.Settings",
+        "Microsoft.Windows.Photos",            // Photos app — real .Name (not the ...Photos.Settings sub-package)
         "Microsoft.WindowsAppRuntime",
         "MicrosoftWindows.Client",             // client framework family
         "Windows.CBSPreview",

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.33.5</Version>
-    <FileVersion>1.33.5.0</FileVersion>
-    <AssemblyVersion>1.33.5.0</AssemblyVersion>
+    <Version>1.33.6</Version>
+    <FileVersion>1.33.6.0</FileVersion>
+    <AssemblyVersion>1.33.6.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem

The Debloater's system-critical denylist had `Microsoft.Windows.Photos.Settings`, but the real Photos package `.Name` from `Get-AppxPackage` is `Microsoft.Windows.Photos`. `IsProtected` matches with `packageName.StartsWith(prefix)` — and the real name (`Microsoft.Windows.Photos`) is *shorter* than the listed prefix (`...Photos.Settings`), so `StartsWith` returned false. **Photos was offered as removable**, defeating the denylist for that app.

A second entry, `Microsoft.Windows.SecHealthUI`, never matched the real Windows Security package either (its real `.Name` is `Microsoft.SecHealthUI`, which was already correctly listed) — dead weight.

## Fix

- `Microsoft.Windows.Photos.Settings` → `Microsoft.Windows.Photos` (the real family name; the prefix still covers the `.Settings` sub-package).
- Removed the redundant, never-matching `Microsoft.Windows.SecHealthUI`.

## Tests

- Protected-true theory expanded to cover each critical package **by its real `.Name`** (Photos, StartMenuExperienceHost, AccountsControl, ContentDeliveryManager, StorePurchaseApp, …) — a too-specific prefix now fails the test.
- `RemoveAsync_RefusesProtectedPackage_WithoutInvokingRunner` — protected package never reaches PowerShell.
- `RemoveAsync_RejectsInjectionInFullName_WithoutInvokingRunner` — injection-shaped / malformed package names are rejected by the validation regex before any script runs.
- `RemoveAsync_ValidRemovableApp_InvokesRunner_AndConfirmsSuccess` — happy path still works.

Main + Tests build 0/0.

## Docs / version

- CHANGELOG under 1.33.6; csproj 1.33.6 (patch, `fix:`).