### PR TITLE
fix: de-duplicate network reset & restore-point code, rename Privacy Monitor tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.33.8] - 2026-06-25
+
+### Changed
+- **Removed the duplicate "Reset Network Stack" button from System Fixes.** The same Winsock + TCP/IP reset and DNS flush already lives on the Network → Network Repair tab (as individual one-click tools), so having it in two places was confusing and risked the two copies drifting apart. System Fixes now links to Network Repair for network resets instead of duplicating them.
+- **Renamed the "Privacy Monitor" tab to "Camera/Mic/Location"** so it is no longer confused with the separate "Privacy & Telemetry" tab. The feature is unchanged — it still shows which apps recently used your camera, microphone, or location.
+
+### Fixed
+- **Performance Mode's "Create restore point" now uses the same code as the Restore Points tab.** The two had separate implementations of the same operation that had begun to diverge; they now share one, which also enables System Restore on the system drive first if it was turned off. No visible change beyond that improvement.
+
 ## [1.33.7] - 2026-06-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ implemented; 17 are work-in-progress placeholders marked with ⚙️:
 | 🏠 Dashboard | Dashboard |
 | 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Legacy Panels · System Fixes · Boot Analyzer · Task Scheduler ⚙️ |
 | 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner ⚙️ · Timer Resolution ⚙️ · CPU Core Affinity ⚙️ · Display Profiles ⚙️ |
-| 📊 Monitor | Process Manager · Resource History ⚙️ · Privacy Monitor · File Lock Detector ⚙️ · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
+| 📊 Monitor | Process Manager · Resource History ⚙️ · Camera/Mic/Location · File Lock Detector ⚙️ · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance ⚙️ |
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS & Hosts |
@@ -205,11 +205,12 @@ One-click repairs for common Windows breakages, each with a clear description an
 a confirmation before it runs:
 - **Reset Windows Update** — stop the update services, clear the
   SoftwareDistribution and catroot2 caches, and restart the services
-- **Reset Network Stack** — Winsock + TCP/IP reset and DNS flush
 - **Reinstall WinGet** — re-register the App Installer when app installs/uninstalls fail
 - **Set up Auto Sign-in** — opens the built-in User Accounts dialog, so Windows
   stores the credential securely and SysManager never handles your password
 - Live output, honest success/failure reporting, admin elevation banner
+- *Network-stack reset (Winsock / TCP-IP / DNS flush) lives on the Network → Network
+  Repair tab, which offers those as individual one-click tools.*
 
 ### Boot Analyzer
 - Shows how long your PC takes to boot — total, core (main path), and
@@ -322,7 +323,7 @@ a confirmation before it runs:
 - Kill process with confirmation dialog
 - Open file location in Explorer
 
-### Privacy Monitor
+### Camera/Mic/Location
 - Shows which apps recently used your **camera, microphone, or location**, and when
 - Reads the Windows access history (CapabilityAccessManager consent store) — covers
   both Store apps and desktop programs

--- a/SysManager/SysManager/Services/PerformanceService.cs
+++ b/SysManager/SysManager/Services/PerformanceService.cs
@@ -537,30 +537,12 @@ public sealed partial class PerformanceService : IDisposable
     /// <summary>
     /// Create a Windows System Restore point. Requires admin elevation.
     /// Returns true if the restore point was created successfully.
+    /// Delegates to <see cref="RestorePointService.CreateAsync"/> so restore-point creation
+    /// has a single source of truth (it also enables System Restore on the system drive
+    /// first) — this method exists only as the Performance tab's convenience entry point.
     /// </summary>
-    public async Task<bool> CreateRestorePointAsync(string description, CancellationToken ct = default)
-    {
-        // NOTE: PowerShell AddParameter binds runtime arguments but does NOT
-        // create script-scope variables, so the description has to be embedded
-        // directly in the script body — with single-quote escaping to avoid
-        // injection via the user-supplied string.
-        var safeDesc = (description ?? "SysManager Restore Point").Replace("'", "''");
-        // Checkpoint-Computer does NOT always throw on failure — e.g. the once-per-24h
-        // rate limit writes a non-terminating error and produces no exception. Force the
-        // error to terminate and emit an explicit success sentinel only when it really
-        // succeeded, so a silent failure can no longer be reported as success.
-        var script =
-            "try { " +
-            $"Checkpoint-Computer -Description '{safeDesc}' -RestorePointType 'MODIFY_SETTINGS' -ErrorAction Stop; " +
-            "'__SM_RESTORE_OK__' " +
-            "} catch { Write-Error $_; exit 1 }";
-        var results = await _ps.RunAsync(script, null, ct).ConfigureAwait(false);
-        var succeeded = results.Any(o =>
-            string.Equals(o?.BaseObject?.ToString(), "__SM_RESTORE_OK__", StringComparison.Ordinal));
-        if (!succeeded)
-            Log.Warning("CreateRestorePoint: Checkpoint-Computer did not confirm success (it may be rate-limited to one per 24h).");
-        return succeeded;
-    }
+    public Task<bool> CreateRestorePointAsync(string description, CancellationToken ct = default)
+        => new RestorePointService(_ps).CreateAsync(description, ct);
 
     // ═══════════════════════════════════════════════════════════════
     //  RAM WORKING SET TRIM — via EmptyWorkingSet (instant)

--- a/SysManager/SysManager/Services/SystemFixService.cs
+++ b/SysManager/SysManager/Services/SystemFixService.cs
@@ -54,20 +54,8 @@ public sealed class SystemFixService : IDisposable
         return RunFixAsync("Reset Windows Update", script, needsReboot: true, ct);
     }
 
-    /// <summary>
-    /// Resets the network stack: Winsock catalog and TCP/IP. Requires admin and a reboot.
-    /// </summary>
-    public Task<SystemFixResult> ResetNetworkAsync(CancellationToken ct = default)
-    {
-        const string script = """
-            $ErrorActionPreference = 'Continue'
-            & netsh winsock reset | Out-String
-            & netsh int ip reset | Out-String
-            & ipconfig /flushdns | Out-String
-            'Network stack reset. Reboot to complete.'
-            """;
-        return RunFixAsync("Reset Network", script, needsReboot: true, ct);
-    }
+    // Network-stack reset (Winsock / TCP-IP / DNS flush) intentionally lives ONLY on the
+    // Network Repair tab — it is not duplicated here. See NetworkRepairService.
 
     /// <summary>
     /// Re-registers the WinGet (App Installer) package so app installs/uninstalls work

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.33.7</Version>
-    <FileVersion>1.33.7.0</FileVersion>
-    <AssemblyVersion>1.33.7.0</AssemblyVersion>
+    <Version>1.33.8</Version>
+    <FileVersion>1.33.8.0</FileVersion>
+    <AssemblyVersion>1.33.8.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -313,7 +313,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         Group("grp-monitor", "Monitor", "",
             Item("nav-processes",         "Process Manager",    "", ProcessManager,      typeof(Views.ProcessManagerView)),
             Item("nav-resource-history",  "Resource History",   "", WipResourceHistory,  typeof(Views.PlaceholderView)),
-            Item("nav-privacy-monitor",   "Privacy Monitor",    "", PrivacyMonitor,      typeof(Views.PrivacyMonitorView)),
+            Item("nav-privacy-monitor",   "Camera/Mic/Location",    "", PrivacyMonitor,      typeof(Views.PrivacyMonitorView)),
             Item("nav-file-lock",         "File Lock Detector", "", WipFileLockDetector, typeof(Views.PlaceholderView)),
             Item("nav-settings-watchdog", "Settings Watchdog",  "", WipSettingsWatchdog, typeof(Views.PlaceholderView)),
             Item("nav-bandwidth-monitor", "Bandwidth Monitor",  "", WipBandwidthMonitor, typeof(Views.PlaceholderView))),

--- a/SysManager/SysManager/ViewModels/SystemFixesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemFixesViewModel.cs
@@ -14,10 +14,11 @@ namespace SysManager.ViewModels;
 
 /// <summary>
 /// ViewModel for the System Fixes tab. Surfaces a small set of well-known one-click
-/// repairs (Windows Update, network stack, WinGet) plus a secure shortcut to the
-/// built-in auto-logon dialog. Each repair confirms first, runs through
-/// <see cref="SystemFixService"/>, streams output, and reports success/failure honestly.
-/// Repairs require administrator rights; the tab shows the standard elevation banner.
+/// repairs (Windows Update, WinGet) plus a secure shortcut to the built-in auto-logon
+/// dialog. Each repair confirms first, runs through <see cref="SystemFixService"/>,
+/// streams output, and reports success/failure honestly. Repairs require administrator
+/// rights; the tab shows the standard elevation banner. (Network-stack reset lives on the
+/// Network Repair tab, which owns Winsock/TCP-IP/DNS-flush, so it is not duplicated here.)
 /// </summary>
 public sealed partial class SystemFixesViewModel : ViewModelBase
 {
@@ -43,7 +44,6 @@ public sealed partial class SystemFixesViewModel : ViewModelBase
         if (e.PropertyName is nameof(IsBusy) or nameof(IsElevated))
         {
             ResetWindowsUpdateCommand.NotifyCanExecuteChanged();
-            ResetNetworkCommand.NotifyCanExecuteChanged();
             ReinstallWinGetCommand.NotifyCanExecuteChanged();
         }
     }
@@ -62,14 +62,6 @@ public sealed partial class SystemFixesViewModel : ViewModelBase
         "(SoftwareDistribution and catroot2, renamed so Windows rebuilds them), and restarts " +
         "the services. Pending updates will re-download. A reboot is recommended afterwards.\n\nContinue?",
         ct => _service.ResetWindowsUpdateAsync(ct));
-
-    [RelayCommand(CanExecute = nameof(CanRunFix))]
-    private Task ResetNetworkAsync() => RunFixAsync(
-        "Reset Network Stack?",
-        "This resets the Winsock catalog and TCP/IP stack and flushes the DNS cache. " +
-        "It can fix many connectivity problems but will briefly drop the connection and " +
-        "needs a reboot to fully apply.\n\nContinue?",
-        ct => _service.ResetNetworkAsync(ct));
 
     [RelayCommand(CanExecute = nameof(CanRunFix))]
     private Task ReinstallWinGetAsync() => RunFixAsync(

--- a/SysManager/SysManager/Views/SystemFixesView.xaml
+++ b/SysManager/SysManager/Views/SystemFixesView.xaml
@@ -81,21 +81,6 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Column="0" VerticalAlignment="Center" Margin="0,0,16,0">
-                        <TextBlock Text="Reset Network Stack" FontWeight="SemiBold" FontSize="13" Foreground="{DynamicResource TextPrimary}"/>
-                        <TextBlock Text="Reset Winsock + TCP/IP and flush DNS — fixes many connectivity issues. Needs a reboot."
-                                   FontSize="11" Foreground="{DynamicResource TextMuted}" TextWrapping="Wrap" Margin="0,2,0,0"/>
-                    </StackPanel>
-                    <Button Grid.Column="1" Content="Run" Command="{Binding ResetNetworkCommand}"
-                            AutomationProperties.Name="Reset network stack"
-                            Style="{StaticResource SecondaryButton}" VerticalAlignment="Center" MinWidth="80"/>
-                </Grid>
-
-                <Grid Margin="0,0,0,10">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <StackPanel Grid.Column="0" VerticalAlignment="Center" Margin="0,0,16,0">
                         <TextBlock Text="Reinstall WinGet" FontWeight="SemiBold" FontSize="13" Foreground="{DynamicResource TextPrimary}"/>
                         <TextBlock Text="Re-register the Windows Package Manager (App Installer) when app installs or uninstalls fail."
                                    FontSize="11" Foreground="{DynamicResource TextMuted}" TextWrapping="Wrap" Margin="0,2,0,0"/>
@@ -119,6 +104,9 @@
                             AutomationProperties.Name="Open auto sign-in settings"
                             Style="{StaticResource GhostButton}" VerticalAlignment="Center" MinWidth="80"/>
                 </Grid>
+
+                <TextBlock Margin="0,12,0,0" FontSize="11" Foreground="{DynamicResource TextMuted}" TextWrapping="Wrap"
+                           Text="Looking to reset the network stack (Winsock / TCP-IP / DNS flush)? Use the Network → Network Repair tab, which provides those as individual one-click tools."/>
             </StackPanel>
         </Border>
 


### PR DESCRIPTION
## Background

An information-architecture review found features duplicated across different sidebar groups. This addresses the three confirmed ones (decisions taken with the maintainer).

## Changes

### Removed the duplicate network reset
`System Fixes` had a **Reset Network Stack** button running `netsh winsock reset` + `netsh int ip reset` + `ipconfig /flushdns` — the *exact* operations the **Network Repair** tab already offers as individual one-click tools. Having the same thing in two groups was confusing. Removed it from System Fixes (button, command, and the now-unused `SystemFixService.ResetNetworkAsync`), and added a one-line pointer to Network Repair.

### De-duplicated restore-point creation
`PerformanceService.CreateRestorePointAsync` had its **own** copy of the `Checkpoint-Computer` logic, separate from `RestorePointService.CreateAsync` — and they'd already drifted (only the latter enables System Restore first). `PerformanceService` now **delegates** to `RestorePointService.CreateAsync` (single source of truth). No constructor-signature change — it reuses the existing `IPowerShellRunner`. The Performance tab keeps its convenience button.

### Renamed the Privacy Monitor tab
`Privacy Monitor` (Monitor group) was easily confused with `Privacy & Telemetry` (Privacy & Security group), though they do different things. Renamed the nav label to **Camera/Mic/Location**. The nav `Id`, the VM, and behavior are unchanged.

## Docs

README updated: sidebar table (tab rename), System Fixes feature list (removed the network line + added the Network Repair cross-link), and the tab section header.

## Build

Main + Tests + IntegrationTests build 0/0. No test referenced the removed method or the old label (the integration test pins the nav `Id`, which is unchanged).

## Version

- CHANGELOG under 1.33.8 (Changed + Fixed); csproj 1.33.8 (patch).