### PR TITLE
docs: correct the 1.33.7 Boot Analyzer note (defensive hardening, not a fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.33.7] - 2026-06-25
 
-### Fixed
-- **The Boot Analyzer now reads boot times on real hardware.** It parsed only the generic `<Data Name="BootTime">` event shape, but the Windows boot-performance provider actually emits event 100 as a `<UserData>` block whose fields are directly-named child elements — so on a real machine the parser found nothing and the tab showed "no boot performance events" even with a full history. The value reader now also resolves directly-named child elements (by local name, ignoring the provider namespace), so both event shapes are handled and the boot history populates.
+### Changed
+- **Boot Analyzer: hardened the event-XML reader to tolerate alternate payload shapes.** The boot-performance reader already parses the standard `<EventData><Data Name="BootTime">` form that Windows emits, and that path is unchanged. This adds a defensive fallback that also resolves directly-named child elements (matched by local name, namespace-agnostic) for any event variant that nests its fields differently, so the reader is robust across builds. No behavior change on current Windows — the boot history is read exactly as before.
 
 ## [1.33.6] - 2026-06-25
 

--- a/SysManager/SysManager.Tests/BootAnalyzerServiceTests.cs
+++ b/SysManager/SysManager.Tests/BootAnalyzerServiceTests.cs
@@ -43,9 +43,10 @@ public class BootAnalyzerServiceTests
     public void DataValue_NullXml_ReturnsNull()
         => Assert.Null(BootAnalyzerService.DataValue(null, "BootTime"));
 
-    // The real Diagnostics-Performance provider emits event 100 as a <UserData> block whose
-    // fields are directly-named child elements in the provider namespace — NOT <Data Name>.
-    // DataValue must read that shape too, or the tab is empty on real hardware.
+    // Windows emits event 100 in the <EventData><Data Name=...> form (verified against a live
+    // event), which the tests above cover. These two also exercise the defensive fallback for
+    // a hypothetical variant that nests the fields as directly-named child elements under a
+    // <UserData> block, so DataValue stays robust if a build ever uses that shape.
     private const string ProviderNs = "http://manifests.microsoft.com/win/2004/08/windows/diagnosis";
 
     private static XElement UserDataEvent(int eventId, params (string Name, string Value)[] fields)

--- a/SysManager/SysManager/Services/BootAnalyzerService.cs
+++ b/SysManager/SysManager/Services/BootAnalyzerService.cs
@@ -92,26 +92,24 @@ public sealed class BootAnalyzerService
     // ── Pure parsing (unit-tested) ─────────────────────────────────────────────
 
     /// <summary>
-    /// Reads a named value from an event's XML payload, handling BOTH shapes the
-    /// Diagnostics-Performance provider can emit:
-    ///  • the generic <c>&lt;EventData&gt;&lt;Data Name="BootTime"&gt;…&lt;/Data&gt;</c> form, and
-    ///  • the provider's real <c>&lt;UserData&gt;&lt;…&gt;&lt;BootTime&gt;…&lt;/BootTime&gt;</c> form,
-    ///    where the field is a directly-named child element (in the provider namespace).
-    /// The named-element fallback is namespace-agnostic (matched by local name), so the
-    /// boot fields resolve regardless of which shape Windows produces.
+    /// Reads a named value from an event's XML payload. Windows emits Diagnostics-Performance
+    /// event 100 in the standard <c>&lt;EventData&gt;&lt;Data Name="BootTime"&gt;…&lt;/Data&gt;</c>
+    /// form (verified against a live event), which the primary lookup handles. A defensive
+    /// fallback also resolves a directly-named leaf element (e.g. <c>&lt;BootTime&gt;…&lt;/BootTime&gt;</c>),
+    /// matched by local name and namespace-agnostic, so the reader still works for any event
+    /// variant that nests its fields differently.
     /// </summary>
     internal static string? DataValue(XElement? eventXml, string name)
     {
         if (eventXml is null) return null;
 
-        // 1) <Data Name="name">value</Data>
+        // 1) Standard shape: <Data Name="name">value</Data>.
         var data = eventXml.Descendants(EvtNs + "Data")
             .FirstOrDefault(d => (string?)d.Attribute("Name") == name);
         if (data is not null) return data.Value;
 
-        // 2) <name>value</name> directly-named child (UserData shape) — match by local name,
-        //    ignoring the provider-specific namespace. Skip container elements that have
-        //    their own child elements (we want the leaf value).
+        // 2) Fallback: a directly-named leaf element <name>value</name> (match by local name,
+        //    ignoring namespace; skip container elements that have their own children).
         var named = eventXml.Descendants()
             .FirstOrDefault(e => e.Name.LocalName == name && !e.HasElements);
         return named?.Value;


### PR DESCRIPTION
## Why

A live capture of a real Diagnostics-Performance **event 100** confirmed Windows emits the standard `<EventData><Data Name="BootTime">…</Data>` shape — exactly what the Boot Analyzer's original parser already read correctly. The boot history was **never** empty on real hardware.

The 1.33.7 change added a harmless defensive fallback (it only triggers if the primary `<Data Name>` lookup misses, which never happens for event 100), so there is **no behavior change**. But the 1.33.7 CHANGELOG entry, code comment, and test comment incorrectly described it as fixing a real defect ("parser found nothing on real hardware").

## What this changes (docs/comments only — no behavior change)

- **CHANGELOG 1.33.7**: moved from *Fixed* to *Changed* and reworded to describe it accurately as defensive hardening with no behavior change. (Section header kept as `## [1.33.7]` — that release already shipped.)
- **Code comment** in `BootAnalyzerService.DataValue`: corrected to state the standard shape is what Windows emits (verified against a live event), and the second branch is a defensive fallback.
- **Test comment**: reworded so the two `UserData`-shape tests are described as exercising the fallback, not "the real shape".

The published GitHub **release notes and announcement for 1.33.7 have already been edited** to match.

No code logic changed; tests build 0/0. `docs:` — no version bump, no release.