### PR TITLE
chore: dedupe restore-point construction and Recycle Bin interop

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -266,6 +266,8 @@ Utility classes that don't fit neatly into Services or ViewModels:
 - `GatewayHelper` — default gateway IP lookup for network tabs.
 - `EtaCalculator` — estimates time remaining for long-running operations.
 - `KnownFolders` — resolves Windows Known Folder paths via shell API.
+- `RecycleBinHelper` — empties the Recycle Bin via the shell API; shared by Deep
+  Cleanup and the One-Click Tune-Up so the interop has one source of truth.
 - `MarkdownTextBlock` — lightweight Markdown-to-WPF inline renderer.
 - Value converters: `EqualityConverter`, `IntGreaterThanZeroConverter`,
   `ValueConverters` (boolean/visibility/inverse helpers).

--- a/SysManager/SysManager.Tests/PerformanceServiceExtendedTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceServiceExtendedTests.cs
@@ -44,7 +44,7 @@ public class PerformanceServiceExtendedTests
     public void Service_AcceptsPowerShellRunner()
     {
         var ps = new PowerShellRunner();
-        var service = new PerformanceService(ps);
+        var service = new PerformanceService(ps, new RestorePointService(ps));
         Assert.NotNull(service);
     }
 }

--- a/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
@@ -13,7 +13,11 @@ namespace SysManager.Tests;
 /// </summary>
 public class PerformanceViewModelTests
 {
-    private static PerformanceViewModel NewVm() => new(new PerformanceService(new PowerShellRunner()));
+    private static PerformanceViewModel NewVm()
+    {
+        var ps = new PowerShellRunner();
+        return new(new PerformanceService(ps, new RestorePointService(ps)));
+    }
 
     // ── Commands exist ──
 

--- a/SysManager/SysManager/Helpers/RecycleBinHelper.cs
+++ b/SysManager/SysManager/Helpers/RecycleBinHelper.cs
@@ -1,0 +1,47 @@
+// SysManager · RecycleBinHelper
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Runtime.InteropServices;
+using Serilog;
+
+namespace SysManager.Helpers;
+
+/// <summary>
+/// Single source of truth for emptying the Windows Recycle Bin via the shell API.
+/// Both Deep Cleanup and the One-Click Tune-Up empty the bin; routing them through one
+/// helper keeps the <c>SHEmptyRecycleBin</c> P/Invoke and the HRESULT handling from
+/// drifting between copies. Uses the shell API rather than <c>Clear-RecycleBin</c> so
+/// ghosted entries are removed reliably.
+/// </summary>
+public static partial class RecycleBinHelper
+{
+    // SHERB_NOCONFIRMATION | SHERB_NOPROGRESSUI | SHERB_NOSOUND
+    private const uint SuppressAllFlags = 0x00000007;
+    private const uint ErrorNoMoreFiles = 0x80070012; // bin already empty
+
+    /// <summary>
+    /// Empties the Recycle Bin on all drives with no confirmation/progress/sound.
+    /// Returns true on success (or when the bin is already empty).
+    /// </summary>
+    public static bool EmptyAllDrives()
+    {
+        try
+        {
+            int hr = NativeMethods.SHEmptyRecycleBin(IntPtr.Zero, null, SuppressAllFlags);
+            // S_OK (>= 0) = success, ERROR_NO_MORE_FILES = bin already empty.
+            return hr >= 0 || unchecked((uint)hr) == ErrorNoMoreFiles;
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            Log.Warning("Empty recycle bin failed: {Error}", ex.Message);
+            return false;
+        }
+    }
+
+    private static partial class NativeMethods
+    {
+        [LibraryImport("shell32.dll", StringMarshalling = StringMarshalling.Utf16, EntryPoint = "SHEmptyRecycleBinW")]
+        internal static partial int SHEmptyRecycleBin(IntPtr hwnd, string? pszRootPath, uint dwFlags);
+    }
+}

--- a/SysManager/SysManager/Services/DeepCleanupService.cs
+++ b/SysManager/SysManager/Services/DeepCleanupService.cs
@@ -3,8 +3,8 @@
 // License: MIT
 
 using System.IO;
-using System.Runtime.InteropServices;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -17,7 +17,7 @@ namespace SysManager.Services;
 /// Both Scan and Clean accept an <see cref="IProgress{T}"/> so the UI can
 /// show a determinate progress bar and the current bucket being scanned.
 /// </summary>
-public sealed partial class DeepCleanupService
+public sealed class DeepCleanupService
 {
     public sealed record ScanProgress(int Current, int Total, string CategoryName);
 
@@ -342,7 +342,7 @@ public sealed partial class DeepCleanupService
             if (cat.IsRecycleBin)
             {
                 var sizeBefore = cat.TotalSizeBytes;
-                if (EmptyRecycleBin())
+                if (RecycleBinHelper.EmptyAllDrives())
                 {
                     freed += sizeBefore;
                     filesDeleted += cat.FileCount;
@@ -488,31 +488,6 @@ public sealed partial class DeepCleanupService
         catch (UnauthorizedAccessException) { return true; }
     }
 
-    // ---------- Recycle Bin (shell API, not raw file delete) ----------
-
-    /// <summary>
-    /// Empties the Recycle Bin on all drives via the documented shell API.
-    /// Returns true on success (or when the bin is already empty).
-    /// </summary>
-    private static bool EmptyRecycleBin()
-    {
-        try
-        {
-            // SHEmptyRecycleBin with SHERB_NOCONFIRMATION | SHERB_NOPROGRESSUI | SHERB_NOSOUND.
-            int hr = NativeMethods.SHEmptyRecycleBin(IntPtr.Zero, null, 0x00000007);
-            // S_OK (0) = success, 0x80070012 (ERROR_NO_MORE_FILES) = bin already empty.
-            return hr >= 0 || unchecked((uint)hr) == 0x80070012;
-        }
-        catch (System.ComponentModel.Win32Exception ex)
-        {
-            Log.Warning("Deep cleanup: empty recycle bin failed: {Error}", ex.Message);
-            return false;
-        }
-    }
-
-    private static partial class NativeMethods
-    {
-        [LibraryImport("shell32.dll", StringMarshalling = StringMarshalling.Utf16, EntryPoint = "SHEmptyRecycleBinW")]
-        internal static partial int SHEmptyRecycleBin(IntPtr hwnd, string? pszRootPath, uint dwFlags);
-    }
+    // Recycle Bin is emptied via the shared RecycleBinHelper (shell API, not raw file
+    // delete) so the SHEmptyRecycleBin interop has a single source of truth.
 }

--- a/SysManager/SysManager/Services/PerformanceService.cs
+++ b/SysManager/SysManager/Services/PerformanceService.cs
@@ -27,6 +27,7 @@ namespace SysManager.Services;
 public sealed partial class PerformanceService : IDisposable
 {
     private readonly PowerShellRunner _ps;
+    private readonly RestorePointService _restorePoints;
     private readonly SemaphoreSlim _psGate = new(1, 1);
     private bool _disposed;
 
@@ -56,7 +57,11 @@ public sealed partial class PerformanceService : IDisposable
     private static partial bool SystemParametersInfoSet(
         uint uiAction, uint uiParam, int pvParam, uint fWinIni);
 
-    public PerformanceService(PowerShellRunner ps) => _ps = ps;
+    public PerformanceService(PowerShellRunner ps, RestorePointService restorePoints)
+    {
+        _ps = ps;
+        _restorePoints = restorePoints;
+    }
 
     // ═══════════════════════════════════════════════════════════════
     //  SNAPSHOT — captures original state for safe restore
@@ -542,7 +547,7 @@ public sealed partial class PerformanceService : IDisposable
     /// first) — this method exists only as the Performance tab's convenience entry point.
     /// </summary>
     public Task<bool> CreateRestorePointAsync(string description, CancellationToken ct = default)
-        => new RestorePointService(_ps).CreateAsync(description, ct);
+        => _restorePoints.CreateAsync(description, ct);
 
     // ═══════════════════════════════════════════════════════════════
     //  RAM WORKING SET TRIM — via EmptyWorkingSet (instant)

--- a/SysManager/SysManager/Services/TuneUpService.cs
+++ b/SysManager/SysManager/Services/TuneUpService.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -19,7 +20,7 @@ namespace SysManager.Services;
 ///
 /// No admin required. No registry edits. No service changes.
 /// </summary>
-public sealed partial class TuneUpService
+public sealed class TuneUpService
 {
     private readonly ShortcutCleanerService _shortcuts;
     private readonly DiskHealthService _diskHealth;
@@ -273,27 +274,5 @@ public sealed partial class TuneUpService
     // ── Recycle Bin ────────────────────────────────────────────────────
 
     private static Task<bool> EmptyRecycleBinAsync(CancellationToken ct)
-        => Task.Run(() => EmptyRecycleBin(), ct);
-
-    private static bool EmptyRecycleBin()
-    {
-        try
-        {
-            // SHEmptyRecycleBin with SHERB_NOCONFIRMATION | SHERB_NOPROGRESSUI | SHERB_NOSOUND
-            int hr = NativeMethods.SHEmptyRecycleBin(IntPtr.Zero, null, 0x00000007);
-            // S_OK (0) = success, 0x80070012 (ERROR_NO_MORE_FILES) = bin already empty
-            return hr >= 0 || unchecked((uint)hr) == 0x80070012;
-        }
-        catch (System.ComponentModel.Win32Exception ex)
-        {
-            Log.Warning("TuneUp empty recycle bin failed: {Error}", ex.Message);
-            return false;
-        }
-    }
-
-    private static partial class NativeMethods
-    {
-        [System.Runtime.InteropServices.LibraryImport("shell32.dll", StringMarshalling = System.Runtime.InteropServices.StringMarshalling.Utf16, EntryPoint = "SHEmptyRecycleBinW")]
-        internal static partial int SHEmptyRecycleBin(IntPtr hwnd, string? pszRootPath, uint dwFlags);
-    }
+        => Task.Run(RecycleBinHelper.EmptyAllDrives, ct);
 }

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -189,7 +189,8 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             ProcessManager = new ProcessManagerViewModel(new ProcessManagerService());
             BatteryHealth = new BatteryHealthViewModel(battery);
             Uninstaller = new UninstallerViewModel(new UninstallerService(runner));
-            Performance = new PerformanceViewModel(new PerformanceService(runner));
+            var restorePoints = new RestorePointService(runner);
+            Performance = new PerformanceViewModel(new PerformanceService(runner, restorePoints));
             Startup = new StartupViewModel(new StartupService());
             NetworkShared = new NetworkSharedState(pinger, tracer, traceMonitor, speedTest, netRepair);
             Ping = new PingViewModel(NetworkShared);
@@ -211,7 +212,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             ContextMenu = new ContextMenuViewModel(new ContextMenuService());
             SystemReport = new SystemReportViewModel(new SystemReportService(sysInfo, diskHealth));
             EnvironmentVariables = new EnvironmentVariablesViewModel(new EnvironmentVariableService());
-            RestorePoints = new RestorePointsViewModel(new RestorePointService(new PowerShellRunner()));
+            RestorePoints = new RestorePointsViewModel(restorePoints);
             Debloater = new DebloaterViewModel(new DebloaterService(new PowerShellRunner()));
             LegacyPanels = new LegacyPanelsViewModel(new LegacyPanelService());
             SystemFixes = new SystemFixesViewModel(new SystemFixService(new PowerShellRunner()));


### PR DESCRIPTION
## What
Two single-source-of-truth cleanups surfaced by the post-marathon audit. **Behavior is identical** before/after — no `fix:`/`feat:`, so no release.

### 1. Restore-point construction
`PerformanceService.CreateRestorePointAsync` built `new RestorePointService(_ps)` on every call — a parallel construction path next to the DI-registered `RestorePointService` singleton that the Restore Points tab already uses (the 1.33.8 dedup routed the *logic* through `CreateAsync` but left this construction). `PerformanceService` now receives `RestorePointService` via its constructor, so there is one instance and one path. The test/designer branch of `MainWindowViewModel` shares a single `RestorePointService` between the Performance and Restore Points tabs.

### 2. Recycle Bin interop
`DeepCleanupService` and `TuneUpService` each declared their **own identical** `SHEmptyRecycleBinW` `[LibraryImport]` + HRESULT handling (`S_OK` / `ERROR_NO_MORE_FILES`). Both now route through a new shared `Helpers/RecycleBinHelper.EmptyAllDrives()`, removing the duplicate P/Invoke declaration. Same shell API, same suppress-all flags, same return semantics.

## Why
The audit found restore-point creation in two places and the Recycle-Bin empty in three; this removes the divergent construction/interop while leaving the three legitimately-distinct cleanup tabs (Quick Cleanup, Deep Cleanup, Tune-Up) untouched.

## Verification
- `dotnet build` main + tests: **0 errors / 0 warnings**.
- Behavior unchanged: same restore-point script, same `SHEmptyRecycleBin` flags and HRESULT handling.
- ARCHITECTURE.md updated with `RecycleBinHelper`.
- Self-review (Protocol I): leak/debug/generic-catch clean.