### PR TITLE
fix: Dashboard Quick Cleanup uses the shared reparse-safe temp cleaner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.33.10] - 2026-06-25
+
+### Fixed
+- **The Dashboard's Quick Cleanup now uses the same safe temp cleaner as the One-Click Tune-Up.** It previously had its own inline cleaner that only looked at the top level of the user TEMP folder, ignored the Windows TEMP folder, and silently swallowed every error. It now cleans both temp folders and never follows a junction or symbolic link out of the temp tree, so it can't be redirected into unrelated files — matching the protection already used elsewhere.
+
 ## [1.33.9] - 2026-06-25
 
 ### Fixed

--- a/SysManager/SysManager/Services/TuneUpService.cs
+++ b/SysManager/SysManager/Services/TuneUpService.cs
@@ -147,7 +147,14 @@ public sealed class TuneUpService
 
     // ── Temp file cleanup ──────────────────────────────────────────────
 
-    private static Task<(long BytesFreed, int FilesDeleted, int Errors)> CleanTempFilesAsync(CancellationToken ct)
+    /// <summary>
+    /// Cleans user + Windows TEMP, never descending into reparse points (junctions /
+    /// symbolic links) so a link inside TEMP can't redirect deletion to unrelated data.
+    /// Returns the bytes freed, files deleted, and per-file error count. Shared by the
+    /// full Tune-Up sequence and the Dashboard's Quick Cleanup shortcut so both use this
+    /// one safe implementation.
+    /// </summary>
+    public static Task<(long BytesFreed, int FilesDeleted, int Errors)> CleanTempFilesAsync(CancellationToken ct = default)
         => Task.Run(() => CleanTempFiles(ct), ct);
 
     private static (long BytesFreed, int FilesDeleted, int Errors) CleanTempFiles(CancellationToken ct)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.33.9</Version>
-    <FileVersion>1.33.9.0</FileVersion>
-    <AssemblyVersion>1.33.9.0</AssemblyVersion>
+    <Version>1.33.10</Version>
+    <FileVersion>1.33.10.0</FileVersion>
+    <AssemblyVersion>1.33.10.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -570,35 +570,15 @@ public sealed partial class DashboardViewModel : ViewModelBase
 
         await RunQuickActionAsync("Quick Cleanup", "Cleanup", "nav-cleanup", async () =>
         {
-            QuickActionDetail = "Scanning temp folders...";
-            QuickActionProgress = 20;
-            var tempPath = Path.GetTempPath();
-            await Task.Run(() =>
-            {
-                try
-                {
-                    return new DirectoryInfo(tempPath)
-                        .EnumerateFiles("*", SearchOption.AllDirectories)
-                        .Sum(f => { try { return f.Length; } catch { return 0L; } });
-                }
-                catch { return 0L; }
-            });
-
             QuickActionDetail = "Cleaning temp files...";
             QuickActionProgress = 50;
-            long freed = 0;
-            await Task.Run(() =>
-            {
-                try
-                {
-                    foreach (var file in new DirectoryInfo(tempPath).EnumerateFiles("*", SearchOption.TopDirectoryOnly))
-                    {
-                        try { var len = file.Length; file.Delete(); freed += len; }
-                        catch { /* locked — skip */ }
-                    }
-                }
-                catch { /* access denied — skip */ }
-            });
+
+            // Delegate to the shared TuneUpService cleaner: it cleans BOTH user and Windows
+            // TEMP and never follows reparse points (junctions / symlinks) out of the temp
+            // tree, so it can't be redirected into unrelated user data. This replaces an
+            // earlier inline cleaner that only scanned the user TEMP top level and swallowed
+            // every error.
+            var (freed, _, _) = await TuneUpService.CleanTempFilesAsync(CancellationToken.None);
 
             QuickActionProgress = 100;
             var freedMB = freed / 1024.0 / 1024.0;


### PR DESCRIPTION
## What
The Dashboard's **Quick Cleanup** quick-action had its own inline temp cleaner that was weaker and less safe than the cleaner used everywhere else:
- Only enumerated the **top level** of the user TEMP folder (`SearchOption.TopDirectoryOnly`) — nested temp files were left behind.
- **Never touched the Windows TEMP folder** (`%SystemRoot%\Temp`).
- Swallowed every error with bare `catch {}` blocks (violates the project's catch-hygiene rule).
- Followed reparse points, unlike the hardened cleaners in Deep Cleanup / Tune-Up / Browser Cleaner.

It now delegates to `TuneUpService.CleanTempFilesAsync` (promoted to `public`), which cleans **both** user and Windows TEMP and **never descends into junctions/symlinks** out of the temp tree — the same safe implementation the One-Click Tune-Up already uses.

## Why
The post-marathon audit found temp-file cleanup re-implemented in four places, with the Dashboard copy being the weakest and the only one missing the reparse-point guard. This removes the duplicate, weaker logic and routes the shortcut through the single safe cleaner. (The Quick Cleanup / Deep Cleanup / Tune-Up *tabs* remain distinct by design — only the Dashboard's duplicated shortcut logic is consolidated.)

## Tests
- Reparse-point data-loss safety is already pinned by `EnumerateFilesSkippingReparsePoints_DoesNotFollowDirectorySymlink` in `TuneUpServiceTests`; the Dashboard now routes through that tested path.
- No new system-touching test added (deleting the real TEMP folder in a unit test would be non-deterministic).

## Verification
- `dotnet build` main + tests: **0 errors / 0 warnings**.
- Self-review (Protocol I): leak/debug clean; the only `catch {}` blocks in the diff are **removals**.
- Confirmation dialog before deletion is unchanged.