### PR TITLE
docs: correct SECURITY browser-data scope and CONTRIBUTING test parallelism

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,8 +118,10 @@ guide. That said, a few explicit rules:
 
 ## Running tests
 
-The suite runs sequentially (see `xunit.runner.json`) so file-system
-fixtures can share temp folders safely.
+Unit tests run in parallel by default (`parallelizeTestCollections: true`).
+Tests that share state or touch OS resources are isolated via xUnit collection
+definitions in `TestCollections.cs` (each `DisableParallelization = true`), so
+file-system fixtures never collide. The integration suite runs sequentially.
 
 Full run:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,11 +66,19 @@ What the app can and cannot do by design:
 - Launch external CLIs: `winget`, Ookla `speedtest`, `tracert`, `ping`.
 - Delete files in user-selected cleanup categories (Deep Cleanup tab).
 - Empty the Recycle Bin.
+- Clear per-browser cache, history, cookies, and sessions (Browser Cleaner tab)
+  — only for categories the user explicitly selects. Cookies and sessions are
+  marked sensitive and unticked by default so a clean never silently signs the
+  user out; locked files (browser open) are skipped, and reparse points are
+  never followed out of the browser's own folders.
 - Download application updates from the official GitHub Releases API.
 
 ### By design — forbidden
 
-- Touching browser caches, cookies, or password stores.
+- Reading or exfiltrating saved passwords or any browser password store.
+- The Deep Cleanup engine touching browser data — that engine never reads or
+  deletes browser caches/cookies; only the dedicated Browser Cleaner tab does,
+  and only with the explicit per-category consent described above.
 - Touching the Windows registry for cleanup.
 - Deleting game files, installed binaries, or any active driver folder. The
   cleanup engine never touches `steamapps\common` or installed game/program


### PR DESCRIPTION
## What
Two documentation drifts found by a fresh docs-accuracy audit (no code change, `docs:` → no release).

### SECURITY.md
`SECURITY.md` listed *"touching browser caches, cookies, or password stores"* under **By design — forbidden**. That became false when the **Browser Cleaner** tab shipped (1.32.0): it clears per-browser cache, history, cookies, and sessions. Corrected to:
- **Allowed:** Browser Cleaner clears those categories **only with explicit per-category consent** — cookies/sessions unticked by default (never silently signs you out), locked files skipped, reparse points never followed out of the browser folders.
- **Forbidden (re-scoped):** reading/exfiltrating saved **passwords** / any password store; and the **Deep Cleanup engine** touching browser data (that engine genuinely never does — only the dedicated Browser Cleaner tab does).

### CONTRIBUTING.md
Said *"the suite runs sequentially (see xunit.runner.json)"*. The unit suite actually runs **in parallel** (`parallelizeTestCollections: true`), with shared-state collections serialized via `TestCollections.cs`; only the integration suite is sequential. This also contradicted TESTING.md — now aligned.

## Verification
- Both claims re-derived from source: `SysManager.Tests/xunit.runner.json` (`parallelizeTestCollections: true`) vs `SysManager.IntegrationTests/xunit.runner.json` (`false`); `BrowserCleanerService` confirmed to clear cache/cookies/history/sessions with consent.
- Leak scan clean.