### PR TITLE
test: cover SafetyDatabase service/feature risk lookups

### DIFF
--- a/SysManager/SysManager.Tests/BrowserCleanerServiceTests.cs
+++ b/SysManager/SysManager.Tests/BrowserCleanerServiceTests.cs
@@ -174,8 +174,12 @@ public sealed class BrowserCleanerServiceTests : IDisposable
         // the deletion path itself refuses to follow the junction.
         var item = new Models.BrowserCleanupItem
         {
-            Browser = "Google Chrome", Category = "Cache", Description = "",
-            Paths = [cacheLink], IsSensitive = false, IsSelected = true
+            Browser = "Google Chrome",
+            Category = "Cache",
+            Description = "",
+            Paths = [cacheLink],
+            IsSensitive = false,
+            IsSelected = true
         };
         var deleted = await _svc.CleanAsync([item]);
 

--- a/SysManager/SysManager.Tests/DebloaterServiceTests.cs
+++ b/SysManager/SysManager.Tests/DebloaterServiceTests.cs
@@ -159,8 +159,13 @@ public class DebloaterServiceTests
 
     private static StoreApp App(string name, string full, bool isProtected = false) => new()
     {
-        Name = name, PackageFullName = full, PackageFamilyName = name + "_abc",
-        DisplayName = name, Publisher = "CN=Microsoft", Version = "1.0.0.0", IsProtected = isProtected
+        Name = name,
+        PackageFullName = full,
+        PackageFamilyName = name + "_abc",
+        DisplayName = name,
+        Publisher = "CN=Microsoft",
+        Version = "1.0.0.0",
+        IsProtected = isProtected
     };
 
     [Fact]

--- a/SysManager/SysManager.Tests/SafetyDatabaseTests.cs
+++ b/SysManager/SysManager.Tests/SafetyDatabaseTests.cs
@@ -1,0 +1,81 @@
+// SysManager · SafetyDatabaseTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="SafetyDatabase"/> — the curated lookup that drives the
+/// risk warnings shown before a user disables a Windows service or feature. The
+/// fail-safe defaults (unknown service → Critical, unknown feature → Caution) are
+/// the load-bearing behavior: a wrong default could let someone disable a core
+/// service without a warning.
+/// </summary>
+public class SafetyDatabaseTests
+{
+    // ---------- services ----------
+
+    [Theory]
+    [InlineData("DiagTrack", SafetyLevel.Safe)]        // telemetry — safe to disable
+    [InlineData("SysMain", SafetyLevel.Safe)]
+    [InlineData("RemoteRegistry", SafetyLevel.Safe)]
+    [InlineData("wuauserv", SafetyLevel.Caution)]      // Windows Update — caution
+    [InlineData("Spooler", SafetyLevel.Caution)]
+    [InlineData("AudioSrv", SafetyLevel.Caution)]
+    [InlineData("RpcSs", SafetyLevel.Critical)]        // core IPC — critical
+    [InlineData("lsass", SafetyLevel.Critical)]
+    [InlineData("WinDefend", SafetyLevel.Critical)]
+    public void GetServiceSafety_MapsKnownServicesToTier(string service, SafetyLevel expected)
+        => Assert.Equal(expected, SafetyDatabase.GetServiceSafety(service).Level);
+
+    [Fact]
+    public void GetServiceSafety_UnknownService_DefaultsToCritical()
+    {
+        // Fail-safe: an unrecognised service must NOT be presented as safe to disable.
+        var (level, description) = SafetyDatabase.GetServiceSafety("Totally.Made.Up.Service");
+        Assert.Equal(SafetyLevel.Critical, level);
+        Assert.Contains("critical", description, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("diagtrack")]   // lower
+    [InlineData("DIAGTRACK")]   // upper
+    [InlineData("DiagTrack")]   // exact
+    public void GetServiceSafety_IsCaseInsensitive(string service)
+        => Assert.Equal(SafetyLevel.Safe, SafetyDatabase.GetServiceSafety(service).Level);
+
+    [Fact]
+    public void GetServiceSafety_KnownService_ReturnsNonEmptyDescription()
+        => Assert.False(string.IsNullOrWhiteSpace(SafetyDatabase.GetServiceSafety("wuauserv").Description));
+
+    // ---------- features ----------
+
+    [Theory]
+    [InlineData("TelnetClient", SafetyLevel.Safe)]
+    [InlineData("SMB1Protocol", SafetyLevel.Safe)]
+    [InlineData("NetFx3", SafetyLevel.Caution)]
+    [InlineData("Printing-Foundation-Features", SafetyLevel.Caution)]
+    [InlineData("Microsoft-Hyper-V-All", SafetyLevel.Critical)]
+    [InlineData("Containers", SafetyLevel.Critical)]
+    public void GetFeatureSafety_MapsKnownFeaturesToTier(string feature, SafetyLevel expected)
+        => Assert.Equal(expected, SafetyDatabase.GetFeatureSafety(feature).Level);
+
+    [Fact]
+    public void GetFeatureSafety_UnknownFeature_DefaultsToCaution()
+    {
+        // Features default to Caution (not Critical) — unknown optional features are
+        // generally reversible, but still warrant a "check the docs" warning.
+        var (level, description) = SafetyDatabase.GetFeatureSafety("Made-Up-Feature");
+        Assert.Equal(SafetyLevel.Caution, level);
+        Assert.False(string.IsNullOrWhiteSpace(description));
+    }
+
+    [Theory]
+    [InlineData("telnetclient")]
+    [InlineData("TELNETCLIENT")]
+    public void GetFeatureSafety_IsCaseInsensitive(string feature)
+        => Assert.Equal(SafetyLevel.Safe, SafetyDatabase.GetFeatureSafety(feature).Level);
+}


### PR DESCRIPTION
## What
`SafetyDatabase` drives the risk warnings shown before a user disables a Windows service or optional feature (Safe / Caution / Critical), but had **zero tests** — flagged by the post-audit test-coverage sweep as the most notable gap among safety-relevant code.

Added a deterministic `[Theory]`/`[Fact]` suite covering:
- Each tier for representative services (DiagTrack/SysMain → Safe, wuauserv/Spooler → Caution, RpcSs/lsass/WinDefend → Critical) and features (TelnetClient/SMB1 → Safe, NetFx3 → Caution, Hyper-V/Containers → Critical).
- **The fail-safe defaults** — the load-bearing behavior: an unknown **service** returns **Critical** (never silently "safe to disable"), an unknown **feature** returns **Caution**.
- Case-insensitive lookup.
- Non-empty descriptions for known entries.

## Verification
- `dotnet build` tests: **0 errors / 0 warnings**; `dotnet format` clean.
- Pure lookup tables, no system dependency — fully deterministic, no DateTime/network/filesystem.
- `test:` only — no app code, no version bump, no release.