### PR TITLE
fix: derive system paths dynamically instead of hardcoding C:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.33.11] - 2026-06-26
+
+### Fixed
+- **Recycle Bin size estimate on the Cleanup tab now counts every fixed drive, not just C:.** It previously looked only at `C:\$Recycle.Bin`, so deleted files on other drives weren't reflected in the estimate. It now sums the hidden `$Recycle.Bin` on each ready fixed drive.
+- **App Blocker no longer assumes Windows is installed on C:.** The sentinel path it writes to block an app is now derived from the real system directory instead of a hardcoded `C:\Windows\System32`, so blocking works on systems where Windows lives on another drive. Existing blocks are unaffected (the value is compared case-insensitively).
+
 ## [1.33.10] - 2026-06-25
 
 ### Fixed

--- a/SysManager/SysManager.Tests/AppBlockerServiceRegistryTests.cs
+++ b/SysManager/SysManager.Tests/AppBlockerServiceRegistryTests.cs
@@ -17,7 +17,12 @@ namespace SysManager.Tests;
 public sealed class AppBlockerServiceRegistryTests : IDisposable
 {
     private const string IfeoPath = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options";
-    private const string BlockerDebugger = @"C:\Windows\System32\SysManager_Blocked.exe";
+
+    // Mirror the service's own derivation (Environment.SystemDirectory) rather than a
+    // hardcoded C:\Windows\System32 — Windows can be installed elsewhere, and asserting a
+    // literal would make this test pass only on a default install.
+    private static readonly string BlockerDebugger =
+        System.IO.Path.Combine(Environment.SystemDirectory, "SysManager_Blocked.exe");
 
     private readonly string _rootName = @"Software\SysManagerTests\AppBlocker_" + Guid.NewGuid().ToString("N");
     private readonly RegistryKey _root;

--- a/SysManager/SysManager/Services/AppBlockerService.cs
+++ b/SysManager/SysManager/Services/AppBlockerService.cs
@@ -25,7 +25,13 @@ namespace SysManager.Services;
 public sealed partial class AppBlockerService : IAppBlockerService
 {
     private const string IfeoPath = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options";
-    private const string BlockerDebugger = @"C:\Windows\System32\SysManager_Blocked.exe";
+
+    // Sentinel "Debugger" path written into IFEO to block an app: it points at a file that
+    // does not exist, so the launch fails. Derived from the real system directory rather than
+    // hardcoding C:\Windows\System32 (Windows can be installed on another drive/directory).
+    // Compared case-insensitively on read, so blocks written with the old literal still match.
+    private static readonly string BlockerDebugger =
+        Path.Combine(Environment.SystemDirectory, "SysManager_Blocked.exe");
 
     /// <summary>
     /// Boot- and logon-critical executables that must never be blocked. An IFEO

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.33.10</Version>
-    <FileVersion>1.33.10.0</FileVersion>
-    <AssemblyVersion>1.33.10.0</AssemblyVersion>
+    <Version>1.33.11</Version>
+    <FileVersion>1.33.11.0</FileVersion>
+    <AssemblyVersion>1.33.11.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -121,12 +121,16 @@ public sealed partial class CleanupViewModel : ViewModelBase
                 try
                 {
                     long binBytes = 0;
-                    var recyclePath = @"C:\$Recycle.Bin";
-                    if (System.IO.Directory.Exists(recyclePath))
+                    // The Recycle Bin lives in a hidden $Recycle.Bin folder on EVERY fixed
+                    // drive, not just C:. Sum them all so the estimate isn't drive-bound.
+                    foreach (var drive in DriveInfo.GetDrives())
                     {
-                        foreach (var f in System.IO.Directory.EnumerateFiles(recyclePath, "*", System.IO.SearchOption.AllDirectories))
+                        if (drive.DriveType != DriveType.Fixed || !drive.IsReady) continue;
+                        var recyclePath = Path.Combine(drive.RootDirectory.FullName, "$Recycle.Bin");
+                        if (!Directory.Exists(recyclePath)) continue;
+                        foreach (var f in Directory.EnumerateFiles(recyclePath, "*", SearchOption.AllDirectories))
                         {
-                            try { binBytes += new System.IO.FileInfo(f).Length; }
+                            try { binBytes += new FileInfo(f).Length; }
                             catch (IOException) { /* skip inaccessible file */ }
                             catch (UnauthorizedAccessException) { /* skip protected file */ }
                         }


### PR DESCRIPTION
## What
Two hardcoded-path issues flagged by the post-audit code review (both trip the project's "no hardcoded paths" rule):

1. **Recycle Bin estimate (Cleanup tab)** measured only `C:\.Bin`, so deleted files on other drives were invisible in the estimate. Now sums the hidden `$Recycle.Bin` on **each ready fixed drive** (`DriveInfo.GetDrives()`).
2. **App Blocker** wrote a sentinel IFEO `Debugger` value hardcoded to `C:\Windows\System32\SysManager_Blocked.exe`. Now derived from `Environment.SystemDirectory`, so blocking works when Windows is on a non-C: drive. The value is compared **case-insensitively on read**, so existing blocks written with the old literal still match — no migration needed.

## Tests
- The AppBlocker round-trip test (`AppBlockerServiceRegistryTests`) now mirrors the same `Environment.SystemDirectory` derivation instead of asserting the `C:\Windows\System32` literal — it verifies the dynamic path works, rather than passing only on a default install.

## Verification
- `dotnet build` main + tests: **0 errors / 0 warnings**.
- Self-review: leak/debug clean; no remaining hardcoded `C:\Windows\System32` / `C:\.Bin` (only an explanatory comment).
- `fix:` → patch release (1.33.11).