### PR TITLE
test: stabilize UI nav clicks (verify tab actually switched)

### DIFF
--- a/SysManager/SysManager.UITests/AppFixture.cs
+++ b/SysManager/SysManager.UITests/AppFixture.cs
@@ -71,8 +71,42 @@ public sealed class AppFixture : IDisposable
         if (item is null)
             throw new InvalidOperationException($"Nav item '{navId}' not found.{DescribeNavTree()}");
 
-        item.Click();
-        Thread.Sleep(250);
+        // Navigation is driven by a MouseLeftButtonUp handler on the nav Border. A single
+        // synthetic Click() on the container peer doesn't reliably fire it on a slow headless
+        // runner — the click can land before the row is hit-testable, so the content pane
+        // never switches and the following FindButton/WaitForText sees the previous tab. Click,
+        // then VERIFY the content host actually changed; retry the click a few times if not.
+        var before = ContentSignature();
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            try { item.Click(); } catch (Exception) { /* re-found below if it went stale */ }
+            // Wait for the content host to differ from its pre-click state.
+            var changed = Retry.WhileFalse(
+                () => ContentSignature() != before,
+                TimeSpan.FromSeconds(3), TimeSpan.FromMilliseconds(150)).Result;
+            if (changed) { Thread.Sleep(200); return; } // settle once switched
+
+            // Re-resolve the item in case the tree was rebuilt, and try again.
+            item = MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(navId)) ?? item;
+        }
+        Thread.Sleep(250); // best-effort; a genuinely missing element is reported by the assert
+    }
+
+    /// <summary>
+    /// A cheap signature of the content-host subtree, used to detect that navigation actually
+    /// switched the active view (the count + first child's name change when the tab changes).
+    /// </summary>
+    private string ContentSignature()
+    {
+        try
+        {
+            var host = MainWindow.FindFirstDescendant(cf => cf.ByAutomationId("ContentHost"));
+            if (host is null) return "";
+            var kids = host.FindAllDescendants();
+            var first = kids.Length > 0 ? kids[0].Properties.Name.ValueOrDefault : "";
+            return $"{kids.Length}|{first}";
+        }
+        catch (Exception) { return ""; }
     }
 
     /// <summary>


### PR DESCRIPTION
## What
Follow-up to the UI-suite revival. The ~39 intermittently-failing UI assertions were diagnosed (from the real `.trx` artifact) as **NOT app bugs** — every button/label they look for exists in XAML, and `AppUpdates_ScanButton_Exists` passes with the exact same `FindButton` mechanism that 'fails' for `Cleanup_CleanTempButton`. The real cause: **navigation didn't take effect**.

Navigation fires from a `MouseLeftButtonUp` handler on the nav `Border`. A single synthetic `Click()` on the container automation peer doesn't reliably trigger it on a slow headless runner — the click lands before the row is hit-testable, the content pane stays on the previous tab, and the follow-up `FindButton`/`WaitForText` sees the wrong view → `Assert.NotNull ... null`. The shared `ICollectionFixture` (one app across all 5 test classes) makes it worse: the default Dashboard tab tests pass (no navigation needed), later classes that must navigate fail.

## Fix (test-only)
`GoToTab` now clicks, then **verifies the content host actually changed** (a cheap content-subtree signature), retrying the click up to 5× with a short settle. No app change.

## Verification
- `dotnet build` UITests 0/0, `dotnet format` clean.
- Will be confirmed by the real CI UI run (the only place these execute — `dotnet test` is firewall-blocked locally). Job stays non-blocking until the pass rate is solid, then it can become a merge gate.
- `test:` only — no version bump, no release.