### PR TITLE
fix: defer Traceroute monitor CTS disposal until the loop finishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.33.13] - 2026-06-26
+
+### Fixed
+- **Traceroute monitor no longer risks a background error when stopped mid-cycle.** Stopping the live traceroute monitor disposed its cancellation source unconditionally, even if a route was still being traced; the still-running cycle could then throw on the disposed token in the background. Disposal is now deferred until the cycle actually finishes, matching the ping monitor. No visible change in normal use.
+
 ## [1.33.12] - 2026-06-26
 
 ### Fixed

--- a/SysManager/SysManager.Tests/TracerouteMonitorServiceLifecycleTests.cs
+++ b/SysManager/SysManager.Tests/TracerouteMonitorServiceLifecycleTests.cs
@@ -1,0 +1,62 @@
+// SysManager · TracerouteMonitorServiceLifecycleTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Lifecycle/regression tests for <see cref="TracerouteMonitorService"/>. The Stop()
+/// path was rewritten to mirror <see cref="PingMonitorService"/>: the
+/// CancellationTokenSource is disposed only once the loop has finished (deferred via a
+/// continuation when the bounded Wait times out), instead of being disposed unconditionally
+/// while the still-running pump may use the token — which previously risked an
+/// ObjectDisposedException on the background thread. These verify start/stop/dispose is safe
+/// and idempotent.
+/// </summary>
+public class TracerouteMonitorServiceLifecycleTests
+{
+    [Fact]
+    public void StartStop_DoesNotThrow()
+    {
+        using var svc = new TracerouteMonitorService();
+        svc.Start();
+        svc.Stop();
+    }
+
+    [Fact]
+    public void Stop_WithoutStart_IsNoOp()
+    {
+        using var svc = new TracerouteMonitorService();
+        svc.Stop(); // never started — must not throw
+    }
+
+    [Fact]
+    public void RepeatedStartStop_DoesNotThrow()
+    {
+        using var svc = new TracerouteMonitorService();
+        for (var i = 0; i < 5; i++)
+        {
+            svc.Start();
+            svc.Stop();
+        }
+    }
+
+    [Fact]
+    public void Dispose_AfterStart_DoesNotThrow()
+    {
+        var svc = new TracerouteMonitorService();
+        svc.Start();
+        svc.Dispose(); // Dispose() routes through Stop()
+    }
+
+    [Fact]
+    public void DoubleStart_IsIdempotent()
+    {
+        using var svc = new TracerouteMonitorService();
+        svc.Start();
+        svc.Start(); // second Start() must be ignored while running, not leak a CTS
+        svc.Stop();
+    }
+}

--- a/SysManager/SysManager/Services/TracerouteMonitorService.cs
+++ b/SysManager/SysManager/Services/TracerouteMonitorService.cs
@@ -64,13 +64,26 @@ public sealed class TracerouteMonitorService : IDisposable
     {
         lock (_stateLock)
         {
-            _cts?.Cancel();
-            try { _loop?.Wait(3000); }
-            catch (AggregateException) { /* task cancellation or faulted — expected during stop */ }
-            catch (ObjectDisposedException) { /* task already cleaned up */ }
-            _cts?.Dispose();
+            var cts = _cts;
+            var loop = _loop;
             _cts = null;
             _loop = null;
+            if (cts is null) return;
+
+            cts.Cancel();
+            try { loop?.Wait(3000); }
+            catch (AggregateException) { /* task cancellation or faulted — expected during stop */ }
+            catch (ObjectDisposedException) { /* task already cleaned up */ }
+
+            // Dispose the CTS only once the loop has actually finished. A traceroute cycle is
+            // heavy (a full route per target), so the 3 s Wait can time out while PumpAsync is
+            // still using the token; disposing now would throw ObjectDisposedException on the
+            // background thread. Defer disposal to a continuation in that case so the CTS is
+            // neither used-after-dispose nor leaked. (Mirrors PingMonitorService.Stop.)
+            if (loop is null || loop.IsCompleted)
+                cts.Dispose();
+            else
+                loop.ContinueWith(_ => cts.Dispose(), TaskScheduler.Default);
         }
     }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.33.12</Version>
-    <FileVersion>1.33.12.0</FileVersion>
-    <AssemblyVersion>1.33.12.0</AssemblyVersion>
+    <Version>1.33.13</Version>
+    <FileVersion>1.33.13.0</FileVersion>
+    <AssemblyVersion>1.33.13.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## What
`TracerouteMonitorService.Stop()` disposed its `CancellationTokenSource` **unconditionally** right after a bounded `Wait(3000)`. A traceroute cycle is heavy (a full route per target, up to 30 hops x 2 s), so the Wait can time out while `PumpAsync` is still using the token — the next token access then throws `ObjectDisposedException` on the background thread.

This is the **exact race `PingMonitorService.Stop()` was already fixed for**; the fix was never propagated to the sibling monitor (fix the class, not just the instance). Found by a full-app audit and verified against both services' source.

## Fix
`Stop()` captures the `cts`/`loop` locals and nulls the fields first, then disposes the CTS **only once the loop has completed** — deferring to a `ContinueWith` when the Wait times out — so the CTS is neither used-after-dispose nor leaked. The same pattern PingMonitor uses.

## Tests
- Added `TracerouteMonitorServiceLifecycleTests` mirroring `PingMonitorServiceLifecycleTests`: start/stop, stop-without-start, repeated start/stop, dispose-after-start, double-start idempotency. Deterministic, no network.

## Verification
- Build main + tests: 0/0; format clean; leak scan clean.
- fix: -> patch release 1.33.13.