### PR TITLE
fix: Quick Cleanup empties Recycle Bin via the shared shell-API helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.33.14] - 2026-06-26
+
+### Fixed
+- **Quick Cleanup empties the Recycle Bin the same reliable way as the rest of the app.** It used a PowerShell `Clear-RecycleBin` call that can leave "ghost" entries behind; it now uses the shared shell-API helper (the same one Deep Cleanup and the One-Click Tune-Up use), which clears every drive's bin cleanly. Keeps the three entry points from drifting apart.
+
 ## [1.33.13] - 2026-06-26
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.33.13</Version>
-    <FileVersion>1.33.13.0</FileVersion>
-    <AssemblyVersion>1.33.13.0</AssemblyVersion>
+    <Version>1.33.14</Version>
+    <FileVersion>1.33.14.0</FileVersion>
+    <AssemblyVersion>1.33.14.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -247,10 +247,12 @@ public sealed partial class CleanupViewModel : ViewModelBase
         _binCts = new CancellationTokenSource();
         try
         {
-            await _runner.RunScriptViaPwshAsync(@"
-                Clear-RecycleBin -Force -ErrorAction SilentlyContinue
-                'Recycle Bin cleared'
-            ", cancellationToken: _binCts.Token);
+            // Use the shared shell-API helper (the single source of truth) rather than an
+            // inline Clear-RecycleBin: the shell API reliably removes ghosted entries that
+            // Clear-RecycleBin can leave behind, and keeps this in step with Deep Cleanup
+            // and the One-Click Tune-Up. Run off the UI thread.
+            var ct = _binCts.Token;
+            await Task.Run(RecycleBinHelper.EmptyAllDrives, ct);
             StatusMessage = "Done";
             ToastService.Instance.Show("Cleanup complete", "Operation finished successfully");
             await PreScanAsync();


### PR DESCRIPTION
## What
Quick Cleanup emptied the Recycle Bin with an inline `Clear-RecycleBin -Force` PowerShell call, while Deep Cleanup and the One-Click Tune-Up both go through the shared `RecycleBinHelper.EmptyAllDrives()` (shell API). `RecycleBinHelper` was created specifically to be the single source of truth for this op — yet Quick Cleanup never adopted it (a missed migration found by the full-app audit).

Two benefits:
- **Reliability:** the shell API removes ghosted entries that `Clear-RecycleBin` can leave behind, and clears **every** drive's bin (not just the system drive).
- **Single source of truth:** the three entry points no longer drift apart.

## Change
`CleanupViewModel.EmptyRecycleBinAsync` now calls `RecycleBinHelper.EmptyAllDrives()` off the UI thread (`Task.Run`). The confirmation dialog, cancel token, toast, and post-clean rescan are unchanged.

## Verification
- Build main: 0/0; format + leak scan clean.
- fix: -> patch release 1.33.14.