### PR TITLE
fix: load registry/drive-backed tabs off the UI thread at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.33.15] - 2026-06-26
+
+### Fixed
+- **Faster, smoother startup — several tabs no longer read the registry or probe drives on the UI thread while the app launches.** The Privacy & Telemetry, Environment Variables, App Blocker, Duplicate Finder, Disk Analyzer, and Profile Export/Import tabs loaded their initial data synchronously as the window was being built, which could briefly freeze launch (worst case: a stalled or disconnected drive). Each now loads in the background like the other tabs, so the window appears promptly and the tab fills in a moment later.
+
 ## [1.33.14] - 2026-06-26
 
 ### Fixed

--- a/SysManager/SysManager.Tests/AppBlockerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppBlockerViewModelTests.cs
@@ -21,13 +21,17 @@ public class AppBlockerViewModelTests
     {
         var blocker = Substitute.For<IAppBlockerService>();
         blocker.GetBlockedApps().Returns([]);
-        return new AppBlockerViewModel(blocker);
+        return NewVm(blocker);
     }
 
+    // The VM loads the blocked list asynchronously off the UI thread; wait for that init to
+    // finish so the background load can't race a test that mutates BlockedApps afterwards.
     private static AppBlockerViewModel NewVm(IAppBlockerService blocker)
     {
         blocker.GetBlockedApps().Returns([]);
-        return new AppBlockerViewModel(blocker);
+        var vm = new AppBlockerViewModel(blocker);
+        vm.InitializationComplete.GetAwaiter().GetResult();
+        return vm;
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/DiskAnalyzerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DiskAnalyzerViewModelTests.cs
@@ -13,10 +13,20 @@ namespace SysManager.Tests;
 /// </summary>
 public class DiskAnalyzerViewModelTests
 {
+    // The VM resolves its preset paths asynchronously off the UI thread (DriveInfo probing
+    // can stall, so it's moved off startup); wait for that init so the preset assertions
+    // observe the populated collection instead of racing the background load.
+    private static DiskAnalyzerViewModel NewVm()
+    {
+        var vm = new DiskAnalyzerViewModel(new Services.DiskAnalyzerService());
+        vm.InitializationComplete.GetAwaiter().GetResult();
+        return vm;
+    }
+
     [Fact]
     public void Constructor_InitialState_IsCorrect()
     {
-        var vm = new DiskAnalyzerViewModel(new Services.DiskAnalyzerService());
+        var vm = NewVm();
         Assert.False(vm.IsBusy);
         Assert.Equal(0, vm.TotalSize);
         Assert.Equal(0, vm.TotalFiles);
@@ -29,21 +39,21 @@ public class DiskAnalyzerViewModelTests
     [Fact]
     public void Constructor_PresetPaths_NotEmpty()
     {
-        var vm = new DiskAnalyzerViewModel(new Services.DiskAnalyzerService());
+        var vm = NewVm();
         Assert.NotEmpty(vm.PresetPaths);
     }
 
     [Fact]
     public void Constructor_SelectedPath_IsSet()
     {
-        var vm = new DiskAnalyzerViewModel(new Services.DiskAnalyzerService());
+        var vm = NewVm();
         Assert.False(string.IsNullOrWhiteSpace(vm.SelectedPath));
     }
 
     [Fact]
     public void Constructor_PresetPaths_ContainFixedDrives()
     {
-        var vm = new DiskAnalyzerViewModel(new Services.DiskAnalyzerService());
+        var vm = NewVm();
         var drives = DriveInfo.GetDrives()
             .Where(d => d.DriveType == DriveType.Fixed && d.IsReady)
             .Select(d => d.RootDirectory.FullName);
@@ -55,49 +65,49 @@ public class DiskAnalyzerViewModelTests
     [Fact]
     public void AnalyzeCommand_Exists()
     {
-        var vm = new DiskAnalyzerViewModel(new Services.DiskAnalyzerService());
+        var vm = NewVm();
         Assert.NotNull(vm.AnalyzeCommand);
     }
 
     [Fact]
     public void CancelAnalysisCommand_Exists()
     {
-        var vm = new DiskAnalyzerViewModel(new Services.DiskAnalyzerService());
+        var vm = NewVm();
         Assert.NotNull(vm.CancelAnalysisCommand);
     }
 
     [Fact]
     public void ShowInExplorerCommand_Exists()
     {
-        var vm = new DiskAnalyzerViewModel(new Services.DiskAnalyzerService());
+        var vm = NewVm();
         Assert.NotNull(vm.ShowInExplorerCommand);
     }
 
     [Fact]
     public void DrillDownCommand_Exists()
     {
-        var vm = new DiskAnalyzerViewModel(new Services.DiskAnalyzerService());
+        var vm = NewVm();
         Assert.NotNull(vm.DrillDownCommand);
     }
 
     [Fact]
     public void GoUpCommand_Exists()
     {
-        var vm = new DiskAnalyzerViewModel(new Services.DiskAnalyzerService());
+        var vm = NewVm();
         Assert.NotNull(vm.GoUpCommand);
     }
 
     [Fact]
     public void BrowseFolderCommand_Exists()
     {
-        var vm = new DiskAnalyzerViewModel(new Services.DiskAnalyzerService());
+        var vm = NewVm();
         Assert.NotNull(vm.BrowseFolderCommand);
     }
 
     [Fact]
     public void SelectedPath_CanBeChanged()
     {
-        var vm = new DiskAnalyzerViewModel(new Services.DiskAnalyzerService());
+        var vm = NewVm();
         vm.SelectedPath = @"C:\Test";
         Assert.Equal(@"C:\Test", vm.SelectedPath);
     }
@@ -105,7 +115,7 @@ public class DiskAnalyzerViewModelTests
     [Fact]
     public void HasDriveInfo_DefaultFalse()
     {
-        var vm = new DiskAnalyzerViewModel(new Services.DiskAnalyzerService());
+        var vm = NewVm();
         Assert.False(vm.HasDriveInfo);
     }
 }

--- a/SysManager/SysManager.Tests/DuplicateFileViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DuplicateFileViewModelTests.cs
@@ -14,10 +14,20 @@ namespace SysManager.Tests;
 /// </summary>
 public class DuplicateFileViewModelTests
 {
+    // The VM resolves its preset folders asynchronously off the UI thread (known-folder +
+    // DriveInfo probing can stall, so it's moved off startup); wait for that init so the
+    // preset assertions observe the populated collection instead of racing the load.
+    private static DuplicateFileViewModel NewVm()
+    {
+        var vm = new DuplicateFileViewModel(new Services.DuplicateFileService());
+        vm.InitializationComplete.GetAwaiter().GetResult();
+        return vm;
+    }
+
     [Fact]
     public void Constructor_InitialState_IsCorrect()
     {
-        var vm = new DuplicateFileViewModel(new Services.DuplicateFileService());
+        var vm = NewVm();
         Assert.False(vm.IsBusy);
         Assert.Equal(0, vm.GroupCount);
         Assert.Equal(0, vm.DuplicateFileCount);
@@ -30,21 +40,21 @@ public class DuplicateFileViewModelTests
     [Fact]
     public void Constructor_PresetFolders_NotEmpty()
     {
-        var vm = new DuplicateFileViewModel(new Services.DuplicateFileService());
+        var vm = NewVm();
         Assert.NotEmpty(vm.PresetFolders);
     }
 
     [Fact]
     public void Constructor_SelectedFolder_IsSet()
     {
-        var vm = new DuplicateFileViewModel(new Services.DuplicateFileService());
+        var vm = NewVm();
         Assert.False(string.IsNullOrWhiteSpace(vm.SelectedFolder));
     }
 
     [Fact]
     public void Constructor_PresetFolders_ContainUserProfile()
     {
-        var vm = new DuplicateFileViewModel(new Services.DuplicateFileService());
+        var vm = NewVm();
         var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         Assert.Contains(vm.PresetFolders, f => f == userProfile);
     }
@@ -52,7 +62,7 @@ public class DuplicateFileViewModelTests
     [Fact]
     public void Constructor_PresetFolders_ContainFixedDrives()
     {
-        var vm = new DuplicateFileViewModel(new Services.DuplicateFileService());
+        var vm = NewVm();
         var drives = DriveInfo.GetDrives()
             .Where(d => d.DriveType == DriveType.Fixed && d.IsReady)
             .Select(d => d.RootDirectory.FullName);
@@ -64,42 +74,42 @@ public class DuplicateFileViewModelTests
     [Fact]
     public void ScanCommand_Exists()
     {
-        var vm = new DuplicateFileViewModel(new Services.DuplicateFileService());
+        var vm = NewVm();
         Assert.NotNull(vm.ScanCommand);
     }
 
     [Fact]
     public void CancelScanCommand_Exists()
     {
-        var vm = new DuplicateFileViewModel(new Services.DuplicateFileService());
+        var vm = NewVm();
         Assert.NotNull(vm.CancelScanCommand);
     }
 
     [Fact]
     public void ShowInExplorerCommand_Exists()
     {
-        var vm = new DuplicateFileViewModel(new Services.DuplicateFileService());
+        var vm = NewVm();
         Assert.NotNull(vm.ShowInExplorerCommand);
     }
 
     [Fact]
     public void CopyPathCommand_Exists()
     {
-        var vm = new DuplicateFileViewModel(new Services.DuplicateFileService());
+        var vm = NewVm();
         Assert.NotNull(vm.CopyPathCommand);
     }
 
     [Fact]
     public void BrowseFolderCommand_Exists()
     {
-        var vm = new DuplicateFileViewModel(new Services.DuplicateFileService());
+        var vm = NewVm();
         Assert.NotNull(vm.BrowseFolderCommand);
     }
 
     [Fact]
     public void MinSizeKb_CanBeChanged()
     {
-        var vm = new DuplicateFileViewModel(new Services.DuplicateFileService());
+        var vm = NewVm();
         vm.MinSizeKb = 500;
         Assert.Equal(500, vm.MinSizeKb);
     }
@@ -107,7 +117,7 @@ public class DuplicateFileViewModelTests
     [Fact]
     public void SelectedFolder_CanBeChanged()
     {
-        var vm = new DuplicateFileViewModel(new Services.DuplicateFileService());
+        var vm = NewVm();
         vm.SelectedFolder = @"C:\Test";
         Assert.Equal(@"C:\Test", vm.SelectedFolder);
     }

--- a/SysManager/SysManager.Tests/PrivacyViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PrivacyViewModelTests.cs
@@ -16,7 +16,15 @@ namespace SysManager.Tests;
 [Collection("DialogService")]
 public class PrivacyViewModelTests
 {
-    private static PrivacyViewModel NewVm() => new(new PrivacyService());
+    // The VM loads its toggles asynchronously off the UI thread (so startup isn't blocked);
+    // wait for that init to finish before asserting loaded state, so the tests observe the
+    // populated collections deterministically instead of racing the background load.
+    private static PrivacyViewModel NewVm()
+    {
+        var vm = new PrivacyViewModel(new PrivacyService());
+        vm.InitializationComplete.GetAwaiter().GetResult();
+        return vm;
+    }
 
     [Fact]
     public void Constructor_Toggles_Populated_With12Items()

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.33.14</Version>
-    <FileVersion>1.33.14.0</FileVersion>
-    <AssemblyVersion>1.33.14.0</AssemblyVersion>
+    <Version>1.33.15</Version>
+    <FileVersion>1.33.15.0</FileVersion>
+    <AssemblyVersion>1.33.15.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AppBlockerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppBlockerViewModel.cs
@@ -31,7 +31,9 @@ public sealed partial class AppBlockerViewModel : ViewModelBase
     {
         _blocker = blocker;
         IsElevated = AdminHelper.IsElevated();
-        RefreshList();
+        // Walk the IFEO registry tree off the UI thread so the eagerly-built VM doesn't
+        // block startup; the UI update runs back on the UI thread (ConfigureAwait true).
+        InitializeAsync(RefreshListAsync);
     }
 
     [RelayCommand]
@@ -41,10 +43,17 @@ public sealed partial class AppBlockerViewModel : ViewModelBase
             Application.Current?.Shutdown();
     }
 
-    [RelayCommand]
-    private void RefreshList()
+    private async Task RefreshListAsync()
     {
-        var apps = _blocker.GetBlockedApps();
+        var apps = await Task.Run(_blocker.GetBlockedApps).ConfigureAwait(true);
+        ApplyBlockedApps(apps);
+    }
+
+    [RelayCommand]
+    private void RefreshList() => ApplyBlockedApps(_blocker.GetBlockedApps());
+
+    private void ApplyBlockedApps(IReadOnlyList<BlockedApp> apps)
+    {
         BlockedApps.ReplaceWith(apps);
         BlockedCount = BlockedApps.Count;
         BlockStatus = BlockedCount == 0

--- a/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
@@ -43,13 +43,26 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
     public DiskAnalyzerViewModel(DiskAnalyzerService service)
     {
         _service = service;
-        PopulatePresets();
+        // Probe drives off the UI thread: DriveInfo.IsReady can stall on a disconnected
+        // mapped/removable volume, which would freeze startup since this VM is built eagerly.
+        // The collection update runs back on the UI thread.
+        InitializeAsync(PopulatePresetsAsync);
     }
 
-    private void PopulatePresets()
+    private async Task PopulatePresetsAsync()
     {
+        var paths = await Task.Run(EnumeratePresetPaths).ConfigureAwait(true);
+        foreach (var p in paths)
+            PresetPaths.Add(p);
+        if (PresetPaths.Count > 0)
+            SelectedPath = PresetPaths[0];
+    }
+
+    private static List<string> EnumeratePresetPaths()
+    {
+        var result = new List<string>();
         foreach (var d in DriveInfo.GetDrives().Where(x => x.DriveType == DriveType.Fixed && x.IsReady))
-            PresetPaths.Add(d.RootDirectory.FullName);
+            result.Add(d.RootDirectory.FullName);
 
         var special = new[]
         {
@@ -57,11 +70,10 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
             Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
             Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
         };
-        foreach (var p in special.Where(x => !string.IsNullOrEmpty(x) && Directory.Exists(x) && !PresetPaths.Contains(x)))
-            PresetPaths.Add(p);
+        foreach (var p in special.Where(x => !string.IsNullOrEmpty(x) && Directory.Exists(x) && !result.Contains(x)))
+            result.Add(p);
 
-        if (PresetPaths.Count > 0)
-            SelectedPath = PresetPaths[0];
+        return result;
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
@@ -37,11 +37,24 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
     public DuplicateFileViewModel(DuplicateFileService service)
     {
         _service = service;
-        PopulatePresets();
+        // Resolve known-folder paths + probe drives off the UI thread: DriveInfo.IsReady can
+        // stall on a disconnected mapped/removable volume, which would freeze startup since
+        // this VM is built eagerly. The collection update runs back on the UI thread.
+        InitializeAsync(PopulatePresetsAsync);
     }
 
-    private void PopulatePresets()
+    private async Task PopulatePresetsAsync()
     {
+        var folders = await Task.Run(EnumeratePresetFolders).ConfigureAwait(true);
+        foreach (var f in folders)
+            PresetFolders.Add(f);
+        if (PresetFolders.Count > 0)
+            SelectedFolder = PresetFolders[0];
+    }
+
+    private static List<string> EnumeratePresetFolders()
+    {
+        var result = new List<string>();
         var folders = new[]
         {
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
@@ -54,14 +67,13 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
         };
 
         foreach (var f in folders.Where(x => !string.IsNullOrEmpty(x) && Directory.Exists(x)))
-            PresetFolders.Add(f);
+            result.Add(f);
 
         // Add fixed drives
         foreach (var d in DriveInfo.GetDrives().Where(x => x.DriveType == DriveType.Fixed && x.IsReady))
-            PresetFolders.Add(d.RootDirectory.FullName);
+            result.Add(d.RootDirectory.FullName);
 
-        if (PresetFolders.Count > 0)
-            SelectedFolder = PresetFolders[0];
+        return result;
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
@@ -71,18 +71,27 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
     {
         _service = service;
         IsElevated = AdminHelper.IsElevated();
-        Load();
+        // Read both env hives off the UI thread so the eagerly-built VM doesn't block
+        // startup; the UI update runs back on the UI thread (ConfigureAwait true).
+        InitializeAsync(LoadAsync);
     }
 
     private static string Key(EnvVariable v) => Key(v.Scope, v.Name);
     private static string Key(EnvVarScope scope, string name) => $"{(int)scope}\0{name.ToUpperInvariant()}";
 
-    private void Load()
+    private async Task LoadAsync()
+    {
+        var loaded = await Task.Run(_service.ReadAll).ConfigureAwait(true);
+        Load(loaded);
+    }
+
+    private void Load() => Load(_service.ReadAll());
+
+    private void Load(List<EnvVariable> loaded)
     {
         foreach (var v in Variables)
             v.PropertyChanged -= OnVariablePropertyChanged;
 
-        var loaded = _service.ReadAll();
         Variables.ReplaceWith(loaded);
 
         _baseline.Clear();

--- a/SysManager/SysManager/ViewModels/PrivacyViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PrivacyViewModel.cs
@@ -38,16 +38,25 @@ public sealed partial class PrivacyViewModel : ViewModelBase
     {
         _service = service;
         IsElevated = AdminHelper.IsElevated();
-        LoadToggles();
+        // Read the registry-backed toggles off the UI thread so the eagerly-built VM
+        // doesn't block startup; the UI update runs back on the UI thread (ConfigureAwait true).
+        InitializeAsync(LoadTogglesAsync);
     }
 
-    private void LoadToggles()
+    private async Task LoadTogglesAsync()
+    {
+        var loaded = await Task.Run(_service.LoadToggles).ConfigureAwait(true);
+        LoadToggles(loaded);
+    }
+
+    private void LoadToggles() => LoadToggles(_service.LoadToggles());
+
+    private void LoadToggles(List<PrivacyToggle> loaded)
     {
         // Unsubscribe from old toggles
         foreach (var t in Toggles)
             t.PropertyChanged -= OnTogglePropertyChanged;
 
-        var loaded = _service.LoadToggles();
         Toggles.ReplaceWith(loaded);
 
         // Capture baseline so we can compute the pending-change count.

--- a/SysManager/SysManager/ViewModels/ProfileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProfileViewModel.cs
@@ -31,15 +31,23 @@ public sealed partial class ProfileViewModel : ViewModelBase
     public ProfileViewModel(ProfileService service)
     {
         _service = service;
-        RefreshSections();
         StatusMessage = "Export your SysManager settings to a file, or import a profile from another PC.";
+        // Read the config files off the UI thread so the eagerly-built VM doesn't block
+        // startup; the collection update runs back on the UI thread.
+        InitializeAsync(RefreshSectionsAsync);
     }
 
-    private void RefreshSections()
+    private async Task RefreshSectionsAsync()
     {
-        var available = _service.AvailableSections()
-            .Select(s => new SelectableSection(s) { IsSelected = true });
-        Sections.ReplaceWith(available);
+        var available = await Task.Run(_service.AvailableSections).ConfigureAwait(true);
+        ApplySections(available);
+    }
+
+    private void RefreshSections() => ApplySections(_service.AvailableSections());
+
+    private void ApplySections(IReadOnlyList<ConfigSection> available)
+    {
+        Sections.ReplaceWith(available.Select(s => new SelectableSection(s) { IsSelected = true }));
         HasSections = Sections.Count > 0;
     }
 

--- a/SysManager/SysManager/ViewModels/ViewModelBase.cs
+++ b/SysManager/SysManager/ViewModels/ViewModelBase.cs
@@ -17,11 +17,25 @@ public abstract partial class ViewModelBase : ObservableObject, IDisposable
     private bool _disposed;
 
     /// <summary>
+    /// Completes when the constructor's <see cref="InitializeAsync"/> work has finished
+    /// (or immediately if the VM does no async init). Production never awaits this — the
+    /// window paints while init runs in the background — but tests can await it to observe
+    /// the loaded state deterministically instead of racing the fire-and-forget load.
+    /// </summary>
+    public Task InitializationComplete { get; private set; } = Task.CompletedTask;
+
+    /// <summary>
     /// Safely launches an async task from a constructor or non-async context.
     /// Exceptions are caught and logged instead of becoming unobserved task
-    /// exceptions that could crash the application (CQ-M3).
+    /// exceptions that could crash the application (CQ-M3). The running task is exposed
+    /// via <see cref="InitializationComplete"/> for deterministic test observation.
     /// </summary>
-    protected static async void InitializeAsync(Func<Task> asyncAction, [System.Runtime.CompilerServices.CallerMemberName] string callerName = "")
+    protected void InitializeAsync(Func<Task> asyncAction, [System.Runtime.CompilerServices.CallerMemberName] string callerName = "")
+    {
+        InitializationComplete = RunInitAsync(asyncAction, callerName);
+    }
+
+    private static async Task RunInitAsync(Func<Task> asyncAction, string callerName)
     {
         try
         {


### PR DESCRIPTION
## What
Six ViewModels read their initial data **synchronously in their constructors**. Because all VMs are resolved eagerly when the main window is built, that work ran serialized on the UI thread before first paint:

| ViewModel | Synchronous ctor work |
|---|---|
| PrivacyViewModel | registry read per toggle (`LoadToggles`) |
| EnvironmentVariablesViewModel | both env hives (`ReadAll`) |
| AppBlockerViewModel | full IFEO registry-tree walk (`GetBlockedApps`) |
| DuplicateFileViewModel | known-folder + `DriveInfo` probing |
| DiskAnalyzerViewModel | `DriveInfo` probing |
| ProfileViewModel | config-file reads (`AvailableSections`) |

`DriveInfo.IsReady` in particular can stall on a disconnected mapped/removable volume, freezing launch. (PrivacyMonitor was already fixed this way in an earlier release; these are the remaining ones, surfaced by the full-app audit.)

## Fix
Each VM now does the heavy read via `Task.Run` inside the established `InitializeAsync` pattern, then updates its collections **back on the UI thread** (`ConfigureAwait(true)`). The synchronous load paths used by post-action refreshes (Apply, Import) are preserved unchanged.

## Testability
`ViewModelBase.InitializeAsync` now exposes the running task as `InitializationComplete` — **production is still fire-and-forget** (the window never awaits it; it paints while init runs), but tests can await it to observe the loaded state deterministically instead of racing the background load. Updated the Privacy / AppBlocker / DiskAnalyzer / DuplicateFile VM tests to await it before asserting preset/toggle counts.

## Verification
- Build main + tests: **0/0**; `dotnet format` clean; leak scan clean.
- fix: -> patch release 1.33.15.