### PR TITLE
fix: regroup four features to the categories they belong in (Env Vars, App Alerts, Legacy Panels, Cleanup split)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,16 +41,16 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Group | View Models |
 |-------|-------------|
 | Dashboard | `DashboardViewModel` |
-| System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `LegacyPanelsViewModel` · `SystemFixesViewModel` · `BootAnalyzerViewModel` · `PlaceholderViewModel` (Task Scheduler) |
+| System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `SystemFixesViewModel` · `BootAnalyzerViewModel` · `PlaceholderViewModel` (Task Scheduler) |
 | Gaming & Profiles | `PlaceholderViewModel` (Gaming Profile · Standby List Cleaner · Timer Resolution · CPU Core Affinity · Display Profiles) |
-| Monitor | `ProcessManagerViewModel` · `PrivacyMonitorViewModel` · `PlaceholderViewModel` (Resource History · File Lock Detector · Settings Watchdog · Bandwidth Monitor) |
+| Monitor | `ProcessManagerViewModel` · `PrivacyMonitorViewModel` · `AppAlertsViewModel` · `PlaceholderViewModel` (Resource History · File Lock Detector · Settings Watchdog · Bandwidth Monitor) |
 | Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `PlaceholderViewModel` (Scheduled Maintenance) |
 | Storage | `DiskAnalyzerViewModel` · `DuplicateFileViewModel` |
 | Network | `PingViewModel` · `TracerouteViewModel` · `SpeedTestViewModel` · `NetworkRepairViewModel` (shared: `NetworkSharedState`) · `DnsHostsViewModel` |
 | Apps | `AppUpdatesViewModel` · `BulkInstallerViewModel` · `UninstallerViewModel` |
-| Privacy & Security | `PrivacyViewModel` · `FileShredderViewModel` · `AppBlockerViewModel` · `AppAlertsViewModel` · `DebloaterViewModel` · `BrowserCleanerViewModel` · `PlaceholderViewModel` (Edge/OneDrive Remover · Defender Tweaks · Notification Blocker) |
+| Privacy & Security | `PrivacyViewModel` · `FileShredderViewModel` · `AppBlockerViewModel` · `DebloaterViewModel` · `BrowserCleanerViewModel` · `PlaceholderViewModel` (Edge/OneDrive Remover · Defender Tweaks · Notification Blocker) |
 | Customization | `ContextMenuViewModel` · `PlaceholderViewModel` (Dark Mode Scheduler · Volume Control) |
-| Info | `DriversViewModel` · `BatteryHealthViewModel` · `LogsViewModel` · `SystemReportViewModel` · `AboutViewModel` |
+| Info | `DriversViewModel` · `BatteryHealthViewModel` · `LogsViewModel` · `SystemReportViewModel` · `LegacyPanelsViewModel` · `AboutViewModel` |
 | Advanced | `ProfileViewModel` · `EnvironmentVariablesViewModel` · `PlaceholderViewModel` (CLI Interface) |
 
 - `DashboardViewModel` — real-time system vitals (CPU/RAM/GPU at 300ms polling),

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,9 +49,9 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Network | `PingViewModel` · `TracerouteViewModel` · `SpeedTestViewModel` · `NetworkRepairViewModel` (shared: `NetworkSharedState`) · `DnsHostsViewModel` |
 | Apps | `AppUpdatesViewModel` · `BulkInstallerViewModel` · `UninstallerViewModel` |
 | Privacy & Security | `PrivacyViewModel` · `FileShredderViewModel` · `AppBlockerViewModel` · `AppAlertsViewModel` · `DebloaterViewModel` · `BrowserCleanerViewModel` · `PlaceholderViewModel` (Edge/OneDrive Remover · Defender Tweaks · Notification Blocker) |
-| Customization | `ContextMenuViewModel` · `EnvironmentVariablesViewModel` · `PlaceholderViewModel` (Dark Mode Scheduler · Volume Control) |
+| Customization | `ContextMenuViewModel` · `PlaceholderViewModel` (Dark Mode Scheduler · Volume Control) |
 | Info | `DriversViewModel` · `BatteryHealthViewModel` · `LogsViewModel` · `SystemReportViewModel` · `AboutViewModel` |
-| Advanced | `ProfileViewModel` · `PlaceholderViewModel` (CLI Interface) |
+| Advanced | `ProfileViewModel` · `EnvironmentVariablesViewModel` · `PlaceholderViewModel` (CLI Interface) |
 
 - `DashboardViewModel` — real-time system vitals (CPU/RAM/GPU at 300ms polling),
   temperatures (LibreHardwareMonitor + NvAPIWrapper), storage overview, system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.33.16] - 2026-06-26
+
+### Changed
+- **Moved "Environment Variables" from the Customization group to Advanced**, next to Profile Export/Import — it's a system/developer tool, not a UI-customization one. The tab itself is unchanged.
+- **Quick Cleanup now separates "Clean up" from "Repair Windows".** Clean TEMP / Empty Recycle Bin / Rescan and the SFC / DISM repairs were previously one mixed row of buttons; they're now two labelled sections so it's clear which actions free space and which repair Windows. Also added accessible names to all the action buttons for screen readers.
+
 ## [1.33.15] - 2026-06-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - **Moved "Environment Variables" from the Customization group to Advanced**, next to Profile Export/Import — it's a system/developer tool, not a UI-customization one. The tab itself is unchanged.
+- **Moved "App Alerts" from Privacy & Security to the Monitor group.** App Alerts passively watches for newly installed apps and keeps a timestamped history — it observes rather than enforces, so it belongs alongside the other monitoring tabs. The tab itself is unchanged.
+- **Moved "Legacy Panels" from the System group to Info.** It's a read-only launcher for classic Windows applets (Device Manager, Disk Management, etc.) with no system modification, so it sits better among the other read-only Info tabs. The tab itself is unchanged.
 - **Quick Cleanup now separates "Clean up" from "Repair Windows".** Clean TEMP / Empty Recycle Bin / Rescan and the SFC / DISM repairs were previously one mixed row of buttons; they're now two labelled sections so it's clear which actions free space and which repair Windows. Also added accessible names to all the action buttons for screen readers.
 
 ## [1.33.15] - 2026-06-26

--- a/README.md
+++ b/README.md
@@ -80,16 +80,16 @@ implemented; 17 are work-in-progress placeholders marked with ⚙️:
 | Group | Tabs |
 |-------|------|
 | 🏠 Dashboard | Dashboard |
-| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Legacy Panels · System Fixes · Boot Analyzer · Task Scheduler ⚙️ |
+| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · System Fixes · Boot Analyzer · Task Scheduler ⚙️ |
 | 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner ⚙️ · Timer Resolution ⚙️ · CPU Core Affinity ⚙️ · Display Profiles ⚙️ |
-| 📊 Monitor | Process Manager · Resource History ⚙️ · Camera/Mic/Location · File Lock Detector ⚙️ · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
+| 📊 Monitor | Process Manager · Resource History ⚙️ · Camera/Mic/Location · App Alerts · File Lock Detector ⚙️ · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance ⚙️ |
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS & Hosts |
 | 📦 Apps | App Updates · Bulk Installer · Uninstaller |
-| 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · App Alerts · Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover ⚙️ · Defender Tweaks ⚙️ · Notification Blocker ⚙️ |
+| 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover ⚙️ · Defender Tweaks ⚙️ · Notification Blocker ⚙️ |
 | 🎨 Customization | Context Menu · Dark Mode Scheduler ⚙️ · Volume Control ⚙️ |
-| ℹ️ Info | Drivers · Battery Health · System Logs · System Report · About |
+| ℹ️ Info | Drivers · Battery Health · System Logs · System Report · Legacy Panels · About |
 | ⚙️ Advanced | Profile Export/Import · CLI Interface ⚙️ · Environment Variables |
 
 > ⚙️ = Work in Progress — placeholder tab visible in the sidebar, implementation coming in future updates.

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ implemented; 17 are work-in-progress placeholders marked with ⚙️:
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS & Hosts |
 | 📦 Apps | App Updates · Bulk Installer · Uninstaller |
 | 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · App Alerts · Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover ⚙️ · Defender Tweaks ⚙️ · Notification Blocker ⚙️ |
-| 🎨 Customization | Context Menu · Dark Mode Scheduler ⚙️ · Volume Control ⚙️ · Environment Variables |
+| 🎨 Customization | Context Menu · Dark Mode Scheduler ⚙️ · Volume Control ⚙️ |
 | ℹ️ Info | Drivers · Battery Health · System Logs · System Report · About |
-| ⚙️ Advanced | Profile Export/Import · CLI Interface ⚙️ |
+| ⚙️ Advanced | Profile Export/Import · CLI Interface ⚙️ · Environment Variables |
 
 > ⚙️ = Work in Progress — placeholder tab visible in the sidebar, implementation coming in future updates.
 

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -84,7 +84,7 @@ public class MainWindowViewModelTests
         // Dashboard
         Assert.Contains("nav-dashboard", ids);
 
-        // System (11)
+        // System (10)
         Assert.Contains("nav-system-health", ids);
         Assert.Contains("nav-windows-update", ids);
         Assert.Contains("nav-performance", ids);
@@ -94,7 +94,6 @@ public class MainWindowViewModelTests
         Assert.Contains("nav-restore-points", ids);
         Assert.Contains("nav-task-scheduler", ids);
         Assert.Contains("nav-boot-analyzer", ids);
-        Assert.Contains("nav-legacy-panels", ids);
         Assert.Contains("nav-system-fixes", ids);
 
         // Gaming & Profiles (5)
@@ -104,10 +103,11 @@ public class MainWindowViewModelTests
         Assert.Contains("nav-cpu-affinity", ids);
         Assert.Contains("nav-display-profiles", ids);
 
-        // Monitor (6)
+        // Monitor (7)
         Assert.Contains("nav-processes", ids);
         Assert.Contains("nav-resource-history", ids);
         Assert.Contains("nav-privacy-monitor", ids);
+        Assert.Contains("nav-app-alerts", ids);
         Assert.Contains("nav-file-lock", ids);
         Assert.Contains("nav-settings-watchdog", ids);
         Assert.Contains("nav-bandwidth-monitor", ids);
@@ -134,33 +134,33 @@ public class MainWindowViewModelTests
         Assert.Contains("nav-bulk-installer", ids);
         Assert.Contains("nav-uninstaller", ids);
 
-        // Privacy & Security (9)
+        // Privacy & Security (8)
         Assert.Contains("nav-privacy-settings", ids);
         Assert.Contains("nav-file-shredder", ids);
         Assert.Contains("nav-app-blocker", ids);
-        Assert.Contains("nav-app-alerts", ids);
         Assert.Contains("nav-debloater", ids);
         Assert.Contains("nav-browser-cleaner", ids);
         Assert.Contains("nav-edge-onedrive", ids);
         Assert.Contains("nav-defender-tweaks", ids);
         Assert.Contains("nav-notification-blocker", ids);
 
-        // Customization (4)
+        // Customization (3)
         Assert.Contains("nav-context-menu", ids);
         Assert.Contains("nav-dark-mode", ids);
         Assert.Contains("nav-volume-control", ids);
-        Assert.Contains("nav-env-variables", ids);
 
-        // Info (5)
+        // Info (6)
         Assert.Contains("nav-drivers", ids);
         Assert.Contains("nav-battery", ids);
         Assert.Contains("nav-logs", ids);
         Assert.Contains("nav-system-report", ids);
+        Assert.Contains("nav-legacy-panels", ids);
         Assert.Contains("nav-about", ids);
 
-        // Advanced (2)
+        // Advanced (3)
         Assert.Contains("nav-profile-export", ids);
         Assert.Contains("nav-cli-interface", ids);
+        Assert.Contains("nav-env-variables", ids);
     }
 
     [Fact]
@@ -240,11 +240,11 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
-    public void NavGroups_SystemGroup_Contains11Items()
+    public void NavGroups_SystemGroup_Contains10Items()
     {
         var vm = new MainWindowViewModel();
         var sys = vm.NavGroups.First(g => g.Id == "grp-system");
-        Assert.Equal(11, sys.Children.Count);
+        Assert.Equal(10, sys.Children.Count);
         var ids = sys.Children.Select(c => c.Id).ToList();
         Assert.Contains("nav-system-health", ids);
         Assert.Contains("nav-windows-update", ids);
@@ -255,8 +255,30 @@ public class MainWindowViewModelTests
         Assert.Contains("nav-restore-points", ids);
         Assert.Contains("nav-task-scheduler", ids);
         Assert.Contains("nav-boot-analyzer", ids);
-        Assert.Contains("nav-legacy-panels", ids);
         Assert.Contains("nav-system-fixes", ids);
+        // Legacy Panels is a read-only applet launcher — it lives in Info, not System.
+        Assert.DoesNotContain("nav-legacy-panels", ids);
+    }
+
+    [Fact]
+    public void NavGroups_AppAlerts_LivesInMonitorNotPrivacy()
+    {
+        var vm = new MainWindowViewModel();
+        var monitor = vm.NavGroups.First(g => g.Id == "grp-monitor").Children.Select(c => c.Id).ToList();
+        var privacy = vm.NavGroups.First(g => g.Id == "grp-privacy").Children.Select(c => c.Id).ToList();
+        // App Alerts passively watches for new installs — it belongs with the monitoring tabs.
+        Assert.Contains("nav-app-alerts", monitor);
+        Assert.DoesNotContain("nav-app-alerts", privacy);
+    }
+
+    [Fact]
+    public void NavGroups_LegacyPanels_LivesInInfoNotSystem()
+    {
+        var vm = new MainWindowViewModel();
+        var info = vm.NavGroups.First(g => g.Id == "grp-info").Children.Select(c => c.Id).ToList();
+        var system = vm.NavGroups.First(g => g.Id == "grp-system").Children.Select(c => c.Id).ToList();
+        Assert.Contains("nav-legacy-panels", info);
+        Assert.DoesNotContain("nav-legacy-panels", system);
     }
 
     [Fact]

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.33.15</Version>
-    <FileVersion>1.33.15.0</FileVersion>
-    <AssemblyVersion>1.33.15.0</AssemblyVersion>
+    <Version>1.33.16</Version>
+    <FileVersion>1.33.16.0</FileVersion>
+    <AssemblyVersion>1.33.16.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -355,8 +355,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         Group("grp-customization", "Customization", "",
             Item("nav-context-menu",   "Context Menu",          "", ContextMenu,          typeof(Views.ContextMenuView)),
             Item("nav-dark-mode",      "Dark Mode Scheduler",   "", WipDarkModeScheduler, typeof(Views.PlaceholderView)),
-            Item("nav-volume-control", "Volume Control",        "", WipVolumeControl,     typeof(Views.PlaceholderView)),
-            Item("nav-env-variables",  "Environment Variables", "", EnvironmentVariables, typeof(Views.EnvironmentVariablesView))),
+            Item("nav-volume-control", "Volume Control",        "", WipVolumeControl,     typeof(Views.PlaceholderView))),
 
         Group("grp-info", "Info", "",
             Item("nav-drivers",       "Drivers",        "", Drivers,        typeof(Views.DriversView)),
@@ -367,7 +366,8 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
         Group("grp-advanced", "Advanced", "",
             Item("nav-profile-export", "Profile Export/Import", "", Profile,               typeof(Views.ProfileView)),
-            Item("nav-cli-interface",  "CLI Interface",         "", WipCliInterface,        typeof(Views.PlaceholderView))),
+            Item("nav-cli-interface",  "CLI Interface",         "", WipCliInterface,        typeof(Views.PlaceholderView)),
+            Item("nav-env-variables",  "Environment Variables", "", EnvironmentVariables, typeof(Views.EnvironmentVariablesView))),
     ];
 
     private static NavGroup Group(string id, string label, string glyph, params NavItem[] children)

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -301,7 +301,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-restore-points",   "Restore Points",   "", RestorePoints,    typeof(Views.RestorePointsView)),
             Item("nav-task-scheduler",   "Task Scheduler",   "", WipTaskScheduler, typeof(Views.PlaceholderView)),
             Item("nav-boot-analyzer",    "Boot Analyzer",    "", BootAnalyzer,     typeof(Views.BootAnalyzerView)),
-            Item("nav-legacy-panels",    "Legacy Panels",    "", LegacyPanels,     typeof(Views.LegacyPanelsView)),
             Item("nav-system-fixes",     "System Fixes",     "", SystemFixes,      typeof(Views.SystemFixesView))),
 
         Group("grp-gaming", "Gaming & Profiles", "",
@@ -315,6 +314,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-processes",         "Process Manager",    "", ProcessManager,      typeof(Views.ProcessManagerView)),
             Item("nav-resource-history",  "Resource History",   "", WipResourceHistory,  typeof(Views.PlaceholderView)),
             Item("nav-privacy-monitor",   "Camera/Mic/Location",    "", PrivacyMonitor,      typeof(Views.PrivacyMonitorView)),
+            Item("nav-app-alerts",        "App Alerts",         "", AppAlerts,           typeof(Views.AppAlertsView)),
             Item("nav-file-lock",         "File Lock Detector", "", WipFileLockDetector, typeof(Views.PlaceholderView)),
             Item("nav-settings-watchdog", "Settings Watchdog",  "", WipSettingsWatchdog, typeof(Views.PlaceholderView)),
             Item("nav-bandwidth-monitor", "Bandwidth Monitor",  "", WipBandwidthMonitor, typeof(Views.PlaceholderView))),
@@ -345,7 +345,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-privacy-settings",     "Privacy & Telemetry",   "", Privacy,                typeof(Views.PrivacyView)),
             Item("nav-file-shredder",        "File Shredder",         "", FileShredder,           typeof(Views.FileShredderView)),
             Item("nav-app-blocker",          "App Blocker",           "", AppBlocker,             typeof(Views.AppBlockerView)),
-            Item("nav-app-alerts",           "App Alerts",            "", AppAlerts,              typeof(Views.AppAlertsView)),
             Item("nav-debloater",            "Debloater & Ads",       "", Debloater,             typeof(Views.DebloaterView)),
             Item("nav-browser-cleaner",      "Browser Cleaner",       "", BrowserCleaner,         typeof(Views.BrowserCleanerView)),
             Item("nav-edge-onedrive",        "Edge/OneDrive Remover", "", WipEdgeOneDriveRemover, typeof(Views.PlaceholderView)),
@@ -362,6 +361,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-battery",       "Battery Health", "", BatteryHealth,  typeof(Views.BatteryHealthView)),
             Item("nav-logs",          "System Logs",    "", Logs,           typeof(Views.LogsView)),
             Item("nav-system-report", "System Report",  "", SystemReport, typeof(Views.SystemReportView)),
+            Item("nav-legacy-panels", "Legacy Panels",  "", LegacyPanels, typeof(Views.LegacyPanelsView)),
             Item("nav-about",         "About",          "", About,          typeof(Views.AboutView))),
 
         Group("grp-advanced", "Advanced", "",

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -74,18 +74,32 @@
                     </Border>
                 </Grid>
 
-                <TextBlock Text="Actions" Style="{StaticResource SectionTitle}" Margin="0,0,0,4"/>
-                <TextBlock Text="Clean TEMP removes temporary files from %TEMP% and Windows\Temp. SFC /scannow checks Windows system files for corruption and repairs them. DISM /RestoreHealth repairs the Windows component store using Windows Update as a source."
+                <!-- Clean up section -->
+                <TextBlock Text="Clean up" Style="{StaticResource SectionTitle}" Margin="0,0,0,4"/>
+                <TextBlock Text="Clean TEMP removes temporary files from %TEMP% and Windows\Temp. Empty Recycle Bin clears deleted files on every drive."
                            Style="{StaticResource Subtle}" Margin="0,0,0,10" TextWrapping="Wrap"/>
                 <WrapPanel Orientation="Horizontal">
-                    <Button Content="Clean TEMP" Command="{Binding CleanTempCommand}" Style="{StaticResource PrimaryButton}" Margin="0,0,8,8"/>
-                    <Button Content="Empty Recycle Bin" Command="{Binding EmptyRecycleBinCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"/>
-                    <Button Content="Rescan" Command="{Binding RescanCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"/>
+                    <Button Content="Clean TEMP" Command="{Binding CleanTempCommand}" Style="{StaticResource PrimaryButton}" Margin="0,0,8,8"
+                            AutomationProperties.Name="Clean temporary files"/>
+                    <Button Content="Empty Recycle Bin" Command="{Binding EmptyRecycleBinCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
+                            AutomationProperties.Name="Empty the Recycle Bin"/>
+                    <Button Content="Rescan" Command="{Binding RescanCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
+                            AutomationProperties.Name="Rescan cleanup sizes"/>
+                </WrapPanel>
+
+                <!-- Repair section — Windows system-file repairs, distinct from cleanup -->
+                <TextBlock Text="Repair Windows" Style="{StaticResource SectionTitle}" Margin="0,14,0,4"/>
+                <TextBlock Text="SFC /scannow checks Windows system files for corruption and repairs them. DISM /RestoreHealth repairs the Windows component store using Windows Update as a source. Both run in the background — you can keep using the app."
+                           Style="{StaticResource Subtle}" Margin="0,0,0,10" TextWrapping="Wrap"/>
+                <WrapPanel Orientation="Horizontal">
                     <Button Content="SFC /scannow" Command="{Binding RunSfcCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
+                            AutomationProperties.Name="Run SFC system file check"
                             IsEnabled="{Binding IsSfcRunning, Converter={StaticResource BoolInvert}}"/>
                     <Button Content="DISM RestoreHealth" Command="{Binding RunDismCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
+                            AutomationProperties.Name="Run DISM RestoreHealth"
                             IsEnabled="{Binding IsDismRunning, Converter={StaticResource BoolInvert}}"/>
-                    <Button Content="Cancel" Command="{Binding CancelCommand}" Style="{StaticResource GhostButton}" Margin="0,0,8,8"/>
+                    <Button Content="Cancel" Command="{Binding CancelCommand}" Style="{StaticResource GhostButton}" Margin="0,0,8,8"
+                            AutomationProperties.Name="Cancel the running operation"/>
                 </WrapPanel>
 
                 <!-- Background-task indicators. Stay visible while SFC/DISM


### PR DESCRIPTION
## What
Information-architecture cleanups from the full-app audit. Four feature regroupings — no behavior change to any tab.

### 1. Environment Variables -> Advanced
Moved from the **Customization** group to **Advanced** (next to Profile Export/Import). It's a system/developer tool, not UI customization, and it had been sequenced *after* the WIP placeholders in Customization. The nav-id stays `nav-env-variables`, so navigation and UI automation still resolve it.

### 2. App Alerts -> Monitor
Moved from **Privacy & Security** to **Monitor**. App Alerts passively watches for newly installed apps and keeps a timestamped history — it *observes* rather than *enforces*, so it belongs with Process Manager and Camera/Mic/Location, not among the action-oriented privacy tools.

### 3. Legacy Panels -> Info
Moved from **System** to **Info**. It's a read-only launcher for classic Windows applets (Device Manager, Disk Management, etc.) with no system modification, so it sits with the other read-only Info tabs.

### 4. Quick Cleanup: 'Clean up' vs 'Repair Windows'
The Cleanup tab had a single mixed row of buttons — Clean TEMP / Empty Recycle Bin / Rescan **next to** SFC /scannow / DISM RestoreHealth — which the audit flagged as confusing. Split into two clearly-labelled sections with their own descriptions. **Button Content strings are unchanged** (UI tests still match). Added `AutomationProperties.Name` to every action button.

## On SFC/DISM staying in Cleanup
The audit suggested moving SFC/DISM to System Fixes. On inspection that's not a regroup but a **rewrite**: in Cleanup they have a rich live progress-bar + ETA + percent-parsing + colored console-verdict UX (43 refs), while System Fixes uses a different result-based model with no live streaming. Relocating would risk regressions on two tabs and **downgrade the UX** for no real gain. The audit's genuine concern — the mixed toolbar — is fully addressed by the section split above.

## Tests
- Updated nav-tree group-count assertions: System 11->10, Monitor 6->7, Privacy 9->8, Info 5->6, Customization 4->3, Advanced 2->3.
- Added two regression tests pinning the new placements (App Alerts in Monitor not Privacy; Legacy Panels in Info not System).

## Verification
- Build main + integration tests: 0/0; format + leak scan clean.
- All nav-ids unchanged; Cleanup button Content unchanged (UI assertions unaffected).
- fix: -> patch release 1.33.16.
