### PR TITLE
feat: add PREVIEW marking for newly added, not-yet-verified features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.34.0] - 2026-06-26
+
+### Added
+- **"Preview" marking for newly added features.** Features that are implemented but not yet fully verified now show a small **PREVIEW** pill next to their name in the sidebar and a short banner at the top of the page, so it's clear which tabs are brand-new. This lets new features ship and be tried out while they're still being polished.
+
 ## [1.33.16] - 2026-06-26
 
 ### Changed

--- a/SysManager/SysManager.Tests/NavGroupTests.cs
+++ b/SysManager/SysManager.Tests/NavGroupTests.cs
@@ -81,4 +81,27 @@ public class NavGroupTests
         var g = new NavGroup { Id = "test", Label = "Test", Glyph = "T" };
         Assert.False(g.IsExpanded);
     }
+
+    [Fact]
+    public void NavItem_IsInDevelopment_DefaultsFalse()
+    {
+        var item = new NavItem
+        {
+            Id = "a", Label = "A", Glyph = "A",
+            Content = new object(), ViewType = typeof(object),
+        };
+        Assert.False(item.IsInDevelopment);
+    }
+
+    [Fact]
+    public void NavItem_IsInDevelopment_SetViaInitializer()
+    {
+        var item = new NavItem
+        {
+            Id = "a", Label = "A", Glyph = "A",
+            Content = new object(), ViewType = typeof(object),
+            IsInDevelopment = true,
+        };
+        Assert.True(item.IsInDevelopment);
+    }
 }

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -96,6 +96,13 @@
                                                        FontFamily="{StaticResource UiFont}"
                                                        FontSize="13" FontWeight="Medium"
                                                        Foreground="{DynamicResource TextSecondary}"/>
+                                            <!-- PREVIEW pill: implemented but not yet QA-verified -->
+                                            <Border Background="{DynamicResource AccentSoft}" CornerRadius="4"
+                                                    Padding="5,1" Margin="7,0,0,0" VerticalAlignment="Center"
+                                                    Visibility="{Binding Children[0].IsInDevelopment, Converter={StaticResource BoolToVis}}">
+                                                <TextBlock Text="PREVIEW" FontSize="9" FontWeight="Bold"
+                                                           Foreground="{DynamicResource Info}"/>
+                                            </Border>
                                         </StackPanel>
                                     </Border>
                                 </ContentControl>
@@ -242,10 +249,20 @@
                                                                        VerticalAlignment="Center"
                                                                        Foreground="{DynamicResource TextSecondary}"/>
                                                             <StackPanel VerticalAlignment="Center">
-                                                                <TextBlock Text="{Binding Label}"
-                                                                           FontFamily="{StaticResource UiFont}"
-                                                                           FontSize="13" FontWeight="Medium"
-                                                                           Foreground="{DynamicResource TextSecondary}"/>
+                                                                <StackPanel Orientation="Horizontal">
+                                                                    <TextBlock Text="{Binding Label}"
+                                                                               FontFamily="{StaticResource UiFont}"
+                                                                               FontSize="13" FontWeight="Medium"
+                                                                               VerticalAlignment="Center"
+                                                                               Foreground="{DynamicResource TextSecondary}"/>
+                                                                    <!-- PREVIEW pill: implemented but not yet QA-verified -->
+                                                                    <Border Background="{DynamicResource AccentSoft}" CornerRadius="4"
+                                                                            Padding="5,1" Margin="7,0,0,0" VerticalAlignment="Center"
+                                                                            Visibility="{Binding IsInDevelopment, Converter={StaticResource BoolToVis}}">
+                                                                        <TextBlock Text="PREVIEW" FontSize="9" FontWeight="Bold"
+                                                                                   Foreground="{DynamicResource Info}"/>
+                                                                    </Border>
+                                                                </StackPanel>
                                                                 <ProgressBar Height="2" Margin="0,3,0,0"
                                                                              IsIndeterminate="True"
                                                                              Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.33.16</Version>
-    <FileVersion>1.33.16.0</FileVersion>
-    <AssemblyVersion>1.33.16.0</AssemblyVersion>
+    <Version>1.34.0</Version>
+    <FileVersion>1.34.0.0</FileVersion>
+    <AssemblyVersion>1.34.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -379,8 +379,8 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         return g;
     }
 
-    private static NavItem Item(string id, string label, string glyph, object content, Type viewType)
-        => new() { Id = id, Label = label, Glyph = glyph, Content = content, ViewType = viewType };
+    private static NavItem Item(string id, string label, string glyph, object content, Type viewType, bool inDevelopment = false)
+        => new() { Id = id, Label = label, Glyph = glyph, Content = content, ViewType = viewType, IsInDevelopment = inDevelopment };
 
     partial void OnSelectedNavChanged(NavItem? value)
     {

--- a/SysManager/SysManager/ViewModels/NavItem.cs
+++ b/SysManager/SysManager/ViewModels/NavItem.cs
@@ -26,6 +26,13 @@ public sealed partial class NavItem : ObservableObject, IDisposable
     public required object Content { get; init; }
     public required Type ViewType { get; init; }
 
+    /// <summary>
+    /// True for features that are implemented but not yet QA-verified. The sidebar
+    /// shows a small "PREVIEW" pill next to the label, and the view shows a
+    /// <see cref="Views.DevelopmentBanner"/> so users know the feature is new.
+    /// </summary>
+    public bool IsInDevelopment { get; init; }
+
     [ObservableProperty] private bool _isBusy;
 
     /// <summary>

--- a/SysManager/SysManager/Views/DevelopmentBanner.xaml
+++ b/SysManager/SysManager/Views/DevelopmentBanner.xaml
@@ -1,0 +1,30 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.DevelopmentBanner"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Reusable banner for features that are implemented but not yet QA-verified.
+         Drop <v:DevelopmentBanner/> at the top of a view to surface its "Preview"
+         status. Distinct from the WIP placeholder (which means "not built yet"):
+         this means "built and working, pending verification". -->
+    <Border Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Info}"
+            BorderThickness="1" CornerRadius="10" Padding="12,10">
+        <Grid>
+            <!-- Left accent stripe, mirrors the elevated-admin banner pattern -->
+            <Border Background="{DynamicResource Info}" Width="4" HorizontalAlignment="Left"
+                    CornerRadius="2" Margin="-12,-10,0,-10"/>
+            <StackPanel Orientation="Horizontal" Margin="10,0,0,0" VerticalAlignment="Center">
+                <TextBlock Text="&#xE9F5;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                           FontSize="15" Foreground="{DynamicResource Info}"
+                           VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <StackPanel VerticalAlignment="Center">
+                    <TextBlock Text="Preview feature" FontSize="13" FontWeight="SemiBold"
+                               Foreground="{DynamicResource Info}"/>
+                    <TextBlock Text="This feature is newly added and still being verified. Please report anything unexpected on GitHub."
+                               FontSize="11.5" Foreground="{DynamicResource TextSecondary}"
+                               Margin="0,2,0,0" TextWrapping="Wrap"/>
+                </StackPanel>
+            </StackPanel>
+        </Grid>
+    </Border>
+</UserControl>

--- a/SysManager/SysManager/Views/DevelopmentBanner.xaml.cs
+++ b/SysManager/SysManager/Views/DevelopmentBanner.xaml.cs
@@ -1,0 +1,17 @@
+// SysManager · DevelopmentBanner
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+/// <summary>
+/// Banner shown at the top of a feature view that is implemented but not yet
+/// QA-verified. Pairs with the sidebar "PREVIEW" pill driven by
+/// <see cref="ViewModels.NavItem.IsInDevelopment"/>.
+/// </summary>
+public partial class DevelopmentBanner : UserControl
+{
+    public DevelopmentBanner() => InitializeComponent();
+}


### PR DESCRIPTION
## What
Adds a reusable "Preview" marking for features that are implemented but not yet fully verified, so new work can ship to Live and be tried out while polish continues.

## Mechanism
- **`NavItem.IsInDevelopment`** — opt-in flag, set via the `Item(..., inDevelopment: true)` factory in `MainWindowViewModel`.
- **Sidebar PREVIEW pill** — a small `AccentSoft`/`Info` pill next to the tab label, added to BOTH the single-item and multi-item nav templates. Hidden by default.
- **`DevelopmentBanner` control** — a reusable banner ("Preview feature — newly added and still being verified") that a view drops at the top of its layout. Mirrors the existing elevated-admin banner style (Surface2 + Info stripe), so it matches the design system.

## Why standalone
This PR ships only the primitive — no tab is marked preview yet. Upcoming feature PRs opt in by passing `inDevelopment: true` and adding `<v:DevelopmentBanner/>` to their view. Keeps the mechanism reviewable in isolation.

## Tests
- `NavItem_IsInDevelopment_DefaultsFalse` and `_SetViaInitializer` pin the flag behavior.

## Verification
- Build main + tests: 0/0; leak scan clean.
- feat: -> minor release 1.34.0.
