### PR TITLE
feat: add Timer Resolution tab for lower game input latency

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,7 +42,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 |-------|-------------|
 | Dashboard | `DashboardViewModel` |
 | System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `SystemFixesViewModel` · `BootAnalyzerViewModel` · `PlaceholderViewModel` (Task Scheduler) |
-| Gaming & Profiles | `PlaceholderViewModel` (Gaming Profile · Standby List Cleaner · Timer Resolution · CPU Core Affinity · Display Profiles) |
+| Gaming & Profiles | `TimerResolutionViewModel` · `PlaceholderViewModel` (Gaming Profile · Standby List Cleaner · CPU Core Affinity · Display Profiles) |
 | Monitor | `ProcessManagerViewModel` · `PrivacyMonitorViewModel` · `AppAlertsViewModel` · `PlaceholderViewModel` (Resource History · File Lock Detector · Settings Watchdog · Bandwidth Monitor) |
 | Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `PlaceholderViewModel` (Scheduled Maintenance) |
 | Storage | `DiskAnalyzerViewModel` · `DuplicateFileViewModel` |
@@ -93,6 +93,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `LegacyPanelsViewModel` — one-click launcher for the fixed catalog of classic Windows applets (pure launchers, no system modification).
 - `SystemFixesViewModel` — consolidated one-click repairs (Windows Update reset, network reset, WinGet reinstall) with per-fix confirmation + live output; opens netplwiz for secure auto-logon.
 - `BootAnalyzerViewModel` — read-only boot-time history + slow-component breakdown from the Diagnostics-Performance log, with a trend vs recent average; needs admin to read the log.
+- `TimerResolutionViewModel` — request the finest Windows timer resolution (≈0.5 ms) for lower game input latency, or release it; shows the live effective value. _Preview._
 - `ProfileViewModel` — export/import SysManager's own config (theme, speed-test history) as a portable JSON profile with selective sections and version checking.
 - `DebloaterViewModel` — list and remove preinstalled Store apps with a curated bloat preset; system-critical packages are denylisted; removal is per-user and reversible via the Store.
 - `BrowserCleanerViewModel` — scan per-browser cache/history/cookies/sessions with sizes and clean the selected categories; cookies/sessions default unticked.
@@ -228,6 +229,10 @@ Key services:
   (event 100 boot durations; 101–110 slow-component events). Event-ID→kind mapping
   and event-XML field parsing are pure, unit-tested static methods; reading the log
   needs admin.
+- `TimerResolutionService` — thin wrapper over ntdll `NtQueryTimerResolution` /
+  `NtSetTimerResolution`. The request is a per-process contribution Windows reverts
+  on exit, so it's fully reversible and needs no admin; the 100ns→ms conversion and
+  high-resolution detection are pure, unit-tested static methods on the model.
 - `LegacyPanelService` — opens classic Windows applets (Control Panel, Sound,
   Device Manager, …) via their `control`/`*.cpl`/`*.msc` commands. The catalog is
   hard-coded and `Launch` re-validates catalog membership, so no input reaches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.35.0] - 2026-06-26
+
+### Added
+- **Timer Resolution tab (Gaming & Profiles).** Request the finest Windows timer resolution (≈0.5 ms instead of the ~15.6 ms default) to reduce input latency in games, and restore it with one click. Shows the live current/finest/default values — it re-queries the *effective* resolution rather than echoing the request, so the number is honest even when Windows stops honoring it (e.g. while minimized on Windows 11). Fully reversible and no admin needed; includes a clear power-consumption warning. Marked **PREVIEW** while it's verified. Closes #326.
+
 ## [1.34.0] - 2026-06-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,14 +74,15 @@ fully open source.
 
 ### Sidebar navigation
 The sidebar organises 57 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 40 tabs are fully
-implemented; 17 are work-in-progress placeholders marked with ⚙️:
+find what you need without scrolling through a flat list. 41 tabs are fully
+implemented; 16 are work-in-progress placeholders marked with ⚙️. Newly added
+tabs still being verified are marked **PREVIEW**:
 
 | Group | Tabs |
 |-------|------|
 | 🏠 Dashboard | Dashboard |
 | 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · System Fixes · Boot Analyzer · Task Scheduler ⚙️ |
-| 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner ⚙️ · Timer Resolution ⚙️ · CPU Core Affinity ⚙️ · Display Profiles ⚙️ |
+| 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner ⚙️ · Timer Resolution 🔬 · CPU Core Affinity ⚙️ · Display Profiles ⚙️ |
 | 📊 Monitor | Process Manager · Resource History ⚙️ · Camera/Mic/Location · App Alerts · File Lock Detector ⚙️ · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance ⚙️ |
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
@@ -93,6 +94,7 @@ implemented; 17 are work-in-progress placeholders marked with ⚙️:
 | ⚙️ Advanced | Profile Export/Import · CLI Interface ⚙️ · Environment Variables |
 
 > ⚙️ = Work in Progress — placeholder tab visible in the sidebar, implementation coming in future updates.
+> 🔬 = Preview — implemented and usable, still being verified; marked with a PREVIEW pill in the app.
 
 Groups expand and collapse with a click. Collapsed groups show a child count
 badge, a subtitle with abbreviated child labels, and a tooltip with the full
@@ -446,6 +448,19 @@ Reclaim space and clear browsing traces, per browser:
 - Select/deselect all, batch uninstall with confirmation dialog
 - Local app support — uninstalls apps not in winget via registry UninstallString
 - Live console output from winget
+
+### Timer Resolution 🔬
+- **Lower input latency for games** — requests the finest Windows timer
+  resolution (≈0.5 ms) instead of the ~15.6 ms default, via the ntdll
+  `NtSetTimerResolution` API
+- **Live current/finest/default readout** — always re-queries the *effective*
+  resolution (Windows 11 may stop honoring a request while the window is
+  minimized), so the number shown is the real one
+- **One-click enable / restore** — fully reversible; the request is released
+  when you restore it or simply close the app. No admin required
+- **Power-cost warning** — a finer timer wakes the CPU more often, increasing
+  power draw and battery drain on laptops
+- _Preview — implemented and usable, still being verified._
 
 ### Performance Mode
 - **Per-tweak Apply buttons** — each setting is independent

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -348,4 +348,16 @@ public class MainWindowViewModelTests
             Assert.Equal(1, owners);
         }
     }
+
+    [Fact]
+    public void NavLeaf_TimerResolution_IsImplementedAndMarkedPreview()
+    {
+        var vm = new MainWindowViewModel();
+        var item = vm.NavItems.First(n => n.Id == "nav-timer-resolution");
+        // Now a real view, not the WIP placeholder.
+        Assert.Equal(typeof(SysManager.Views.TimerResolutionView), item.ViewType);
+        Assert.IsType<TimerResolutionViewModel>(item.Content);
+        // Surfaced as PREVIEW until verified.
+        Assert.True(item.IsInDevelopment);
+    }
 }

--- a/SysManager/SysManager.Tests/TimerResolutionStatusTests.cs
+++ b/SysManager/SysManager.Tests/TimerResolutionStatusTests.cs
@@ -1,0 +1,59 @@
+// SysManager · TimerResolutionStatusTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Tests;
+
+public class TimerResolutionStatusTests
+{
+    [Theory]
+    [InlineData(5000u, 0.5)]
+    [InlineData(10000u, 1.0)]
+    [InlineData(156250u, 15.625)]
+    [InlineData(0u, 0.0)]
+    public void ToMilliseconds_Converts100NsUnits(uint hundredNs, double expectedMs)
+        => Assert.Equal(expectedMs, TimerResolutionStatus.ToMilliseconds(hundredNs), 3);
+
+    [Fact]
+    public void DisplayProperties_FormatMilliseconds()
+    {
+        var s = new TimerResolutionStatus(5000, 156250, 5000, true);
+        Assert.Equal("0.5 ms", s.FinestDisplay);
+        Assert.Equal("15.625 ms", s.CoarsestDisplay);
+        Assert.Equal("0.5 ms", s.CurrentDisplay);
+    }
+
+    [Fact]
+    public void IsHighResolution_TrueWhenCurrentNearFinest()
+    {
+        // Current exactly at the finest achievable → high resolution.
+        var s = new TimerResolutionStatus(5000, 156250, 5000, true);
+        Assert.True(s.IsHighResolution);
+    }
+
+    [Fact]
+    public void IsHighResolution_TrueWithinTolerance()
+    {
+        // The effective value can land a few units off the requested one.
+        var s = new TimerResolutionStatus(5000, 156250, 5400, true);
+        Assert.True(s.IsHighResolution);
+    }
+
+    [Fact]
+    public void IsHighResolution_FalseAtDefaultCoarseTimer()
+    {
+        // Sitting at the ~15.6 ms Windows default → not high resolution.
+        var s = new TimerResolutionStatus(5000, 156250, 156250, false);
+        Assert.False(s.IsHighResolution);
+    }
+
+    [Fact]
+    public void FormatMs_TrimsTrailingZeros()
+    {
+        Assert.Equal("1 ms", TimerResolutionStatus.FormatMs(1.0));
+        Assert.Equal("0.5 ms", TimerResolutionStatus.FormatMs(0.5));
+        Assert.Equal("15.625 ms", TimerResolutionStatus.FormatMs(15.625));
+    }
+}

--- a/SysManager/SysManager/Models/TimerResolutionStatus.cs
+++ b/SysManager/SysManager/Models/TimerResolutionStatus.cs
@@ -1,0 +1,42 @@
+// SysManager · TimerResolutionStatus
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// A snapshot of the Windows multimedia timer resolution. All raw values are in
+/// 100-nanosecond units (the unit NtQueryTimerResolution reports); the display
+/// helpers convert to milliseconds (value / 10000).
+///
+/// Note the deliberately counter-intuitive Windows naming: the *finest* achievable
+/// resolution is the SMALLEST number (e.g. 5000 = 0.5 ms), and the *coarsest*
+/// (default) is the LARGEST (e.g. 156250 ≈ 15.6 ms).
+/// </summary>
+public sealed record TimerResolutionStatus(
+    uint FinestHundredNs,
+    uint CoarsestHundredNs,
+    uint CurrentHundredNs,
+    bool EnabledByApp)
+{
+    /// <summary>100-nanosecond units → milliseconds.</summary>
+    public static double ToMilliseconds(uint hundredNs) => hundredNs / 10000.0;
+
+    public double FinestMs => ToMilliseconds(FinestHundredNs);
+    public double CoarsestMs => ToMilliseconds(CoarsestHundredNs);
+    public double CurrentMs => ToMilliseconds(CurrentHundredNs);
+
+    public string FinestDisplay => FormatMs(FinestMs);
+    public string CoarsestDisplay => FormatMs(CoarsestMs);
+    public string CurrentDisplay => FormatMs(CurrentMs);
+
+    /// <summary>
+    /// True when the timer is running at (near) its finest achievable resolution —
+    /// i.e. a high-resolution timer is in effect. Uses a small tolerance because the
+    /// effective value can be a few units off the requested one.
+    /// </summary>
+    public bool IsHighResolution => CurrentHundredNs <= FinestHundredNs + 500;
+
+    /// <summary>Formats a millisecond value compactly, e.g. "0.5 ms" / "15.625 ms".</summary>
+    public static string FormatMs(double ms) => $"{ms:0.###} ms";
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -72,6 +72,7 @@ public static class ServiceRegistration
         services.AddSingleton<PrivacyMonitorService>();
         services.AddSingleton<BootAnalyzerService>();
         services.AddSingleton<WindowsUpdateService>();
+        services.AddSingleton<TimerResolutionService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
         services.AddSingleton<DashboardViewModel>();
@@ -116,6 +117,7 @@ public static class ServiceRegistration
         services.AddSingleton<BrowserCleanerViewModel>();
         services.AddSingleton<PrivacyMonitorViewModel>();
         services.AddSingleton<BootAnalyzerViewModel>();
+        services.AddSingleton<TimerResolutionViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/TimerResolutionService.cs
+++ b/SysManager/SysManager/Services/TimerResolutionService.cs
@@ -1,0 +1,123 @@
+// SysManager · TimerResolutionService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Runtime.InteropServices;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Controls the Windows multimedia timer resolution via the ntdll
+/// <c>NtQueryTimerResolution</c> / <c>NtSetTimerResolution</c> APIs.
+///
+/// A finer timer resolution (e.g. 0.5 ms instead of the ~15.6 ms default) reduces
+/// input latency for games at the cost of higher power draw. The request is a
+/// per-process contribution that Windows reverts when this process exits, so it is
+/// fully reversible and needs no admin rights.
+///
+/// IMPORTANT lifetime caveat (Windows 10 2004+ / Windows 11): a request is honored
+/// for the requesting process but is no longer a system-wide global override, and on
+/// Windows 11 it can stop being honored while this app's window is occluded/minimized.
+/// We therefore always re-query the EFFECTIVE resolution after a set rather than
+/// trusting the requested value.
+/// </summary>
+public sealed partial class TimerResolutionService
+{
+    private bool _enabledByApp;
+
+    /// <summary>0.5 ms expressed in 100-nanosecond units — the common gaming target.</summary>
+    public const uint HalfMilliInHundredNs = 5000;
+
+    /// <summary>Read the achievable range and the resolution currently in effect.</summary>
+    public TimerResolutionStatus Query()
+    {
+        try
+        {
+            int status = NativeMethods.NtQueryTimerResolution(out uint finest, out uint coarsest, out uint current);
+            if (status != NativeMethods.StatusSuccess)
+            {
+                Log.Debug("NtQueryTimerResolution failed: NTSTATUS 0x{Status:X8}", status);
+                return new TimerResolutionStatus(0, 0, 0, _enabledByApp);
+            }
+            return new TimerResolutionStatus(finest, coarsest, current, _enabledByApp);
+        }
+        catch (DllNotFoundException ex)
+        {
+            Log.Warning("Timer resolution query unavailable: {Error}", ex.Message);
+            return new TimerResolutionStatus(0, 0, 0, _enabledByApp);
+        }
+    }
+
+    /// <summary>
+    /// Request the finest achievable timer resolution (clamped to the device's
+    /// reported minimum). Returns the status after re-querying the effective value.
+    /// </summary>
+    public TimerResolutionStatus Enable()
+    {
+        var status = Query();
+        if (status.FinestHundredNs == 0) return status; // query failed; nothing to set
+
+        // Never request finer than the hardware allows.
+        uint target = Math.Max(status.FinestHundredNs, HalfMilliInHundredNs);
+        if (target > status.FinestHundredNs) target = status.FinestHundredNs;
+
+        try
+        {
+            int set = NativeMethods.NtSetTimerResolution(target, true, out _);
+            if (set != NativeMethods.StatusSuccess)
+                Log.Debug("NtSetTimerResolution(enable) failed: NTSTATUS 0x{Status:X8}", set);
+            else
+                _enabledByApp = true;
+        }
+        catch (DllNotFoundException ex)
+        {
+            Log.Warning("Timer resolution set unavailable: {Error}", ex.Message);
+        }
+        return Query();
+    }
+
+    /// <summary>
+    /// Release this process's timer-resolution request, returning the timer toward the
+    /// system default. Returns the status after re-querying the effective value.
+    /// </summary>
+    public TimerResolutionStatus Disable()
+    {
+        var status = Query();
+        if (status.CoarsestHundredNs == 0) { _enabledByApp = false; return status; }
+
+        try
+        {
+            // SetResolution=false releases this process's prior request.
+            int rel = NativeMethods.NtSetTimerResolution(status.CoarsestHundredNs, false, out _);
+            if (rel != NativeMethods.StatusSuccess)
+                Log.Debug("NtSetTimerResolution(disable) failed: NTSTATUS 0x{Status:X8}", rel);
+        }
+        catch (DllNotFoundException ex)
+        {
+            Log.Warning("Timer resolution release unavailable: {Error}", ex.Message);
+        }
+        _enabledByApp = false;
+        return Query();
+    }
+
+    private static partial class NativeMethods
+    {
+        /// <summary>STATUS_SUCCESS.</summary>
+        public const int StatusSuccess = 0;
+
+        // NTSTATUS NtQueryTimerResolution(PULONG MaximumTime, PULONG MinimumTime, PULONG CurrentTime)
+        // Param order is (finest, coarsest, current) — "Maximum" (finest) comes FIRST.
+        [LibraryImport("ntdll.dll")]
+        internal static partial int NtQueryTimerResolution(out uint finest, out uint coarsest, out uint current);
+
+        // NTSTATUS NtSetTimerResolution(ULONG DesiredTime, BOOLEAN SetResolution, PULONG ActualTime)
+        // BOOLEAN is a 1-byte type → marshal bool as U1.
+        [LibraryImport("ntdll.dll")]
+        internal static partial int NtSetTimerResolution(
+            uint desiredTime,
+            [MarshalAs(UnmanagedType.U1)] bool setResolution,
+            out uint actualTime);
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.34.0</Version>
-    <FileVersion>1.34.0.0</FileVersion>
-    <AssemblyVersion>1.34.0.0</AssemblyVersion>
+    <Version>1.35.0</Version>
+    <FileVersion>1.35.0.0</FileVersion>
+    <AssemblyVersion>1.35.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -57,6 +57,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public BrowserCleanerViewModel BrowserCleaner { get; }
     public PrivacyMonitorViewModel PrivacyMonitor { get; }
     public BootAnalyzerViewModel BootAnalyzer { get; }
+    public TimerResolutionViewModel TimerResolution { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -159,6 +160,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             BrowserCleaner = sp.GetRequiredService<BrowserCleanerViewModel>();
             PrivacyMonitor = sp.GetRequiredService<PrivacyMonitorViewModel>();
             BootAnalyzer = sp.GetRequiredService<BootAnalyzerViewModel>();
+            TimerResolution = sp.GetRequiredService<TimerResolutionViewModel>();
         }
         else
         {
@@ -220,6 +222,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             BrowserCleaner = new BrowserCleanerViewModel(new BrowserCleanerService());
             PrivacyMonitor = new PrivacyMonitorViewModel(new PrivacyMonitorService());
             BootAnalyzer = new BootAnalyzerViewModel(new BootAnalyzerService());
+            TimerResolution = new TimerResolutionViewModel(new TimerResolutionService());
         }
 
         InitPlaceholders();
@@ -306,7 +309,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         Group("grp-gaming", "Gaming & Profiles", "",
             Item("nav-gaming-profile",   "Gaming Profile",       "", WipGamingProfile,      typeof(Views.PlaceholderView)),
             Item("nav-standby-cleaner",  "Standby List Cleaner", "", WipStandbyListCleaner, typeof(Views.PlaceholderView)),
-            Item("nav-timer-resolution", "Timer Resolution",     "", WipTimerResolution,    typeof(Views.PlaceholderView)),
+            Item("nav-timer-resolution", "Timer Resolution",     "", TimerResolution,       typeof(Views.TimerResolutionView), inDevelopment: true),
             Item("nav-cpu-affinity",     "CPU Core Affinity",    "", WipCpuAffinity,        typeof(Views.PlaceholderView)),
             Item("nav-display-profiles", "Display Profiles",     "", WipDisplayProfiles,    typeof(Views.PlaceholderView))),
 

--- a/SysManager/SysManager/ViewModels/TimerResolutionViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TimerResolutionViewModel.cs
@@ -1,0 +1,78 @@
+// SysManager · TimerResolutionViewModel
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the Timer Resolution tab. Shows the current Windows timer
+/// resolution and lets the user request the finest available (≈0.5 ms) to reduce
+/// input latency in games, or release it back toward the default. Fully reversible;
+/// no admin required.
+/// </summary>
+public sealed partial class TimerResolutionViewModel : ViewModelBase
+{
+    private readonly TimerResolutionService _service;
+
+    [ObservableProperty] private string _currentDisplay = "—";
+    [ObservableProperty] private string _finestDisplay = "—";
+    [ObservableProperty] private string _coarsestDisplay = "—";
+    [ObservableProperty] private bool _isHighResolution;
+    [ObservableProperty] private bool _isSupported = true;
+
+    public TimerResolutionViewModel(TimerResolutionService service)
+    {
+        _service = service;
+        StatusMessage = "Reading timer resolution…";
+        InitializeAsync(RefreshAsync);
+    }
+
+    [RelayCommand]
+    private async Task RefreshAsync()
+    {
+        var status = await Task.Run(_service.Query).ConfigureAwait(true);
+        Apply(status);
+        StatusMessage = IsSupported
+            ? (IsHighResolution
+                ? "High-resolution timer is active."
+                : "Timer is at the Windows default.")
+            : "Timer resolution information is not available on this system.";
+    }
+
+    [RelayCommand(CanExecute = nameof(CanEnable))]
+    private async Task EnableAsync()
+    {
+        var status = await Task.Run(_service.Enable).ConfigureAwait(true);
+        Apply(status);
+        StatusMessage = IsHighResolution
+            ? $"High-resolution timer enabled ({status.CurrentDisplay})."
+            : "Could not raise the timer resolution on this system.";
+    }
+
+    [RelayCommand(CanExecute = nameof(CanDisable))]
+    private async Task DisableAsync()
+    {
+        var status = await Task.Run(_service.Disable).ConfigureAwait(true);
+        Apply(status);
+        StatusMessage = "Released the timer request — back to the Windows default.";
+    }
+
+    private bool CanEnable => IsSupported && !IsHighResolution;
+    private bool CanDisable => IsSupported && IsHighResolution;
+
+    private void Apply(TimerResolutionStatus status)
+    {
+        IsSupported = status.CoarsestHundredNs != 0;
+        CurrentDisplay = IsSupported ? status.CurrentDisplay : "—";
+        FinestDisplay = IsSupported ? status.FinestDisplay : "—";
+        CoarsestDisplay = IsSupported ? status.CoarsestDisplay : "—";
+        IsHighResolution = IsSupported && status.IsHighResolution;
+        EnableCommand.NotifyCanExecuteChanged();
+        DisableCommand.NotifyCanExecuteChanged();
+    }
+}

--- a/SysManager/SysManager/Views/TimerResolutionView.xaml
+++ b/SysManager/SysManager/Views/TimerResolutionView.xaml
@@ -1,0 +1,100 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.TimerResolutionView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:TimerResolutionViewModel}"
+             Background="{DynamicResource Surface0}">
+
+    <Grid Margin="28,24,28,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Preview banner -->
+        <v:DevelopmentBanner Grid.Row="0" Margin="0,0,0,16"/>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="1" Margin="0,0,0,16">
+            <TextBlock Text="Timer Resolution" Style="{StaticResource Display}"/>
+            <TextBlock Text="Request a finer Windows timer for lower input latency in games. Fully reversible — released when you turn it off or close the app."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <!-- Current resolution card -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12">
+            <StackPanel>
+                <TextBlock Text="Current resolution" Style="{StaticResource SectionTitle}"/>
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0" VerticalAlignment="Center">
+                    <TextBlock Text="{Binding CurrentDisplay}" FontSize="30" FontWeight="Bold"
+                               Foreground="{DynamicResource TextPrimary}"/>
+                    <Border CornerRadius="6" Padding="8,3" Margin="14,0,0,0" VerticalAlignment="Center"
+                            Background="{DynamicResource Surface3}"
+                            Visibility="{Binding IsHighResolution, Converter={StaticResource FlexVis}}">
+                        <TextBlock Text="HIGH RESOLUTION" FontSize="11" FontWeight="Bold"
+                                   Foreground="{DynamicResource Success}"/>
+                    </Border>
+                </StackPanel>
+                <Grid Margin="0,14,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Border Grid.Column="0" Style="{StaticResource CardInner}" Margin="0,0,6,0">
+                        <StackPanel>
+                            <TextBlock Text="FINEST AVAILABLE" Style="{StaticResource Caption}"/>
+                            <TextBlock Text="{Binding FinestDisplay}" FontSize="16" FontWeight="SemiBold"
+                                       Foreground="{DynamicResource Info}" Margin="0,4,0,0"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Column="1" Style="{StaticResource CardInner}" Margin="6,0,0,0">
+                        <StackPanel>
+                            <TextBlock Text="WINDOWS DEFAULT" Style="{StaticResource Caption}"/>
+                            <TextBlock Text="{Binding CoarsestDisplay}" FontSize="16" FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextSecondary}" Margin="0,4,0,0"/>
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </StackPanel>
+        </Border>
+
+        <!-- Power warning -->
+        <Border Grid.Row="3" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
+                BorderThickness="1" CornerRadius="10" Padding="12,10" Margin="0,0,0,16">
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="&#xE9CE;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                           FontSize="14" Foreground="{DynamicResource WarningText}"
+                           VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <TextBlock Text="A finer timer wakes the CPU more often, which can increase power draw, heat and battery drain — most noticeable on laptops."
+                           Foreground="{DynamicResource WarningText}" FontSize="12.5"
+                           VerticalAlignment="Center" TextWrapping="Wrap"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Actions -->
+        <WrapPanel Grid.Row="4" Orientation="Horizontal" VerticalAlignment="Top">
+            <Button Content="Enable 0.5 ms timer" Command="{Binding EnableCommand}"
+                    Style="{StaticResource PrimaryButton}" Margin="0,0,8,8"
+                    AutomationProperties.Name="Enable high-resolution timer"/>
+            <Button Content="Restore default" Command="{Binding DisableCommand}"
+                    Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
+                    AutomationProperties.Name="Restore default timer resolution"/>
+            <Button Content="Refresh" Command="{Binding RefreshCommand}"
+                    Style="{StaticResource GhostButton}" Margin="0,0,8,8"
+                    AutomationProperties.Name="Refresh timer resolution"/>
+        </WrapPanel>
+
+        <!-- Status -->
+        <TextBlock Grid.Row="5" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+                   VerticalAlignment="Bottom" Margin="0,8,0,0" TextWrapping="Wrap"/>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/TimerResolutionView.xaml.cs
+++ b/SysManager/SysManager/Views/TimerResolutionView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · TimerResolutionView
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class TimerResolutionView : UserControl
+{
+    public TimerResolutionView() => InitializeComponent();
+}


### PR DESCRIPTION
## What
Implements **Timer Resolution** (Gaming & Profiles), replacing its WIP placeholder. Closes #326.

Lets gamers request the finest Windows timer resolution (~0.5 ms instead of the ~15.6 ms default) to reduce input latency, and restore it with one click.

## How
- **`TimerResolutionService`** — thin wrapper over ntdll `NtQueryTimerResolution` / `NtSetTimerResolution`.
  - Correct param order (`finest, coarsest, current` — "Maximum"/finest comes first).
  - `BOOLEAN` marshalled as `[MarshalAs(UnmanagedType.U1)]` (1-byte, not 4-byte BOOL).
  - The request is a **per-process contribution** Windows reverts on exit → fully reversible, **no admin** required.
- **Honest readout** — after a set it re-queries the *effective* resolution rather than echoing the requested value, because since Win10 2004 / Win11 the request can stop being honored (e.g. while the window is minimized/occluded).
- **`TimerResolutionStatus`** — holds the pure 100ns→ms conversion and high-resolution detection; unit-tested in isolation (no OS dependency).
- **View** — current / finest / default cards, a power-consumption warning, enable / restore / refresh actions, AutomationProperties.Name on all buttons.

## Preview
Marked **PREVIEW** (sidebar pill + banner) via the badge mechanism — implemented and usable, pending QA verification.

## Tests
- `TimerResolutionStatusTests` — 100ns→ms conversion (0.5/1/15.625 ms), display formatting, high-resolution detection + tolerance, default-timer case.
- Integration: `NavLeaf_TimerResolution_IsImplementedAndMarkedPreview` pins the WIP→real-view swap + the preview flag.

## Verification
- Build main + unit + integration: 0/0. Leak scan clean. P/Invoke has no A/W variants (no EntryPoint needed).
- README + ARCHITECTURE updated (counts 40→41 implemented / 17→16 WIP; new service/VM described). feat: -> minor 1.35.0.
