### PR TITLE
feat: add File Lock Detector tab to find and release file lockers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,7 +43,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Dashboard | `DashboardViewModel` |
 | System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `SystemFixesViewModel` · `BootAnalyzerViewModel` · `PlaceholderViewModel` (Task Scheduler) |
 | Gaming & Profiles | `TimerResolutionViewModel` · `PlaceholderViewModel` (Gaming Profile · Standby List Cleaner · CPU Core Affinity · Display Profiles) |
-| Monitor | `ProcessManagerViewModel` · `PrivacyMonitorViewModel` · `AppAlertsViewModel` · `PlaceholderViewModel` (Resource History · File Lock Detector · Settings Watchdog · Bandwidth Monitor) |
+| Monitor | `ProcessManagerViewModel` · `PrivacyMonitorViewModel` · `AppAlertsViewModel` · `FileLockViewModel` · `PlaceholderViewModel` (Resource History · Settings Watchdog · Bandwidth Monitor) |
 | Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `PlaceholderViewModel` (Scheduled Maintenance) |
 | Storage | `DiskAnalyzerViewModel` · `DuplicateFileViewModel` |
 | Network | `PingViewModel` · `TracerouteViewModel` · `SpeedTestViewModel` · `NetworkRepairViewModel` (shared: `NetworkSharedState`) · `DnsHostsViewModel` |
@@ -94,6 +94,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `SystemFixesViewModel` — consolidated one-click repairs (Windows Update reset, network reset, WinGet reinstall) with per-fix confirmation + live output; opens netplwiz for secure auto-logon.
 - `BootAnalyzerViewModel` — read-only boot-time history + slow-component breakdown from the Diagnostics-Performance log, with a trend vs recent average; needs admin to read the log.
 - `TimerResolutionViewModel` — request the finest Windows timer resolution (≈0.5 ms) for lower game input latency, or release it; shows the live effective value. _Preview._
+- `FileLockViewModel` — find which processes are holding a file/folder (Restart Manager) and optionally end a selected one after confirmation; critical processes are protected. _Preview._
 - `ProfileViewModel` — export/import SysManager's own config (theme, speed-test history) as a portable JSON profile with selective sections and version checking.
 - `DebloaterViewModel` — list and remove preinstalled Store apps with a curated bloat preset; system-critical packages are denylisted; removal is per-user and reversible via the Store.
 - `BrowserCleanerViewModel` — scan per-browser cache/history/cookies/sessions with sizes and clean the selected categories; cookies/sessions default unticked.
@@ -233,6 +234,10 @@ Key services:
   `NtSetTimerResolution`. The request is a per-process contribution Windows reverts
   on exit, so it's fully reversible and needs no admin; the 100ns→ms conversion and
   high-resolution detection are pure, unit-tested static methods on the model.
+- `FileLockService` — Restart Manager (`rstrtmgr.dll`) wrapper that lists the processes
+  using a file/folder and can terminate one. The one place we use classic `[DllImport]`
+  (not `[LibraryImport]`): `RM_PROCESS_INFO` has inline `ByValTStr` buffers and
+  `RmStartSession` needs a `StringBuilder`, neither supported by the source generator.
 - `LegacyPanelService` — opens classic Windows applets (Control Panel, Sound,
   Device Manager, …) via their `control`/`*.cpl`/`*.msc` commands. The catalog is
   hard-coded and `Launch` re-validates catalog membership, so no input reaches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.36.0] - 2026-06-26
+
+### Added
+- **File Lock Detector tab (Monitor).** When you hit a "file is in use" error, enter or browse to the file/folder and see exactly which process is holding it — name, PID, type and start time — via the Windows Restart Manager (the same mechanism Explorer's own dialog uses). You can end a selected locking process (with confirmation) to release the file; critical system processes are protected. Detecting works as a standard user; ending a process owned by SYSTEM or another user needs admin (surfaced cleanly, never crashes). Marked **PREVIEW** while it's verified. Closes #333.
+
 ## [1.35.0] - 2026-06-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ fully open source.
 
 ### Sidebar navigation
 The sidebar organises 57 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 41 tabs are fully
-implemented; 16 are work-in-progress placeholders marked with ⚙️. Newly added
+find what you need without scrolling through a flat list. 42 tabs are fully
+implemented; 15 are work-in-progress placeholders marked with ⚙️. Newly added
 tabs still being verified are marked **PREVIEW**:
 
 | Group | Tabs |
@@ -83,7 +83,7 @@ tabs still being verified are marked **PREVIEW**:
 | 🏠 Dashboard | Dashboard |
 | 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · System Fixes · Boot Analyzer · Task Scheduler ⚙️ |
 | 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner ⚙️ · Timer Resolution 🔬 · CPU Core Affinity ⚙️ · Display Profiles ⚙️ |
-| 📊 Monitor | Process Manager · Resource History ⚙️ · Camera/Mic/Location · App Alerts · File Lock Detector ⚙️ · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
+| 📊 Monitor | Process Manager · Resource History ⚙️ · Camera/Mic/Location · App Alerts · File Lock Detector 🔬 · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance ⚙️ |
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS & Hosts |
@@ -324,6 +324,17 @@ a confirmation before it runs:
   (System, Trusted, Unknown)
 - Kill process with confirmation dialog
 - Open file location in Explorer
+
+### File Lock Detector 🔬
+- **Find what's holding a file** — when you get a "file in use" error, enter or
+  browse to a file/folder path and see which process(es) are using it, via the
+  Windows Restart Manager (the same mechanism Explorer's own dialog uses)
+- Shows process name, PID, type, and start time for each locker
+- **End process** — terminate a selected locker (with confirmation) to release
+  the file; critical system processes are protected from termination
+- Detection works as a standard user; ending a process owned by SYSTEM or
+  another user needs administrator rights (surfaced, not crashed)
+- _Preview — implemented and usable, still being verified._
 
 ### Camera/Mic/Location
 - Shows which apps recently used your **camera, microphone, or location**, and when

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -360,4 +360,14 @@ public class MainWindowViewModelTests
         // Surfaced as PREVIEW until verified.
         Assert.True(item.IsInDevelopment);
     }
+
+    [Fact]
+    public void NavLeaf_FileLock_IsImplementedAndMarkedPreview()
+    {
+        var vm = new MainWindowViewModel();
+        var item = vm.NavItems.First(n => n.Id == "nav-file-lock");
+        Assert.Equal(typeof(SysManager.Views.FileLockView), item.ViewType);
+        Assert.IsType<FileLockViewModel>(item.Content);
+        Assert.True(item.IsInDevelopment);
+    }
 }

--- a/SysManager/SysManager.Tests/FileLockerTests.cs
+++ b/SysManager/SysManager.Tests/FileLockerTests.cs
@@ -1,0 +1,43 @@
+// SysManager · FileLockerTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Tests;
+
+public class FileLockerTests
+{
+    [Fact]
+    public void Display_CombinesNameAndPid()
+    {
+        var l = new FileLocker(1234, "explorer.exe", "RmExplorer", null);
+        Assert.Equal("explorer.exe (1234)", l.Display);
+    }
+
+    [Fact]
+    public void StartTimeDisplay_ShowsDashWhenNull()
+    {
+        var l = new FileLocker(1, "a.exe", "RmMainWindow", null);
+        Assert.Equal("—", l.StartTimeDisplay);
+    }
+
+    [Fact]
+    public void StartTimeDisplay_FormatsWhenPresent()
+    {
+        var when = new DateTime(2026, 6, 26, 14, 30, 5, DateTimeKind.Local);
+        var l = new FileLocker(1, "a.exe", "RmMainWindow", when);
+        Assert.Equal("2026-06-26 14:30:05", l.StartTimeDisplay);
+    }
+
+    [Theory]
+    [InlineData("RmCritical", true)]
+    [InlineData("rmcritical", true)]
+    [InlineData("RmMainWindow", false)]
+    [InlineData("RmService", false)]
+    public void IsCritical_TrueOnlyForCriticalAppType(string appType, bool expected)
+    {
+        var l = new FileLocker(1, "a.exe", appType, null);
+        Assert.Equal(expected, l.IsCritical);
+    }
+}

--- a/SysManager/SysManager/Models/FileLocker.cs
+++ b/SysManager/SysManager/Models/FileLocker.cs
@@ -1,0 +1,27 @@
+// SysManager · FileLocker
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// A single process that the Windows Restart Manager reports as holding a lock on
+/// (or otherwise using) a queried file or folder.
+/// </summary>
+public sealed record FileLocker(
+    int ProcessId,
+    string ProcessName,
+    string AppType,
+    DateTime? StartTime)
+{
+    /// <summary>Friendly label, e.g. "explorer.exe (12345)".</summary>
+    public string Display => $"{ProcessName} ({ProcessId})";
+
+    public string StartTimeDisplay => StartTime is { } t ? t.ToString("yyyy-MM-dd HH:mm:ss") : "—";
+
+    /// <summary>
+    /// True for processes the Restart Manager flags as critical/system — terminating
+    /// these is dangerous and the UI should warn or block.
+    /// </summary>
+    public bool IsCritical => AppType.Equals("RmCritical", StringComparison.OrdinalIgnoreCase);
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -73,6 +73,7 @@ public static class ServiceRegistration
         services.AddSingleton<BootAnalyzerService>();
         services.AddSingleton<WindowsUpdateService>();
         services.AddSingleton<TimerResolutionService>();
+        services.AddSingleton<FileLockService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
         services.AddSingleton<DashboardViewModel>();
@@ -118,6 +119,7 @@ public static class ServiceRegistration
         services.AddSingleton<PrivacyMonitorViewModel>();
         services.AddSingleton<BootAnalyzerViewModel>();
         services.AddSingleton<TimerResolutionViewModel>();
+        services.AddSingleton<FileLockViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/FileLockService.cs
+++ b/SysManager/SysManager/Services/FileLockService.cs
@@ -1,0 +1,207 @@
+// SysManager · FileLockService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using Serilog;
+using SysManager.Models;
+using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Identifies which processes are holding a lock on (or otherwise using) a file or
+/// folder, using the Windows Restart Manager (rstrtmgr.dll) — the same mechanism
+/// Explorer uses for its "file in use" dialog. Enumeration works for a standard user;
+/// terminating a locker owned by SYSTEM or another user requires elevation.
+///
+/// NOTE on interop style: this is the one place we use classic <c>[DllImport]</c> with
+/// <c>CharSet.Unicode</c> rather than the project-preferred <c>[LibraryImport]</c>.
+/// <c>RM_PROCESS_INFO</c> contains inline <c>ByValTStr</c> buffers (non-blittable), and
+/// <c>RmStartSession</c> takes a <c>StringBuilder</c> out-buffer — neither is supported
+/// by the <c>[LibraryImport]</c> source generator (it emits SYSLIB1051). The Restart
+/// Manager functions have no A/W variants, so no <c>EntryPoint</c> suffix is needed.
+/// </summary>
+public sealed class FileLockService
+{
+    /// <summary>
+    /// Returns the processes currently using <paramref name="path"/> (a file or folder).
+    /// Empty when nothing holds it. Throws <see cref="ArgumentException"/> for bad input.
+    /// </summary>
+    public IReadOnlyList<FileLocker> FindLockers(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("Path must not be empty.", nameof(path));
+
+        var key = new StringBuilder(NativeMethods.CchRmSessionKey + 1); // 33 chars
+        int rv = NativeMethods.RmStartSession(out uint handle, 0, key);
+        if (rv != NativeMethods.ErrorSuccess)
+        {
+            Log.Debug("RmStartSession failed: {Code}", rv);
+            return [];
+        }
+
+        try
+        {
+            string[] resources = [path];
+            rv = NativeMethods.RmRegisterResources(handle,
+                (uint)resources.Length, resources, 0, null, 0, null);
+            if (rv != NativeMethods.ErrorSuccess)
+            {
+                Log.Debug("RmRegisterResources failed: {Code}", rv);
+                return [];
+            }
+
+            const int maxRetries = 6;
+            uint pnProcInfo = 0;
+            NativeMethods.RM_PROCESS_INFO[]? info = null;
+
+            for (int attempt = 0; attempt < maxRetries; attempt++)
+            {
+                rv = NativeMethods.RmGetList(handle, out uint needed, ref pnProcInfo, info, out _);
+
+                if (rv == NativeMethods.ErrorSuccess)
+                {
+                    if (pnProcInfo == 0 || info is null) return [];
+                    var result = new List<FileLocker>((int)pnProcInfo);
+                    for (int i = 0; i < pnProcInfo; i++)
+                        result.Add(Map(info[i]));
+                    return result;
+                }
+
+                if (rv != NativeMethods.ErrorMoreData)
+                {
+                    Log.Debug("RmGetList failed: {Code}", rv);
+                    return [];
+                }
+
+                // Restart Manager re-snapshots each call, so the count can grow — loop.
+                pnProcInfo = needed;
+                info = new NativeMethods.RM_PROCESS_INFO[needed];
+            }
+
+            Log.Debug("RmGetList: locker list kept growing past retry limit for {Path}", path);
+            return [];
+        }
+        finally
+        {
+            NativeMethods.RmEndSession(handle);
+        }
+    }
+
+    /// <summary>
+    /// Terminates the process with the given id. Returns true on success. Returns false
+    /// (and logs) if the process is gone, access is denied (needs elevation), or it exits
+    /// on its own. Callers must confirm with the user first.
+    /// </summary>
+    public bool KillProcess(int processId)
+    {
+        try
+        {
+            using var p = Process.GetProcessById(processId);
+            p.Kill();
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            // Process already exited / no such id.
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+        catch (Win32Exception ex)
+        {
+            // Typically access denied — the target is higher integrity / another user.
+            Log.Debug("Kill process {Pid} denied: {Error}", processId, ex.Message);
+            return false;
+        }
+    }
+
+    private static FileLocker Map(in NativeMethods.RM_PROCESS_INFO p)
+    {
+        DateTime? start = null;
+        try
+        {
+            long ft = ((long)p.Process.ProcessStartTime.dwHighDateTime << 32)
+                      | (uint)p.Process.ProcessStartTime.dwLowDateTime;
+            if (ft > 0) start = DateTime.FromFileTime(ft);
+        }
+        catch (ArgumentOutOfRangeException) { /* leave start null on bad FILETIME */ }
+
+        string name = string.IsNullOrWhiteSpace(p.strAppName) ? "(unknown)" : p.strAppName;
+        return new FileLocker((int)p.Process.dwProcessId, name, p.ApplicationType.ToString(), start);
+    }
+
+    private static class NativeMethods
+    {
+        public const int ErrorSuccess = 0;
+        public const int ErrorMoreData = 234;
+        public const int CchRmSessionKey = 32;       // CCH_RM_SESSION_KEY (buffer = +1)
+        private const int CchRmMaxAppName = 255;     // CCH_RM_MAX_APP_NAME
+        private const int CchRmMaxSvcName = 63;      // CCH_RM_MAX_SVC_NAME
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct RM_UNIQUE_PROCESS
+        {
+            public uint dwProcessId;
+            public FILETIME ProcessStartTime;
+        }
+
+        public enum RM_APP_TYPE
+        {
+            RmUnknownApp = 0,
+            RmMainWindow = 1,
+            RmOtherWindow = 2,
+            RmService = 3,
+            RmExplorer = 4,
+            RmConsole = 5,
+            RmCritical = 1000,
+        }
+
+        // CharSet.Unicode on the struct is REQUIRED so ByValTStr reads 2-byte WCHARs.
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct RM_PROCESS_INFO
+        {
+            public RM_UNIQUE_PROCESS Process;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CchRmMaxAppName + 1)]
+            public string strAppName;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CchRmMaxSvcName + 1)]
+            public string strServiceShortName;
+
+            public RM_APP_TYPE ApplicationType;
+            public uint AppStatus;
+            public uint TSSessionId;
+
+            [MarshalAs(UnmanagedType.Bool)]
+            public bool bRestartable;
+        }
+
+        [DllImport("rstrtmgr.dll", CharSet = CharSet.Unicode)]
+        public static extern int RmStartSession(out uint pSessionHandle, int dwSessionFlags, StringBuilder strSessionKey);
+
+        [DllImport("rstrtmgr.dll", CharSet = CharSet.Unicode)]
+        public static extern int RmRegisterResources(
+            uint pSessionHandle,
+            uint nFiles, string[]? rgsFilenames,
+            uint nApplications, RM_UNIQUE_PROCESS[]? rgApplications,
+            uint nServices, string[]? rgsServiceNames);
+
+        [DllImport("rstrtmgr.dll", CharSet = CharSet.Unicode)]
+        public static extern int RmGetList(
+            uint dwSessionHandle,
+            out uint pnProcInfoNeeded,
+            ref uint pnProcInfo,
+            [In, Out] RM_PROCESS_INFO[]? rgAffectedApps,
+            out uint lpdwRebootReasons);
+
+        [DllImport("rstrtmgr.dll")]
+        public static extern int RmEndSession(uint pSessionHandle);
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.35.0</Version>
-    <FileVersion>1.35.0.0</FileVersion>
-    <AssemblyVersion>1.35.0.0</AssemblyVersion>
+    <Version>1.36.0</Version>
+    <FileVersion>1.36.0.0</FileVersion>
+    <AssemblyVersion>1.36.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/FileLockViewModel.cs
+++ b/SysManager/SysManager/ViewModels/FileLockViewModel.cs
@@ -1,0 +1,130 @@
+// SysManager · FileLockViewModel
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the File Lock Detector tab. Takes a file/folder path and reports the
+/// processes using it via the Restart Manager, with an option to terminate a locker
+/// (after confirmation). Detection works as a standard user; killing a locker owned by
+/// SYSTEM or another user needs elevation, surfaced rather than thrown.
+/// </summary>
+public sealed partial class FileLockViewModel : ViewModelBase
+{
+    private readonly FileLockService _service;
+
+    public BulkObservableCollection<FileLocker> Lockers { get; } = new();
+
+    [ObservableProperty] private string _path = "";
+    [ObservableProperty] private bool _hasScanned;
+    [ObservableProperty] private FileLocker? _selectedLocker;
+
+    public FileLockViewModel(FileLockService service)
+    {
+        _service = service;
+        StatusMessage = "Enter a file or folder path, then scan to see what's using it.";
+        PropertyChanged += OnVmPropertyChanged;
+    }
+
+    private bool CanScan => !IsBusy && !string.IsNullOrWhiteSpace(Path);
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(IsBusy))
+        {
+            ScanCommand.NotifyCanExecuteChanged();
+            KillSelectedCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    partial void OnPathChanged(string value) => ScanCommand.NotifyCanExecuteChanged();
+    partial void OnSelectedLockerChanged(FileLocker? value) => KillSelectedCommand.NotifyCanExecuteChanged();
+
+    [RelayCommand]
+    private void Browse()
+    {
+        var dialog = new Microsoft.Win32.OpenFileDialog
+        {
+            Title = "Select a file to check",
+            CheckFileExists = false,
+            Filter = "All files (*.*)|*.*"
+        };
+        if (dialog.ShowDialog() == true)
+            Path = dialog.FileName;
+    }
+
+    [RelayCommand(CanExecute = nameof(CanScan))]
+    private async Task ScanAsync()
+    {
+        IsBusy = true;
+        IsProgressIndeterminate = true;
+        StatusMessage = "Scanning…";
+        try
+        {
+            string target = Path.Trim().Trim('"');
+            var lockers = await Task.Run(() => _service.FindLockers(target)).ConfigureAwait(true);
+            Lockers.ReplaceWith(lockers);
+            HasScanned = true;
+            StatusMessage = lockers.Count == 0
+                ? "No process is currently using that path."
+                : $"{lockers.Count} process(es) are using that path.";
+        }
+        catch (ArgumentException)
+        {
+            StatusMessage = "Please enter a valid file or folder path.";
+        }
+        finally
+        {
+            IsBusy = false;
+            IsProgressIndeterminate = false;
+        }
+    }
+
+    private bool CanKill => !IsBusy && SelectedLocker is not null;
+
+    [RelayCommand(CanExecute = nameof(CanKill))]
+    private void KillSelected()
+    {
+        var locker = SelectedLocker;
+        if (locker is null) return;
+
+        if (locker.IsCritical)
+        {
+            DialogService.Instance.Confirm(
+                $"\"{locker.ProcessName}\" is a critical system process and cannot be safely ended from here.",
+                "Cannot End Process");
+            return;
+        }
+
+        if (!DialogService.Instance.Confirm(
+            $"End \"{locker.Display}\"?\n\nUnsaved work in that process will be lost. This force-terminates the process to release the file.",
+            "End Process — Confirm")) return;
+
+        bool ok = _service.KillProcess(locker.ProcessId);
+        if (ok)
+        {
+            Log.Information("User ended locking process {Pid} ({Name})", locker.ProcessId, locker.ProcessName);
+            StatusMessage = $"Ended {locker.Display}. Re-scanning…";
+            ScanCommand.Execute(null);
+        }
+        else
+        {
+            StatusMessage = $"Couldn't end {locker.Display} — it may need administrator rights, or it already exited.";
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+            PropertyChanged -= OnVmPropertyChanged;
+        base.Dispose(disposing);
+    }
+}

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -58,6 +58,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public PrivacyMonitorViewModel PrivacyMonitor { get; }
     public BootAnalyzerViewModel BootAnalyzer { get; }
     public TimerResolutionViewModel TimerResolution { get; }
+    public FileLockViewModel FileLock { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -161,6 +162,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             PrivacyMonitor = sp.GetRequiredService<PrivacyMonitorViewModel>();
             BootAnalyzer = sp.GetRequiredService<BootAnalyzerViewModel>();
             TimerResolution = sp.GetRequiredService<TimerResolutionViewModel>();
+            FileLock = sp.GetRequiredService<FileLockViewModel>();
         }
         else
         {
@@ -223,6 +225,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             PrivacyMonitor = new PrivacyMonitorViewModel(new PrivacyMonitorService());
             BootAnalyzer = new BootAnalyzerViewModel(new BootAnalyzerService());
             TimerResolution = new TimerResolutionViewModel(new TimerResolutionService());
+            FileLock = new FileLockViewModel(new FileLockService());
         }
 
         InitPlaceholders();
@@ -318,7 +321,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-resource-history",  "Resource History",   "", WipResourceHistory,  typeof(Views.PlaceholderView)),
             Item("nav-privacy-monitor",   "Camera/Mic/Location",    "", PrivacyMonitor,      typeof(Views.PrivacyMonitorView)),
             Item("nav-app-alerts",        "App Alerts",         "", AppAlerts,           typeof(Views.AppAlertsView)),
-            Item("nav-file-lock",         "File Lock Detector", "", WipFileLockDetector, typeof(Views.PlaceholderView)),
+            Item("nav-file-lock",         "File Lock Detector", "", FileLock,            typeof(Views.FileLockView), inDevelopment: true),
             Item("nav-settings-watchdog", "Settings Watchdog",  "", WipSettingsWatchdog, typeof(Views.PlaceholderView)),
             Item("nav-bandwidth-monitor", "Bandwidth Monitor",  "", WipBandwidthMonitor, typeof(Views.PlaceholderView))),
 

--- a/SysManager/SysManager/Views/FileLockView.xaml
+++ b/SysManager/SysManager/Views/FileLockView.xaml
@@ -1,0 +1,91 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.FileLockView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:FileLockViewModel}"
+             Background="{DynamicResource Surface0}">
+
+    <Grid Margin="28,24,28,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Preview banner -->
+        <v:DevelopmentBanner Grid.Row="0" Margin="0,0,0,16"/>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="1" Margin="0,0,0,16">
+            <TextBlock Text="File Lock Detector" Style="{StaticResource Display}"/>
+            <TextBlock Text="Find out which process is holding a file or folder open when you get a &quot;file in use&quot; error."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <!-- Input toolbar -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBox Grid.Column="0" Text="{Binding Path, UpdateSourceTrigger=PropertyChanged}"
+                         VerticalContentAlignment="Center" Padding="10,8" FontSize="13"
+                         AutomationProperties.Name="File or folder path"
+                         ToolTip="Enter or paste a full file/folder path"/>
+                <Button Grid.Column="1" Content="Browse…" Command="{Binding BrowseCommand}"
+                        Style="{StaticResource SecondaryButton}" Margin="8,0,0,0" Padding="14,8"
+                        AutomationProperties.Name="Browse for a file"/>
+                <Button Grid.Column="2" Content="Scan" Command="{Binding ScanCommand}"
+                        Style="{StaticResource PrimaryButton}" Margin="8,0,0,0" Padding="18,8"
+                        AutomationProperties.Name="Scan for locking processes"/>
+            </Grid>
+        </Border>
+
+        <!-- Results -->
+        <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
+            <Grid>
+                <DataGrid ItemsSource="{Binding Lockers}" SelectedItem="{Binding SelectedLocker}"
+                          AutomationProperties.Name="Locking processes"
+                          AutoGenerateColumns="False" HeadersVisibility="Column"
+                          CanUserAddRows="False" IsReadOnly="True" SelectionMode="Single"
+                          Background="Transparent" BorderThickness="0" GridLinesVisibility="None"
+                          VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Process" Binding="{Binding ProcessName}" Width="*"/>
+                        <DataGridTextColumn Header="PID" Binding="{Binding ProcessId}" Width="80"/>
+                        <DataGridTextColumn Header="Type" Binding="{Binding AppType}" Width="120"/>
+                        <DataGridTextColumn Header="Started" Binding="{Binding StartTimeDisplay}" Width="160"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+
+                <!-- Empty state -->
+                <TextBlock Text="No results yet — scan a path to see what's using it."
+                           Foreground="{DynamicResource TextMuted}" FontSize="13"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           Visibility="{Binding HasScanned, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+            </Grid>
+        </Border>
+
+        <!-- Actions + status -->
+        <Grid Grid.Row="4" Margin="0,12,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+                       VerticalAlignment="Center" TextWrapping="Wrap"/>
+            <Button Grid.Column="1" Content="End process" Command="{Binding KillSelectedCommand}"
+                    Style="{StaticResource DangerButton}" Padding="14,8"
+                    AutomationProperties.Name="End the selected process"/>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/FileLockView.xaml.cs
+++ b/SysManager/SysManager/Views/FileLockView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · FileLockView
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class FileLockView : UserControl
+{
+    public FileLockView() => InitializeComponent();
+}


### PR DESCRIPTION
## What
Implements **File Lock Detector** (Monitor group), replacing its WIP placeholder. Closes #333.

When you hit a "file is in use" error, this tab tells you exactly which process is holding the file or folder — and lets you end it to release the file.

## How
- **`FileLockService`** — wraps the Windows **Restart Manager** (`rstrtmgr.dll`): `RmStartSession` → `RmRegisterResources` → `RmGetList` (two-call grow loop, retries on `ERROR_MORE_DATA`) → `RmEndSession` in a `finally`. Same mechanism Explorer's own dialog uses.
- **Interop note** — this is the one place using classic `[DllImport]` with `CharSet.Unicode` instead of `[LibraryImport]`: `RM_PROCESS_INFO` has inline `ByValTStr` buffers (non-blittable) and `RmStartSession` needs a `StringBuilder` — neither is supported by the `[LibraryImport]` source generator (SYSLIB1051). The functions have no A/W variants, so no `EntryPoint` is needed. Documented in the file + ARCHITECTURE.
- **Safety** — ending a process goes through `DialogService.Confirm`; processes the Restart Manager flags `RmCritical` are blocked from termination. Killing a higher-integrity / SYSTEM / other-user process needs admin — that's surfaced as a friendly status, never an unhandled exception (`Win32Exception`/`InvalidOperationException`/`ArgumentException` all handled specifically).

## Preview
Marked **PREVIEW** (sidebar pill + banner).

## Tests
- `FileLockerTests` — display formatting, null start-time, and `IsCritical` detection (incl. case-insensitive).
- Integration: `NavLeaf_FileLock_IsImplementedAndMarkedPreview` pins the WIP→real-view swap + preview flag.

## Verification
- Build main + unit + integration: 0/0. Leak scan clean. No generic/empty catch, no debug code.
- README + ARCHITECTURE updated (counts 41→42 implemented / 16→15 WIP; new service/VM described). feat: -> minor 1.36.0.
