### PR TITLE
feat: add Display Profiles tab to switch resolution and refresh rate

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,7 +42,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 |-------|-------------|
 | Dashboard | `DashboardViewModel` |
 | System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `SystemFixesViewModel` · `BootAnalyzerViewModel` · `PlaceholderViewModel` (Task Scheduler) |
-| Gaming & Profiles | `TimerResolutionViewModel` · `PlaceholderViewModel` (Gaming Profile · Standby List Cleaner · CPU Core Affinity · Display Profiles) |
+| Gaming & Profiles | `TimerResolutionViewModel` · `DisplayProfileViewModel` · `PlaceholderViewModel` (Gaming Profile · Standby List Cleaner · CPU Core Affinity) |
 | Monitor | `ProcessManagerViewModel` · `PrivacyMonitorViewModel` · `AppAlertsViewModel` · `FileLockViewModel` · `PlaceholderViewModel` (Resource History · Settings Watchdog · Bandwidth Monitor) |
 | Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `PlaceholderViewModel` (Scheduled Maintenance) |
 | Storage | `DiskAnalyzerViewModel` · `DuplicateFileViewModel` |
@@ -95,6 +95,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `BootAnalyzerViewModel` — read-only boot-time history + slow-component breakdown from the Diagnostics-Performance log, with a trend vs recent average; needs admin to read the log.
 - `TimerResolutionViewModel` — request the finest Windows timer resolution (≈0.5 ms) for lower game input latency, or release it; shows the live effective value. _Preview._
 - `FileLockViewModel` — find which processes are holding a file/folder (Restart Manager) and optionally end a selected one after confirmation; critical processes are protected. _Preview._
+- `DisplayProfileViewModel` — list displays and supported resolution/refresh modes and switch between them; applies for the session with a 15-second auto-revert safety net. _Preview._
 - `ProfileViewModel` — export/import SysManager's own config (theme, speed-test history) as a portable JSON profile with selective sections and version checking.
 - `DebloaterViewModel` — list and remove preinstalled Store apps with a curated bloat preset; system-critical packages are denylisted; removal is per-user and reversible via the Store.
 - `BrowserCleanerViewModel` — scan per-browser cache/history/cookies/sessions with sizes and clean the selected categories; cookies/sessions default unticked.
@@ -238,6 +239,10 @@ Key services:
   using a file/folder and can terminate one. The one place we use classic `[DllImport]`
   (not `[LibraryImport]`): `RM_PROCESS_INFO` has inline `ByValTStr` buffers and
   `RmStartSession` needs a `StringBuilder`, neither supported by the source generator.
+- `DisplayProfileService` — `user32` display APIs (`EnumDisplayDevicesW` /
+  `EnumDisplaySettingsW` / `ChangeDisplaySettingsExW`) to read and switch resolution +
+  refresh rate. Session-only apply (reverts on reboot); validated with `CDS_TEST` first.
+  Also classic `[DllImport]` (DEVMODE has non-blittable inline buffers).
 - `LegacyPanelService` — opens classic Windows applets (Control Panel, Sound,
   Device Manager, …) via their `control`/`*.cpl`/`*.msc` commands. The catalog is
   hard-coded and `Launch` re-validates catalog membership, so no input reaches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.37.0] - 2026-06-26
+
+### Added
+- **Display Profiles tab (Gaming & Profiles).** Quickly switch resolution and refresh rate per monitor — e.g. 165 Hz for gaming, 60 Hz for work — from the list of modes your display actually supports, using only the Windows display APIs (no NVIDIA/AMD tool conflict). Safe by design: changes apply for the session (a reboot reverts), and a **15-second auto-revert** restores the previous mode unless you confirm "Keep", so a bad mode can never strand you on a blank screen. Each mode is validated before applying; no admin needed. Marked **PREVIEW** while it's verified. Closes #328.
+
 ## [1.36.0] - 2026-06-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ fully open source.
 
 ### Sidebar navigation
 The sidebar organises 57 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 42 tabs are fully
-implemented; 15 are work-in-progress placeholders marked with ⚙️. Newly added
+find what you need without scrolling through a flat list. 43 tabs are fully
+implemented; 14 are work-in-progress placeholders marked with ⚙️. Newly added
 tabs still being verified are marked **PREVIEW**:
 
 | Group | Tabs |
 |-------|------|
 | 🏠 Dashboard | Dashboard |
 | 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · System Fixes · Boot Analyzer · Task Scheduler ⚙️ |
-| 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner ⚙️ · Timer Resolution 🔬 · CPU Core Affinity ⚙️ · Display Profiles ⚙️ |
+| 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner ⚙️ · Timer Resolution 🔬 · CPU Core Affinity ⚙️ · Display Profiles 🔬 |
 | 📊 Monitor | Process Manager · Resource History ⚙️ · Camera/Mic/Location · App Alerts · File Lock Detector 🔬 · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance ⚙️ |
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
@@ -471,6 +471,17 @@ Reclaim space and clear browsing traces, per browser:
   when you restore it or simply close the app. No admin required
 - **Power-cost warning** — a finer timer wakes the CPU more often, increasing
   power draw and battery drain on laptops
+- _Preview — implemented and usable, still being verified._
+
+### Display Profiles 🔬
+- **Quick-switch resolution + refresh rate** — pick a mode (e.g. 165 Hz for
+  gaming, 60 Hz for work) from the list of everything your display supports,
+  using only the Windows display APIs (no NVIDIA/AMD tool conflict)
+- **Safe by design** — applies for the session, so a reboot reverts; on top of
+  that a **15-second auto-revert** restores the previous mode unless you confirm
+  "Keep", so a bad mode can never strand you on a blank screen
+- **Per-display** — choose which monitor to configure; shows the current mode
+- Validates each mode (CDS_TEST) before applying; no admin required
 - _Preview — implemented and usable, still being verified._
 
 ### Performance Mode

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -370,4 +370,14 @@ public class MainWindowViewModelTests
         Assert.IsType<FileLockViewModel>(item.Content);
         Assert.True(item.IsInDevelopment);
     }
+
+    [Fact]
+    public void NavLeaf_DisplayProfiles_IsImplementedAndMarkedPreview()
+    {
+        var vm = new MainWindowViewModel();
+        var item = vm.NavItems.First(n => n.Id == "nav-display-profiles");
+        Assert.Equal(typeof(SysManager.Views.DisplayProfileView), item.ViewType);
+        Assert.IsType<DisplayProfileViewModel>(item.Content);
+        Assert.True(item.IsInDevelopment);
+    }
 }

--- a/SysManager/SysManager.Tests/DisplayModeTests.cs
+++ b/SysManager/SysManager.Tests/DisplayModeTests.cs
@@ -1,0 +1,38 @@
+// SysManager · DisplayModeTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Tests;
+
+public class DisplayModeTests
+{
+    [Fact]
+    public void Display_FormatsResolutionAndRefresh()
+    {
+        var m = new DisplayMode(2560, 1440, 165, 32);
+        Assert.Equal("2560 × 1440 @ 165 Hz", m.Display);
+        Assert.Equal("2560×1440", m.ResolutionDisplay);
+        Assert.Equal("165 Hz", m.RefreshDisplay);
+    }
+
+    [Fact]
+    public void Equality_IsValueBased()
+    {
+        var a = new DisplayMode(1920, 1080, 60, 32);
+        var b = new DisplayMode(1920, 1080, 60, 32);
+        var c = new DisplayMode(1920, 1080, 144, 32);
+        Assert.Equal(a, b);
+        Assert.NotEqual(a, c);
+    }
+
+    [Theory]
+    [InlineData(true, "Dell U2720Q (primary)")]
+    [InlineData(false, "Dell U2720Q")]
+    public void DisplayDevice_Display_TagsPrimary(bool primary, string expected)
+    {
+        var d = new DisplayDevice(@"\\.\DISPLAY1", "Dell U2720Q", primary, true);
+        Assert.Equal(expected, d.Display);
+    }
+}

--- a/SysManager/SysManager/Models/DisplayMode.cs
+++ b/SysManager/SysManager/Models/DisplayMode.cs
@@ -1,0 +1,23 @@
+// SysManager · DisplayMode
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>A selectable display mode: resolution + refresh rate.</summary>
+public sealed record DisplayMode(int Width, int Height, int RefreshHz, int BitsPerPixel)
+{
+    /// <summary>e.g. "2560 × 1440 @ 165 Hz".</summary>
+    public string Display => $"{Width} × {Height} @ {RefreshHz} Hz";
+
+    /// <summary>e.g. "2560×1440".</summary>
+    public string ResolutionDisplay => $"{Width}×{Height}";
+
+    public string RefreshDisplay => $"{RefreshHz} Hz";
+}
+
+/// <summary>An attached display adapter and its current/available modes.</summary>
+public sealed record DisplayDevice(string DeviceName, string FriendlyName, bool IsPrimary, bool IsActive)
+{
+    public string Display => IsPrimary ? $"{FriendlyName} (primary)" : FriendlyName;
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -74,6 +74,7 @@ public static class ServiceRegistration
         services.AddSingleton<WindowsUpdateService>();
         services.AddSingleton<TimerResolutionService>();
         services.AddSingleton<FileLockService>();
+        services.AddSingleton<DisplayProfileService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
         services.AddSingleton<DashboardViewModel>();
@@ -120,6 +121,7 @@ public static class ServiceRegistration
         services.AddSingleton<BootAnalyzerViewModel>();
         services.AddSingleton<TimerResolutionViewModel>();
         services.AddSingleton<FileLockViewModel>();
+        services.AddSingleton<DisplayProfileViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/DisplayProfileService.cs
+++ b/SysManager/SysManager/Services/DisplayProfileService.cs
@@ -1,0 +1,229 @@
+// SysManager · DisplayProfileService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Reads and switches display resolution + refresh rate via the Windows display
+/// APIs (EnumDisplayDevices / EnumDisplaySettings / ChangeDisplaySettingsEx). Uses
+/// only the OS APIs — no NVIDIA/AMD SDK — so it never conflicts with vendor tools.
+///
+/// Applying a mode for the session (dwflags = 0, not CDS_UPDATEREGISTRY) is reversible
+/// by design: a logoff/reboot restores the previous mode, and the ViewModel keeps a
+/// timed auto-revert in case a bad mode blanks the panel. No admin required.
+///
+/// NOTE on interop style: classic <c>[DllImport]</c> with <c>CharSet.Unicode</c> and
+/// explicit <c>EntryPoint="...W"</c> rather than <c>[LibraryImport]</c> — DEVMODE and
+/// DISPLAY_DEVICE contain inline <c>ByValTStr</c> buffers (non-blittable), unsupported
+/// by the source generator (SYSLIB1051). These functions have A/W variants, so the W
+/// entry point is named explicitly.
+/// </summary>
+public sealed class DisplayProfileService
+{
+    /// <summary>Enumerate active display adapters.</summary>
+    public IReadOnlyList<DisplayDevice> GetDisplays()
+    {
+        var results = new List<DisplayDevice>();
+        try
+        {
+            var dd = new NativeMethods.DISPLAY_DEVICE { cb = (uint)Marshal.SizeOf<NativeMethods.DISPLAY_DEVICE>() };
+            for (uint i = 0; NativeMethods.EnumDisplayDevices(null, i, ref dd, 0); i++)
+            {
+                bool active = (dd.StateFlags & NativeMethods.DisplayDeviceActive) != 0;
+                if (active)
+                {
+                    bool primary = (dd.StateFlags & NativeMethods.DisplayDevicePrimary) != 0;
+                    string adapter = dd.DeviceName;
+                    string friendly = dd.DeviceString;
+
+                    var mon = new NativeMethods.DISPLAY_DEVICE { cb = (uint)Marshal.SizeOf<NativeMethods.DISPLAY_DEVICE>() };
+                    if (NativeMethods.EnumDisplayDevices(adapter, 0, ref mon, 0) && !string.IsNullOrWhiteSpace(mon.DeviceString))
+                        friendly = mon.DeviceString;
+
+                    results.Add(new DisplayDevice(adapter, string.IsNullOrWhiteSpace(friendly) ? adapter : friendly, primary, active));
+                }
+                dd = new NativeMethods.DISPLAY_DEVICE { cb = (uint)Marshal.SizeOf<NativeMethods.DISPLAY_DEVICE>() };
+            }
+        }
+        catch (DllNotFoundException ex) { Log.Warning("Display enumeration unavailable: {Error}", ex.Message); }
+        return results;
+    }
+
+    /// <summary>The mode currently in effect for a device, or null if it can't be read.</summary>
+    public DisplayMode? GetCurrentMode(string deviceName)
+    {
+        try
+        {
+            var dm = new NativeMethods.DEVMODE { dmSize = (ushort)Marshal.SizeOf<NativeMethods.DEVMODE>() };
+            if (NativeMethods.EnumDisplaySettings(deviceName, NativeMethods.EnumCurrentSettings, ref dm))
+                return new DisplayMode((int)dm.dmPelsWidth, (int)dm.dmPelsHeight, (int)dm.dmDisplayFrequency, (int)dm.dmBitsPerPel);
+        }
+        catch (DllNotFoundException ex) { Log.Warning("Read current display mode failed: {Error}", ex.Message); }
+        return null;
+    }
+
+    /// <summary>All distinct supported modes (by width×height×refresh), newest-first by resolution then refresh.</summary>
+    public IReadOnlyList<DisplayMode> GetSupportedModes(string deviceName)
+    {
+        var seen = new HashSet<(int, int, int)>();
+        var modes = new List<DisplayMode>();
+        try
+        {
+            var dm = new NativeMethods.DEVMODE { dmSize = (ushort)Marshal.SizeOf<NativeMethods.DEVMODE>() };
+            for (int i = 0; NativeMethods.EnumDisplaySettings(deviceName, i, ref dm); i++)
+            {
+                int w = (int)dm.dmPelsWidth, h = (int)dm.dmPelsHeight, hz = (int)dm.dmDisplayFrequency;
+                if (hz > 1 && seen.Add((w, h, hz)))
+                    modes.Add(new DisplayMode(w, h, hz, (int)dm.dmBitsPerPel));
+                dm = new NativeMethods.DEVMODE { dmSize = (ushort)Marshal.SizeOf<NativeMethods.DEVMODE>() };
+            }
+        }
+        catch (DllNotFoundException ex) { Log.Warning("Enumerate display modes failed: {Error}", ex.Message); }
+
+        return modes
+            .OrderByDescending(m => (long)m.Width * m.Height)
+            .ThenByDescending(m => m.RefreshHz)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Apply a mode for the current session (reverts on logoff/reboot). Validates with
+    /// CDS_TEST first. Returns true on success; otherwise sets <paramref name="error"/>.
+    /// </summary>
+    public bool TryApplyMode(string deviceName, int width, int height, int refreshHz, out string error)
+    {
+        error = "";
+        try
+        {
+            var dm = new NativeMethods.DEVMODE { dmSize = (ushort)Marshal.SizeOf<NativeMethods.DEVMODE>() };
+            if (!NativeMethods.EnumDisplaySettings(deviceName, NativeMethods.EnumCurrentSettings, ref dm))
+            {
+                error = "Could not read the current display mode.";
+                return false;
+            }
+
+            dm.dmPelsWidth = (uint)width;
+            dm.dmPelsHeight = (uint)height;
+            dm.dmDisplayFrequency = (uint)refreshHz;
+            dm.dmFields = NativeMethods.DM_PELSWIDTH | NativeMethods.DM_PELSHEIGHT | NativeMethods.DM_DISPLAYFREQUENCY;
+
+            int test = NativeMethods.ChangeDisplaySettingsEx(deviceName, ref dm, IntPtr.Zero, NativeMethods.CDS_TEST, IntPtr.Zero);
+            if (test != NativeMethods.DispChangeSuccessful)
+            {
+                error = Describe(test);
+                return false;
+            }
+
+            int apply = NativeMethods.ChangeDisplaySettingsEx(deviceName, ref dm, IntPtr.Zero, 0, IntPtr.Zero);
+            if (apply == NativeMethods.DispChangeSuccessful) return true;
+
+            error = Describe(apply);
+            return false;
+        }
+        catch (DllNotFoundException ex) { error = $"Display API unavailable: {ex.Message}"; return false; }
+        catch (EntryPointNotFoundException ex) { error = $"Display API missing: {ex.Message}"; return false; }
+        catch (Win32Exception ex) { error = $"Display change failed: {ex.Message}"; return false; }
+    }
+
+    private static string Describe(int code) => code switch
+    {
+        NativeMethods.DispChangeRestart => "A restart is required for this mode.",
+        NativeMethods.DispChangeFailed => "The display driver rejected the mode.",
+        NativeMethods.DispChangeBadMode => "The requested mode is not supported by the display.",
+        NativeMethods.DispChangeNotUpdated => "Could not save the display settings.",
+        NativeMethods.DispChangeBadFlags => "Invalid flags passed to the display API.",
+        NativeMethods.DispChangeBadParam => "Invalid parameter passed to the display API.",
+        _ => $"The display change failed (code {code}).",
+    };
+
+    private static class NativeMethods
+    {
+        public const int EnumCurrentSettings = -1;
+        public const uint DM_PELSWIDTH = 0x00080000;
+        public const uint DM_PELSHEIGHT = 0x00100000;
+        public const uint DM_DISPLAYFREQUENCY = 0x00400000;
+        public const uint CDS_TEST = 0x00000002;
+        public const uint DisplayDeviceActive = 0x00000001;
+        public const uint DisplayDevicePrimary = 0x00000004;
+
+        public const int DispChangeSuccessful = 0;
+        public const int DispChangeRestart = 1;
+        public const int DispChangeFailed = -1;
+        public const int DispChangeBadMode = -2;
+        public const int DispChangeNotUpdated = -3;
+        public const int DispChangeBadFlags = -4;
+        public const int DispChangeBadParam = -5;
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct DISPLAY_DEVICE
+        {
+            public uint cb;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)] public string DeviceName;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)] public string DeviceString;
+            public uint StateFlags;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)] public string DeviceID;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)] public string DeviceKey;
+        }
+
+        // DEVMODEW. Union #1 modeled with the printer short-branch (8 shorts = 16 bytes),
+        // which sizes the union correctly on x64; the display fields we use (width/height/
+        // frequency) sit after it. dmSize is set from Marshal.SizeOf before every call.
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct DEVMODE
+        {
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)] public string dmDeviceName;
+            public ushort dmSpecVersion;
+            public ushort dmDriverVersion;
+            public ushort dmSize;
+            public ushort dmDriverExtra;
+            public uint dmFields;
+
+            public short dmOrientation;
+            public short dmPaperSize;
+            public short dmPaperLength;
+            public short dmPaperWidth;
+            public short dmScale;
+            public short dmCopies;
+            public short dmDefaultSource;
+            public short dmPrintQuality;
+
+            public short dmColor;
+            public short dmDuplex;
+            public short dmYResolution;
+            public short dmTTOption;
+            public short dmCollate;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)] public string dmFormName;
+            public ushort dmLogPixels;
+            public uint dmBitsPerPel;
+            public uint dmPelsWidth;
+            public uint dmPelsHeight;
+            public uint dmDisplayFlags;
+            public uint dmDisplayFrequency;
+            public uint dmICMMethod;
+            public uint dmICMIntent;
+            public uint dmMediaType;
+            public uint dmDitherType;
+            public uint dmReserved1;
+            public uint dmReserved2;
+            public uint dmPanningWidth;
+            public uint dmPanningHeight;
+        }
+
+        [DllImport("user32.dll", EntryPoint = "EnumDisplayDevicesW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool EnumDisplayDevices(string? lpDevice, uint iDevNum, ref DISPLAY_DEVICE lpDisplayDevice, uint dwFlags);
+
+        [DllImport("user32.dll", EntryPoint = "EnumDisplaySettingsW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool EnumDisplaySettings(string lpszDeviceName, int iModeNum, ref DEVMODE lpDevMode);
+
+        [DllImport("user32.dll", EntryPoint = "ChangeDisplaySettingsExW", CharSet = CharSet.Unicode)]
+        public static extern int ChangeDisplaySettingsEx(string lpszDeviceName, ref DEVMODE lpDevMode, IntPtr hwnd, uint dwflags, IntPtr lParam);
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.36.0</Version>
-    <FileVersion>1.36.0.0</FileVersion>
-    <AssemblyVersion>1.36.0.0</AssemblyVersion>
+    <Version>1.37.0</Version>
+    <FileVersion>1.37.0.0</FileVersion>
+    <AssemblyVersion>1.37.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DisplayProfileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DisplayProfileViewModel.cs
@@ -1,0 +1,168 @@
+// SysManager · DisplayProfileViewModel
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the Display Profiles tab. Lists displays and their supported
+/// resolution/refresh modes, and switches to a selected mode for lower-latency gaming
+/// or comfortable work. Applies for the session only, so a reboot reverts; on top of
+/// that, a 15-second in-tab auto-revert restores the previous mode if the user doesn't
+/// confirm — the safety net for a mode that blanks the panel. No admin required.
+/// </summary>
+public sealed partial class DisplayProfileViewModel : ViewModelBase
+{
+    private readonly DisplayProfileService _service;
+    private DispatcherTimer? _revertTimer;
+    private DisplayMode? _previousMode;
+    private const int RevertSeconds = 15;
+
+    public BulkObservableCollection<DisplayDevice> Displays { get; } = new();
+    public BulkObservableCollection<DisplayMode> Modes { get; } = new();
+
+    [ObservableProperty] private DisplayDevice? _selectedDisplay;
+    [ObservableProperty] private DisplayMode? _selectedMode;
+    [ObservableProperty] private DisplayMode? _currentMode;
+    [ObservableProperty] private bool _isSupported = true;
+
+    // Pending-confirmation state (the auto-revert window).
+    [ObservableProperty] private bool _isAwaitingConfirm;
+    [ObservableProperty] private int _revertCountdown;
+
+    public DisplayProfileViewModel(DisplayProfileService service)
+    {
+        _service = service;
+        StatusMessage = "Reading displays…";
+        InitializeAsync(LoadDisplaysAsync);
+    }
+
+    private async Task LoadDisplaysAsync()
+    {
+        var displays = await Task.Run(_service.GetDisplays).ConfigureAwait(true);
+        Displays.ReplaceWith(displays);
+        IsSupported = displays.Count > 0;
+        if (!IsSupported)
+        {
+            StatusMessage = "No active displays were found.";
+            return;
+        }
+        SelectedDisplay = displays.FirstOrDefault(d => d.IsPrimary) ?? displays[0];
+        StatusMessage = "Pick a resolution and refresh rate, then apply.";
+    }
+
+    partial void OnSelectedDisplayChanged(DisplayDevice? value)
+    {
+        if (value is null) return;
+        var modes = _service.GetSupportedModes(value.DeviceName);
+        Modes.ReplaceWith(modes);
+        CurrentMode = _service.GetCurrentMode(value.DeviceName);
+        SelectedMode = modes.FirstOrDefault(m =>
+            CurrentMode is not null && m.Width == CurrentMode.Width &&
+            m.Height == CurrentMode.Height && m.RefreshHz == CurrentMode.RefreshHz);
+        ApplyCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnSelectedModeChanged(DisplayMode? value) => ApplyCommand.NotifyCanExecuteChanged();
+
+    private bool CanApply => IsSupported && !IsAwaitingConfirm && SelectedDisplay is not null
+        && SelectedMode is not null && !SelectedMode.Equals(CurrentMode);
+
+    [RelayCommand(CanExecute = nameof(CanApply))]
+    private void Apply()
+    {
+        var display = SelectedDisplay;
+        var mode = SelectedMode;
+        if (display is null || mode is null) return;
+
+        _previousMode = _service.GetCurrentMode(display.DeviceName);
+
+        bool ok = _service.TryApplyMode(display.DeviceName, mode.Width, mode.Height, mode.RefreshHz, out string error);
+        if (!ok)
+        {
+            StatusMessage = error;
+            return;
+        }
+
+        Log.Information("Applied display mode {Mode} to {Device}", mode.Display, display.DeviceName);
+        CurrentMode = _service.GetCurrentMode(display.DeviceName);
+
+        // Begin the auto-revert window — the user must confirm to keep the change.
+        BeginRevertCountdown();
+    }
+
+    [RelayCommand]
+    private void KeepSettings()
+    {
+        StopRevertTimer();
+        IsAwaitingConfirm = false;
+        _previousMode = null;
+        StatusMessage = $"Display set to {CurrentMode?.Display}.";
+        ApplyCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand]
+    private void RevertNow() => RevertToPrevious("Reverted to the previous display mode.");
+
+    private void BeginRevertCountdown()
+    {
+        IsAwaitingConfirm = true;
+        RevertCountdown = RevertSeconds;
+        StatusMessage = $"Keep these settings? Reverting in {RevertCountdown}s…";
+        ApplyCommand.NotifyCanExecuteChanged();
+
+        StopRevertTimer();
+        _revertTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        _revertTimer.Tick += OnRevertTick;
+        _revertTimer.Start();
+    }
+
+    private void OnRevertTick(object? sender, EventArgs e)
+    {
+        RevertCountdown--;
+        if (RevertCountdown > 0)
+        {
+            StatusMessage = $"Keep these settings? Reverting in {RevertCountdown}s…";
+            return;
+        }
+        RevertToPrevious("No confirmation — reverted to the previous display mode.");
+    }
+
+    private void RevertToPrevious(string message)
+    {
+        StopRevertTimer();
+        IsAwaitingConfirm = false;
+
+        var display = SelectedDisplay;
+        if (display is not null && _previousMode is not null)
+        {
+            _service.TryApplyMode(display.DeviceName, _previousMode.Width, _previousMode.Height, _previousMode.RefreshHz, out _);
+            CurrentMode = _service.GetCurrentMode(display.DeviceName);
+        }
+        _previousMode = null;
+        StatusMessage = message;
+        ApplyCommand.NotifyCanExecuteChanged();
+    }
+
+    private void StopRevertTimer()
+    {
+        if (_revertTimer is null) return;
+        _revertTimer.Stop();
+        _revertTimer.Tick -= OnRevertTick;
+        _revertTimer = null;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing) StopRevertTimer();
+        base.Dispose(disposing);
+    }
+}

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -59,6 +59,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public BootAnalyzerViewModel BootAnalyzer { get; }
     public TimerResolutionViewModel TimerResolution { get; }
     public FileLockViewModel FileLock { get; }
+    public DisplayProfileViewModel DisplayProfile { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -163,6 +164,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             BootAnalyzer = sp.GetRequiredService<BootAnalyzerViewModel>();
             TimerResolution = sp.GetRequiredService<TimerResolutionViewModel>();
             FileLock = sp.GetRequiredService<FileLockViewModel>();
+            DisplayProfile = sp.GetRequiredService<DisplayProfileViewModel>();
         }
         else
         {
@@ -226,6 +228,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             BootAnalyzer = new BootAnalyzerViewModel(new BootAnalyzerService());
             TimerResolution = new TimerResolutionViewModel(new TimerResolutionService());
             FileLock = new FileLockViewModel(new FileLockService());
+            DisplayProfile = new DisplayProfileViewModel(new DisplayProfileService());
         }
 
         InitPlaceholders();
@@ -314,7 +317,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-standby-cleaner",  "Standby List Cleaner", "", WipStandbyListCleaner, typeof(Views.PlaceholderView)),
             Item("nav-timer-resolution", "Timer Resolution",     "", TimerResolution,       typeof(Views.TimerResolutionView), inDevelopment: true),
             Item("nav-cpu-affinity",     "CPU Core Affinity",    "", WipCpuAffinity,        typeof(Views.PlaceholderView)),
-            Item("nav-display-profiles", "Display Profiles",     "", WipDisplayProfiles,    typeof(Views.PlaceholderView))),
+            Item("nav-display-profiles", "Display Profiles",     "", DisplayProfile,        typeof(Views.DisplayProfileView), inDevelopment: true)),
 
         Group("grp-monitor", "Monitor", "",
             Item("nav-processes",         "Process Manager",    "", ProcessManager,      typeof(Views.ProcessManagerView)),

--- a/SysManager/SysManager/Views/DisplayProfileView.xaml
+++ b/SysManager/SysManager/Views/DisplayProfileView.xaml
@@ -1,0 +1,106 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.DisplayProfileView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:DisplayProfileViewModel}"
+             Background="{DynamicResource Surface0}">
+
+    <Grid Margin="28,24,28,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Preview banner -->
+        <v:DevelopmentBanner Grid.Row="0" Margin="0,0,0,16"/>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="1" Margin="0,0,0,16">
+            <TextBlock Text="Display Profiles" Style="{StaticResource Display}"/>
+            <TextBlock Text="Quickly switch resolution and refresh rate — e.g. 165 Hz for gaming, 60 Hz for work. Applies for this session and reverts on reboot."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <!-- Display picker + current mode -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0">
+                    <TextBlock Text="DISPLAY" Style="{StaticResource Caption}"/>
+                    <ComboBox ItemsSource="{Binding Displays}" SelectedItem="{Binding SelectedDisplay}"
+                              DisplayMemberPath="Display" Margin="0,4,0,0" Padding="8,6" FontSize="13"
+                              AutomationProperties.Name="Display to configure"/>
+                </StackPanel>
+                <StackPanel Grid.Column="1" Margin="16,0,0,0" VerticalAlignment="Center">
+                    <TextBlock Text="CURRENT" Style="{StaticResource Caption}"/>
+                    <TextBlock Text="{Binding CurrentMode.Display, FallbackValue=—}" FontSize="15" FontWeight="SemiBold"
+                               Foreground="{DynamicResource Info}" Margin="0,4,0,0"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Auto-revert confirmation bar -->
+        <Border Grid.Row="3" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
+                BorderThickness="1" CornerRadius="10" Padding="12,10" Margin="0,0,0,12"
+                Visibility="{Binding IsAwaitingConfirm, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Column="0" VerticalAlignment="Center" TextWrapping="Wrap"
+                           Foreground="{DynamicResource WarningText}" FontWeight="SemiBold">
+                    <Run Text="Keep these settings? Reverting in"/>
+                    <Run Text="{Binding RevertCountdown, Mode=OneWay}"/><Run Text="s."/>
+                </TextBlock>
+                <Button Grid.Column="1" Content="Keep" Command="{Binding KeepSettingsCommand}"
+                        Style="{StaticResource PrimaryButton}" Margin="0,0,8,0" Padding="16,6"
+                        AutomationProperties.Name="Keep the new display settings"/>
+                <Button Grid.Column="2" Content="Revert now" Command="{Binding RevertNowCommand}"
+                        Style="{StaticResource SecondaryButton}" Padding="14,6"
+                        AutomationProperties.Name="Revert display settings now"/>
+            </Grid>
+        </Border>
+
+        <!-- Modes grid -->
+        <Border Grid.Row="4" Style="{StaticResource Card}" Padding="0">
+            <DataGrid ItemsSource="{Binding Modes}" SelectedItem="{Binding SelectedMode}"
+                      AutomationProperties.Name="Supported display modes"
+                      AutoGenerateColumns="False" HeadersVisibility="Column"
+                      CanUserAddRows="False" IsReadOnly="True" SelectionMode="Single"
+                      Background="Transparent" BorderThickness="0" GridLinesVisibility="None"
+                      VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Resolution" Binding="{Binding ResolutionDisplay}" Width="*"/>
+                    <DataGridTextColumn Header="Refresh rate" Binding="{Binding RefreshDisplay}" Width="160"/>
+                </DataGrid.Columns>
+            </DataGrid>
+        </Border>
+
+        <!-- Actions + status -->
+        <Grid Grid.Row="5" Margin="0,12,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+                       VerticalAlignment="Center" TextWrapping="Wrap"/>
+            <Button Grid.Column="1" Content="Apply mode" Command="{Binding ApplyCommand}"
+                    Style="{StaticResource PrimaryButton}" Padding="16,8"
+                    AutomationProperties.Name="Apply the selected display mode"/>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/DisplayProfileView.xaml.cs
+++ b/SysManager/SysManager/Views/DisplayProfileView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · DisplayProfileView
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class DisplayProfileView : UserControl
+{
+    public DisplayProfileView() => InitializeComponent();
+}


### PR DESCRIPTION
## What
Implements **Display Profiles** (Gaming & Profiles), replacing its WIP placeholder. Closes #328.

Quick-switch resolution + refresh rate per monitor — e.g. 165 Hz for gaming, 60 Hz for work — from the list of modes the display actually supports.

## How
- **`DisplayProfileService`** — `user32` display APIs: `EnumDisplayDevicesW` (list adapters), `EnumDisplaySettingsW` (current + supported modes), `ChangeDisplaySettingsExW` (apply). Validates each mode with **`CDS_TEST`** before applying. Applies for the **session only** (`dwflags=0`) so a reboot reverts; no admin required. Uses only Windows APIs — no NVIDIA/AMD SDK, so no vendor-tool conflict.
- **Interop note** — classic `[DllImport]` with explicit `EntryPoint="...W"` + `CharSet.Unicode` (not `[LibraryImport]`): `DEVMODE`/`DISPLAY_DEVICE` have inline `ByValTStr` buffers (non-blittable) → SYSLIB1051. `dmSize` is set from `Marshal.SizeOf` before every call; the DEVMODE union is sized correctly for x64.
- **Safety (the important part)** — applying starts a **15-second in-tab auto-revert** (`DispatcherTimer`): the user must click **Keep** to retain the change, otherwise it restores the previous mode. A bad mode (e.g. unsupported refresh) can blank the panel, so a modal the user can't see would be useless — the countdown bar + session-only apply + reboot-reverts give three layers of safety.

## Preview
Marked **PREVIEW** (sidebar pill + banner).

## Tests
- `DisplayModeTests` — resolution/refresh formatting, value equality, primary-display tagging.
- Integration: `NavLeaf_DisplayProfiles_IsImplementedAndMarkedPreview` pins the WIP→real-view swap + preview flag.

## Verification
- Build main + unit + integration: 0/0. Leak scan clean. No generic/empty catch, no debug code. A/W P/Invokes have explicit `...W` EntryPoints.
- README + ARCHITECTURE updated (counts 42→43 implemented / 15→14 WIP; new service/VM described). feat: -> minor 1.37.0.

## Future follow-up (out of scope)
HDR toggle + color profile use a different API family (CCD `DisplayConfigSetDeviceInfo`) and are noted for a later pass.
