### PR TITLE
feat: add CPU Core Affinity tab with P-core/E-core awareness

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,7 +42,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 |-------|-------------|
 | Dashboard | `DashboardViewModel` |
 | System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `SystemFixesViewModel` · `BootAnalyzerViewModel` · `PlaceholderViewModel` (Task Scheduler) |
-| Gaming & Profiles | `TimerResolutionViewModel` · `DisplayProfileViewModel` · `PlaceholderViewModel` (Gaming Profile · Standby List Cleaner · CPU Core Affinity) |
+| Gaming & Profiles | `TimerResolutionViewModel` · `DisplayProfileViewModel` · `CpuAffinityViewModel` · `PlaceholderViewModel` (Gaming Profile · Standby List Cleaner) |
 | Monitor | `ProcessManagerViewModel` · `PrivacyMonitorViewModel` · `AppAlertsViewModel` · `FileLockViewModel` · `PlaceholderViewModel` (Resource History · Settings Watchdog · Bandwidth Monitor) |
 | Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `PlaceholderViewModel` (Scheduled Maintenance) |
 | Storage | `DiskAnalyzerViewModel` · `DuplicateFileViewModel` |
@@ -96,6 +96,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `TimerResolutionViewModel` — request the finest Windows timer resolution (≈0.5 ms) for lower game input latency, or release it; shows the live effective value. _Preview._
 - `FileLockViewModel` — find which processes are holding a file/folder (Restart Manager) and optionally end a selected one after confirmation; critical processes are protected. _Preview._
 - `DisplayProfileViewModel` — list displays and supported resolution/refresh modes and switch between them; applies for the session with a 15-second auto-revert safety net. _Preview._
+- `CpuAffinityViewModel` — pin a running process to specific logical CPUs with P-core/E-core labels on hybrid CPUs; per-process and reverts on process exit. _Preview._
 - `ProfileViewModel` — export/import SysManager's own config (theme, speed-test history) as a portable JSON profile with selective sections and version checking.
 - `DebloaterViewModel` — list and remove preinstalled Store apps with a curated bloat preset; system-critical packages are denylisted; removal is per-user and reversible via the Store.
 - `BrowserCleanerViewModel` — scan per-browser cache/history/cookies/sessions with sizes and clean the selected categories; cookies/sessions default unticked.
@@ -243,6 +244,10 @@ Key services:
   `EnumDisplaySettingsW` / `ChangeDisplaySettingsExW`) to read and switch resolution +
   refresh rate. Session-only apply (reverts on reboot); validated with `CDS_TEST` first.
   Also classic `[DllImport]` (DEVMODE has non-blittable inline buffers).
+- `CpuAffinityService` — gets/sets per-process CPU affinity via `Process.ProcessorAffinity`
+  and detects P-core/E-core topology via kernel32 `GetLogicalProcessorInformationEx`
+  (variable-length buffer walked by each record's `Size`). The mask helpers
+  (build/test/all-cores) are pure, unit-tested static methods.
 - `LegacyPanelService` — opens classic Windows applets (Control Panel, Sound,
   Device Manager, …) via their `control`/`*.cpl`/`*.msc` commands. The catalog is
   hard-coded and `Launch` re-validates catalog membership, so no input reaches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.38.0] - 2026-06-26
+
+### Added
+- **CPU Core Affinity tab (Gaming & Profiles).** Pin a running process to specific CPU cores — useful for games on Intel hybrid CPUs, where **P-cores and E-cores are detected and labelled** (via `GetLogicalProcessorInformationEx`). One-click "P-cores" / "All cores" presets, a per-core checkbox map, Apply and Restore. Affinity is per-running-process and is lost when the process exits, so it's inherently temporary and reversible; no admin needed for your own processes (changing another user's process is surfaced as needing admin, not a crash). An empty core selection is rejected (Windows would treat 0 as "let the OS decide"). Marked **PREVIEW** while it's verified. Closes #327.
+
 ## [1.37.0] - 2026-06-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ fully open source.
 
 ### Sidebar navigation
 The sidebar organises 57 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 43 tabs are fully
-implemented; 14 are work-in-progress placeholders marked with ⚙️. Newly added
+find what you need without scrolling through a flat list. 44 tabs are fully
+implemented; 13 are work-in-progress placeholders marked with ⚙️. Newly added
 tabs still being verified are marked **PREVIEW**:
 
 | Group | Tabs |
 |-------|------|
 | 🏠 Dashboard | Dashboard |
 | 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · System Fixes · Boot Analyzer · Task Scheduler ⚙️ |
-| 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner ⚙️ · Timer Resolution 🔬 · CPU Core Affinity ⚙️ · Display Profiles 🔬 |
+| 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner ⚙️ · Timer Resolution 🔬 · CPU Core Affinity 🔬 · Display Profiles 🔬 |
 | 📊 Monitor | Process Manager · Resource History ⚙️ · Camera/Mic/Location · App Alerts · File Lock Detector 🔬 · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance ⚙️ |
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
@@ -482,6 +482,19 @@ Reclaim space and clear browsing traces, per browser:
   "Keep", so a bad mode can never strand you on a blank screen
 - **Per-display** — choose which monitor to configure; shows the current mode
 - Validates each mode (CDS_TEST) before applying; no admin required
+- _Preview — implemented and usable, still being verified._
+
+### CPU Core Affinity 🔬
+- **Pin a process to specific CPU cores** — pick a running process and choose
+  which logical CPUs it may run on, then Apply (or Restore the original)
+- **Hybrid-CPU aware** — on Intel 12th-gen+ CPUs, P-cores and E-cores are
+  detected and labelled (via `GetLogicalProcessorInformationEx`), with one-click
+  **P-cores** / **All cores** presets
+- **Safe and temporary** — affinity is per-running-process and reverts when the
+  process exits; no admin for your own processes (changing another user's
+  process is surfaced as needing admin, not a crash)
+- An empty selection is rejected — Windows treats an empty mask as "let the OS
+  decide", so the app never silently does the opposite of what you picked
 - _Preview — implemented and usable, still being verified._
 
 ### Performance Mode

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -380,4 +380,14 @@ public class MainWindowViewModelTests
         Assert.IsType<DisplayProfileViewModel>(item.Content);
         Assert.True(item.IsInDevelopment);
     }
+
+    [Fact]
+    public void NavLeaf_CpuAffinity_IsImplementedAndMarkedPreview()
+    {
+        var vm = new MainWindowViewModel();
+        var item = vm.NavItems.First(n => n.Id == "nav-cpu-affinity");
+        Assert.Equal(typeof(SysManager.Views.CpuAffinityView), item.ViewType);
+        Assert.IsType<CpuAffinityViewModel>(item.Content);
+        Assert.True(item.IsInDevelopment);
+    }
 }

--- a/SysManager/SysManager.Tests/CpuAffinityServiceTests.cs
+++ b/SysManager/SysManager.Tests/CpuAffinityServiceTests.cs
@@ -1,0 +1,61 @@
+// SysManager · CpuAffinityServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+public class CpuAffinityServiceTests
+{
+    [Theory]
+    [InlineData(1, 0b1L)]
+    [InlineData(2, 0b11L)]
+    [InlineData(4, 0b1111L)]
+    [InlineData(8, 0xFFL)]
+    public void AllCoresMask_SetsLowBits(int count, long expected)
+        => Assert.Equal(expected, CpuAffinityService.AllCoresMask(count));
+
+    [Fact]
+    public void AllCoresMask_64_IsAllBits()
+        => Assert.Equal(-1L, CpuAffinityService.AllCoresMask(64));
+
+    [Fact]
+    public void MaskFromIndices_BuildsBitmask()
+    {
+        Assert.Equal(0b1011L, CpuAffinityService.MaskFromIndices([0, 1, 3]));
+        Assert.Equal(0L, CpuAffinityService.MaskFromIndices([]));
+    }
+
+    [Fact]
+    public void MaskFromIndices_IgnoresOutOfRangeIndices()
+    {
+        // Negative and >=64 are dropped, not crash.
+        Assert.Equal(0b1L, CpuAffinityService.MaskFromIndices([0, -1, 64, 99]));
+    }
+
+    [Theory]
+    [InlineData(0b1010L, 1, true)]
+    [InlineData(0b1010L, 0, false)]
+    [InlineData(0b1010L, 3, true)]
+    [InlineData(0b1010L, 2, false)]
+    public void IsCoreInMask_ChecksBit(long mask, int index, bool expected)
+        => Assert.Equal(expected, CpuAffinityService.IsCoreInMask(mask, index));
+
+    [Fact]
+    public void IsCoreInMask_OutOfRange_IsFalse()
+    {
+        Assert.False(CpuAffinityService.IsCoreInMask(-1L, -1));
+        Assert.False(CpuAffinityService.IsCoreInMask(-1L, 64));
+    }
+
+    [Fact]
+    public void RoundTrip_IndicesToMaskToCheck()
+    {
+        long mask = CpuAffinityService.MaskFromIndices([2, 5, 7]);
+        Assert.True(CpuAffinityService.IsCoreInMask(mask, 2));
+        Assert.True(CpuAffinityService.IsCoreInMask(mask, 5));
+        Assert.True(CpuAffinityService.IsCoreInMask(mask, 7));
+        Assert.False(CpuAffinityService.IsCoreInMask(mask, 3));
+    }
+}

--- a/SysManager/SysManager.Tests/CpuCoreTests.cs
+++ b/SysManager/SysManager.Tests/CpuCoreTests.cs
@@ -1,0 +1,25 @@
+// SysManager · CpuCoreTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Tests;
+
+public class CpuCoreTests
+{
+    [Fact]
+    public void Display_UsesLogicalIndex()
+        => Assert.Equal("CPU 5", new CpuCore(5, 1, "Performance").Display);
+
+    [Theory]
+    [InlineData("Performance", true, false)]
+    [InlineData("Efficiency", false, true)]
+    [InlineData("Standard", false, false)]
+    public void TypeFlags_MatchCoreType(string type, bool perf, bool eff)
+    {
+        var c = new CpuCore(0, 0, type);
+        Assert.Equal(perf, c.IsPerformance);
+        Assert.Equal(eff, c.IsEfficiency);
+    }
+}

--- a/SysManager/SysManager/Models/CpuCore.cs
+++ b/SysManager/SysManager/Models/CpuCore.cs
@@ -1,0 +1,17 @@
+// SysManager · CpuCore
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// A single logical CPU and its hybrid-core classification. On Intel 12th-gen+
+/// hybrid CPUs cores are labelled "Performance" (P-core) or "Efficiency" (E-core)
+/// from their Windows EfficiencyClass; on homogeneous CPUs every core is "Standard".
+/// </summary>
+public sealed record CpuCore(int LogicalIndex, byte EfficiencyClass, string CoreType)
+{
+    public string Display => $"CPU {LogicalIndex}";
+    public bool IsPerformance => CoreType == "Performance";
+    public bool IsEfficiency => CoreType == "Efficiency";
+}

--- a/SysManager/SysManager/Models/RunningProcess.cs
+++ b/SysManager/SysManager/Models/RunningProcess.cs
@@ -1,0 +1,15 @@
+// SysManager · RunningProcess
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// A running process the user can target for CPU affinity. <see cref="AffinityMask"/>
+/// is the current processor-affinity bitmask (bit i = logical CPU i), or 0 if it
+/// couldn't be read (e.g. access denied).
+/// </summary>
+public sealed record RunningProcess(int ProcessId, string Name, long AffinityMask)
+{
+    public string Display => $"{Name} ({ProcessId})";
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -75,6 +75,7 @@ public static class ServiceRegistration
         services.AddSingleton<TimerResolutionService>();
         services.AddSingleton<FileLockService>();
         services.AddSingleton<DisplayProfileService>();
+        services.AddSingleton<CpuAffinityService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
         services.AddSingleton<DashboardViewModel>();
@@ -122,6 +123,7 @@ public static class ServiceRegistration
         services.AddSingleton<TimerResolutionViewModel>();
         services.AddSingleton<FileLockViewModel>();
         services.AddSingleton<DisplayProfileViewModel>();
+        services.AddSingleton<CpuAffinityViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/CpuAffinityService.cs
+++ b/SysManager/SysManager/Services/CpuAffinityService.cs
@@ -1,0 +1,219 @@
+// SysManager · CpuAffinityService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Reads CPU topology (P-core / E-core classification on Intel hybrid CPUs) and gets/
+/// sets per-process CPU affinity. Setting affinity uses .NET's
+/// <see cref="Process.ProcessorAffinity"/>; it applies only to the running process and
+/// is lost when that process exits, so it's inherently temporary and reversible (the
+/// caller captures the original mask to restore). Affinity for your own processes needs
+/// no admin; other users' / elevated processes raise access-denied, surfaced cleanly.
+///
+/// Scope: a single processor group (≤64 logical processors), which covers all consumer
+/// hybrid CPUs. Topology detection uses the kernel32 GetLogicalProcessorInformationEx
+/// API via classic <c>[DllImport]</c> (the returned buffer is a variable-length record
+/// stream walked by each record's Size — not something the source generator marshals).
+/// </summary>
+public sealed class CpuAffinityService
+{
+    /// <summary>Total logical processors as Windows schedules them.</summary>
+    public int LogicalProcessorCount => Environment.ProcessorCount;
+
+    /// <summary>
+    /// Enumerate each logical CPU with its hybrid classification. Returns a plain
+    /// 0..N-1 "Standard" list if the topology API is unavailable or fails.
+    /// </summary>
+    public IReadOnlyList<CpuCore> GetCores()
+    {
+        try
+        {
+            var cores = ReadTopology();
+            if (cores.Count > 0) return cores;
+        }
+        catch (Win32Exception ex) { Log.Debug("CPU topology query failed: {Error}", ex.Message); }
+        catch (DllNotFoundException ex) { Log.Debug("CPU topology API unavailable: {Error}", ex.Message); }
+
+        // Fallback: flat list, all Standard.
+        var list = new List<CpuCore>(LogicalProcessorCount);
+        for (int i = 0; i < LogicalProcessorCount; i++)
+            list.Add(new CpuCore(i, 0, "Standard"));
+        return list;
+    }
+
+    /// <summary>List running processes with their current affinity mask (0 if unreadable).</summary>
+    public IReadOnlyList<RunningProcess> GetProcesses()
+    {
+        var result = new List<RunningProcess>();
+        foreach (var p in Process.GetProcesses())
+        {
+            try
+            {
+                long mask = (long)p.ProcessorAffinity;
+                result.Add(new RunningProcess(p.Id, p.ProcessName, mask));
+            }
+            catch (Win32Exception) { result.Add(new RunningProcess(p.Id, p.ProcessName, 0)); }
+            catch (InvalidOperationException) { /* exited between enumerate and read */ }
+            finally { p.Dispose(); }
+        }
+        return result.OrderBy(r => r.Name, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    /// <summary>Read the current affinity mask for a process, or null if unavailable.</summary>
+    public long? GetAffinity(int processId)
+    {
+        try
+        {
+            using var p = Process.GetProcessById(processId);
+            p.Refresh();
+            return (long)p.ProcessorAffinity;
+        }
+        catch (ArgumentException) { return null; }
+        catch (InvalidOperationException) { return null; }
+        catch (Win32Exception) { return null; }
+    }
+
+    /// <summary>
+    /// Apply an affinity mask to a process. Returns true on success; on failure sets
+    /// <paramref name="error"/>. A mask of 0 is rejected (Windows treats it as
+    /// "OS decides", which is not what an explicit selection means).
+    /// </summary>
+    public bool TrySetAffinity(int processId, long mask, out string error)
+    {
+        error = "";
+        if (mask == 0)
+        {
+            error = "Select at least one CPU core.";
+            return false;
+        }
+        long allCores = AllCoresMask(LogicalProcessorCount);
+        if ((mask & ~allCores) != 0)
+        {
+            error = "The selection includes a CPU that does not exist.";
+            return false;
+        }
+
+        try
+        {
+            using var p = Process.GetProcessById(processId);
+            p.ProcessorAffinity = (IntPtr)mask;
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            error = "That process is no longer running.";
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            error = "That process has exited.";
+            return false;
+        }
+        catch (Win32Exception ex)
+        {
+            Log.Debug("Set affinity for {Pid} failed: {Error}", processId, ex.Message);
+            error = "Couldn't change this process — it may belong to another user and need administrator rights.";
+            return false;
+        }
+    }
+
+    /// <summary>Bitmask with the low <paramref name="count"/> bits set (all logical CPUs).</summary>
+    public static long AllCoresMask(int count) => count >= 64 ? -1L : (1L << count) - 1;
+
+    /// <summary>Build a mask from a set of logical-CPU indices.</summary>
+    public static long MaskFromIndices(IEnumerable<int> indices)
+    {
+        long mask = 0;
+        foreach (int i in indices)
+            if (i is >= 0 and < 64) mask |= 1L << i;
+        return mask;
+    }
+
+    /// <summary>True if logical CPU <paramref name="index"/> is set in <paramref name="mask"/>.</summary>
+    public static bool IsCoreInMask(long mask, int index) => index is >= 0 and < 64 && (mask & (1L << index)) != 0;
+
+    // ── Topology via GetLogicalProcessorInformationEx ──────────────────
+    private static List<CpuCore> ReadTopology()
+    {
+        uint length = 0;
+        // Pass 1: probe required size (must fail with ERROR_INSUFFICIENT_BUFFER).
+        if (NativeMethods.GetLogicalProcessorInformationEx(NativeMethods.RelationProcessorCore, IntPtr.Zero, ref length))
+            return [];
+        if (Marshal.GetLastWin32Error() != NativeMethods.ErrorInsufficientBuffer || length == 0)
+            return [];
+
+        IntPtr buffer = Marshal.AllocHGlobal((int)length);
+        try
+        {
+            if (!NativeMethods.GetLogicalProcessorInformationEx(NativeMethods.RelationProcessorCore, buffer, ref length))
+                return [];
+
+            var raw = new List<(int Index, byte Efficiency)>();
+            byte maxEff = 0, minEff = byte.MaxValue;
+
+            long offset = 0;
+            while (offset < length)
+            {
+                IntPtr record = buffer + (int)offset;
+                int size = Marshal.ReadInt32(record, NativeMethods.OffsetSize);
+                if (size <= 0 || offset + size > length) break; // guard against corrupt record
+
+                byte efficiency = Marshal.ReadByte(record, NativeMethods.OffsetEfficiencyClass);
+                long groupMask = IntPtr.Size == 8
+                    ? Marshal.ReadInt64(record, NativeMethods.OffsetGroupMask0)
+                    : Marshal.ReadInt32(record, NativeMethods.OffsetGroupMask0);
+
+                for (int bit = 0; bit < 64; bit++)
+                {
+                    if ((groupMask & (1L << bit)) != 0)
+                    {
+                        raw.Add((bit, efficiency));
+                        if (efficiency > maxEff) maxEff = efficiency;
+                        if (efficiency < minEff) minEff = efficiency;
+                    }
+                }
+                offset += size;
+            }
+
+            bool hybrid = maxEff != minEff;
+            var cores = new List<CpuCore>(raw.Count);
+            foreach (var (index, efficiency) in raw)
+            {
+                string label = !hybrid ? "Standard"
+                    : efficiency == maxEff ? "Performance" : "Efficiency";
+                cores.Add(new CpuCore(index, efficiency, label));
+            }
+            cores.Sort((a, b) => a.LogicalIndex.CompareTo(b.LogicalIndex));
+            return cores;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    private static class NativeMethods
+    {
+        public const int RelationProcessorCore = 0;
+        public const int ErrorInsufficientBuffer = 122;
+
+        // Fixed byte offsets inside each SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX
+        // (RelationProcessorCore variant) on x64.
+        public const int OffsetSize = 4;            // DWORD Size at +4
+        public const int OffsetEfficiencyClass = 9; // +8 Flags, +9 EfficiencyClass
+        public const int OffsetGroupMask0 = 32;     // GROUP_AFFINITY GroupMask[0].Mask
+
+        // No A/W variant (not a string function) → no EntryPoint suffix needed.
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetLogicalProcessorInformationEx(int relationshipType, IntPtr buffer, ref uint returnedLength);
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.37.0</Version>
-    <FileVersion>1.37.0.0</FileVersion>
-    <AssemblyVersion>1.37.0.0</AssemblyVersion>
+    <Version>1.38.0</Version>
+    <FileVersion>1.38.0.0</FileVersion>
+    <AssemblyVersion>1.38.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/CpuAffinityViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CpuAffinityViewModel.cs
@@ -1,0 +1,136 @@
+// SysManager · CpuAffinityViewModel
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>A selectable logical CPU with its P/E label and checked state.</summary>
+public sealed partial class CoreToggle : ObservableObject
+{
+    public required CpuCore Core { get; init; }
+    [ObservableProperty] private bool _isSelected = true;
+    public int Index => Core.LogicalIndex;
+    public string Label => Core.Display;
+    public string TypeLabel => Core.CoreType;
+}
+
+/// <summary>
+/// ViewModel for the CPU Core Affinity tab. Lists running processes and lets the user
+/// pin one to specific logical CPUs, with P-core / E-core labels on Intel hybrid CPUs.
+/// Affinity is per-running-process and lost on exit, so it's temporary and reversible;
+/// no admin for your own processes.
+/// </summary>
+public sealed partial class CpuAffinityViewModel : ViewModelBase
+{
+    private readonly CpuAffinityService _service;
+    private long _originalMask;
+    private bool _hasOriginal;
+
+    public BulkObservableCollection<RunningProcess> Processes { get; } = new();
+    public BulkObservableCollection<CoreToggle> Cores { get; } = new();
+
+    [ObservableProperty] private RunningProcess? _selectedProcess;
+    [ObservableProperty] private bool _isHybrid;
+
+    public CpuAffinityViewModel(CpuAffinityService service)
+    {
+        _service = service;
+        StatusMessage = "Reading CPU topology…";
+        InitializeAsync(LoadAsync);
+    }
+
+    private async Task LoadAsync()
+    {
+        var cores = await Task.Run(_service.GetCores).ConfigureAwait(true);
+        IsHybrid = cores.Any(c => c.IsPerformance) && cores.Any(c => c.IsEfficiency);
+        Cores.ReplaceWith(cores.Select(c => new CoreToggle { Core = c }));
+        await RefreshProcessesAsync();
+    }
+
+    [RelayCommand]
+    private async Task RefreshProcessesAsync()
+    {
+        var procs = await Task.Run(_service.GetProcesses).ConfigureAwait(true);
+        Processes.ReplaceWith(procs);
+        StatusMessage = IsHybrid
+            ? "Hybrid CPU detected — P-cores and E-cores are labelled. Pick a process."
+            : "Pick a process, choose cores, then apply.";
+    }
+
+    partial void OnSelectedProcessChanged(RunningProcess? value)
+    {
+        _hasOriginal = false;
+        if (value is null) return;
+
+        long? mask = _service.GetAffinity(value.ProcessId);
+        if (mask is { } m)
+        {
+            _originalMask = m;
+            _hasOriginal = true;
+            foreach (var c in Cores) c.IsSelected = CpuAffinityService.IsCoreInMask(m, c.Index);
+        }
+        ApplyCommand.NotifyCanExecuteChanged();
+        RestoreCommand.NotifyCanExecuteChanged();
+    }
+
+    private bool HasSelection => SelectedProcess is not null;
+
+    [RelayCommand(CanExecute = nameof(HasSelection))]
+    private void Apply()
+    {
+        var proc = SelectedProcess;
+        if (proc is null) return;
+
+        long mask = CpuAffinityService.MaskFromIndices(Cores.Where(c => c.IsSelected).Select(c => c.Index));
+        if (_service.TrySetAffinity(proc.ProcessId, mask, out string error))
+        {
+            Log.Information("Set CPU affinity 0x{Mask:X} on {Name} ({Pid})", mask, proc.Name, proc.ProcessId);
+            StatusMessage = $"Pinned {proc.Name} to {CountBits(mask)} core(s). Reverts when the process exits.";
+        }
+        else
+        {
+            StatusMessage = error;
+        }
+    }
+
+    private bool CanRestore => SelectedProcess is not null && _hasOriginal;
+
+    [RelayCommand(CanExecute = nameof(CanRestore))]
+    private void Restore()
+    {
+        var proc = SelectedProcess;
+        if (proc is null || !_hasOriginal) return;
+        if (_service.TrySetAffinity(proc.ProcessId, _originalMask, out string error))
+        {
+            foreach (var c in Cores) c.IsSelected = CpuAffinityService.IsCoreInMask(_originalMask, c.Index);
+            StatusMessage = $"Restored {proc.Name} to its original cores.";
+        }
+        else
+        {
+            StatusMessage = error;
+        }
+    }
+
+    [RelayCommand]
+    private void SelectPerformanceCores()
+    {
+        foreach (var c in Cores) c.IsSelected = IsHybrid ? c.Core.IsPerformance : true;
+        StatusMessage = IsHybrid ? "Selected P-cores." : "Selected all cores.";
+    }
+
+    [RelayCommand]
+    private void SelectAllCores()
+    {
+        foreach (var c in Cores) c.IsSelected = true;
+        StatusMessage = "Selected all cores.";
+    }
+
+    private static int CountBits(long mask) => System.Numerics.BitOperations.PopCount((ulong)mask);
+}

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -60,6 +60,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public TimerResolutionViewModel TimerResolution { get; }
     public FileLockViewModel FileLock { get; }
     public DisplayProfileViewModel DisplayProfile { get; }
+    public CpuAffinityViewModel CpuAffinity { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -165,6 +166,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             TimerResolution = sp.GetRequiredService<TimerResolutionViewModel>();
             FileLock = sp.GetRequiredService<FileLockViewModel>();
             DisplayProfile = sp.GetRequiredService<DisplayProfileViewModel>();
+            CpuAffinity = sp.GetRequiredService<CpuAffinityViewModel>();
         }
         else
         {
@@ -229,6 +231,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             TimerResolution = new TimerResolutionViewModel(new TimerResolutionService());
             FileLock = new FileLockViewModel(new FileLockService());
             DisplayProfile = new DisplayProfileViewModel(new DisplayProfileService());
+            CpuAffinity = new CpuAffinityViewModel(new CpuAffinityService());
         }
 
         InitPlaceholders();
@@ -316,7 +319,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-gaming-profile",   "Gaming Profile",       "", WipGamingProfile,      typeof(Views.PlaceholderView)),
             Item("nav-standby-cleaner",  "Standby List Cleaner", "", WipStandbyListCleaner, typeof(Views.PlaceholderView)),
             Item("nav-timer-resolution", "Timer Resolution",     "", TimerResolution,       typeof(Views.TimerResolutionView), inDevelopment: true),
-            Item("nav-cpu-affinity",     "CPU Core Affinity",    "", WipCpuAffinity,        typeof(Views.PlaceholderView)),
+            Item("nav-cpu-affinity",     "CPU Core Affinity",    "", CpuAffinity,           typeof(Views.CpuAffinityView), inDevelopment: true),
             Item("nav-display-profiles", "Display Profiles",     "", DisplayProfile,        typeof(Views.DisplayProfileView), inDevelopment: true)),
 
         Group("grp-monitor", "Monitor", "",

--- a/SysManager/SysManager/Views/CpuAffinityView.xaml
+++ b/SysManager/SysManager/Views/CpuAffinityView.xaml
@@ -1,0 +1,110 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.CpuAffinityView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:CpuAffinityViewModel}"
+             Background="{DynamicResource Surface0}">
+
+    <Grid Margin="28,24,28,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Preview banner -->
+        <v:DevelopmentBanner Grid.Row="0" Margin="0,0,0,16"/>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="1" Margin="0,0,0,16">
+            <TextBlock Text="CPU Core Affinity" Style="{StaticResource Display}"/>
+            <TextBlock Text="Pin a process to specific CPU cores. On Intel hybrid CPUs, P-cores and E-cores are labelled. Affinity reverts when the process exits."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <!-- Process picker -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0">
+                    <TextBlock Text="PROCESS" Style="{StaticResource Caption}"/>
+                    <ComboBox ItemsSource="{Binding Processes}" SelectedItem="{Binding SelectedProcess}"
+                              DisplayMemberPath="Display" Margin="0,4,0,0" Padding="8,6" FontSize="13"
+                              MaxDropDownHeight="320"
+                              AutomationProperties.Name="Process to set affinity for"/>
+                </StackPanel>
+                <Button Grid.Column="1" Content="Refresh" Command="{Binding RefreshProcessesCommand}"
+                        Style="{StaticResource GhostButton}" Margin="8,0,0,0" Padding="14,8" VerticalAlignment="Bottom"
+                        AutomationProperties.Name="Refresh process list"/>
+            </Grid>
+        </Border>
+
+        <!-- Core grid -->
+        <Border Grid.Row="3" Style="{StaticResource Card}">
+            <StackPanel>
+                <Grid Margin="0,0,0,10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" Text="Logical processors" Style="{StaticResource SectionTitle}" VerticalAlignment="Center"/>
+                    <StackPanel Grid.Column="1" Orientation="Horizontal">
+                        <Button Content="P-cores" Command="{Binding SelectPerformanceCoresCommand}"
+                                Style="{StaticResource SecondaryButton}" Margin="0,0,8,0" Padding="12,5"
+                                Visibility="{Binding IsHybrid, Converter={StaticResource FlexVis}}"
+                                AutomationProperties.Name="Select performance cores"/>
+                        <Button Content="All cores" Command="{Binding SelectAllCoresCommand}"
+                                Style="{StaticResource SecondaryButton}" Padding="12,5"
+                                AutomationProperties.Name="Select all cores"/>
+                    </StackPanel>
+                </Grid>
+                <ItemsControl ItemsSource="{Binding Cores}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <WrapPanel Orientation="Horizontal"/>
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Style="{StaticResource CardInner}" Margin="0,0,8,8" Padding="10,8" Width="120">
+                                <StackPanel>
+                                    <CheckBox IsChecked="{Binding IsSelected}" Content="{Binding Label}"
+                                              FontWeight="SemiBold"
+                                              AutomationProperties.Name="{Binding Label}"/>
+                                    <TextBlock Text="{Binding TypeLabel}" Style="{StaticResource Caption}" Margin="0,4,0,0"/>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </Border>
+
+        <!-- Actions + status -->
+        <Grid Grid.Row="4" Margin="0,12,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+                       VerticalAlignment="Center" TextWrapping="Wrap"/>
+            <Button Grid.Column="1" Content="Restore" Command="{Binding RestoreCommand}"
+                    Style="{StaticResource SecondaryButton}" Margin="0,0,8,0" Padding="14,8"
+                    AutomationProperties.Name="Restore original affinity"/>
+            <Button Grid.Column="2" Content="Apply affinity" Command="{Binding ApplyCommand}"
+                    Style="{StaticResource PrimaryButton}" Padding="16,8"
+                    AutomationProperties.Name="Apply CPU affinity"/>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/CpuAffinityView.xaml.cs
+++ b/SysManager/SysManager/Views/CpuAffinityView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · CpuAffinityView
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class CpuAffinityView : UserControl
+{
+    public CpuAffinityView() => InitializeComponent();
+}


### PR DESCRIPTION
## What
Implements **CPU Core Affinity** (Gaming & Profiles), replacing its WIP placeholder. Closes #327.

Pin a running process to specific CPU cores — useful for games on Intel hybrid CPUs where P-cores and E-cores behave differently.

## How
- **`CpuAffinityService`**:
  - **Set/get affinity** via .NET's `Process.ProcessorAffinity` (no P/Invoke for the set; the runtime calls `SetProcessAffinityMask`).
  - **P/E detection** via kernel32 `GetLogicalProcessorInformationEx(RelationProcessorCore)` — the variable-length buffer is walked by **each record's `Size`** (not `Marshal.SizeOf`, which would corrupt), reading `EfficiencyClass` at a fixed offset. Highest class = P-core; if all equal → homogeneous → "Standard". Classic `[DllImport]` (raw IntPtr buffer, no A/W variant → no EntryPoint).
  - Single processor group (≤64 logical CPUs) — covers all consumer hybrid CPUs.
- **Safety**:
  - An **empty mask is rejected** — Windows treats `0` as "let the OS decide", so without this guard an empty selection would silently do the opposite of what the user picked.
  - Affinity is **per-running-process and lost on exit** → inherently temporary and reversible; the VM also snapshots the original mask for an explicit **Restore**.
  - No admin for your own processes; another user's / elevated process raises access-denied → surfaced as "needs admin", never an unhandled exception.
- **`CpuAffinityViewModel`**: process picker, per-core checkbox map with P/E labels, **P-cores** / **All cores** presets, Apply + Restore.

## Preview
Marked **PREVIEW** (sidebar pill + banner).

## Tests
- `CpuAffinityServiceTests` — `AllCoresMask`, `MaskFromIndices` (incl. out-of-range drop), `IsCoreInMask`, round-trip.
- `CpuCoreTests` — display + P/E type flags.
- Integration: `NavLeaf_CpuAffinity_IsImplementedAndMarkedPreview` pins the WIP→real-view swap + preview flag.

## Verification
- Build main + unit + integration: 0/0. Leak scan clean. No generic/empty catch, no debug code.
- README + ARCHITECTURE updated (counts 43→44 implemented / 14→13 WIP). feat: -> minor 1.38.0.

## Future scope (out of scope here)
Auto-apply-on-launch and per-game saved profiles need a watcher / launcher and are noted for a later pass.
