### PR TITLE
feat: add Defender Tweaks tab (status, PUA/CFA toggles, exclusions)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,7 +48,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Storage | `DiskAnalyzerViewModel` · `DuplicateFileViewModel` |
 | Network | `PingViewModel` · `TracerouteViewModel` · `SpeedTestViewModel` · `NetworkRepairViewModel` (shared: `NetworkSharedState`) · `DnsHostsViewModel` |
 | Apps | `AppUpdatesViewModel` · `BulkInstallerViewModel` · `UninstallerViewModel` |
-| Privacy & Security | `PrivacyViewModel` · `FileShredderViewModel` · `AppBlockerViewModel` · `DebloaterViewModel` · `BrowserCleanerViewModel` · `PlaceholderViewModel` (Edge/OneDrive Remover · Defender Tweaks · Notification Blocker) |
+| Privacy & Security | `PrivacyViewModel` · `FileShredderViewModel` · `AppBlockerViewModel` · `DebloaterViewModel` · `BrowserCleanerViewModel` · `DefenderViewModel` · `PlaceholderViewModel` (Edge/OneDrive Remover · Notification Blocker) |
 | Customization | `ContextMenuViewModel` · `PlaceholderViewModel` (Dark Mode Scheduler · Volume Control) |
 | Info | `DriversViewModel` · `BatteryHealthViewModel` · `LogsViewModel` · `SystemReportViewModel` · `LegacyPanelsViewModel` · `AboutViewModel` |
 | Advanced | `ProfileViewModel` · `EnvironmentVariablesViewModel` · `PlaceholderViewModel` (CLI Interface) |
@@ -97,6 +97,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `FileLockViewModel` — find which processes are holding a file/folder (Restart Manager) and optionally end a selected one after confirmation; critical processes are protected. _Preview._
 - `DisplayProfileViewModel` — list displays and supported resolution/refresh modes and switch between them; applies for the session with a 15-second auto-revert safety net. _Preview._
 - `CpuAffinityViewModel` — pin a running process to specific logical CPUs with P-core/E-core labels on hybrid CPUs; per-process and reverts on process exit. _Preview._
+- `DefenderViewModel` — view Microsoft Defender status, toggle PUA / Controlled Folder Access, and manage scan-exclusion folders; every change is admin-gated, confirmed, and verified by read-back (Tamper Protection can silently reject). _Preview._
 - `ProfileViewModel` — export/import SysManager's own config (theme, speed-test history) as a portable JSON profile with selective sections and version checking.
 - `DebloaterViewModel` — list and remove preinstalled Store apps with a curated bloat preset; system-critical packages are denylisted; removal is per-user and reversible via the Store.
 - `BrowserCleanerViewModel` — scan per-browser cache/history/cookies/sessions with sizes and clean the selected categories; cookies/sessions default unticked.
@@ -248,6 +249,11 @@ Key services:
   and detects P-core/E-core topology via kernel32 `GetLogicalProcessorInformationEx`
   (variable-length buffer walked by each record's `Size`). The mask helpers
   (build/test/all-cores) are pure, unit-tested static methods.
+- `DefenderService` — Microsoft Defender via the Defender PowerShell module
+  (`Get-MpPreference` / `Set-MpPreference` / `Add`/`Remove-MpPreference`) through
+  `IPowerShellRunner`. Normalizes the inverted `Disable*` booleans; exclusion paths are
+  bound parameters (never interpolated); every change is verified by reading the value
+  back (Tamper Protection can silently reject). The parse helpers are pure, unit-tested.
 - `LegacyPanelService` — opens classic Windows applets (Control Panel, Sound,
   Device Manager, …) via their `control`/`*.cpl`/`*.msc` commands. The catalog is
   hard-coded and `Launch` re-validates catalog membership, so no input reaches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.39.0] - 2026-06-26
+
+### Added
+- **Defender Tweaks tab (Privacy & Security).** See your Microsoft Defender status at a glance (real-time protection, cloud protection, PUA and Controlled Folder Access), toggle PUA protection and Controlled Folder Access, and manage scan-exclusion folders (add/remove). Built to be safe: every change requires administrator and is **verified by reading the value back** — because Tamper Protection can silently ignore changes, the tab detects it and shows a clear warning, and never reports a change as done unless Windows actually applied it. Exclusion folders are validated (rooted, existing, no wildcards) before use, and changes are confirmed first. Marked **PREVIEW** while it's verified. Closes #344.
+
 ## [1.38.0] - 2026-06-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ fully open source.
 
 ### Sidebar navigation
 The sidebar organises 57 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 44 tabs are fully
-implemented; 13 are work-in-progress placeholders marked with ⚙️. Newly added
+find what you need without scrolling through a flat list. 45 tabs are fully
+implemented; 12 are work-in-progress placeholders marked with ⚙️. Newly added
 tabs still being verified are marked **PREVIEW**:
 
 | Group | Tabs |
@@ -88,7 +88,7 @@ tabs still being verified are marked **PREVIEW**:
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS & Hosts |
 | 📦 Apps | App Updates · Bulk Installer · Uninstaller |
-| 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover ⚙️ · Defender Tweaks ⚙️ · Notification Blocker ⚙️ |
+| 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover ⚙️ · Defender Tweaks 🔬 · Notification Blocker ⚙️ |
 | 🎨 Customization | Context Menu · Dark Mode Scheduler ⚙️ · Volume Control ⚙️ |
 | ℹ️ Info | Drivers · Battery Health · System Logs · System Report · Legacy Panels · About |
 | ⚙️ Advanced | Profile Export/Import · CLI Interface ⚙️ · Environment Variables |
@@ -445,6 +445,21 @@ Reclaim space and clear browsing traces, per browser:
 - **Confirmation with an impact summary** before anything is deleted
 - Per-user (no admin); locked files (browser open) are skipped, not forced, and
   symlinks/junctions are never followed
+
+### Defender Tweaks 🔬
+Manage Microsoft Defender without digging through Windows Security:
+- **Status at a glance** — real-time protection, cloud protection (MAPS), PUA
+  protection, and Controlled Folder Access
+- **Toggle PUA protection and Controlled Folder Access** (ransomware protection)
+- **Scan exclusions** — add or remove folders Defender should skip (handy for
+  big game libraries); paths are validated and additions never replace your
+  existing exclusions
+- **Honest about Tamper Protection** — if it's on, Windows can silently ignore
+  changes, so the tab detects it, warns you, and only reports a change as done
+  after reading it back and confirming Windows actually applied it
+- Changes need administrator and are confirmed first; lowering a protection is
+  always an explicit, reversible choice
+- _Preview — implemented and usable, still being verified._
 
 ### Battery Health
 - Charge %, health %, wear level, cycle count, chemistry

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -390,4 +390,14 @@ public class MainWindowViewModelTests
         Assert.IsType<CpuAffinityViewModel>(item.Content);
         Assert.True(item.IsInDevelopment);
     }
+
+    [Fact]
+    public void NavLeaf_Defender_IsImplementedAndMarkedPreview()
+    {
+        var vm = new MainWindowViewModel();
+        var item = vm.NavItems.First(n => n.Id == "nav-defender-tweaks");
+        Assert.Equal(typeof(SysManager.Views.DefenderView), item.ViewType);
+        Assert.IsType<DefenderViewModel>(item.Content);
+        Assert.True(item.IsInDevelopment);
+    }
 }

--- a/SysManager/SysManager.Tests/DefenderExclusionValidationTests.cs
+++ b/SysManager/SysManager.Tests/DefenderExclusionValidationTests.cs
@@ -1,0 +1,47 @@
+// SysManager · DefenderExclusionValidationTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+public class DefenderExclusionValidationTests
+{
+    [Fact]
+    public void Rejects_NullOrEmpty()
+    {
+        Assert.False(DefenderViewModel.IsValidExclusionPath(""));
+        Assert.False(DefenderViewModel.IsValidExclusionPath("   "));
+    }
+
+    [Fact]
+    public void Rejects_RelativePath()
+        => Assert.False(DefenderViewModel.IsValidExclusionPath(@"Games\Cache"));
+
+    [Theory]
+    [InlineData(@"C:\Games\*")]
+    [InlineData(@"C:\Games\?temp")]
+    public void Rejects_Wildcards(string path)
+        => Assert.False(DefenderViewModel.IsValidExclusionPath(path));
+
+    [Fact]
+    public void Rejects_NonexistentFolder()
+        => Assert.False(DefenderViewModel.IsValidExclusionPath(@"C:\definitely\not\a\real\sysmanager\folder\xyz123"));
+
+    [Fact]
+    public void Accepts_RealRootedExistingFolder()
+    {
+        string temp = Path.Combine(Path.GetTempPath(), "sm-defender-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temp);
+        try
+        {
+            Assert.True(DefenderViewModel.IsValidExclusionPath(temp));
+        }
+        finally
+        {
+            Directory.Delete(temp);
+        }
+    }
+}

--- a/SysManager/SysManager.Tests/DefenderServiceTests.cs
+++ b/SysManager/SysManager.Tests/DefenderServiceTests.cs
@@ -1,0 +1,87 @@
+// SysManager · DefenderServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Management.Automation;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+public class DefenderServiceTests
+{
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    [InlineData("True", true)]
+    [InlineData("False", false)]
+    [InlineData(null, false)]
+    public void ToBool_HandlesBoolAndStringAndNull(object? input, bool expected)
+        => Assert.Equal(expected, DefenderService.ToBool(input));
+
+    [Theory]
+    [InlineData(2, 2)]
+    [InlineData("1", 1)]
+    [InlineData(null, 0)]
+    [InlineData("garbage", 0)]
+    public void ToInt_ParsesOrZero(object? input, int expected)
+        => Assert.Equal(expected, DefenderService.ToInt(input));
+
+    [Fact]
+    public void ToStringList_FromArray()
+    {
+        var list = DefenderService.ToStringList(new object[] { @"C:\Games", @"D:\Steam", "" });
+        Assert.Equal(2, list.Count);
+        Assert.Contains(@"C:\Games", list);
+        Assert.DoesNotContain("", list);
+    }
+
+    [Fact]
+    public void ToStringList_FromSingleAndNull()
+    {
+        Assert.Single(DefenderService.ToStringList(@"C:\One"));
+        Assert.Empty(DefenderService.ToStringList(null));
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(3, 0)]   // out of range → clamp to 0
+    [InlineData(-1, 0)]
+    public void ClampTri_KeepsZeroToTwo(int input, int expected)
+        => Assert.Equal(expected, DefenderService.ClampTri(input));
+
+    [Fact]
+    public void ParseStatus_NormalizesInvertedRealtimeBoolean()
+    {
+        // DisableRealtimeMonitoring = true means real-time protection is OFF.
+        var obj = new PSObject();
+        obj.Properties.Add(new PSNoteProperty("DisableRealtimeMonitoring", true));
+        obj.Properties.Add(new PSNoteProperty("PUAProtection", 1));
+        obj.Properties.Add(new PSNoteProperty("MAPSReporting", 2));
+        obj.Properties.Add(new PSNoteProperty("EnableControlledFolderAccess", 0));
+        obj.Properties.Add(new PSNoteProperty("ExclusionPath", new object[] { @"C:\Games" }));
+        obj.Properties.Add(new PSNoteProperty("ExclusionExtension", new object[] { }));
+        obj.Properties.Add(new PSNoteProperty("ExclusionProcess", new object[] { }));
+        obj.Properties.Add(new PSNoteProperty("IsTamperProtected", true));
+
+        var status = DefenderService.ParseStatus(obj);
+
+        Assert.True(status.Available);
+        Assert.False(status.RealtimeProtection); // inverted: Disable=true → protection OFF
+        Assert.True(status.IsTamperProtected);
+        Assert.Equal(1, status.PuaProtection);
+        Assert.Equal(2, status.MapsReporting);
+        Assert.Equal(0, status.ControlledFolderAccess);
+        Assert.Single(status.ExclusionPaths);
+    }
+
+    [Fact]
+    public void ParseStatus_RealtimeOn_WhenDisableFalse()
+    {
+        var obj = new PSObject();
+        obj.Properties.Add(new PSNoteProperty("DisableRealtimeMonitoring", false));
+        var status = DefenderService.ParseStatus(obj);
+        Assert.True(status.RealtimeProtection);
+    }
+}

--- a/SysManager/SysManager/Models/DefenderStatus.cs
+++ b/SysManager/SysManager/Models/DefenderStatus.cs
@@ -1,0 +1,47 @@
+// SysManager · DefenderStatus
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// A read-only snapshot of the Microsoft Defender settings SysManager surfaces.
+/// Note that several underlying Defender properties are inverted "Disable" booleans;
+/// they are normalized here to positive meaning (e.g. <see cref="RealtimeProtection"/>
+/// is true when protection is ON).
+/// </summary>
+public sealed record DefenderStatus(
+    bool Available,
+    bool IsTamperProtected,
+    bool RealtimeProtection,
+    int PuaProtection,            // 0=Disabled, 1=Enabled, 2=AuditMode
+    int MapsReporting,            // 0=Disabled, 1=Basic, 2=Advanced
+    int ControlledFolderAccess,  // 0=Disabled, 1=Enabled, 2=AuditMode
+    IReadOnlyList<string> ExclusionPaths,
+    IReadOnlyList<string> ExclusionExtensions,
+    IReadOnlyList<string> ExclusionProcesses)
+{
+    public static string TriStateLabel(int v) => v switch
+    {
+        0 => "Disabled",
+        1 => "Enabled",
+        2 => "Audit mode",
+        _ => "Unknown",
+    };
+
+    public static string MapsLabel(int v) => v switch
+    {
+        0 => "Disabled",
+        1 => "Basic",
+        2 => "Advanced",
+        _ => "Unknown",
+    };
+
+    public string PuaDisplay => TriStateLabel(PuaProtection);
+    public string CfaDisplay => TriStateLabel(ControlledFolderAccess);
+    public string MapsDisplay => MapsLabel(MapsReporting);
+    public string RealtimeDisplay => RealtimeProtection ? "On" : "Off";
+
+    public static DefenderStatus Unavailable { get; } =
+        new(false, false, false, 0, 0, 0, [], [], []);
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -76,6 +76,7 @@ public static class ServiceRegistration
         services.AddSingleton<FileLockService>();
         services.AddSingleton<DisplayProfileService>();
         services.AddSingleton<CpuAffinityService>();
+        services.AddSingleton<DefenderService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
         services.AddSingleton<DashboardViewModel>();
@@ -124,6 +125,7 @@ public static class ServiceRegistration
         services.AddSingleton<FileLockViewModel>();
         services.AddSingleton<DisplayProfileViewModel>();
         services.AddSingleton<CpuAffinityViewModel>();
+        services.AddSingleton<DefenderViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/DefenderService.cs
+++ b/SysManager/SysManager/Services/DefenderService.cs
@@ -1,0 +1,146 @@
+// SysManager · DefenderService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Reads and tweaks Microsoft Defender settings through the Defender PowerShell module
+/// (Get-MpPreference / Set-MpPreference / Add-MpPreference / Remove-MpPreference) via the
+/// shared <see cref="IPowerShellRunner"/> seam.
+///
+/// Two correctness rules baked in:
+/// 1. Several Defender properties are inverted "Disable" booleans; they are normalized
+///    to positive meaning when read.
+/// 2. Tamper Protection can SILENTLY reject a Set (it "appears to succeed but is
+///    ignored"), and the runner forwards PowerShell errors to its line stream rather
+///    than throwing — so every change is verified by reading the value back and
+///    comparing, never by trusting the Set call.
+///
+/// Changing Defender requires administrator; without it the Set is rejected and the
+/// read-back simply shows no change, surfaced cleanly to the user.
+/// </summary>
+public sealed class DefenderService
+{
+    private readonly IPowerShellRunner _ps;
+
+    public DefenderService(IPowerShellRunner ps) => _ps = ps;
+
+    /// <summary>Read the current Defender status, or <see cref="DefenderStatus.Unavailable"/>.</summary>
+    public async Task<DefenderStatus> GetStatusAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            const string script = """
+                $p = Get-MpPreference
+                $s = Get-MpComputerStatus
+                [PSCustomObject]@{
+                    DisableRealtimeMonitoring   = $p.DisableRealtimeMonitoring
+                    PUAProtection               = [int]$p.PUAProtection
+                    MAPSReporting               = [int]$p.MAPSReporting
+                    EnableControlledFolderAccess = [int]$p.EnableControlledFolderAccess
+                    ExclusionPath               = @($p.ExclusionPath)
+                    ExclusionExtension          = @($p.ExclusionExtension)
+                    ExclusionProcess            = @($p.ExclusionProcess)
+                    IsTamperProtected           = [bool]$s.IsTamperProtected
+                }
+                """;
+            Collection<PSObject> results = await _ps.RunAsync(script, cancellationToken: ct).ConfigureAwait(false);
+            if (results.Count == 0) return DefenderStatus.Unavailable;
+            return ParseStatus(results[0]);
+        }
+        catch (System.Management.Automation.RuntimeException ex)
+        {
+            Log.Debug("Defender status read failed: {Error}", ex.Message);
+            return DefenderStatus.Unavailable;
+        }
+    }
+
+    /// <summary>Parse a Get-MpPreference/Get-MpComputerStatus projection into a status.</summary>
+    public static DefenderStatus ParseStatus(PSObject obj)
+    {
+        bool disableRtp = ToBool(Prop(obj, "DisableRealtimeMonitoring"));
+        return new DefenderStatus(
+            Available: true,
+            IsTamperProtected: ToBool(Prop(obj, "IsTamperProtected")),
+            RealtimeProtection: !disableRtp, // normalize the inverted "Disable" boolean
+            PuaProtection: ToInt(Prop(obj, "PUAProtection")),
+            MapsReporting: ToInt(Prop(obj, "MAPSReporting")),
+            ControlledFolderAccess: ToInt(Prop(obj, "EnableControlledFolderAccess")),
+            ExclusionPaths: ToStringList(Prop(obj, "ExclusionPath")),
+            ExclusionExtensions: ToStringList(Prop(obj, "ExclusionExtension")),
+            ExclusionProcesses: ToStringList(Prop(obj, "ExclusionProcess")));
+    }
+
+    /// <summary>
+    /// Set PUA protection (0/1/2) and verify the change took effect. Returns the
+    /// re-read status; compare its PuaProtection to confirm success.
+    /// </summary>
+    public Task<DefenderStatus> SetPuaProtectionAsync(int value, CancellationToken ct = default)
+        => ApplyAndVerifyAsync("Set-MpPreference -PUAProtection $Value", new() { ["Value"] = ClampTri(value) }, ct);
+
+    /// <summary>Set Controlled Folder Access (0/1/2) and verify.</summary>
+    public Task<DefenderStatus> SetControlledFolderAccessAsync(int value, CancellationToken ct = default)
+        => ApplyAndVerifyAsync("Set-MpPreference -EnableControlledFolderAccess $Value", new() { ["Value"] = ClampTri(value) }, ct);
+
+    /// <summary>Add a folder exclusion (additive — never replaces the array). Verifies.</summary>
+    public Task<DefenderStatus> AddExclusionPathAsync(string path, CancellationToken ct = default)
+        => ApplyAndVerifyAsync("Add-MpPreference -ExclusionPath $Path", new() { ["Path"] = path }, ct);
+
+    /// <summary>Remove a folder exclusion. Verifies.</summary>
+    public Task<DefenderStatus> RemoveExclusionPathAsync(string path, CancellationToken ct = default)
+        => ApplyAndVerifyAsync("Remove-MpPreference -ExclusionPath $Path", new() { ["Path"] = path }, ct);
+
+    /// <summary>
+    /// Run a hard-coded Set/Add/Remove script with bound parameters (never interpolated),
+    /// then return a fresh status read so the caller can verify the change actually applied
+    /// (Tamper Protection / missing admin can silently reject it).
+    /// </summary>
+    private async Task<DefenderStatus> ApplyAndVerifyAsync(string script, Dictionary<string, object?> parameters, CancellationToken ct)
+    {
+        try
+        {
+            await _ps.RunAsync(script, parameters, ct).ConfigureAwait(false);
+        }
+        catch (System.Management.Automation.RuntimeException ex)
+        {
+            Log.Debug("Defender set failed: {Error}", ex.Message);
+        }
+        return await GetStatusAsync(ct).ConfigureAwait(false);
+    }
+
+    // ── Pure parse helpers (testable) ──────────────────────────────────
+    private static object? Prop(PSObject obj, string name) => obj.Properties[name]?.Value;
+
+    internal static bool ToBool(object? v) => v switch
+    {
+        bool b => b,
+        not null when bool.TryParse(v.ToString(), out bool r) => r,
+        _ => false,
+    };
+
+    internal static int ToInt(object? v)
+    {
+        if (v is null) return 0;
+        try { return Convert.ToInt32(v); }
+        catch (FormatException) { return 0; }
+        catch (InvalidCastException) { return 0; }
+        catch (OverflowException) { return 0; }
+    }
+
+    internal static IReadOnlyList<string> ToStringList(object? v)
+    {
+        if (v is null) return [];
+        if (v is object[] arr)
+            return arr.Where(x => x is not null).Select(x => x.ToString() ?? "").Where(s => s.Length > 0).ToList();
+        string single = v.ToString() ?? "";
+        return single.Length > 0 ? [single] : [];
+    }
+
+    internal static int ClampTri(int value) => value is >= 0 and <= 2 ? value : 0;
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.38.0</Version>
-    <FileVersion>1.38.0.0</FileVersion>
-    <AssemblyVersion>1.38.0.0</AssemblyVersion>
+    <Version>1.39.0</Version>
+    <FileVersion>1.39.0.0</FileVersion>
+    <AssemblyVersion>1.39.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DefenderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DefenderViewModel.cs
@@ -1,0 +1,154 @@
+// SysManager · DefenderViewModel
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the Defender Tweaks tab. Shows the current Microsoft Defender status,
+/// toggles PUA protection and Controlled Folder Access, and manages scan exclusion
+/// folders. Every change requires admin and is verified by reading the value back
+/// (Tamper Protection can silently reject it); changes are confirmed first.
+/// </summary>
+public sealed partial class DefenderViewModel : ViewModelBase
+{
+    private readonly DefenderService _service;
+
+    public BulkObservableCollection<string> ExclusionPaths { get; } = new();
+
+    [ObservableProperty] private bool _isAvailable = true;
+    [ObservableProperty] private bool _isTamperProtected;
+    [ObservableProperty] private string _realtimeDisplay = "—";
+    [ObservableProperty] private string _puaDisplay = "—";
+    [ObservableProperty] private string _cfaDisplay = "—";
+    [ObservableProperty] private string _mapsDisplay = "—";
+    [ObservableProperty] private bool _puaEnabled;
+    [ObservableProperty] private bool _cfaEnabled;
+    [ObservableProperty] private string? _selectedExclusion;
+
+    public DefenderViewModel(DefenderService service)
+    {
+        _service = service;
+        StatusMessage = "Reading Defender status…";
+        InitializeAsync(RefreshAsync);
+    }
+
+    [RelayCommand]
+    private async Task RefreshAsync()
+    {
+        IsBusy = true;
+        try
+        {
+            var status = await _service.GetStatusAsync().ConfigureAwait(true);
+            Apply(status);
+            StatusMessage = !IsAvailable
+                ? "Microsoft Defender is not available on this system."
+                : IsTamperProtected
+                    ? "Tamper Protection is ON — some changes may be ignored by Windows until you turn it off in Windows Security."
+                    : "Defender status loaded.";
+        }
+        finally { IsBusy = false; }
+    }
+
+    [RelayCommand]
+    private async Task TogglePuaAsync()
+    {
+        if (!Confirm($"{(PuaEnabled ? "Disable" : "Enable")} potentially-unwanted-app (PUA) protection?")) return;
+        int target = PuaEnabled ? 0 : 1;
+        var status = await _service.SetPuaProtectionAsync(target).ConfigureAwait(true);
+        Apply(status);
+        ReportVerified("PUA protection", status.PuaProtection == target);
+    }
+
+    [RelayCommand]
+    private async Task ToggleCfaAsync()
+    {
+        if (!Confirm($"{(CfaEnabled ? "Disable" : "Enable")} Controlled Folder Access (ransomware protection)?")) return;
+        int target = CfaEnabled ? 0 : 1;
+        var status = await _service.SetControlledFolderAccessAsync(target).ConfigureAwait(true);
+        Apply(status);
+        ReportVerified("Controlled Folder Access", status.ControlledFolderAccess == target);
+    }
+
+    [RelayCommand]
+    private async Task AddExclusionAsync()
+    {
+        var dialog = new Microsoft.Win32.OpenFolderDialog { Title = "Select a folder to exclude from scanning" };
+        if (dialog.ShowDialog() != true) return;
+
+        string path = dialog.FolderName;
+        if (!IsValidExclusionPath(path))
+        {
+            StatusMessage = "That folder path is not valid.";
+            return;
+        }
+        if (!Confirm($"Exclude \"{path}\" from Defender scanning?\n\nFiles in an excluded folder are not scanned for malware.")) return;
+
+        var status = await _service.AddExclusionPathAsync(path).ConfigureAwait(true);
+        Apply(status);
+        ReportVerified("Exclusion", status.ExclusionPaths.Any(p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [RelayCommand(CanExecute = nameof(HasSelectedExclusion))]
+    private async Task RemoveExclusionAsync()
+    {
+        string? path = SelectedExclusion;
+        if (path is null) return;
+        if (!Confirm($"Stop excluding \"{path}\"?\n\nThe folder will be scanned for malware again.")) return;
+
+        var status = await _service.RemoveExclusionPathAsync(path).ConfigureAwait(true);
+        Apply(status);
+        ReportVerified("Exclusion removal", !status.ExclusionPaths.Any(p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    private bool HasSelectedExclusion => SelectedExclusion is not null;
+    partial void OnSelectedExclusionChanged(string? value) => RemoveExclusionCommand.NotifyCanExecuteChanged();
+
+    /// <summary>A valid exclusion is a rooted, existing folder with no wildcards.</summary>
+    internal static bool IsValidExclusionPath(string path)
+        => !string.IsNullOrWhiteSpace(path)
+           && Path.IsPathRooted(path)
+           && !path.Contains('*') && !path.Contains('?')
+           && path.Length <= 260
+           && Directory.Exists(path);
+
+    private void Apply(DefenderStatus status)
+    {
+        IsAvailable = status.Available;
+        IsTamperProtected = status.IsTamperProtected;
+        RealtimeDisplay = status.RealtimeDisplay;
+        PuaDisplay = status.PuaDisplay;
+        CfaDisplay = status.CfaDisplay;
+        MapsDisplay = status.MapsDisplay;
+        PuaEnabled = status.PuaProtection == 1;
+        CfaEnabled = status.ControlledFolderAccess == 1;
+        ExclusionPaths.ReplaceWith(status.ExclusionPaths);
+        RemoveExclusionCommand.NotifyCanExecuteChanged();
+    }
+
+    private void ReportVerified(string what, bool applied)
+    {
+        if (applied)
+        {
+            StatusMessage = $"{what} updated.";
+            Log.Information("Defender: {What} change applied", what);
+        }
+        else
+        {
+            StatusMessage = IsTamperProtected
+                ? $"{what} was not changed — Tamper Protection blocked it. Turn it off in Windows Security first."
+                : $"{what} was not changed — this needs administrator rights.";
+        }
+    }
+
+    private static bool Confirm(string message)
+        => DialogService.Instance.Confirm(message, "Defender — Confirm");
+}

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -61,6 +61,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public FileLockViewModel FileLock { get; }
     public DisplayProfileViewModel DisplayProfile { get; }
     public CpuAffinityViewModel CpuAffinity { get; }
+    public DefenderViewModel Defender { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -167,6 +168,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             FileLock = sp.GetRequiredService<FileLockViewModel>();
             DisplayProfile = sp.GetRequiredService<DisplayProfileViewModel>();
             CpuAffinity = sp.GetRequiredService<CpuAffinityViewModel>();
+            Defender = sp.GetRequiredService<DefenderViewModel>();
         }
         else
         {
@@ -232,6 +234,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             FileLock = new FileLockViewModel(new FileLockService());
             DisplayProfile = new DisplayProfileViewModel(new DisplayProfileService());
             CpuAffinity = new CpuAffinityViewModel(new CpuAffinityService());
+            Defender = new DefenderViewModel(new DefenderService(new PowerShellRunner()));
         }
 
         InitPlaceholders();
@@ -360,7 +363,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-debloater",            "Debloater & Ads",       "", Debloater,             typeof(Views.DebloaterView)),
             Item("nav-browser-cleaner",      "Browser Cleaner",       "", BrowserCleaner,         typeof(Views.BrowserCleanerView)),
             Item("nav-edge-onedrive",        "Edge/OneDrive Remover", "", WipEdgeOneDriveRemover, typeof(Views.PlaceholderView)),
-            Item("nav-defender-tweaks",      "Defender Tweaks",       "", WipDefenderTweaks,      typeof(Views.PlaceholderView)),
+            Item("nav-defender-tweaks",      "Defender Tweaks",       "", Defender,               typeof(Views.DefenderView), inDevelopment: true),
             Item("nav-notification-blocker", "Notification Blocker",  "", WipNotificationBlocker, typeof(Views.PlaceholderView))),
 
         Group("grp-customization", "Customization", "",

--- a/SysManager/SysManager/Views/DefenderView.xaml
+++ b/SysManager/SysManager/Views/DefenderView.xaml
@@ -1,0 +1,120 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.DefenderView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:DefenderViewModel}"
+             Background="{DynamicResource Surface0}">
+
+    <Grid Margin="28,24,28,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Preview banner -->
+        <v:DevelopmentBanner Grid.Row="0" Margin="0,0,0,16"/>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="1" Margin="0,0,0,16">
+            <TextBlock Text="Defender Tweaks" Style="{StaticResource Display}"/>
+            <TextBlock Text="View Microsoft Defender status, toggle PUA and ransomware protection, and manage scan-exclusion folders. Changes need administrator rights."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <!-- Tamper Protection warning -->
+        <Border Grid.Row="2" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
+                BorderThickness="1" CornerRadius="10" Padding="12,10" Margin="0,0,0,12"
+                Visibility="{Binding IsTamperProtected, Converter={StaticResource FlexVis}}">
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="&#xE730;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                           FontSize="14" Foreground="{DynamicResource WarningText}" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <TextBlock Text="Tamper Protection is ON. Windows may silently ignore changes here until you turn it off in Windows Security."
+                           Foreground="{DynamicResource WarningText}" FontSize="12.5" VerticalAlignment="Center" TextWrapping="Wrap"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Status cards -->
+        <Border Grid.Row="3" Style="{StaticResource Card}" Margin="0,0,0,12">
+            <StackPanel>
+                <TextBlock Text="Protection status" Style="{StaticResource SectionTitle}"/>
+                <Grid Margin="0,10,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Border Grid.Column="0" Style="{StaticResource CardInner}" Margin="0,0,4,0">
+                        <StackPanel>
+                            <TextBlock Text="REAL-TIME" Style="{StaticResource Caption}"/>
+                            <TextBlock Text="{Binding RealtimeDisplay}" FontSize="16" FontWeight="SemiBold"
+                                       Foreground="{DynamicResource Success}" Margin="0,4,0,0"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Column="1" Style="{StaticResource CardInner}" Margin="4,0,4,0">
+                        <StackPanel>
+                            <TextBlock Text="CLOUD (MAPS)" Style="{StaticResource Caption}"/>
+                            <TextBlock Text="{Binding MapsDisplay}" FontSize="16" FontWeight="SemiBold"
+                                       Foreground="{DynamicResource Info}" Margin="0,4,0,0"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Column="2" Style="{StaticResource CardInner}" Margin="4,0,0,0">
+                        <StackPanel>
+                            <TextBlock Text="PUA / CFA" Style="{StaticResource Caption}"/>
+                            <TextBlock Margin="0,4,0,0" FontSize="13" FontWeight="SemiBold" Foreground="{DynamicResource TextSecondary}">
+                                <Run Text="{Binding PuaDisplay, Mode=OneWay}"/><Run Text=" · "/><Run Text="{Binding CfaDisplay, Mode=OneWay}"/>
+                            </TextBlock>
+                        </StackPanel>
+                    </Border>
+                </Grid>
+                <WrapPanel Orientation="Horizontal" Margin="0,14,0,0">
+                    <Button Content="Toggle PUA protection" Command="{Binding TogglePuaCommand}"
+                            Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
+                            AutomationProperties.Name="Toggle PUA protection"/>
+                    <Button Content="Toggle Controlled Folder Access" Command="{Binding ToggleCfaCommand}"
+                            Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
+                            AutomationProperties.Name="Toggle Controlled Folder Access"/>
+                    <Button Content="Refresh" Command="{Binding RefreshCommand}"
+                            Style="{StaticResource GhostButton}" Margin="0,0,8,8"
+                            AutomationProperties.Name="Refresh Defender status"/>
+                </WrapPanel>
+            </StackPanel>
+        </Border>
+
+        <!-- Exclusions -->
+        <Border Grid.Row="4" Style="{StaticResource Card}" Padding="0">
+            <DockPanel>
+                <Grid DockPanel.Dock="Top" Margin="14,12,14,8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" Text="Scan exclusions (folders)" Style="{StaticResource SectionTitle}" VerticalAlignment="Center"/>
+                    <Button Grid.Column="1" Content="Add folder…" Command="{Binding AddExclusionCommand}"
+                            Style="{StaticResource PrimaryButton}" Margin="0,0,8,0" Padding="12,6"
+                            AutomationProperties.Name="Add an exclusion folder"/>
+                    <Button Grid.Column="2" Content="Remove" Command="{Binding RemoveExclusionCommand}"
+                            Style="{StaticResource DangerButton}" Padding="12,6"
+                            AutomationProperties.Name="Remove the selected exclusion"/>
+                </Grid>
+                <ListBox ItemsSource="{Binding ExclusionPaths}" SelectedItem="{Binding SelectedExclusion}"
+                         Background="Transparent" BorderThickness="0" Margin="6,0,6,6"
+                         AutomationProperties.Name="Exclusion folders"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+            </DockPanel>
+        </Border>
+
+        <!-- Status -->
+        <TextBlock Grid.Row="5" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+                   Margin="0,12,0,0" TextWrapping="Wrap"/>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/DefenderView.xaml.cs
+++ b/SysManager/SysManager/Views/DefenderView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · DefenderView
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class DefenderView : UserControl
+{
+    public DefenderView() => InitializeComponent();
+}


### PR DESCRIPTION
## What
Implements **Defender Tweaks** (Privacy & Security), replacing its WIP placeholder. Closes #344.

Manage Microsoft Defender from the app: see status, toggle PUA + Controlled Folder Access, and manage scan-exclusion folders.

## Correctness — two traps handled
1. **Inverted booleans** — Defender's `DisableRealtimeMonitoring` etc. are "Disable" flags. The service normalizes them to positive meaning so the UI shows plain on/off without inverting bugs.
2. **Tamper Protection can silently reject changes** — a `Set-MpPreference` "may appear to succeed but is ignored", and the `IPowerShellRunner` forwards PS errors to its line stream rather than throwing. So **every change is verified by reading the value back and comparing** — success is never inferred from the Set call. The tab also detects Tamper Protection (`Get-MpComputerStatus.IsTamperProtected`) and shows a warning banner.

## Scope (deliberately safe v1)
- **Read-only status**: real-time protection, cloud (MAPS), PUA, Controlled Folder Access.
- **Toggles**: PUA protection, Controlled Folder Access (both reversible enums).
- **Exclusions**: add/remove folders. `Add-MpPreference` is additive (never replaces the array → no data loss). Paths validated (rooted, existing, no wildcards) at the trust boundary.
- **Deferred** (intentionally not built): disabling real-time protection (tamper-blocked on default Win11 + dangerous); SmartScreen (it's a registry/Shell feature, not a Defender setting).

## Safety
- Every change requires admin and goes through `DialogService.Confirm`; failures surface as "needs admin" or "blocked by Tamper Protection" — never an unhandled exception. No `MessageBox.Show`. Specific exceptions only.

## Preview
Marked **PREVIEW** (sidebar pill + banner).

## Tests
- `DefenderServiceTests` — inverted realtime boolean normalization, enum/bool/list parsing, tri-state clamp.
- `DefenderExclusionValidationTests` — rejects empty/relative/wildcard/nonexistent, accepts a real rooted folder.
- Integration: `NavLeaf_Defender_IsImplementedAndMarkedPreview`.

## Verification
- Build main + unit + integration: 0/0. Leak scan clean.
- README + ARCHITECTURE updated (counts 44→45 implemented / 13→12 WIP). feat: -> minor 1.39.0.
