### PR TITLE
feat: add Task Scheduler tab (browse, classify, enable/disable)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,7 +41,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Group | View Models |
 |-------|-------------|
 | Dashboard | `DashboardViewModel` |
-| System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `SystemFixesViewModel` · `BootAnalyzerViewModel` · `PlaceholderViewModel` (Task Scheduler) |
+| System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `SystemFixesViewModel` · `BootAnalyzerViewModel` · `TaskSchedulerViewModel` |
 | Gaming & Profiles | `TimerResolutionViewModel` · `DisplayProfileViewModel` · `CpuAffinityViewModel` · `PlaceholderViewModel` (Gaming Profile · Standby List Cleaner) |
 | Monitor | `ProcessManagerViewModel` · `PrivacyMonitorViewModel` · `AppAlertsViewModel` · `FileLockViewModel` · `PlaceholderViewModel` (Resource History · Settings Watchdog · Bandwidth Monitor) |
 | Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `PlaceholderViewModel` (Scheduled Maintenance) |
@@ -98,6 +98,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `DisplayProfileViewModel` — list displays and supported resolution/refresh modes and switch between them; applies for the session with a 15-second auto-revert safety net. _Preview._
 - `CpuAffinityViewModel` — pin a running process to specific logical CPUs with P-core/E-core labels on hybrid CPUs; per-process and reverts on process exit. _Preview._
 - `DefenderViewModel` — view Microsoft Defender status, toggle PUA / Controlled Folder Access, and manage scan-exclusion folders; every change is admin-gated, confirmed, and verified by read-back (Tamper Protection can silently reject). _Preview._
+- `TaskSchedulerViewModel` — browse Windows scheduled tasks with a safety classification and enable/disable them (reversible, never deletes); system tasks warn before disabling, changes verified by read-back. _Preview._
 - `ProfileViewModel` — export/import SysManager's own config (theme, speed-test history) as a portable JSON profile with selective sections and version checking.
 - `DebloaterViewModel` — list and remove preinstalled Store apps with a curated bloat preset; system-critical packages are denylisted; removal is per-user and reversible via the Store.
 - `BrowserCleanerViewModel` — scan per-browser cache/history/cookies/sessions with sizes and clean the selected categories; cookies/sessions default unticked.
@@ -254,6 +255,10 @@ Key services:
   `IPowerShellRunner`. Normalizes the inverted `Disable*` booleans; exclusion paths are
   bound parameters (never interpolated); every change is verified by reading the value
   back (Tamper Protection can silently reject). The parse helpers are pure, unit-tested.
+- `TaskSchedulerService` — the `ScheduledTasks` PowerShell module (`Get-ScheduledTask`
+  / `Get-ScheduledTaskInfo` / `Enable`/`Disable-ScheduledTask`) through `IPowerShellRunner`.
+  Disabling is reversible and never unregisters; toggles are verified by read-back. The
+  `ClassifyTask` safety heuristic (telemetry/system/third-party) is a pure, unit-tested method.
 - `LegacyPanelService` — opens classic Windows applets (Control Panel, Sound,
   Device Manager, …) via their `control`/`*.cpl`/`*.msc` commands. The catalog is
   hard-coded and `Launch` re-validates catalog membership, so no input reaches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.40.0] - 2026-06-26
+
+### Added
+- **Task Scheduler tab (System).** Browse all Windows scheduled tasks and turn them on or off. Tasks are color-coded by type — Third-party, well-known Telemetry (CEIP / Compatibility Appraiser / Feedback / Error Reporting), and System — so it's clear what's safe to touch. Filter by name/path, optionally hide system tasks, and see each task's last/next run. Disabling is **fully reversible and never deletes a task**; system tasks show an extra confirmation warning, changes need administrator, and each toggle is verified by reading the task's state back. Marked **PREVIEW** while it's verified. Closes #334.
+
 ## [1.39.0] - 2026-06-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,14 +74,14 @@ fully open source.
 
 ### Sidebar navigation
 The sidebar organises 57 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 45 tabs are fully
-implemented; 12 are work-in-progress placeholders marked with ⚙️. Newly added
+find what you need without scrolling through a flat list. 46 tabs are fully
+implemented; 11 are work-in-progress placeholders marked with ⚙️. Newly added
 tabs still being verified are marked **PREVIEW**:
 
 | Group | Tabs |
 |-------|------|
 | 🏠 Dashboard | Dashboard |
-| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · System Fixes · Boot Analyzer · Task Scheduler ⚙️ |
+| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · System Fixes · Boot Analyzer · Task Scheduler 🔬 |
 | 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner ⚙️ · Timer Resolution 🔬 · CPU Core Affinity 🔬 · Display Profiles 🔬 |
 | 📊 Monitor | Process Manager · Resource History ⚙️ · Camera/Mic/Location · App Alerts · File Lock Detector 🔬 · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance ⚙️ |
@@ -223,6 +223,17 @@ a confirmation before it runs:
 - Lists the apps, drivers, services, and devices Windows flagged as slowing boot,
   with the delay attributed to each
 - Read-only; reading the log requires administrator (elevation banner shown)
+
+### Task Scheduler 🔬
+- **Browse every Windows scheduled task** with its state, type, and last/next run
+- **Color-coded by type** — Third-party, well-known **Telemetry** (Compatibility
+  Appraiser, CEIP, Feedback, Error Reporting), and **System** — so it's obvious
+  what's safe to touch
+- **Enable / disable** any task; disabling is **fully reversible and never deletes
+  the task** — System tasks show an extra warning before you disable them
+- Filter by name or path, and optionally hide system tasks to focus on the rest
+- Changes need administrator and are verified by reading the task's state back
+- _Preview — implemented and usable, still being verified._
 
 ### Windows Update (Windows Update Agent COM API)
 - Direct Windows Update Agent COM integration (`Microsoft.Update.Session`) —

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -400,4 +400,14 @@ public class MainWindowViewModelTests
         Assert.IsType<DefenderViewModel>(item.Content);
         Assert.True(item.IsInDevelopment);
     }
+
+    [Fact]
+    public void NavLeaf_TaskScheduler_IsImplementedAndMarkedPreview()
+    {
+        var vm = new MainWindowViewModel();
+        var item = vm.NavItems.First(n => n.Id == "nav-task-scheduler");
+        Assert.Equal(typeof(SysManager.Views.TaskSchedulerView), item.ViewType);
+        Assert.IsType<TaskSchedulerViewModel>(item.Content);
+        Assert.True(item.IsInDevelopment);
+    }
 }

--- a/SysManager/SysManager.Tests/ScheduledTaskInfoTests.cs
+++ b/SysManager/SysManager.Tests/ScheduledTaskInfoTests.cs
@@ -1,0 +1,47 @@
+// SysManager · ScheduledTaskInfoTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Tests;
+
+public class ScheduledTaskInfoTests
+{
+    private static ScheduledTaskInfo Make(string state, TaskCategory cat = TaskCategory.ThirdParty)
+        => new("MyTask", @"\Vendor\", state, "Vendor", "desc", cat, null, null);
+
+    [Theory]
+    [InlineData("Ready", true)]
+    [InlineData("Running", true)]
+    [InlineData("Queued", true)]
+    [InlineData("Disabled", false)]
+    public void IsEnabled_TrueUnlessDisabled(string state, bool expected)
+        => Assert.Equal(expected, Make(state).IsEnabled);
+
+    [Fact]
+    public void FullPath_CombinesPathAndName()
+        => Assert.Equal(@"\Vendor\MyTask", Make("Ready").FullPath);
+
+    [Theory]
+    [InlineData(TaskCategory.Telemetry, "Telemetry")]
+    [InlineData(TaskCategory.System, "System")]
+    [InlineData(TaskCategory.ThirdParty, "Third-party")]
+    public void CategoryLabel_Maps(TaskCategory cat, string label)
+        => Assert.Equal(label, Make("Ready", cat).CategoryLabel);
+
+    [Fact]
+    public void RunDisplays_ShowDashWhenNull()
+    {
+        var t = Make("Ready");
+        Assert.Equal("—", t.LastRunDisplay);
+        Assert.Equal("—", t.NextRunDisplay);
+    }
+
+    [Fact]
+    public void IsSystem_TrueOnlyForSystemCategory()
+    {
+        Assert.True(Make("Ready", TaskCategory.System).IsSystem);
+        Assert.False(Make("Ready", TaskCategory.Telemetry).IsSystem);
+    }
+}

--- a/SysManager/SysManager.Tests/TaskSchedulerServiceTests.cs
+++ b/SysManager/SysManager.Tests/TaskSchedulerServiceTests.cs
@@ -1,0 +1,45 @@
+// SysManager · TaskSchedulerServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+public class TaskSchedulerServiceTests
+{
+    [Theory]
+    [InlineData(@"\Microsoft\Windows\Application Experience\", "Microsoft Corporation")]
+    [InlineData(@"\Microsoft\Windows\Customer Experience Improvement Program\", "Microsoft")]
+    [InlineData(@"\Microsoft\Windows\DiskDiagnostic\", "Microsoft")]
+    [InlineData(@"\Microsoft\Windows\Feedback\Siuf\", "Microsoft")]
+    [InlineData(@"\Microsoft\Windows\Windows Error Reporting\", "Microsoft")]
+    public void ClassifyTask_KnownTelemetryFolders_AreTelemetry(string path, string author)
+        => Assert.Equal(TaskCategory.Telemetry, TaskSchedulerService.ClassifyTask(path, author));
+
+    [Fact]
+    public void ClassifyTask_AutochkProxy_IsTelemetry()
+        => Assert.Equal(TaskCategory.Telemetry, TaskSchedulerService.ClassifyTask(@"\Microsoft\Windows\Autochk\Proxy", "Microsoft"));
+
+    [Theory]
+    [InlineData(@"\Microsoft\Windows\Defrag\", "Microsoft Corporation")]
+    [InlineData(@"\Microsoft\Windows\UpdateOrchestrator\", "Microsoft")]
+    public void ClassifyTask_OtherMicrosoftTasks_AreSystem(string path, string author)
+        => Assert.Equal(TaskCategory.System, TaskSchedulerService.ClassifyTask(path, author));
+
+    [Theory]
+    [InlineData(@"\", "Valve")]
+    [InlineData(@"\GoogleSystem\", "Google")]
+    [InlineData(@"\", null)]
+    public void ClassifyTask_NonMicrosoft_AreThirdParty(string path, string? author)
+        => Assert.Equal(TaskCategory.ThirdParty, TaskSchedulerService.ClassifyTask(path, author));
+
+    [Fact]
+    public void ClassifyTask_MicrosoftAuthorButRootPath_IsSystem()
+        => Assert.Equal(TaskCategory.System, TaskSchedulerService.ClassifyTask(@"\", "Microsoft Corporation"));
+
+    [Fact]
+    public void ClassifyTask_NullPath_IsThirdParty()
+        => Assert.Equal(TaskCategory.ThirdParty, TaskSchedulerService.ClassifyTask(null!, null));
+}

--- a/SysManager/SysManager/Models/ScheduledTaskInfo.cs
+++ b/SysManager/SysManager/Models/ScheduledTaskInfo.cs
@@ -1,0 +1,47 @@
+// SysManager · ScheduledTaskInfo
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>Safety classification for a scheduled task — drives UI color and confirmation.</summary>
+public enum TaskCategory
+{
+    /// <summary>User/vendor task — safe to toggle.</summary>
+    ThirdParty,
+
+    /// <summary>Well-known telemetry/CEIP task — commonly disabled by debloat tools.</summary>
+    Telemetry,
+
+    /// <summary>Windows system task — may be load-bearing; confirm before disabling.</summary>
+    System,
+}
+
+/// <summary>
+/// A Windows scheduled task projected for the UI. <see cref="LastRun"/>/<see cref="NextRun"/>
+/// are null until lazily loaded on selection (a separate per-task query).
+/// </summary>
+public sealed record ScheduledTaskInfo(
+    string Name,
+    string Path,
+    string State,
+    string? Author,
+    string? Description,
+    TaskCategory Category,
+    DateTime? LastRun,
+    DateTime? NextRun)
+{
+    public bool IsEnabled => !string.Equals(State, "Disabled", StringComparison.OrdinalIgnoreCase);
+    public bool IsSystem => Category == TaskCategory.System;
+
+    public string CategoryLabel => Category switch
+    {
+        TaskCategory.Telemetry => "Telemetry",
+        TaskCategory.System => "System",
+        _ => "Third-party",
+    };
+
+    public string FullPath => $"{Path}{Name}";
+    public string LastRunDisplay => LastRun is { } t ? t.ToString("yyyy-MM-dd HH:mm") : "—";
+    public string NextRunDisplay => NextRun is { } t ? t.ToString("yyyy-MM-dd HH:mm") : "—";
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -77,6 +77,7 @@ public static class ServiceRegistration
         services.AddSingleton<DisplayProfileService>();
         services.AddSingleton<CpuAffinityService>();
         services.AddSingleton<DefenderService>();
+        services.AddSingleton<TaskSchedulerService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
         services.AddSingleton<DashboardViewModel>();
@@ -126,6 +127,7 @@ public static class ServiceRegistration
         services.AddSingleton<DisplayProfileViewModel>();
         services.AddSingleton<CpuAffinityViewModel>();
         services.AddSingleton<DefenderViewModel>();
+        services.AddSingleton<TaskSchedulerViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/TaskSchedulerService.cs
+++ b/SysManager/SysManager/Services/TaskSchedulerService.cs
@@ -1,0 +1,174 @@
+// SysManager · TaskSchedulerService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.Frozen;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Management.Automation;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Browses Windows scheduled tasks and enables/disables them through the Defender-free
+/// <c>ScheduledTasks</c> PowerShell module (<c>Get-ScheduledTask</c> /
+/// <c>Get-ScheduledTaskInfo</c> / <c>Enable</c>/<c>Disable-ScheduledTask</c>) via the
+/// shared <see cref="IPowerShellRunner"/> seam.
+///
+/// Disabling a task is fully reversible and non-destructive (it sets State=Disabled, it
+/// does NOT unregister the task); this service never deletes a task. Modifying a system
+/// task needs admin — without it the cmdlet fails on the error stream rather than
+/// throwing, so every toggle is verified by reading the task's state back.
+/// </summary>
+public sealed class TaskSchedulerService
+{
+    private readonly IPowerShellRunner _ps;
+
+    public TaskSchedulerService(IPowerShellRunner ps) => _ps = ps;
+
+    private const string ListScript = """
+        Get-ScheduledTask | ForEach-Object {
+            [PSCustomObject]@{
+                TaskName    = $_.TaskName
+                TaskPath    = $_.TaskPath
+                State       = [string]$_.State
+                Author      = $_.Author
+                Description = $_.Description
+            }
+        }
+        """;
+
+    private const string InfoScript = """
+        param([string]$Name, [string]$Path)
+        Get-ScheduledTaskInfo -TaskName $Name -TaskPath $Path | Select-Object LastRunTime, NextRunTime
+        """;
+
+    private const string SetEnabledScript = """
+        param([string]$Name, [string]$Path, [bool]$Enabled)
+        if ($Enabled) { Enable-ScheduledTask -TaskName $Name -TaskPath $Path -ErrorAction SilentlyContinue | Out-Null }
+        else { Disable-ScheduledTask -TaskName $Name -TaskPath $Path -ErrorAction SilentlyContinue | Out-Null }
+        Get-ScheduledTask -TaskName $Name -TaskPath $Path |
+            Select-Object TaskName, TaskPath, @{ n='State'; e={ [string]$_.State } }, Author, Description
+        """;
+
+    /// <summary>List all scheduled tasks (run info loaded lazily on selection).</summary>
+    public async Task<IReadOnlyList<ScheduledTaskInfo>> ListTasksAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            Collection<PSObject> results = await _ps.RunAsync(ListScript, cancellationToken: ct).ConfigureAwait(false);
+            var list = new List<ScheduledTaskInfo>(results.Count);
+            foreach (var item in results)
+            {
+                string? name = Str(item, "TaskName");
+                string? path = Str(item, "TaskPath");
+                if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(path)) continue;
+
+                string? author = Str(item, "Author");
+                list.Add(new ScheduledTaskInfo(
+                    name, path, Str(item, "State") ?? "Unknown", author,
+                    Str(item, "Description"), ClassifyTask(path, author), null, null));
+            }
+            return list.OrderBy(t => t.Path, StringComparer.OrdinalIgnoreCase)
+                       .ThenBy(t => t.Name, StringComparer.OrdinalIgnoreCase).ToList();
+        }
+        catch (System.Management.Automation.RuntimeException ex)
+        {
+            Log.Debug("List scheduled tasks failed: {Error}", ex.Message);
+            return [];
+        }
+    }
+
+    /// <summary>Fetch last/next run for one task (separate per-task query).</summary>
+    public async Task<ScheduledTaskInfo> LoadRunInfoAsync(ScheduledTaskInfo task, CancellationToken ct = default)
+    {
+        try
+        {
+            var parameters = new Dictionary<string, object?> { ["Name"] = task.Name, ["Path"] = task.Path };
+            Collection<PSObject> results = await _ps.RunAsync(InfoScript, parameters, ct).ConfigureAwait(false);
+            var row = results.Count > 0 ? results[0] : null;
+            return task with { LastRun = Date(row, "LastRunTime"), NextRun = Date(row, "NextRunTime") };
+        }
+        catch (System.Management.Automation.RuntimeException ex)
+        {
+            Log.Debug("Read task run info failed: {Error}", ex.Message);
+            return task;
+        }
+    }
+
+    /// <summary>
+    /// Enable or disable a task, then re-read its state to verify. Returns the observed
+    /// task on success, or null if the change didn't take effect (e.g. needs admin).
+    /// </summary>
+    public async Task<ScheduledTaskInfo?> SetEnabledAsync(string name, string path, bool enabled, CancellationToken ct = default)
+    {
+        try
+        {
+            var parameters = new Dictionary<string, object?> { ["Name"] = name, ["Path"] = path, ["Enabled"] = enabled };
+            Collection<PSObject> results = await _ps.RunAsync(SetEnabledScript, parameters, ct).ConfigureAwait(false);
+            var row = results.Count > 0 ? results[0] : null;
+            if (row is null) return null;
+
+            string observed = Str(row, "State") ?? "Unknown";
+            bool observedDisabled = string.Equals(observed, "Disabled", StringComparison.OrdinalIgnoreCase);
+            // Intent check: enable => not disabled; disable => disabled.
+            if (enabled == observedDisabled) return null;
+
+            string? author = Str(row, "Author");
+            return new ScheduledTaskInfo(
+                Str(row, "TaskName") ?? name, Str(row, "TaskPath") ?? path, observed,
+                author, Str(row, "Description"), ClassifyTask(path, author), null, null);
+        }
+        catch (System.Management.Automation.RuntimeException ex)
+        {
+            Log.Debug("Set task enabled failed: {Error}", ex.Message);
+            return null;
+        }
+    }
+
+    // Well-known telemetry/CEIP folders targeted by reputable debloat tools — small and
+    // conservative, prefix-matched on TaskPath.
+    private static readonly FrozenSet<string> TelemetryFolders = new[]
+    {
+        @"\Microsoft\Windows\Application Experience\",
+        @"\Microsoft\Windows\Customer Experience Improvement Program\",
+        @"\Microsoft\Windows\DiskDiagnostic\",
+        @"\Microsoft\Windows\Feedback\",
+        @"\Microsoft\Windows\Windows Error Reporting\",
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    private static readonly FrozenSet<string> TelemetryFullPaths = new[]
+    {
+        @"\Microsoft\Windows\Autochk\Proxy",
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Pure classification: telemetry folders first (safe-to-disable), then any other
+    /// Microsoft/Windows task as System (caution), else Third-party.
+    /// </summary>
+    public static TaskCategory ClassifyTask(string path, string? author)
+    {
+        path ??= "";
+        foreach (var folder in TelemetryFolders)
+            if (path.StartsWith(folder, StringComparison.OrdinalIgnoreCase))
+                return TaskCategory.Telemetry;
+
+        if (TelemetryFullPaths.Contains(path.TrimEnd('\\')))
+            return TaskCategory.Telemetry;
+
+        bool microsoftPath = path.StartsWith(@"\Microsoft\Windows\", StringComparison.OrdinalIgnoreCase);
+        bool microsoftAuthor = author is not null && author.Contains("Microsoft", StringComparison.OrdinalIgnoreCase);
+        return microsoftPath || microsoftAuthor ? TaskCategory.System : TaskCategory.ThirdParty;
+    }
+
+    private static string? Str(PSObject? obj, string property) => obj?.Properties[property]?.Value?.ToString();
+
+    private static DateTime? Date(PSObject? obj, string property) => obj?.Properties[property]?.Value switch
+    {
+        DateTime dt => dt,
+        string s when DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.None, out var p) => p,
+        _ => null,
+    };
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.39.0</Version>
-    <FileVersion>1.39.0.0</FileVersion>
-    <AssemblyVersion>1.39.0.0</AssemblyVersion>
+    <Version>1.40.0</Version>
+    <FileVersion>1.40.0.0</FileVersion>
+    <AssemblyVersion>1.40.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -62,6 +62,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public DisplayProfileViewModel DisplayProfile { get; }
     public CpuAffinityViewModel CpuAffinity { get; }
     public DefenderViewModel Defender { get; }
+    public TaskSchedulerViewModel TaskScheduler { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -169,6 +170,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             DisplayProfile = sp.GetRequiredService<DisplayProfileViewModel>();
             CpuAffinity = sp.GetRequiredService<CpuAffinityViewModel>();
             Defender = sp.GetRequiredService<DefenderViewModel>();
+            TaskScheduler = sp.GetRequiredService<TaskSchedulerViewModel>();
         }
         else
         {
@@ -235,6 +237,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             DisplayProfile = new DisplayProfileViewModel(new DisplayProfileService());
             CpuAffinity = new CpuAffinityViewModel(new CpuAffinityService());
             Defender = new DefenderViewModel(new DefenderService(new PowerShellRunner()));
+            TaskScheduler = new TaskSchedulerViewModel(new TaskSchedulerService(new PowerShellRunner()));
         }
 
         InitPlaceholders();
@@ -314,7 +317,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-startup",          "Startup Manager",  "", Startup,          typeof(Views.StartupView)),
             Item("nav-windows-features", "Windows Features", "", WindowsFeatures,  typeof(Views.WindowsFeaturesView)),
             Item("nav-restore-points",   "Restore Points",   "", RestorePoints,    typeof(Views.RestorePointsView)),
-            Item("nav-task-scheduler",   "Task Scheduler",   "", WipTaskScheduler, typeof(Views.PlaceholderView)),
+            Item("nav-task-scheduler",   "Task Scheduler",   "", TaskScheduler,    typeof(Views.TaskSchedulerView), inDevelopment: true),
             Item("nav-boot-analyzer",    "Boot Analyzer",    "", BootAnalyzer,     typeof(Views.BootAnalyzerView)),
             Item("nav-system-fixes",     "System Fixes",     "", SystemFixes,      typeof(Views.SystemFixesView))),
 

--- a/SysManager/SysManager/ViewModels/TaskSchedulerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TaskSchedulerViewModel.cs
@@ -1,0 +1,131 @@
+// SysManager · TaskSchedulerViewModel
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the Task Scheduler tab. Lists Windows scheduled tasks with a
+/// safety classification (Third-party / Telemetry / System), and enables or disables
+/// the selected task. Disabling is reversible; tasks are never deleted. System tasks
+/// require a confirmation warning; changes need admin and are verified by read-back.
+/// </summary>
+public sealed partial class TaskSchedulerViewModel : ViewModelBase
+{
+    private readonly TaskSchedulerService _service;
+    private List<ScheduledTaskInfo> _all = [];
+
+    public BulkObservableCollection<ScheduledTaskInfo> Tasks { get; } = new();
+
+    [ObservableProperty] private ScheduledTaskInfo? _selectedTask;
+    [ObservableProperty] private string _filter = "";
+    [ObservableProperty] private bool _hideSystemTasks;
+
+    public TaskSchedulerViewModel(TaskSchedulerService service)
+    {
+        _service = service;
+        StatusMessage = "Loading scheduled tasks…";
+        InitializeAsync(RefreshAsync);
+    }
+
+    [RelayCommand]
+    private async Task RefreshAsync()
+    {
+        IsBusy = true;
+        IsProgressIndeterminate = true;
+        StatusMessage = "Loading scheduled tasks…";
+        try
+        {
+            _all = (await _service.ListTasksAsync().ConfigureAwait(true)).ToList();
+            ApplyFilter();
+            StatusMessage = _all.Count == 0
+                ? "No scheduled tasks found."
+                : $"{_all.Count} tasks. Select one to see when it last ran.";
+        }
+        finally
+        {
+            IsBusy = false;
+            IsProgressIndeterminate = false;
+        }
+    }
+
+    partial void OnFilterChanged(string value) => ApplyFilter();
+    partial void OnHideSystemTasksChanged(bool value) => ApplyFilter();
+
+    private void ApplyFilter()
+    {
+        IEnumerable<ScheduledTaskInfo> q = _all;
+        if (HideSystemTasks) q = q.Where(t => !t.IsSystem);
+        if (!string.IsNullOrWhiteSpace(Filter))
+        {
+            string f = Filter.Trim();
+            q = q.Where(t => t.Name.Contains(f, StringComparison.OrdinalIgnoreCase)
+                          || t.Path.Contains(f, StringComparison.OrdinalIgnoreCase));
+        }
+        Tasks.ReplaceWith(q.ToList());
+        ToggleEnabledCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnSelectedTaskChanged(ScheduledTaskInfo? value)
+    {
+        ToggleEnabledCommand.NotifyCanExecuteChanged();
+        if (value is not null) _ = LoadRunInfoAsync(value);
+    }
+
+    private async Task LoadRunInfoAsync(ScheduledTaskInfo task)
+    {
+        var withInfo = await _service.LoadRunInfoAsync(task).ConfigureAwait(true);
+        // Update the item in place if it's still the selection.
+        if (ReferenceEquals(SelectedTask, task))
+        {
+            int idx = Tasks.IndexOf(task);
+            if (idx >= 0) Tasks[idx] = withInfo;
+            SelectedTask = withInfo;
+        }
+    }
+
+    private bool HasSelection => SelectedTask is not null;
+
+    [RelayCommand(CanExecute = nameof(HasSelection))]
+    private async Task ToggleEnabledAsync()
+    {
+        var task = SelectedTask;
+        if (task is null) return;
+
+        bool enabling = !task.IsEnabled;
+        string verb = enabling ? "Enable" : "Disable";
+
+        string message = task.IsSystem
+            ? $"{verb} the Windows system task \"{task.Name}\"?\n\nThis is a system task — disabling it may affect Windows features. It can be re-enabled at any time."
+            : $"{verb} the task \"{task.Name}\"?\n\nIt can be re-enabled at any time.";
+        if (!DialogService.Instance.Confirm(message, $"{verb} Task — Confirm")) return;
+
+        var result = await _service.SetEnabledAsync(task.Name, task.Path, enabling).ConfigureAwait(true);
+        if (result is not null)
+        {
+            Log.Information("Task {Path} {Verb}d", task.FullPath, verb);
+            ReplaceTask(task, result);
+            StatusMessage = $"{result.Name} is now {(result.IsEnabled ? "enabled" : "disabled")}.";
+        }
+        else
+        {
+            StatusMessage = $"Couldn't change \"{task.Name}\" — this usually needs administrator rights.";
+        }
+    }
+
+    private void ReplaceTask(ScheduledTaskInfo oldTask, ScheduledTaskInfo newTask)
+    {
+        int allIdx = _all.FindIndex(t => t.FullPath == oldTask.FullPath);
+        if (allIdx >= 0) _all[allIdx] = newTask;
+        int idx = Tasks.IndexOf(oldTask);
+        if (idx >= 0) Tasks[idx] = newTask;
+        SelectedTask = newTask;
+    }
+}

--- a/SysManager/SysManager/Views/TaskSchedulerView.xaml
+++ b/SysManager/SysManager/Views/TaskSchedulerView.xaml
@@ -1,0 +1,83 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.TaskSchedulerView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:TaskSchedulerViewModel}"
+             Background="{DynamicResource Surface0}">
+
+    <Grid Margin="28,24,28,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Preview banner -->
+        <v:DevelopmentBanner Grid.Row="0" Margin="0,0,0,16"/>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="1" Margin="0,0,0,16">
+            <TextBlock Text="Task Scheduler" Style="{StaticResource Display}"/>
+            <TextBlock Text="Browse Windows scheduled tasks and turn them on or off. Tasks are color-coded by type; disabling is always reversible and never deletes a task."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <!-- Toolbar -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBox Grid.Column="0" Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged}"
+                         VerticalContentAlignment="Center" Padding="10,8" FontSize="13"
+                         AutomationProperties.Name="Filter tasks by name or path"/>
+                <CheckBox Grid.Column="1" Content="Hide system tasks" IsChecked="{Binding HideSystemTasks}"
+                          VerticalAlignment="Center" Margin="12,0,0,0"
+                          AutomationProperties.Name="Hide system tasks"/>
+                <Button Grid.Column="2" Content="Refresh" Command="{Binding RefreshCommand}"
+                        Style="{StaticResource GhostButton}" Margin="12,0,0,0" Padding="14,8"
+                        AutomationProperties.Name="Refresh task list"/>
+            </Grid>
+        </Border>
+
+        <!-- Tasks grid -->
+        <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
+            <DataGrid ItemsSource="{Binding Tasks}" SelectedItem="{Binding SelectedTask}"
+                      AutomationProperties.Name="Scheduled tasks"
+                      AutoGenerateColumns="False" HeadersVisibility="Column"
+                      CanUserAddRows="False" IsReadOnly="True" SelectionMode="Single"
+                      Background="Transparent" BorderThickness="0" GridLinesVisibility="None"
+                      VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Task" Binding="{Binding Name}" Width="2*"/>
+                    <DataGridTextColumn Header="Path" Binding="{Binding Path}" Width="2*"/>
+                    <DataGridTextColumn Header="Type" Binding="{Binding CategoryLabel}" Width="110"/>
+                    <DataGridTextColumn Header="State" Binding="{Binding State}" Width="90"/>
+                    <DataGridTextColumn Header="Last run" Binding="{Binding LastRunDisplay}" Width="140"/>
+                </DataGrid.Columns>
+            </DataGrid>
+        </Border>
+
+        <!-- Actions + status -->
+        <Grid Grid.Row="4" Margin="0,12,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+                       VerticalAlignment="Center" TextWrapping="Wrap"/>
+            <Button Grid.Column="1" Content="Enable / Disable" Command="{Binding ToggleEnabledCommand}"
+                    Style="{StaticResource PrimaryButton}" Padding="16,8"
+                    AutomationProperties.Name="Enable or disable the selected task"/>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/TaskSchedulerView.xaml.cs
+++ b/SysManager/SysManager/Views/TaskSchedulerView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · TaskSchedulerView
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class TaskSchedulerView : UserControl
+{
+    public TaskSchedulerView() => InitializeComponent();
+}


### PR DESCRIPTION
## What
Implements **Task Scheduler Manager** (System group), replacing its WIP placeholder. Closes #334.

Browse Windows scheduled tasks and turn them on/off, color-coded by type.

## How
- **`TaskSchedulerService`** — the `ScheduledTasks` PowerShell module via `IPowerShellRunner`:
  - `Get-ScheduledTask` for the fast full list (typed objects, stable integer `State` enum — no `schtasks.exe` CSV/localization fragility).
  - `Get-ScheduledTaskInfo` lazily on selection (it's a per-task call — not run for all ~200 up front).
  - `Enable`/`Disable-ScheduledTask` to toggle.
- **Reversible & non-destructive** — disabling sets `State=Disabled`; the task stays registered. **No `Unregister-ScheduledTask` anywhere** — the UI cannot delete a task.
- **Verify-by-readback** — admin-denied failures surface on the PS error stream (not as a throw), so after a toggle the service re-reads the task's `State` and reports success only if it actually changed.
- **`ClassifyTask`** (pure, unit-tested) — small conservative heuristic: known telemetry folders (Compatibility Appraiser / CEIP / Feedback / Error Reporting / DiskDiagnostic) → **Telemetry**; other `\Microsoft\Windows\` or Microsoft-authored → **System** (caution); rest → **Third-party**.
- **`TaskSchedulerViewModel`** — filter by name/path, hide-system toggle, color-coded grid, enable/disable with a confirmation that **warns for System tasks** and names the reversibility.

## Preview
Marked **PREVIEW** (sidebar pill + banner).

## Tests
- `TaskSchedulerServiceTests` — `ClassifyTask` across telemetry folders, the Autochk\Proxy special case, "other Microsoft task = System not Telemetry", third-party, null path.
- `ScheduledTaskInfoTests` — IsEnabled, FullPath, CategoryLabel, IsSystem, run-display dashes.
- Integration: `NavLeaf_TaskScheduler_IsImplementedAndMarkedPreview`.

## Verification
- Build main + unit + integration: 0/0. Leak scan clean. No delete/Unregister, no MessageBox, specific exceptions only.
- README + ARCHITECTURE updated (counts 45→46 implemented / 12→11 WIP). feat: -> minor 1.40.0.
