### PR TITLE
fix: run display-mode changes off the UI thread and serialise Defender toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.42.2] - 2026-06-27
+
+### Fixed
+- **Display Profiles applies and auto-reverts without freezing the window.** Switching resolution/refresh rate, picking a display, and the 15-second auto-revert all called the Windows display APIs (`EnumDisplaySettings` / `ChangeDisplaySettingsEx`) directly on the UI thread, so the app could briefly stop responding while the driver re-trained the panel — and that stall could hold up the very countdown meant to rescue you from a bad mode. These calls now run on a background thread, so the window and the auto-revert timer stay responsive throughout.
+- **Defender Tweaks no longer lets two changes overlap.** The PUA, Controlled Folder Access, exclusion-add and exclusion-remove actions could be triggered again while a previous change was still being written and verified, starting overlapping operations whose read-back checks could race and show a misleading "not changed" message. Each action now disables the others until it finishes, matching how the rest of the app serialises long-running operations. No change to what any action does.
+
 ## [1.42.1] - 2026-06-27
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DefenderViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DefenderViewModelTests.cs
@@ -1,0 +1,85 @@
+// SysManager · DefenderViewModelTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+using NSubstitute;
+using SysManager.Services;
+using SysManager.ViewModels;
+using Xunit;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="DefenderViewModel"/> — focuses on the re-entrancy guard
+/// (NotBusy) that serialises the mutating Defender commands so two overlapping
+/// Set-MpPreference operations can't race the read-back verification.
+/// </summary>
+[Collection("DialogService")]
+public class DefenderViewModelTests
+{
+    private static DefenderViewModel NewVm()
+    {
+        // Runner returns an empty result set, so GetStatusAsync produces a default
+        // (unavailable) status without touching real PowerShell/Defender.
+        var ps = Substitute.For<IPowerShellRunner>();
+        ps.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<System.Threading.CancellationToken>())
+          .Returns(new Collection<PSObject>());
+        var vm = new DefenderViewModel(new DefenderService(ps));
+        vm.InitializationComplete.GetAwaiter().GetResult();
+        return vm;
+    }
+
+    [Fact]
+    public void AfterInit_NotBusy_IsTrue()
+    {
+        var vm = NewVm();
+        Assert.False(vm.IsBusy);
+        Assert.True(vm.NotBusy);
+    }
+
+    [Fact]
+    public void MutatingCommands_AreGatedOnNotBusy()
+    {
+        var vm = NewVm();
+
+        // While not busy, the always-available mutating commands can run.
+        Assert.True(vm.TogglePuaCommand.CanExecute(null));
+        Assert.True(vm.ToggleCfaCommand.CanExecute(null));
+        Assert.True(vm.AddExclusionCommand.CanExecute(null));
+        Assert.True(vm.RefreshCommand.CanExecute(null));
+
+        // Simulate an in-flight operation: every mutating command must refuse to start.
+        vm.IsBusy = true;
+        Assert.False(vm.NotBusy);
+        Assert.False(vm.TogglePuaCommand.CanExecute(null));
+        Assert.False(vm.ToggleCfaCommand.CanExecute(null));
+        Assert.False(vm.AddExclusionCommand.CanExecute(null));
+        Assert.False(vm.RemoveExclusionCommand.CanExecute(null));
+        Assert.False(vm.RefreshCommand.CanExecute(null));
+
+        // Clearing busy re-enables them.
+        vm.IsBusy = false;
+        Assert.True(vm.TogglePuaCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void RemoveExclusion_RequiresBothSelectionAndNotBusy()
+    {
+        var vm = NewVm();
+
+        // No selection -> cannot remove even when idle.
+        Assert.Null(vm.SelectedExclusion);
+        Assert.False(vm.RemoveExclusionCommand.CanExecute(null));
+
+        // With a selection and idle -> can remove.
+        vm.SelectedExclusion = @"C:\some\folder";
+        Assert.True(vm.RemoveExclusionCommand.CanExecute(null));
+
+        // Busy overrides the selection -> cannot remove.
+        vm.IsBusy = true;
+        Assert.False(vm.RemoveExclusionCommand.CanExecute(null));
+    }
+}

--- a/SysManager/SysManager.Tests/DisplayProfileViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DisplayProfileViewModelTests.cs
@@ -1,0 +1,51 @@
+// SysManager · DisplayProfileViewModelTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.Input;
+using SysManager.Services;
+using SysManager.ViewModels;
+using Xunit;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="DisplayProfileViewModel"/> — pins that the display-mode
+/// commands are asynchronous, so their blocking P/Invoke work (EnumDisplaySettings /
+/// ChangeDisplaySettingsEx) runs off the UI thread and the auto-revert DispatcherTimer
+/// keeps ticking during a mode switch.
+/// </summary>
+[Collection("DialogService")]
+public class DisplayProfileViewModelTests
+{
+    private static DisplayProfileViewModel NewVm()
+    {
+        var vm = new DisplayProfileViewModel(new DisplayProfileService());
+        vm.InitializationComplete.GetAwaiter().GetResult();
+        return vm;
+    }
+
+    [Fact]
+    public void ApplyCommand_IsAsync()
+    {
+        // An IAsyncRelayCommand means the body is awaited (offloaded), not run
+        // synchronously on the dispatcher — and it disables itself while in flight.
+        var vm = NewVm();
+        Assert.IsAssignableFrom<IAsyncRelayCommand>(vm.ApplyCommand);
+    }
+
+    [Fact]
+    public void RevertNowCommand_IsAsync()
+    {
+        var vm = NewVm();
+        Assert.IsAssignableFrom<IAsyncRelayCommand>(vm.RevertNowCommand);
+    }
+
+    [Fact]
+    public void NewVm_DoesNotThrow_AndExposesCollections()
+    {
+        var vm = NewVm();
+        Assert.NotNull(vm.Displays);
+        Assert.NotNull(vm.Modes);
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.42.1</Version>
-    <FileVersion>1.42.1.0</FileVersion>
-    <AssemblyVersion>1.42.1.0</AssemblyVersion>
+    <Version>1.42.2</Version>
+    <FileVersion>1.42.2.0</FileVersion>
+    <AssemblyVersion>1.42.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DefenderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DefenderViewModel.cs
@@ -38,10 +38,28 @@ public sealed partial class DefenderViewModel : ViewModelBase
     {
         _service = service;
         StatusMessage = "Reading Defender status…";
+        PropertyChanged += OnVmPropertyChanged;
         InitializeAsync(RefreshAsync);
     }
 
-    [RelayCommand]
+    /// <summary>True when no Defender operation is in flight — gates the mutating
+    /// commands so a user can't start a second Set-MpPreference while the first is
+    /// still running (each spins its own runspace and the read-back verification
+    /// could race). Mirrors the NotBusy convention used across the other VMs.</summary>
+    public bool NotBusy => !IsBusy;
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(IsBusy)) return;
+        OnPropertyChanged(nameof(NotBusy));
+        RefreshCommand.NotifyCanExecuteChanged();
+        TogglePuaCommand.NotifyCanExecuteChanged();
+        ToggleCfaCommand.NotifyCanExecuteChanged();
+        AddExclusionCommand.NotifyCanExecuteChanged();
+        RemoveExclusionCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task RefreshAsync()
     {
         IsBusy = true;
@@ -58,27 +76,37 @@ public sealed partial class DefenderViewModel : ViewModelBase
         finally { IsBusy = false; }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task TogglePuaAsync()
     {
         if (!Confirm($"{(PuaEnabled ? "Disable" : "Enable")} potentially-unwanted-app (PUA) protection?")) return;
-        int target = PuaEnabled ? 0 : 1;
-        var status = await _service.SetPuaProtectionAsync(target).ConfigureAwait(true);
-        Apply(status);
-        ReportVerified("PUA protection", status.PuaProtection == target);
+        IsBusy = true;
+        try
+        {
+            int target = PuaEnabled ? 0 : 1;
+            var status = await _service.SetPuaProtectionAsync(target).ConfigureAwait(true);
+            Apply(status);
+            ReportVerified("PUA protection", status.PuaProtection == target);
+        }
+        finally { IsBusy = false; }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task ToggleCfaAsync()
     {
         if (!Confirm($"{(CfaEnabled ? "Disable" : "Enable")} Controlled Folder Access (ransomware protection)?")) return;
-        int target = CfaEnabled ? 0 : 1;
-        var status = await _service.SetControlledFolderAccessAsync(target).ConfigureAwait(true);
-        Apply(status);
-        ReportVerified("Controlled Folder Access", status.ControlledFolderAccess == target);
+        IsBusy = true;
+        try
+        {
+            int target = CfaEnabled ? 0 : 1;
+            var status = await _service.SetControlledFolderAccessAsync(target).ConfigureAwait(true);
+            Apply(status);
+            ReportVerified("Controlled Folder Access", status.ControlledFolderAccess == target);
+        }
+        finally { IsBusy = false; }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task AddExclusionAsync()
     {
         var dialog = new Microsoft.Win32.OpenFolderDialog { Title = "Select a folder to exclude from scanning" };
@@ -92,24 +120,36 @@ public sealed partial class DefenderViewModel : ViewModelBase
         }
         if (!Confirm($"Exclude \"{path}\" from Defender scanning?\n\nFiles in an excluded folder are not scanned for malware.")) return;
 
-        var status = await _service.AddExclusionPathAsync(path).ConfigureAwait(true);
-        Apply(status);
-        ReportVerified("Exclusion", status.ExclusionPaths.Any(p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase)));
+        IsBusy = true;
+        try
+        {
+            var status = await _service.AddExclusionPathAsync(path).ConfigureAwait(true);
+            Apply(status);
+            ReportVerified("Exclusion", status.ExclusionPaths.Any(p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase)));
+        }
+        finally { IsBusy = false; }
     }
 
-    [RelayCommand(CanExecute = nameof(HasSelectedExclusion))]
+    [RelayCommand(CanExecute = nameof(CanRemoveExclusion))]
     private async Task RemoveExclusionAsync()
     {
         string? path = SelectedExclusion;
         if (path is null) return;
         if (!Confirm($"Stop excluding \"{path}\"?\n\nThe folder will be scanned for malware again.")) return;
 
-        var status = await _service.RemoveExclusionPathAsync(path).ConfigureAwait(true);
-        Apply(status);
-        ReportVerified("Exclusion removal", !status.ExclusionPaths.Any(p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase)));
+        IsBusy = true;
+        try
+        {
+            var status = await _service.RemoveExclusionPathAsync(path).ConfigureAwait(true);
+            Apply(status);
+            ReportVerified("Exclusion removal", !status.ExclusionPaths.Any(p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase)));
+        }
+        finally { IsBusy = false; }
     }
 
     private bool HasSelectedExclusion => SelectedExclusion is not null;
+    // Remove must be both busy-gated and have a selection.
+    private bool CanRemoveExclusion => NotBusy && HasSelectedExclusion;
     partial void OnSelectedExclusionChanged(string? value) => RemoveExclusionCommand.NotifyCanExecuteChanged();
 
     /// <summary>A valid exclusion is a rooted, existing folder with no wildcards.</summary>

--- a/SysManager/SysManager/ViewModels/DisplayProfileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DisplayProfileViewModel.cs
@@ -62,9 +62,19 @@ public sealed partial class DisplayProfileViewModel : ViewModelBase
     partial void OnSelectedDisplayChanged(DisplayDevice? value)
     {
         if (value is null) return;
-        var modes = _service.GetSupportedModes(value.DeviceName);
+        // Enumerating modes loops EnumDisplaySettings over every supported mode and
+        // reads the current mode — both are blocking P/Invoke, so run them off the UI
+        // thread and marshal the results back (ConfigureAwait(true)). Launched through
+        // the guarded helper so an unexpected failure is logged, not unobserved.
+        InitializeAsync(() => LoadModesAsync(value.DeviceName));
+    }
+
+    private async Task LoadModesAsync(string deviceName)
+    {
+        var modes = await Task.Run(() => _service.GetSupportedModes(deviceName)).ConfigureAwait(true);
+        var current = await Task.Run(() => _service.GetCurrentMode(deviceName)).ConfigureAwait(true);
         Modes.ReplaceWith(modes);
-        CurrentMode = _service.GetCurrentMode(value.DeviceName);
+        CurrentMode = current;
         SelectedMode = modes.FirstOrDefault(m =>
             CurrentMode is not null && m.Width == CurrentMode.Width &&
             m.Height == CurrentMode.Height && m.RefreshHz == CurrentMode.RefreshHz);
@@ -77,15 +87,22 @@ public sealed partial class DisplayProfileViewModel : ViewModelBase
         && SelectedMode is not null && !SelectedMode.Equals(CurrentMode);
 
     [RelayCommand(CanExecute = nameof(CanApply))]
-    private void Apply()
+    private async Task ApplyAsync()
     {
         var display = SelectedDisplay;
         var mode = SelectedMode;
         if (display is null || mode is null) return;
 
-        _previousMode = _service.GetCurrentMode(display.DeviceName);
+        // ChangeDisplaySettingsEx can block while the driver re-trains the panel, and
+        // GetCurrentMode is a P/Invoke read — run them off the UI thread so the window
+        // (and the auto-revert DispatcherTimer) stays responsive during the switch.
+        _previousMode = await Task.Run(() => _service.GetCurrentMode(display.DeviceName)).ConfigureAwait(true);
 
-        bool ok = _service.TryApplyMode(display.DeviceName, mode.Width, mode.Height, mode.RefreshHz, out string error);
+        var (ok, error) = await Task.Run(() =>
+        {
+            bool applied = _service.TryApplyMode(display.DeviceName, mode.Width, mode.Height, mode.RefreshHz, out string err);
+            return (applied, err);
+        }).ConfigureAwait(true);
         if (!ok)
         {
             StatusMessage = error;
@@ -93,7 +110,7 @@ public sealed partial class DisplayProfileViewModel : ViewModelBase
         }
 
         Log.Information("Applied display mode {Mode} to {Device}", mode.Display, display.DeviceName);
-        CurrentMode = _service.GetCurrentMode(display.DeviceName);
+        CurrentMode = await Task.Run(() => _service.GetCurrentMode(display.DeviceName)).ConfigureAwait(true);
 
         // Begin the auto-revert window — the user must confirm to keep the change.
         BeginRevertCountdown();
@@ -110,7 +127,7 @@ public sealed partial class DisplayProfileViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void RevertNow() => RevertToPrevious("Reverted to the previous display mode.");
+    private Task RevertNowAsync() => RevertToPreviousAsync("Reverted to the previous display mode.");
 
     private void BeginRevertCountdown()
     {
@@ -133,10 +150,12 @@ public sealed partial class DisplayProfileViewModel : ViewModelBase
             StatusMessage = $"Keep these settings? Reverting in {RevertCountdown}s…";
             return;
         }
-        RevertToPrevious("No confirmation — reverted to the previous display mode.");
+        // Launch the (async) revert through the guarded helper — the timer callback is
+        // void, so an awaited failure would otherwise be unobserved.
+        InitializeAsync(() => RevertToPreviousAsync("No confirmation — reverted to the previous display mode."));
     }
 
-    private void RevertToPrevious(string message)
+    private async Task RevertToPreviousAsync(string message)
     {
         StopRevertTimer();
         IsAwaitingConfirm = false;
@@ -144,8 +163,10 @@ public sealed partial class DisplayProfileViewModel : ViewModelBase
         var display = SelectedDisplay;
         if (display is not null && _previousMode is not null)
         {
-            _service.TryApplyMode(display.DeviceName, _previousMode.Width, _previousMode.Height, _previousMode.RefreshHz, out _);
-            CurrentMode = _service.GetCurrentMode(display.DeviceName);
+            var prev = _previousMode;
+            await Task.Run(() =>
+                _service.TryApplyMode(display.DeviceName, prev.Width, prev.Height, prev.RefreshHz, out _)).ConfigureAwait(true);
+            CurrentMode = await Task.Run(() => _service.GetCurrentMode(display.DeviceName)).ConfigureAwait(true);
         }
         _previousMode = null;
         StatusMessage = message;


### PR DESCRIPTION
## Problem
Two responsiveness/correctness issues found by the full-app audit:

1. **Display Profiles ran blocking display P/Invoke on the UI thread.** `Apply`, the selected-display change, and the 15-second auto-revert all called `GetSupportedModes` (loops `EnumDisplaySettings`), `GetCurrentMode`, and `TryApplyMode` (`ChangeDisplaySettingsEx`) synchronously on the dispatcher — unlike `LoadDisplaysAsync`, which already offloads. `ChangeDisplaySettingsEx` can block while the driver re-trains the panel, so the window could stop responding during a switch — and that stall could hold up the very auto-revert countdown meant to rescue the user from a bad mode.
2. **Defender Tweaks had no cross-command re-entrancy guard.** The PUA / CFA / add-exclusion / remove-exclusion commands didn't set `IsBusy` or check it, so clicking a second one while the first was still writing + verifying started overlapping `Set-MpPreference` operations (each spinning its own runspace) whose read-back checks could race and surface a misleading "not changed" message.

## Fix
- **`DisplayProfileViewModel`**: `Apply`/`RevertToPrevious`/selected-display handling are now async and run the display P/Invoke via `Task.Run`, marshalling results back with `ConfigureAwait(true)` and keeping VM-state mutation on the UI thread. The auto-revert `DispatcherTimer` keeps ticking during a mode switch. The timer callback launches the async revert through the guarded `InitializeAsync` helper so a failure can't become an unobserved task exception.
- **`DefenderViewModel`**: adds the codebase's standard `NotBusy` guard — every mutating command is `[RelayCommand(CanExecute = nameof(NotBusy))]` (remove also requires a selection), sets `IsBusy` in `try/finally`, and `NotifyCanExecuteChanged` fires when `IsBusy` flips. This serialises the Defender mutations, matching how the other VMs (BrowserCleaner, Debloater, …) already work.

## Tests
- `DefenderViewModelTests` (new): `MutatingCommands_AreGatedOnNotBusy`, `RemoveExclusion_RequiresBothSelectionAndNotBusy`, `AfterInit_NotBusy_IsTrue` — mock `IPowerShellRunner`, assert each mutating command's `CanExecute` is false while busy.
- `DisplayProfileViewModelTests` (new): `ApplyCommand_IsAsync`, `RevertNowCommand_IsAsync` — pin that the commands are `IAsyncRelayCommand` (offloaded + self-disabling while in flight).
- Main + Tests build 0 warnings / 0 errors.

## Verification
- `dotnet build` main + tests: **0 errors / 0 warnings**. Protocol I leak/debug scan clean; no generic `catch (Exception)`; no `MessageBox`.
- Built the single-file exe and launched it: the app starts and runs clean — no UI-thread/exception entries in the rotating log across the session (the app self-logs dispatcher exceptions).
- CHANGELOG entry under `1.42.2`; csproj bumped `1.42.1` → `1.42.2`.
- `fix:` -> patch release `1.42.2`.
