### PR TITLE
fix: show empty-state messages on data lists and fix count-based visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.42.3] - 2026-06-27
+
+### Fixed
+- **Lists that are empty now say so, instead of showing a blank area.** Several tabs (Services, Startup Manager, Process Manager, Uninstaller, Windows Features, DNS & Hosts, Disk Analyzer) showed an empty table with no explanation when there was nothing to display or a filter matched nothing — leaving you unsure whether it was still loading, found nothing, or had failed. Each now shows a short, centred message in that case. This also fixes the empty-state messages on the Speed Test history, which previously never appeared: the visibility converter treated a list's item count as "always present", so a count of zero was misread — numeric values are now correctly treated as empty when zero.
+
 ## [1.42.2] - 2026-06-27
 
 ### Fixed

--- a/SysManager/SysManager.Tests/ConverterTests.cs
+++ b/SysManager/SysManager.Tests/ConverterTests.cs
@@ -108,6 +108,52 @@ public class ConverterTests
             conv.ConvertBack(Visibility.Visible, typeof(bool), null!, CultureInfo.InvariantCulture));
     }
 
+    // Numeric values drive visibility by their non-zero-ness — this is what lets an
+    // empty-state message bind to a collection's .Count with ConverterParameter=Inverse
+    // (show the message only when Count == 0). Before this, any int was treated as a
+    // non-null object => always truthy, so count-bound empty states never appeared.
+
+    [Fact]
+    public void FlexibleBool_ZeroCount_ReturnsCollapsed()
+    {
+        var conv = new FlexibleBoolToVisibilityConverter();
+        var result = conv.Convert(0, typeof(Visibility), null!, CultureInfo.InvariantCulture);
+        Assert.Equal(Visibility.Collapsed, result);
+    }
+
+    [Fact]
+    public void FlexibleBool_NonZeroCount_ReturnsVisible()
+    {
+        var conv = new FlexibleBoolToVisibilityConverter();
+        var result = conv.Convert(5, typeof(Visibility), null!, CultureInfo.InvariantCulture);
+        Assert.Equal(Visibility.Visible, result);
+    }
+
+    [Fact]
+    public void FlexibleBool_Inverse_ZeroCount_ReturnsVisible()
+    {
+        // The empty-state pattern: Count == 0 with Inverse => the message shows.
+        var conv = new FlexibleBoolToVisibilityConverter();
+        var result = conv.Convert(0, typeof(Visibility), "Inverse", CultureInfo.InvariantCulture);
+        Assert.Equal(Visibility.Visible, result);
+    }
+
+    [Fact]
+    public void FlexibleBool_Inverse_NonZeroCount_ReturnsCollapsed()
+    {
+        // Count > 0 with Inverse => the message is hidden (the list has content).
+        var conv = new FlexibleBoolToVisibilityConverter();
+        var result = conv.Convert(12, typeof(Visibility), "Inverse", CultureInfo.InvariantCulture);
+        Assert.Equal(Visibility.Collapsed, result);
+    }
+
+    [Fact]
+    public void FlexibleBool_ZeroLong_ReturnsCollapsed()
+    {
+        var conv = new FlexibleBoolToVisibilityConverter();
+        Assert.Equal(Visibility.Collapsed, conv.Convert(0L, typeof(Visibility), null!, CultureInfo.InvariantCulture));
+    }
+
     [Fact]
     public void FlexibleBool_EmptyString_ReturnsCollapsed()
     {

--- a/SysManager/SysManager/Helpers/ValueConverters.cs
+++ b/SysManager/SysManager/Helpers/ValueConverters.cs
@@ -35,8 +35,11 @@ public sealed class OutputKindToBrushConverter : IValueConverter
 
 /// <summary>
 /// BooleanToVisibility with optional inversion via ConverterParameter="Inverse".
-/// Also treats any non-null object reference as "true" so it can be used to
-/// toggle visibility based on a nullable result being populated.
+/// Truthiness rules: a bool is itself; null is false; a non-empty string is true;
+/// a numeric value is true only when non-zero; any other non-null object is true.
+/// The numeric rule lets a collection's <c>.Count</c> drive visibility directly
+/// (e.g. an empty-state message bound to <c>Items.Count</c> with <c>Inverse</c>),
+/// which is the common "show this when the list is empty" pattern.
 /// </summary>
 public sealed class FlexibleBoolToVisibilityConverter : IValueConverter
 {
@@ -47,6 +50,8 @@ public sealed class FlexibleBoolToVisibilityConverter : IValueConverter
             bool b => b,
             null => false,
             string s => !string.IsNullOrWhiteSpace(s),
+            sbyte or byte or short or ushort or int or uint or long or ulong => System.Convert.ToInt64(value) != 0,
+            float or double or decimal => System.Convert.ToDecimal(value) != 0m,
             _ => true
         };
         var invert = parameter as string == "Inverse";

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.42.2</Version>
-    <FileVersion>1.42.2.0</FileVersion>
-    <AssemblyVersion>1.42.2.0</AssemblyVersion>
+    <Version>1.42.3</Version>
+    <FileVersion>1.42.3.0</FileVersion>
+    <AssemblyVersion>1.42.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/DiskAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/DiskAnalyzerView.xaml
@@ -69,6 +69,7 @@
 
         <!-- Folder list -->
         <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
+            <Grid>
             <ListView AutomationProperties.Name="Folder size list" ItemsSource="{Binding Entries}" Background="Transparent" BorderThickness="0"
                       ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                       HorizontalContentAlignment="Stretch">
@@ -145,6 +146,13 @@
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>
+
+            <!-- Empty state -->
+            <TextBlock Text="No results yet — pick a folder and scan to see what's using space."
+                       Style="{StaticResource Subtle}" TextWrapping="Wrap" MaxWidth="360"
+                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                       Visibility="{Binding Entries.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+            </Grid>
         </Border>
 
         <!-- Status bar -->

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -121,7 +121,8 @@
                 </DockPanel>
 
                 <!-- DataGrid -->
-                <DataGrid Grid.Row="1" ItemsSource="{Binding HostEntries}"
+                <Grid Grid.Row="1">
+                <DataGrid ItemsSource="{Binding HostEntries}"
                           AutoGenerateColumns="False" CanUserAddRows="False"
                           CanUserDeleteRows="False" HeadersVisibility="Column"
                           CanUserResizeColumns="True"
@@ -150,6 +151,13 @@
                         </DataGridTemplateColumn>
                     </DataGrid.Columns>
                 </DataGrid>
+
+                <!-- Empty state -->
+                <TextBlock Text="No host entries yet. Add one above, or your hosts file is empty."
+                           Style="{StaticResource Subtle}" TextWrapping="Wrap" MaxWidth="360"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           Visibility="{Binding HostEntries.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                </Grid>
 
                 <!-- Add entry row -->
                 <DockPanel Grid.Row="2" Margin="0,12,0,0">

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -57,6 +57,7 @@
 
         <!-- Process list -->
         <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
+            <Grid>
             <DataGrid AutomationProperties.Name="Running processes" ItemsSource="{Binding FilteredProcesses}"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
                       Background="Transparent" BorderThickness="0"
@@ -189,6 +190,13 @@
                     </DataGridTemplateColumn>
                 </DataGrid.Columns>
             </DataGrid>
+
+            <!-- Empty state -->
+            <TextBlock Text="No processes match the current filter."
+                       Style="{StaticResource Subtle}" TextWrapping="Wrap" MaxWidth="360"
+                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                       Visibility="{Binding FilteredProcesses.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+            </Grid>
         </Border>
 
         <!-- Status bar -->

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -105,7 +105,8 @@
         </Border>
 
         <!-- Services list -->
-        <DataGrid AutomationProperties.Name="Windows services" Grid.Row="3" ItemsSource="{Binding Services}"
+        <Grid Grid.Row="3">
+        <DataGrid AutomationProperties.Name="Windows services" ItemsSource="{Binding Services}"
                   SelectedItem="{Binding SelectedService}"
                   AutoGenerateColumns="False" HeadersVisibility="Column"
                   Background="Transparent" BorderThickness="0"
@@ -176,6 +177,13 @@
                 </DataGridTemplateColumn>
             </DataGrid.Columns>
         </DataGrid>
+
+            <!-- Empty state -->
+            <TextBlock Text="No services to show yet. They load automatically — use Refresh if the list stays empty."
+                       Style="{StaticResource Subtle}" TextWrapping="Wrap" MaxWidth="360"
+                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                       Visibility="{Binding Services.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+        </Grid>
 
         <!-- Status bar -->
         <DockPanel Grid.Row="4" Margin="0,8,0,0">

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -46,6 +46,7 @@
 
         <!-- Startup items list -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
+            <Grid>
             <DataGrid AutomationProperties.Name="Startup programs" ItemsSource="{Binding Entries}"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
                       CanUserAddRows="False"
@@ -171,6 +172,13 @@
                     </DataGridTemplateColumn>
                 </DataGrid.Columns>
             </DataGrid>
+
+            <!-- Empty state -->
+            <TextBlock Text="No startup programs found yet. They load automatically — use Refresh if the list stays empty."
+                       Style="{StaticResource Subtle}" TextWrapping="Wrap" MaxWidth="360"
+                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                       Visibility="{Binding Entries.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+            </Grid>
         </Border>
 
         <!-- Status bar -->

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -91,6 +91,7 @@
 
         <!-- App list -->
         <Border Grid.Row="4" Style="{StaticResource Card}" Padding="0">
+            <Grid>
             <DataGrid AutomationProperties.Name="Installed applications" ItemsSource="{Binding FilteredApps}"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
                       Background="Transparent" BorderThickness="0"
@@ -250,6 +251,13 @@
                     </DataGridTemplateColumn>
                 </DataGrid.Columns>
             </DataGrid>
+
+            <!-- Empty state -->
+            <TextBlock Text="No applications match the current filter."
+                       Style="{StaticResource Subtle}" TextWrapping="Wrap" MaxWidth="360"
+                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                       Visibility="{Binding FilteredApps.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+            </Grid>
         </Border>
 
         <!-- Status bar -->

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -89,6 +89,7 @@
 
         <!-- Feature list -->
         <Border Grid.Row="4" Style="{StaticResource Card}" Padding="0">
+            <Grid>
             <DataGrid AutomationProperties.Name="Features table" ItemsSource="{Binding FilteredFeatures}"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
                       Background="Transparent" BorderThickness="0"
@@ -263,6 +264,13 @@
                     </DataGridTemplateColumn>
                 </DataGrid.Columns>
             </DataGrid>
+
+            <!-- Empty state -->
+            <TextBlock Text="No Windows features match the current filter."
+                       Style="{StaticResource Subtle}" TextWrapping="Wrap" MaxWidth="360"
+                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                       Visibility="{Binding FilteredFeatures.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+            </Grid>
         </Border>
 
         <!-- Status bar -->


### PR DESCRIPTION
## Problem
Found by the full-app audit. ~26 data-bound list views showed a blank area with no message when their list was empty (nothing scanned yet, a filter matched nothing, or a genuine empty result), leaving the user unsure whether the tab was loading, found nothing, or failed. Only ~10 views had a proper empty state. Worse, the shared `FlexibleBoolToVisibilityConverter` treated **any** numeric value as truthy (`_ => true`), so the existing count-bound empty states on **Speed Test** (`OoklaHistory.Count` / `HttpHistory.Count` with `Inverse`) never actually appeared — a count of zero was misread as "present".

## Fix
- **`FlexibleBoolToVisibilityConverter`**: numeric values are now truthy only when non-zero (integers and floating-point). This is backward-compatible (bool/null/string/other-object rules unchanged) and is exactly what lets an empty-state message bind to a collection's `.Count` with `ConverterParameter=Inverse` — "show this only when the list is empty". This repairs the Speed Test empty states as a side effect, and fixes `BulkInstallerView` showing its results container even when empty.
- Added empty-state messages to the highest-traffic list views that lacked one, each overlaid on the list via the existing `FileLockView` pattern (a centred `Subtle` TextBlock in the same cell, `Visibility` bound to `<Collection>.Count` `Inverse`): **Services, Startup Manager, Process Manager, Uninstaller, Windows Features, DNS & Hosts, Disk Analyzer**.

## Tests
- `ConverterTests` (added): `FlexibleBool_ZeroCount_ReturnsCollapsed`, `FlexibleBool_NonZeroCount_ReturnsVisible`, `FlexibleBool_Inverse_ZeroCount_ReturnsVisible`, `FlexibleBool_Inverse_NonZeroCount_ReturnsCollapsed`, `FlexibleBool_ZeroLong_ReturnsCollapsed` — pin the count-aware behaviour that the empty-state pattern relies on.
- Main + Tests build 0 warnings / 0 errors.

## Verification
- `dotnet build` main + tests: **0 errors / 0 warnings**. Protocol I leak/debug scan clean.
- Built the single-file exe and launched it: starts clean, MainWindow initialises, and the rotating log shows no XAML-parse or binding errors across the modified views.
- CHANGELOG entry under `1.42.3`; csproj bumped `1.42.2` → `1.42.3`.
- `fix:` -> patch release `1.42.3`.
