### PR TITLE
fix: use theme brushes for System Logs detail panel and System Health bars

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -15,12 +15,15 @@ query-filters:
   # exclude) if a genuine useless-assignment is ever introduced in source.
   - exclude:
       id: cs/useless-assignment-to-local
-  # Intentional use of CreateFromSignedFile for Authenticode verification —
-  # no modern .NET replacement exists without P/Invoke. Already suppressed
-  # with #pragma warning disable SYSLIB0057.
+  # Intentional use of CreateFromSignedFile for Authenticode verification — no modern
+  # .NET replacement exists without P/Invoke. Used in UpdateService.cs AND
+  # SpeedTestService.cs, both already wrapped in #pragma warning disable SYSLIB0057.
+  # Excluded by id alone: the `path:` key is NOT honoured inside query-filters (only
+  # `id`/`tags` are — see the cs/useless-upcast note below), so a path-scoped exclude
+  # silently covered the whole repo anyway AND would have missed the SpeedTestService
+  # usage if it ever were honoured. There are no other call sites, so id-only is correct.
   - exclude:
       id: cs/call-to-obsolete-method
-      path: SysManager/SysManager/Services/UpdateService.cs
   # cs/useless-cast-to-self fires only on [GeneratedRegex] source-generator output
   # under obj/ (RegexGenerator.g.cs). Like cs/useless-assignment-to-local above, the
   # manual-build CodeQL database traces generated files into analysis. Zero

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.42.4] - 2026-06-27
+
+### Fixed
+- **Event Viewer detail panel and System Health bars now follow the theme correctly.** A few surfaces used fixed dark colours instead of theme brushes, so under a light or custom theme the "What this means" / "What to try" cards in System Logs, their monospace message/XML boxes, and the small health/usage bars on System Health could lose contrast (light text on a still-dark panel). They now use the shared theme brushes and adapt to any preset or custom theme.
+
 ## [1.42.3] - 2026-06-27
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.42.3</Version>
-    <FileVersion>1.42.3.0</FileVersion>
-    <AssemblyVersion>1.42.3.0</AssemblyVersion>
+    <Version>1.42.4</Version>
+    <FileVersion>1.42.4.0</FileVersion>
+    <AssemblyVersion>1.42.4.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -352,12 +352,12 @@
                             </Border>
 
                             <TextBlock Text="What this means" Style="{StaticResource SectionTitle}" Margin="0,18,0,6"/>
-                            <Border Padding="12" CornerRadius="8" Background="#102028" BorderBrush="#1E3A4A" BorderThickness="1">
+                            <Border Style="{StaticResource CardInner}">
                                 <TextBlock Text="{Binding SelectedEntry.Explanation}" TextWrapping="Wrap" Foreground="{DynamicResource TextPrimary}"/>
                             </Border>
 
                             <TextBlock Text="What to try" Style="{StaticResource SectionTitle}" Margin="0,14,0,6"/>
-                            <Border Padding="12" CornerRadius="8" Background="#141B14" BorderBrush="#2D4A2D" BorderThickness="1">
+                            <Border Style="{StaticResource CardInner}">
                                 <TextBlock Text="{Binding SelectedEntry.Recommendation}" TextWrapping="Wrap" Foreground="{DynamicResource TextPrimary}"/>
                             </Border>
 
@@ -374,7 +374,7 @@
                                              IsReadOnly="True" TextWrapping="Wrap"
                                              Background="Transparent" BorderThickness="0"
                                              FontFamily="{StaticResource MonoFont}" FontSize="11"
-                                             Foreground="#C0C6CC"
+                                             Foreground="{DynamicResource TextSecondary}"
                                              MaxHeight="240"
                                              VerticalScrollBarVisibility="Auto"/>
                                 </Border>
@@ -388,7 +388,7 @@
                                              IsReadOnly="True" TextWrapping="NoWrap"
                                              Background="Transparent" BorderThickness="0"
                                              FontFamily="{StaticResource MonoFont}" FontSize="11"
-                                             Foreground="#8A9198"
+                                             Foreground="{DynamicResource TextMuted}"
                                              MaxHeight="260"
                                              VerticalScrollBarVisibility="Auto"
                                              HorizontalScrollBarVisibility="Auto"/>

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -207,7 +207,7 @@
                                                         <TextBlock Text="{Binding HealthPercent, StringFormat={}{0}%, FallbackValue=—}" FontSize="18" FontWeight="Bold"
                                                                    Foreground="{Binding HealthPercentColorHex, Converter={StaticResource HexBrush}}"/>
                                                     </StackPanel>
-                                                    <Border Height="4" CornerRadius="2" Background="#1A1F2E" Margin="0,4,0,0">
+                                                    <Border Height="4" CornerRadius="2" Background="{DynamicResource Surface0}" Margin="0,4,0,0">
                                                         <Border HorizontalAlignment="Left" CornerRadius="2"
                                                                 Width="{Binding HealthPercent, FallbackValue=0}"
                                                                 MaxWidth="120" Height="4"
@@ -219,7 +219,7 @@
                                                     <TextBlock Text="TEMPERATURE" Style="{StaticResource Caption}"/>
                                                     <TextBlock Text="{Binding TemperatureC, StringFormat={}{0:F0} °C, FallbackValue=—}" FontSize="14"
                                                                Foreground="{Binding TemperatureColorHex, Converter={StaticResource HexBrush}}" Margin="0,4,0,0"/>
-                                                    <Border Height="4" CornerRadius="2" Background="#1A1F2E" Margin="0,4,0,0">
+                                                    <Border Height="4" CornerRadius="2" Background="{DynamicResource Surface0}" Margin="0,4,0,0">
                                                         <Border HorizontalAlignment="Left" CornerRadius="2"
                                                                 Width="{Binding TemperatureGauge}" MaxWidth="100" Height="4"
                                                                 Background="{Binding TemperatureColorHex, Converter={StaticResource HexBrush}}"/>
@@ -230,7 +230,7 @@
                                                     <TextBlock Text="LIFE REMAINING" Style="{StaticResource Caption}"/>
                                                     <TextBlock Text="{Binding WearGauge, StringFormat={}{0}%}" FontSize="14"
                                                                Foreground="{Binding WearColorHex, Converter={StaticResource HexBrush}}" Margin="0,4,0,0"/>
-                                                    <Border Height="4" CornerRadius="2" Background="#1A1F2E" Margin="0,4,0,0">
+                                                    <Border Height="4" CornerRadius="2" Background="{DynamicResource Surface0}" Margin="0,4,0,0">
                                                         <Border HorizontalAlignment="Left" CornerRadius="2"
                                                                 Width="{Binding WearGauge}" MaxWidth="100" Height="4"
                                                                 Background="{Binding WearColorHex, Converter={StaticResource HexBrush}}"/>


### PR DESCRIPTION
## Problem
Two cleanups from the full-app audit (verified findings F5/F8 + a CodeQL config accuracy issue):
1. **A few surfaces used fixed dark colours instead of theme brushes**, so under a light or custom theme they lost contrast (light `{DynamicResource}` text on a still-dark hardcoded panel). Genuine offenders: the System Logs detail panel's "What this means" / "What to try" cards (`#102028` / `#141B14`) and its monospace message/XML boxes (`#C0C6CC` / `#8A9198`), and the three small health/usage bar tracks on System Health (`#1A1F2E`).
2. **The CodeQL `cs/call-to-obsolete-method` exclusion used a `path:` key that isn't honoured** inside query-filters (the config's own `cs/useless-upcast` note documents this). `CreateFromSignedFile` is actually used in two files (UpdateService.cs **and** SpeedTestService.cs), both already `#pragma`-suppressed, so the path scope was misleading.

## Fix
- **LogsView**: the two detail cards now use the shared `CardInner` style (`Surface2` + `Border1`); the two read-only mono boxes use `{DynamicResource TextSecondary}` / `TextMuted`.
- **SystemHealthView**: the three progress-bar tracks use `{DynamicResource Surface0}`.
- **codeql-config.yml**: `cs/call-to-obsolete-method` is now excluded by `id` alone, with a comment explaining the `path:` key isn't honoured and that both call sites are the same legitimate Authenticode pattern.

Deliberately left unchanged (not theme bugs — intentional design, consistent with the audit's "leave semantic colours alone"): the Logs severity-count tiles' glass tints, the category/severity status pills, Dashboard's per-metric brand colours, white-glass overlay borders, and Ping's 5%-alpha accent card wash.

## Tests
No new tests — this is a styling/config change with no behaviour change. Existing suite unaffected; main + tests build 0 warnings / 0 errors.

## Verification
- `dotnet build` main + tests: **0 errors / 0 warnings**. Protocol I leak/debug scan clean.
- Built the single-file exe and launched it: starts clean, no XAML-parse / missing-resource / binding errors in the rotating log (the new `CardInner` / `Surface0` / `TextMuted` references all resolve).
- CHANGELOG entry under `1.42.4`; csproj bumped `1.42.3` → `1.42.4`.
- `fix:` -> patch release `1.42.4`.
