### PR TITLE
fix: auto-revert restores the display the mode was applied to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.42.5] - 2026-06-27
+
+### Fixed
+- **Display Profiles auto-revert now restores the correct monitor.** If you applied a mode and then switched to a different display in the dropdown during the 15-second "Keep these settings?" countdown, the automatic revert could restore the *previous* display's old mode onto the *newly selected* one. The pending revert now remembers the exact display it belongs to and only ever restores that one. Also hardened against rapid display switching: an in-flight mode list for a display you've already switched away from no longer overwrites the current one.
+
 ## [1.42.4] - 2026-06-27
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DisplayProfileViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DisplayProfileViewModelTests.cs
@@ -48,4 +48,17 @@ public class DisplayProfileViewModelTests
         Assert.NotNull(vm.Displays);
         Assert.NotNull(vm.Modes);
     }
+
+    [Fact]
+    public void Revert_CapturesTheAppliedDevice_NotJustTheMode()
+    {
+        // Regression pin for the cross-display revert bug: the auto-revert must target
+        // the display the change was APPLIED to (captured at Apply time), not whatever
+        // is selected when the 15 s timer fires. That requires the VM to remember the
+        // device alongside the previous mode — assert the capture field exists.
+        var device = typeof(DisplayProfileViewModel).GetField(
+            "_previousDevice", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(device);
+        Assert.Equal("SysManager.Models.DisplayDevice", device!.FieldType.FullName);
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.42.4</Version>
-    <FileVersion>1.42.4.0</FileVersion>
-    <AssemblyVersion>1.42.4.0</AssemblyVersion>
+    <Version>1.42.5</Version>
+    <FileVersion>1.42.5.0</FileVersion>
+    <AssemblyVersion>1.42.5.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DisplayProfileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DisplayProfileViewModel.cs
@@ -24,6 +24,11 @@ public sealed partial class DisplayProfileViewModel : ViewModelBase
     private readonly DisplayProfileService _service;
     private DispatcherTimer? _revertTimer;
     private DisplayMode? _previousMode;
+    // The display the pending revert belongs to, captured at Apply time. The user can
+    // switch SelectedDisplay during the 15 s countdown, so revert must target THIS
+    // device — not whatever is selected when the timer fires — or it would apply
+    // display A's old mode to display B.
+    private DisplayDevice? _previousDevice;
     private const int RevertSeconds = 15;
 
     public BulkObservableCollection<DisplayDevice> Displays { get; } = new();
@@ -73,6 +78,10 @@ public sealed partial class DisplayProfileViewModel : ViewModelBase
     {
         var modes = await Task.Run(() => _service.GetSupportedModes(deviceName)).ConfigureAwait(true);
         var current = await Task.Run(() => _service.GetCurrentMode(deviceName)).ConfigureAwait(true);
+        // Rapid display switches launch overlapping loads; if the selection moved on while
+        // this one was running, drop its results so a slow earlier load can't overwrite
+        // the newer display's modes (last-writer-wins).
+        if (SelectedDisplay is null || SelectedDisplay.DeviceName != deviceName) return;
         Modes.ReplaceWith(modes);
         CurrentMode = current;
         SelectedMode = modes.FirstOrDefault(m =>
@@ -96,6 +105,9 @@ public sealed partial class DisplayProfileViewModel : ViewModelBase
         // ChangeDisplaySettingsEx can block while the driver re-trains the panel, and
         // GetCurrentMode is a P/Invoke read — run them off the UI thread so the window
         // (and the auto-revert DispatcherTimer) stays responsive during the switch.
+        // Capture the device alongside its previous mode so a revert targets THIS
+        // display even if the user changes the selection during the countdown.
+        _previousDevice = display;
         _previousMode = await Task.Run(() => _service.GetCurrentMode(display.DeviceName)).ConfigureAwait(true);
 
         var (ok, error) = await Task.Run(() =>
@@ -122,6 +134,7 @@ public sealed partial class DisplayProfileViewModel : ViewModelBase
         StopRevertTimer();
         IsAwaitingConfirm = false;
         _previousMode = null;
+        _previousDevice = null;
         StatusMessage = $"Display set to {CurrentMode?.Display}.";
         ApplyCommand.NotifyCanExecuteChanged();
     }
@@ -160,15 +173,22 @@ public sealed partial class DisplayProfileViewModel : ViewModelBase
         StopRevertTimer();
         IsAwaitingConfirm = false;
 
-        var display = SelectedDisplay;
-        if (display is not null && _previousMode is not null)
+        // Revert the device the change was APPLIED to (captured at Apply time), not the
+        // one currently selected — the user may have switched the picker during the
+        // countdown, and reverting the wrong display would corrupt its mode.
+        var device = _previousDevice;
+        var prev = _previousMode;
+        if (device is not null && prev is not null)
         {
-            var prev = _previousMode;
             await Task.Run(() =>
-                _service.TryApplyMode(display.DeviceName, prev.Width, prev.Height, prev.RefreshHz, out _)).ConfigureAwait(true);
-            CurrentMode = await Task.Run(() => _service.GetCurrentMode(display.DeviceName)).ConfigureAwait(true);
+                _service.TryApplyMode(device.DeviceName, prev.Width, prev.Height, prev.RefreshHz, out _)).ConfigureAwait(true);
+            // Only refresh CurrentMode if the reverted device is still the selected one,
+            // so we don't overwrite the display the user has since switched to.
+            if (ReferenceEquals(device, SelectedDisplay))
+                CurrentMode = await Task.Run(() => _service.GetCurrentMode(device.DeviceName)).ConfigureAwait(true);
         }
         _previousMode = null;
+        _previousDevice = null;
         StatusMessage = message;
         ApplyCommand.NotifyCanExecuteChanged();
     }


### PR DESCRIPTION
## Problem
Found by a full-app audit (a regression my own #1093 widened). In Display Profiles, the 15-second auto-revert restored the previous mode onto `SelectedDisplay` — read at the moment the timer fires. If the user switched the display dropdown during the countdown, the revert applied display **A**'s old mode to display **B**, corrupting B's mode. Async-ifying the revert in #1093 widened the window for this. A related issue: rapid display switching launched overlapping `LoadModesAsync` calls where a slow earlier one could overwrite the newer display's mode list (last-writer-wins).

## Fix
- **`DisplayProfileViewModel`** now captures the applied `DisplayDevice` (`_previousDevice`) alongside `_previousMode` at Apply time, and the auto-revert restores **that** device — never whatever is selected when the timer fires. `CurrentMode` is only refreshed if the reverted device is still selected, so it can't clobber the display the user switched to. `_previousDevice` is cleared on Keep and after revert.
- `LoadModesAsync` drops its results if the selection moved on while it was running (guards against the last-writer-wins race).

## Tests
- `DisplayProfileViewModelTests.Revert_CapturesTheAppliedDevice_NotJustTheMode` — pins that the VM remembers the applied device (the capture field exists with the right type), so the cross-display revert fix can't regress. (The apply/revert P/Invoke mutates real hardware, so the behavioural path isn't unit-exercised; the structural pin guards the fix.)
- Main + Tests build 0 warnings / 0 errors.

## Verification
- `dotnet build` main + tests: **0 errors / 0 warnings**. Protocol I leak/debug scan clean.
- Built the single-file exe and launched it: starts clean, Display Profiles renders, no XAML/exception entries in the log.
- CHANGELOG entry under `1.42.5`; csproj bumped `1.42.4` → `1.42.5`.
- `fix:` -> patch release `1.42.5`.
