### PR TITLE
fix: guard temp-cleanup root against reparse points and re-verify cached Ookla CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.42.6] - 2026-06-27
+
+### Fixed
+- **Temp cleanup can't be tricked into deleting files outside the temp folder.** The cleanup scan already refused to descend into junctions/symlinks it found *inside* the temp tree, but didn't check whether the starting folder itself was a junction — so a redirected temp root could, in theory, lead it to enumerate (and delete) files elsewhere on disk, especially when run as administrator. The scan now treats a junction/symlink root the same way and stops immediately.
+- **Speed Test re-verifies the bundled Ookla CLI's signature every run.** The Ookla command-line tool is cached under your local app data (a user-writable folder). Its Authenticode signature was checked right after download but not on later reuse, leaving a window where a swapped binary could be launched. It is now re-verified (Ookla-signed, fail-closed) before every run, not only on first download.
+
 ## [1.42.5] - 2026-06-27
 
 ### Fixed

--- a/SysManager/SysManager.Tests/TuneUpServiceTests.cs
+++ b/SysManager/SysManager.Tests/TuneUpServiceTests.cs
@@ -328,4 +328,44 @@ public class TuneUpServiceTests
             try { System.IO.Directory.Delete(root, recursive: true); } catch { /* best effort */ }
         }
     }
+
+    [Fact]
+    public void EnumerateFilesSkippingReparsePoints_DoesNotFollowReparsePointRoot()
+    {
+        // Regression for the root-not-guarded gap: if the traversal ROOT is itself a
+        // junction/symlink (not just a child), enumeration must NOT follow it out of
+        // the temp tree. Build:  outside/secret.txt  and  rootLink -> outside.
+        // Walking rootLink must yield NOTHING (never secret.txt).
+        var baseDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "smtu_" + Guid.NewGuid().ToString("N"));
+        var outside = System.IO.Path.Combine(baseDir, "outside");
+        System.IO.Directory.CreateDirectory(outside);
+        System.IO.File.WriteAllText(System.IO.Path.Combine(outside, "secret.txt"), "must never be enumerated");
+
+        var rootLink = System.IO.Path.Combine(baseDir, "rootlink");
+        try
+        {
+            System.IO.Directory.CreateSymbolicLink(rootLink, outside);
+        }
+        catch (Exception)
+        {
+            // Symlink creation needs privilege/Developer Mode — skip if unavailable.
+            System.IO.Directory.Delete(baseDir, recursive: true);
+            return;
+        }
+
+        try
+        {
+            var found = TuneUpService
+                .EnumerateFilesSkippingReparsePoints(rootLink, CancellationToken.None)
+                .ToList();
+
+            Assert.Empty(found);
+            Assert.DoesNotContain(found, f => f.EndsWith("secret.txt", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { System.IO.Directory.Delete(rootLink, recursive: false); } catch { /* best effort */ }
+            try { System.IO.Directory.Delete(baseDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
 }

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -327,7 +327,14 @@ public sealed class SpeedTestService
         }, ct).ConfigureAwait(false);
 
         var exe = Path.Join(toolsDir, "speedtest.exe");
-        if (!needsDownload) return exe;
+        if (!needsDownload)
+        {
+            // TOCTOU guard: the cached exe lives in a user-writable dir, so an attacker
+            // could swap it between runs. Re-verify its Authenticode signature every
+            // time before we hand it back to be executed — not only right after download.
+            await Task.Run(() => VerifyOoklaSignature(exe), ct).ConfigureAwait(false);
+            return exe;
+        }
 
         progress?.Report((5, "Downloading Ookla CLI…"));
         var arch = Environment.Is64BitOperatingSystem ? "win64" : "win32";
@@ -399,38 +406,48 @@ public sealed class SpeedTestService
         if (!File.Exists(exe))
             throw new FileNotFoundException("speedtest.exe not found after extraction");
 
-        // Verify Authenticode signature on extracted binary — fail-closed.
-        // If the binary is not signed by Ookla, delete it and throw.
-        await Task.Run(() =>
-        {
-            try
-            {
-#pragma warning disable SYSLIB0057 // CreateFromSignedFile is obsolete — no direct replacement for Authenticode verification
-                var cert = System.Security.Cryptography.X509Certificates.X509Certificate.CreateFromSignedFile(exe);
-#pragma warning restore SYSLIB0057
-                if (cert is null || !cert.Subject.Contains("Ookla", StringComparison.OrdinalIgnoreCase))
-                {
-                    Log.Warning("Ookla speedtest.exe Authenticode subject mismatch: {Subject}", cert?.Subject ?? "none");
-                    try { File.Delete(exe); }
-                    catch (IOException ex2) { Log.Debug("Cleanup failed (locked): {Error}", LogService.SanitizePath(ex2.Message)); }
-                    catch (UnauthorizedAccessException ex2) { Log.Debug("Cleanup failed (access): {Error}", LogService.SanitizePath(ex2.Message)); }
-                    throw new InvalidOperationException(
-                        $"Ookla speedtest.exe failed Authenticode verification (subject: {cert?.Subject ?? "none"}). Binary deleted for security.");
-                }
-                Log.Information("Ookla speedtest.exe Authenticode verified: {Subject}", cert.Subject);
-            }
-            catch (System.Security.Cryptography.CryptographicException ex)
-            {
-                Log.Warning(ex, "Ookla speedtest.exe has no valid Authenticode signature");
-                try { File.Delete(exe); }
-                catch (IOException ex2) { Log.Debug("Cleanup failed (locked): {Error}", LogService.SanitizePath(ex2.Message)); }
-                catch (UnauthorizedAccessException ex2) { Log.Debug("Cleanup failed (access): {Error}", LogService.SanitizePath(ex2.Message)); }
-                throw new InvalidOperationException(
-                    "Ookla speedtest.exe has no valid Authenticode signature. Binary deleted for security.", ex);
-            }
-        }, ct).ConfigureAwait(false);
+        // Verify Authenticode signature on the freshly-extracted binary — fail-closed.
+        await Task.Run(() => VerifyOoklaSignature(exe), ct).ConfigureAwait(false);
 
         return exe;
+    }
+
+    /// <summary>
+    /// Verifies that <paramref name="exe"/> carries a valid Authenticode signature whose
+    /// subject is Ookla's — fail-closed (deletes the binary and throws on any mismatch or
+    /// missing signature). Runs both right after download AND on every cached-exe reuse,
+    /// since the cache lives in a user-writable directory (TOCTOU).
+    /// </summary>
+    private static void VerifyOoklaSignature(string exe)
+    {
+        try
+        {
+#pragma warning disable SYSLIB0057 // CreateFromSignedFile is obsolete — no direct replacement for Authenticode verification
+            var cert = System.Security.Cryptography.X509Certificates.X509Certificate.CreateFromSignedFile(exe);
+#pragma warning restore SYSLIB0057
+            if (cert is null || !cert.Subject.Contains("Ookla", StringComparison.OrdinalIgnoreCase))
+            {
+                Log.Warning("Ookla speedtest.exe Authenticode subject mismatch: {Subject}", cert?.Subject ?? "none");
+                TryDeleteExe(exe);
+                throw new InvalidOperationException(
+                    $"Ookla speedtest.exe failed Authenticode verification (subject: {cert?.Subject ?? "none"}). Binary deleted for security.");
+            }
+            Log.Information("Ookla speedtest.exe Authenticode verified: {Subject}", cert.Subject);
+        }
+        catch (System.Security.Cryptography.CryptographicException ex)
+        {
+            Log.Warning(ex, "Ookla speedtest.exe has no valid Authenticode signature");
+            TryDeleteExe(exe);
+            throw new InvalidOperationException(
+                "Ookla speedtest.exe has no valid Authenticode signature. Binary deleted for security.", ex);
+        }
+    }
+
+    private static void TryDeleteExe(string exe)
+    {
+        try { File.Delete(exe); }
+        catch (IOException ex) { Log.Debug("Cleanup failed (locked): {Error}", LogService.SanitizePath(ex.Message)); }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Cleanup failed (access): {Error}", LogService.SanitizePath(ex.Message)); }
     }
 
     /// <summary>

--- a/SysManager/SysManager/Services/TuneUpService.cs
+++ b/SysManager/SysManager/Services/TuneUpService.cs
@@ -229,6 +229,11 @@ public sealed class TuneUpService
     /// </summary>
     internal static IEnumerable<string> EnumerateFilesSkippingReparsePoints(string root, CancellationToken ct)
     {
+        // Guard the traversal ROOT too: if the root itself is a junction/symlink,
+        // descending into it would follow the link out of the temp tree and yield
+        // (then delete) unrelated files — amplified when running elevated. Child dirs
+        // are already filtered below; the root needs the same check.
+        if (IsReparsePoint(root)) yield break;
         var stack = new Stack<string>();
         stack.Push(root);
         while (stack.Count > 0 && !ct.IsCancellationRequested)
@@ -254,6 +259,9 @@ public sealed class TuneUpService
     private static IEnumerable<string> EnumerateDirectoriesSkippingReparsePoints(string root, CancellationToken ct)
     {
         List<string> all = [];
+        // Same root guard as EnumerateFilesSkippingReparsePoints: never recurse a
+        // junction/symlink root out of the temp tree.
+        if (IsReparsePoint(root)) return all;
         var stack = new Stack<string>();
         stack.Push(root);
         while (stack.Count > 0 && !ct.IsCancellationRequested)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.42.5</Version>
-    <FileVersion>1.42.5.0</FileVersion>
-    <AssemblyVersion>1.42.5.0</AssemblyVersion>
+    <Version>1.42.6</Version>
+    <FileVersion>1.42.6.0</FileVersion>
+    <AssemblyVersion>1.42.6.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem
Two safety hardenings found by a full-app audit (both Medium; both narrow real-world reach but high blast radius if hit):
1. **Temp-cleanup traversal didn't guard its ROOT against being a reparse point.** `TuneUpService.EnumerateFilesSkippingReparsePoints` (and its directory sibling) skipped junctions/symlinks found *inside* the tree but pushed the `root` unconditionally — so if the root itself were a junction/symlink, enumeration would follow it out of the temp tree and could delete unrelated files (amplified when elevated).
2. **Speed Test didn't re-verify the cached Ookla CLI before reuse.** `speedtest.exe` is cached under `%LOCALAPPDATA%\SysManager\tools` (user-writable). Its Authenticode signature was verified right after download/extract, but on a later run the cached binary was returned and executed without re-checking — a TOCTOU window for a swapped binary.

## Fix
- **`TuneUpService`**: both `EnumerateFilesSkippingReparsePoints` and `EnumerateDirectoriesSkippingReparsePoints` now `IsReparsePoint(root)` → bail before traversing, matching the existing per-child guard. (`IsReparsePoint` already fails-closed to `true` on error.)
- **`SpeedTestService`**: the Authenticode check is extracted to `VerifyOoklaSignature(exe)` (Ookla subject, fail-closed, deletes on mismatch) and is now invoked on **every** cached-exe reuse as well as right after download. Shared `TryDeleteExe` helper.

## Tests
- `TuneUpServiceTests.EnumerateFilesSkippingReparsePoints_DoesNotFollowReparsePointRoot` — points the traversal at a symlink root over an "outside" folder and asserts it yields nothing (never the outside file). Mirrors the existing child-symlink test; skips gracefully if symlink creation needs privilege.
- Main + Tests build 0 warnings / 0 errors.

## Verification
- `dotnet build` main + tests: **0 errors / 0 warnings**. Protocol I leak/debug scan clean (no production generic catch added).
- Built the single-file exe and launched it: starts clean, no errors in the log.
- CHANGELOG entry under `1.42.6`; csproj bumped `1.42.5` → `1.42.6`.
- `fix:` -> patch release `1.42.6`.

Note: a third related audit item — the elevated self-update `.cmd` written to a user-writable dir (TOCTOU) — is intentionally **not** included here. It touches the self-update path, which can't be exercised locally (needs a signed release + elevation + restart) and must never regress across the installed base; it's tracked for a dedicated, carefully-verified change.
