### PR TITLE
fix: keep Process Manager polling alive and absorb transient WMI COM faults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.42.7] - 2026-06-27
+
+### Fixed
+- **Process Manager keeps auto-refreshing even if one refresh hits a snag.** Its 1-second live refresh loop only handled cancellation; any other transient fault (a process vanishing mid-read, a brief WMI hiccup) would stop the auto-refresh for the rest of the session. A failed refresh is now logged and the loop simply continues, matching the Dashboard's polling.
+- **Disk and battery readings shrug off transient WMI COM faults.** System Health's reliability/SMART read and the Battery Health queries now also catch the COM-level exception WMI can throw under load, so a one-off glitch no longer drops the whole disk list or aborts the battery scan.
+- **"Trim RAM" no longer briefly freezes the window.** Emptying every process's working set (a per-process system call across hundreds of processes) now runs on a background thread, keeping the Performance tab responsive while it works.
+- **Defender status read reports errors instead of failing silently.** If reading Defender status hit a PowerShell host fault, the tab could end up stuck; it now shows a clear message.
+
 ## [1.42.6] - 2026-06-27
 
 ### Fixed

--- a/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
@@ -193,4 +193,14 @@ public class PerformanceViewModelTests
         Assert.Contains("IsProcessorStateLocked", changed);
         Assert.Contains("IsProcessorStateEditable", changed);
     }
+
+    [Fact]
+    public void TrimRamCommand_IsAsync()
+    {
+        // TrimRam enumerates every process and calls EmptyWorkingSet (P/Invoke) on each;
+        // it must run off the UI thread. An IAsyncRelayCommand proves the work is awaited
+        // (offloaded), not executed synchronously on the dispatcher.
+        var vm = NewVm();
+        Assert.IsAssignableFrom<CommunityToolkit.Mvvm.Input.IAsyncRelayCommand>(vm.TrimRamCommand);
+    }
 }

--- a/SysManager/SysManager/Services/BatteryService.cs
+++ b/SysManager/SysManager/Services/BatteryService.cs
@@ -48,6 +48,7 @@ public sealed class BatteryService
         }
         catch (ManagementException) { /* WMI class not available */ }
         catch (UnauthorizedAccessException) { /* insufficient permissions */ }
+        catch (System.Runtime.InteropServices.COMException) { /* transient WMI COM fault — return what we have */ }
 
         if (!info.HasBattery)
         {
@@ -73,6 +74,7 @@ public sealed class BatteryService
         }
         catch (ManagementException) { /* WMI class not present on this device */ }
         catch (UnauthorizedAccessException) { /* needs elevation for root\WMI */ }
+        catch (System.Runtime.InteropServices.COMException) { /* transient WMI COM fault — return what we have */ }
 
         // ── BatteryFullChargedCapacity (current max) ──
         try
@@ -92,6 +94,7 @@ public sealed class BatteryService
         }
         catch (ManagementException) { /* WMI class not present on this device */ }
         catch (UnauthorizedAccessException) { /* needs elevation for root\WMI */ }
+        catch (System.Runtime.InteropServices.COMException) { /* transient WMI COM fault — return what we have */ }
 
         // ── BatteryCycleCount ──
         try
@@ -111,6 +114,7 @@ public sealed class BatteryService
         }
         catch (ManagementException) { /* WMI class not present on this device */ }
         catch (UnauthorizedAccessException) { /* needs elevation for root\WMI */ }
+        catch (System.Runtime.InteropServices.COMException) { /* transient WMI COM fault — return what we have */ }
 
         return info;
     }

--- a/SysManager/SysManager/Services/DiskHealthService.cs
+++ b/SysManager/SysManager/Services/DiskHealthService.cs
@@ -123,6 +123,7 @@ public sealed class DiskHealthService
         catch (ManagementException) { /* driver may not expose counters */ }
         catch (UnauthorizedAccessException) { /* WMI access denied */ }
         catch (InvalidOperationException) { /* object lacks a full path to navigate from — treat as no counter */ }
+        catch (System.Runtime.InteropServices.COMException) { /* GetRelated can surface a transient WMI COM fault — treat as no counter, don't abort the whole disk enumeration */ }
     }
 
     /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.42.6</Version>
-    <FileVersion>1.42.6.0</FileVersion>
-    <AssemblyVersion>1.42.6.0</AssemblyVersion>
+    <Version>1.42.7</Version>
+    <FileVersion>1.42.7.0</FileVersion>
+    <AssemblyVersion>1.42.7.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DefenderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DefenderViewModel.cs
@@ -73,6 +73,11 @@ public sealed partial class DefenderViewModel : ViewModelBase
                     ? "Tamper Protection is ON — some changes may be ignored by Windows until you turn it off in Windows Security."
                     : "Defender status loaded.";
         }
+        // GetStatusAsync runs PowerShell; a runspace-level fault (not just a script
+        // RuntimeException the service catches) would otherwise escape this async
+        // command unobserved. Surface it as a status message instead.
+        catch (InvalidOperationException ex) { StatusMessage = $"Could not read Defender status: {ex.Message}"; }
+        catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"Could not read Defender status: {ex.Message}"; }
         finally { IsBusy = false; }
     }
 

--- a/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
@@ -414,7 +414,7 @@ public sealed partial class PerformanceViewModel : ViewModelBase
     // ═══════════════════════════════════════════════════════════════
 
     [RelayCommand]
-    private void TrimRam()
+    private async Task TrimRamAsync()
     {
         if (!DialogService.Instance.Confirm(
             "Trim the working set of all processes?\n\n"
@@ -426,7 +426,10 @@ public sealed partial class PerformanceViewModel : ViewModelBase
 
         try
         {
-            var count = PerformanceService.TrimWorkingSets();
+            // TrimWorkingSets enumerates every process and calls EmptyWorkingSet
+            // (P/Invoke) on each — run it off the UI thread so the window stays
+            // responsive while hundreds of processes are trimmed.
+            var count = await Task.Run(PerformanceService.TrimWorkingSets).ConfigureAwait(true);
             StatusMessage = $"✓ Trimmed working set of {count} processes.";
             Log.Information("RAM trim completed: {Count} processes trimmed", count);
         }

--- a/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
@@ -52,16 +52,19 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
 
     private async Task AutoRefreshLoopAsync(CancellationToken ct)
     {
-        try
+        while (!ct.IsCancellationRequested)
         {
-            while (!ct.IsCancellationRequested)
+            try
             {
                 await Task.Delay(1000, ct);
                 if (!IsActive) continue;
                 await RefreshAsync();
             }
+            catch (OperationCanceledException) { break; /* expected on shutdown */ }
+            // A single refresh fault (transient process/WMI/Win32 hiccup) must not kill
+            // the loop permanently — log and keep polling, mirroring DashboardViewModel.
+            catch (Exception ex) { Log.Debug("Process auto-refresh error: {Error}", ex.Message); }
         }
-        catch (OperationCanceledException) { /* expected on shutdown */ }
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Problem
A cluster of robustness gaps found by the full-app audit:
1. **Process Manager's 1 Hz auto-refresh loop only caught `OperationCanceledException`** — any other transient fault (a process exiting mid-read, a brief WMI hiccup) escaped the loop and permanently stopped live refresh for the session.
2. **`DiskHealthService.EnrichWithReliability` and the four `BatteryService` WMI reads didn't catch `COMException`** — WMI can surface a COM-level fault under load, which would abort the whole disk enumeration / battery scan instead of degrading gracefully.
3. **`PerformanceViewModel.TrimRam` ran synchronously on the UI thread** — enumerating every process and calling `EmptyWorkingSet` (P/Invoke) on each froze the window briefly.
4. **`DefenderViewModel.RefreshAsync` had a `finally` but no `catch`** — a PowerShell host-level fault (not the script `RuntimeException` the service handles) escaped the async command unobserved.

## Fix
- **`ProcessManagerViewModel`**: the try/catch moved INSIDE the while loop — `OperationCanceledException` breaks, any other exception is logged and the loop continues (mirrors `DashboardViewModel`'s polling).
- **`DiskHealthService` / `BatteryService`**: added `catch (COMException)` alongside the existing WMI catches (treat as no-data, keep going).
- **`PerformanceViewModel.TrimRam`** → `TrimRamAsync`, `await Task.Run(...)` for the working-set sweep (command name unchanged → XAML binding intact).
- **`DefenderViewModel.RefreshAsync`**: added `catch (InvalidOperationException | Win32Exception)` → status message.

## Tests
- `PerformanceViewModelTests.TrimRamCommand_IsAsync` — pins that Trim RAM is an `IAsyncRelayCommand` (offloaded).
- Main + Tests build 0 warnings / 0 errors.

## Verification
- `dotnet build` main + tests: **0 errors / 0 warnings**. Protocol I leak/debug scan clean. (The new `ProcessManager` loop `catch (Exception)` is the documented last-resort poll-loop net, matching DashboardViewModel — the same pattern CodeQL is configured to allow here.)
- Built the single-file exe and launched it: starts clean, no errors in the log.
- CHANGELOG entry under `1.42.7`; csproj bumped `1.42.6` → `1.42.7`.
- `fix:` -> patch release `1.42.7`.
