### PR TITLE
fix: clearer empty-state copy, dispose preview tabs on exit, doc accuracy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,7 +41,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Group | View Models |
 |-------|-------------|
 | Dashboard | `DashboardViewModel` |
-| System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `SystemFixesViewModel` · `BootAnalyzerViewModel` · `TaskSchedulerViewModel` |
+| System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `TaskSchedulerViewModel` · `BootAnalyzerViewModel` · `SystemFixesViewModel` |
 | Gaming & Profiles | `TimerResolutionViewModel` · `DisplayProfileViewModel` · `CpuAffinityViewModel` · `StandbyMemoryViewModel` · `PlaceholderViewModel` (Gaming Profile) |
 | Monitor | `ProcessManagerViewModel` · `PrivacyMonitorViewModel` · `AppAlertsViewModel` · `FileLockViewModel` · `PlaceholderViewModel` (Resource History · Settings Watchdog · Bandwidth Monitor) |
 | Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `PlaceholderViewModel` (Scheduled Maintenance) |
@@ -58,7 +58,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
   alerts (auto-scan at boot), quick actions with inline progress, health score,
   and recent activity log. IsActive pattern pauses polling when tab not visible.
 - `AppUpdatesViewModel` — winget scan and bulk upgrade.
-- `WindowsUpdateViewModel` — PSWindowsUpdate wrapper with auto-check.
+- `WindowsUpdateViewModel` — user-triggered Windows Update scan/install via the WUA COM API.
 - `SystemHealthViewModel` — SMART, memory diagnostic, multi-drive chkdsk.
 - `CleanupViewModel` — TEMP, Recycle Bin, SFC, DISM (background-aware).
 - `DeepCleanupViewModel` — scan-first deep cleanup + large-files finder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.42.8] - 2026-06-27
+
+### Fixed
+- **Empty-list messages are clearer and no longer misleading.** The "nothing to show" text on Services, Startup Manager, Process Manager, Uninstaller, Windows Features and DNS & Hosts previously assumed a specific cause (e.g. "use Refresh" or "no match for the filter") even when a different one applied, and could flash briefly while a tab was still loading. The wording is now neutral and accurate in every state.
+- **Preview tabs are now released cleanly on exit.** The newer tabs (Display Profiles, Defender Tweaks, Task Scheduler, CPU Affinity, Timer Resolution, File Lock Detector, Standby List Cleaner, Dark Mode Scheduler) weren't being disposed when the app closed, so their timers and event subscriptions could linger. They're now disposed with the rest, and Defender Tweaks unsubscribes its internal handler.
+
+### Changed
+- Documentation accuracy: corrected the System-group tab order in the README and ARCHITECTURE feature tables, fixed the Windows Update description (it uses the Windows Update COM API, user-triggered — not a PSWindowsUpdate auto-check), and aligned the SECURITY supported-versions table with the "latest minor only" policy.
+
 ## [1.42.7] - 2026-06-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ tabs still being verified are marked **PREVIEW**:
 | Group | Tabs |
 |-------|------|
 | 🏠 Dashboard | Dashboard |
-| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · System Fixes · Boot Analyzer · Task Scheduler 🔬 |
+| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Task Scheduler 🔬 · Boot Analyzer · System Fixes |
 | 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner 🔬 · Timer Resolution 🔬 · CPU Core Affinity 🔬 · Display Profiles 🔬 |
 | 📊 Monitor | Process Manager · Resource History ⚙️ · Camera/Mic/Location · App Alerts · File Lock Detector 🔬 · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance ⚙️ |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,10 +10,10 @@ app and its releases matters — thank you for helping keep it safe.
 Security fixes are applied to the latest minor release only. If you're on an
 older build, the first step is usually to update.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 1.x     | :white_check_mark: |
-| < 1.0   | :x:                |
+| Version  | Supported          |
+| -------- | ------------------ |
+| 1.42.x   | :white_check_mark: |
+| < 1.42   | :x:                |
 
 ## Reporting a vulnerability
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.42.7</Version>
-    <FileVersion>1.42.7.0</FileVersion>
-    <AssemblyVersion>1.42.7.0</AssemblyVersion>
+    <Version>1.42.8</Version>
+    <FileVersion>1.42.8.0</FileVersion>
+    <AssemblyVersion>1.42.8.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DefenderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DefenderViewModel.cs
@@ -59,6 +59,12 @@ public sealed partial class DefenderViewModel : ViewModelBase
         RemoveExclusionCommand.NotifyCanExecuteChanged();
     }
 
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing) PropertyChanged -= OnVmPropertyChanged;
+        base.Dispose(disposing);
+    }
+
     [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task RefreshAsync()
     {

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -487,6 +487,18 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         FileShredder?.Dispose();
         DnsHosts?.Dispose();
 
+        // Implemented PREVIEW tabs — these own timers / event subscriptions
+        // (e.g. DisplayProfile's revert DispatcherTimer, Defender's PropertyChanged),
+        // so they must be disposed on shutdown like every other real VM.
+        TimerResolution?.Dispose();
+        FileLock?.Dispose();
+        DisplayProfile?.Dispose();
+        CpuAffinity?.Dispose();
+        Defender?.Dispose();
+        TaskScheduler?.Dispose();
+        DarkMode?.Dispose();
+        StandbyMemory?.Dispose();
+
         // WIP placeholders
         WipResourceHistory?.Dispose();
         WipFileLockDetector?.Dispose();

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -153,7 +153,7 @@
                 </DataGrid>
 
                 <!-- Empty state -->
-                <TextBlock Text="No host entries yet. Add one above, or your hosts file is empty."
+                <TextBlock Text="No host entries to show. Add one above to get started."
                            Style="{StaticResource Subtle}" TextWrapping="Wrap" MaxWidth="360"
                            HorizontalAlignment="Center" VerticalAlignment="Center"
                            Visibility="{Binding HostEntries.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -192,7 +192,7 @@
             </DataGrid>
 
             <!-- Empty state -->
-            <TextBlock Text="No processes match the current filter."
+            <TextBlock Text="No processes to show."
                        Style="{StaticResource Subtle}" TextWrapping="Wrap" MaxWidth="360"
                        HorizontalAlignment="Center" VerticalAlignment="Center"
                        Visibility="{Binding FilteredProcesses.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -179,7 +179,7 @@
         </DataGrid>
 
             <!-- Empty state -->
-            <TextBlock Text="No services to show yet. They load automatically — use Refresh if the list stays empty."
+            <TextBlock Text="No services to show. If this looks wrong, use Refresh."
                        Style="{StaticResource Subtle}" TextWrapping="Wrap" MaxWidth="360"
                        HorizontalAlignment="Center" VerticalAlignment="Center"
                        Visibility="{Binding Services.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -174,7 +174,7 @@
             </DataGrid>
 
             <!-- Empty state -->
-            <TextBlock Text="No startup programs found yet. They load automatically — use Refresh if the list stays empty."
+            <TextBlock Text="No startup programs to show. If this looks wrong, use Refresh."
                        Style="{StaticResource Subtle}" TextWrapping="Wrap" MaxWidth="360"
                        HorizontalAlignment="Center" VerticalAlignment="Center"
                        Visibility="{Binding Entries.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -253,7 +253,7 @@
             </DataGrid>
 
             <!-- Empty state -->
-            <TextBlock Text="No applications match the current filter."
+            <TextBlock Text="No applications to show."
                        Style="{StaticResource Subtle}" TextWrapping="Wrap" MaxWidth="360"
                        HorizontalAlignment="Center" VerticalAlignment="Center"
                        Visibility="{Binding FilteredApps.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -266,7 +266,7 @@
             </DataGrid>
 
             <!-- Empty state -->
-            <TextBlock Text="No Windows features match the current filter."
+            <TextBlock Text="No Windows features to show."
                        Style="{StaticResource Subtle}" TextWrapping="Wrap" MaxWidth="360"
                        HorizontalAlignment="Center" VerticalAlignment="Center"
                        Visibility="{Binding FilteredFeatures.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>


### PR DESCRIPTION
## Problem
The low-severity cluster from the full-app audit:
1. **Empty-state copy assumed a cause that wasn't always true** — Services/Startup said "use Refresh", Process Manager/Uninstaller/Windows Features said "no match for the filter", DNS & Hosts said "your hosts file is empty" — even when the real reason was a different filter state, and some flashed briefly during the initial async load.
2. **The eight implemented PREVIEW tabs were never disposed on exit** — `MainWindowViewModel.Dispose` listed the WIP placeholders but not the real Display Profiles / Defender / Task Scheduler / CPU Affinity / Timer Resolution / File Lock / Standby / Dark Mode VMs, which own timers and event subscriptions. `DefenderViewModel` also self-subscribed `PropertyChanged` with no unsubscribe.
3. **Doc drift**: README & ARCHITECTURE listed the System-group tabs in the wrong order; ARCHITECTURE described Windows Update as a "PSWindowsUpdate wrapper with auto-check" (it's the WUA COM API, user-triggered, and explicitly replaced PSWindowsUpdate); SECURITY's supported-versions table green-checked all `1.x` while the prose says latest-minor-only.

## Fix
- Reworded the six empty states to neutral, always-accurate copy ("No … to show." / "… If this looks wrong, use Refresh." / "Add one above to get started.").
- `MainWindowViewModel.Dispose` now disposes the eight real PREVIEW VMs; `DefenderViewModel` adds a `Dispose(bool)` override that unsubscribes its `PropertyChanged` handler.
- Docs: corrected the System-group order (README + ARCHITECTURE), the Windows Update description, and the SECURITY table (`1.42.x` supported, `< 1.42` not).

## Tests
No new tests (wording/lifecycle/doc changes). Existing suite unaffected; main + tests build 0 warnings / 0 errors.

## Verification
- `dotnet build` main + tests: **0 errors / 0 warnings**. Protocol I leak/debug scan clean.
- Built the single-file exe and launched it: starts clean, no errors in the log.
- CHANGELOG entry under `1.42.8`; csproj bumped `1.42.7` → `1.42.8`.
- `fix:` -> patch release `1.42.8`.

Note: pure collection-expression / `SearchValues` modernization items from the audit are intentionally deferred to a separate optional sweep — they're cosmetic, behaviour-neutral, and one target (`TargetPreset.cs`) collides with the identity-leak pre-commit scan's `aws` term (legitimate PUBG endpoints), so they warrant their own careful pass.
