### PR TITLE
fix: restore theme-aware blue/green tint on System Logs detail cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.42.9] - 2026-06-27
+
+### Fixed
+- **System Logs detail cards regained their colour coding.** The "What this means" and "What to try" panels are tinted blue and green again to tell them apart at a glance — this time using theme-aware translucent tints, so they stay legible on light and custom themes (the previous fix had flattened them to a neutral surface).
+
 ## [1.42.8] - 2026-06-27
 
 ### Fixed

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -78,6 +78,13 @@
             <SolidColorBrush x:Key="WarningStripe" Color="#FBBF24"/>
             <SolidColorBrush x:Key="WarningText" Color="#FCD34D"/>
 
+            <!-- Info / Success category surfaces (low-alpha tints layer over any
+                 theme surface, so they stay readable on light and dark presets). -->
+            <SolidColorBrush x:Key="InfoBgSubtle" Color="#1A38BDF8"/>
+            <SolidColorBrush x:Key="InfoBorder" Color="#3338BDF8"/>
+            <SolidColorBrush x:Key="SuccessBgSubtle" Color="#1A22C55E"/>
+            <SolidColorBrush x:Key="SuccessBorder" Color="#3322C55E"/>
+
             <!-- Console output coloring (legacy) -->
             <SolidColorBrush x:Key="OutErrorBrush"   Color="#F87171" />
             <SolidColorBrush x:Key="OutWarnBrush"    Color="#FBBF24" />

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.42.8</Version>
-    <FileVersion>1.42.8.0</FileVersion>
-    <AssemblyVersion>1.42.8.0</AssemblyVersion>
+    <Version>1.42.9</Version>
+    <FileVersion>1.42.9.0</FileVersion>
+    <AssemblyVersion>1.42.9.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -37,9 +37,9 @@ public sealed partial class LogsViewModel : ViewModelBase
     public BulkObservableCollection<FriendlyEventEntry> Entries { get; } = new();
     public ICollectionView EntriesView { get; }
 
-    public string[] AvailableLogs { get; } = { "System", "Application", "Security", "Setup" };
-    public string[] TimeRanges { get; } = { "Last hour", "Last 24 hours", "Last 7 days", "Last 30 days", "All" };
-    public string[] MaxResultOptions { get; } = { "200", "500", "1000", "5000" };
+    public string[] AvailableLogs { get; } = ["System", "Application", "Security", "Setup"];
+    public string[] TimeRanges { get; } = ["Last hour", "Last 24 hours", "Last 7 days", "Last 30 days", "All"];
+    public string[] MaxResultOptions { get; } = ["200", "500", "1000", "5000"];
 
     [ObservableProperty] private string _selectedLog = "System";
     [ObservableProperty] private string _selectedTimeRange = "Last 24 hours";

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -352,12 +352,14 @@
                             </Border>
 
                             <TextBlock Text="What this means" Style="{StaticResource SectionTitle}" Margin="0,18,0,6"/>
-                            <Border Style="{StaticResource CardInner}">
+                            <Border Style="{StaticResource CardInner}"
+                                    Background="{DynamicResource InfoBgSubtle}" BorderBrush="{DynamicResource InfoBorder}">
                                 <TextBlock Text="{Binding SelectedEntry.Explanation}" TextWrapping="Wrap" Foreground="{DynamicResource TextPrimary}"/>
                             </Border>
 
                             <TextBlock Text="What to try" Style="{StaticResource SectionTitle}" Margin="0,14,0,6"/>
-                            <Border Style="{StaticResource CardInner}">
+                            <Border Style="{StaticResource CardInner}"
+                                    Background="{DynamicResource SuccessBgSubtle}" BorderBrush="{DynamicResource SuccessBorder}">
                                 <TextBlock Text="{Binding SelectedEntry.Recommendation}" TextWrapping="Wrap" Foreground="{DynamicResource TextPrimary}"/>
                             </Border>
 


### PR DESCRIPTION
## Problem
A follow-up to the theming cleanup (1.42.4) flagged by the audit: migrating the System Logs detail cards to the shared `CardInner` style flattened their intentional **blue (info) / green (success)** tint that distinguished "What this means" from "What to try" — losing an at-a-glance cue. The original used hardcoded opaque hex, which is exactly what 1.42.4 set out to remove, so simply reverting wasn't right either.

## Fix
- Added theme-aware semantic surface brushes mirroring the existing `Warning*` family: `InfoBgSubtle` / `InfoBorder` and `SuccessBgSubtle` / `SuccessBorder`, using **low-alpha tints** (`#1A…` over the card's themed surface) so they stay legible on light and custom presets.
- `LogsView` now layers those over `CardInner` (keeping the shared style for padding/radius/border, adding the translucent semantic tint on top).
- Minor: modernized three legacy `string[] = { … }` initializers in `LogsViewModel` to collection expressions `[ … ]` while in the file.

## Tests
No new tests (styling change). Existing suite unaffected; main + tests build 0 warnings / 0 errors.

## Verification
- `dotnet build` main + tests: **0 errors / 0 warnings**. Protocol I leak/debug scan clean.
- Built the single-file exe and launched it: starts clean; the new `InfoBgSubtle`/`SuccessBorder` DynamicResources resolve with no missing-resource or XAML errors in the log.
- CHANGELOG entry under `1.42.9`; csproj bumped `1.42.8` → `1.42.9`.
- `fix:` -> patch release `1.42.9`.
