### PR TITLE
fix: harden in-app updater script against local tampering window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.42.10] - 2026-06-27
+
+### Fixed
+- **The in-app updater is hardened against a local tampering window.** When applying a downloaded update, SysManager writes a small batch script that swaps in the new executable after the app closes. That script was previously written into the same predictable, user-writable folder as the download and launched via the bare `cmd.exe` name. A malicious program running as the same user could, in theory, replace the script (or plant a fake `cmd.exe` on the search path) during the brief window before it ran, getting its own commands executed by the update step. The script is now written to a fresh, randomly-named private folder, launched via the full system path to `cmd.exe`, refuses any path containing an illegal character, and cleans up its own folder afterwards. Hash and Authenticode verification of the downloaded binary were already in place and are unchanged.
+
 ## [1.42.9] - 2026-06-27
 
 ### Fixed

--- a/SysManager/SysManager.Tests/UpdaterScriptTests.cs
+++ b/SysManager/SysManager.Tests/UpdaterScriptTests.cs
@@ -1,0 +1,99 @@
+// SysManager · UpdaterScriptTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Regression tests for the self-update script hardening (updater TOCTOU).
+/// Before the fix the script was written into the predictable, user-writable
+/// download folder and launched via the bare "cmd.exe" name, so a same-user
+/// process could pre-plant the script or a fake interpreter and have it run
+/// during the elevated copy step (local elevation-of-privilege). These tests
+/// pin the hardened behaviour: random isolated directory, absolute interpreter
+/// path, and rejection of paths that could break out of the batch quoting.
+/// </summary>
+public class UpdaterScriptTests
+{
+    [Fact]
+    public void UpdaterCmdPath_IsAbsolutePathUnderSystem32()
+    {
+        var path = AboutViewModel.UpdaterCmdPath;
+
+        // Must be rooted (absolute), not a bare "cmd.exe" resolved via PATH.
+        Assert.True(Path.IsPathFullyQualified(path), $"Expected absolute path, got: {path}");
+        Assert.Equal("cmd.exe", Path.GetFileName(path));
+        Assert.StartsWith(Environment.SystemDirectory, path, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CreateUpdaterDirectory_IsFreshRandomAndNotTheDownloadFolder()
+    {
+        var downloadFolder = Path.Join(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "SysManager", "updates");
+
+        var dir = AboutViewModel.CreateUpdaterDirectory();
+        try
+        {
+            Assert.True(Directory.Exists(dir), "Updater directory should exist after creation.");
+
+            // The whole point of the fix: NOT the predictable download folder.
+            Assert.NotEqual(
+                Path.GetFullPath(downloadFolder),
+                Path.GetFullPath(dir));
+            Assert.False(
+                Path.GetFullPath(dir).StartsWith(Path.GetFullPath(downloadFolder), StringComparison.OrdinalIgnoreCase),
+                "Updater directory must not live under the user-writable download folder.");
+        }
+        finally
+        {
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CreateUpdaterDirectory_ReturnsUniquePathEachCall()
+    {
+        var a = AboutViewModel.CreateUpdaterDirectory();
+        var b = AboutViewModel.CreateUpdaterDirectory();
+        try
+        {
+            Assert.NotEqual(a, b);
+        }
+        finally
+        {
+            if (Directory.Exists(a)) Directory.Delete(a, recursive: true);
+            if (Directory.Exists(b)) Directory.Delete(b, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void BuildUpdaterScript_EmbedsBothPathsQuoted()
+    {
+        const string src = @"C:\Temp\SysManager-1.2.3.exe";
+        const string dst = @"C:\Program Files\SysManager\SysManager.exe";
+
+        var script = AboutViewModel.BuildUpdaterScript(1234, src, dst);
+
+        Assert.Contains($"copy /Y \"{src}\" \"{dst}\"", script);
+        Assert.Contains("PID eq 1234", script);
+        // Self-cleanup removes the isolated directory, not just the script file.
+        Assert.Contains("rmdir /S /Q \"%~dp0\"", script);
+    }
+
+    [Theory]
+    [InlineData(@"C:\Temp\evil"" & calc & "".exe", @"C:\Program Files\SysManager\SysManager.exe")]
+    [InlineData(@"C:\Temp\ok.exe", @"C:\Program Files\""whoami""\SysManager.exe")]
+    public void BuildUpdaterScript_RejectsQuoteInPath(string src, string dst)
+    {
+        // A double quote can't legally appear in a Windows path; its presence
+        // means tampering/injection. The builder must refuse rather than emit a
+        // script whose quoting can be escaped.
+        Assert.Throws<InvalidOperationException>(
+            () => AboutViewModel.BuildUpdaterScript(1, src, dst));
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.42.9</Version>
-    <FileVersion>1.42.9.0</FileVersion>
-    <AssemblyVersion>1.42.9.0</AssemblyVersion>
+    <Version>1.42.10</Version>
+    <FileVersion>1.42.10.0</FileVersion>
+    <AssemblyVersion>1.42.10.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -519,47 +519,21 @@ public sealed partial class AboutViewModel : ViewModelBase
             return;
         }
 
-        // The updater script is written next to the downloaded binary. Resolve that
-        // directory up front: Path.GetDirectoryName returns null for a rooted/invalid
-        // path, which would otherwise NRE inside Path.Join below.
-        var downloadDir = string.IsNullOrWhiteSpace(DownloadedPath)
-            ? null : Path.GetDirectoryName(DownloadedPath);
-        if (string.IsNullOrEmpty(downloadDir))
-        {
-            DownloadStatus = "Cannot determine the downloaded update's location.";
-            return;
-        }
-
-        // Step 3: Write an updater script that waits for this process to exit,
-        // copies the new exe over the old one, then launches the new version.
+        // Step 3: Write an updater script to an isolated, randomly-named temp
+        // directory — never the predictable, user-writable download folder — then
+        // launch it via the absolute path to cmd.exe. The old code wrote the script
+        // next to the download and ran "cmd.exe" by bare name, so a same-user process
+        // could pre-plant the script (or a fake interpreter on the search path) and
+        // have it run during the elevated copy step (updater TOCTOU → local EoP). The
+        // script waits for this process to exit, copies the verified new exe over the
+        // old one, relaunches it, then removes its own directory.
         try
         {
             var pid = Environment.ProcessId;
-            var scriptPath = Path.Join(
-                downloadDir,
-                $"update-{Guid.NewGuid():N}.cmd");
-
-            var script = $"""
-                @echo off
-                title SysManager Updater
-                echo Waiting for SysManager to close...
-                :wait
-                tasklist /FI "PID eq {pid}" 2>NUL | find /I "{pid}" >NUL
-                if not errorlevel 1 (
-                    timeout /t 1 /nobreak >NUL
-                    goto wait
-                )
-                echo Applying update...
-                copy /Y "{DownloadedPath}" "{currentExe}" >NUL
-                if errorlevel 1 (
-                    echo Update failed — could not copy file. Press any key to exit.
-                    pause >NUL
-                    exit /b 1
-                )
-                echo Starting SysManager...
-                start "" "{currentExe}"
-                del "%~f0"
-                """;
+            var scriptDir = CreateUpdaterDirectory();
+            var scriptPath = Path.Join(scriptDir, "update.cmd");
+            // DownloadedPath is non-null here: validated by File.Exists above.
+            var script = BuildUpdaterScript(pid, DownloadedPath!, currentExe);
 
             await File.WriteAllTextAsync(scriptPath, script);
 
@@ -567,7 +541,7 @@ public sealed partial class AboutViewModel : ViewModelBase
 
             Process.Start(new ProcessStartInfo
             {
-                FileName = "cmd.exe",
+                FileName = UpdaterCmdPath,
                 Arguments = $"/C \"{scriptPath}\"",
                 UseShellExecute = false,
                 CreateNoWindow = true,
@@ -594,6 +568,64 @@ public sealed partial class AboutViewModel : ViewModelBase
         {
             DownloadStatus = $"Update failed: {ex.Message}";
         }
+    }
+
+    // ---------- Updater script (TOCTOU-hardened) ----------
+
+    /// <summary>
+    /// Absolute path to the system cmd.exe. Launching the interpreter by bare
+    /// name ("cmd.exe") resolves it via the search path, which a same-user
+    /// process could hijack; resolving it under %SystemRoot%\System32 pins the
+    /// real interpreter.
+    /// </summary>
+    internal static string UpdaterCmdPath { get; } =
+        Path.Join(Environment.SystemDirectory, "cmd.exe");
+
+    /// <summary>
+    /// Creates a fresh, randomly-named directory for the updater script. The
+    /// unpredictable name (under the per-user temp root) is what defeats the
+    /// TOCTOU: an attacker cannot pre-plant a malicious update.cmd at a path it
+    /// can't know, and the directory does not exist until we create it.
+    /// </summary>
+    internal static string CreateUpdaterDirectory() =>
+        Directory.CreateTempSubdirectory("SysMgrUpd_").FullName;
+
+    /// <summary>
+    /// Builds the updater batch script. Pure and side-effect free so it can be
+    /// asserted in tests. Windows paths cannot legally contain a double quote,
+    /// so a quote in either path means tampering/injection — reject rather than
+    /// emit a script that could break out of its quoting.
+    /// </summary>
+    internal static string BuildUpdaterScript(int pid, string downloadedPath, string currentExe)
+    {
+        if (downloadedPath.Contains('"') || currentExe.Contains('"'))
+            throw new InvalidOperationException("Update path contains an invalid character.");
+
+        return $"""
+            @echo off
+            title SysManager Updater
+            echo Waiting for SysManager to close...
+            :wait
+            tasklist /FI "PID eq {pid}" 2>NUL | find /I "{pid}" >NUL
+            if not errorlevel 1 (
+                timeout /t 1 /nobreak >NUL
+                goto wait
+            )
+            echo Applying update...
+            copy /Y "{downloadedPath}" "{currentExe}" >NUL
+            if errorlevel 1 (
+                echo Update failed — could not copy file. Press any key to exit.
+                pause >NUL
+                exit /b 1
+            )
+            echo Starting SysManager...
+            start "" "{currentExe}"
+            rem Self-delete this script's isolated directory. (goto) 2>nul releases
+            rem cmd's handle on the running batch first, so rmdir can remove it. This
+            rem is the last, non-critical step — the update already applied above, so
+            rem a cleanup failure here can never affect the update.
+            (goto) 2>nul & rmdir /S /Q "%~dp0"
+            """;
     }
 
     [RelayCommand]


### PR DESCRIPTION
## What

Hardens the in-app self-update flow against a local time-of-check/time-of-use (TOCTOU) window.

When applying a downloaded update, the app writes a small batch script that waits for the process to exit, copies the new exe over the old one, and relaunches. Previously that script was:
- written into the **predictable, user-writable** download folder (`%LOCALAPPDATA%\SysManager\updates`), and
- launched via the **bare `cmd.exe` name** (search-path resolution).

A program running as the same user could replace the script — or plant a fake `cmd.exe` earlier on the search path — in the brief window before it ran, getting its own commands executed by the update step (local elevation-of-privilege if the update is applied elevated).

## Change

- Script is written to a **fresh, randomly-named private directory** (`Directory.CreateTempSubdirectory`) instead of the predictable download folder.
- Launched via the **absolute System32 path** to `cmd.exe`, not the bare name.
- The script builder **rejects any path containing a quote** (illegal in Windows paths → tampering/injection) instead of emitting breakable quoting.
- The script **removes its own private directory** after applying.
- Directory creation, interpreter path, and script construction extracted as testable seams.

Hash + Authenticode verification of the downloaded binary were already present and are unchanged.

## Tests

New `UpdaterScriptTests`:
- interpreter path is absolute and under System32;
- updater directory is fresh, unique per call, and **not** under the download folder;
- script embeds both paths correctly quoted and self-cleans;
- quote-injected paths are rejected.

Each test fails against the pre-fix behaviour and passes after.

## Verification

- `dotnet build` Release + Tests: clean, 0 warnings / 0 errors.
- Launch-verified: app starts, Dashboard + About load, no new errors in the session log.
- The elevated copy-over-exe + restart step is inherently only exercisable on a real installed build; that behaviour is unchanged by this PR.