### PR TITLE
fix: reduce Dashboard polling overhead, scrub update-log paths, harden update edge cases

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -365,10 +365,15 @@ retained). The in-app Console mirrors the same stream per tab.
 
 `UpdateService` hits `api.github.com/repos/laurentiu021/SystemManager/releases`
 at startup and on demand. Downloads land in
-`%LOCALAPPDATA%\SysManager\updates\SysManager-{version}.exe` with size
-checksum so re-opening the app doesn't re-download a good copy. The "Install"
-button launches the new exe and closes the current instance; Windows swaps
-them cleanly.
+`%LOCALAPPDATA%\SysManager\updates\SysManager-{version}.exe` with a companion
+`.sha256` so re-opening the app doesn't re-download a good copy. The "Install"
+button verifies the download's SHA256 and Authenticode signature, then hands
+off to `UpdateApplier`: the freshly-downloaded exe is relaunched with
+`--apply-update`, which `App.OnStartup` intercepts before any window opens. That
+process waits for the old instance to exit, swaps itself over the old executable
+via a staged atomic move (a sibling `.new` file plus `File.Move`, so an
+interrupted copy can never leave a half-written binary), and relaunches —
+inheriting the original's elevation. No on-disk script is involved.
 
 ## Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.42.12] - 2026-06-27
+
+### Fixed
+- **The Dashboard is lighter on the system while it's open.** Two background readings were doing far more work than needed on their refresh timers: the GPU widget re-initialised the graphics API (and re-queried the adapter on non-NVIDIA machines) several times a second, and — when running as administrator — the temperature panel opened and closed its hardware-monitoring driver on every two-second poll. Both now initialise once and reuse that handle, so the live Dashboard uses noticeably less CPU and fewer system handles without changing what you see.
+- **Log files no longer record your Windows username from the update path.** A couple of update-related log lines wrote the full executable path (which for a per-user install includes `C:\Users\<name>\…`) without the existing path-scrubbing the rest of the app applies. They now scrub the username like everywhere else.
+- **A failed update recovers instantly instead of stalling.** If the downloaded file went missing right before applying (e.g. removed by antivirus), the updater treated it as a temporarily-locked file and retried for several seconds before giving up; it now detects the missing file immediately and reports it.
+
 ## [1.42.11] - 2026-06-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -605,7 +605,8 @@ Manage Microsoft Defender without digging through Windows Security:
 - Background download of the new build with a progress bar. If the
   download is blocked, a "Manual download" button opens GitHub in the
   browser.
-- SHA256 hash verification before install — blocks corrupted downloads.
+- SHA256 hash + Authenticode signature verification before install — blocks
+  corrupted or tampered downloads.
 - One-click "Install" replaces the running executable in-place and
   restarts automatically (no manual file copying needed).
 - Full release-note history pulled live from GitHub.

--- a/SysManager/SysManager.Tests/UpdateApplierTests.cs
+++ b/SysManager/SysManager.Tests/UpdateApplierTests.cs
@@ -125,7 +125,12 @@ public class UpdateApplierTests
             var target = Path.Combine(dir.FullName, "current.exe");
             File.WriteAllText(target, "OLD-BUILD");
 
-            var ok = UpdateApplier.ApplyCopy(source, target, maxAttempts: 2, delayMs: 0);
+            // A missing source is non-recoverable: the early-exit guard returns false
+            // immediately, so even a large maxAttempts must NOT spin the retry/backoff
+            // loop (it would otherwise misread FileNotFoundException as a transient lock).
+            // delayMs is large on purpose — if the guard regressed and the loop ran, the
+            // test would hang noticeably rather than return instantly.
+            var ok = UpdateApplier.ApplyCopy(source, target, maxAttempts: 10, delayMs: 10_000);
 
             // A failed copy must never destroy the working executable.
             Assert.False(ok);

--- a/SysManager/SysManager/Services/AppAlertService.cs
+++ b/SysManager/SysManager/Services/AppAlertService.cs
@@ -105,11 +105,14 @@ public sealed class AppAlertService : IDisposable
     /// </summary>
     public void Stop()
     {
-        _registryTimer?.Dispose();
-        _registryTimer = null;
-
         lock (_watcherLock)
         {
+            // Dispose the timer under the same lock that creates it in Start(), so a
+            // concurrent Start()/Stop() can't race on _registryTimer (Start creates it
+            // inside the lock; tearing it down outside would reopen that window).
+            _registryTimer?.Dispose();
+            _registryTimer = null;
+
             foreach (var w in _watchers)
             {
                 w.EnableRaisingEvents = false;

--- a/SysManager/SysManager/Services/DeepCleanupService.cs
+++ b/SysManager/SysManager/Services/DeepCleanupService.cs
@@ -56,8 +56,7 @@ public sealed class DeepCleanupService
         {
             new("NVIDIA installer leftovers",
                 "Extracted driver packages NVIDIA drops on your drive root and in ProgramData during an install. Safe to remove once the driver is installed.",
-                new[]
-                {
+                [
                     Path.Combine(systemDrive, "NVIDIA"),
                     Path.Combine(programData, "NVIDIA Corporation", "Downloader"),
                     Path.Combine(programData, "NVIDIA Corporation", "NV_Cache"),
@@ -65,55 +64,54 @@ public sealed class DeepCleanupService
                     Path.Combine(localAppData, "NVIDIA", "GLCache"),
                     Path.Combine(localAppData, "NVIDIA", "DXCache"),
                     Path.Combine(localAppData, "NVIDIA", "ComputeCache"),
-                }),
+                ]),
 
             new("AMD installer leftovers",
                 "Unpacked driver installer folder AMD creates on the root of C:\\. Confirmed safe by AMD community docs.",
-                new[] { Path.Combine(systemDrive, "AMD") }),
+                [Path.Combine(systemDrive, "AMD")]),
 
             new("Intel driver extracts",
                 "Temporary driver package extracts from Intel installers.",
-                new[] { Path.Combine(systemDrive, "Intel") }),
+                [Path.Combine(systemDrive, "Intel")]),
 
             new("Windows Update cache",
                 "Previously downloaded Windows Update packages. Windows re-downloads anything it still needs next time.",
-                new[] { Path.Combine(windowsDir, "SoftwareDistribution", "Download") }),
+                [Path.Combine(windowsDir, "SoftwareDistribution", "Download")]),
 
             new("Delivery Optimization cache",
                 "Peer-to-peer update cache. Regenerated on demand.",
-                new[] { Path.Combine(windowsDir, "SoftwareDistribution", "DeliveryOptimization", "Cache") }),
+                [Path.Combine(windowsDir, "SoftwareDistribution", "DeliveryOptimization", "Cache")]),
 
             new("Windows Installer patch cache",
                 "C:\\Windows\\Installer\\$PatchCache$ stores baseline patch files used only when uninstalling an MSI patch. Safe per Microsoft devblog.",
-                new[] { Path.Combine(windowsDir, "Installer", "$PatchCache$") }),
+                [Path.Combine(windowsDir, "Installer", "$PatchCache$")]),
 
             new("Temporary files",
                 "Per-user and system TEMP folders. Anything still in use is skipped automatically.",
-                new[] { tempUser, Path.Combine(windowsDir, "Temp") }),
+                [tempUser, Path.Combine(windowsDir, "Temp")]),
 
             new("Prefetch files",
                 "Windows boot/launch prefetch cache. Windows rebuilds it as apps are used.",
-                new[] { Path.Combine(windowsDir, "Prefetch") }),
+                [Path.Combine(windowsDir, "Prefetch")]),
 
             new("Crash dumps & error reports",
                 "Windows Error Reporting queue and user-mode crash dumps (*.dmp).",
-                new[]
-                {
+                [
                     Path.Combine(localAppData, "CrashDumps"),
                     Path.Combine(localAppData, "Microsoft", "Windows", "WER", "ReportQueue"),
                     Path.Combine(localAppData, "Microsoft", "Windows", "WER", "ReportArchive"),
                     Path.Combine(programData, "Microsoft", "Windows", "WER", "ReportQueue"),
                     Path.Combine(programData, "Microsoft", "Windows", "WER", "ReportArchive"),
-                }),
+                ]),
 
             new("Old Windows servicing logs (> 30 days)",
                 "CBS logs older than 30 days. Windows keeps rolling ones itself.",
-                new[] { Path.Combine(windowsDir, "Logs", "CBS") },
+                [Path.Combine(windowsDir, "Logs", "CBS")],
                 OlderThan: TimeSpan.FromDays(30)),
 
             new("DirectX shader cache",
                 "Precompiled GPU shaders cached by Windows. Rebuilt automatically the next time games run — clearing can fix stutter.",
-                new[] { Path.Combine(localAppData, "D3DSCache") }),
+                [Path.Combine(localAppData, "D3DSCache")]),
 
             new("Recycle Bin (all drives)",
                 "Emptying the recycle bin on every fixed drive.",
@@ -133,23 +131,21 @@ public sealed class DeepCleanupService
 
             new("Epic Games Launcher — webcache & logs",
                 "Epic Launcher browser webcache and log files. Doesn't affect your Epic login or installed games.",
-                new[]
-                {
+                [
                     Path.Combine(localAppData, "EpicGamesLauncher", "Saved", "webcache"),
                     Path.Combine(localAppData, "EpicGamesLauncher", "Saved", "webcache_4147"),
                     Path.Combine(localAppData, "EpicGamesLauncher", "Saved", "webcache_4430"),
                     Path.Combine(localAppData, "EpicGamesLauncher", "Saved", "Logs"),
                     Path.Combine(localAppData, "UnrealEngineLauncher", "Saved", "webcache"),
-                }),
+                ]),
 
             new("Battle.net — cache",
                 "Battle.net agent and Blizzard launcher cache. Doesn't touch installed games or logins.",
-                new[]
-                {
+                [
                     Path.Combine(programData, "Battle.net", "Agent", "data", "cache"),
                     Path.Combine(programData, "Blizzard Entertainment", "Battle.net", "Cache"),
                     Path.Combine(localAppData, "Battle.net", "Cache"),
-                }),
+                ]),
 
             new("Riot Client / League of Legends — logs",
                 "Riot Client and League client logs only. No game files or credentials.",
@@ -157,21 +153,19 @@ public sealed class DeepCleanupService
 
             new("GOG Galaxy — cache",
                 "GOG Galaxy launcher webcache and redists installer cache.",
-                new[]
-                {
+                [
                     Path.Combine(localAppData, "GOG.com", "Galaxy", "webcache"),
                     Path.Combine(programData, "GOG.com", "Galaxy", "redists"),
-                }),
+                ]),
 
             new("EA App / Origin — cache",
                 "EA Desktop (and legacy Origin) browser cache and logs. Doesn't affect installed games or logins.",
-                new[]
-                {
+                [
                     Path.Combine(localAppData, "Electronic Arts", "EA Desktop", "CEF-Cache"),
                     Path.Combine(localAppData, "Electronic Arts", "EA Desktop", "Logs"),
                     Path.Combine(localAppData, "Origin", "Logs"),
                     Path.Combine(programData, "Origin", "Logs"),
-                }),
+                ]),
         };
 
         // Windows.old — optional, never auto-selected
@@ -181,7 +175,7 @@ public sealed class DeepCleanupService
             defs.Add(new Def(
                 "Windows.old (previous Windows installation)",
                 "Remove only if you're sure you don't want to roll back to your previous Windows version. Windows normally auto-deletes this after 10 days.",
-                new[] { windowsOld },
+                [windowsOld],
                 IsDestructiveHint: true));
         }
 

--- a/SysManager/SysManager/Services/TemperatureService.cs
+++ b/SysManager/SysManager/Services/TemperatureService.cs
@@ -15,10 +15,19 @@ namespace SysManager.Services;
 /// With admin: LibreHardwareMonitor gives ALL temps (CPU, GPU, Disk, Motherboard).
 /// Without admin: NVIDIA GPU (via NvAPIWrapper) + Disk SMART temps only.
 /// </summary>
-public sealed class TemperatureService
+public sealed class TemperatureService : IDisposable
 {
     private readonly DiskHealthService _diskHealth;
     private readonly bool _skipHardwareInit;
+
+    // LibreHardwareMonitor's Computer.Open() loads a ring0 kernel driver and
+    // enumerates all hardware — far too heavy to do on every 2s poll. Open it once
+    // (lazily, on the first elevated read) and keep it alive for the service
+    // lifetime; each poll then only calls Update(). The lock serialises the
+    // not-thread-safe LHM access in case more than one caller polls at once.
+    private readonly Lock _lhmLock = new();
+    private Computer? _computer;
+    private bool _disposed;
 
     public TemperatureService(DiskHealthService diskHealth, bool skipHardwareInit = false)
     {
@@ -51,142 +60,160 @@ public sealed class TemperatureService
         return readings;
     }
 
-    private static void ReadViaLibreHardwareMonitor(List<TemperatureReading> readings)
+    private void ReadViaLibreHardwareMonitor(List<TemperatureReading> readings)
     {
-        Computer? computer = null;
-        try
+        lock (_lhmLock)
         {
-            computer = new Computer
+            if (_disposed) return;
+            try
             {
-                IsCpuEnabled = true,
-                IsGpuEnabled = true,
-                IsStorageEnabled = true,
-                IsMotherboardEnabled = true
-            };
-            computer.Open();
+                // Open the kernel-level monitor once and reuse it; subsequent polls
+                // only Update() the already-enumerated hardware.
+                _computer ??= OpenComputer();
 
-            // Pre-fetch disk names from WMI for cross-reference
-            var diskNames = GetDiskNamesFromWmi();
+                // Pre-fetch disk names from WMI for cross-reference
+                var diskNames = GetDiskNamesFromWmi();
 
-            foreach (var hardware in computer.Hardware)
-            {
-                hardware.Update();
-
-                foreach (var subHardware in hardware.SubHardware)
-                    subHardware.Update();
-
-                Log.Debug("LHM: {Type} '{Name}' — {SensorCount} temp sensors",
-                    hardware.HardwareType, hardware.Name,
-                    hardware.Sensors.Count(s => s.SensorType == SensorType.Temperature));
-
-                var component = hardware.HardwareType switch
+                foreach (var hardware in _computer.Hardware)
                 {
-                    HardwareType.Cpu => "CPU",
-                    HardwareType.GpuNvidia or HardwareType.GpuAmd or HardwareType.GpuIntel => "GPU",
-                    HardwareType.Storage => "Storage",
-                    HardwareType.Motherboard => "Motherboard",
-                    _ => null
-                };
+                    hardware.Update();
 
-                if (component is null) continue;
+                    foreach (var subHardware in hardware.SubHardware)
+                        subHardware.Update();
 
-                var tempSensors = hardware.Sensors
-                    .Where(s => s.SensorType == SensorType.Temperature && s.Value.HasValue && s.Value > 0)
-                    .ToList();
+                    Log.Debug("LHM: {Type} '{Name}' — {SensorCount} temp sensors",
+                        hardware.HardwareType, hardware.Name,
+                        hardware.Sensors.Count(s => s.SensorType == SensorType.Temperature));
 
-                // Also check sub-hardware (e.g. motherboard chips)
-                foreach (var sub in hardware.SubHardware)
-                {
-                    tempSensors.AddRange(sub.Sensors
-                        .Where(s => s.SensorType == SensorType.Temperature && s.Value.HasValue && s.Value > 0));
-                }
-
-                if (component == "CPU")
-                {
-                    // Take "CPU Package" or first available
-                    var packageSensor = tempSensors.FirstOrDefault(s =>
-                        s.Name.Contains("Package", StringComparison.OrdinalIgnoreCase)) ?? tempSensors.FirstOrDefault();
-
-                    if (packageSensor is not null)
+                    var component = hardware.HardwareType switch
                     {
-                        readings.Add(new TemperatureReading("CPU", $"CPU Package ({hardware.Name})",
-                            packageSensor.Value));
-                    }
+                        HardwareType.Cpu => "CPU",
+                        HardwareType.GpuNvidia or HardwareType.GpuAmd or HardwareType.GpuIntel => "GPU",
+                        HardwareType.Storage => "Storage",
+                        HardwareType.Motherboard => "Motherboard",
+                        _ => null
+                    };
 
-                    // Add highest core temp if different from package
-                    var maxCore = tempSensors
-                        .Where(s => s.Name.Contains("Core", StringComparison.OrdinalIgnoreCase))
-                        .MaxBy(s => s.Value);
-                    if (maxCore is not null && !ReferenceEquals(maxCore, packageSensor))
-                    {
-                        readings.Add(new TemperatureReading("CPU", $"Hottest Core ({maxCore.Name})",
-                            maxCore.Value));
-                    }
-                }
-                else if (component == "GPU")
-                {
-                    var gpuTemp = tempSensors.FirstOrDefault(s =>
-                        s.Name.Contains("Core", StringComparison.OrdinalIgnoreCase) ||
-                        s.Name.Contains("GPU", StringComparison.OrdinalIgnoreCase)) ?? tempSensors.FirstOrDefault();
+                    if (component is null) continue;
 
-                    if (gpuTemp is not null)
-                    {
-                        readings.Add(new TemperatureReading("GPU Core",
-                            hardware.Name, gpuTemp.Value));
-                    }
+                    var tempSensors = hardware.Sensors
+                        .Where(s => s.SensorType == SensorType.Temperature && s.Value.HasValue && s.Value > 0)
+                        .ToList();
 
-                    var hotSpot = tempSensors.FirstOrDefault(s =>
-                        s.Name.Contains("Hot Spot", StringComparison.OrdinalIgnoreCase) ||
-                        s.Name.Contains("Junction", StringComparison.OrdinalIgnoreCase));
-                    if (hotSpot is not null)
-                    {
-                        readings.Add(new TemperatureReading("GPU Hot Spot",
-                            hardware.Name, hotSpot.Value));
-                    }
-                }
-                else if (component == "Storage")
-                {
-                    var diskTemp = tempSensors.FirstOrDefault();
-                    if (diskTemp is not null)
-                    {
-                        var name = hardware.Name;
-
-                        // LHM often returns empty or cryptic names for storage
-                        if (string.IsNullOrWhiteSpace(name) || name.Length <= 3 || name.All(char.IsDigit))
-                        {
-                            // Try matching by index from WMI disk list
-                            var storageIndex = readings.Count(r => r.Component == "Storage");
-                            name = storageIndex < diskNames.Count
-                                ? diskNames[storageIndex]
-                                : $"Drive {storageIndex + 1}";
-                        }
-
-                        readings.Add(new TemperatureReading("Storage", name, diskTemp.Value));
-                    }
-                }
-                else if (component == "Motherboard")
-                {
+                    // Also check sub-hardware (e.g. motherboard chips)
                     foreach (var sub in hardware.SubHardware)
                     {
-                        var chipTemp = sub.Sensors
-                            .Where(s => s.SensorType == SensorType.Temperature && s.Value.HasValue && s.Value > 0)
-                            .FirstOrDefault();
-                        if (chipTemp is not null)
+                        tempSensors.AddRange(sub.Sensors
+                            .Where(s => s.SensorType == SensorType.Temperature && s.Value.HasValue && s.Value > 0));
+                    }
+
+                    if (component == "CPU")
+                    {
+                        // Take "CPU Package" or first available
+                        var packageSensor = tempSensors.FirstOrDefault(s =>
+                            s.Name.Contains("Package", StringComparison.OrdinalIgnoreCase)) ?? tempSensors.FirstOrDefault();
+
+                        if (packageSensor is not null)
                         {
-                            readings.Add(new TemperatureReading("Motherboard", $"{sub.Name}", chipTemp.Value));
+                            readings.Add(new TemperatureReading("CPU", $"CPU Package ({hardware.Name})",
+                                packageSensor.Value));
+                        }
+
+                        // Add highest core temp if different from package
+                        var maxCore = tempSensors
+                            .Where(s => s.Name.Contains("Core", StringComparison.OrdinalIgnoreCase))
+                            .MaxBy(s => s.Value);
+                        if (maxCore is not null && !ReferenceEquals(maxCore, packageSensor))
+                        {
+                            readings.Add(new TemperatureReading("CPU", $"Hottest Core ({maxCore.Name})",
+                                maxCore.Value));
+                        }
+                    }
+                    else if (component == "GPU")
+                    {
+                        var gpuTemp = tempSensors.FirstOrDefault(s =>
+                            s.Name.Contains("Core", StringComparison.OrdinalIgnoreCase) ||
+                            s.Name.Contains("GPU", StringComparison.OrdinalIgnoreCase)) ?? tempSensors.FirstOrDefault();
+
+                        if (gpuTemp is not null)
+                        {
+                            readings.Add(new TemperatureReading("GPU Core",
+                                hardware.Name, gpuTemp.Value));
+                        }
+
+                        var hotSpot = tempSensors.FirstOrDefault(s =>
+                            s.Name.Contains("Hot Spot", StringComparison.OrdinalIgnoreCase) ||
+                            s.Name.Contains("Junction", StringComparison.OrdinalIgnoreCase));
+                        if (hotSpot is not null)
+                        {
+                            readings.Add(new TemperatureReading("GPU Hot Spot",
+                                hardware.Name, hotSpot.Value));
+                        }
+                    }
+                    else if (component == "Storage")
+                    {
+                        var diskTemp = tempSensors.FirstOrDefault();
+                        if (diskTemp is not null)
+                        {
+                            var name = hardware.Name;
+
+                            // LHM often returns empty or cryptic names for storage
+                            if (string.IsNullOrWhiteSpace(name) || name.Length <= 3 || name.All(char.IsDigit))
+                            {
+                                // Try matching by index from WMI disk list
+                                var storageIndex = readings.Count(r => r.Component == "Storage");
+                                name = storageIndex < diskNames.Count
+                                    ? diskNames[storageIndex]
+                                    : $"Drive {storageIndex + 1}";
+                            }
+
+                            readings.Add(new TemperatureReading("Storage", name, diskTemp.Value));
+                        }
+                    }
+                    else if (component == "Motherboard")
+                    {
+                        foreach (var sub in hardware.SubHardware)
+                        {
+                            var chipTemp = sub.Sensors
+                                .Where(s => s.SensorType == SensorType.Temperature && s.Value.HasValue && s.Value > 0)
+                                .FirstOrDefault();
+                            if (chipTemp is not null)
+                            {
+                                readings.Add(new TemperatureReading("Motherboard", $"{sub.Name}", chipTemp.Value));
+                            }
                         }
                     }
                 }
             }
+            catch (Exception ex)
+            {
+                Log.Debug("LibreHardwareMonitor failed: {Error}", ex.Message);
+            }
         }
-        catch (Exception ex)
+    }
+
+    private static Computer OpenComputer()
+    {
+        var computer = new Computer
         {
-            Log.Debug("LibreHardwareMonitor failed: {Error}", ex.Message);
-        }
-        finally
+            IsCpuEnabled = true,
+            IsGpuEnabled = true,
+            IsStorageEnabled = true,
+            IsMotherboardEnabled = true
+        };
+        computer.Open();
+        return computer;
+    }
+
+    public void Dispose()
+    {
+        lock (_lhmLock)
         {
-            try { computer?.Close(); }
+            if (_disposed) return;
+            _disposed = true;
+            try { _computer?.Close(); }
             catch (Exception ex) { Log.Debug(ex, "LibreHardwareMonitor close failed"); }
+            _computer = null;
         }
     }
 

--- a/SysManager/SysManager/Services/UpdateApplier.cs
+++ b/SysManager/SysManager/Services/UpdateApplier.cs
@@ -73,6 +73,15 @@ internal static class UpdateApplier
     /// </summary>
     internal static bool ApplyCopy(string sourceExe, string targetExe, int maxAttempts = 10, int delayMs = 500)
     {
+        // A missing source is non-recoverable — without this guard File.Copy throws
+        // FileNotFoundException (an IOException subtype), which the retry block below
+        // would misread as a transient lock and burn the full backoff before failing.
+        if (!File.Exists(sourceExe))
+        {
+            Log.Error("Update apply: source executable not found at {Source}", LogService.SanitizePath(sourceExe));
+            return false;
+        }
+
         var staging = targetExe + ".new";
         for (var attempt = 1; attempt <= maxAttempts; attempt++)
         {
@@ -90,12 +99,12 @@ internal static class UpdateApplier
             }
             catch (UnauthorizedAccessException ex)
             {
-                Log.Warning(ex, "Update apply: access denied writing {Target}", targetExe);
+                Log.Warning(ex, "Update apply: access denied writing {Target}", LogService.SanitizePath(targetExe));
                 TryDelete(staging);
                 return false;
             }
         }
-        Log.Error("Update apply: gave up after {Max} attempts — {Target} stayed locked", maxAttempts, targetExe);
+        Log.Error("Update apply: gave up after {Max} attempts — {Target} stayed locked", maxAttempts, LogService.SanitizePath(targetExe));
         return false;
     }
 
@@ -133,7 +142,7 @@ internal static class UpdateApplier
         }
         catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception)
         {
-            Log.Error(ex, "Update apply: failed to relaunch {Target}", targetExe);
+            Log.Error(ex, "Update apply: failed to relaunch {Target}", LogService.SanitizePath(targetExe));
         }
     }
 

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -280,9 +280,9 @@ public sealed class UpdateService
             var match = string.Equals(expectedHash, actualHash, StringComparison.OrdinalIgnoreCase);
             if (!match)
                 Serilog.Log.Warning("SHA256 mismatch for {File}: expected {Expected}, got {Actual}",
-                    filePath, expectedHash, actualHash);
+                    LogService.SanitizePath(filePath), expectedHash, actualHash);
             else
-                Serilog.Log.Information("SHA256 verified for {File}: {Hash}", filePath, actualHash);
+                Serilog.Log.Information("SHA256 verified for {File}: {Hash}", LogService.SanitizePath(filePath), actualHash);
 
             return (match, expectedHash, actualHash);
         }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.42.11</Version>
-    <FileVersion>1.42.11.0</FileVersion>
-    <AssemblyVersion>1.42.11.0</AssemblyVersion>
+    <Version>1.42.12</Version>
+    <FileVersion>1.42.12.0</FileVersion>
+    <AssemblyVersion>1.42.12.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
@@ -86,7 +86,10 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
         {
             var icon = await _iconService.GetIconAsync(app.WingetId).ConfigureAwait(false);
             if (icon != null)
-                App.Current?.Dispatcher.Invoke(() => app.Icon = icon);
+                // BeginInvoke (non-blocking) matches the rest of the project's off-thread
+                // UI updates; a synchronous Invoke here would stall this loop against UI
+                // availability for every app.
+                App.Current?.Dispatcher.BeginInvoke(() => app.Icon = icon);
         }
     }
 

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -22,6 +22,14 @@ public sealed partial class DashboardViewModel : ViewModelBase
     private CancellationTokenSource? _tuneUpCts;
     private CancellationTokenSource? _pollingCts;
 
+    // GPU adapter name and usage availability are effectively static for a session,
+    // but the polling loop runs every 300ms — so initialise the NVIDIA API at most
+    // once and resolve the adapter name only once (via NvAPI, else a single WMI
+    // query), instead of re-initialising and re-querying on every tick.
+    private bool _nvApiInitTried;
+    private bool _nvApiAvailable;
+    private bool _gpuNameResolved;
+
     // ── Real-time vitals (300ms polling) ──────────────────────────────────
     [ObservableProperty] private double _cpuPercent;
     [ObservableProperty] private string _cpuName = "";
@@ -160,36 +168,57 @@ public sealed partial class DashboardViewModel : ViewModelBase
 
     private void UpdateGpuUsage()
     {
-        try
+        // Initialise NvAPI at most once per session. Repeated Initialize() calls on
+        // the 300ms loop are wasted work; once we know it's unavailable (non-NVIDIA),
+        // we never retry and fall through to the one-time WMI name lookup.
+        if (!_nvApiInitTried)
         {
-            NvAPIWrapper.NVIDIA.Initialize();
-            var gpus = NvAPIWrapper.GPU.PhysicalGPU.GetPhysicalGPUs();
-            if (gpus.Length > 0)
+            _nvApiInitTried = true;
+            try
             {
-                var gpu = gpus[0];
-                var usage = gpu.UsageInformation.GPU.Percentage;
-                var memTotal = gpu.MemoryInformation.DedicatedVideoMemoryInkB / 1024.0 / 1024.0;
-                var memUsed = (gpu.MemoryInformation.DedicatedVideoMemoryInkB -
-                               gpu.MemoryInformation.AvailableDedicatedVideoMemoryInkB) / 1024.0 / 1024.0;
-
-                System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
-                {
-                    GpuPercent = usage;
-                    GpuName = gpu.FullName;
-                    GpuVram = $"{memUsed:F1} / {memTotal:F1} GB VRAM";
-                });
-                return;
+                NvAPIWrapper.NVIDIA.Initialize();
+                _nvApiAvailable = NvAPIWrapper.GPU.PhysicalGPU.GetPhysicalGPUs().Length > 0;
+            }
+            catch (Exception ex)
+            {
+                _nvApiAvailable = false;
+                Log.Debug("NVIDIA GPU API unavailable: {Error}", ex.Message);
             }
         }
-        catch (Exception ex)
+
+        if (_nvApiAvailable)
         {
-            Log.Debug("NVIDIA GPU polling unavailable: {Error}", ex.Message);
+            try
+            {
+                var gpus = NvAPIWrapper.GPU.PhysicalGPU.GetPhysicalGPUs();
+                if (gpus.Length > 0)
+                {
+                    var gpu = gpus[0];
+                    var usage = gpu.UsageInformation.GPU.Percentage;
+                    var memTotal = gpu.MemoryInformation.DedicatedVideoMemoryInkB / 1024.0 / 1024.0;
+                    var memUsed = (gpu.MemoryInformation.DedicatedVideoMemoryInkB -
+                                   gpu.MemoryInformation.AvailableDedicatedVideoMemoryInkB) / 1024.0 / 1024.0;
+
+                    System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
+                    {
+                        GpuPercent = usage;
+                        GpuName = gpu.FullName;
+                        GpuVram = $"{memUsed:F1} / {memTotal:F1} GB VRAM";
+                    });
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("NVIDIA GPU polling error: {Error}", ex.Message);
+            }
         }
 
-        // No NVIDIA GPU (NvAPI only covers NVIDIA). Fall back to WMI so AMD/Intel
-        // GPUs at least show the adapter name. Live usage % is NVIDIA-only because
-        // it requires vendor-specific APIs.
-        UpdateGpuNameFromWmi();
+        // No NVIDIA GPU (NvAPI only covers NVIDIA). The adapter name is static, so
+        // resolve it via WMI exactly once — live usage % is NVIDIA-only because it
+        // requires vendor-specific APIs.
+        if (!_gpuNameResolved)
+            UpdateGpuNameFromWmi();
     }
 
     private void UpdateGpuNameFromWmi()
@@ -205,6 +234,7 @@ public sealed partial class DashboardViewModel : ViewModelBase
                 {
                     var name = mo["Name"]?.ToString()?.Trim();
                     if (string.IsNullOrEmpty(name)) continue;
+                    _gpuNameResolved = true; // static value — don't query WMI again
                     System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
                     {
                         GpuName = name;

--- a/SysManager/SysManager/ViewModels/NetworkSharedState.cs
+++ b/SysManager/SysManager/ViewModels/NetworkSharedState.cs
@@ -100,10 +100,10 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
             FlushTimer.Tick += (_, _) => FlushPending();
         }
 
-        LatencyXAxes = new[] { BuildTimeAxis() };
-        LatencyYAxes = new[] { BuildValueAxis("Latency (ms)") };
-        TraceXAxes = new[] { BuildHopAxis() };
-        TraceYAxes = new[] { BuildValueAxis("Latency (ms)") };
+        LatencyXAxes = [BuildTimeAxis()];
+        LatencyYAxes = [BuildValueAxis("Latency (ms)")];
+        TraceXAxes = [BuildHopAxis()];
+        TraceYAxes = [BuildValueAxis("Latency (ms)")];
 
         Pinger.SampleReceived += OnSample;
         TraceMonitor.RouteCompleted += OnRouteCompleted;


### PR DESCRIPTION
Follow-ups from a deep review pass (198 agents; 62 raw → 25 confirmed after triple adversarial verification: **0 Critical, 0 High, 3 Medium, 22 Low**). Only confirmed, real findings are addressed here.

## Performance (Medium)

- **DashboardViewModel GPU polling** — was calling `NvAPIWrapper.NVIDIA.Initialize()` + enumerating GPUs every 300ms, and on non-NVIDIA machines spinning a fresh `ManagementObjectSearcher` WMI query 3×/sec for the (static) adapter name. Now initialises NvAPI once and resolves the adapter name once.
- **TemperatureService (elevated)** — was opening **and closing** the LibreHardwareMonitor `Computer` (a ring0 driver load + full hardware enumeration) on every 2s poll. Now opens once, reuses it (per-poll `Update()` only), serialises access with a lock, implements `IDisposable`, and the DI container closes the driver on exit.

## Privacy (Low — regression I introduced in the applier)

- `UpdateApplier` (3 sites) and `UpdateService.VerifyHashAsync` logged the raw executable path, which for a per-user install contains `C:\Users\<username>\…`. They now use `LogService.SanitizePath`, matching the established idiom in `SpeedTestService`.

## Robustness (Low)

- `UpdateApplier.ApplyCopy` early-exits on a missing source exe instead of misreading `FileNotFoundException` as a transient lock and burning ~4.5s of retries. Test updated to prove the early-exit (large delay + instant return).
- `AppAlertService.Stop` disposes the registry timer inside the same lock `Start` uses to create it (closes a Start/Stop race).
- `BulkInstaller` icon loading uses non-blocking `Dispatcher.BeginInvoke` (was synchronous `Invoke` in a per-app loop).

## Modernization (Low)

- `DeepCleanupService` + `NetworkSharedState` array initialisers → collection expressions, matching the codebase idiom. (Excluded `var`-typed and `foreach`-over-`new[]` cases that have no target type; left `TargetPreset.cs` alone — it collides with a leak-scan term.)

## Docs

- `ARCHITECTURE.md` / `README.md` updated to describe the in-process applier and the Authenticode check accurately.

## Verification

- Release + test build clean (0/0).
- **Launch-verified non-admin**: Dashboard runs, zero GPU-init log spam, zero errors.
- **Launch-verified elevated**: LibreHardwareMonitor `Computer` reused across 2s polls (real sensors: CPU/GPU/NVMe), zero `LibreHardwareMonitor failed` errors — the old open/close churn error is gone.
- UI re-tested this session (System Logs blue/green tint, empty-state messages on Disk Analyzer/Uninstaller, Process Manager live poll) — all render correctly on v1.42.11.

## Audit findings intentionally NOT actioned here

- The 6 critic 'test-coverage gaps' (DI smoke test, applier-mode startup test, Authenticode negative test, etc.) are real but are net-new test scaffolding, not defects — separate follow-up.
- Release-pipeline 'unsigned binary / dangling-tag' findings are the known signing limitation (documented in SECURITY.md) — gated on a code-signing certificate.