### PR TITLE
feat: show admin-elevation banner on six privileged tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.43.0] - 2026-06-27
+
+### Added
+- **Six more tabs now tell you when they need administrator rights.** Process Manager, Startup Manager, Task Scheduler, Defender Tweaks, File Lock Detector and Shortcut Cleaner all perform actions that require elevation (ending system processes, toggling startup entries and scheduled tasks, changing Defender settings, unlocking protected files, removing shortcuts in shared locations) — but unlike the rest of the app they gave no upfront hint. Each now shows the same banner the other tabs use: a "Run as administrator" prompt when you're not elevated, and a confirmation strip when you are. Consistent with Services, DNS & Hosts, Uninstaller, and the others.
+
 ## [1.42.12] - 2026-06-27
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.42.12</Version>
-    <FileVersion>1.42.12.0</FileVersion>
-    <AssemblyVersion>1.42.12.0</AssemblyVersion>
+    <Version>1.43.0</Version>
+    <FileVersion>1.43.0.0</FileVersion>
+    <AssemblyVersion>1.43.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DefenderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DefenderViewModel.cs
@@ -24,6 +24,7 @@ public sealed partial class DefenderViewModel : ViewModelBase
 
     public BulkObservableCollection<string> ExclusionPaths { get; } = new();
 
+    [ObservableProperty] private bool _isElevated;
     [ObservableProperty] private bool _isAvailable = true;
     [ObservableProperty] private bool _isTamperProtected;
     [ObservableProperty] private string _realtimeDisplay = "—";
@@ -37,9 +38,17 @@ public sealed partial class DefenderViewModel : ViewModelBase
     public DefenderViewModel(DefenderService service)
     {
         _service = service;
+        IsElevated = AdminHelper.IsElevated();
         StatusMessage = "Reading Defender status…";
         PropertyChanged += OnVmPropertyChanged;
         InitializeAsync(RefreshAsync);
+    }
+
+    [RelayCommand]
+    private void RelaunchAsAdmin()
+    {
+        if (AdminHelper.RelaunchAsAdmin())
+            System.Windows.Application.Current?.Shutdown();
     }
 
     /// <summary>True when no Defender operation is in flight — gates the mutating

--- a/SysManager/SysManager/ViewModels/FileLockViewModel.cs
+++ b/SysManager/SysManager/ViewModels/FileLockViewModel.cs
@@ -23,6 +23,7 @@ public sealed partial class FileLockViewModel : ViewModelBase
 
     public BulkObservableCollection<FileLocker> Lockers { get; } = new();
 
+    [ObservableProperty] private bool _isElevated;
     [ObservableProperty] private string _path = "";
     [ObservableProperty] private bool _hasScanned;
     [ObservableProperty] private FileLocker? _selectedLocker;
@@ -30,8 +31,16 @@ public sealed partial class FileLockViewModel : ViewModelBase
     public FileLockViewModel(FileLockService service)
     {
         _service = service;
+        IsElevated = AdminHelper.IsElevated();
         StatusMessage = "Enter a file or folder path, then scan to see what's using it.";
         PropertyChanged += OnVmPropertyChanged;
+    }
+
+    [RelayCommand]
+    private void RelaunchAsAdmin()
+    {
+        if (AdminHelper.RelaunchAsAdmin())
+            System.Windows.Application.Current?.Shutdown();
     }
 
     private bool CanScan => !IsBusy && !string.IsNullOrWhiteSpace(Path);

--- a/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
@@ -24,6 +24,7 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
     public BulkObservableCollection<ProcessEntry> Processes { get; } = new();
     public BulkObservableCollection<ProcessEntry> FilteredProcesses { get; } = new();
 
+    [ObservableProperty] private bool _isElevated;
     [ObservableProperty] private string _filterText = "";
     [ObservableProperty] private bool _showOnlyApps;
     [ObservableProperty] private bool _isActive = true;
@@ -37,7 +38,15 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
     public ProcessManagerViewModel(ProcessManagerService service)
     {
         _service = service;
+        IsElevated = AdminHelper.IsElevated();
         InitializeAsync(InitAsync);
+    }
+
+    [RelayCommand]
+    private void RelaunchAsAdmin()
+    {
+        if (AdminHelper.RelaunchAsAdmin())
+            System.Windows.Application.Current?.Shutdown();
     }
 
     private async Task InitAsync()

--- a/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
@@ -22,6 +22,7 @@ public sealed partial class ShortcutCleanerViewModel : ViewModelBase
 
     public BulkObservableCollection<BrokenShortcut> BrokenShortcuts { get; } = new();
 
+    [ObservableProperty] private bool _isElevated;
     [ObservableProperty] private string _scanStatus = "Click Scan to find broken shortcuts.";
     [ObservableProperty] private string _currentLocation = "";
     [ObservableProperty] private int _brokenCount;
@@ -32,6 +33,14 @@ public sealed partial class ShortcutCleanerViewModel : ViewModelBase
     public ShortcutCleanerViewModel(ShortcutCleanerService service)
     {
         _service = service;
+        IsElevated = AdminHelper.IsElevated();
+    }
+
+    [RelayCommand]
+    private void RelaunchAsAdmin()
+    {
+        if (AdminHelper.RelaunchAsAdmin())
+            System.Windows.Application.Current?.Shutdown();
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/StartupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StartupViewModel.cs
@@ -23,6 +23,7 @@ public sealed partial class StartupViewModel : ViewModelBase
 
     public BulkObservableCollection<StartupEntry> Entries { get; } = new();
 
+    [ObservableProperty] private bool _isElevated;
     [ObservableProperty] private int _enabledCount;
     [ObservableProperty] private int _disabledCount;
     [ObservableProperty] private int _totalCount;
@@ -32,6 +33,7 @@ public sealed partial class StartupViewModel : ViewModelBase
     public StartupViewModel(StartupService service)
     {
         _service = service;
+        IsElevated = AdminHelper.IsElevated();
         // Scan, EnableAll and ToggleEntry all read or write the same startup registry/task
         // state; running them concurrently could interleave registry writes and produce
         // inconsistent counts. Re-evaluate their CanExecute when IsBusy flips so only one
@@ -67,6 +69,13 @@ public sealed partial class StartupViewModel : ViewModelBase
         try { await ScanAsync(); }
         catch (InvalidOperationException ex) { Log.Warning("Startup auto-scan failed: {Error}", ex.Message); }
         catch (UnauthorizedAccessException ex) { Log.Warning("Startup auto-scan failed: {Error}", ex.Message); }
+    }
+
+    [RelayCommand]
+    private void RelaunchAsAdmin()
+    {
+        if (AdminHelper.RelaunchAsAdmin())
+            System.Windows.Application.Current?.Shutdown();
     }
 
     [RelayCommand(CanExecute = nameof(NotBusy))]

--- a/SysManager/SysManager/ViewModels/TaskSchedulerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TaskSchedulerViewModel.cs
@@ -24,6 +24,7 @@ public sealed partial class TaskSchedulerViewModel : ViewModelBase
 
     public BulkObservableCollection<ScheduledTaskInfo> Tasks { get; } = new();
 
+    [ObservableProperty] private bool _isElevated;
     [ObservableProperty] private ScheduledTaskInfo? _selectedTask;
     [ObservableProperty] private string _filter = "";
     [ObservableProperty] private bool _hideSystemTasks;
@@ -31,8 +32,16 @@ public sealed partial class TaskSchedulerViewModel : ViewModelBase
     public TaskSchedulerViewModel(TaskSchedulerService service)
     {
         _service = service;
+        IsElevated = AdminHelper.IsElevated();
         StatusMessage = "Loading scheduled tasks…";
         InitializeAsync(RefreshAsync);
+    }
+
+    [RelayCommand]
+    private void RelaunchAsAdmin()
+    {
+        if (AdminHelper.RelaunchAsAdmin())
+            System.Windows.Application.Current?.Shutdown();
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/Views/DefenderView.xaml
+++ b/SysManager/SysManager/Views/DefenderView.xaml
@@ -16,6 +16,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -30,8 +31,40 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
+        <!-- Elevation banner: not elevated -->
+        <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
+                        AutomationProperties.Name="Run as administrator"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
+                    <TextBlock Text="Changing Microsoft Defender settings requires administrator privileges."
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- Elevation banner: elevated -->
+        <Border Grid.Row="2" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — you can change Defender settings."
+                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
         <!-- Tamper Protection warning -->
-        <Border Grid.Row="2" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
+        <Border Grid.Row="3" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
                 BorderThickness="1" CornerRadius="10" Padding="12,10" Margin="0,0,0,12"
                 Visibility="{Binding IsTamperProtected, Converter={StaticResource FlexVis}}">
             <StackPanel Orientation="Horizontal">
@@ -43,7 +76,7 @@
         </Border>
 
         <!-- Status cards -->
-        <Border Grid.Row="3" Style="{StaticResource Card}" Margin="0,0,0,12">
+        <Border Grid.Row="4" Style="{StaticResource Card}" Margin="0,0,0,12">
             <StackPanel>
                 <TextBlock Text="Protection status" Style="{StaticResource SectionTitle}"/>
                 <Grid Margin="0,10,0,0">
@@ -90,7 +123,7 @@
         </Border>
 
         <!-- Exclusions -->
-        <Border Grid.Row="4" Style="{StaticResource Card}" Padding="0">
+        <Border Grid.Row="5" Style="{StaticResource Card}" Padding="0">
             <DockPanel>
                 <Grid DockPanel.Dock="Top" Margin="14,12,14,8">
                     <Grid.ColumnDefinitions>
@@ -114,7 +147,7 @@
         </Border>
 
         <!-- Status -->
-        <TextBlock Grid.Row="5" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+        <TextBlock Grid.Row="6" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
                    Margin="0,12,0,0" TextWrapping="Wrap"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/FileLockView.xaml
+++ b/SysManager/SysManager/Views/FileLockView.xaml
@@ -15,6 +15,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -29,8 +30,40 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
+        <!-- Elevation banner: not elevated -->
+        <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
+                        AutomationProperties.Name="Run as administrator"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
+                    <TextBlock Text="Unlocking files in protected locations requires administrator privileges."
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- Elevation banner: elevated -->
+        <Border Grid.Row="2" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — you can unlock and close handles on protected files."
+                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
         <!-- Input toolbar -->
-        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+        <Border Grid.Row="3" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
@@ -51,7 +84,7 @@
         </Border>
 
         <!-- Results -->
-        <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
+        <Border Grid.Row="4" Style="{StaticResource Card}" Padding="0">
             <Grid>
                 <DataGrid ItemsSource="{Binding Lockers}" SelectedItem="{Binding SelectedLocker}"
                           AutomationProperties.Name="Locking processes"
@@ -76,7 +109,7 @@
         </Border>
 
         <!-- Actions + status -->
-        <Grid Grid.Row="4" Margin="0,12,0,0">
+        <Grid Grid.Row="5" Margin="0,12,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -14,6 +14,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -25,8 +26,40 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
         </StackPanel>
 
+        <!-- Elevation banner: not elevated -->
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
+                        AutomationProperties.Name="Run as administrator"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
+                    <TextBlock Text="Ending system processes requires administrator privileges."
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- Elevation banner: elevated -->
+        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — you can end any process."
+                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
         <!-- Toolbar -->
-        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
             <WrapPanel>
                 <Button Content="Refresh" Command="{Binding RefreshCommand}"
                         Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"
@@ -51,12 +84,12 @@
         </Border>
 
         <!-- Summary -->
-        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+        <Border Grid.Row="3" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
             <TextBlock Text="{Binding Summary}" FontWeight="SemiBold" FontSize="13"/>
         </Border>
 
         <!-- Process list -->
-        <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
+        <Border Grid.Row="4" Style="{StaticResource Card}" Padding="0">
             <Grid>
             <DataGrid AutomationProperties.Name="Running processes" ItemsSource="{Binding FilteredProcesses}"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
@@ -200,7 +233,7 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="4" Margin="0,8,0,0">
+        <DockPanel Grid.Row="5" Margin="0,8,0,0">
             <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml
@@ -12,6 +12,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -25,8 +26,40 @@
                        Visibility="{Binding IsScanning, Converter={StaticResource BoolToVis}}"/>
         </StackPanel>
 
+        <!-- Elevation banner: not elevated -->
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,16,28,0"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
+                        AutomationProperties.Name="Run as administrator"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
+                    <TextBlock Text="Removing broken shortcuts in shared locations requires administrator privileges."
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- Elevation banner: elevated -->
+        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="28,16,28,0"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — you can remove broken shortcuts everywhere."
+                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
         <!-- Toolbar -->
-        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="28,16,28,0" Padding="12">
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,0" Padding="12">
             <WrapPanel>
                 <Button Content="Scan" Command="{Binding ScanCommand}"
                         AutomationProperties.Name="Scan for broken shortcuts"
@@ -51,7 +84,7 @@
         </Border>
 
         <!-- Results DataGrid -->
-        <DataGrid Grid.Row="2" ItemsSource="{Binding BrokenShortcuts}"
+        <DataGrid Grid.Row="3" ItemsSource="{Binding BrokenShortcuts}"
                   AutomationProperties.Name="Broken shortcuts"
                   AutoGenerateColumns="False" IsReadOnly="False"
                   CanUserAddRows="False" CanUserDeleteRows="False"
@@ -81,7 +114,7 @@
         </DataGrid>
 
         <!-- Footer -->
-        <Border Grid.Row="3" Margin="28,8,28,16" Padding="8">
+        <Border Grid.Row="4" Margin="28,8,28,16" Padding="8">
             <TextBlock Style="{StaticResource Subtle}">
                 <Run Text="{Binding BrokenCount, Mode=OneWay}"/>
                 <Run Text=" broken · "/>

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -13,6 +13,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -24,8 +25,40 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
         </StackPanel>
 
+        <!-- Elevation banner: not elevated -->
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
+                        AutomationProperties.Name="Run as administrator"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
+                    <TextBlock Text="Changing startup entries requires administrator privileges."
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- Elevation banner: elevated -->
+        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — you can enable and disable any startup entry."
+                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
         <!-- Toolbar -->
-        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
             <DockPanel>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
                     <Button Content="Refresh" Command="{Binding ScanCommand}"
@@ -45,7 +78,7 @@
         </Border>
 
         <!-- Startup items list -->
-        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
+        <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
             <Grid>
             <DataGrid AutomationProperties.Name="Startup programs" ItemsSource="{Binding Entries}"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
@@ -182,6 +215,6 @@
         </Border>
 
         <!-- Status bar -->
-        <TextBlock Grid.Row="3" Text="{Binding StatusMessage}" Style="{StaticResource Caption}" Margin="0,8,0,0"/>
+        <TextBlock Grid.Row="4" Text="{Binding StatusMessage}" Style="{StaticResource Caption}" Margin="0,8,0,0"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/TaskSchedulerView.xaml
+++ b/SysManager/SysManager/Views/TaskSchedulerView.xaml
@@ -15,6 +15,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -29,8 +30,40 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
+        <!-- Elevation banner: not elevated -->
+        <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
+                        AutomationProperties.Name="Run as administrator"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
+                    <TextBlock Text="Enabling or disabling scheduled tasks requires administrator privileges."
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- Elevation banner: elevated -->
+        <Border Grid.Row="2" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
+                CornerRadius="10" Padding="12,8" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — you can enable and disable scheduled tasks."
+                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
         <!-- Toolbar -->
-        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+        <Border Grid.Row="3" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
@@ -50,7 +83,7 @@
         </Border>
 
         <!-- Tasks grid -->
-        <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
+        <Border Grid.Row="4" Style="{StaticResource Card}" Padding="0">
             <DataGrid ItemsSource="{Binding Tasks}" SelectedItem="{Binding SelectedTask}"
                       AutomationProperties.Name="Scheduled tasks"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
@@ -68,7 +101,7 @@
         </Border>
 
         <!-- Actions + status -->
-        <Grid Grid.Row="4" Margin="0,12,0,0">
+        <Grid Grid.Row="5" Margin="0,12,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>


### PR DESCRIPTION
## What

Adds the canonical 'requires administrator' banner to six tabs that perform admin-gated actions but previously gave no upfront hint — found by a UI-uniformity audit across all 52 views.

**Tabs fixed:** Process Manager, Startup Manager, Task Scheduler, Defender Tweaks, File Lock Detector, Shortcut Cleaner.

These perform elevation-requiring actions (end system processes, toggle startup entries / scheduled tasks, change Defender settings, unlock protected files, remove shortcuts in shared locations) yet — unlike Services, DNS & Hosts, Uninstaller, etc. — showed no banner, and their viewmodels didn't even expose `IsElevated` / `RelaunchAsAdmin` (confirmed: 0 grep matches in all six before this change).

## How

Each of the 6 viewmodels gets the identical wiring from `ServicesViewModel`:
- `[ObservableProperty] private bool _isElevated;`
- `IsElevated = AdminHelper.IsElevated();` in the constructor
- a `[RelayCommand] RelaunchAsAdmin()` (verbatim)

Each of the 6 views gets the canonical two-banner pair (copied from `ServicesView`): a not-elevated 'Run as administrator' prompt and an elevated confirmation strip, both `Grid.Row`-placed after the header with subsequent rows shifted down. Only the per-tab message sentence differs; all brushes, glyphs, padding, `FlexVis` bindings are identical to the reference.

## Verification

- Release + test build clean (0/0).
- RowDefinitions count = max Grid.Row + 1 on all 6 views (no off-by-one).
- VM diffs are exactly the three canonical additions, nothing else.
- Launch-verified **non-elevated**: the 'Run as administrator' banner renders on Process Manager between the header and toolbar, and content lays out correctly (no overlap/break). Elevated variant uses the same proven markup as ServicesView.

## Scope

This is the High-severity systemic theme from the uniformity audit. The remaining themes (status-bar busy indicator, empty-states, token-level font/color uniformity) are separate follow-up batches.