### PR TITLE
test: FlaUI smoke coverage for all 57 tabs + admin-banner regression

### DIFF
--- a/SysManager/SysManager.UITests/AdminBannerUiTests.cs
+++ b/SysManager/SysManager.UITests/AdminBannerUiTests.cs
@@ -1,0 +1,52 @@
+// SysManager · AdminBannerUiTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.UITests;
+
+/// <summary>
+/// Regression net for the elevation-banner uniformity work: every tab that
+/// performs admin-gated actions must surface the shared "requires administrator"
+/// banner when the app is NOT elevated. The UI test host runs the app
+/// non-elevated, so the not-elevated banner variant is the one in view. If a
+/// future refactor drops the banner from one of these tabs (as had happened to
+/// six of them), the corresponding case fails by name.
+/// </summary>
+[Collection("App")]
+public class AdminBannerUiTests
+{
+    private readonly AppFixture _fx;
+    public AdminBannerUiTests(AppFixture fx) => _fx = fx;
+
+    public static IEnumerable<object[]> PrivilegedTabs() => new[]
+    {
+        // Originally had the banner (reference implementations)
+        new object[] { "nav-services" },
+        new object[] { "nav-dns-hosts" },
+        new object[] { "nav-uninstaller" },
+        // Added by the uniformity fix (v1.43.0) — these regressed silently before
+        new object[] { "nav-processes" },
+        new object[] { "nav-startup" },
+        new object[] { "nav-task-scheduler" },
+        new object[] { "nav-defender-tweaks" },
+        new object[] { "nav-file-lock" },
+        new object[] { "nav-shortcut-cleaner" },
+    };
+
+    [Theory]
+    [MemberData(nameof(PrivilegedTabs))]
+    public void PrivilegedTab_ShowsAdminBanner_WhenNotElevated(string navId)
+    {
+        // Guard: this assertion is only meaningful when the test host is NOT
+        // elevated (the banner's not-elevated variant is what carries the
+        // "requires administrator" phrase). If the suite is ever run elevated,
+        // skip rather than report a false failure.
+        if (Helpers.AdminHelper.IsElevated())
+            return;
+
+        _fx.GoToTab(navId);
+        Assert.True(
+            _fx.HasAdminBanner(),
+            $"Privileged tab '{navId}' did not show the 'requires administrator' banner when not elevated.");
+    }
+}

--- a/SysManager/SysManager.UITests/AllTabsSmokeUiTests.cs
+++ b/SysManager/SysManager.UITests/AllTabsSmokeUiTests.cs
@@ -1,0 +1,118 @@
+// SysManager · AllTabsSmokeUiTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.UITests;
+
+/// <summary>
+/// Breadth smoke coverage for EVERY navigable tab (all 57). For each tab this
+/// asserts the app can navigate to it and the content area renders the tab's
+/// expected page header — i.e. the view loaded rather than crashing or showing
+/// a blank/wrong page. This is the regression net that catches a tab that stops
+/// rendering after a refactor. Per-tab button/behaviour assertions live in the
+/// dedicated *TabUiTests classes; this class is intentionally one assertion per
+/// tab so a single broken tab is pinpointed by name.
+/// </summary>
+[Collection("App")]
+public class AllTabsSmokeUiTests
+{
+    private readonly AppFixture _fx;
+    public AllTabsSmokeUiTests(AppFixture fx) => _fx = fx;
+
+    /// <summary>
+    /// nav AutomationId → a substring of the page header that view renders.
+    /// Substrings are used so an ampersand-encoded or suffixed title still matches
+    /// (e.g. "DNS &amp; Hosts Editor" matches "DNS"). Placeholder/preview tabs show
+    /// their nav label as the title.
+    /// </summary>
+    public static IEnumerable<object[]> AllTabs() => new[]
+    {
+        // ── System ──
+        new object[] { "nav-dashboard", "Dashboard" },
+        new object[] { "nav-system-health", "System Health" },
+        new object[] { "nav-windows-update", "Windows Update" },
+        new object[] { "nav-performance", "Performance Mode" },
+        new object[] { "nav-services", "Services" },
+        new object[] { "nav-startup", "Startup Manager" },
+        new object[] { "nav-windows-features", "Windows Features" },
+        new object[] { "nav-restore-points", "Restore Points" },
+        new object[] { "nav-task-scheduler", "Task Scheduler" },
+        new object[] { "nav-boot-analyzer", "Boot Analyzer" },
+        new object[] { "nav-system-fixes", "System Fixes" },
+        // ── Gaming & Profiles ──
+        new object[] { "nav-gaming-profile", "Gaming Profile" },
+        new object[] { "nav-standby-cleaner", "Standby List Cleaner" },
+        new object[] { "nav-timer-resolution", "Timer Resolution" },
+        new object[] { "nav-cpu-affinity", "CPU Core Affinity" },
+        new object[] { "nav-display-profiles", "Display Profiles" },
+        // ── Monitor ──
+        new object[] { "nav-processes", "Process Manager" },
+        new object[] { "nav-resource-history", "Resource History" },
+        new object[] { "nav-privacy-monitor", "Privacy Monitor" },
+        new object[] { "nav-app-alerts", "App Installation Alerts" },
+        new object[] { "nav-file-lock", "File Lock Detector" },
+        new object[] { "nav-settings-watchdog", "Settings Watchdog" },
+        new object[] { "nav-bandwidth-monitor", "Bandwidth Monitor" },
+        // ── Cleanup ──
+        new object[] { "nav-cleanup", "Quick Cleanup" },
+        new object[] { "nav-deep-cleanup", "Deep Cleanup" },
+        new object[] { "nav-shortcut-cleaner", "Shortcut Cleaner" },
+        new object[] { "nav-scheduled-maintenance", "Scheduled Maintenance" },
+        // ── Storage ──
+        new object[] { "nav-disk-analyzer", "Disk Analyzer" },
+        new object[] { "nav-duplicates", "Duplicate Finder" },
+        // ── Network ──
+        new object[] { "nav-ping", "Ping" },
+        new object[] { "nav-traceroute", "Traceroute" },
+        new object[] { "nav-speed-test", "Speed Test" },
+        new object[] { "nav-network-repair", "Network Repair" },
+        new object[] { "nav-dns-hosts", "DNS" },
+        // ── Apps ──
+        new object[] { "nav-app-updates", "App updates" },
+        new object[] { "nav-bulk-installer", "Bulk Installer" },
+        new object[] { "nav-uninstaller", "Uninstaller" },
+        // ── Privacy & Security ──
+        new object[] { "nav-privacy-settings", "Privacy" },
+        new object[] { "nav-file-shredder", "File Shredder" },
+        new object[] { "nav-app-blocker", "Application Blocker" },
+        new object[] { "nav-debloater", "Debloater" },
+        new object[] { "nav-browser-cleaner", "Browser Cleaner" },
+        new object[] { "nav-edge-onedrive", "Edge/OneDrive Remover" },
+        new object[] { "nav-defender-tweaks", "Defender Tweaks" },
+        new object[] { "nav-notification-blocker", "Notification Blocker" },
+        // ── Customization ──
+        new object[] { "nav-context-menu", "Context Menu" },
+        new object[] { "nav-dark-mode", "Dark Mode Scheduler" },
+        new object[] { "nav-volume-control", "Volume Control" },
+        // ── Info ──
+        new object[] { "nav-drivers", "Drivers" },
+        new object[] { "nav-battery", "Battery Health" },
+        new object[] { "nav-logs", "System Logs" },
+        new object[] { "nav-system-report", "System Report" },
+        new object[] { "nav-legacy-panels", "Legacy Panels" },
+        new object[] { "nav-about", "About" },
+        // ── Advanced ──
+        new object[] { "nav-profile-export", "Profile Export" },
+        new object[] { "nav-cli-interface", "CLI Interface" },
+        new object[] { "nav-env-variables", "Environment Variables" },
+    };
+
+    [Theory]
+    [MemberData(nameof(AllTabs))]
+    public void Tab_Navigates_And_ShowsHeader(string navId, string expectedHeader)
+    {
+        _fx.GoToTab(navId);
+        Assert.True(
+            _fx.HasText(expectedHeader),
+            $"Tab '{navId}' did not render its expected header '{expectedHeader}'.");
+    }
+
+    [Fact]
+    public void AllTabs_HaveStableAutomationIds()
+    {
+        // Every nav id used above must be resolvable in the tree — a renamed or
+        // dropped nav id is a navigation contract break and fails here loudly.
+        foreach (var row in AllTabs())
+            Assert.NotNull(_fx.FindById((string)row[0]));
+    }
+}

--- a/SysManager/SysManager.UITests/AppFixture.cs
+++ b/SysManager/SysManager.UITests/AppFixture.cs
@@ -148,6 +148,30 @@ public sealed class AppFixture : IDisposable
     public AutomationElement? FindById(string automationId) =>
         MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(automationId));
 
+    /// <summary>
+    /// True if any descendant's Name contains <paramref name="text"/>
+    /// (case-insensitive), waiting up to <paramref name="timeoutSeconds"/>.
+    /// A convenience over WaitForText for boolean presence assertions.
+    /// </summary>
+    public bool HasText(string text, int timeoutSeconds = 5)
+        => WaitForText(text, timeoutSeconds) is not null;
+
+    /// <summary>
+    /// True when the current tab shows the shared "requires administrator"
+    /// elevation banner (the not-elevated variant carries that phrase). Used to
+    /// assert that privileged tabs surface the banner when the app is not elevated.
+    /// </summary>
+    public bool HasAdminBanner(int timeoutSeconds = 5)
+        => WaitForText("requires administrator", timeoutSeconds) is not null;
+
+    /// <summary>
+    /// Count Button controls currently realized anywhere in the window. A crude
+    /// but useful smoke signal that a tab rendered its action surface rather than
+    /// an empty/crashed view.
+    /// </summary>
+    public int VisibleButtonCount()
+        => MainWindow.FindAllDescendants(cf => cf.ByControlType(ControlType.Button)).Length;
+
     /// <summary>Exit code of the launched app, or a marker if it can't be read.</summary>
     private string SafeExitCode()
     {


### PR DESCRIPTION
## What

Adds breadth UI-automation coverage (FlaUI, runs on CI's UI-tests job with a real desktop session).

### AllTabsSmokeUiTests
A `[Theory]` over **every one of the 57 navigable tabs**: navigates to it and asserts the content area renders the tab's expected page header — i.e. the view loaded rather than crashing/blanking. One case per tab, so a single broken tab is pinpointed by name. Plus a structural test that every nav `AutomationId` resolves (a renamed/dropped nav id fails loudly).

The nav-id → header table is derived directly from `MainWindowViewModel` and each view's `Display` header (placeholder tabs show their nav label, verified against `PlaceholderViewModel` construction).

### AdminBannerUiTests
Asserts the shared "requires administrator" banner appears on all **9 privileged tabs** when the app runs non-elevated — Services/DNS/Uninstaller (reference) plus the six fixed in v1.43.0 (Process Manager, Startup, Task Scheduler, Defender, File Lock, Shortcut Cleaner). This locks in the banner-uniformity fix so it can't silently regress. Skips when the host is elevated (the not-elevated banner variant is the asserted one).

### AppFixture helpers
`HasText`, `HasAdminBanner`, `VisibleButtonCount`.

## Scope / honesty

- **Test-only** — no app code, no version bump (tests aren't in the shipped exe).
- I can't run FlaUI locally (`dotnet test` is environment-blocked + it needs an interactive desktop). The UI-tests CI job runs them on `windows-latest` and uploads a `.trx` artifact; I'll read that to confirm pass/fail and fix any header-substring mismatch in a follow-up. The UI-tests job is non-required (won't block merge) by existing repo policy.
- The required "Build & unit tests" gate still applies and must pass.

This is Phase 2 of the UI-testing expansion. Phases 3 (functionality/button-effect tests) and 4 (stress/perf/security harness) follow separately.