### PR TITLE
test: functional + performance UI tests (button effects, stress, responsiveness)

### DIFF
--- a/SysManager/SysManager.UITests/FunctionalUiTests.cs
+++ b/SysManager/SysManager.UITests/FunctionalUiTests.cs
@@ -1,0 +1,126 @@
+// SysManager · FunctionalUiTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using FlaUI.Core.AutomationElements;
+
+namespace SysManager.UITests;
+
+/// <summary>
+/// Functional UI tests: invoke SAFE, read-only actions and assert the
+/// observable effect, not just that a control exists. Only non-destructive,
+/// non-elevating operations are exercised here (scans, refreshes, list loads) —
+/// nothing that changes system state, deletes files, or requires admin. Each
+/// test drives the real app through UI Automation exactly as a user would.
+/// </summary>
+[Collection("App")]
+public class FunctionalUiTests
+{
+    private readonly AppFixture _fx;
+    public FunctionalUiTests(AppFixture fx) => _fx = fx;
+
+    [Fact]
+    public void Services_Refresh_PopulatesList()
+    {
+        _fx.GoToTab("nav-services");
+        var refresh = _fx.FindButton("Refresh");
+        Assert.NotNull(refresh);
+        refresh!.Invoke();
+
+        // A populated services list shows the "running / total" summary with a
+        // non-zero total — every Windows box has dozens of services. Give the
+        // background scan a few seconds to complete.
+        var ok = FlaUI.Core.Tools.Retry.WhileFalse(
+            () =>
+            {
+                var totalText = _fx.WaitForText("total", 1);
+                // The summary reads e.g. "120 running / 250 total"; assert it isn't "0 total".
+                return totalText is not null
+                    && _fx.MainWindow.FindAllDescendants()
+                        .Any(e => !string.IsNullOrEmpty(e.Name)
+                                  && e.Name.Contains("total", StringComparison.OrdinalIgnoreCase)
+                                  && !e.Name.TrimStart().StartsWith("0 ", StringComparison.Ordinal));
+            },
+            TimeSpan.FromSeconds(15)).Success;
+
+        Assert.True(ok, "Services list did not populate with a non-zero total after Refresh.");
+    }
+
+    [Fact]
+    public void Logs_Refresh_LoadsEventsOrReportsState()
+    {
+        _fx.GoToTab("nav-logs");
+        var refresh = _fx.FindButton("Refresh");
+        Assert.NotNull(refresh);
+        refresh!.Invoke();
+
+        // After a refresh the status bar resolves to a terminal state: either
+        // "Loaded N events …" on success, or a clear access/error message. Any of
+        // these proves the command ran to completion rather than hanging.
+        var resolved = FlaUI.Core.Tools.Retry.WhileNull(
+            () => _fx.WaitForText("Loaded", 1)
+                  ?? _fx.WaitForText("Access denied", 1)
+                  ?? _fx.WaitForText("Event log error", 1),
+            TimeSpan.FromSeconds(20)).Result;
+
+        Assert.NotNull(resolved);
+    }
+
+    [Fact]
+    public void Drivers_List_ProducesCountOrDone()
+    {
+        _fx.GoToTab("nav-drivers");
+        var list = _fx.FindButton("List drivers");
+        Assert.NotNull(list);
+        list!.Invoke();
+
+        // The scan ends with a "<N> drivers found" summary (or a parse-error
+        // fallback). Either terminal message proves the action completed.
+        var done = FlaUI.Core.Tools.Retry.WhileNull(
+            () => _fx.WaitForText("drivers found", 1)
+                  ?? _fx.WaitForText("Parse error", 1),
+            TimeSpan.FromSeconds(25)).Result;
+
+        Assert.NotNull(done);
+    }
+
+    [Fact]
+    public void DiskAnalyzer_ShowsReadOnlyEmptyState_BeforeScan()
+    {
+        // Read-only tab: before analyzing anything it must show its neutral
+        // empty-state guidance, never a stale or error state.
+        _fx.GoToTab("nav-disk-analyzer");
+        Assert.True(
+            _fx.HasText("pick a folder") || _fx.HasText("No results"),
+            "Disk Analyzer did not show its pre-scan empty-state message.");
+    }
+
+    [Fact]
+    public void ProcessManager_AutoPopulates_ProcessList()
+    {
+        _fx.GoToTab("nav-processes");
+        // Process Manager auto-refreshes on a 1s loop; the summary resolves to
+        // "<N> processes · <size> total memory" once the scan completes. Match the
+        // "total memory" tail so this doesn't trivially pass on the banner text
+        // ("Ending system processes requires administrator privileges.").
+        var populated = FlaUI.Core.Tools.Retry.WhileNull(
+            () => _fx.WaitForText("total memory", 1),
+            TimeSpan.FromSeconds(12)).Result;
+        Assert.NotNull(populated);
+    }
+
+    [Fact]
+    public void RapidTabSwitching_DoesNotCrash_AndDashboardRecovers()
+    {
+        // Stress the navigation: hop across heavy tabs quickly, then confirm the
+        // app is still alive and the Dashboard still renders its score.
+        foreach (var id in new[] {
+            "nav-processes", "nav-logs", "nav-services", "nav-system-health",
+            "nav-disk-analyzer", "nav-dns-hosts", "nav-dashboard" })
+        {
+            _fx.GoToTab(id);
+        }
+        Assert.False(_fx.App.HasExited, "App exited during rapid tab switching.");
+        Assert.True(_fx.HasText("Dashboard"), "Dashboard did not recover after rapid tab switching.");
+    }
+}

--- a/SysManager/SysManager.UITests/PerformanceUiTests.cs
+++ b/SysManager/SysManager.UITests/PerformanceUiTests.cs
@@ -1,0 +1,71 @@
+// SysManager · PerformanceUiTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Diagnostics;
+
+namespace SysManager.UITests;
+
+/// <summary>
+/// Coarse performance / responsiveness guards. These assert generous upper
+/// bounds — they exist to catch a regression that makes the app hang or a tab
+/// take pathologically long to render, NOT to benchmark. Bounds are deliberately
+/// loose so a slow CI runner doesn't cause false failures (the real signal is
+/// "seconds, not minutes"). Wall-clock timing is acceptable here because we're
+/// asserting an upper bound on a user-facing latency, not testing logic.
+/// </summary>
+[Collection("App")]
+public class PerformanceUiTests
+{
+    private readonly AppFixture _fx;
+    public PerformanceUiTests(AppFixture fx) => _fx = fx;
+
+    [Fact]
+    public void TabNavigation_RendersHeader_WithinBudget()
+    {
+        // Switching to a content-heavy tab must surface its header well within a
+        // few seconds. 10s is a generous ceiling for a cold CI runner.
+        var sw = Stopwatch.StartNew();
+        _fx.GoToTab("nav-logs");
+        var header = _fx.WaitForText("System Logs", timeoutSeconds: 10);
+        sw.Stop();
+
+        Assert.NotNull(header);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(10),
+            $"Navigating to System Logs took {sw.Elapsed.TotalSeconds:F1}s — over the 10s budget.");
+    }
+
+    [Fact]
+    public void RepeatedNavigation_StaysResponsive()
+    {
+        // 20 tab switches across light + heavy tabs must complete without the app
+        // becoming unresponsive or exiting. Catches a leak/deadlock that degrades
+        // navigation over time.
+        var sw = Stopwatch.StartNew();
+        string[] cycle = { "nav-dashboard", "nav-services", "nav-logs", "nav-ping" };
+        for (var i = 0; i < 20; i++)
+            _fx.GoToTab(cycle[i % cycle.Length]);
+        sw.Stop();
+
+        Assert.False(_fx.App.HasExited, "App exited during repeated navigation.");
+        Assert.True(_fx.HasText("Ping") || _fx.HasText("Dashboard"),
+            "App stopped rendering tab content after repeated navigation.");
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(60),
+            $"20 tab switches took {sw.Elapsed.TotalSeconds:F1}s — over the 60s budget (possible degradation).");
+    }
+
+    [Fact]
+    public void MainWindow_StaysResponsive_NotHung()
+    {
+        // A hung UI thread shows up as an unresponsive window. After exercising a
+        // tab, the main window must still answer UI Automation queries promptly.
+        _fx.GoToTab("nav-dashboard");
+        var sw = Stopwatch.StartNew();
+        var title = _fx.MainWindow.Title;
+        sw.Stop();
+
+        Assert.Contains("SysManager", title, StringComparison.OrdinalIgnoreCase);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5),
+            $"Reading the main window title took {sw.Elapsed.TotalSeconds:F1}s — UI thread may be blocked.");
+    }
+}


### PR DESCRIPTION
## What

Phase 3+4 of the UI-testing expansion — functional and performance coverage on top of the breadth smoke tests (#1117).

### FunctionalUiTests — assert observable *effects* of safe actions
Not just "button exists" — these invoke read-only/non-destructive commands and verify the result:
- **Services Refresh** → list populates (non-zero "… total").
- **Logs Refresh** → status resolves to a terminal state (Loaded N events / access denied / error) — proves it doesn't hang.
- **Drivers List** → "<N> drivers found" summary.
- **Disk Analyzer** → shows its read-only pre-scan empty-state.
- **Process Manager** → auto-populates the "<N> processes · <size> total memory" summary.
- **Rapid tab switching** across heavy tabs → no crash, Dashboard recovers.

Only safe, non-elevating, non-destructive operations are exercised (no deletes, no system changes, no admin actions).

### PerformanceUiTests — coarse upper-bound guards
Loose, CI-safe ceilings to catch a hang/leak regression (not benchmarks):
- Tab navigation renders its header within 10s.
- 20 repeated switches complete < 60s and stay responsive.
- Main window answers UIA queries < 5s (UI thread not blocked).

## Scope / honesty

- **Test-only** — no app code, no version bump.
- Runs on the CI UI-tests job (real desktop session); I'll read the `.trx` artifact to confirm green.
- **Security trust-boundaries** (uninstaller local-privilege-escalation, file-shredder path traversal/symlink) are already well covered by 37 existing UninstallerService tests + FileShredder/DeepCleanup tests — I did not pad with redundant cases.

Required "Build & unit tests" gate still applies.