### PR TITLE
fix: correct four real bugs in preview features (readiness audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.43.1] - 2026-06-27
+
+### Fixed
+- **Task Scheduler enable/disable now always acts on exactly the task you picked.** Windows task names can contain characters like `* ? [ ]`; the enable/disable used these verbatim against a wildcard-matching command, so a task whose name contained them could have toggled *more than one* task (or silently none) while still reporting success. Names and paths are now matched literally, and the operation reports success only when exactly the selected task changed.
+- **The Standby List Cleaner no longer freezes the window while purging.** The memory purge ran on the UI thread; on a large cache that briefly locked up the app. It now runs in the background, both for the manual button and the automatic threshold purge (which also no longer stacks if a purge is still running).
+- **Display Profiles tells you if it couldn't undo a change.** If the 15-second auto-revert failed to restore your previous resolution/refresh rate (e.g. the driver rejected it), the app used to claim it had reverted. It now detects the failure and tells you how to recover via Windows display settings.
+- **Defender Tweaks no longer reports a change that didn't happen.** Turning a protection off or removing an exclusion could show "updated" even when the change silently failed (e.g. without administrator rights), because the verification matched the unavailable/empty fallback state. It now confirms Defender status was actually readable before reporting success.
+
 ## [1.43.0] - 2026-06-27
 
 ### Added

--- a/SysManager/SysManager.Tests/DefenderViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DefenderViewModelTests.cs
@@ -82,4 +82,38 @@ public class DefenderViewModelTests
         vm.IsBusy = true;
         Assert.False(vm.RemoveExclusionCommand.CanExecute(null));
     }
+
+    [Fact]
+    public async Task TogglePua_Off_WhenStatusUnavailable_ReportsFailureNotSuccess()
+    {
+        // Regression: a disable-toggle targets PuaProtection==0. If the Set silently fails
+        // (needs admin / PS fault) the service returns the all-zeros Unavailable status,
+        // whose PuaProtection is also 0 — which would FALSELY satisfy the read-back check.
+        // The verdict must require status.Available, so this reports "not changed", not
+        // "updated".
+        var ps = Substitute.For<IPowerShellRunner>();
+        ps.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<System.Threading.CancellationToken>())
+          .Returns(new Collection<PSObject>()); // empty -> DefenderStatus.Unavailable (all zeros)
+        var vm = new DefenderViewModel(new DefenderService(ps));
+        await vm.InitializationComplete;
+
+        // Pretend PUA was on so the toggle requests OFF (target 0), the dangerous case.
+        vm.PuaEnabled = true;
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true); // auto-confirm
+        DialogService.Instance = dialog;
+        try
+        {
+            await vm.TogglePuaCommand.ExecuteAsync(null);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+
+        Assert.Contains("was not changed", vm.StatusMessage, System.StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("updated", vm.StatusMessage, System.StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/SysManager/SysManager.Tests/TaskSchedulerServiceTests.cs
+++ b/SysManager/SysManager.Tests/TaskSchedulerServiceTests.cs
@@ -2,6 +2,10 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+using NSubstitute;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -9,6 +13,69 @@ namespace SysManager.Tests;
 
 public class TaskSchedulerServiceTests
 {
+    // ── SetEnabledAsync read-back: exactly-one-match guard (wildcard-injection hardening) ──
+
+    private static PSObject TaskRow(string name, string path, string state)
+    {
+        var o = new PSObject();
+        o.Properties.Add(new PSNoteProperty("TaskName", name));
+        o.Properties.Add(new PSNoteProperty("TaskPath", path));
+        o.Properties.Add(new PSNoteProperty("State", state));
+        o.Properties.Add(new PSNoteProperty("Author", "Tester"));
+        o.Properties.Add(new PSNoteProperty("Description", ""));
+        return o;
+    }
+
+    private static TaskSchedulerService ServiceReturning(params PSObject[] readBackRows)
+    {
+        var ps = Substitute.For<IPowerShellRunner>();
+        ps.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<System.Threading.CancellationToken>())
+          .Returns(new Collection<PSObject>(readBackRows.ToList()));
+        return new TaskSchedulerService(ps);
+    }
+
+    [Fact]
+    public async Task SetEnabledAsync_ExactlyOneMatch_CorrectState_Succeeds()
+    {
+        var svc = ServiceReturning(TaskRow("Backup", @"\Vendor\", "Disabled"));
+        var result = await svc.SetEnabledAsync("Backup", @"\Vendor\", enabled: false);
+        Assert.NotNull(result);
+        Assert.Equal("Disabled", result!.State);
+    }
+
+    [Fact]
+    public async Task SetEnabledAsync_OverMatch_MultipleRows_ReturnsNull()
+    {
+        // A wildcard over-match (e.g. a "Backup*" name) would disable several tasks and the
+        // read-back would return >1 row. We can't honestly claim the selected task toggled,
+        // so the result must be null (failure) — not a false success from results[0].
+        var svc = ServiceReturning(
+            TaskRow("BackupA", @"\Vendor\", "Disabled"),
+            TaskRow("BackupB", @"\Vendor\", "Disabled"));
+        var result = await svc.SetEnabledAsync("Backup", @"\Vendor\", enabled: false);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task SetEnabledAsync_NoMatch_ReturnsNull()
+    {
+        // A bracket-named task ([Pro]) that doesn't match itself, or a needs-admin no-op,
+        // yields zero read-back rows — must report failure, not crash or false success.
+        var svc = ServiceReturning();
+        var result = await svc.SetEnabledAsync("Adobe [Pro] Updater", @"\Vendor\", enabled: false);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task SetEnabledAsync_StateDoesNotMatchIntent_ReturnsNull()
+    {
+        // Disable requested but the task is still Ready (the change didn't take) → failure.
+        var svc = ServiceReturning(TaskRow("Backup", @"\Vendor\", "Ready"));
+        var result = await svc.SetEnabledAsync("Backup", @"\Vendor\", enabled: false);
+        Assert.Null(result);
+    }
+
+
     [Theory]
     [InlineData(@"\Microsoft\Windows\Application Experience\", "Microsoft Corporation")]
     [InlineData(@"\Microsoft\Windows\Customer Experience Improvement Program\", "Microsoft")]

--- a/SysManager/SysManager/Services/TaskSchedulerService.cs
+++ b/SysManager/SysManager/Services/TaskSchedulerService.cs
@@ -42,14 +42,25 @@ public sealed class TaskSchedulerService
 
     private const string InfoScript = """
         param([string]$Name, [string]$Path)
-        Get-ScheduledTaskInfo -TaskName $Name -TaskPath $Path | Select-Object LastRunTime, NextRunTime
+        # -TaskName/-TaskPath are wildcard parameters in the ScheduledTasks module (there is
+        # no -LiteralName), so escape * ? [ ] in the values to force an exact match — a task
+        # legitimately named e.g. "Adobe [Pro] Updater" would otherwise be read as a pattern.
+        $n = [System.Management.Automation.WildcardPattern]::Escape($Name)
+        $p = [System.Management.Automation.WildcardPattern]::Escape($Path)
+        Get-ScheduledTaskInfo -TaskName $n -TaskPath $p | Select-Object LastRunTime, NextRunTime
         """;
 
     private const string SetEnabledScript = """
         param([string]$Name, [string]$Path, [bool]$Enabled)
-        if ($Enabled) { Enable-ScheduledTask -TaskName $Name -TaskPath $Path -ErrorAction SilentlyContinue | Out-Null }
-        else { Disable-ScheduledTask -TaskName $Name -TaskPath $Path -ErrorAction SilentlyContinue | Out-Null }
-        Get-ScheduledTask -TaskName $Name -TaskPath $Path |
+        # Escape wildcard metacharacters: -TaskName/-TaskPath interpret * ? [ ] as patterns,
+        # so an un-escaped name could over-match siblings (disabling MORE than the selected
+        # task) or fail to match its own literal name. Escaping pins the operation to exactly
+        # the chosen task. See WildcardPattern.Escape.
+        $n = [System.Management.Automation.WildcardPattern]::Escape($Name)
+        $p = [System.Management.Automation.WildcardPattern]::Escape($Path)
+        if ($Enabled) { Enable-ScheduledTask -TaskName $n -TaskPath $p -ErrorAction SilentlyContinue | Out-Null }
+        else { Disable-ScheduledTask -TaskName $n -TaskPath $p -ErrorAction SilentlyContinue | Out-Null }
+        Get-ScheduledTask -TaskName $n -TaskPath $p |
             Select-Object TaskName, TaskPath, @{ n='State'; e={ [string]$_.State } }, Author, Description
         """;
 
@@ -108,8 +119,13 @@ public sealed class TaskSchedulerService
         {
             var parameters = new Dictionary<string, object?> { ["Name"] = name, ["Path"] = path, ["Enabled"] = enabled };
             Collection<PSObject> results = await _ps.RunAsync(SetEnabledScript, parameters, ct).ConfigureAwait(false);
-            var row = results.Count > 0 ? results[0] : null;
-            if (row is null) return null;
+
+            // The read-back must resolve to EXACTLY one task. Wildcards are escaped in the
+            // script, so the only way to see != 1 row is a genuine miss (0, e.g. needs admin
+            // / vanished) or an ambiguous match (>1) — either way we can't honestly claim the
+            // selected task toggled, so report failure rather than trusting results[0].
+            if (results.Count != 1) return null;
+            var row = results[0];
 
             string observed = Str(row, "State") ?? "Unknown";
             bool observedDisabled = string.Equals(observed, "Disabled", StringComparison.OrdinalIgnoreCase);

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.43.0</Version>
-    <FileVersion>1.43.0.0</FileVersion>
-    <AssemblyVersion>1.43.0.0</AssemblyVersion>
+    <Version>1.43.1</Version>
+    <FileVersion>1.43.1.0</FileVersion>
+    <AssemblyVersion>1.43.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DefenderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DefenderViewModel.cs
@@ -106,7 +106,7 @@ public sealed partial class DefenderViewModel : ViewModelBase
             int target = PuaEnabled ? 0 : 1;
             var status = await _service.SetPuaProtectionAsync(target).ConfigureAwait(true);
             Apply(status);
-            ReportVerified("PUA protection", status.PuaProtection == target);
+            ReportVerified("PUA protection", status, status.PuaProtection == target);
         }
         finally { IsBusy = false; }
     }
@@ -121,7 +121,7 @@ public sealed partial class DefenderViewModel : ViewModelBase
             int target = CfaEnabled ? 0 : 1;
             var status = await _service.SetControlledFolderAccessAsync(target).ConfigureAwait(true);
             Apply(status);
-            ReportVerified("Controlled Folder Access", status.ControlledFolderAccess == target);
+            ReportVerified("Controlled Folder Access", status, status.ControlledFolderAccess == target);
         }
         finally { IsBusy = false; }
     }
@@ -145,7 +145,7 @@ public sealed partial class DefenderViewModel : ViewModelBase
         {
             var status = await _service.AddExclusionPathAsync(path).ConfigureAwait(true);
             Apply(status);
-            ReportVerified("Exclusion", status.ExclusionPaths.Any(p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase)));
+            ReportVerified("Exclusion", status, status.ExclusionPaths.Any(p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase)));
         }
         finally { IsBusy = false; }
     }
@@ -162,7 +162,7 @@ public sealed partial class DefenderViewModel : ViewModelBase
         {
             var status = await _service.RemoveExclusionPathAsync(path).ConfigureAwait(true);
             Apply(status);
-            ReportVerified("Exclusion removal", !status.ExclusionPaths.Any(p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase)));
+            ReportVerified("Exclusion removal", status, !status.ExclusionPaths.Any(p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase)));
         }
         finally { IsBusy = false; }
     }
@@ -194,9 +194,14 @@ public sealed partial class DefenderViewModel : ViewModelBase
         RemoveExclusionCommand.NotifyCanExecuteChanged();
     }
 
-    private void ReportVerified(string what, bool applied)
+    private void ReportVerified(string what, DefenderStatus status, bool applied)
     {
-        if (applied)
+        // A read-back only proves anything when the status is actually readable. When the
+        // Set failed (needs admin / PowerShell host fault), the service returns the all-zeros
+        // DefenderStatus.Unavailable — against which a disable-toggle (target 0) or an
+        // exclusion removal (empty list) would FALSELY satisfy `applied`. Treat an
+        // unavailable read-back as a failure, never a silent success.
+        if (applied && status.Available)
         {
             StatusMessage = $"{what} updated.";
             Log.Information("Defender: {What} change applied", what);

--- a/SysManager/SysManager/ViewModels/DisplayProfileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DisplayProfileViewModel.cs
@@ -178,10 +178,21 @@ public sealed partial class DisplayProfileViewModel : ViewModelBase
         // countdown, and reverting the wrong display would corrupt its mode.
         var device = _previousDevice;
         var prev = _previousMode;
+        bool revertFailed = false;
         if (device is not null && prev is not null)
         {
-            await Task.Run(() =>
-                _service.TryApplyMode(device.DeviceName, prev.Width, prev.Height, prev.RefreshHz, out _)).ConfigureAwait(true);
+            // Revert is the only in-app safety net for a mode that blanked the panel, so its
+            // success matters — don't discard it. If the driver rejects the previous mode,
+            // tell the user exactly how to recover via Windows rather than claiming success.
+            var (reverted, revertError) = await Task.Run(() =>
+            {
+                var ok = _service.TryApplyMode(device.DeviceName, prev.Width, prev.Height, prev.RefreshHz, out var err);
+                return (ok, err);
+            }).ConfigureAwait(true);
+            revertFailed = !reverted;
+            if (revertFailed)
+                Log.Warning("Display auto-revert failed for {Device}: {Error}", device.DeviceName, revertError);
+
             // Only refresh CurrentMode if the reverted device is still the selected one,
             // so we don't overwrite the display the user has since switched to.
             if (ReferenceEquals(device, SelectedDisplay))
@@ -189,7 +200,9 @@ public sealed partial class DisplayProfileViewModel : ViewModelBase
         }
         _previousMode = null;
         _previousDevice = null;
-        StatusMessage = message;
+        StatusMessage = revertFailed
+            ? "Couldn't restore the previous display mode — if the screen looks wrong, press Esc or use Windows Settings ▸ System ▸ Display to reset it."
+            : message;
         ApplyCommand.NotifyCanExecuteChanged();
     }
 

--- a/SysManager/SysManager/ViewModels/StandbyMemoryViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StandbyMemoryViewModel.cs
@@ -63,33 +63,57 @@ public sealed partial class StandbyMemoryViewModel : ViewModelBase
         LoadDisplay = status.LoadDisplay;
     }
 
-    private void Tick()
+    private bool _autoPurgeInFlight;
+
+    private async void Tick()
     {
         var status = _service.GetMemoryStatus();
         TotalDisplay = status.TotalDisplay;
         AvailableDisplay = status.AvailableDisplay;
         LoadDisplay = status.LoadDisplay;
 
-        if (AutoPurgeEnabled && IsElevated && ShouldAutoPurge(status.AvailableMb, ThresholdMb))
+        // Auto-purge off the UI thread (same reason as PurgeAsync). _autoPurgeInFlight
+        // guards against the 2s timer stacking a second purge on top of one still running.
+        if (AutoPurgeEnabled && IsElevated && !_autoPurgeInFlight
+            && ShouldAutoPurge(status.AvailableMb, ThresholdMb))
         {
-            if (_service.TryPurgeStandbyList(out _))
+            _autoPurgeInFlight = true;
+            try
             {
-                Log.Information("Auto-purged standby list (available {Avail:F0} MB < {Threshold:F0} MB)", status.AvailableMb, ThresholdMb);
-                StatusMessage = $"Auto-purged — available RAM was below {ThresholdMb:F0} MB.";
-                Refresh();
+                var avail = status.AvailableMb;
+                var purged = await Task.Run(() => _service.TryPurgeStandbyList(out _)).ConfigureAwait(true);
+                if (purged)
+                {
+                    Log.Information("Auto-purged standby list (available {Avail:F0} MB < {Threshold:F0} MB)", avail, ThresholdMb);
+                    StatusMessage = $"Auto-purged — available RAM was below {ThresholdMb:F0} MB.";
+                    Refresh();
+                }
             }
+            finally { _autoPurgeInFlight = false; }
         }
     }
 
     [RelayCommand]
-    private void Purge()
+    private async Task PurgeAsync()
     {
         if (!IsElevated)
         {
             StatusMessage = "Purging the standby list requires administrator rights.";
             return;
         }
-        if (_service.TryPurgeStandbyList(out string error))
+
+        // The native standby-list purge (NtSetSystemInformation) can block for a noticeable
+        // time on a large cache, so run it off the UI thread to keep the window responsive —
+        // mirrors PerformanceViewModel.TrimRamAsync. ConfigureAwait(true) resumes on the UI
+        // thread so the status/Refresh updates marshal correctly.
+        StatusMessage = "Purging standby list…";
+        var (ok, error) = await Task.Run(() =>
+        {
+            var success = _service.TryPurgeStandbyList(out var err);
+            return (success, err);
+        }).ConfigureAwait(true);
+
+        if (ok)
         {
             Log.Information("User purged standby list");
             StatusMessage = "Standby list purged — cached memory released to the free list.";


### PR DESCRIPTION
## What

A deep production-readiness assessment of the 8 PREVIEW features — with an **adversarial challenge** pass that re-checks every 'ready' verdict against the real code — surfaced four genuine defects. None graduate the preview tag until these are fixed. This PR fixes all four (the bugs are real regardless of preview status: wildcard injection and a UI-thread freeze are real correctness/stability issues).

### 1. Task Scheduler — wildcard over-match / false verification (most serious)
`Disable-ScheduledTask -TaskName/-TaskPath` use **wildcard** parameters (no `-LiteralName` exists). A task named e.g. `Backup*` or `Adobe [Pro] Updater` could disable **multiple** unintended tasks, or silently match nothing — while the read-back (same wildcard, `results[0]`, no count guard) reported success. **Fix:** escape `* ? [ ]` with `WildcardPattern.Escape`, and require the read-back to resolve to **exactly one** task before claiming success.

### 2. Standby List Cleaner — UI-thread freeze
The native standby-list purge ran **synchronously on the UI thread**, locking the window on a large cache. **Fix:** run it off-thread (manual button + the 2s auto-purge), with a re-entrancy guard so the timer can't stack purges. Mirrors `PerformanceViewModel.TrimRamAsync`.

### 3. Display Profiles — silent failed revert
The 15s auto-revert (the only in-app safety net for a screen-blanking mode) **discarded** `TryApplyMode`'s result, so a failed revert was reported as success — leaving the user stuck. **Fix:** capture the result; on failure, surface a clear recovery message (Esc / Windows display settings).

### 4. Defender Tweaks — false 'updated' on silent failure
A disable-toggle (target 0) or exclusion removal verified against the all-zeros **Unavailable** fallback status, so a silently-failed Set (e.g. no admin) reported 'updated'. **Fix:** require `status.Available` before treating the read-back as confirmation.

## Tests

- `TaskSchedulerServiceTests`: over-match (>1 row) → null, no-match → null, wrong-state → null, exact-match → success (fake `IPowerShellRunner`).
- `DefenderViewModelTests`: disable-toggle against Unavailable status reports 'not changed', never 'updated' (auto-confirm dialog stub).

## Verification

- Release + test build clean (0/0).
- All preview tabs launch and render without crash (verified non-elevated; Defender screenshot confirmed).

This is step 1 of preview-feature graduation: **fix blockers first**. Next: add the remaining test coverage (all 8 preview VMs/services are light on tests), then remove the preview tag from the features that are then fully verified.