### PR TITLE
test: ViewModel coverage for four preview features

### DIFF
--- a/SysManager/SysManager.Tests/CpuAffinityViewModelTests.cs
+++ b/SysManager/SysManager.Tests/CpuAffinityViewModelTests.cs
@@ -1,0 +1,144 @@
+// SysManager · CpuAffinityViewModelTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Services;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="CpuAffinityViewModel"/>. <see cref="CpuAffinityService"/> is sealed
+/// with no interface, so it cannot be substituted; these drive the real service (its
+/// <c>GetCores</c> / <c>GetProcesses</c> are read-only enumerations). Coverage is the
+/// deterministic surface: construction/topology load, the pure core-selection commands
+/// (<c>SelectAllCores</c> / <c>SelectPerformanceCores</c>, which only flip in-memory
+/// <see cref="CoreToggle"/> state), Apply/Restore CanExecute gating, and the null-selection
+/// branch of <c>OnSelectedProcessChanged</c>. <c>Apply</c> and <c>Restore</c> mutate a real
+/// process's affinity, so they are NOT executed.
+/// </summary>
+public class CpuAffinityViewModelTests
+{
+    // The constructor loads CPU topology + the running-process list asynchronously off the
+    // UI thread; await init so Cores/Processes are populated before asserting.
+    private static CpuAffinityViewModel NewVm()
+    {
+        var vm = new CpuAffinityViewModel(new CpuAffinityService());
+        vm.InitializationComplete.GetAwaiter().GetResult();
+        return vm;
+    }
+
+    [Fact]
+    public void Constructor_LoadsCores_OnePerLogicalCpu()
+    {
+        var vm = NewVm();
+        // GetCores always returns at least the flat fallback list of Environment.ProcessorCount.
+        Assert.Equal(Environment.ProcessorCount, vm.Cores.Count);
+        Assert.NotNull(vm.RefreshProcessesCommand);
+        Assert.NotNull(vm.ApplyCommand);
+        Assert.NotNull(vm.RestoreCommand);
+        Assert.NotNull(vm.SelectAllCoresCommand);
+        Assert.NotNull(vm.SelectPerformanceCoresCommand);
+    }
+
+    [Fact]
+    public void Constructor_SetsStatusMessage_AfterInit()
+    {
+        var vm = NewVm();
+        Assert.False(string.IsNullOrWhiteSpace(vm.StatusMessage));
+        Assert.False(vm.IsBusy);
+    }
+
+    [Fact]
+    public void Constructor_PopulatesProcessList()
+    {
+        var vm = NewVm();
+        // The current process at minimum is enumerable, so the list is never empty.
+        Assert.True(vm.Processes.Count > 0);
+    }
+
+    [Fact]
+    public void Apply_RequiresSelection()
+    {
+        var vm = NewVm();
+        // HasSelection gate: no SelectedProcess -> Apply is disabled.
+        Assert.Null(vm.SelectedProcess);
+        Assert.False(vm.ApplyCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void Restore_RequiresSelectionAndCapturedOriginal()
+    {
+        var vm = NewVm();
+        // CanRestore needs both a selection and a previously-captured original mask. With no
+        // selection neither holds, so Restore is disabled.
+        Assert.False(vm.RestoreCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void SelectAllCores_SelectsEveryCore_AndSetsStatus()
+    {
+        var vm = NewVm();
+        // Clear first so the assertion is meaningful.
+        foreach (var c in vm.Cores) c.IsSelected = false;
+
+        vm.SelectAllCoresCommand.Execute(null);
+
+        Assert.All(vm.Cores, c => Assert.True(c.IsSelected));
+        Assert.Contains("all cores", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SelectPerformanceCores_OnNonHybrid_SelectsAllCores()
+    {
+        var vm = NewVm();
+        foreach (var c in vm.Cores) c.IsSelected = false;
+
+        vm.SelectPerformanceCoresCommand.Execute(null);
+
+        if (vm.IsHybrid)
+        {
+            // On a hybrid CPU only P-cores are selected; E-cores must be left unselected.
+            Assert.All(vm.Cores, c => Assert.Equal(c.Core.IsPerformance, c.IsSelected));
+            Assert.Contains("P-cores", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            // On a homogeneous CPU "performance cores" means every core.
+            Assert.All(vm.Cores, c => Assert.True(c.IsSelected));
+            Assert.Contains("all cores", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void NoSelection_DisablesApplyAndRestore()
+    {
+        // Characterizes the no-selection state deterministically (no real process needed):
+        // with SelectedProcess null, the captured-original flag is unset, so HasSelection and
+        // CanRestore both gate their commands off. This is the safe half of the
+        // OnSelectedProcessChanged behaviour (the populated branch needs a real process to
+        // read affinity from, which we deliberately avoid).
+        var vm = NewVm();
+        Assert.Null(vm.SelectedProcess);
+        Assert.False(vm.RestoreCommand.CanExecute(null));
+        Assert.False(vm.ApplyCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void IsHybrid_MatchesCoreClassification()
+    {
+        var vm = NewVm();
+        // IsHybrid is derived from the loaded cores: true iff both P- and E-cores are present.
+        bool expected = vm.Cores.Any(c => c.Core.IsPerformance) && vm.Cores.Any(c => c.Core.IsEfficiency);
+        Assert.Equal(expected, vm.IsHybrid);
+    }
+
+    [Fact]
+    public async Task RefreshProcessesCommand_DoesNotThrow_AndRepopulates()
+    {
+        var vm = NewVm();
+        await vm.RefreshProcessesCommand.ExecuteAsync(null);
+        Assert.True(vm.Processes.Count > 0);
+        Assert.False(vm.IsBusy);
+    }
+}

--- a/SysManager/SysManager.Tests/DarkModeViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DarkModeViewModelTests.cs
@@ -1,0 +1,69 @@
+// SysManager · DarkModeViewModelTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Services;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="DarkModeViewModel"/>. <see cref="WindowsThemeService"/> is sealed
+/// with no interface, so it cannot be substituted; these drive the real service but stay on
+/// its read-only surface (<c>GetCurrentTheme</c> / <c>LoadSchedule</c>). The
+/// <c>SwitchToDark</c> / <c>SwitchToLight</c> commands and any schedule-enabling mutation call
+/// the real <c>SetTheme</c>, which writes HKCU and flips the actual Windows theme, so they are
+/// NOT executed here. The pure schedule predicate <c>WindowsThemeService.ShouldBeDark</c> is
+/// already covered by <see cref="WindowsThemeServiceTests"/> and is not duplicated.
+///
+/// With no <c>Application.Current</c> in the test host, the constructor skips the
+/// DispatcherTimer/immediate-evaluate block, so building the VM does not apply the schedule.
+/// </summary>
+public class DarkModeViewModelTests
+{
+    private static DarkModeViewModel NewVm() => new(new WindowsThemeService());
+
+    [Fact]
+    public void Constructor_Succeeds_WithCommands()
+    {
+        var vm = NewVm();
+        Assert.NotNull(vm.SwitchToDarkCommand);
+        Assert.NotNull(vm.SwitchToLightCommand);
+    }
+
+    [Fact]
+    public void Constructor_SetsStatusMessage()
+    {
+        var vm = NewVm();
+        Assert.False(string.IsNullOrWhiteSpace(vm.StatusMessage));
+    }
+
+    [Fact]
+    public void IsDarkNow_MatchesLiveWindowsTheme()
+    {
+        var vm = NewVm();
+        // The VM seeds IsDarkNow from the live registry read; it must agree with a direct query.
+        bool live = new WindowsThemeService().GetCurrentTheme() == WindowsTheme.Dark;
+        Assert.Equal(live, vm.IsDarkNow);
+    }
+
+    [Fact]
+    public void StatusMessage_ReflectsScheduleState()
+    {
+        var vm = NewVm();
+        // The constructor picks the status text from ScheduleEnabled (loaded from disk).
+        if (vm.ScheduleEnabled)
+            Assert.Contains("Schedule is on", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        else
+            Assert.Contains("schedule", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TimeStrings_AreNonEmpty_AfterLoad()
+    {
+        var vm = NewVm();
+        // LoadFromSchedule populates the dark/light start strings (defaults if no saved file).
+        Assert.False(string.IsNullOrWhiteSpace(vm.DarkStart));
+        Assert.False(string.IsNullOrWhiteSpace(vm.LightStart));
+    }
+}

--- a/SysManager/SysManager.Tests/FileLockViewModelTests.cs
+++ b/SysManager/SysManager.Tests/FileLockViewModelTests.cs
@@ -1,0 +1,171 @@
+// SysManager · FileLockViewModelTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using NSubstitute;
+using SysManager.Models;
+using SysManager.Services;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="FileLockViewModel"/>. <see cref="FileLockService"/> is sealed with
+/// no interface, so it cannot be substituted; these drive the real service. Its
+/// <c>FindLockers</c> is a read-only Restart Manager query (safe to run against a temp file),
+/// but <c>KillProcess</c> would terminate a real process, so the success path of
+/// <c>KillSelected</c> is NOT executed — only the confirmation-gated branches (critical-process
+/// block and user-declines) and CanExecute gating are covered.
+///
+/// Serialized because the critical-process and decline tests swap the global
+/// <see cref="DialogService.Instance"/> static.
+/// </summary>
+[Collection("DialogService")]
+public class FileLockViewModelTests
+{
+    private static FileLockViewModel NewVm() => new(new FileLockService());
+
+    [Fact]
+    public void Constructor_Succeeds_WithInitialState()
+    {
+        var vm = NewVm();
+        Assert.Equal("", vm.Path);
+        Assert.False(vm.HasScanned);
+        Assert.Empty(vm.Lockers);
+        Assert.False(string.IsNullOrWhiteSpace(vm.StatusMessage));
+        Assert.NotNull(vm.ScanCommand);
+        Assert.NotNull(vm.KillSelectedCommand);
+        Assert.NotNull(vm.BrowseCommand);
+        Assert.NotNull(vm.RelaunchAsAdminCommand);
+    }
+
+    [Fact]
+    public void Scan_RequiresNonEmptyPath()
+    {
+        var vm = NewVm();
+        // CanScan == !IsBusy && Path is non-whitespace.
+        Assert.False(vm.ScanCommand.CanExecute(null));
+
+        vm.Path = @"C:\some\file.txt";
+        Assert.True(vm.ScanCommand.CanExecute(null));
+
+        vm.Path = "   ";
+        Assert.False(vm.ScanCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void Scan_DisabledWhileBusy()
+    {
+        var vm = NewVm();
+        vm.Path = @"C:\some\file.txt";
+        Assert.True(vm.ScanCommand.CanExecute(null));
+
+        vm.IsBusy = true;
+        Assert.False(vm.ScanCommand.CanExecute(null));
+
+        vm.IsBusy = false;
+        Assert.True(vm.ScanCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void Kill_RequiresSelectionAndNotBusy()
+    {
+        var vm = NewVm();
+        // CanKill == !IsBusy && SelectedLocker is not null.
+        Assert.Null(vm.SelectedLocker);
+        Assert.False(vm.KillSelectedCommand.CanExecute(null));
+
+        vm.SelectedLocker = new FileLocker(1234, "notepad.exe", "RmMainWindow", null);
+        Assert.True(vm.KillSelectedCommand.CanExecute(null));
+
+        vm.IsBusy = true;
+        Assert.False(vm.KillSelectedCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task Scan_OnUnlockedTempFile_ReportsNoLockers()
+    {
+        // A freshly-created temp file we are not holding open has no Restart Manager lockers,
+        // so the read-only scan should complete and report zero processes deterministically.
+        string temp = Path.Combine(Path.GetTempPath(), "sysmgr_filelock_test_" + Guid.NewGuid().ToString("N") + ".tmp");
+        File.WriteAllText(temp, "x");
+        try
+        {
+            var vm = NewVm();
+            vm.Path = temp;
+            await vm.ScanCommand.ExecuteAsync(null);
+
+            Assert.True(vm.HasScanned);
+            Assert.False(vm.IsBusy);
+            Assert.Empty(vm.Lockers);
+            Assert.Contains("No process", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(temp);
+        }
+    }
+
+    [Fact]
+    public void KillSelected_OnCriticalProcess_ShowsBlockDialog_AndDoesNotKill()
+    {
+        // A critical (RmCritical) locker must be blocked: the VM shows a single informational
+        // confirm and returns without ever attempting to terminate it. No kill is issued, so
+        // this exercises the guard branch safely without touching a real process.
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            var vm = NewVm();
+            vm.SelectedLocker = new FileLocker(4, "System", "RmCritical", null);
+
+            vm.KillSelectedCommand.Execute(null);
+
+            // Exactly one (informational) confirm for the "cannot end" message; nothing else.
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public void KillSelected_WhenUserDeclines_DoesNothing()
+    {
+        // Declining the confirm short-circuits before KillProcess, so no process is touched
+        // and the status message is left untouched from construction.
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false); // user clicks "No"
+        DialogService.Instance = dialog;
+        try
+        {
+            var vm = NewVm();
+            string statusBefore = vm.StatusMessage;
+            vm.SelectedLocker = new FileLocker(999999, "phantom.exe", "RmMainWindow", null);
+
+            vm.KillSelectedCommand.Execute(null);
+
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            Assert.Equal(statusBefore, vm.StatusMessage);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public void RelaunchAsAdmin_WithoutWpfApp_DoesNotThrow()
+    {
+        // In a test host Application.Current is null, so AdminHelper.RelaunchAsAdmin returns
+        // false early and the command is a safe no-op (no shutdown, no elevation prompt).
+        var vm = NewVm();
+        var ex = Record.Exception(() => vm.RelaunchAsAdminCommand.Execute(null));
+        Assert.Null(ex);
+    }
+}

--- a/SysManager/SysManager.Tests/TimerResolutionViewModelTests.cs
+++ b/SysManager/SysManager.Tests/TimerResolutionViewModelTests.cs
@@ -1,0 +1,105 @@
+// SysManager · TimerResolutionViewModelTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Services;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="TimerResolutionViewModel"/>. <see cref="TimerResolutionService"/>
+/// is sealed with no interface, so it cannot be substituted; these drive the real service
+/// (its <c>Query</c> is a harmless read-only NT call) and exercise the deterministic
+/// surface only: construction, post-init state, and the mutually-exclusive Enable/Disable
+/// CanExecute gating. The Enable/Disable commands themselves issue a real
+/// <c>NtSetTimerResolution</c> against this process, so they are NOT executed here.
+/// </summary>
+public class TimerResolutionViewModelTests
+{
+    // The constructor kicks off an async RefreshAsync that reads the live timer state;
+    // await it so the observable state is settled before asserting (mirrors the
+    // DefenderViewModel / PrivacyViewModel idiom).
+    private static TimerResolutionViewModel NewVm()
+    {
+        var vm = new TimerResolutionViewModel(new TimerResolutionService());
+        vm.InitializationComplete.GetAwaiter().GetResult();
+        return vm;
+    }
+
+    [Fact]
+    public void Constructor_Succeeds_AndIsNotBusyAfterInit()
+    {
+        var vm = NewVm();
+        Assert.False(vm.IsBusy);
+        Assert.NotNull(vm.RefreshCommand);
+        Assert.NotNull(vm.EnableCommand);
+        Assert.NotNull(vm.DisableCommand);
+    }
+
+    [Fact]
+    public void Constructor_PopulatesStatusMessage()
+    {
+        var vm = NewVm();
+        // RefreshAsync always sets a final status message (supported or not).
+        Assert.False(string.IsNullOrWhiteSpace(vm.StatusMessage));
+    }
+
+    [Fact]
+    public void AfterInit_DisplayProperties_AreSet()
+    {
+        var vm = NewVm();
+        // Whether or not the API is available, the three display strings are non-empty:
+        // either a formatted "x ms" value or the "—" placeholder.
+        Assert.False(string.IsNullOrEmpty(vm.CurrentDisplay));
+        Assert.False(string.IsNullOrEmpty(vm.FinestDisplay));
+        Assert.False(string.IsNullOrEmpty(vm.CoarsestDisplay));
+    }
+
+    [Fact]
+    public void EnableAndDisable_AreMutuallyExclusive_WhenSupported()
+    {
+        var vm = NewVm();
+        // CanEnable and CanDisable are guarded so exactly one is available at a time on a
+        // supported system (Enable requires not-high-res; Disable requires high-res).
+        // The two can only be simultaneously false when the API is unsupported.
+        if (vm.IsSupported)
+        {
+            Assert.NotEqual(vm.EnableCommand.CanExecute(null), vm.DisableCommand.CanExecute(null));
+        }
+        else
+        {
+            Assert.False(vm.EnableCommand.CanExecute(null));
+            Assert.False(vm.DisableCommand.CanExecute(null));
+        }
+    }
+
+    [Fact]
+    public void Enable_DisabledOnUnsupportedSystem()
+    {
+        var vm = NewVm();
+        // CanEnable == IsSupported && !IsHighResolution. When unsupported, never enabled.
+        if (!vm.IsSupported)
+            Assert.False(vm.EnableCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void Disable_DisabledWhenNotHighResolution()
+    {
+        var vm = NewVm();
+        // CanDisable == IsSupported && IsHighResolution. With no high-res request in effect
+        // (the default for a freshly-constructed VM), Disable must be unavailable.
+        if (!vm.IsHighResolution)
+            Assert.False(vm.DisableCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task RefreshCommand_DoesNotThrow_AndKeepsStatus()
+    {
+        var vm = NewVm();
+        // Refresh re-queries the live timer (read-only) — safe to execute repeatedly.
+        await vm.RefreshCommand.ExecuteAsync(null);
+        Assert.False(string.IsNullOrWhiteSpace(vm.StatusMessage));
+        Assert.False(vm.IsBusy);
+    }
+}


### PR DESCRIPTION
Adds unit tests (30 methods) for the TimerResolution, CpuAffinity, FileLock, and DarkMode preview-feature ViewModels — part of the preview-graduation effort.

**Covered (deterministic):** construction + post-init state, command CanExecute gating with state transitions, read-only command paths, the pure CPU selection commands (SelectAll / SelectPerformanceCores incl. hybrid P-core branch), a real read-only FileLock scan against a temp file, and FileLock's safety-gated branches (critical-process block + user-declines) via the swappable `DialogService.Instance` stub.

**Honest limitation:** all four services are `sealed` with no interface, so the *mutating* paths (set timer, set affinity, kill-success, switch theme) can't be fake-verified without a production seam or mutating the real OS — they are NOT exercised here. A follow-up PR adds service interfaces so those paths can be tested before the preview tag is removed.

Test-only; no production code, no version bump. Required build+unit-test gate applies.