### PR TITLE
refactor: extract service interfaces for preview features + test mutating paths

### DIFF
--- a/SysManager/SysManager.Tests/CpuAffinityViewModelTests.cs
+++ b/SysManager/SysManager.Tests/CpuAffinityViewModelTests.cs
@@ -2,20 +2,23 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using NSubstitute;
+using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
 
 namespace SysManager.Tests;
 
 /// <summary>
-/// Tests for <see cref="CpuAffinityViewModel"/>. <see cref="CpuAffinityService"/> is sealed
-/// with no interface, so it cannot be substituted; these drive the real service (its
-/// <c>GetCores</c> / <c>GetProcesses</c> are read-only enumerations). Coverage is the
-/// deterministic surface: construction/topology load, the pure core-selection commands
-/// (<c>SelectAllCores</c> / <c>SelectPerformanceCores</c>, which only flip in-memory
-/// <see cref="CoreToggle"/> state), Apply/Restore CanExecute gating, and the null-selection
-/// branch of <c>OnSelectedProcessChanged</c>. <c>Apply</c> and <c>Restore</c> mutate a real
-/// process's affinity, so they are NOT executed.
+/// Tests for <see cref="CpuAffinityViewModel"/>. Two layers of coverage: the
+/// deterministic-surface tests drive the real <see cref="CpuAffinityService"/> (its
+/// <c>GetCores</c> / <c>GetProcesses</c> are read-only enumerations) and cover
+/// construction/topology load, the pure core-selection commands, Apply/Restore
+/// CanExecute gating, and the null-selection branch of <c>OnSelectedProcessChanged</c>;
+/// the mutating-path tests substitute <see cref="ICpuAffinityService"/> with a
+/// deterministic topology + process so <c>Apply</c> and <c>Restore</c> can be executed
+/// (asserting <c>TrySetAffinity</c> is called with the correct mask) without touching a
+/// real process. The static bitmask helpers stay on the concrete class and are used as-is.
 /// </summary>
 public class CpuAffinityViewModelTests
 {
@@ -26,6 +29,32 @@ public class CpuAffinityViewModelTests
         var vm = new CpuAffinityViewModel(new CpuAffinityService());
         vm.InitializationComplete.GetAwaiter().GetResult();
         return vm;
+    }
+
+    private static CpuAffinityViewModel NewVm(ICpuAffinityService service)
+    {
+        var vm = new CpuAffinityViewModel(service);
+        vm.InitializationComplete.GetAwaiter().GetResult();
+        return vm;
+    }
+
+    // A deterministic 4-core homogeneous topology and one target process at pid 4242 whose
+    // original affinity is core 0 only (mask 0b0001). Lets Apply/Restore run against a fake.
+    private static ICpuAffinityService FourCoreServiceWith(int pid, long originalMask)
+    {
+        var service = Substitute.For<ICpuAffinityService>();
+        service.LogicalProcessorCount.Returns(4);
+        service.GetCores().Returns(new List<CpuCore>
+        {
+            new(0, 0, "Standard"), new(1, 0, "Standard"),
+            new(2, 0, "Standard"), new(3, 0, "Standard"),
+        });
+        service.GetProcesses().Returns(new List<RunningProcess>
+        {
+            new(pid, "target.exe", originalMask),
+        });
+        service.GetAffinity(pid).Returns(originalMask);
+        return service;
     }
 
     [Fact]
@@ -140,5 +169,71 @@ public class CpuAffinityViewModelTests
         await vm.RefreshProcessesCommand.ExecuteAsync(null);
         Assert.True(vm.Processes.Count > 0);
         Assert.False(vm.IsBusy);
+    }
+
+    // ── Mutating-path tests (substituted ICpuAffinityService) ──────────────
+
+    [Fact]
+    public void Apply_AfterSelectAllCores_CallsTrySetAffinityWithFullMask()
+    {
+        const int pid = 4242;
+        const long originalMask = 0b0001; // core 0 only
+        var service = FourCoreServiceWith(pid, originalMask);
+        service.TrySetAffinity(pid, Arg.Any<long>(), out Arg.Any<string>()).Returns(true);
+
+        var vm = NewVm(service);
+        // Selecting the loaded process captures its original mask via GetAffinity(pid).
+        vm.SelectedProcess = vm.Processes.Single(p => p.ProcessId == pid);
+        vm.SelectAllCoresCommand.Execute(null);
+        Assert.True(vm.ApplyCommand.CanExecute(null));
+
+        vm.ApplyCommand.Execute(null);
+
+        // All four cores selected → mask 0b1111 (the low 4 bits).
+        long expectedMask = CpuAffinityService.AllCoresMask(4);
+        service.Received(1).TrySetAffinity(pid, expectedMask, out Arg.Any<string>());
+        Assert.Contains("Pinned", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Apply_OnServiceFailure_SurfacesErrorMessage()
+    {
+        const int pid = 4242;
+        var service = FourCoreServiceWith(pid, 0b0001);
+        // Service rejects the change and reports an error via the out parameter.
+        service.TrySetAffinity(pid, Arg.Any<long>(), out Arg.Any<string>())
+            .Returns(call => { call[2] = "needs administrator rights."; return false; });
+
+        var vm = NewVm(service);
+        vm.SelectedProcess = vm.Processes.Single(p => p.ProcessId == pid);
+        vm.SelectAllCoresCommand.Execute(null);
+
+        vm.ApplyCommand.Execute(null);
+
+        service.Received(1).TrySetAffinity(pid, Arg.Any<long>(), out Arg.Any<string>());
+        Assert.Equal("needs administrator rights.", vm.StatusMessage);
+    }
+
+    [Fact]
+    public void Restore_CallsTrySetAffinityWithCapturedOriginalMask()
+    {
+        const int pid = 4242;
+        const long originalMask = 0b0010; // core 1 only — the captured original
+        var service = FourCoreServiceWith(pid, originalMask);
+        service.TrySetAffinity(pid, Arg.Any<long>(), out Arg.Any<string>()).Returns(true);
+
+        var vm = NewVm(service);
+        // Selecting captures originalMask; flipping the selection proves Restore uses the
+        // captured value, not the current checkbox state.
+        vm.SelectedProcess = vm.Processes.Single(p => p.ProcessId == pid);
+        vm.SelectAllCoresCommand.Execute(null);
+        Assert.True(vm.RestoreCommand.CanExecute(null));
+
+        vm.RestoreCommand.Execute(null);
+
+        service.Received(1).TrySetAffinity(pid, originalMask, out Arg.Any<string>());
+        // The checkboxes were reset to reflect the restored original mask (core 1 only).
+        Assert.All(vm.Cores, c => Assert.Equal(c.Index == 1, c.IsSelected));
+        Assert.Contains("Restored", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/SysManager/SysManager.Tests/DarkModeViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DarkModeViewModelTests.cs
@@ -2,19 +2,23 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using NSubstitute;
+using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
 
 namespace SysManager.Tests;
 
 /// <summary>
-/// Tests for <see cref="DarkModeViewModel"/>. <see cref="WindowsThemeService"/> is sealed
-/// with no interface, so it cannot be substituted; these drive the real service but stay on
-/// its read-only surface (<c>GetCurrentTheme</c> / <c>LoadSchedule</c>). The
-/// <c>SwitchToDark</c> / <c>SwitchToLight</c> commands and any schedule-enabling mutation call
-/// the real <c>SetTheme</c>, which writes HKCU and flips the actual Windows theme, so they are
-/// NOT executed here. The pure schedule predicate <c>WindowsThemeService.ShouldBeDark</c> is
-/// already covered by <see cref="WindowsThemeServiceTests"/> and is not duplicated.
+/// Tests for <see cref="DarkModeViewModel"/>. The deterministic-surface tests drive the
+/// real <see cref="WindowsThemeService"/> on its read-only surface (<c>GetCurrentTheme</c>
+/// / <c>LoadSchedule</c>); the mutating-path tests substitute
+/// <see cref="IWindowsThemeService"/> so the <c>SwitchToDark</c> / <c>SwitchToLight</c>
+/// commands and the schedule-enabling persistence can be executed (asserting
+/// <c>SetTheme</c> / <c>SaveSchedule</c> are called with the correct arguments) without
+/// writing HKCU or flipping the real Windows theme. The pure schedule predicate
+/// <c>WindowsThemeService.ShouldBeDark</c> is already covered by
+/// <see cref="WindowsThemeServiceTests"/> and is not duplicated.
 ///
 /// With no <c>Application.Current</c> in the test host, the constructor skips the
 /// DispatcherTimer/immediate-evaluate block, so building the VM does not apply the schedule.
@@ -22,6 +26,19 @@ namespace SysManager.Tests;
 public class DarkModeViewModelTests
 {
     private static DarkModeViewModel NewVm() => new(new WindowsThemeService());
+
+    private static DarkModeViewModel NewVm(IWindowsThemeService service) => new(service);
+
+    // A substitute that loads a known schedule (so LoadFromSchedule has a non-null result)
+    // and reports the Windows theme as light by default. SetTheme succeeds unless overridden.
+    private static IWindowsThemeService FakeThemeService(DarkModeSchedule? schedule = null)
+    {
+        var service = Substitute.For<IWindowsThemeService>();
+        service.LoadSchedule().Returns(schedule ?? new DarkModeSchedule { Enabled = false });
+        service.GetCurrentTheme().Returns(WindowsTheme.Light);
+        service.SetTheme(Arg.Any<bool>(), Arg.Any<bool>()).Returns(true);
+        return service;
+    }
 
     [Fact]
     public void Constructor_Succeeds_WithCommands()
@@ -65,5 +82,66 @@ public class DarkModeViewModelTests
         // LoadFromSchedule populates the dark/light start strings (defaults if no saved file).
         Assert.False(string.IsNullOrWhiteSpace(vm.DarkStart));
         Assert.False(string.IsNullOrWhiteSpace(vm.LightStart));
+    }
+
+    // ── Mutating-path tests (substituted IWindowsThemeService) ─────────────
+
+    [Fact]
+    public void SwitchToDark_CallsSetThemeTrueOnce_AndReflectsState()
+    {
+        var service = FakeThemeService();
+        var vm = NewVm(service);
+        vm.ApplyToSystem = true;
+
+        vm.SwitchToDarkCommand.Execute(null);
+
+        // SetTheme(dark: true, includeSystem from ApplyToSystem) is the mutating call.
+        service.Received(1).SetTheme(true, true);
+        Assert.True(vm.IsDarkNow);
+        Assert.Contains("dark", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SwitchToLight_CallsSetThemeFalseOnce_AndReflectsState()
+    {
+        var service = FakeThemeService();
+        var vm = NewVm(service);
+        vm.ApplyToSystem = false;
+
+        vm.SwitchToLightCommand.Execute(null);
+
+        service.Received(1).SetTheme(false, false);
+        Assert.False(vm.IsDarkNow);
+        Assert.Contains("light", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SwitchToDark_WhenServiceFails_SurfacesErrorAndLeavesStateUnchanged()
+    {
+        var service = FakeThemeService();
+        service.SetTheme(Arg.Any<bool>(), Arg.Any<bool>()).Returns(false); // registry write denied
+        var vm = NewVm(service);
+        Assert.False(vm.IsDarkNow); // seeded from GetCurrentTheme() == Light
+
+        vm.SwitchToDarkCommand.Execute(null);
+
+        service.Received(1).SetTheme(true, Arg.Any<bool>());
+        Assert.False(vm.IsDarkNow); // unchanged on failure
+        Assert.Contains("Couldn't", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void EnablingSchedule_PersistsViaSaveSchedule_WithEnabledTrue()
+    {
+        // Start from a disabled schedule so toggling ScheduleEnabled is a real change.
+        var service = FakeThemeService(new DarkModeSchedule { Enabled = false });
+        var vm = NewVm(service);
+        // Construction loads under _suppressSave, so no SaveSchedule yet.
+        service.DidNotReceive().SaveSchedule(Arg.Any<DarkModeSchedule>());
+
+        vm.ScheduleEnabled = true;
+
+        // OnScheduleEnabledChanged persists the new schedule with Enabled == true.
+        service.Received().SaveSchedule(Arg.Is<DarkModeSchedule>(s => s.Enabled));
     }
 }

--- a/SysManager/SysManager.Tests/FileLockViewModelTests.cs
+++ b/SysManager/SysManager.Tests/FileLockViewModelTests.cs
@@ -11,20 +11,22 @@ using SysManager.ViewModels;
 namespace SysManager.Tests;
 
 /// <summary>
-/// Tests for <see cref="FileLockViewModel"/>. <see cref="FileLockService"/> is sealed with
-/// no interface, so it cannot be substituted; these drive the real service. Its
-/// <c>FindLockers</c> is a read-only Restart Manager query (safe to run against a temp file),
-/// but <c>KillProcess</c> would terminate a real process, so the success path of
-/// <c>KillSelected</c> is NOT executed — only the confirmation-gated branches (critical-process
-/// block and user-declines) and CanExecute gating are covered.
+/// Tests for <see cref="FileLockViewModel"/>. The read-only / gating tests drive the real
+/// <see cref="FileLockService"/> (its <c>FindLockers</c> is a read-only Restart Manager
+/// query, safe against a temp file); the mutating-path test substitutes
+/// <see cref="IFileLockService"/> so the confirmed <c>KillSelected</c> success path can be
+/// executed (asserting <c>KillProcess</c> is called with the selected pid) without
+/// terminating a real process. The confirmation-gated branches (critical-process block,
+/// user-declines) and CanExecute gating are covered against the real service.
 ///
-/// Serialized because the critical-process and decline tests swap the global
-/// <see cref="DialogService.Instance"/> static.
+/// Serialized because several tests swap the global <see cref="DialogService.Instance"/> static.
 /// </summary>
 [Collection("DialogService")]
 public class FileLockViewModelTests
 {
     private static FileLockViewModel NewVm() => new(new FileLockService());
+
+    private static FileLockViewModel NewVm(IFileLockService service) => new(service);
 
     [Fact]
     public void Constructor_Succeeds_WithInitialState()
@@ -167,5 +169,44 @@ public class FileLockViewModelTests
         var vm = NewVm();
         var ex = Record.Exception(() => vm.RelaunchAsAdminCommand.Execute(null));
         Assert.Null(ex);
+    }
+
+    // ── Mutating-path test (substituted IFileLockService) ──────────────────
+
+    [Fact]
+    public async Task KillSelected_WhenConfirmed_CallsKillProcessWithPid_AndRescans()
+    {
+        // A non-critical locker, the user confirms, and the service reports a successful kill.
+        // The VM must call KillProcess(pid) exactly once, then trigger the re-scan via the
+        // substituted FindLockers (returning no lockers). No real process is touched.
+        const int pid = 4242;
+        var service = Substitute.For<IFileLockService>();
+        service.KillProcess(pid).Returns(true);
+        service.FindLockers(Arg.Any<string>()).Returns(new List<FileLocker>()); // post-kill re-scan
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true); // user clicks "Yes"
+        DialogService.Instance = dialog;
+        try
+        {
+            var vm = NewVm(service);
+            vm.Path = @"C:\some\locked\file.txt"; // CanScan needs a non-empty path for the re-scan
+            vm.SelectedLocker = new FileLocker(pid, "target.exe", "RmMainWindow", null);
+
+            vm.KillSelectedCommand.Execute(null);
+
+            service.Received(1).KillProcess(pid);
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+
+            // KillSelected fires ScanCommand.Execute (async) to refresh the locker list; await it.
+            await vm.ScanCommand.ExecuteAsync(null);
+            service.Received().FindLockers(Arg.Any<string>());
+            Assert.Empty(vm.Lockers);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
     }
 }

--- a/SysManager/SysManager.Tests/TimerResolutionViewModelTests.cs
+++ b/SysManager/SysManager.Tests/TimerResolutionViewModelTests.cs
@@ -2,18 +2,22 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using NSubstitute;
+using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
 
 namespace SysManager.Tests;
 
 /// <summary>
-/// Tests for <see cref="TimerResolutionViewModel"/>. <see cref="TimerResolutionService"/>
-/// is sealed with no interface, so it cannot be substituted; these drive the real service
-/// (its <c>Query</c> is a harmless read-only NT call) and exercise the deterministic
-/// surface only: construction, post-init state, and the mutually-exclusive Enable/Disable
-/// CanExecute gating. The Enable/Disable commands themselves issue a real
-/// <c>NtSetTimerResolution</c> against this process, so they are NOT executed here.
+/// Tests for <see cref="TimerResolutionViewModel"/>. Two layers of coverage:
+/// the deterministic-surface tests drive the real <see cref="TimerResolutionService"/>
+/// (its <c>Query</c> is a harmless read-only NT call) and assert construction, post-init
+/// state, and the mutually-exclusive Enable/Disable CanExecute gating; the
+/// mutating-path tests substitute <see cref="ITimerResolutionService"/> so the
+/// Enable/Disable commands can be exercised without issuing a real
+/// <c>NtSetTimerResolution</c> against this process — they assert the VM calls the
+/// service exactly once and reflects the returned <see cref="TimerResolutionStatus"/>.
 /// </summary>
 public class TimerResolutionViewModelTests
 {
@@ -23,6 +27,22 @@ public class TimerResolutionViewModelTests
     private static TimerResolutionViewModel NewVm()
     {
         var vm = new TimerResolutionViewModel(new TimerResolutionService());
+        vm.InitializationComplete.GetAwaiter().GetResult();
+        return vm;
+    }
+
+    // A supported, default-resolution status: finest 0.5 ms, coarsest ~15.6 ms, current at
+    // the coarse default → IsSupported, not high-res (so Enable is the available command).
+    private static TimerResolutionStatus DefaultStatus()
+        => new(FinestHundredNs: 5000, CoarsestHundredNs: 156250, CurrentHundredNs: 156250, EnabledByApp: false);
+
+    // A supported, high-resolution status: current is at the finest → IsHighResolution.
+    private static TimerResolutionStatus HighResStatus()
+        => new(FinestHundredNs: 5000, CoarsestHundredNs: 156250, CurrentHundredNs: 5000, EnabledByApp: true);
+
+    private static TimerResolutionViewModel NewVm(ITimerResolutionService service)
+    {
+        var vm = new TimerResolutionViewModel(service);
         vm.InitializationComplete.GetAwaiter().GetResult();
         return vm;
     }
@@ -101,5 +121,58 @@ public class TimerResolutionViewModelTests
         await vm.RefreshCommand.ExecuteAsync(null);
         Assert.False(string.IsNullOrWhiteSpace(vm.StatusMessage));
         Assert.False(vm.IsBusy);
+    }
+
+    // ── Mutating-path tests (substituted ITimerResolutionService) ──────────
+
+    [Fact]
+    public async Task EnableCommand_CallsServiceEnableOnce_AndReflectsHighResStatus()
+    {
+        var service = Substitute.For<ITimerResolutionService>();
+        // Construction's RefreshAsync sees the default (not high-res) state so Enable is gated on.
+        service.Query().Returns(DefaultStatus());
+        // The Enable command's outcome is the high-res status the service returns.
+        service.Enable().Returns(HighResStatus());
+
+        var vm = NewVm(service);
+        Assert.True(vm.IsSupported);
+        Assert.False(vm.IsHighResolution);
+        Assert.True(vm.EnableCommand.CanExecute(null));
+
+        await vm.EnableCommand.ExecuteAsync(null);
+
+        service.Received(1).Enable();
+        // The VM applied the returned status: it is now at high resolution.
+        Assert.True(vm.IsHighResolution);
+        Assert.Equal(HighResStatus().CurrentDisplay, vm.CurrentDisplay);
+        Assert.Contains("enabled", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        // Enable→Disable are mutually exclusive: after a successful enable, Disable is the gate.
+        Assert.False(vm.EnableCommand.CanExecute(null));
+        Assert.True(vm.DisableCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task DisableCommand_CallsServiceDisableOnce_AndReflectsDefaultStatus()
+    {
+        var service = Substitute.For<ITimerResolutionService>();
+        // Construction sees a high-res state so Disable is the gated-on command.
+        service.Query().Returns(HighResStatus());
+        // The Disable command returns the timer to the coarse default.
+        service.Disable().Returns(DefaultStatus());
+
+        var vm = NewVm(service);
+        Assert.True(vm.IsHighResolution);
+        Assert.True(vm.DisableCommand.CanExecute(null));
+
+        await vm.DisableCommand.ExecuteAsync(null);
+
+        service.Received(1).Disable();
+        // The VM applied the returned status: no longer high resolution.
+        Assert.False(vm.IsHighResolution);
+        Assert.Equal(DefaultStatus().CurrentDisplay, vm.CurrentDisplay);
+        Assert.Contains("default", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        // Mutually exclusive again: after disable, Enable is back on and Disable is off.
+        Assert.True(vm.EnableCommand.CanExecute(null));
+        Assert.False(vm.DisableCommand.CanExecute(null));
     }
 }

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -72,13 +72,13 @@ public static class ServiceRegistration
         services.AddSingleton<PrivacyMonitorService>();
         services.AddSingleton<BootAnalyzerService>();
         services.AddSingleton<WindowsUpdateService>();
-        services.AddSingleton<TimerResolutionService>();
-        services.AddSingleton<FileLockService>();
+        services.AddSingleton<ITimerResolutionService, TimerResolutionService>();
+        services.AddSingleton<IFileLockService, FileLockService>();
         services.AddSingleton<DisplayProfileService>();
-        services.AddSingleton<CpuAffinityService>();
+        services.AddSingleton<ICpuAffinityService, CpuAffinityService>();
         services.AddSingleton<DefenderService>();
         services.AddSingleton<TaskSchedulerService>();
-        services.AddSingleton<WindowsThemeService>();
+        services.AddSingleton<IWindowsThemeService, WindowsThemeService>();
         services.AddSingleton<StandbyMemoryService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────

--- a/SysManager/SysManager/Services/CpuAffinityService.cs
+++ b/SysManager/SysManager/Services/CpuAffinityService.cs
@@ -23,7 +23,7 @@ namespace SysManager.Services;
 /// API via classic <c>[DllImport]</c> (the returned buffer is a variable-length record
 /// stream walked by each record's Size — not something the source generator marshals).
 /// </summary>
-public sealed class CpuAffinityService
+public sealed class CpuAffinityService : ICpuAffinityService
 {
     /// <summary>Total logical processors as Windows schedules them.</summary>
     public int LogicalProcessorCount => Environment.ProcessorCount;

--- a/SysManager/SysManager/Services/FileLockService.cs
+++ b/SysManager/SysManager/Services/FileLockService.cs
@@ -25,7 +25,7 @@ namespace SysManager.Services;
 /// by the <c>[LibraryImport]</c> source generator (it emits SYSLIB1051). The Restart
 /// Manager functions have no A/W variants, so no <c>EntryPoint</c> suffix is needed.
 /// </summary>
-public sealed class FileLockService
+public sealed class FileLockService : IFileLockService
 {
     /// <summary>
     /// Returns the processes currently using <paramref name="path"/> (a file or folder).

--- a/SysManager/SysManager/Services/ICpuAffinityService.cs
+++ b/SysManager/SysManager/Services/ICpuAffinityService.cs
@@ -1,0 +1,43 @@
+// SysManager · ICpuAffinityService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Abstraction over <see cref="CpuAffinityService"/> — reads CPU topology and gets/sets
+/// per-process CPU affinity. Extracting this interface lets <c>CpuAffinityViewModel</c>'s
+/// mutating command paths (Apply / Restore) be unit-tested with a substituted service
+/// against a deterministic process+topology instead of touching a real process
+/// (Gate-ARCH: system-mutating services are testable).
+///
+/// <para>Only the instance members are abstracted; the pure bitmask helpers
+/// (<c>AllCoresMask</c> / <c>MaskFromIndices</c> / <c>IsCoreInMask</c>) remain static
+/// on <see cref="CpuAffinityService"/>.</para>
+/// </summary>
+public interface ICpuAffinityService
+{
+    /// <summary>Total logical processors as Windows schedules them.</summary>
+    int LogicalProcessorCount { get; }
+
+    /// <summary>
+    /// Enumerate each logical CPU with its hybrid classification. Returns a plain
+    /// 0..N-1 "Standard" list if the topology API is unavailable or fails.
+    /// </summary>
+    IReadOnlyList<CpuCore> GetCores();
+
+    /// <summary>List running processes with their current affinity mask (0 if unreadable).</summary>
+    IReadOnlyList<RunningProcess> GetProcesses();
+
+    /// <summary>Read the current affinity mask for a process, or null if unavailable.</summary>
+    long? GetAffinity(int processId);
+
+    /// <summary>
+    /// Apply an affinity mask to a process. Returns true on success; on failure sets
+    /// <paramref name="error"/>. A mask of 0 is rejected (Windows treats it as
+    /// "OS decides", which is not what an explicit selection means).
+    /// </summary>
+    bool TrySetAffinity(int processId, long mask, out string error);
+}

--- a/SysManager/SysManager/Services/IFileLockService.cs
+++ b/SysManager/SysManager/Services/IFileLockService.cs
@@ -1,0 +1,30 @@
+// SysManager · IFileLockService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Abstraction over <see cref="FileLockService"/> — identifies which processes are
+/// holding a lock on a file/folder via the Windows Restart Manager, and terminates a
+/// locker. Extracting this interface lets <c>FileLockViewModel</c>'s mutating command
+/// path (KillSelected) be unit-tested with a substituted service instead of terminating
+/// a real process (Gate-ARCH: system-mutating services are testable).
+/// </summary>
+public interface IFileLockService
+{
+    /// <summary>
+    /// Returns the processes currently using <paramref name="path"/> (a file or folder).
+    /// Empty when nothing holds it. Throws <see cref="ArgumentException"/> for bad input.
+    /// </summary>
+    IReadOnlyList<FileLocker> FindLockers(string path);
+
+    /// <summary>
+    /// Terminates the process with the given id. Returns true on success. Returns false
+    /// (and logs) if the process is gone, access is denied (needs elevation), or it exits
+    /// on its own. Callers must confirm with the user first.
+    /// </summary>
+    bool KillProcess(int processId);
+}

--- a/SysManager/SysManager/Services/ITimerResolutionService.cs
+++ b/SysManager/SysManager/Services/ITimerResolutionService.cs
@@ -1,0 +1,33 @@
+// SysManager · ITimerResolutionService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Abstraction over <see cref="TimerResolutionService"/> — controls the Windows
+/// multimedia timer resolution. Extracting this interface lets
+/// <c>TimerResolutionViewModel</c>'s mutating command paths (Enable / Disable) be
+/// unit-tested with a substituted service instead of issuing real
+/// <c>NtSetTimerResolution</c> calls against the host process (Gate-ARCH:
+/// system-mutating services are testable).
+/// </summary>
+public interface ITimerResolutionService
+{
+    /// <summary>Read the achievable range and the resolution currently in effect.</summary>
+    TimerResolutionStatus Query();
+
+    /// <summary>
+    /// Request the finest achievable timer resolution (clamped to the device's
+    /// reported minimum). Returns the status after re-querying the effective value.
+    /// </summary>
+    TimerResolutionStatus Enable();
+
+    /// <summary>
+    /// Release this process's timer-resolution request, returning the timer toward the
+    /// system default. Returns the status after re-querying the effective value.
+    /// </summary>
+    TimerResolutionStatus Disable();
+}

--- a/SysManager/SysManager/Services/IWindowsThemeService.cs
+++ b/SysManager/SysManager/Services/IWindowsThemeService.cs
@@ -1,0 +1,37 @@
+// SysManager · IWindowsThemeService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Abstraction over <see cref="WindowsThemeService"/> — switches the per-user Windows
+/// light/dark theme and loads/saves the dark-mode schedule. Extracting this interface
+/// lets <c>DarkModeViewModel</c>'s mutating command paths (SwitchToDark / SwitchToLight
+/// and schedule persistence) be unit-tested with a substituted service instead of
+/// writing HKCU and flipping the real Windows theme (Gate-ARCH: system-mutating
+/// services are testable).
+///
+/// <para>Only the instance members are abstracted; the pure
+/// <see cref="WindowsThemeService.ShouldBeDark"/> schedule predicate remains static on
+/// the concrete class.</para>
+/// </summary>
+public interface IWindowsThemeService
+{
+    /// <summary>Read the current Windows app theme (absent value = Light, the OS default).</summary>
+    WindowsTheme GetCurrentTheme();
+
+    /// <summary>
+    /// Set the Windows theme. When <paramref name="includeSystem"/>, also flips the
+    /// taskbar/Start. Returns false if the registry write was denied.
+    /// </summary>
+    bool SetTheme(bool dark, bool includeSystem);
+
+    /// <summary>Load the saved schedule, or defaults if none exists / it's unreadable.</summary>
+    DarkModeSchedule LoadSchedule();
+
+    /// <summary>Persist the schedule as indented JSON in the app's roaming AppData folder.</summary>
+    void SaveSchedule(DarkModeSchedule schedule);
+}

--- a/SysManager/SysManager/Services/TimerResolutionService.cs
+++ b/SysManager/SysManager/Services/TimerResolutionService.cs
@@ -23,7 +23,7 @@ namespace SysManager.Services;
 /// We therefore always re-query the EFFECTIVE resolution after a set rather than
 /// trusting the requested value.
 /// </summary>
-public sealed partial class TimerResolutionService
+public sealed partial class TimerResolutionService : ITimerResolutionService
 {
     private bool _enabledByApp;
 

--- a/SysManager/SysManager/Services/WindowsThemeService.cs
+++ b/SysManager/SysManager/Services/WindowsThemeService.cs
@@ -26,7 +26,7 @@ public enum WindowsTheme { Light, Dark }
 ///
 /// Fully reversible: writing the opposite DWORD restores the previous theme.
 /// </summary>
-public sealed partial class WindowsThemeService
+public sealed partial class WindowsThemeService : IWindowsThemeService
 {
     private const string PersonalizeKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize";
     private const string AppsValue = "AppsUseLightTheme";

--- a/SysManager/SysManager/ViewModels/CpuAffinityViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CpuAffinityViewModel.cs
@@ -29,7 +29,7 @@ public sealed partial class CoreToggle : ObservableObject
 /// </summary>
 public sealed partial class CpuAffinityViewModel : ViewModelBase
 {
-    private readonly CpuAffinityService _service;
+    private readonly ICpuAffinityService _service;
     private long _originalMask;
     private bool _hasOriginal;
 
@@ -39,7 +39,7 @@ public sealed partial class CpuAffinityViewModel : ViewModelBase
     [ObservableProperty] private RunningProcess? _selectedProcess;
     [ObservableProperty] private bool _isHybrid;
 
-    public CpuAffinityViewModel(CpuAffinityService service)
+    public CpuAffinityViewModel(ICpuAffinityService service)
     {
         _service = service;
         StatusMessage = "Reading CPU topology…";

--- a/SysManager/SysManager/ViewModels/DarkModeViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DarkModeViewModel.cs
@@ -18,7 +18,7 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class DarkModeViewModel : ViewModelBase
 {
-    private readonly WindowsThemeService _service;
+    private readonly IWindowsThemeService _service;
     private readonly DispatcherTimer? _timer;
     private bool _suppressSave;
 
@@ -28,7 +28,7 @@ public sealed partial class DarkModeViewModel : ViewModelBase
     [ObservableProperty] private string _lightStart = "07:00";
     [ObservableProperty] private bool _applyToSystem = true;
 
-    public DarkModeViewModel(WindowsThemeService service)
+    public DarkModeViewModel(IWindowsThemeService service)
     {
         _service = service;
         LoadFromSchedule();

--- a/SysManager/SysManager/ViewModels/FileLockViewModel.cs
+++ b/SysManager/SysManager/ViewModels/FileLockViewModel.cs
@@ -19,7 +19,7 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class FileLockViewModel : ViewModelBase
 {
-    private readonly FileLockService _service;
+    private readonly IFileLockService _service;
 
     public BulkObservableCollection<FileLocker> Lockers { get; } = new();
 
@@ -28,7 +28,7 @@ public sealed partial class FileLockViewModel : ViewModelBase
     [ObservableProperty] private bool _hasScanned;
     [ObservableProperty] private FileLocker? _selectedLocker;
 
-    public FileLockViewModel(FileLockService service)
+    public FileLockViewModel(IFileLockService service)
     {
         _service = service;
         IsElevated = AdminHelper.IsElevated();

--- a/SysManager/SysManager/ViewModels/TimerResolutionViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TimerResolutionViewModel.cs
@@ -17,7 +17,7 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class TimerResolutionViewModel : ViewModelBase
 {
-    private readonly TimerResolutionService _service;
+    private readonly ITimerResolutionService _service;
 
     [ObservableProperty] private string _currentDisplay = "—";
     [ObservableProperty] private string _finestDisplay = "—";
@@ -25,7 +25,7 @@ public sealed partial class TimerResolutionViewModel : ViewModelBase
     [ObservableProperty] private bool _isHighResolution;
     [ObservableProperty] private bool _isSupported = true;
 
-    public TimerResolutionViewModel(TimerResolutionService service)
+    public TimerResolutionViewModel(ITimerResolutionService service)
     {
         _service = service;
         StatusMessage = "Reading timer resolution…";


### PR DESCRIPTION
Adds testability seams (ITimerResolutionService / ICpuAffinityService / IFileLockService / IWindowsThemeService) over the existing sealed preview-feature services — interface only, no method-body changes — and retargets the four ViewModels + DI to the interfaces. Non-breaking (nothing resolves the concrete types directly).

Unlocks fake-verified tests for the previously-untestable MUTATING command paths:
- CpuAffinity Apply → TrySetAffinity with the exact computed mask; Restore → captured original mask; failure surfaces the error.
- TimerResolution Enable/Disable → called once, status reflected.
- FileLock KillSelected (confirmed) → KillProcess(pid) + re-scan.
- DarkMode SwitchToDark/Light → SetTheme(true/false); enabling schedule → SaveSchedule.

Part of preview-feature graduation (step: test the mutating paths). No version bump. Required build+unit-test gate applies; the OS-effect of the mutating calls will be verified live before any preview tag is removed.