### PR TITLE
feat: add a shared empty-state placeholder and use it across all tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.45.0] - 2026-06-29
+
+### Changed
+- **Consistent "empty list" messages across every tab.** Lists and tables that can start empty — App Updates, App Blocker, App Alerts, Shortcut Cleaner, File Shredder, Duplicate Finder, Context Menu, Task Scheduler, Display Profiles, Boot Analyzer, Defender exclusions and the live output console — now show the same centred placeholder (an icon, a short title and a one-line hint on how to populate the list) instead of a blank area or nothing at all. The handful of tabs that already had a placeholder (Debloater, Restore Points, Camera/Mic/Location, Browser Cleaner, System Logs, System Report) were moved onto the same shared component so the look can't drift between tabs again. A 📂 emoji in the Disk Analyzer and a shield emoji in Process Manager were also swapped for the proper icon font. Purely visual — no behaviour changes.
+
 ## [1.44.1] - 2026-06-28
 
 ### Changed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.44.1</Version>
-    <FileVersion>1.44.1.0</FileVersion>
-    <AssemblyVersion>1.44.1.0</AssemblyVersion>
+    <Version>1.45.0</Version>
+    <FileVersion>1.45.0.0</FileVersion>
+    <AssemblyVersion>1.45.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AppAlertsView.xaml
+++ b/SysManager/SysManager/Views/AppAlertsView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:AppAlertsViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -53,6 +54,7 @@
 
         <!-- Alerts list -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
+            <Grid>
             <DataGrid AutomationProperties.Name="App installation alerts"
                       ItemsSource="{Binding Alerts}"
                       AutoGenerateColumns="False" IsReadOnly="True"
@@ -117,6 +119,13 @@
                     </DataGridTextColumn>
                 </DataGrid.Columns>
             </DataGrid>
+
+            <!-- Empty state -->
+            <v:EmptyState Glyph="&#xEC05;"
+                          Title="No installations detected yet"
+                          Message="New application installs will appear here as they happen."
+                          Visibility="{Binding Alerts.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+            </Grid>
         </Border>
 
         <!-- Status bar -->

--- a/SysManager/SysManager/Views/AppBlockerView.xaml
+++ b/SysManager/SysManager/Views/AppBlockerView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:AppBlockerViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -91,6 +92,12 @@
                 <DataGridTextColumn Header="Executable" Binding="{Binding ExecutableName}" Width="*" MinWidth="120" IsReadOnly="True" />
             </DataGrid.Columns>
         </DataGrid>
+
+        <!-- Empty state -->
+        <v:EmptyState Grid.Row="4" Glyph="&#xE730;"
+                      Title="No blocked applications"
+                      Message="Block an app above to stop it from launching."
+                      Visibility="{Binding BlockedApps.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
 
         <!-- Footer -->
         <StackPanel Grid.Row="5" Orientation="Horizontal" Margin="0,8,0,0">

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml
@@ -62,6 +62,7 @@
         </Border>
 
         <Border Grid.Row="3" Style="{StaticResource Card}" Margin="28,16,28,0" Padding="0">
+            <Grid>
             <DataGrid AutomationProperties.Name="Upgradable packages" ItemsSource="{Binding Packages}"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
                       GridLinesVisibility="None" CanUserAddRows="False"
@@ -95,6 +96,13 @@
                     <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="*" MinWidth="80" SortMemberPath="Status"/>
                 </DataGrid.Columns>
             </DataGrid>
+
+            <!-- Empty state -->
+            <v:EmptyState Glyph="&#xE896;"
+                          Title="No updates available"
+                          Message="All detected packages are up to date. Run a check to refresh."
+                          Visibility="{Binding Packages.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+            </Grid>
         </Border>
 
         <Border Grid.Row="4" Style="{StaticResource Card}" Margin="28,16,28,0" Padding="0">

--- a/SysManager/SysManager/Views/BootAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/BootAnalyzerView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:BootAnalyzerViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -74,6 +75,7 @@
             <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0" Margin="0,0,6,0">
                 <DockPanel>
                     <TextBlock DockPanel.Dock="Top" Text="Boot history" Style="{StaticResource SectionTitle}" Margin="14,12,14,0"/>
+                    <Grid>
                     <DataGrid ItemsSource="{Binding Boots}" Margin="0,8,0,0"
                               AutomationProperties.Name="Boot history"
                               AutoGenerateColumns="False" HeadersVisibility="Column"
@@ -85,12 +87,20 @@
                             <DataGridTextColumn Header="Boot time" Binding="{Binding BootSecondsDisplay}" Width="100"/>
                         </DataGrid.Columns>
                     </DataGrid>
+
+                    <!-- Empty state -->
+                    <v:EmptyState Glyph="&#xE946;"
+                                  Title="No boot records"
+                                  Message="Boot history needs administrator to read."
+                                  Visibility="{Binding Boots.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                    </Grid>
                 </DockPanel>
             </Border>
 
             <Border Grid.Column="1" Style="{StaticResource Card}" Padding="0" Margin="6,0,0,0">
                 <DockPanel>
                     <TextBlock DockPanel.Dock="Top" Text="Slowed boot" Style="{StaticResource SectionTitle}" Margin="14,12,14,0"/>
+                    <Grid>
                     <DataGrid ItemsSource="{Binding Degradations}" Margin="0,8,0,0"
                               AutomationProperties.Name="Components that slowed boot"
                               AutoGenerateColumns="False" HeadersVisibility="Column"
@@ -103,6 +113,13 @@
                             <DataGridTextColumn Header="Delay" Binding="{Binding DurationDisplay}" Width="80"/>
                         </DataGrid.Columns>
                     </DataGrid>
+
+                    <!-- Empty state -->
+                    <v:EmptyState Glyph="&#xE946;"
+                                  Title="Nothing slowed boot"
+                                  Message="No components were flagged as delaying startup."
+                                  Visibility="{Binding Degradations.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                    </Grid>
                 </DockPanel>
             </Border>
         </Grid>

--- a/SysManager/SysManager/Views/BrowserCleanerView.xaml
+++ b/SysManager/SysManager/Views/BrowserCleanerView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:BrowserCleanerViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -78,7 +79,7 @@
                                                 <TextBlock Text="signs you out" FontSize="10" Foreground="{DynamicResource WarningStripe}"/>
                                             </Border>
                                         </StackPanel>
-                                        <TextBlock Text="{Binding Description}" FontSize="11" Foreground="{DynamicResource TextMuted}"
+                                        <TextBlock Text="{Binding Description}" Style="{StaticResource Caption}"
                                                    TextWrapping="Wrap" Margin="0,2,16,0"/>
                                     </StackPanel>
                                 </DataTemplate>
@@ -89,15 +90,10 @@
                 </DataGrid>
 
                 <!-- Empty state -->
-                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center"
-                            Visibility="{Binding HasItems, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-                    <TextBlock Text="&#xE774;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="32"
-                               HorizontalAlignment="Center" Margin="0,0,0,8" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="No browser data found" FontSize="14" FontWeight="SemiBold"
-                               Foreground="{DynamicResource TextSecondary}" HorizontalAlignment="Center"/>
-                    <TextBlock Text="Press Scan to look for cleanable cache, history, and cookies."
-                               Style="{StaticResource Subtle}" HorizontalAlignment="Center" Margin="0,4,0,0"/>
-                </StackPanel>
+                <v:EmptyState Glyph="&#xE774;"
+                              Title="No browser data found"
+                              Message="Press Scan to look for cleanable cache, history, and cookies."
+                              Visibility="{Binding HasItems, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
             </Grid>
         </Border>
 

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -91,8 +91,7 @@
         <!-- Custom winget search -->
         <Border Grid.Row="3" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
             <StackPanel>
-                <TextBlock Text="Search winget packages" FontWeight="SemiBold" FontSize="14"
-                           Foreground="{DynamicResource TextPrimary}"/>
+                <TextBlock Text="Search winget packages" Style="{StaticResource SectionTitle}"/>
                 <TextBlock Text="Find and install any app available on winget."
                            Style="{StaticResource Subtle}" Margin="0,2,0,12"/>
                 <DockPanel>

--- a/SysManager/SysManager/Views/ConsoleView.xaml
+++ b/SysManager/SysManager/Views/ConsoleView.xaml
@@ -1,7 +1,8 @@
 <!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.ConsoleView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views">
     <!-- Card style for uniform surface/border/radius; Padding kept at 0 because the
          toolbar and output list manage their own spacing. -->
     <Border Style="{StaticResource Card}" Padding="0">
@@ -52,6 +53,12 @@
                     </DataTemplate>
                 </ListBox.ItemTemplate>
             </ListBox>
+
+            <!-- Empty state -->
+            <v:EmptyState Grid.Row="1" Glyph="&#xE946;"
+                          Title="No output yet"
+                          Message="Output from running operations will stream here."
+                          Visibility="{Binding Lines.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
         </Grid>
     </Border>
 </UserControl>

--- a/SysManager/SysManager/Views/ContextMenuView.xaml
+++ b/SysManager/SysManager/Views/ContextMenuView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:ContextMenuViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -177,6 +178,7 @@
 
         <!-- Context menu entries list -->
         <Border Grid.Row="4" Style="{StaticResource Card}" Padding="0">
+            <Grid>
             <DataGrid AutomationProperties.Name="Context menu entries"
                       ItemsSource="{Binding Entries}"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
@@ -249,6 +251,13 @@
                     </DataGridTextColumn>
                 </DataGrid.Columns>
             </DataGrid>
+
+            <!-- Empty state -->
+            <v:EmptyState Glyph="&#xE946;"
+                          Title="No context menu entries"
+                          Message="Run a scan to list right-click menu entries you can toggle."
+                          Visibility="{Binding Entries.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+            </Grid>
         </Border>
 
         <!-- Status bar -->

--- a/SysManager/SysManager/Views/DebloaterView.xaml
+++ b/SysManager/SysManager/Views/DebloaterView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:DebloaterViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -109,15 +110,10 @@
                 </DataGrid>
 
                 <!-- Empty state -->
-                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center"
-                            Visibility="{Binding HasApps, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-                    <TextBlock Text="&#xECAA;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="32"
-                               HorizontalAlignment="Center" Margin="0,0,0,8" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="No apps loaded" FontSize="14" FontWeight="SemiBold"
-                               Foreground="{DynamicResource TextSecondary}" HorizontalAlignment="Center"/>
-                    <TextBlock Text="Press Refresh to scan installed Store apps."
-                               Style="{StaticResource Subtle}" HorizontalAlignment="Center" Margin="0,4,0,0"/>
-                </StackPanel>
+                <v:EmptyState Glyph="&#xECAA;"
+                              Title="No apps loaded"
+                              Message="Press Refresh to scan installed Store apps."
+                              Visibility="{Binding HasApps, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
             </Grid>
         </Border>
 

--- a/SysManager/SysManager/Views/DefenderView.xaml
+++ b/SysManager/SysManager/Views/DefenderView.xaml
@@ -138,10 +138,18 @@
                             Style="{StaticResource DangerButton}" Padding="12,6"
                             AutomationProperties.Name="Remove the selected exclusion"/>
                 </Grid>
-                <ListBox ItemsSource="{Binding ExclusionPaths}" SelectedItem="{Binding SelectedExclusion}"
-                         Background="Transparent" BorderThickness="0" Margin="6,0,6,6"
-                         AutomationProperties.Name="Exclusion folders"
-                         ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+                <Grid>
+                    <ListBox ItemsSource="{Binding ExclusionPaths}" SelectedItem="{Binding SelectedExclusion}"
+                             Background="Transparent" BorderThickness="0" Margin="6,0,6,6"
+                             AutomationProperties.Name="Exclusion folders"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+
+                    <!-- Empty state -->
+                    <v:EmptyState Glyph="&#xE730;"
+                                  Title="No exclusion folders"
+                                  Message="Add a folder above to exclude it from Defender scans."
+                                  Visibility="{Binding ExclusionPaths.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                </Grid>
             </DockPanel>
         </Border>
 

--- a/SysManager/SysManager/Views/DiskAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/DiskAnalyzerView.xaml
@@ -136,7 +136,7 @@
                                        HorizontalAlignment="Right"/>
 
                             <!-- Open in Explorer -->
-                            <Button Grid.Column="4" Content="📂" ToolTip="Show in Explorer"
+                            <Button Grid.Column="4" Content="&#xE838;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" ToolTip="Show in Explorer"
                                     AutomationProperties.Name="{Binding Name, StringFormat='Show {0} in Explorer'}"
                                     Command="{Binding DataContext.ShowInExplorerCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
                                     CommandParameter="{Binding}"

--- a/SysManager/SysManager/Views/DisplayProfileView.xaml
+++ b/SysManager/SysManager/Views/DisplayProfileView.xaml
@@ -76,6 +76,7 @@
 
         <!-- Modes grid -->
         <Border Grid.Row="4" Style="{StaticResource Card}" Padding="0">
+            <Grid>
             <DataGrid ItemsSource="{Binding Modes}" SelectedItem="{Binding SelectedMode}"
                       AutomationProperties.Name="Supported display modes"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
@@ -87,6 +88,13 @@
                     <DataGridTextColumn Header="Refresh rate" Binding="{Binding RefreshDisplay}" Width="160"/>
                 </DataGrid.Columns>
             </DataGrid>
+
+            <!-- Empty state -->
+            <v:EmptyState Glyph="&#xE946;"
+                          Title="No display modes found"
+                          Message="No supported resolutions were reported for this display."
+                          Visibility="{Binding Modes.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+            </Grid>
         </Border>
 
         <!-- Actions + status -->

--- a/SysManager/SysManager/Views/DuplicateFileView.xaml
+++ b/SysManager/SysManager/Views/DuplicateFileView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:DuplicateFileViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -60,6 +61,7 @@
 
         <!-- Results: grouped list (virtualized for performance) -->
         <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
+            <Grid>
             <ListView AutomationProperties.Name="Duplicate file groups"
                       ItemsSource="{Binding Groups}"
                       Background="Transparent" BorderThickness="0"
@@ -133,6 +135,13 @@
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>
+
+            <!-- Empty state -->
+            <v:EmptyState Glyph="&#xE946;"
+                          Title="No duplicates found"
+                          Message="Pick a folder and scan to find files with identical content."
+                          Visibility="{Binding Groups.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+            </Grid>
         </Border>
 
         <!-- Status bar -->

--- a/SysManager/SysManager/Views/EmptyState.xaml
+++ b/SysManager/SysManager/Views/EmptyState.xaml
@@ -1,0 +1,34 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.EmptyState"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Name="Root">
+
+    <!-- Reusable empty-state placeholder for any list/grid that can be empty.
+         Single source of truth for the "icon + title + message" idiom so the
+         look can never drift between views. Drop it as a sibling of the
+         collection control inside a Grid and bind its Visibility to the
+         collection's emptiness, e.g.:
+           <Grid>
+             <DataGrid ItemsSource="{Binding Items}"/>
+             <v:EmptyState Glyph="&#xE777;" Title="No items" Message="Run a scan to check."
+                           Visibility="{Binding Items.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+           </Grid>
+         Glyph is optional — omit it for a title/message-only state. -->
+    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Margin="24">
+        <TextBlock Text="{Binding Glyph, ElementName=Root}"
+                   FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="32"
+                   HorizontalAlignment="Center" Margin="0,0,0,8"
+                   Foreground="{DynamicResource TextSecondary}"
+                   Visibility="{Binding Glyph, ElementName=Root, Converter={StaticResource FlexVis}}"/>
+        <TextBlock Text="{Binding Title, ElementName=Root}"
+                   FontSize="14" FontWeight="SemiBold"
+                   Foreground="{DynamicResource TextSecondary}"
+                   HorizontalAlignment="Center" TextAlignment="Center" TextWrapping="Wrap" MaxWidth="420"/>
+        <TextBlock Text="{Binding Message, ElementName=Root}"
+                   Style="{StaticResource Subtle}"
+                   HorizontalAlignment="Center" TextAlignment="Center" TextWrapping="Wrap" MaxWidth="420"
+                   Margin="0,4,0,0"
+                   Visibility="{Binding Message, ElementName=Root, Converter={StaticResource FlexVis}}"/>
+    </StackPanel>
+</UserControl>

--- a/SysManager/SysManager/Views/EmptyState.xaml.cs
+++ b/SysManager/SysManager/Views/EmptyState.xaml.cs
@@ -1,0 +1,50 @@
+// SysManager · EmptyState
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows;
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+/// <summary>
+/// Reusable empty-state placeholder (icon + title + message) for any list or
+/// grid that can be empty. Centralizes the idiom so its look can never drift
+/// between views. Place it as a sibling of the collection control inside a
+/// <see cref="Grid"/> and bind <see cref="UIElement.Visibility"/> to the
+/// collection's emptiness via the FlexVis converter with ConverterParameter=Inverse.
+/// </summary>
+public partial class EmptyState : UserControl
+{
+    public EmptyState() => InitializeComponent();
+
+    /// <summary>Optional Segoe Fluent Icons glyph shown above the title. Omit for a text-only state.</summary>
+    public static readonly DependencyProperty GlyphProperty =
+        DependencyProperty.Register(nameof(Glyph), typeof(string), typeof(EmptyState), new PropertyMetadata(string.Empty));
+
+    /// <summary>Primary line — what the empty list means (e.g. "No broken shortcuts found").</summary>
+    public static readonly DependencyProperty TitleProperty =
+        DependencyProperty.Register(nameof(Title), typeof(string), typeof(EmptyState), new PropertyMetadata(string.Empty));
+
+    /// <summary>Optional secondary line — how to populate the list (e.g. "Run a scan to check").</summary>
+    public static readonly DependencyProperty MessageProperty =
+        DependencyProperty.Register(nameof(Message), typeof(string), typeof(EmptyState), new PropertyMetadata(string.Empty));
+
+    public string Glyph
+    {
+        get => (string)GetValue(GlyphProperty);
+        set => SetValue(GlyphProperty, value);
+    }
+
+    public string Title
+    {
+        get => (string)GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
+    }
+
+    public string Message
+    {
+        get => (string)GetValue(MessageProperty);
+        set => SetValue(MessageProperty, value);
+    }
+}

--- a/SysManager/SysManager/Views/FileShredderView.xaml
+++ b/SysManager/SysManager/Views/FileShredderView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              xmlns:svc="clr-namespace:SysManager.Services"
              d:DataContext="{d:DesignInstance vm:FileShredderViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -103,6 +104,12 @@
                 </DataGridTemplateColumn>
             </DataGrid.Columns>
         </DataGrid>
+
+        <!-- Empty state -->
+        <v:EmptyState Grid.Row="2" Glyph="&#xE7BA;"
+                      Title="No files queued"
+                      Message="Add files above to securely erase them beyond recovery."
+                      Visibility="{Binding Items.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
 
         <!-- Footer -->
         <Border Grid.Row="3" Margin="28,8,28,16" Padding="8">

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -1,7 +1,8 @@
 <!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.LogsView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views">
     <UserControl.Resources>
         <Style x:Key="SevDot" TargetType="Ellipse">
             <Setter Property="Width" Value="8"/>
@@ -283,14 +284,10 @@
                 </DataGrid>
 
                     <!-- No-results overlay -->
-                    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center"
-                                Visibility="{Binding HasNoResults, Converter={StaticResource FlexVis}}">
-                        <TextBlock Text="&#xE721;" FontFamily="Segoe MDL2 Assets" FontSize="32" HorizontalAlignment="Center" Margin="0,0,0,8"/>
-                        <TextBlock Text="No events match your filters" FontSize="14" FontWeight="SemiBold"
-                                   Foreground="{DynamicResource TextSecondary}" HorizontalAlignment="Center"/>
-                        <TextBlock Text="Try adjusting severity checkboxes or clearing the search"
-                                   Style="{StaticResource Subtle}" HorizontalAlignment="Center" Margin="0,4,0,0"/>
-                    </StackPanel>
+                    <v:EmptyState Glyph="&#xE721;"
+                                  Title="No events match your filters"
+                                  Message="Try adjusting severity checkboxes or clearing the search."
+                                  Visibility="{Binding HasNoResults, Converter={StaticResource FlexVis}}"/>
                 </Grid>
             </Border>
 

--- a/SysManager/SysManager/Views/PrivacyMonitorView.xaml
+++ b/SysManager/SysManager/Views/PrivacyMonitorView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:PrivacyMonitorViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -56,15 +57,10 @@
                 </DataGrid>
 
                 <!-- Empty state -->
-                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center"
-                            Visibility="{Binding HasEntries, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-                    <TextBlock Text="&#xE730;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="32"
-                               HorizontalAlignment="Center" Margin="0,0,0,8" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="No access recorded" FontSize="14" FontWeight="SemiBold"
-                               Foreground="{DynamicResource TextSecondary}" HorizontalAlignment="Center"/>
-                    <TextBlock Text="Windows hasn't logged any camera, microphone, or location access yet."
-                               Style="{StaticResource Subtle}" HorizontalAlignment="Center" Margin="0,4,0,0"/>
-                </StackPanel>
+                <v:EmptyState Glyph="&#xE730;"
+                              Title="No access recorded"
+                              Message="Windows hasn't logged any camera, microphone, or location access yet."
+                              Visibility="{Binding HasEntries, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
             </Grid>
         </Border>
 

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -51,7 +51,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center" Foreground="{DynamicResource WarningText}"/>
                     <TextBlock Text="Running as administrator — you can end any process."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/RestorePointsView.xaml
+++ b/SysManager/SysManager/Views/RestorePointsView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:RestorePointsViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -105,15 +106,10 @@
                 </DataGrid>
 
                 <!-- Empty state -->
-                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center"
-                            Visibility="{Binding HasPoints, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-                    <TextBlock Text="&#xE777;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="32"
-                               HorizontalAlignment="Center" Margin="0,0,0,8" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="No restore points" FontSize="14" FontWeight="SemiBold"
-                               Foreground="{DynamicResource TextSecondary}" HorizontalAlignment="Center"/>
-                    <TextBlock Text="Create one above, or enable System Restore in Windows if the list stays empty."
-                               Style="{StaticResource Subtle}" HorizontalAlignment="Center" Margin="0,4,0,0"/>
-                </StackPanel>
+                <v:EmptyState Glyph="&#xE777;"
+                              Title="No restore points"
+                              Message="Create one above, or enable System Restore in Windows if the list stays empty."
+                              Visibility="{Binding HasPoints, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
             </Grid>
         </Border>
 

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:ShortcutCleanerViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -112,6 +113,12 @@
                 <DataGridTextColumn Header="Target (missing)" Binding="{Binding TargetPath}" Width="*" MinWidth="120" IsReadOnly="True"/>
             </DataGrid.Columns>
         </DataGrid>
+
+        <!-- Empty state -->
+        <v:EmptyState Grid.Row="3" Glyph="&#xE74D;"
+                      Title="No broken shortcuts found"
+                      Message="Run a scan to find shortcuts pointing at missing targets."
+                      Visibility="{Binding BrokenShortcuts.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
 
         <!-- Footer -->
         <Border Grid.Row="4" Margin="28,8,28,16" Padding="8">

--- a/SysManager/SysManager/Views/SystemReportView.xaml
+++ b/SysManager/SysManager/Views/SystemReportView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:SystemReportViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -69,16 +70,10 @@
                 </ScrollViewer>
 
                 <!-- Empty state -->
-                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center"
-                            Visibility="{Binding HasReport, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-                    <TextBlock Text="&#xE9D9;" FontFamily="Segoe MDL2 Assets" FontSize="32"
-                               HorizontalAlignment="Center" Margin="0,0,0,8"
-                               Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="No report yet" FontSize="14" FontWeight="SemiBold"
-                               Foreground="{DynamicResource TextSecondary}" HorizontalAlignment="Center"/>
-                    <TextBlock Text="Click Generate to build a full system snapshot."
-                               Style="{StaticResource Subtle}" HorizontalAlignment="Center" Margin="0,4,0,0"/>
-                </StackPanel>
+                <v:EmptyState Glyph="&#xE9D9;"
+                              Title="No report yet"
+                              Message="Click Generate to build a full system snapshot."
+                              Visibility="{Binding HasReport, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
             </Grid>
         </Border>
 

--- a/SysManager/SysManager/Views/TaskSchedulerView.xaml
+++ b/SysManager/SysManager/Views/TaskSchedulerView.xaml
@@ -83,6 +83,7 @@
 
         <!-- Tasks grid -->
         <Border Grid.Row="4" Style="{StaticResource Card}" Padding="0">
+            <Grid>
             <DataGrid ItemsSource="{Binding Tasks}" SelectedItem="{Binding SelectedTask}"
                       AutomationProperties.Name="Scheduled tasks"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
@@ -97,6 +98,13 @@
                     <DataGridTextColumn Header="Last run" Binding="{Binding LastRunDisplay}" Width="140"/>
                 </DataGrid.Columns>
             </DataGrid>
+
+            <!-- Empty state -->
+            <v:EmptyState Glyph="&#xE946;"
+                          Title="No scheduled tasks found"
+                          Message="Run a scan to list Windows scheduled tasks you can manage."
+                          Visibility="{Binding Tasks.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+            </Grid>
         </Border>
 
         <!-- Actions + status -->


### PR DESCRIPTION
## What

Introduces a single reusable `EmptyState` control (`Glyph`/`Title`/`Message` dependency properties) and routes every empty-list placeholder in the app through it, so the look can't drift between tabs.

### Lists that gained an empty-state (had none before)
App Updates, App Blocker, App Alerts, Shortcut Cleaner, File Shredder, Duplicate Finder, Context Menu, Task Scheduler, Display Profiles, Boot Analyzer (history + slowed-boot), Defender exclusions, and the live output console. Each list is wrapped in a `Grid` so the centred placeholder overlays it only when the bound collection's `.Count` is 0 (via the existing `FlexVis` converter, `ConverterParameter=Inverse`).

### Existing hand-rolled placeholders consolidated onto the shared control
Debloater, Restore Points, Camera/Mic/Location, Browser Cleaner, System Logs, System Report — six bespoke icon+title+message StackPanels that had drifted, now one component.

### Small typography/icon fixes alongside
- 📂 emoji → icon font in Disk Analyzer; shield emoji → icon font in Process Manager.
- Hardcoded `SectionTitle`/`Caption` text properties replaced with the shared styles (Bulk Installer header, Browser Cleaner caption).

## Why
Several lists rendered a blank area when empty (no "nothing here yet" affordance), and the six tabs that *did* have a placeholder each hand-rolled it, so they had already diverged. One control = single source of truth.

## Verification
- `dotnet build` clean (0 warnings, 0 errors).
- Launched the built exe and confirmed live: the placeholder renders centred **with its glyph** (no hollow-box codepoints — only glyphs already in use elsewhere were chosen), and stays hidden when the list has items (Browser Cleaner auto-populates → no placeholder shown).
- All glyphs verified against the set already rendering in the app.

Purely visual consistency — no behaviour changes. Bumps version to 1.45.0 (minor) and adds the CHANGELOG entry.