### PR TITLE
fix: let the CPU core list scroll on high-core-count machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.45.1] - 2026-06-29
+
+### Fixed
+- **CPU Core Affinity now scrolls when there are many cores.** On a machine with a high logical-processor count (or a short window), the core tiles overflowed the card and the lower ones were cut off with no way to reach them. The core grid now scrolls, with the header and select buttons pinned, so every core is reachable regardless of core count or window size.
+
 ## [1.45.0] - 2026-06-29
 
 ### Changed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.45.0</Version>
-    <FileVersion>1.45.0.0</FileVersion>
-    <AssemblyVersion>1.45.0.0</AssemblyVersion>
+    <Version>1.45.1</Version>
+    <FileVersion>1.45.1.0</FileVersion>
+    <AssemblyVersion>1.45.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/CpuAffinityView.xaml
+++ b/SysManager/SysManager/Views/CpuAffinityView.xaml
@@ -50,8 +50,12 @@
 
         <!-- Core grid -->
         <Border Grid.Row="3" Style="{StaticResource Card}">
-            <StackPanel>
-                <Grid Margin="0,0,0,10">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Grid Grid.Row="0" Margin="0,0,0,10">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
@@ -67,26 +71,29 @@
                                 AutomationProperties.Name="Select all cores"/>
                     </StackPanel>
                 </Grid>
-                <ItemsControl ItemsSource="{Binding Cores}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <WrapPanel Orientation="Horizontal"/>
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <Border Style="{StaticResource CardInner}" Margin="0,0,8,8" Padding="10,8" Width="120">
-                                <StackPanel>
-                                    <CheckBox IsChecked="{Binding IsSelected}" Content="{Binding Label}"
-                                              FontWeight="SemiBold"
-                                              AutomationProperties.Name="{Binding Label}"/>
-                                    <TextBlock Text="{Binding TypeLabel}" Style="{StaticResource Caption}" Margin="0,4,0,0"/>
-                                </StackPanel>
-                            </Border>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
+                <!-- Scrolls so the core tiles stay reachable on high-core-count CPUs in a short window -->
+                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                    <ItemsControl ItemsSource="{Binding Cores}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel Orientation="Horizontal"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Style="{StaticResource CardInner}" Margin="0,0,8,8" Padding="10,8" Width="120">
+                                    <StackPanel>
+                                        <CheckBox IsChecked="{Binding IsSelected}" Content="{Binding Label}"
+                                                  FontWeight="SemiBold"
+                                                  AutomationProperties.Name="{Binding Label}"/>
+                                        <TextBlock Text="{Binding TypeLabel}" Style="{StaticResource Caption}" Margin="0,4,0,0"/>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+            </Grid>
         </Border>
 
         <!-- Actions + status -->


### PR DESCRIPTION
## What
The logical-processor tiles in **CPU Core Affinity** were laid out in an unbounded `StackPanel`. On a CPU with many cores — or just a short window — the wrapping grid grew past the card and the lower core tiles were clipped, with no way to scroll to them (so you couldn't select or even see those cores).

## Fix
Wrapped the core-tile `ItemsControl` in a height-constrained `ScrollViewer` (the card's content is now a 2-row Grid: pinned header row with the "Logical processors" label + P-cores/All-cores buttons, and a `*` row that scrolls). Every core stays reachable regardless of core count or window height.

## Why it was deferred
Surfaced by the structural-uniformity audit as the one *functional* finding among otherwise-cosmetic items; it's a behaviour/layout change so it was kept out of the pure-visual v1.45.0 batch.

## Verification
- `dotnet build` clean (0/0).
- Launched the built exe and confirmed live: all 22 logical processors render in the card with the header pinned; layout unchanged where tiles already fit. On higher core counts / shorter windows the grid now scrolls instead of clipping.

Patch bump to 1.45.1 + CHANGELOG entry.