### PR TITLE
fix: sync docs to graduated state and scrub remaining update-log paths

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -93,14 +93,14 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `LegacyPanelsViewModel` — one-click launcher for the fixed catalog of classic Windows applets (pure launchers, no system modification).
 - `SystemFixesViewModel` — consolidated one-click repairs (Windows Update reset, network reset, WinGet reinstall) with per-fix confirmation + live output; opens netplwiz for secure auto-logon.
 - `BootAnalyzerViewModel` — read-only boot-time history + slow-component breakdown from the Diagnostics-Performance log, with a trend vs recent average; needs admin to read the log.
-- `TimerResolutionViewModel` — request the finest Windows timer resolution (≈0.5 ms) for lower game input latency, or release it; shows the live effective value. _Preview._
-- `FileLockViewModel` — find which processes are holding a file/folder (Restart Manager) and optionally end a selected one after confirmation; critical processes are protected. _Preview._
-- `DisplayProfileViewModel` — list displays and supported resolution/refresh modes and switch between them; applies for the session with a 15-second auto-revert safety net. _Preview._
-- `CpuAffinityViewModel` — pin a running process to specific logical CPUs with P-core/E-core labels on hybrid CPUs; per-process and reverts on process exit. _Preview._
-- `DefenderViewModel` — view Microsoft Defender status, toggle PUA / Controlled Folder Access, and manage scan-exclusion folders; every change is admin-gated, confirmed, and verified by read-back (Tamper Protection can silently reject). _Preview._
-- `TaskSchedulerViewModel` — browse Windows scheduled tasks with a safety classification and enable/disable them (reversible, never deletes); system tasks warn before disabling, changes verified by read-back. _Preview._
-- `DarkModeViewModel` — switch the Windows light/dark theme manually or on a fixed-time schedule (DispatcherTimer poll while the app runs); persists the schedule. _Preview._
-- `StandbyMemoryViewModel` — live memory stats (2s poll) with on-demand and threshold-based auto-purge of the Windows standby list; purge needs admin. _Preview._
+- `TimerResolutionViewModel` — request the finest Windows timer resolution (≈0.5 ms) for lower game input latency, or release it; shows the live effective value.
+- `FileLockViewModel` — find which processes are holding a file/folder (Restart Manager) and optionally end a selected one after confirmation; critical processes are protected.
+- `DisplayProfileViewModel` — list displays and supported resolution/refresh modes and switch between them; applies for the session with a 15-second auto-revert safety net.
+- `CpuAffinityViewModel` — pin a running process to specific logical CPUs with P-core/E-core labels on hybrid CPUs; per-process and reverts on process exit.
+- `DefenderViewModel` — view Microsoft Defender status, toggle PUA / Controlled Folder Access, and manage scan-exclusion folders; every change is admin-gated, confirmed, and verified by read-back (Tamper Protection can silently reject).
+- `TaskSchedulerViewModel` — browse Windows scheduled tasks with a safety classification and enable/disable them (reversible, never deletes); system tasks warn before disabling, changes verified by read-back.
+- `DarkModeViewModel` — switch the Windows light/dark theme manually or on a fixed-time schedule (DispatcherTimer poll while the app runs); persists the schedule.
+- `StandbyMemoryViewModel` — live memory stats (2s poll) with on-demand and threshold-based auto-purge of the Windows standby list; purge needs admin.
 - `ProfileViewModel` — export/import SysManager's own config (theme, speed-test history) as a portable JSON profile with selective sections and version checking.
 - `DebloaterViewModel` — list and remove preinstalled Store apps with a curated bloat preset; system-critical packages are denylisted; removal is per-user and reversible via the Store.
 - `BrowserCleanerViewModel` — scan per-browser cache/history/cookies/sessions with sizes and clean the selected categories; cookies/sessions default unticked.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.45.2] - 2026-06-29
+
+### Fixed
+- **Docs now match the app after the eight features left Preview.** The README still showed those eight tabs with a "Preview" marker and ARCHITECTURE still tagged them "Preview" even though they had graduated — both are now corrected so the documentation reflects the shipped state.
+- **Update log no longer records the full user folder path** in three places (an invalid-signature warning and two cleanup messages); they now use the same path-scrubbing the rest of the updater already applied, so a shared log can't reveal the account name.
+
 ## [1.45.1] - 2026-06-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -75,26 +75,24 @@ fully open source.
 ### Sidebar navigation
 The sidebar organises 57 feature tabs into 12 collapsible groups so you can
 find what you need without scrolling through a flat list. 48 tabs are fully
-implemented; 9 are work-in-progress placeholders marked with ⚙️. Newly added
-tabs still being verified are marked **PREVIEW**:
+implemented; 9 are work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |
 |-------|------|
 | 🏠 Dashboard | Dashboard |
-| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Task Scheduler 🔬 · Boot Analyzer · System Fixes |
-| 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner 🔬 · Timer Resolution 🔬 · CPU Core Affinity 🔬 · Display Profiles 🔬 |
-| 📊 Monitor | Process Manager · Resource History ⚙️ · Camera/Mic/Location · App Alerts · File Lock Detector 🔬 · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
+| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Task Scheduler · Boot Analyzer · System Fixes |
+| 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner · Timer Resolution · CPU Core Affinity · Display Profiles |
+| 📊 Monitor | Process Manager · Resource History ⚙️ · Camera/Mic/Location · App Alerts · File Lock Detector · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance ⚙️ |
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS & Hosts |
 | 📦 Apps | App Updates · Bulk Installer · Uninstaller |
-| 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover ⚙️ · Defender Tweaks 🔬 · Notification Blocker ⚙️ |
-| 🎨 Customization | Context Menu · Dark Mode Scheduler 🔬 · Volume Control ⚙️ |
+| 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover ⚙️ · Defender Tweaks · Notification Blocker ⚙️ |
+| 🎨 Customization | Context Menu · Dark Mode Scheduler · Volume Control ⚙️ |
 | ℹ️ Info | Drivers · Battery Health · System Logs · System Report · Legacy Panels · About |
 | ⚙️ Advanced | Profile Export/Import · CLI Interface ⚙️ · Environment Variables |
 
 > ⚙️ = Work in Progress — placeholder tab visible in the sidebar, implementation coming in future updates.
-> 🔬 = Preview — implemented and usable, still being verified; marked with a PREVIEW pill in the app.
 
 Groups expand and collapse with a click. Collapsed groups show a child count
 badge, a subtitle with abbreviated child labels, and a tooltip with the full
@@ -135,7 +133,7 @@ Edit Windows environment variables without the cramped built-in dialog:
 - System-scope edits need administrator rights (standard elevation banner); user
   variables can be edited without it
 
-### Dark Mode Scheduler 🔬
+### Dark Mode Scheduler
 - **Switch the Windows light/dark theme** instantly — apps only, or the taskbar
   and Start too
 - **Schedule it** — set a dark time and a light time (e.g. 19:00 / 07:00) and the
@@ -143,7 +141,6 @@ Edit Windows environment variables without the cramped built-in dialog:
 - Applies immediately with no sign-out, no admin needed, and is fully reversible
 - **Honest about its limits** — the schedule runs while SysManager (or its tray)
   is open; it's not a background Windows service
-- _Preview — implemented and usable, still being verified._
 
 ### Network monitor
 - Live ping across multiple targets overlaid on a single latency chart
@@ -234,7 +231,7 @@ a confirmation before it runs:
   with the delay attributed to each
 - Read-only; reading the log requires administrator (elevation banner shown)
 
-### Task Scheduler 🔬
+### Task Scheduler
 - **Browse every Windows scheduled task** with its state, type, and last/next run
 - **Color-coded by type** — Third-party, well-known **Telemetry** (Compatibility
   Appraiser, CEIP, Feedback, Error Reporting), and **System** — so it's obvious
@@ -243,7 +240,6 @@ a confirmation before it runs:
   the task** — System tasks show an extra warning before you disable them
 - Filter by name or path, and optionally hide system tasks to focus on the rest
 - Changes need administrator and are verified by reading the task's state back
-- _Preview — implemented and usable, still being verified._
 
 ### Windows Update (Windows Update Agent COM API)
 - Direct Windows Update Agent COM integration (`Microsoft.Update.Session`) —
@@ -346,7 +342,7 @@ a confirmation before it runs:
 - Kill process with confirmation dialog
 - Open file location in Explorer
 
-### File Lock Detector 🔬
+### File Lock Detector
 - **Find what's holding a file** — when you get a "file in use" error, enter or
   browse to a file/folder path and see which process(es) are using it, via the
   Windows Restart Manager (the same mechanism Explorer's own dialog uses)
@@ -355,7 +351,6 @@ a confirmation before it runs:
   the file; critical system processes are protected from termination
 - Detection works as a standard user; ending a process owned by SYSTEM or
   another user needs administrator rights (surfaced, not crashed)
-- _Preview — implemented and usable, still being verified._
 
 ### Camera/Mic/Location
 - Shows which apps recently used your **camera, microphone, or location**, and when
@@ -467,7 +462,7 @@ Reclaim space and clear browsing traces, per browser:
 - Per-user (no admin); locked files (browser open) are skipped, not forced, and
   symlinks/junctions are never followed
 
-### Defender Tweaks 🔬
+### Defender Tweaks
 Manage Microsoft Defender without digging through Windows Security:
 - **Status at a glance** — real-time protection, cloud protection (MAPS), PUA
   protection, and Controlled Folder Access
@@ -480,7 +475,6 @@ Manage Microsoft Defender without digging through Windows Security:
   after reading it back and confirming Windows actually applied it
 - Changes need administrator and are confirmed first; lowering a protection is
   always an explicit, reversible choice
-- _Preview — implemented and usable, still being verified._
 
 ### Battery Health
 - Charge %, health %, wear level, cycle count, chemistry
@@ -496,7 +490,7 @@ Manage Microsoft Defender without digging through Windows Security:
 - Local app support — uninstalls apps not in winget via registry UninstallString
 - Live console output from winget
 
-### Timer Resolution 🔬
+### Timer Resolution
 - **Lower input latency for games** — requests the finest Windows timer
   resolution (≈0.5 ms) instead of the ~15.6 ms default, via the ntdll
   `NtSetTimerResolution` API
@@ -507,9 +501,8 @@ Manage Microsoft Defender without digging through Windows Security:
   when you restore it or simply close the app. No admin required
 - **Power-cost warning** — a finer timer wakes the CPU more often, increasing
   power draw and battery drain on laptops
-- _Preview — implemented and usable, still being verified._
 
-### Display Profiles 🔬
+### Display Profiles
 - **Quick-switch resolution + refresh rate** — pick a mode (e.g. 165 Hz for
   gaming, 60 Hz for work) from the list of everything your display supports,
   using only the Windows display APIs (no NVIDIA/AMD tool conflict)
@@ -518,9 +511,8 @@ Manage Microsoft Defender without digging through Windows Security:
   "Keep", so a bad mode can never strand you on a blank screen
 - **Per-display** — choose which monitor to configure; shows the current mode
 - Validates each mode (CDS_TEST) before applying; no admin required
-- _Preview — implemented and usable, still being verified._
 
-### CPU Core Affinity 🔬
+### CPU Core Affinity
 - **Pin a process to specific CPU cores** — pick a running process and choose
   which logical CPUs it may run on, then Apply (or Restore the original)
 - **Hybrid-CPU aware** — on Intel 12th-gen+ CPUs, P-cores and E-cores are
@@ -531,9 +523,8 @@ Manage Microsoft Defender without digging through Windows Security:
   process is surfaced as needing admin, not a crash)
 - An empty selection is rejected — Windows treats an empty mask as "let the OS
   decide", so the app never silently does the opposite of what you picked
-- _Preview — implemented and usable, still being verified._
 
-### Standby List Cleaner 🔬
+### Standby List Cleaner
 - **Frees cached standby memory** — the built-in equivalent of ISLC, to reduce
   stutter when RAM runs low in games
 - **Live stats** — total RAM, available, and memory load %, refreshed every 2s
@@ -543,7 +534,6 @@ Manage Microsoft Defender without digging through Windows Security:
   cache, so clearing it loses nothing; Windows reloads from disk on next use
 - Reading stats needs no admin; purging requires administrator (it enables the
   same privilege RAMMap and ISLC use) and reports cleanly if not elevated
-- _Preview — implemented and usable, still being verified._
 
 ### Performance Mode
 - **Per-tweak Apply buttons** — each setting is independent

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -349,85 +349,86 @@ public class MainWindowViewModelTests
         }
     }
 
+    // These eight features graduated out of Preview (#1123). The tests pin both the
+    // real-view wiring AND the graduated state (IsInDevelopment == false), so a future
+    // accidental re-flag to preview fails here.
     [Fact]
-    public void NavLeaf_TimerResolution_IsImplementedAndMarkedPreview()
+    public void NavLeaf_TimerResolution_IsImplementedAndGraduated()
     {
         var vm = new MainWindowViewModel();
         var item = vm.NavItems.First(n => n.Id == "nav-timer-resolution");
-        // Now a real view, not the WIP placeholder.
         Assert.Equal(typeof(SysManager.Views.TimerResolutionView), item.ViewType);
         Assert.IsType<TimerResolutionViewModel>(item.Content);
-        // Surfaced as PREVIEW until verified.
-        Assert.True(item.IsInDevelopment);
+        Assert.False(item.IsInDevelopment);
     }
 
     [Fact]
-    public void NavLeaf_FileLock_IsImplementedAndMarkedPreview()
+    public void NavLeaf_FileLock_IsImplementedAndGraduated()
     {
         var vm = new MainWindowViewModel();
         var item = vm.NavItems.First(n => n.Id == "nav-file-lock");
         Assert.Equal(typeof(SysManager.Views.FileLockView), item.ViewType);
         Assert.IsType<FileLockViewModel>(item.Content);
-        Assert.True(item.IsInDevelopment);
+        Assert.False(item.IsInDevelopment);
     }
 
     [Fact]
-    public void NavLeaf_DisplayProfiles_IsImplementedAndMarkedPreview()
+    public void NavLeaf_DisplayProfiles_IsImplementedAndGraduated()
     {
         var vm = new MainWindowViewModel();
         var item = vm.NavItems.First(n => n.Id == "nav-display-profiles");
         Assert.Equal(typeof(SysManager.Views.DisplayProfileView), item.ViewType);
         Assert.IsType<DisplayProfileViewModel>(item.Content);
-        Assert.True(item.IsInDevelopment);
+        Assert.False(item.IsInDevelopment);
     }
 
     [Fact]
-    public void NavLeaf_CpuAffinity_IsImplementedAndMarkedPreview()
+    public void NavLeaf_CpuAffinity_IsImplementedAndGraduated()
     {
         var vm = new MainWindowViewModel();
         var item = vm.NavItems.First(n => n.Id == "nav-cpu-affinity");
         Assert.Equal(typeof(SysManager.Views.CpuAffinityView), item.ViewType);
         Assert.IsType<CpuAffinityViewModel>(item.Content);
-        Assert.True(item.IsInDevelopment);
+        Assert.False(item.IsInDevelopment);
     }
 
     [Fact]
-    public void NavLeaf_Defender_IsImplementedAndMarkedPreview()
+    public void NavLeaf_Defender_IsImplementedAndGraduated()
     {
         var vm = new MainWindowViewModel();
         var item = vm.NavItems.First(n => n.Id == "nav-defender-tweaks");
         Assert.Equal(typeof(SysManager.Views.DefenderView), item.ViewType);
         Assert.IsType<DefenderViewModel>(item.Content);
-        Assert.True(item.IsInDevelopment);
+        Assert.False(item.IsInDevelopment);
     }
 
     [Fact]
-    public void NavLeaf_TaskScheduler_IsImplementedAndMarkedPreview()
+    public void NavLeaf_TaskScheduler_IsImplementedAndGraduated()
     {
         var vm = new MainWindowViewModel();
         var item = vm.NavItems.First(n => n.Id == "nav-task-scheduler");
         Assert.Equal(typeof(SysManager.Views.TaskSchedulerView), item.ViewType);
         Assert.IsType<TaskSchedulerViewModel>(item.Content);
-        Assert.True(item.IsInDevelopment);
+        Assert.False(item.IsInDevelopment);
     }
 
     [Fact]
-    public void NavLeaf_DarkMode_IsImplementedAndMarkedPreview()
+    public void NavLeaf_DarkMode_IsImplementedAndGraduated()
     {
         var vm = new MainWindowViewModel();
         var item = vm.NavItems.First(n => n.Id == "nav-dark-mode");
         Assert.Equal(typeof(SysManager.Views.DarkModeView), item.ViewType);
         Assert.IsType<DarkModeViewModel>(item.Content);
-        Assert.True(item.IsInDevelopment);
+        Assert.False(item.IsInDevelopment);
     }
 
     [Fact]
-    public void NavLeaf_StandbyCleaner_IsImplementedAndMarkedPreview()
+    public void NavLeaf_StandbyCleaner_IsImplementedAndGraduated()
     {
         var vm = new MainWindowViewModel();
         var item = vm.NavItems.First(n => n.Id == "nav-standby-cleaner");
         Assert.Equal(typeof(SysManager.Views.StandbyMemoryView), item.ViewType);
         Assert.IsType<StandbyMemoryViewModel>(item.Content);
-        Assert.True(item.IsInDevelopment);
+        Assert.False(item.IsInDevelopment);
     }
 }

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -339,7 +339,7 @@ public sealed class UpdateService
         catch (System.Security.Cryptography.CryptographicException)
         {
             // Invalid/tampered signature — file HAS a signature but it's broken.
-            Serilog.Log.Warning("Update binary has INVALID Authenticode signature — possible tampering: {File}", filePath);
+            Serilog.Log.Warning("Update binary has INVALID Authenticode signature — possible tampering: {File}", LogService.SanitizePath(filePath));
             return false;
         }
     }
@@ -347,8 +347,8 @@ public sealed class UpdateService
     private static void CleanupFile(string path)
     {
         try { if (File.Exists(path)) File.Delete(path); }
-        catch (IOException ex) { Serilog.Log.Debug(ex, "Update cleanup: could not delete {Path}", path); }
-        catch (UnauthorizedAccessException ex) { Serilog.Log.Debug(ex, "Update cleanup: access denied deleting {Path}", path); }
+        catch (IOException ex) { Serilog.Log.Debug(ex, "Update cleanup: could not delete {Path}", LogService.SanitizePath(path)); }
+        catch (UnauthorizedAccessException ex) { Serilog.Log.Debug(ex, "Update cleanup: access denied deleting {Path}", LogService.SanitizePath(path)); }
     }
 
     // ---------- internals ----------

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.45.1</Version>
-    <FileVersion>1.45.1.0</FileVersion>
-    <AssemblyVersion>1.45.1.0</AssemblyVersion>
+    <Version>1.45.2</Version>
+    <FileVersion>1.45.2.0</FileVersion>
+    <AssemblyVersion>1.45.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## What
Follow-up fixes from a full audit of the work that landed while I was away (1.42.0 → 1.45.1, ~20 PRs). The audit found the code, security, tests, and rules all in good shape — these are the only two real findings, both hygiene (no behavior change).

## Fixes
### 1. Docs out of sync after Preview graduation (#1123)
The eight features graduated out of Preview in the app, but the docs weren't updated to match:
- README still showed 🔬 PREVIEW on 5 sidebar rows + 8 section headers, kept the `_Preview_` footers, and a now-stale legend.
- ARCHITECTURE still tagged 8 ViewModels `_Preview._`.

All preview markers removed so the docs are 1:1 with the shipped app. The implemented/WIP counts (48 / 9) were already correct and are unchanged.

### 2. Three update-log lines still leaked the user path
The #1113 path-scrub wrapped most updater log lines in `LogService.SanitizePath`, but missed three: the invalid-Authenticode-signature warning and two cleanup messages still emitted the raw `%LOCALAPPDATA%` path, which embeds the Windows username. Now scrubbed like the rest — a shared log can't reveal the account name. (Low severity: private rotating local log.)

### 3. Eight stale integration tests
`NavLeaf_*_IsImplementedAndMarkedPreview` still asserted `IsInDevelopment == true` after graduation flipped it to `false`. The IntegrationTests suite is compile-only in CI (never executed), so they never failed — but they contradicted reality. Renamed to `_IsImplementedAndGraduated` and flipped to `Assert.False(...)`, pinning the graduated state so an accidental re-flag fails.

## Verification
- Build main + unit + integration: 0/0. Leak scan clean. 0 `🔬` / `_Preview._` left in docs.
- fix: -> patch 1.45.2.

## Audit summary (no action needed, FYI)
Leak/identity: clean (0 hits, all commits `laurentiu021`). Code quality + rules: PASS on all dimensions. The four "#1119" bug fixes: all genuine (Defender false-success, TaskScheduler wildcard, cross-display revert, SMART-via-WMI, reparse-root guard). Updater rework: SHA256-verified-before-apply, no on-disk script window, HTTPS-only, no telemetry, safe rollback. ~80 tests / 180+ assertions added, real behavioral coverage.
