### PR TITLE
fix: record opened features and operations in Recent Activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.45.3] - 2026-06-29
+
+### Fixed
+- **Dashboard "Recent activity" now reflects what you actually do.** Previously it only recorded a handful of Dashboard quick-action buttons, so it stayed empty for normal use. It now records the features you open and the operations you complete across the app (temp cleanup, DNS changes, app removals, restore points, standby purge, …), newest first. Closes #1132.
+
 ## [1.45.2] - 2026-06-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -573,8 +573,8 @@ Manage Microsoft Defender without digging through Windows Security:
 - **Real-time vitals** — CPU, RAM, and GPU usage refreshed at 300 ms while
   the tab is visible (polling pauses automatically when it isn't), with live
   indicator dots.
-- **Recent Activity** — the last few actions you ran (Quick Cleanup, Update
-  All Apps, Check Updates, …) with timestamps.
+- **Recent Activity** — the last features you opened and actions you ran
+  (cleanups, DNS changes, app removals, restore points, …) with timestamps.
 - **Quick Tune-Up** — one-click wizard that cleans temp files, optionally
   empties the Recycle Bin, scans for broken shortcuts, checks disk SMART
   health, flags high uptime (14+ days) and high RAM usage (85%+). Displays

--- a/SysManager/SysManager.Tests/ActivityEntryTests.cs
+++ b/SysManager/SysManager.Tests/ActivityEntryTests.cs
@@ -1,0 +1,42 @@
+// SysManager · ActivityEntryTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Tests;
+
+public class ActivityEntryTests
+{
+    // TimeAgo is relative to DateTime.Now; build timestamps as offsets from now so the
+    // assertions are deterministic regardless of when the test runs.
+    private static ActivityEntry Aged(TimeSpan ago) => new("Opened", "Cleanup", DateTime.Now - ago);
+
+    [Fact]
+    public void TimeAgo_JustNow_UnderAMinute()
+        => Assert.Equal("Just now", Aged(TimeSpan.FromSeconds(20)).TimeAgo);
+
+    [Fact]
+    public void TimeAgo_Minutes()
+        => Assert.Equal("5m ago", Aged(TimeSpan.FromMinutes(5)).TimeAgo);
+
+    [Fact]
+    public void TimeAgo_Hours()
+        => Assert.Equal("3h ago", Aged(TimeSpan.FromHours(3)).TimeAgo);
+
+    [Fact]
+    public void TimeAgo_Yesterday()
+        => Assert.Equal("Yesterday", Aged(TimeSpan.FromHours(30)).TimeAgo);
+
+    [Fact]
+    public void TimeAgo_Days()
+        => Assert.Equal("4 days ago", Aged(TimeSpan.FromDays(4)).TimeAgo);
+
+    [Fact]
+    public void Record_PreservesActionAndDetail()
+    {
+        var e = new ActivityEntry("DNS & Hosts", "Set DNS to Cloudflare", DateTime.Now);
+        Assert.Equal("DNS & Hosts", e.Action);
+        Assert.Equal("Set DNS to Cloudflare", e.Detail);
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.45.2</Version>
-    <FileVersion>1.45.2.0</FileVersion>
-    <AssemblyVersion>1.45.2.0</AssemblyVersion>
+    <Version>1.45.3</Version>
+    <FileVersion>1.45.3.0</FileVersion>
+    <AssemblyVersion>1.45.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -224,6 +224,7 @@ public sealed partial class CleanupViewModel : ViewModelBase
             ", cancellationToken: _tempCts.Token);
             StatusMessage = "Temp cleanup done";
             Log.Information("Temp cleanup completed");
+            ActivityLogService.Instance.Log("Quick Cleanup", "Cleared temporary files");
             await PreScanAsync();
         }
         catch (OperationCanceledException) { StatusMessage = "Temp cleanup cancelled."; }

--- a/SysManager/SysManager/ViewModels/DebloaterViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DebloaterViewModel.cs
@@ -170,6 +170,8 @@ public sealed partial class DebloaterViewModel : ViewModelBase
                 ? $"Removed {removed} app{(removed == 1 ? "" : "s")}. Reinstall any from the Microsoft Store if needed."
                 : $"Removed {removed}; {failed} could not be removed.";
             Log.Information("Debloater: removed {Removed}, failed {Failed}", removed, failed);
+            if (removed > 0)
+                ActivityLogService.Instance.Log("Debloater", $"Removed {removed} app{(removed == 1 ? "" : "s")}");
         }
         catch (OperationCanceledException)
         {

--- a/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
@@ -171,6 +171,7 @@ public sealed partial class DnsHostsViewModel : ViewModelBase
                 StatusMessage = $"DNS set to {SelectedPreset.Name} ({SelectedPreset.Primary}, {SelectedPreset.Secondary}).");
             Log.Information("DNS changed to {Preset} ({Primary}, {Secondary})",
                 SelectedPreset.Name, SelectedPreset.Primary, SelectedPreset.Secondary);
+            ActivityLogService.Instance.Log("DNS & Hosts", $"Set DNS to {SelectedPreset.Name}");
         }
         catch (OperationCanceledException) { }
         catch (Exception ex)

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -411,6 +411,12 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         if (value is null) return;
         Log.Information("Tab navigated: {TabLabel}", value.Label);
 
+        // Record the feature the user opened in the Dashboard's "Recent activity"
+        // (skip Dashboard itself — Recent activity lives there, so logging every return
+        // to view it would just push real entries out of the list).
+        if (value.Id != "nav-dashboard")
+            ActivityLogService.Instance.Log("Opened", value.Label);
+
         // Auto-expand the parent group when a child is selected.
         var parentGroup = NavGroups.FirstOrDefault(g => g.Children.Contains(value));
         if (parentGroup is not null) parentGroup.IsExpanded = true;

--- a/SysManager/SysManager/ViewModels/RestorePointsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/RestorePointsViewModel.cs
@@ -101,6 +101,7 @@ public sealed partial class RestorePointsViewModel : ViewModelBase
             {
                 NewDescription = "";
                 StatusMessage = "Restore point created.";
+                ActivityLogService.Instance.Log("Restore point", $"Created \"{description}\"");
                 ToastService.Instance.Show("Restore point created", description);
                 var points = await _service.ListAsync(_cts.Token).ConfigureAwait(true);
                 RestorePoints.ReplaceWith(points);

--- a/SysManager/SysManager/ViewModels/StandbyMemoryViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StandbyMemoryViewModel.cs
@@ -116,6 +116,7 @@ public sealed partial class StandbyMemoryViewModel : ViewModelBase
         if (ok)
         {
             Log.Information("User purged standby list");
+            ActivityLogService.Instance.Log("Standby cleaner", "Purged the standby memory list");
             StatusMessage = "Standby list purged — cached memory released to the free list.";
             Refresh();
         }


### PR DESCRIPTION
## What
Closes #1132 — Dashboard "Recent activity" was empty for normal use.

## Root cause
The only writers to `ActivityLogService` were five Dashboard quick-action buttons (Quick Cleanup, App Updates, Windows Update, Speed Test, Tune-Up). Using any actual feature tab — or navigating around — recorded nothing, so the list showed "No activity recorded yet". The reader, binding, and empty-state were all correct; the feature was simply never wired to record real usage.

## Fix
- **Navigation** — `MainWindowViewModel.OnSelectedNavChanged` now logs `Opened <feature>` when you switch tabs (skips the Dashboard itself, so opening the Dashboard to *view* the list doesn't push real entries out).
- **Operations** — five high-value actions now log on success: temp cleanup, DNS change, Debloater removal, restore-point creation, standby purge. (No double-logging: these are distinct from the Dashboard quick-action call sites.)

"Recent activity" now reflects the features you opened and the operations you completed, newest first — exactly what the issue asked for.

## Tests
- `ActivityEntryTests` — `TimeAgo` across Just now / minutes / hours / Yesterday / days (deterministic via now-relative offsets) + record round-trip.

## Verification
- Build main + unit tests: 0/0. Leak scan clean. No debug/generic-catch.
- README "Recent Activity" description updated to match. fix: -> patch 1.45.3.
