### PR TITLE
feat: clearer App Updates status with structured winget result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.46.0] - 2026-06-29
+
+### Changed
+- **Clearer App Updates status.** When updating apps, each row now shows a plain-English result instead of a raw exit code — e.g. "Updated", "No applicable update found", "Update installed — restart required", or "App is running — close it and retry" — and unknown failures show a tidy hex code rather than a giant negative number. The summary line now reports successes and failures honestly ("Updated 3 of 4 · 1 failed") instead of counting every attempt as done. winget's progress bar is also suppressed (`--no-progress`), so the live output no longer fills with garbled block characters. Closes #1130.
+
 ## [1.45.3] - 2026-06-29
 
 ### Fixed

--- a/SysManager/SysManager.Tests/WingetResultTests.cs
+++ b/SysManager/SysManager.Tests/WingetResultTests.cs
@@ -1,0 +1,52 @@
+// SysManager · WingetResultTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Tests;
+
+public class WingetResultTests
+{
+    [Fact]
+    public void From_Zero_IsSucceededAndUpdated()
+    {
+        var r = WingetResult.From(0);
+        Assert.True(r.Succeeded);
+        Assert.Equal(0, r.ExitCode);
+        Assert.Equal("Updated", r.FriendlyMessage);
+    }
+
+    [Fact]
+    public void From_NonZero_IsNotSucceeded()
+    {
+        var r = WingetResult.From(unchecked((int)0x8A150011));
+        Assert.False(r.Succeeded);
+        Assert.Equal("No applicable update found", r.FriendlyMessage);
+    }
+
+    [Theory]
+    [InlineData(0x8A150109u, "Update installed — restart required")]
+    [InlineData(0x8A150049u, "Another install is in progress — try again shortly")]
+    [InlineData(0x8A15010Cu, "App is running — close it and retry")]
+    [InlineData(0x8A150010u, "Couldn't find the app in the catalog")]
+    public void Describe_KnownCodes_AreFriendly(uint code, string expected)
+        => Assert.Equal(expected, WingetExitCodes.Describe(unchecked((int)code)));
+
+    [Fact]
+    public void Describe_UnknownCode_FallsBackToHex_NotRawDecimal()
+    {
+        // An unmapped non-zero code must render as hex, never a bare signed decimal
+        // like "exit -1978335189" (the thing issue #1130 complained about).
+        var msg = WingetExitCodes.Describe(unchecked((int)0x8A150099));
+        Assert.Equal("Failed (winget code 0x8A150099)", msg);
+        Assert.DoesNotContain("-", msg);
+    }
+
+    [Fact]
+    public void Cancelled_IsNotSucceeded()
+    {
+        Assert.False(WingetResult.Cancelled.Succeeded);
+        Assert.Equal("Cancelled", WingetResult.Cancelled.FriendlyMessage);
+    }
+}

--- a/SysManager/SysManager/Models/WingetResult.cs
+++ b/SysManager/SysManager/Models/WingetResult.cs
@@ -1,0 +1,40 @@
+// SysManager · WingetResult
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// The outcome of a winget operation, translated from the raw process exit code into a
+/// human-readable result so the UI never has to surface a bare numeric code.
+/// </summary>
+public sealed record WingetResult(int ExitCode, bool Succeeded, string FriendlyMessage)
+{
+    public static WingetResult From(int exitCode) =>
+        new(exitCode, exitCode == 0, WingetExitCodes.Describe(exitCode));
+
+    /// <summary>A cancelled operation (no meaningful exit code).</summary>
+    public static WingetResult Cancelled { get; } = new(-1, false, "Cancelled");
+}
+
+/// <summary>
+/// Maps the documented winget (APPINSTALLER_CLI_ERROR_*) exit codes to short, friendly
+/// English. Unknown non-zero codes fall back to a hex form. Pure and unit-testable.
+/// </summary>
+public static class WingetExitCodes
+{
+    public static string Describe(int exitCode) => unchecked((uint)exitCode) switch
+    {
+        0x00000000 => "Updated",
+        0x8A150011 => "No applicable update found",
+        0x8A15002B => "No applicable update found",
+        0x8A150109 => "Update installed — restart required",
+        0x8A150049 => "Another install is in progress — try again shortly",
+        0x8A150019 => "Cancelled",
+        0x8A15010C => "App is running — close it and retry",
+        0x8A150056 => "Installer failed — see the log",
+        0x8A150010 => "Couldn't find the app in the catalog",
+        0x8A150047 => "Network error reaching the source",
+        _ => $"Failed (winget code 0x{unchecked((uint)exitCode):X8})",
+    };
+}

--- a/SysManager/SysManager/Services/WingetService.cs
+++ b/SysManager/SysManager/Services/WingetService.cs
@@ -70,7 +70,7 @@ public sealed partial class WingetService
         return packages;
     }
 
-    public async Task<int> UpgradeAsync(string packageId, CancellationToken ct = default)
+    public async Task<WingetResult> UpgradeAsync(string packageId, CancellationToken ct = default)
     {
         // Validate packageId: allowlist alphanumeric, dots, hyphens, underscores,
         // forward slashes (scoped IDs), and plus signs (e.g. "Notepad++.Notepad++").
@@ -78,8 +78,11 @@ public sealed partial class WingetService
             || !PackageIdPattern().IsMatch(packageId))
             throw new ArgumentException("Invalid package ID.", nameof(packageId));
 
-        var args = $"upgrade --id \"{packageId}\" -e --silent --accept-source-agreements --accept-package-agreements --disable-interactivity --include-unknown";
-        return await _runner.RunProcessAsync("winget", args, ct).ConfigureAwait(false);
+        // --no-progress suppresses winget's animated block-character progress bar, which
+        // otherwise streams as garbled glyphs into the live console.
+        var args = $"upgrade --id \"{packageId}\" -e --silent --no-progress --accept-source-agreements --accept-package-agreements --disable-interactivity --include-unknown";
+        int code = await _runner.RunProcessAsync("winget", args, ct).ConfigureAwait(false);
+        return WingetResult.From(code);
     }
 
     /// <summary>
@@ -95,9 +98,10 @@ public sealed partial class WingetService
     [GeneratedRegex(@"^\d+\s+(upgrades|packages|package)\s+", RegexOptions.IgnoreCase)]
     private static partial Regex UpgradeSummaryPattern();
 
-    public async Task<int> UpgradeAllAsync(CancellationToken ct = default)
+    public async Task<WingetResult> UpgradeAllAsync(CancellationToken ct = default)
     {
-        var args = "upgrade --all --silent --accept-source-agreements --accept-package-agreements --disable-interactivity --include-unknown";
-        return await _runner.RunProcessAsync("winget", args, ct).ConfigureAwait(false);
+        var args = "upgrade --all --silent --no-progress --accept-source-agreements --accept-package-agreements --disable-interactivity --include-unknown";
+        int code = await _runner.RunProcessAsync("winget", args, ct).ConfigureAwait(false);
+        return WingetResult.From(code);
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.45.3</Version>
-    <FileVersion>1.45.3.0</FileVersion>
-    <AssemblyVersion>1.45.3.0</AssemblyVersion>
+    <Version>1.46.0</Version>
+    <FileVersion>1.46.0.0</FileVersion>
+    <AssemblyVersion>1.46.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
@@ -95,7 +95,7 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
         IsBusy = true;
         _cts?.Dispose();
         _cts = new CancellationTokenSource();
-        int done = 0;
+        int attempted = 0, succeeded = 0, failed = 0;
         UpgradeEtaText = string.Empty;
         _upgradeEta.Reset();
         try
@@ -103,23 +103,31 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
             foreach (var pkg in toUpgrade)
             {
                 if (_cts.IsCancellationRequested) break;
-                pkg.Status = "Upgrading...";
-                StatusMessage = $"Upgrading {pkg.Name} ({done + 1}/{toUpgrade.Count})";
-                Progress = (int)((done / (double)toUpgrade.Count) * 100);
+                pkg.Status = "Upgrading…";
+                StatusMessage = $"Upgrading {pkg.Name} ({attempted + 1}/{toUpgrade.Count})";
+                Progress = (int)((attempted / (double)toUpgrade.Count) * 100);
                 UpgradeEtaText = _upgradeEta.Update(Progress);
                 try
                 {
-                    var code = await _winget.UpgradeAsync(pkg.Id, _cts.Token);
-                    pkg.Status = code == 0 ? "Done" : $"Failed (exit {code})";
+                    // WingetResult carries a friendly message translated from the exit code,
+                    // so the per-app status is human-readable (never a raw "exit 0x8A15…").
+                    var result = await _winget.UpgradeAsync(pkg.Id, _cts.Token);
+                    pkg.Status = result.FriendlyMessage;
+                    if (result.Succeeded) succeeded++; else failed++;
                 }
                 catch (OperationCanceledException) { pkg.Status = "Cancelled"; break; }
-                catch (InvalidOperationException ex) { pkg.Status = $"Error: {ex.Message}"; }
-                done++;
+                catch (InvalidOperationException ex) { pkg.Status = $"Error: {ex.Message}"; failed++; }
+                attempted++;
             }
             Progress = 100;
             UpgradeEtaText = string.Empty;
-            StatusMessage = $"Completed {done}/{toUpgrade.Count}";
-            Log.Information("App upgrade batch completed: {Done}/{Total}", done, toUpgrade.Count);
+            // Honest summary: separate succeeded from failed, and only mention failures
+            // when there are any.
+            StatusMessage = failed == 0
+                ? $"Updated {succeeded} of {toUpgrade.Count}."
+                : $"Updated {succeeded} of {toUpgrade.Count} · {failed} failed.";
+            Log.Information("App upgrade batch: {Succeeded} ok, {Failed} failed of {Total}",
+                succeeded, failed, toUpgrade.Count);
         }
         finally { IsBusy = false; UpgradeEtaText = string.Empty; }
     }


### PR DESCRIPTION
## What
Closes #1130 — the App Updates tab showed an unclear/technical status during/after updates.

## Problems (verified in code)
1. **Raw exit code on failure** — `pkg.Status = $"Failed (exit {code})"` surfaced winget's exit code verbatim, e.g. `Failed (exit -1978335189)`.
2. **Misleading summary** — `done++` incremented for every app regardless of outcome, so 1-of-4 failing still ended with `Completed 4/4`.
3. **Garbled live output** — the winget process ran without `--no-progress`, so its animated █-block progress bar streamed into the console as mojibake (`â–ˆâ–ˆâ–ˆ`).

## Fix (structured result rework — the clean option)
- **`WingetResult { ExitCode, Succeeded, FriendlyMessage }`** + a pure, unit-tested **`WingetExitCodes.Describe()`** mapping the documented `APPINSTALLER_CLI_ERROR_*` codes to plain English ("No applicable update found", "Update installed — restart required", "App is running — close it and retry", …). Unknown non-zero codes render as a tidy `0x8A150099` hex, never a bare negative decimal.
- **`WingetService.UpgradeAsync`/`UpgradeAllAsync`** now return `WingetResult` and pass **`--no-progress`** (kills the garbled progress bar).
- **`AppUpdatesViewModel`** counts succeeded/failed separately and ends with an honest summary — **"Updated 3 of 4 · 1 failed"** (only mentions failures when there are any); per-row `Status` shows the friendly message.

## Tests
- `WingetResultTests` — `From(0)` succeeded/"Updated"; known codes map to friendly text; **unknown code falls back to hex with no `-`** (pins the exact #1130 complaint); Cancelled not-succeeded.

## Verification
- Build main + unit tests: 0/0. Leak scan clean. No debug/generic-catch. Only existing caller (AppUpdatesViewModel) updated for the new return type; `UpgradeAllAsync` has no other callers.
- feat: -> minor 1.46.0.
