### PR TITLE
feat: add Resource History tab with usage/temperature timeline and CSV export

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,7 +43,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Dashboard | `DashboardViewModel` |
 | System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `TaskSchedulerViewModel` · `BootAnalyzerViewModel` · `SystemFixesViewModel` |
 | Gaming & Profiles | `TimerResolutionViewModel` · `DisplayProfileViewModel` · `CpuAffinityViewModel` · `StandbyMemoryViewModel` · `PlaceholderViewModel` (Gaming Profile) |
-| Monitor | `ProcessManagerViewModel` · `PrivacyMonitorViewModel` · `AppAlertsViewModel` · `FileLockViewModel` · `PlaceholderViewModel` (Resource History · Settings Watchdog · Bandwidth Monitor) |
+| Monitor | `ProcessManagerViewModel` · `ResourceHistoryViewModel` · `PrivacyMonitorViewModel` · `AppAlertsViewModel` · `FileLockViewModel` · `PlaceholderViewModel` (Settings Watchdog · Bandwidth Monitor) |
 | Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `PlaceholderViewModel` (Scheduled Maintenance) |
 | Storage | `DiskAnalyzerViewModel` · `DuplicateFileViewModel` |
 | Network | `PingViewModel` · `TracerouteViewModel` · `SpeedTestViewModel` · `NetworkRepairViewModel` (shared: `NetworkSharedState`) · `DnsHostsViewModel` |
@@ -290,6 +290,12 @@ Key services:
   polling with 2s interval.
 - `ActivityLogService` — persists last 20 user actions to JSON file for
   Dashboard recent activity display.
+- `ResourceHistoryService` — always-on background sampler (started at app startup,
+  runs while minimized to tray) that records CPU/RAM/GPU usage + CPU/GPU temperatures
+  every 10s as append-only NDJSON in `%LocalAppData%\SysManager\resource-history.ndjson`,
+  with 7/14/30-day retention (periodic prune). Reuses `SystemInfoService` + NvAPIWrapper +
+  `TemperatureService`; serialize/parse/prune/downsample/CSV are pure, unit-tested static
+  helpers. Strictly local — no system writes, nothing leaves the machine.
 - `SafetyDatabase` — curated safety ratings for Windows services.
 - `ThemeService` — runtime theme switching with 12 presets and persistence.
 - `ToastService` — global glass-style toast notifications.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.47.0] - 2026-06-29
+
+### Added
+- **Resource History tab (Preview).** A new Monitor tab that records your CPU, RAM and GPU usage plus CPU/GPU temperatures every 10 seconds in the background — including while the app is minimized to the tray — so you can investigate what caused a slowdown hours or days ago instead of only seeing the live moment. Pick a range (last hour through 30 days) to scroll a usage chart and a temperature chart, keep 7/14/30 days of history, and export the visible range to CSV. Strictly local: history lives in your `%LocalAppData%\SysManager` folder and nothing leaves the machine. Closes #13.
+
 ## [1.46.0] - 2026-06-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ fully open source.
 
 ### Sidebar navigation
 The sidebar organises 57 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 48 tabs are fully
-implemented; 9 are work-in-progress placeholders marked with ⚙️:
+find what you need without scrolling through a flat list. 49 tabs are fully
+implemented; 8 are work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |
 |-------|------|
 | 🏠 Dashboard | Dashboard |
 | 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Task Scheduler · Boot Analyzer · System Fixes |
 | 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner · Timer Resolution · CPU Core Affinity · Display Profiles |
-| 📊 Monitor | Process Manager · Resource History ⚙️ · Camera/Mic/Location · App Alerts · File Lock Detector · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
+| 📊 Monitor | Process Manager · Resource History · Camera/Mic/Location · App Alerts · File Lock Detector · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance ⚙️ |
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS & Hosts |
@@ -341,6 +341,20 @@ a confirmation before it runs:
   (System, Trusted, Unknown)
 - Kill process with confirmation dialog
 - Open file location in Explorer
+
+### Resource History
+- **Historical CPU, RAM, GPU usage and temperatures** — the app samples your
+  vitals every 10 seconds in the background (including while minimized to the
+  tray), so you can investigate what caused a spike yesterday instead of seeing
+  only the live moment
+- **Scrollable timeline** — pick a range (last hour, 6 hours, 24 hours, 7 days,
+  30 days); the usage chart (CPU / RAM / GPU %) and a separate temperature chart
+  (CPU / GPU °C) redraw to fit, downsampled so even a 30-day view stays smooth
+- **Configurable retention** — keep 7, 14, or 30 days of history; older samples
+  are pruned automatically
+- **Export to CSV** — save the visible range for analysis in Excel or elsewhere
+- Strictly local: history is stored in your `%LocalAppData%\SysManager` folder
+  and nothing ever leaves the machine
 
 ### File Lock Detector
 - **Find what's holding a file** — when you get a "file in use" error, enter or

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -431,4 +431,18 @@ public class MainWindowViewModelTests
         Assert.IsType<StandbyMemoryViewModel>(item.Content);
         Assert.False(item.IsInDevelopment);
     }
+
+    // Resource History (#13) is implemented but newly added — it's wired to a real
+    // view/VM and flagged PREVIEW (IsInDevelopment == true) until QA-verified, not a
+    // PlaceholderView stub. This pins both facts so an accidental regression to the
+    // placeholder, or a premature graduation, fails here.
+    [Fact]
+    public void NavLeaf_ResourceHistory_IsImplementedAndInPreview()
+    {
+        var vm = new MainWindowViewModel();
+        var item = vm.NavItems.First(n => n.Id == "nav-resource-history");
+        Assert.Equal(typeof(SysManager.Views.ResourceHistoryView), item.ViewType);
+        Assert.IsType<ResourceHistoryViewModel>(item.Content);
+        Assert.True(item.IsInDevelopment);
+    }
 }

--- a/SysManager/SysManager.Tests/ResourceHistoryServiceTests.cs
+++ b/SysManager/SysManager.Tests/ResourceHistoryServiceTests.cs
@@ -1,0 +1,167 @@
+// SysManager · ResourceHistoryServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+public class ResourceHistoryServiceTests
+{
+    private static ResourceSample Sample(DateTime t, double cpu = 10, double ram = 20,
+        double? gpu = null, double? cpuTemp = null, double? gpuTemp = null)
+        => new(t, cpu, ram, gpu, cpuTemp, gpuTemp);
+
+    // ── Serialize / parse round-trip ──────────────────────────────────────
+
+    [Fact]
+    public void SerializeThenParse_RoundTripsAllFields()
+    {
+        var original = Sample(new DateTime(2026, 6, 29, 12, 30, 0), cpu: 42.5, ram: 63.1,
+            gpu: 88.0, cpuTemp: 55.5, gpuTemp: 70.0);
+
+        var line = ResourceHistoryService.Serialize(original);
+        Assert.True(ResourceHistoryService.TryParse(line, out var parsed));
+
+        Assert.Equal(original.Timestamp, parsed!.Timestamp);
+        Assert.Equal(42.5, parsed.CpuPercent);
+        Assert.Equal(63.1, parsed.RamPercent);
+        Assert.Equal(88.0, parsed.GpuPercent);
+        Assert.Equal(55.5, parsed.CpuTempC);
+        Assert.Equal(70.0, parsed.GpuTempC);
+    }
+
+    [Fact]
+    public void Serialize_UsesShortKeys_ToBoundFileSize()
+    {
+        var line = ResourceHistoryService.Serialize(Sample(new DateTime(2026, 1, 1), gpu: 1, cpuTemp: 2, gpuTemp: 3));
+        // Compact property names keep the on-disk NDJSON small.
+        Assert.Contains("\"c\":", line);
+        Assert.Contains("\"r\":", line);
+        Assert.DoesNotContain("CpuPercent", line);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not json")]
+    [InlineData("{ broken")]
+    public void TryParse_RejectsBlankOrMalformed(string? line)
+    {
+        Assert.False(ResourceHistoryService.TryParse(line, out var s));
+        Assert.Null(s);
+    }
+
+    // ── Prune ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Prune_DropsExpiredAndMalformed_KeepsRecent_OldestFirst()
+    {
+        var now = new DateTime(2026, 6, 29, 12, 0, 0);
+        var lines = new[]
+        {
+            ResourceHistoryService.Serialize(Sample(now.AddDays(-10))), // expired (7d window)
+            "garbage line",                                              // malformed
+            ResourceHistoryService.Serialize(Sample(now.AddHours(-1))), // keep
+            ResourceHistoryService.Serialize(Sample(now.AddDays(-3))),  // keep
+        };
+
+        var kept = ResourceHistoryService.Prune(lines, now, TimeSpan.FromDays(7));
+
+        Assert.Equal(2, kept.Count);
+        // Oldest-first: the -3d sample precedes the -1h sample.
+        Assert.True(ResourceHistoryService.TryParse(kept[0], out var first));
+        Assert.True(ResourceHistoryService.TryParse(kept[1], out var second));
+        Assert.Equal(now.AddDays(-3), first!.Timestamp);
+        Assert.Equal(now.AddHours(-1), second!.Timestamp);
+    }
+
+    [Fact]
+    public void Prune_EmptyInput_ReturnsEmpty()
+        => Assert.Empty(ResourceHistoryService.Prune([], DateTime.Now, TimeSpan.FromDays(7)));
+
+    // ── Downsample ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Downsample_BelowCap_ReturnsInputUnchanged()
+    {
+        var now = new DateTime(2026, 6, 29);
+        var input = new[] { Sample(now), Sample(now.AddMinutes(1)), Sample(now.AddMinutes(2)) };
+        var result = ResourceHistoryService.Downsample(input, 400);
+        Assert.Same(input, result);
+    }
+
+    [Fact]
+    public void Downsample_AboveCap_ReducesToAtMostMaxPoints()
+    {
+        var now = new DateTime(2026, 6, 29);
+        var input = Enumerable.Range(0, 1000).Select(i => Sample(now.AddSeconds(i * 10), cpu: i % 100)).ToList();
+        var result = ResourceHistoryService.Downsample(input, 100);
+        Assert.True(result.Count <= 100);
+        Assert.True(result.Count > 0);
+    }
+
+    [Fact]
+    public void Downsample_AveragesUsageWithinBucket()
+    {
+        var now = new DateTime(2026, 6, 29);
+        // Two buckets: first four samples avg to 30, last four avg to 70.
+        var input = new[]
+        {
+            Sample(now.AddSeconds(0), cpu: 20), Sample(now.AddSeconds(10), cpu: 40),
+            Sample(now.AddSeconds(20), cpu: 20), Sample(now.AddSeconds(30), cpu: 40),
+            Sample(now.AddSeconds(40), cpu: 60), Sample(now.AddSeconds(50), cpu: 80),
+            Sample(now.AddSeconds(60), cpu: 60), Sample(now.AddSeconds(70), cpu: 80),
+        };
+        var result = ResourceHistoryService.Downsample(input, 2);
+        Assert.Equal(2, result.Count);
+        Assert.Equal(30, result[0].CpuPercent);
+        Assert.Equal(70, result[1].CpuPercent);
+    }
+
+    [Fact]
+    public void Downsample_BucketWithNoGpu_LeavesGpuNull()
+    {
+        var now = new DateTime(2026, 6, 29);
+        var input = Enumerable.Range(0, 50).Select(i => Sample(now.AddSeconds(i), cpu: 10, gpu: null)).ToList();
+        var result = ResourceHistoryService.Downsample(input, 5);
+        Assert.All(result, s => Assert.Null(s.GpuPercent));
+    }
+
+    // ── CSV ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ToCsv_HasHeader_AndRowPerSample_WithEmptyCellsForMissing()
+    {
+        var now = new DateTime(2026, 6, 29, 8, 0, 0);
+        var samples = new[]
+        {
+            Sample(now, cpu: 12.3, ram: 45.6, gpu: 78.9, cpuTemp: 50, gpuTemp: 60),
+            Sample(now.AddSeconds(10), cpu: 1, ram: 2, gpu: null, cpuTemp: null, gpuTemp: null),
+        };
+
+        var csv = ResourceHistoryService.ToCsv(samples);
+        var lines = csv.Trim().Split('\n').Select(l => l.TrimEnd('\r')).ToArray();
+
+        Assert.Equal("Timestamp,CPU %,RAM %,GPU %,CPU Temp °C,GPU Temp °C", lines[0]);
+        Assert.Equal(3, lines.Length); // header + 2 rows
+        Assert.Equal("2026-06-29 08:00:00,12.3,45.6,78.9,50.0,60.0", lines[1]);
+        // Missing GPU/temps render as empty trailing cells.
+        Assert.Equal("2026-06-29 08:00:10,1.0,2.0,,,", lines[2]);
+    }
+
+    [Fact]
+    public void ToCsv_UsesInvariantDecimalSeparator()
+    {
+        var csv = ResourceHistoryService.ToCsv([Sample(new DateTime(2026, 6, 29), cpu: 12.5)]);
+        Assert.Contains("12.5", csv);   // dot, never comma — comma is the CSV delimiter
+    }
+
+    // ── Config contract ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void RetentionOptions_AreSevenFourteenThirty()
+        => Assert.Equal([7, 14, 30], ResourceHistoryService.RetentionOptions);
+}

--- a/SysManager/SysManager.Tests/ResourceHistoryViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ResourceHistoryViewModelTests.cs
@@ -1,0 +1,44 @@
+// SysManager · ResourceHistoryViewModelTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+public class ResourceHistoryViewModelTests
+{
+    private static ResourceSample Sample(double cpu, double ram, double? cpuTemp = null)
+        => new(new DateTime(2026, 6, 29), cpu, ram, null, cpuTemp, null);
+
+    [Fact]
+    public void BuildSummary_EmptySamples_IsEmpty()
+        => Assert.Equal("", ResourceHistoryViewModel.BuildSummary([]));
+
+    [Fact]
+    public void BuildSummary_ReportsCpuAndRamAveragesAndPeaks()
+    {
+        var samples = new[] { Sample(20, 40), Sample(60, 80) };
+        var summary = ResourceHistoryViewModel.BuildSummary(samples);
+        Assert.Contains("CPU avg 40%", summary);
+        Assert.Contains("peak 60%", summary);
+        Assert.Contains("RAM avg 60%", summary);
+        Assert.Contains("peak 80%", summary);
+    }
+
+    [Fact]
+    public void BuildSummary_WithoutTemps_OmitsTempSegment()
+    {
+        var summary = ResourceHistoryViewModel.BuildSummary([Sample(10, 10)]);
+        Assert.DoesNotContain("temp", summary);
+    }
+
+    [Fact]
+    public void BuildSummary_WithTemps_IncludesPeakTemp()
+    {
+        var samples = new[] { Sample(10, 10, cpuTemp: 55), Sample(10, 10, cpuTemp: 72) };
+        var summary = ResourceHistoryViewModel.BuildSummary(samples);
+        Assert.Contains("CPU temp peak 72°C", summary);
+    }
+}

--- a/SysManager/SysManager/App.xaml.cs
+++ b/SysManager/SysManager/App.xaml.cs
@@ -95,6 +95,11 @@ public partial class App : Application
         // Initialize tray icon service from DI
         _trayService = Services.GetRequiredService<TrayIconService>();
 
+        // Start the always-on resource history sampler so usage/temperature trends
+        // accrue for the whole session, including while minimized to the tray. The
+        // service is disposed with the DI container on exit (stops the loop).
+        Services.GetRequiredService<ResourceHistoryService>().Start();
+
         DispatcherUnhandledException += OnUi;
         AppDomain.CurrentDomain.UnhandledException += OnDomain;
         TaskScheduler.UnobservedTaskException += OnTask;

--- a/SysManager/SysManager/Models/ResourceSample.cs
+++ b/SysManager/SysManager/Models/ResourceSample.cs
@@ -1,0 +1,21 @@
+// SysManager · ResourceSample — one point-in-time reading of system resource usage
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Text.Json.Serialization;
+
+namespace SysManager.Models;
+
+/// <summary>
+/// A single sample of system vitals captured by the always-on resource history sampler.
+/// Stored one-per-line as NDJSON. Usage values are percentages (0-100); temperatures are
+/// in °C. GPU usage and temperatures are nullable because they are best-effort (NVIDIA-only
+/// usage, admin-only CPU temperature). Property names are kept short to bound the on-disk size.
+/// </summary>
+public sealed record ResourceSample(
+    [property: JsonPropertyName("t")] DateTime Timestamp,
+    [property: JsonPropertyName("c")] double CpuPercent,
+    [property: JsonPropertyName("r")] double RamPercent,
+    [property: JsonPropertyName("g")] double? GpuPercent,
+    [property: JsonPropertyName("ct")] double? CpuTempC,
+    [property: JsonPropertyName("gt")] double? GpuTempC);

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -80,6 +80,7 @@ public static class ServiceRegistration
         services.AddSingleton<TaskSchedulerService>();
         services.AddSingleton<IWindowsThemeService, WindowsThemeService>();
         services.AddSingleton<StandbyMemoryService>();
+        services.AddSingleton<ResourceHistoryService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
         services.AddSingleton<DashboardViewModel>();
@@ -132,6 +133,7 @@ public static class ServiceRegistration
         services.AddSingleton<TaskSchedulerViewModel>();
         services.AddSingleton<DarkModeViewModel>();
         services.AddSingleton<StandbyMemoryViewModel>();
+        services.AddSingleton<ResourceHistoryViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/ResourceHistoryService.cs
+++ b/SysManager/SysManager/Services/ResourceHistoryService.cs
@@ -1,0 +1,361 @@
+// SysManager · ResourceHistoryService — always-on sampler that records system vitals to disk
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Records CPU, RAM and (best-effort) GPU usage plus CPU/GPU temperatures at a fixed
+/// interval for the whole app lifetime, so the user can scroll back through hours or
+/// days of history. Samples are appended one-per-line as NDJSON to
+/// <c>%LocalAppData%\SysManager\resource-history.ndjson</c> with a configurable
+/// retention window (7 / 14 / 30 days). Strictly local: nothing is written to the
+/// system and nothing leaves the machine.
+/// </summary>
+public sealed class ResourceHistoryService : IDisposable
+{
+    /// <summary>How often a sample is taken. Matches the issue's "every 5-10 seconds".</summary>
+    public const int SampleIntervalSeconds = 10;
+
+    /// <summary>Retention options offered in the UI (days).</summary>
+    public static readonly int[] RetentionOptions = [7, 14, 30];
+
+    // Prune (rewrite to drop expired lines) at most once an hour while running, so a
+    // long-lived session doesn't let the file grow past the retention window on disk.
+    private const int PruneEverySamples = 360; // 360 × 10s = 1 hour
+
+    private static readonly string DataDir = Path.Join(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager");
+    private static readonly string DataPath = Path.Join(DataDir, "resource-history.ndjson");
+    private static readonly string ConfigPath = Path.Join(DataDir, "resource-history-config.json");
+
+    private static readonly JsonSerializerOptions SampleJson = new() { WriteIndented = false };
+
+    private readonly SystemInfoService _sys;
+    private readonly TemperatureService _temps;
+    private readonly SemaphoreSlim _fileLock = new(1, 1);
+
+    private CancellationTokenSource? _cts;
+    private bool _disposed;
+    private int _samplesSincePrune;
+
+    // GPU usage is NVIDIA-only and the adapter availability is static for a session —
+    // initialise the vendor API at most once, exactly like DashboardViewModel does.
+    private bool _nvApiInitTried;
+    private bool _nvApiAvailable;
+
+    private int _retentionDays = 7;
+
+    public ResourceHistoryService(SystemInfoService sys, TemperatureService temps)
+    {
+        _sys = sys;
+        _temps = temps;
+        _retentionDays = LoadRetention();
+    }
+
+    /// <summary>Days of history to keep. Persisted; shrinking it prunes the file.</summary>
+    public int RetentionDays
+    {
+        get => _retentionDays;
+        set
+        {
+            var clamped = RetentionOptions.Contains(value) ? value : 7;
+            if (clamped == _retentionDays) return;
+            _retentionDays = clamped;
+            SaveRetention(clamped);
+            _ = PruneAsync();
+        }
+    }
+
+    public DateTime? LastSampleAt { get; private set; }
+
+    /// <summary>
+    /// Starts the background sampling loop. Idempotent — a second call is a no-op while a
+    /// loop is already running. Called once at app startup so history accrues even when the
+    /// window is hidden to the tray.
+    /// </summary>
+    public void Start()
+    {
+        if (_disposed || _cts is not null) return;
+        _cts = new CancellationTokenSource();
+        var ct = _cts.Token;
+
+        // Prune stale/malformed lines from a previous session before accruing new ones.
+        _ = PruneAsync();
+
+        _ = Task.Run(async () =>
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                try
+                {
+                    var sample = await CaptureSampleAsync(ct).ConfigureAwait(false);
+                    await AppendAsync(sample, ct).ConfigureAwait(false);
+                    LastSampleAt = sample.Timestamp;
+
+                    if (++_samplesSincePrune >= PruneEverySamples)
+                    {
+                        _samplesSincePrune = 0;
+                        await PruneAsync().ConfigureAwait(false);
+                    }
+
+                    await Task.Delay(TimeSpan.FromSeconds(SampleIntervalSeconds), ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) { break; }
+                catch (Exception ex)
+                {
+                    Log.Debug("Resource history sampling error: {Error}", ex.Message);
+                    try { await Task.Delay(TimeSpan.FromSeconds(SampleIntervalSeconds), ct).ConfigureAwait(false); }
+                    catch (OperationCanceledException) { break; }
+                }
+            }
+        }, ct);
+    }
+
+    private async Task<ResourceSample> CaptureSampleAsync(CancellationToken ct)
+    {
+        var snap = await _sys.CaptureAsync(ct).ConfigureAwait(false);
+        double? gpuPercent = ReadGpuUsage();
+
+        double? cpuTemp = null, gpuTemp = null;
+        try
+        {
+            var readings = await _temps.ReadAllAsync().ConfigureAwait(false);
+            cpuTemp = readings
+                .Where(r => r.Component == "CPU" && r.TemperatureC.HasValue)
+                .Select(r => r.TemperatureC).Max();
+            gpuTemp = readings
+                .Where(r => r.Component.StartsWith("GPU", StringComparison.Ordinal) && r.TemperatureC.HasValue)
+                .Select(r => r.TemperatureC).DefaultIfEmpty(null).Max();
+        }
+        catch (Exception ex) when (ex is System.Management.ManagementException or InvalidOperationException)
+        {
+            Log.Debug("Resource history temperature read failed: {Error}", ex.Message);
+        }
+
+        return new ResourceSample(snap.CapturedAt, snap.Cpu.LoadPercent, snap.Memory.UsedPercent,
+            gpuPercent, cpuTemp, gpuTemp);
+    }
+
+    private double? ReadGpuUsage()
+    {
+        if (!_nvApiInitTried)
+        {
+            _nvApiInitTried = true;
+            try
+            {
+                NvAPIWrapper.NVIDIA.Initialize();
+                _nvApiAvailable = NvAPIWrapper.GPU.PhysicalGPU.GetPhysicalGPUs().Length > 0;
+            }
+            catch (Exception ex)
+            {
+                _nvApiAvailable = false;
+                Log.Debug("Resource history: NVIDIA GPU API unavailable: {Error}", ex.Message);
+            }
+        }
+
+        if (!_nvApiAvailable) return null;
+        try
+        {
+            var gpus = NvAPIWrapper.GPU.PhysicalGPU.GetPhysicalGPUs();
+            return gpus.Length > 0 ? gpus[0].UsageInformation.GPU.Percentage : null;
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("Resource history: NVIDIA GPU usage read failed: {Error}", ex.Message);
+            return null;
+        }
+    }
+
+    // ── Disk access ──────────────────────────────────────────────────────
+
+    private async Task AppendAsync(ResourceSample sample, CancellationToken ct)
+    {
+        await _fileLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            Directory.CreateDirectory(DataDir);
+            await File.AppendAllTextAsync(DataPath, Serialize(sample) + "\n", ct).ConfigureAwait(false);
+        }
+        catch (IOException ex) { Log.Debug("Resource history append failed: {Error}", ex.Message); }
+        finally { _fileLock.Release(); }
+    }
+
+    /// <summary>
+    /// Loads samples newer than <paramref name="range"/> ago, oldest-first. Malformed lines
+    /// are skipped. Returns an empty list when no history exists yet.
+    /// </summary>
+    public async Task<IReadOnlyList<ResourceSample>> LoadAsync(TimeSpan range, CancellationToken ct = default)
+    {
+        await _fileLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (!File.Exists(DataPath)) return [];
+            var lines = await File.ReadAllLinesAsync(DataPath, ct).ConfigureAwait(false);
+            var cutoff = DateTime.Now - range;
+            var samples = new List<ResourceSample>(lines.Length);
+            foreach (var line in lines)
+            {
+                if (TryParse(line, out var s) && s!.Timestamp >= cutoff)
+                    samples.Add(s);
+            }
+            samples.Sort((a, b) => a.Timestamp.CompareTo(b.Timestamp));
+            return samples;
+        }
+        catch (IOException ex) { Log.Debug("Resource history load failed: {Error}", ex.Message); return []; }
+        finally { _fileLock.Release(); }
+    }
+
+    /// <summary>Rewrites the file dropping samples older than the retention window and any malformed lines.</summary>
+    public async Task PruneAsync()
+    {
+        await _fileLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (!File.Exists(DataPath)) return;
+            var lines = await File.ReadAllLinesAsync(DataPath).ConfigureAwait(false);
+            var kept = Prune(lines, DateTime.Now, TimeSpan.FromDays(_retentionDays));
+            // Only rewrite when something actually changed, to avoid needless disk churn.
+            if (kept.Count == lines.Length) return;
+            await File.WriteAllLinesAsync(DataPath, kept).ConfigureAwait(false);
+        }
+        catch (IOException ex) { Log.Debug("Resource history prune failed: {Error}", ex.Message); }
+        finally { _fileLock.Release(); }
+    }
+
+    // ── Pure helpers (unit-testable, no WPF / WMI / file IO) ───────────────
+
+    /// <summary>Serializes one sample to a single NDJSON line.</summary>
+    public static string Serialize(ResourceSample sample) => JsonSerializer.Serialize(sample, SampleJson);
+
+    /// <summary>Parses one NDJSON line. Returns false (and null) for blank or malformed input.</summary>
+    public static bool TryParse(string? line, out ResourceSample? sample)
+    {
+        sample = null;
+        if (string.IsNullOrWhiteSpace(line)) return false;
+        try
+        {
+            sample = JsonSerializer.Deserialize<ResourceSample>(line, SampleJson);
+            return sample is not null;
+        }
+        catch (JsonException) { return false; }
+    }
+
+    /// <summary>Returns the input lines that parse and are newer than <paramref name="now"/> minus retention, oldest-first.</summary>
+    public static List<string> Prune(IEnumerable<string> lines, DateTime now, TimeSpan retention)
+    {
+        var cutoff = now - retention;
+        var kept = new List<ResourceSample>();
+        foreach (var line in lines)
+            if (TryParse(line, out var s) && s!.Timestamp >= cutoff)
+                kept.Add(s);
+        kept.Sort((a, b) => a.Timestamp.CompareTo(b.Timestamp));
+        return kept.Select(Serialize).ToList();
+    }
+
+    /// <summary>
+    /// Reduces a sample series to at most <paramref name="maxPoints"/> evenly-spaced buckets,
+    /// averaging usage within each bucket, so a multi-day series renders without choking the
+    /// chart. Series at or below the cap are returned unchanged. Pure and order-preserving.
+    /// </summary>
+    public static IReadOnlyList<ResourceSample> Downsample(IReadOnlyList<ResourceSample> samples, int maxPoints)
+    {
+        if (maxPoints < 1) maxPoints = 1;
+        if (samples.Count <= maxPoints) return samples;
+
+        var result = new List<ResourceSample>(maxPoints);
+        // Bucket by position so the time spacing stays uniform across the whole range.
+        double bucketSize = samples.Count / (double)maxPoints;
+        for (int b = 0; b < maxPoints; b++)
+        {
+            int start = (int)(b * bucketSize);
+            int end = (int)((b + 1) * bucketSize);
+            if (end <= start) end = start + 1;
+            if (end > samples.Count) end = samples.Count;
+
+            double cpu = 0, ram = 0, gpu = 0, ctemp = 0, gtemp = 0;
+            int n = 0, gN = 0, ctN = 0, gtN = 0;
+            for (int i = start; i < end; i++)
+            {
+                var s = samples[i];
+                cpu += s.CpuPercent; ram += s.RamPercent; n++;
+                if (s.GpuPercent.HasValue) { gpu += s.GpuPercent.Value; gN++; }
+                if (s.CpuTempC.HasValue) { ctemp += s.CpuTempC.Value; ctN++; }
+                if (s.GpuTempC.HasValue) { gtemp += s.GpuTempC.Value; gtN++; }
+            }
+            if (n == 0) continue;
+            // The bucket's timestamp is its midpoint sample's, so the X axis stays truthful.
+            var mid = samples[Math.Min(start + (end - start) / 2, samples.Count - 1)].Timestamp;
+            result.Add(new ResourceSample(mid,
+                Math.Round(cpu / n, 1),
+                Math.Round(ram / n, 1),
+                gN > 0 ? Math.Round(gpu / gN, 1) : null,
+                ctN > 0 ? Math.Round(ctemp / ctN, 1) : null,
+                gtN > 0 ? Math.Round(gtemp / gtN, 1) : null));
+        }
+        return result;
+    }
+
+    /// <summary>Renders a sample series as CSV with a header row. Empty cells for missing GPU/temperature values.</summary>
+    public static string ToCsv(IEnumerable<ResourceSample> samples)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Timestamp,CPU %,RAM %,GPU %,CPU Temp °C,GPU Temp °C");
+        foreach (var s in samples)
+        {
+            sb.Append(s.Timestamp.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)).Append(',');
+            sb.Append(s.CpuPercent.ToString("F1", CultureInfo.InvariantCulture)).Append(',');
+            sb.Append(s.RamPercent.ToString("F1", CultureInfo.InvariantCulture)).Append(',');
+            sb.Append(s.GpuPercent?.ToString("F1", CultureInfo.InvariantCulture)).Append(',');
+            sb.Append(s.CpuTempC?.ToString("F1", CultureInfo.InvariantCulture)).Append(',');
+            sb.AppendLine(s.GpuTempC?.ToString("F1", CultureInfo.InvariantCulture));
+        }
+        return sb.ToString();
+    }
+
+    // ── Retention config persistence ───────────────────────────────────────
+
+    private sealed record RetentionConfig(int RetentionDays);
+
+    private static int LoadRetention()
+    {
+        try
+        {
+            if (!File.Exists(ConfigPath)) return 7;
+            var cfg = JsonSerializer.Deserialize<RetentionConfig>(File.ReadAllText(ConfigPath));
+            return cfg is not null && RetentionOptions.Contains(cfg.RetentionDays) ? cfg.RetentionDays : 7;
+        }
+        catch (Exception ex) when (ex is JsonException or IOException)
+        {
+            Log.Debug("Resource history config load failed: {Error}", ex.Message);
+            return 7;
+        }
+    }
+
+    private static void SaveRetention(int days)
+    {
+        try
+        {
+            Directory.CreateDirectory(DataDir);
+            File.WriteAllText(ConfigPath, JsonSerializer.Serialize(new RetentionConfig(days)));
+        }
+        catch (IOException ex) { Log.Debug("Resource history config save failed: {Error}", ex.Message); }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = null;
+        _fileLock.Dispose();
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.46.0</Version>
-    <FileVersion>1.46.0.0</FileVersion>
-    <AssemblyVersion>1.46.0.0</AssemblyVersion>
+    <Version>1.47.0</Version>
+    <FileVersion>1.47.0.0</FileVersion>
+    <AssemblyVersion>1.47.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -65,10 +65,10 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public TaskSchedulerViewModel TaskScheduler { get; }
     public DarkModeViewModel DarkMode { get; }
     public StandbyMemoryViewModel StandbyMemory { get; }
+    public ResourceHistoryViewModel ResourceHistory { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
-    public PlaceholderViewModel WipResourceHistory { get; private set; } = null!;
     public PlaceholderViewModel WipFileLockDetector { get; private set; } = null!;
     public PlaceholderViewModel WipSettingsWatchdog { get; private set; } = null!;
     public PlaceholderViewModel WipBandwidthMonitor { get; private set; } = null!;
@@ -175,6 +175,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             TaskScheduler = sp.GetRequiredService<TaskSchedulerViewModel>();
             DarkMode = sp.GetRequiredService<DarkModeViewModel>();
             StandbyMemory = sp.GetRequiredService<StandbyMemoryViewModel>();
+            ResourceHistory = sp.GetRequiredService<ResourceHistoryViewModel>();
         }
         else
         {
@@ -244,6 +245,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             TaskScheduler = new TaskSchedulerViewModel(new TaskSchedulerService(new PowerShellRunner()));
             DarkMode = new DarkModeViewModel(new WindowsThemeService());
             StandbyMemory = new StandbyMemoryViewModel(new StandbyMemoryService());
+            ResourceHistory = new ResourceHistoryViewModel(new ResourceHistoryService(sysInfo, new TemperatureService(diskHealth)));
         }
 
         InitPlaceholders();
@@ -255,7 +257,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         // ── WIP placeholders for planned features ──────────────────────
 
         // Monitor group
-        WipResourceHistory = new PlaceholderViewModel("Resource History", "Historical CPU, RAM, GPU and temperature graphs with timeline.", "#13");
         WipFileLockDetector = new PlaceholderViewModel("File Lock Detector", "Find which process is locking a file and optionally release the handle.", "#333");
         WipSettingsWatchdog = new PlaceholderViewModel("Settings Watchdog", "Detect when Windows Update resets your settings and offer one-click restore.", "#335");
         WipBandwidthMonitor = new PlaceholderViewModel("Bandwidth Monitor", "Real-time per-app network usage with history graphs and alerts.", "#337");
@@ -336,7 +337,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
         Group("grp-monitor", "Monitor", "",
             Item("nav-processes",         "Process Manager",    "", ProcessManager,      typeof(Views.ProcessManagerView)),
-            Item("nav-resource-history",  "Resource History",   "", WipResourceHistory,  typeof(Views.PlaceholderView)),
+            Item("nav-resource-history",  "Resource History",   "", ResourceHistory,     typeof(Views.ResourceHistoryView), inDevelopment: true),
             Item("nav-privacy-monitor",   "Camera/Mic/Location",    "", PrivacyMonitor,      typeof(Views.PrivacyMonitorView)),
             Item("nav-app-alerts",        "App Alerts",         "", AppAlerts,           typeof(Views.AppAlertsView)),
             Item("nav-file-lock",         "File Lock Detector", "", FileLock,            typeof(Views.FileLockView)),
@@ -504,9 +505,9 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         TaskScheduler?.Dispose();
         DarkMode?.Dispose();
         StandbyMemory?.Dispose();
+        ResourceHistory?.Dispose();
 
         // WIP placeholders
-        WipResourceHistory?.Dispose();
         WipFileLockDetector?.Dispose();
         WipSettingsWatchdog?.Dispose();
         WipBandwidthMonitor?.Dispose();

--- a/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
@@ -1,0 +1,259 @@
+// SysManager · ResourceHistoryViewModel
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Text;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using LiveChartsCore;
+using LiveChartsCore.Defaults;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Painting;
+using Microsoft.Win32;
+using Serilog;
+using SkiaSharp;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// Shows the history recorded by <see cref="ResourceHistoryService"/> as a scrollable
+/// usage chart (CPU / RAM / GPU %) and a temperature chart (CPU / GPU °C), with a
+/// selectable time range and CSV export. Read-only: it never modifies the system and the
+/// CSV is written only to a file the user picks. Nothing leaves the machine.
+/// </summary>
+public sealed partial class ResourceHistoryViewModel : ViewModelBase
+{
+    // A chart renders cleanly with a few hundred points; more just costs CPU with no
+    // visible benefit, so any range is downsampled to this cap before plotting.
+    private const int MaxChartPoints = 400;
+
+    private readonly ResourceHistoryService _service;
+    private IReadOnlyList<ResourceSample> _loaded = [];
+
+    public sealed record RangeOption(string Label, TimeSpan Range);
+
+    public IReadOnlyList<RangeOption> RangeOptions { get; } =
+    [
+        new("Last hour", TimeSpan.FromHours(1)),
+        new("Last 6 hours", TimeSpan.FromHours(6)),
+        new("Last 24 hours", TimeSpan.FromDays(1)),
+        new("Last 7 days", TimeSpan.FromDays(7)),
+        new("Last 30 days", TimeSpan.FromDays(30)),
+    ];
+
+    public int[] RetentionOptions => ResourceHistoryService.RetentionOptions;
+
+    [ObservableProperty] private RangeOption _selectedRange;
+    [ObservableProperty] private int _retentionDays;
+    [ObservableProperty] private int _sampleCount;
+    [ObservableProperty] private bool _hasData;
+    [ObservableProperty] private string _summary = "";
+
+    // ── Charts (built once, buffers replaced on reload) ───────────────────
+    public ObservableCollection<ISeries> UsageSeries { get; } = new();
+    public Axis[] UsageXAxes { get; }
+    public Axis[] UsageYAxes { get; }
+
+    public ObservableCollection<ISeries> TemperatureSeries { get; } = new();
+    public Axis[] TemperatureXAxes { get; }
+    public Axis[] TemperatureYAxes { get; }
+
+    public SolidColorPaint LegendTextPaint { get; } = new(SKColor.Parse("E6E9EE")) { SKTypeface = SKTypeface.FromFamilyName("Segoe UI") };
+    public SolidColorPaint LegendBackgroundPaint { get; } = new(SKColors.Transparent);
+    public SolidColorPaint TooltipTextPaint { get; } = new(SKColor.Parse("E6E9EE"));
+    public SolidColorPaint TooltipBackgroundPaint { get; } = new(SKColor.Parse("1C2230"));
+
+    private readonly BulkObservableCollection<DateTimePoint> _cpuBuffer = new();
+    private readonly BulkObservableCollection<DateTimePoint> _ramBuffer = new();
+    private readonly BulkObservableCollection<DateTimePoint> _gpuBuffer = new();
+    private readonly BulkObservableCollection<DateTimePoint> _cpuTempBuffer = new();
+    private readonly BulkObservableCollection<DateTimePoint> _gpuTempBuffer = new();
+
+    public ResourceHistoryViewModel(ResourceHistoryService service)
+    {
+        _service = service;
+        _retentionDays = service.RetentionDays;
+        _selectedRange = RangeOptions[2]; // Last 24 hours
+
+        UsageXAxes = [BuildTimeAxis()];
+        UsageYAxes = [BuildPercentAxis()];
+        TemperatureXAxes = [BuildTimeAxis()];
+        TemperatureYAxes = [BuildTempAxis()];
+
+        UsageSeries.Add(BuildLine("CPU", "#60A5FA", _cpuBuffer));
+        UsageSeries.Add(BuildLine("RAM", "#A78BFA", _ramBuffer));
+        UsageSeries.Add(BuildLine("GPU", "#34D399", _gpuBuffer));
+        TemperatureSeries.Add(BuildLine("CPU °C", "#F59E0B", _cpuTempBuffer));
+        TemperatureSeries.Add(BuildLine("GPU °C", "#EF4444", _gpuTempBuffer));
+
+        InitializeAsync(() => ReloadAsync());
+    }
+
+    partial void OnSelectedRangeChanged(RangeOption value) => _ = ReloadAsync();
+
+    partial void OnRetentionDaysChanged(int value)
+    {
+        _service.RetentionDays = value;
+        StatusMessage = $"Keeping {value} days of history.";
+    }
+
+    [RelayCommand]
+    private async Task ReloadAsync()
+    {
+        IsBusy = true;
+        try
+        {
+            _loaded = await _service.LoadAsync(SelectedRange.Range);
+            var points = ResourceHistoryService.Downsample(_loaded, MaxChartPoints);
+
+            _cpuBuffer.ReplaceWith(points.Select(p => new DateTimePoint(p.Timestamp, p.CpuPercent)));
+            _ramBuffer.ReplaceWith(points.Select(p => new DateTimePoint(p.Timestamp, p.RamPercent)));
+            _gpuBuffer.ReplaceWith(points.Select(p => new DateTimePoint(p.Timestamp, p.GpuPercent)));
+            _cpuTempBuffer.ReplaceWith(points.Select(p => new DateTimePoint(p.Timestamp, p.CpuTempC)));
+            _gpuTempBuffer.ReplaceWith(points.Select(p => new DateTimePoint(p.Timestamp, p.GpuTempC)));
+
+            SampleCount = _loaded.Count;
+            HasData = _loaded.Count > 0;
+            Summary = BuildSummary(_loaded);
+            StatusMessage = HasData
+                ? $"Showing {_loaded.Count} sample(s) over {SelectedRange.Label.ToLowerInvariant()}."
+                : "No history yet — samples are recorded every 10 seconds while the app runs.";
+        }
+        finally { IsBusy = false; }
+    }
+
+    /// <summary>Pure: averages/peaks for the summary strip. Testable without WPF.</summary>
+    internal static string BuildSummary(IReadOnlyList<ResourceSample> samples)
+    {
+        if (samples.Count == 0) return "";
+        double avgCpu = samples.Average(s => s.CpuPercent);
+        double maxCpu = samples.Max(s => s.CpuPercent);
+        double avgRam = samples.Average(s => s.RamPercent);
+        double maxRam = samples.Max(s => s.RamPercent);
+        var sb = new StringBuilder();
+        sb.Append($"CPU avg {avgCpu:F0}% · peak {maxCpu:F0}%   ·   RAM avg {avgRam:F0}% · peak {maxRam:F0}%");
+        var temps = samples.Where(s => s.CpuTempC.HasValue).Select(s => s.CpuTempC!.Value).ToList();
+        if (temps.Count > 0)
+            sb.Append($"   ·   CPU temp peak {temps.Max():F0}°C");
+        return sb.ToString();
+    }
+
+    [RelayCommand(CanExecute = nameof(HasData))]
+    private async Task ExportCsvAsync()
+    {
+        var dlg = new SaveFileDialog
+        {
+            FileName = $"SysManager-Resources-{DateTime.Now:yyyy-MM-dd-HHmmss}.csv",
+            Filter = "CSV file (*.csv)|*.csv|All files (*.*)|*.*"
+        };
+        if (dlg.ShowDialog() != true) return;
+
+        IsBusy = true;
+        try
+        {
+            var csv = ResourceHistoryService.ToCsv(_loaded);
+            await File.WriteAllTextAsync(dlg.FileName, csv, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            StatusMessage = $"Exported {_loaded.Count} sample(s) to {Path.GetFileName(dlg.FileName)}.";
+            ToastService.Instance.Show("Resource history exported", Path.GetFileName(dlg.FileName));
+        }
+        catch (IOException ex) { StatusMessage = $"Export failed: {ex.Message}"; }
+        catch (UnauthorizedAccessException ex) { StatusMessage = $"Export failed (access denied): {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    partial void OnHasDataChanged(bool value) => ExportCsvCommand.NotifyCanExecuteChanged();
+
+    // ── Chart factories (mirror NetworkSharedState's idiom) ────────────────
+
+    private static LineSeries<DateTimePoint> BuildLine(string name, string hex, BulkObservableCollection<DateTimePoint> values)
+    {
+        var color = SKColor.Parse(hex.TrimStart('#')).WithAlpha(230);
+        return new LineSeries<DateTimePoint>
+        {
+            Name = name,
+            Values = values,
+            Fill = null,
+            GeometrySize = 0,
+            LineSmoothness = 0.3,
+            Stroke = new SolidColorPaint(color, 2),
+            AnimationsSpeed = TimeSpan.Zero
+        };
+    }
+
+    private static Axis BuildTimeAxis() => new()
+    {
+        Labeler = v => v > 0 && v < DateTime.MaxValue.Ticks ? new DateTime((long)v).ToString("MM-dd HH:mm") : "",
+        TextSize = 12,
+        NamePaint = new SolidColorPaint(SKColor.Parse("A3ADBF")),
+        LabelsPaint = new SolidColorPaint(SKColor.Parse("E6E9EE")) { SKTypeface = SKTypeface.FromFamilyName("Segoe UI") },
+        SeparatorsPaint = new SolidColorPaint(SKColor.Parse("2A3244").WithAlpha(80))
+    };
+
+    private static Axis BuildPercentAxis() => new()
+    {
+        Name = "Usage (%)",
+        MinLimit = 0,
+        MaxLimit = 100,
+        TextSize = 13,
+        NamePaint = new SolidColorPaint(SKColor.Parse("E6E9EE")) { SKTypeface = SKTypeface.FromFamilyName("Segoe UI") },
+        LabelsPaint = new SolidColorPaint(SKColor.Parse("E6E9EE")) { SKTypeface = SKTypeface.FromFamilyName("Segoe UI") },
+        SeparatorsPaint = new SolidColorPaint(SKColor.Parse("2A3244").WithAlpha(80)) { StrokeThickness = 1 },
+        Labeler = v => $"{v:F0}%",
+        NameTextSize = 14
+    };
+
+    private static Axis BuildTempAxis() => new()
+    {
+        Name = "Temperature (°C)",
+        MinLimit = 0,
+        TextSize = 13,
+        NamePaint = new SolidColorPaint(SKColor.Parse("E6E9EE")) { SKTypeface = SKTypeface.FromFamilyName("Segoe UI") },
+        LabelsPaint = new SolidColorPaint(SKColor.Parse("E6E9EE")) { SKTypeface = SKTypeface.FromFamilyName("Segoe UI") },
+        SeparatorsPaint = new SolidColorPaint(SKColor.Parse("2A3244").WithAlpha(80)) { StrokeThickness = 1 },
+        Labeler = v => $"{v:F0}°C",
+        NameTextSize = 14
+    };
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            foreach (var s in UsageSeries) DisposeSeries(s);
+            foreach (var s in TemperatureSeries) DisposeSeries(s);
+            DisposeAxisPaints(UsageXAxes);
+            DisposeAxisPaints(UsageYAxes);
+            DisposeAxisPaints(TemperatureXAxes);
+            DisposeAxisPaints(TemperatureYAxes);
+            LegendTextPaint.SKTypeface?.Dispose();
+            (LegendTextPaint as IDisposable)?.Dispose();
+            (LegendBackgroundPaint as IDisposable)?.Dispose();
+            (TooltipTextPaint as IDisposable)?.Dispose();
+            (TooltipBackgroundPaint as IDisposable)?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+
+    private static void DisposeSeries(ISeries series)
+    {
+        if (series is LineSeries<DateTimePoint> line)
+        {
+            (line.Stroke as IDisposable)?.Dispose();
+            (line.Fill as IDisposable)?.Dispose();
+        }
+    }
+
+    private static void DisposeAxisPaints(Axis[] axes)
+    {
+        foreach (var axis in axes)
+        {
+            (axis.NamePaint as IDisposable)?.Dispose();
+            (axis.LabelsPaint as IDisposable)?.Dispose();
+            (axis.SeparatorsPaint as IDisposable)?.Dispose();
+        }
+    }
+}

--- a/SysManager/SysManager/Views/ResourceHistoryView.xaml
+++ b/SysManager/SysManager/Views/ResourceHistoryView.xaml
@@ -1,0 +1,112 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.ResourceHistoryView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.WPF;assembly=LiveChartsCore.SkiaSharpView.WPF"
+             xmlns:v="clr-namespace:SysManager.Views"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:ResourceHistoryViewModel}">
+
+    <Grid Background="{DynamicResource Surface0}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Preview banner -->
+        <v:DevelopmentBanner Grid.Row="0" Margin="28,24,28,0"/>
+
+        <!-- Header + controls -->
+        <DockPanel Grid.Row="1" Margin="28,16,28,0">
+            <StackPanel>
+                <TextBlock Text="Resource History" Style="{StaticResource Display}"/>
+                <TextBlock Text="Historical CPU, RAM, GPU usage and temperatures. Samples are recorded every 10 seconds while the app runs — scroll back through hours or days, then export to CSV."
+                           Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap" MaxWidth="820"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
+                        DockPanel.Dock="Right" VerticalAlignment="Center">
+                <TextBlock Text="Range" Style="{StaticResource Subtle}" VerticalAlignment="Center"/>
+                <ComboBox ItemsSource="{Binding RangeOptions}" DisplayMemberPath="Label"
+                          SelectedItem="{Binding SelectedRange, Mode=TwoWay}" Width="150" Margin="8,0,0,0"
+                          AutomationProperties.Name="History time range"/>
+                <TextBlock Text="Keep" Style="{StaticResource Subtle}" VerticalAlignment="Center" Margin="16,0,0,0"/>
+                <ComboBox ItemsSource="{Binding RetentionOptions}"
+                          SelectedItem="{Binding RetentionDays, Mode=TwoWay}" Width="64" Margin="8,0,0,0"
+                          AutomationProperties.Name="History retention in days"/>
+                <TextBlock Text="days" Style="{StaticResource Subtle}" VerticalAlignment="Center" Margin="6,0,0,0"/>
+                <Button Content="Refresh" Command="{Binding ReloadCommand}"
+                        Style="{StaticResource GhostButton}" Margin="16,0,0,0"
+                        AutomationProperties.Name="Refresh history"/>
+                <Button Content="Export CSV" Command="{Binding ExportCsvCommand}"
+                        Style="{StaticResource SecondaryButton}" Margin="6,0,0,0"
+                        AutomationProperties.Name="Export history to CSV"/>
+            </StackPanel>
+        </DockPanel>
+
+        <!-- Summary strip -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,0"
+                Visibility="{Binding HasData, Converter={StaticResource FlexVis}}">
+            <TextBlock Text="{Binding Summary}" Foreground="{DynamicResource TextSecondary}"
+                       FontSize="13" TextWrapping="Wrap"/>
+        </Border>
+
+        <!-- Charts -->
+        <Grid Grid.Row="3" Margin="28,16,28,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="3*"/>
+                <RowDefinition Height="2*"/>
+            </Grid.RowDefinitions>
+
+            <!-- Usage chart -->
+            <Border Grid.Row="0" Style="{StaticResource Card}" Margin="0,0,0,12">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock Grid.Row="0" Text="Usage" Style="{StaticResource SectionTitle}" Margin="0,0,0,12"/>
+                    <lvc:CartesianChart Grid.Row="1" Background="Transparent" MinHeight="180"
+                                        Series="{Binding UsageSeries}"
+                                        XAxes="{Binding UsageXAxes}" YAxes="{Binding UsageYAxes}"
+                                        LegendPosition="Bottom"
+                                        LegendTextPaint="{Binding LegendTextPaint}"
+                                        LegendBackgroundPaint="{Binding LegendBackgroundPaint}"
+                                        TooltipTextPaint="{Binding TooltipTextPaint}"
+                                        TooltipBackgroundPaint="{Binding TooltipBackgroundPaint}"/>
+                    <v:EmptyState Grid.Row="1" Glyph="&#xE9D9;" Title="No history yet"
+                                  Message="Resource samples are recorded every 10 seconds while the app runs. Come back after a while to see your usage trend."
+                                  Visibility="{Binding HasData, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                </Grid>
+            </Border>
+
+            <!-- Temperature chart -->
+            <Border Grid.Row="1" Style="{StaticResource Card}">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock Grid.Row="0" Text="Temperature" Style="{StaticResource SectionTitle}" Margin="0,0,0,12"/>
+                    <lvc:CartesianChart Grid.Row="1" Background="Transparent" MinHeight="120"
+                                        Series="{Binding TemperatureSeries}"
+                                        XAxes="{Binding TemperatureXAxes}" YAxes="{Binding TemperatureYAxes}"
+                                        LegendPosition="Bottom"
+                                        LegendTextPaint="{Binding LegendTextPaint}"
+                                        LegendBackgroundPaint="{Binding LegendBackgroundPaint}"
+                                        TooltipTextPaint="{Binding TooltipTextPaint}"
+                                        TooltipBackgroundPaint="{Binding TooltipBackgroundPaint}"/>
+                </Grid>
+            </Border>
+        </Grid>
+
+        <!-- Status -->
+        <TextBlock Grid.Row="4" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+                   Margin="28,12,28,24" TextWrapping="Wrap"/>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/ResourceHistoryView.xaml.cs
+++ b/SysManager/SysManager/Views/ResourceHistoryView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · ResourceHistoryView
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class ResourceHistoryView : UserControl
+{
+    public ResourceHistoryView() => InitializeComponent();
+}


### PR DESCRIPTION
## What

Implements **#13 — Resource Monitor**: a new **Resource History** tab under Monitor that tracks CPU, RAM, GPU usage and CPU/GPU temperatures over time, so a spike or slowdown can be investigated after the fact instead of only being visible live.

## How

- **`ResourceHistoryService`** — always-on singleton sampler started at app startup (records even while minimized to the tray). Samples every 10s and appends compact NDJSON to `%LocalAppData%\SysManager\resource-history.ndjson`. Configurable 7/14/30-day retention with periodic prune. Reuses `SystemInfoService` + NvAPIWrapper + `TemperatureService` (no new system access). Serialize / parse / prune / downsample / CSV are **pure, unit-tested static helpers**.
- **`ResourceHistoryViewModel`** — loads a selectable range (last hour → 30 days), downsamples to ≤400 points, drives a usage chart (CPU/RAM/GPU %) and a temperature chart (CPU/GPU °C) using the existing LiveCharts axis/paint idiom; CSV export via `SaveFileDialog`.
- **`ResourceHistoryView`** — Strategy-2 layout (matches PingView), `DevelopmentBanner` for Preview, `EmptyState` for no-history.
- Graduates the `WipResourceHistory` placeholder to the real view/VM, flagged **PREVIEW** (`inDevelopment: true`).

## Safety / privacy

Strictly local — **no system writes, no network, no telemetry**. History lives only in the user's LocalAppData folder.

## Tests

- `ResourceHistoryServiceTests` — serialize/parse round-trip + short keys, malformed-line rejection, prune (expiry + malformed + ordering), downsample (cap / averaging / null-GPU), CSV (header, empty cells, invariant decimal), retention options.
- `ResourceHistoryViewModelTests` — summary averages/peaks + temp segment.
- `MainWindowViewModelTests.NavLeaf_ResourceHistory_IsImplementedAndInPreview` — pins real wiring + Preview state.

## Docs

README (sidebar table, counts 49 impl / 8 WIP, new feature section), ARCHITECTURE (Monitor row + service entry), CHANGELOG (1.47.0), version bump to 1.47.0 — all in this PR.

Closes #13