### PR TITLE
feat: add Settings Watchdog tab to detect settings reset by Windows Update

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,7 +43,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Dashboard | `DashboardViewModel` |
 | System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `TaskSchedulerViewModel` · `BootAnalyzerViewModel` · `SystemFixesViewModel` |
 | Gaming & Profiles | `TimerResolutionViewModel` · `DisplayProfileViewModel` · `CpuAffinityViewModel` · `StandbyMemoryViewModel` · `PlaceholderViewModel` (Gaming Profile) |
-| Monitor | `ProcessManagerViewModel` · `ResourceHistoryViewModel` · `PrivacyMonitorViewModel` · `AppAlertsViewModel` · `FileLockViewModel` · `PlaceholderViewModel` (Settings Watchdog · Bandwidth Monitor) |
+| Monitor | `ProcessManagerViewModel` · `ResourceHistoryViewModel` · `PrivacyMonitorViewModel` · `AppAlertsViewModel` · `FileLockViewModel` · `SettingsWatchdogViewModel` · `PlaceholderViewModel` (Bandwidth Monitor) |
 | Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `PlaceholderViewModel` (Scheduled Maintenance) |
 | Storage | `DiskAnalyzerViewModel` · `DuplicateFileViewModel` |
 | Network | `PingViewModel` · `TracerouteViewModel` · `SpeedTestViewModel` · `NetworkRepairViewModel` (shared: `NetworkSharedState`) · `DnsHostsViewModel` |
@@ -296,6 +296,12 @@ Key services:
   with 7/14/30-day retention (periodic prune). Reuses `SystemInfoService` + NvAPIWrapper +
   `TemperatureService`; serialize/parse/prune/downsample/CSV are pure, unit-tested static
   helpers. Strictly local — no system writes, nothing leaves the machine.
+- `SettingsWatchdogService` — snapshots a curated catalog of settings Windows Update
+  tends to reset (telemetry, web search, widgets, lock-screen ads, Start suggestions, …)
+  as a JSON baseline in `%LocalAppData%\SysManager\settings-baseline.json`, then diffs the
+  live registry against it and restores drifted values on request. `DetectChanges` is a
+  pure, unit-tested diff; registry access reuses the validated HKCU/HKLM helper pattern
+  from `PrivacyService`. Reads/writes only well-known values; nothing leaves the machine.
 - `SafetyDatabase` — curated safety ratings for Windows services.
 - `ThemeService` — runtime theme switching with 12 presets and persistence.
 - `ToastService` — global glass-style toast notifications.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.48.0] - 2026-06-29
+
+### Added
+- **Settings Watchdog tab (Preview).** A new Monitor tab that catches the settings Windows Update silently resets — telemetry level, web search in Start, the Widgets board, lock-screen ads, and Start-menu suggestions. Save a baseline of your current preferences with one click; after an update, "Check now" lists anything that drifted in plain language (e.g. "Diagnostic data: was 'Off', now 'Full'") and "Restore changed" writes them back to your baseline in one step. Strictly local: the baseline lives in your `%LocalAppData%\SysManager` folder and only a fixed list of well-known registry values is ever read or written. Closes #335.
+
 ## [1.47.0] - 2026-06-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ fully open source.
 
 ### Sidebar navigation
 The sidebar organises 57 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 49 tabs are fully
-implemented; 8 are work-in-progress placeholders marked with ⚙️:
+find what you need without scrolling through a flat list. 50 tabs are fully
+implemented; 7 are work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |
 |-------|------|
 | 🏠 Dashboard | Dashboard |
 | 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Task Scheduler · Boot Analyzer · System Fixes |
 | 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner · Timer Resolution · CPU Core Affinity · Display Profiles |
-| 📊 Monitor | Process Manager · Resource History · Camera/Mic/Location · App Alerts · File Lock Detector · Settings Watchdog ⚙️ · Bandwidth Monitor ⚙️ |
+| 📊 Monitor | Process Manager · Resource History · Camera/Mic/Location · App Alerts · File Lock Detector · Settings Watchdog · Bandwidth Monitor ⚙️ |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance ⚙️ |
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS & Hosts |
@@ -373,6 +373,20 @@ a confirmation before it runs:
 - Devices **in use right now** are flagged and sorted to the top
 - Read-only: an **Open privacy settings** button hands off to Windows to grant or
   revoke a permission — SysManager never changes capability permissions itself
+
+### Settings Watchdog
+- **Catch the settings Windows Update silently resets** — feature and quality
+  updates often flip telemetry back to Full, re-enable web search, the Widgets
+  board, lock-screen ads, and Start-menu suggestions
+- **Save a baseline** of your current preferences with one click; the watchdog
+  remembers exactly what each watched setting was
+- **Check now** re-reads the live values and lists any drift in plain language —
+  e.g. *"Diagnostic data: was 'Off (Security)', now 'Full'"* — with the category
+  and a before/after comparison
+- **Restore changed** writes the drifted settings back to your baseline values in
+  one step (HKLM-backed settings need administrator rights, surfaced not crashed)
+- Strictly local: the baseline lives in your `%LocalAppData%\SysManager` folder and
+  the watchdog only ever reads or writes a fixed list of well-known registry values
 
 ### Operation Lock
 - Prevents conflicting concurrent operations across tabs

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -445,4 +445,15 @@ public class MainWindowViewModelTests
         Assert.IsType<ResourceHistoryViewModel>(item.Content);
         Assert.True(item.IsInDevelopment);
     }
+
+    // Settings Watchdog (#335) — implemented, wired to a real view/VM, flagged PREVIEW.
+    [Fact]
+    public void NavLeaf_SettingsWatchdog_IsImplementedAndInPreview()
+    {
+        var vm = new MainWindowViewModel();
+        var item = vm.NavItems.First(n => n.Id == "nav-settings-watchdog");
+        Assert.Equal(typeof(SysManager.Views.SettingsWatchdogView), item.ViewType);
+        Assert.IsType<SettingsWatchdogViewModel>(item.Content);
+        Assert.True(item.IsInDevelopment);
+    }
 }

--- a/SysManager/SysManager.Tests/SettingsWatchdogServiceTests.cs
+++ b/SysManager/SysManager.Tests/SettingsWatchdogServiceTests.cs
@@ -1,0 +1,100 @@
+// SysManager · SettingsWatchdogServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+public class SettingsWatchdogServiceTests
+{
+    private static WatchedSetting Setting(string key, params (int, string)[] labels)
+        => new(key, $"Name {key}", $"Desc {key}", "Cat", $@"HKCU\Software\Test\{key}", "Val",
+            labels.ToDictionary(l => l.Item1, l => l.Item2));
+
+    private static readonly IReadOnlyList<WatchedSetting> Catalog =
+    [
+        Setting("a", (0, "Off"), (1, "On")),
+        Setting("b", (0, "Off"), (3, "Full")),
+        Setting("c"),
+    ];
+
+    // ── DetectChanges ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void DetectChanges_NoDifference_ReturnsEmpty()
+    {
+        var baseline = new Dictionary<string, int?> { ["a"] = 0, ["b"] = 0, ["c"] = 1 };
+        var current = new Dictionary<string, int?> { ["a"] = 0, ["b"] = 0, ["c"] = 1 };
+        Assert.Empty(SettingsWatchdogService.DetectChanges(Catalog, baseline, current));
+    }
+
+    [Fact]
+    public void DetectChanges_FlagsOnlyChangedSettings()
+    {
+        var baseline = new Dictionary<string, int?> { ["a"] = 0, ["b"] = 0, ["c"] = 1 };
+        var current = new Dictionary<string, int?> { ["a"] = 1, ["b"] = 0, ["c"] = 1 };
+
+        var drifts = SettingsWatchdogService.DetectChanges(Catalog, baseline, current);
+
+        var drift = Assert.Single(drifts);
+        Assert.Equal("a", drift.Setting.Key);
+        Assert.Equal(0, drift.BaselineValue);
+        Assert.Equal(1, drift.CurrentValue);
+    }
+
+    [Fact]
+    public void DetectChanges_ValuePresentThenAbsent_IsDrift()
+    {
+        var baseline = new Dictionary<string, int?> { ["a"] = 1 };
+        var current = new Dictionary<string, int?> { ["a"] = null };
+        var drift = Assert.Single(SettingsWatchdogService.DetectChanges(Catalog, baseline, current));
+        Assert.Equal(1, drift.BaselineValue);
+        Assert.Null(drift.CurrentValue);
+    }
+
+    [Fact]
+    public void DetectChanges_SettingNotInBaseline_IsSkipped()
+    {
+        // 'b' was never captured (absent from baseline) — even though current has a value,
+        // it must not be reported (we have no baseline to compare/restore to).
+        var baseline = new Dictionary<string, int?> { ["a"] = 0 };
+        var current = new Dictionary<string, int?> { ["a"] = 0, ["b"] = 3 };
+        Assert.Empty(SettingsWatchdogService.DetectChanges(Catalog, baseline, current));
+    }
+
+    [Fact]
+    public void DetectChanges_PreservesCatalogOrder()
+    {
+        var baseline = new Dictionary<string, int?> { ["a"] = 0, ["b"] = 0 };
+        var current = new Dictionary<string, int?> { ["a"] = 1, ["b"] = 3 };
+        var drifts = SettingsWatchdogService.DetectChanges(Catalog, baseline, current);
+        Assert.Equal(["a", "b"], drifts.Select(d => d.Setting.Key));
+    }
+
+    // ── Catalog contract ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Catalog_IsNonEmpty_WithUniqueKeys()
+    {
+        var svc = new SettingsWatchdogService();
+        Assert.NotEmpty(svc.Catalog);
+        var keys = svc.Catalog.Select(s => s.Key).ToList();
+        Assert.Equal(keys.Count, keys.Distinct().Count());
+    }
+
+    [Fact]
+    public void Catalog_EverySettingHasNameAndRegistryPath()
+    {
+        var svc = new SettingsWatchdogService();
+        Assert.All(svc.Catalog, s =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(s.Name));
+            Assert.False(string.IsNullOrWhiteSpace(s.RegistryPath));
+            Assert.False(string.IsNullOrWhiteSpace(s.ValueName));
+            // Only HKCU / HKLM hives are ever touched.
+            Assert.Matches(@"^(HKCU|HKLM)\\", s.RegistryPath);
+        });
+    }
+}

--- a/SysManager/SysManager.Tests/WatchedSettingTests.cs
+++ b/SysManager/SysManager.Tests/WatchedSettingTests.cs
@@ -1,0 +1,42 @@
+// SysManager · WatchedSettingTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Tests;
+
+public class WatchedSettingTests
+{
+    private static WatchedSetting MakeSetting() => new(
+        "telemetry", "Diagnostic data", "desc", "Privacy",
+        @"HKLM\SOFTWARE\Test", "AllowTelemetry",
+        new Dictionary<int, string> { [0] = "Off", [3] = "Full" });
+
+    [Fact]
+    public void Describe_NullValue_IsNotSet()
+        => Assert.Equal("Not set", MakeSetting().Describe(null));
+
+    [Fact]
+    public void Describe_MappedValue_UsesLabel()
+    {
+        var s = MakeSetting();
+        Assert.Equal("Off", s.Describe(0));
+        Assert.Equal("Full", s.Describe(3));
+    }
+
+    [Fact]
+    public void Describe_UnmappedValue_FallsBackToNumber()
+        => Assert.Equal("7", MakeSetting().Describe(7));
+
+    [Fact]
+    public void SettingDrift_Summary_ReadsInPlainLanguage()
+    {
+        var drift = new SettingDrift(MakeSetting(), BaselineValue: 0, CurrentValue: 3);
+        Assert.Equal("Diagnostic data: was \"Off\", now \"Full\"", drift.Summary);
+    }
+
+    [Fact]
+    public void SettingDrift_DefaultsToRestorable()
+        => Assert.True(new SettingDrift(MakeSetting(), 0, 3).CanRestore);
+}

--- a/SysManager/SysManager/Models/WatchedSetting.cs
+++ b/SysManager/SysManager/Models/WatchedSetting.cs
@@ -1,0 +1,45 @@
+// SysManager · WatchedSetting — a Windows setting the Settings Watchdog snapshots and monitors
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// Definition of a single registry-backed Windows setting the watchdog tracks.
+/// Settings here are ones Windows Update (or a feature update) commonly resets —
+/// telemetry level, web search, widgets, lock-screen ads, and so on. The watchdog
+/// snapshots the user's current value as a baseline and later flags any drift.
+/// </summary>
+public sealed record WatchedSetting(
+    string Key,
+    string Name,
+    string Description,
+    string Category,
+    string RegistryPath,
+    string ValueName,
+    // Human-readable interpretation of a raw value (e.g. 0 → "Off", 3 → "Full"), so the
+    // before/after comparison reads in plain language rather than as bare numbers.
+    IReadOnlyDictionary<int, string> ValueLabels)
+{
+    /// <summary>Renders a raw value in plain language, falling back to the number when unmapped or absent.</summary>
+    public string Describe(int? value) =>
+        value is null ? "Not set"
+        : ValueLabels.TryGetValue(value.Value, out var label) ? label
+        : value.Value.ToString();
+}
+
+/// <summary>
+/// One detected difference between the saved baseline and the current system state.
+/// CanRestore is false for read-only watched values (e.g. default browser), which are
+/// surfaced for awareness but cannot be written back safely.
+/// </summary>
+public sealed record SettingDrift(
+    WatchedSetting Setting,
+    int? BaselineValue,
+    int? CurrentValue,
+    bool CanRestore = true)
+{
+    public string BaselineLabel => Setting.Describe(BaselineValue);
+    public string CurrentLabel => Setting.Describe(CurrentValue);
+    public string Summary => $"{Setting.Name}: was \"{BaselineLabel}\", now \"{CurrentLabel}\"";
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -81,6 +81,7 @@ public static class ServiceRegistration
         services.AddSingleton<IWindowsThemeService, WindowsThemeService>();
         services.AddSingleton<StandbyMemoryService>();
         services.AddSingleton<ResourceHistoryService>();
+        services.AddSingleton<SettingsWatchdogService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
         services.AddSingleton<DashboardViewModel>();
@@ -134,6 +135,7 @@ public static class ServiceRegistration
         services.AddSingleton<DarkModeViewModel>();
         services.AddSingleton<StandbyMemoryViewModel>();
         services.AddSingleton<ResourceHistoryViewModel>();
+        services.AddSingleton<SettingsWatchdogViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/SettingsWatchdogService.cs
+++ b/SysManager/SysManager/Services/SettingsWatchdogService.cs
@@ -1,0 +1,219 @@
+// SysManager · SettingsWatchdogService — snapshots and monitors settings Windows Update tends to reset
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Security;
+using System.Text.Json;
+using Microsoft.Win32;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Watches a curated set of Windows settings that feature/quality updates frequently
+/// reset (telemetry level, web search, widgets, lock-screen ads, …). The user saves a
+/// baseline snapshot of their preferences; later the watchdog re-reads the live values
+/// and reports any drift in plain language, with one-click restore of the registry-backed
+/// settings. Strictly local — reads/writes only well-known registry values, nothing leaves
+/// the machine. Registry access mirrors <see cref="PrivacyService"/>'s validated helper.
+/// </summary>
+public sealed class SettingsWatchdogService
+{
+    private static readonly string BaselinePath = Path.Join(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "SysManager", "settings-baseline.json");
+
+    /// <summary>The catalog of settings the watchdog tracks. Stable order for the UI.</summary>
+    public IReadOnlyList<WatchedSetting> Catalog { get; } = BuildCatalog();
+
+    /// <summary>Reads the current raw value of each watched setting (null if absent).</summary>
+    public IReadOnlyDictionary<string, int?> ReadCurrent()
+    {
+        var map = new Dictionary<string, int?>(Catalog.Count);
+        foreach (var s in Catalog)
+            map[s.Key] = ReadValue(s);
+        return map;
+    }
+
+    /// <summary>Captures the current values as the saved baseline. Returns the snapshot taken.</summary>
+    public IReadOnlyDictionary<string, int?> SaveBaseline(DateTime takenAt)
+    {
+        var current = ReadCurrent();
+        Persist(new BaselineSnapshot(takenAt, new Dictionary<string, int?>(current)));
+        return current;
+    }
+
+    /// <summary>Loads the saved baseline, or null if none exists yet.</summary>
+    public BaselineSnapshot? LoadBaseline()
+    {
+        try
+        {
+            if (!File.Exists(BaselinePath)) return null;
+            return JsonSerializer.Deserialize<BaselineSnapshot>(File.ReadAllText(BaselinePath));
+        }
+        catch (Exception ex) when (ex is JsonException or IOException)
+        {
+            Log.Debug("Settings baseline load failed: {Error}", ex.Message);
+            return null;
+        }
+    }
+
+    public bool HasBaseline => File.Exists(BaselinePath);
+
+    /// <summary>
+    /// Compares the saved baseline against the live system and returns the drifted settings.
+    /// Returns an empty list when there is no baseline or nothing changed.
+    /// </summary>
+    public IReadOnlyList<SettingDrift> DetectDrift()
+    {
+        var baseline = LoadBaseline();
+        if (baseline is null) return [];
+        return DetectChanges(Catalog, baseline.Values, ReadCurrent());
+    }
+
+    /// <summary>
+    /// Writes the baseline value back for a single drifted setting. Returns true on success,
+    /// false if the value can't be restored (read-only, no baseline value, or write denied).
+    /// </summary>
+    public bool Restore(SettingDrift drift)
+    {
+        ArgumentNullException.ThrowIfNull(drift);
+        if (!drift.CanRestore || drift.BaselineValue is null) return false;
+
+        try
+        {
+            using var key = OpenOrCreateKey(drift.Setting.RegistryPath, writable: true);
+            if (key is null) return false;
+            key.SetValue(drift.Setting.ValueName, drift.BaselineValue.Value, RegistryValueKind.DWord);
+            Log.Information("Settings Watchdog restored {Name} to {Value}",
+                drift.Setting.Name, drift.BaselineValue.Value);
+            return true;
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or SecurityException or IOException or ArgumentException)
+        {
+            Log.Warning(ex, "Settings Watchdog could not restore {Name}", drift.Setting.Name);
+            return false;
+        }
+    }
+
+    // ── Pure diff (unit-testable, no registry/file IO) ─────────────────────
+
+    /// <summary>
+    /// Returns the settings whose current value differs from the baseline. A setting absent
+    /// from the baseline map is skipped (it was never captured). Pure and order-preserving.
+    /// </summary>
+    public static IReadOnlyList<SettingDrift> DetectChanges(
+        IReadOnlyList<WatchedSetting> catalog,
+        IReadOnlyDictionary<string, int?> baseline,
+        IReadOnlyDictionary<string, int?> current)
+    {
+        var drifts = new List<SettingDrift>();
+        foreach (var setting in catalog)
+        {
+            if (!baseline.TryGetValue(setting.Key, out var baseValue)) continue;
+            current.TryGetValue(setting.Key, out var curValue);
+            if (baseValue != curValue)
+                drifts.Add(new SettingDrift(setting, baseValue, curValue));
+        }
+        return drifts;
+    }
+
+    // ── Registry access (mirrors PrivacyService) ───────────────────────────
+
+    private static int? ReadValue(WatchedSetting setting)
+    {
+        try
+        {
+            using var key = OpenOrCreateKey(setting.RegistryPath, writable: false);
+            var value = key?.GetValue(setting.ValueName);
+            if (value is int i) return i;
+            if (value is not null && int.TryParse(value.ToString(), out var parsed)) return parsed;
+            return null;
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or SecurityException)
+        {
+            Log.Debug("Settings Watchdog cannot read {Path}\\{Value}: {Error}",
+                setting.RegistryPath, setting.ValueName, ex.Message);
+            return null;
+        }
+    }
+
+    private static RegistryKey? OpenOrCreateKey(string fullPath, bool writable)
+    {
+        var sep = fullPath.IndexOf('\\');
+        if (sep < 0) return null;
+        var hiveName = fullPath[..sep].ToUpperInvariant();
+        var subPath = fullPath[(sep + 1)..];
+        var hive = hiveName switch
+        {
+            "HKCU" or "HKEY_CURRENT_USER" => Registry.CurrentUser,
+            "HKLM" or "HKEY_LOCAL_MACHINE" => Registry.LocalMachine,
+            _ => null
+        };
+        if (hive is null) return null;
+        return writable ? hive.CreateSubKey(subPath, writable: true) : hive.OpenSubKey(subPath, writable: false);
+    }
+
+    private static void Persist(BaselineSnapshot snapshot)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(BaselinePath)!);
+            File.WriteAllText(BaselinePath, JsonSerializer.Serialize(snapshot,
+                new JsonSerializerOptions { WriteIndented = true }));
+        }
+        catch (IOException ex) { Log.Debug("Settings baseline save failed: {Error}", ex.Message); }
+    }
+
+    // ── Catalog ─────────────────────────────────────────────────────────────
+
+    private static List<WatchedSetting> BuildCatalog()
+    {
+        var onOff = new Dictionary<int, string> { [0] = "Off", [1] = "On" };
+        var offOn = new Dictionary<int, string> { [0] = "Enabled", [1] = "Disabled" };
+
+        return
+        [
+            new WatchedSetting("telemetry", "Diagnostic data (telemetry)",
+                "Windows Update can raise the telemetry level back to Full.",
+                "Privacy", @"HKLM\SOFTWARE\Policies\Microsoft\Windows\DataCollection", "AllowTelemetry",
+                new Dictionary<int, string> { [0] = "Off (Security)", [1] = "Required", [2] = "Enhanced", [3] = "Full" }),
+
+            new WatchedSetting("advertising-id", "Advertising ID",
+                "Targeted-ad ID that updates sometimes re-enable.",
+                "Privacy", @"HKCU\Software\Microsoft\Windows\CurrentVersion\AdvertisingInfo", "Enabled", onOff),
+
+            new WatchedSetting("activity-feed", "Activity history",
+                "Collection of your activity timeline.",
+                "Privacy", @"HKLM\SOFTWARE\Policies\Microsoft\Windows\System", "EnableActivityFeed", onOff),
+
+            new WatchedSetting("web-search", "Web search in Start",
+                "Bing web results in the Start-menu search box.",
+                "Search", @"HKCU\Software\Policies\Microsoft\Windows\Explorer", "DisableSearchBoxSuggestions", offOn),
+
+            new WatchedSetting("widgets", "Widgets (news & interests)",
+                "The taskbar Widgets board, often re-enabled by updates.",
+                "Taskbar", @"HKLM\SOFTWARE\Policies\Microsoft\Dsh", "AllowNewsAndInterests", onOff),
+
+            new WatchedSetting("start-suggestions", "Start menu suggestions",
+                "Suggested apps and promoted content in Start.",
+                "UI Declutter", @"HKCU\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager",
+                "SubscribedContent-338388Enabled", onOff),
+
+            new WatchedSetting("lockscreen-ads", "Lock-screen tips & ads",
+                "Spotlight tips and promotions on the lock screen.",
+                "UI Declutter", @"HKCU\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager",
+                "RotatingLockScreenOverlayEnabled", onOff),
+
+            new WatchedSetting("tips", "Windows tips",
+                "Tips-and-suggestions notifications.",
+                "UI Declutter", @"HKCU\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager",
+                "SoftLandingEnabled", onOff),
+        ];
+    }
+}
+
+/// <summary>The saved baseline of watched setting values, with when it was captured.</summary>
+public sealed record BaselineSnapshot(DateTime TakenAt, Dictionary<string, int?> Values);

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.47.0</Version>
-    <FileVersion>1.47.0.0</FileVersion>
-    <AssemblyVersion>1.47.0.0</AssemblyVersion>
+    <Version>1.48.0</Version>
+    <FileVersion>1.48.0.0</FileVersion>
+    <AssemblyVersion>1.48.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -66,11 +66,11 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public DarkModeViewModel DarkMode { get; }
     public StandbyMemoryViewModel StandbyMemory { get; }
     public ResourceHistoryViewModel ResourceHistory { get; }
+    public SettingsWatchdogViewModel SettingsWatchdog { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
     public PlaceholderViewModel WipFileLockDetector { get; private set; } = null!;
-    public PlaceholderViewModel WipSettingsWatchdog { get; private set; } = null!;
     public PlaceholderViewModel WipBandwidthMonitor { get; private set; } = null!;
 
     // Gaming & Profiles group
@@ -176,6 +176,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             DarkMode = sp.GetRequiredService<DarkModeViewModel>();
             StandbyMemory = sp.GetRequiredService<StandbyMemoryViewModel>();
             ResourceHistory = sp.GetRequiredService<ResourceHistoryViewModel>();
+            SettingsWatchdog = sp.GetRequiredService<SettingsWatchdogViewModel>();
         }
         else
         {
@@ -246,6 +247,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             DarkMode = new DarkModeViewModel(new WindowsThemeService());
             StandbyMemory = new StandbyMemoryViewModel(new StandbyMemoryService());
             ResourceHistory = new ResourceHistoryViewModel(new ResourceHistoryService(sysInfo, new TemperatureService(diskHealth)));
+            SettingsWatchdog = new SettingsWatchdogViewModel(new SettingsWatchdogService());
         }
 
         InitPlaceholders();
@@ -258,7 +260,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
         // Monitor group
         WipFileLockDetector = new PlaceholderViewModel("File Lock Detector", "Find which process is locking a file and optionally release the handle.", "#333");
-        WipSettingsWatchdog = new PlaceholderViewModel("Settings Watchdog", "Detect when Windows Update resets your settings and offer one-click restore.", "#335");
         WipBandwidthMonitor = new PlaceholderViewModel("Bandwidth Monitor", "Real-time per-app network usage with history graphs and alerts.", "#337");
 
         // Gaming & Profiles group
@@ -341,7 +342,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-privacy-monitor",   "Camera/Mic/Location",    "", PrivacyMonitor,      typeof(Views.PrivacyMonitorView)),
             Item("nav-app-alerts",        "App Alerts",         "", AppAlerts,           typeof(Views.AppAlertsView)),
             Item("nav-file-lock",         "File Lock Detector", "", FileLock,            typeof(Views.FileLockView)),
-            Item("nav-settings-watchdog", "Settings Watchdog",  "", WipSettingsWatchdog, typeof(Views.PlaceholderView)),
+            Item("nav-settings-watchdog", "Settings Watchdog",  "", SettingsWatchdog,    typeof(Views.SettingsWatchdogView), inDevelopment: true),
             Item("nav-bandwidth-monitor", "Bandwidth Monitor",  "", WipBandwidthMonitor, typeof(Views.PlaceholderView))),
 
         Group("grp-cleanup", "Cleanup", "",
@@ -506,10 +507,10 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         DarkMode?.Dispose();
         StandbyMemory?.Dispose();
         ResourceHistory?.Dispose();
+        SettingsWatchdog?.Dispose();
 
         // WIP placeholders
         WipFileLockDetector?.Dispose();
-        WipSettingsWatchdog?.Dispose();
         WipBandwidthMonitor?.Dispose();
         WipGamingProfile?.Dispose();
         WipStandbyListCleaner?.Dispose();

--- a/SysManager/SysManager/ViewModels/SettingsWatchdogViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SettingsWatchdogViewModel.cs
@@ -1,0 +1,125 @@
+// SysManager · SettingsWatchdogViewModel
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the Settings Watchdog tab. The user saves a baseline of preferences that
+/// Windows Update tends to reset; the watchdog later re-reads the live values and lists any
+/// drift in plain language, offering one-click restore. Read-only until the user explicitly
+/// saves a baseline or restores a setting; restore writes only well-known registry values.
+/// </summary>
+public sealed partial class SettingsWatchdogViewModel : ViewModelBase
+{
+    private readonly SettingsWatchdogService _service;
+
+    public BulkObservableCollection<DriftRow> Drifts { get; } = new();
+    public BulkObservableCollection<WatchedSetting> Watched { get; } = new();
+
+    [ObservableProperty] private bool _hasBaseline;
+    [ObservableProperty] private string _baselineTaken = "";
+    [ObservableProperty] private bool _hasDrift;
+    [ObservableProperty] private bool _isElevated;
+
+    public SettingsWatchdogViewModel(SettingsWatchdogService service)
+    {
+        _service = service;
+        IsElevated = AdminHelper.IsElevated();
+        Watched.ReplaceWith(_service.Catalog);
+        InitializeAsync(() => { Refresh(); return System.Threading.Tasks.Task.CompletedTask; });
+    }
+
+    [RelayCommand]
+    private void RelaunchAsAdmin()
+    {
+        if (AdminHelper.RelaunchAsAdmin())
+            System.Windows.Application.Current?.Shutdown();
+    }
+
+    /// <summary>Re-reads the baseline and live state and rebuilds the drift list.</summary>
+    [RelayCommand]
+    private void Refresh()
+    {
+        var baseline = _service.LoadBaseline();
+        HasBaseline = baseline is not null;
+        BaselineTaken = baseline is not null ? $"Baseline saved {baseline.TakenAt:yyyy-MM-dd HH:mm}" : "";
+
+        var drifts = _service.DetectDrift();
+        Drifts.ReplaceWith(drifts.Select(d => new DriftRow(d)));
+        HasDrift = Drifts.Count > 0;
+        RestoreSelectedCommand.NotifyCanExecuteChanged();
+
+        StatusMessage = !HasBaseline
+            ? "No baseline yet — save your current settings to start watching for changes."
+            : HasDrift
+                ? $"{Drifts.Count} setting(s) changed since your baseline."
+                : "All watched settings match your baseline.";
+    }
+
+    /// <summary>Captures the current settings as the new baseline (with confirmation).</summary>
+    [RelayCommand]
+    private void SaveBaseline()
+    {
+        if (HasBaseline && !DialogService.Instance.Confirm(
+                "Overwrite your saved baseline with the current settings?\n\n" +
+                "Any current drift will be accepted as the new normal.",
+                "Save Baseline — Confirm"))
+            return;
+
+        _service.SaveBaseline(DateTime.Now);
+        ActivityLogService.Instance.Log("Settings Watchdog", "Saved settings baseline");
+        Refresh();
+        StatusMessage = "Baseline saved. The watchdog will flag future changes.";
+    }
+
+    private bool CanRestore() => Drifts.Any(d => d.Drift.CanRestore);
+
+    /// <summary>Restores every restorable drifted setting to its baseline value (with confirmation).</summary>
+    [RelayCommand(CanExecute = nameof(CanRestore))]
+    private void RestoreSelected()
+    {
+        var restorable = Drifts.Where(d => d.Drift.CanRestore).ToList();
+        if (restorable.Count == 0) return;
+
+        if (!DialogService.Instance.Confirm(
+                $"Restore {restorable.Count} setting(s) to your saved baseline?\n\n" +
+                "Each will be written back to the value it had when you saved the baseline.",
+                "Restore Settings — Confirm"))
+            return;
+
+        int restored = 0, failed = 0;
+        foreach (var row in restorable)
+        {
+            if (_service.Restore(row.Drift)) restored++; else failed++;
+        }
+
+        if (restored > 0)
+            ActivityLogService.Instance.Log("Settings Watchdog", $"Restored {restored} setting(s) to baseline");
+        Log.Information("Settings Watchdog restore: {Restored} ok, {Failed} failed", restored, failed);
+
+        Refresh();
+        StatusMessage = failed == 0
+            ? $"Restored {restored} setting(s) to your baseline."
+            : $"Restored {restored} setting(s) · {failed} could not be written (try running as administrator).";
+    }
+
+    /// <summary>One drifted setting, wrapping the immutable <see cref="SettingDrift"/> for binding.</summary>
+    public sealed partial class DriftRow(SettingDrift drift) : ObservableObject
+    {
+        public SettingDrift Drift { get; } = drift;
+        public string Name => Drift.Setting.Name;
+        public string Category => Drift.Setting.Category;
+        public string Description => Drift.Setting.Description;
+        public string BaselineLabel => Drift.BaselineLabel;
+        public string CurrentLabel => Drift.CurrentLabel;
+        public bool CanRestore => Drift.CanRestore;
+    }
+}

--- a/SysManager/SysManager/Views/SettingsWatchdogView.xaml
+++ b/SysManager/SysManager/Views/SettingsWatchdogView.xaml
@@ -1,0 +1,98 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.SettingsWatchdogView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:SettingsWatchdogViewModel}"
+             Background="{DynamicResource Surface0}">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Preview banner -->
+        <v:DevelopmentBanner Grid.Row="0" Margin="28,24,28,0"/>
+
+        <!-- Header -->
+        <DockPanel Grid.Row="1" Margin="28,16,28,0">
+            <StackPanel>
+                <TextBlock Text="Settings Watchdog" Style="{StaticResource Display}"/>
+                <TextBlock Text="Save a baseline of the Windows settings that feature updates tend to reset — telemetry, web search, widgets, lock-screen ads — and the watchdog will flag anything that drifts, with one-click restore."
+                           Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap" MaxWidth="820"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
+                        DockPanel.Dock="Right" VerticalAlignment="Center">
+                <Button Content="Save baseline" Command="{Binding SaveBaselineCommand}"
+                        Style="{StaticResource PrimaryButton}"
+                        AutomationProperties.Name="Save settings baseline"/>
+                <Button Content="Check now" Command="{Binding RefreshCommand}"
+                        Style="{StaticResource SecondaryButton}" Margin="6,0,0,0"
+                        AutomationProperties.Name="Check for setting changes now"/>
+                <Button Content="Restore changed" Command="{Binding RestoreSelectedCommand}"
+                        Style="{StaticResource SecondaryButton}" Margin="6,0,0,0"
+                        AutomationProperties.Name="Restore changed settings to baseline"/>
+            </StackPanel>
+        </DockPanel>
+
+        <!-- Baseline status banner -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,12,28,0" Padding="14,10"
+                Visibility="{Binding HasBaseline, Converter={StaticResource FlexVis}}">
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                <TextBlock Text="&#xE73E;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                           FontSize="15" Foreground="{DynamicResource Success}" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <TextBlock Text="{Binding BaselineTaken}" Foreground="{DynamicResource TextSecondary}"
+                           FontSize="13" VerticalAlignment="Center"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Drift summary banner (warning) -->
+        <Border Grid.Row="3" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
+                BorderThickness="1" CornerRadius="10" Padding="12,10" Margin="28,12,28,0"
+                Visibility="{Binding HasDrift, Converter={StaticResource FlexVis}}">
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="&#xE7BA;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                           FontSize="14" Foreground="{DynamicResource WarningText}" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <TextBlock Text="Some settings have changed since your baseline. Review them below and restore if they weren't your doing."
+                           Foreground="{DynamicResource WarningText}" FontSize="12.5"
+                           VerticalAlignment="Center" TextWrapping="Wrap"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Drift list -->
+        <Border Grid.Row="4" Style="{StaticResource Card}" Margin="28,16,28,0">
+            <Grid>
+                <DataGrid ItemsSource="{Binding Drifts}" AutoGenerateColumns="False" IsReadOnly="True"
+                          HeadersVisibility="Column" GridLinesVisibility="None" Background="Transparent"
+                          BorderThickness="0" CanUserAddRows="False"
+                          VirtualizingPanel.IsVirtualizing="True"
+                          AutomationProperties.Name="Changed settings"
+                          Visibility="{Binding HasDrift, Converter={StaticResource FlexVis}}">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Setting" Binding="{Binding Name}" Width="2*"/>
+                        <DataGridTextColumn Header="Category" Binding="{Binding Category}" Width="*"/>
+                        <DataGridTextColumn Header="Was" Binding="{Binding BaselineLabel}" Width="*"/>
+                        <DataGridTextColumn Header="Now" Binding="{Binding CurrentLabel}" Width="*"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+
+                <v:EmptyState Glyph="&#xE73E;" Title="No changes detected"
+                              Message="Save a baseline, then check back after a Windows update. Any setting that drifted from your baseline will appear here, ready to restore."
+                              Visibility="{Binding HasDrift, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+            </Grid>
+        </Border>
+
+        <!-- Status -->
+        <TextBlock Grid.Row="5" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+                   Margin="28,12,28,24" TextWrapping="Wrap"/>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/SettingsWatchdogView.xaml.cs
+++ b/SysManager/SysManager/Views/SettingsWatchdogView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · SettingsWatchdogView
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class SettingsWatchdogView : UserControl
+{
+    public SettingsWatchdogView() => InitializeComponent();
+}


### PR DESCRIPTION
## What

Implements **#335 — Settings Watchdog**: a new Monitor tab that catches the settings Windows Update silently resets (telemetry level, web search in Start, the Widgets board, lock-screen ads, Start-menu suggestions). The user saves a baseline of their preferences; after an update, the watchdog lists any drift and restores it in one step.

## How

- **`SettingsWatchdogService`** — owns a curated catalog of registry-backed settings WU commonly flips. `SaveBaseline` snapshots current values to `%LocalAppData%\SysManager\settings-baseline.json`; `DetectDrift` diffs the live registry against the baseline; `Restore` writes a baseline value back. `DetectChanges` is a **pure, unit-tested** diff. Registry read/write reuses the validated HKCU/HKLM helper pattern from `PrivacyService`.
- **`WatchedSetting` / `SettingDrift`** models — value-label maps render raw DWORDs in plain language ("Off" / "Full"), so the before/after comparison is readable.
- **`SettingsWatchdogViewModel`** — Save baseline / Check now / Restore changed commands, all destructive/overwrite actions gated by `DialogService.Confirm`; drift rows in a DataGrid.
- **`SettingsWatchdogView`** — Strategy-2 layout (matches CleanupView), `DevelopmentBanner` for Preview, `EmptyState` for no-drift.
- Graduates the `WipSettingsWatchdog` placeholder to the real view/VM, flagged **PREVIEW**.

## Safety / privacy

Strictly local — only a fixed list of **well-known registry values** is ever read or written; HKLM-backed settings need admin (surfaced, not crashed); restore is confirmed first. No network, no telemetry.

## Tests

- `SettingsWatchdogServiceTests` — DetectChanges (no-diff, changed-only, present→absent, not-in-baseline-skipped, order-preserving), catalog contract (unique keys, HKCU/HKLM-only paths).
- `WatchedSettingTests` — `Describe` (null/mapped/unmapped), drift `Summary` plain-language, default restorable.
- `MainWindowViewModelTests.NavLeaf_SettingsWatchdog_IsImplementedAndInPreview` — pins real wiring + Preview state.

## Docs

README (sidebar table, counts 50 impl / 7 WIP, new feature section), ARCHITECTURE (Monitor row + service entry), CHANGELOG (1.48.0), version bump to 1.48.0 — all in this PR.

Closes #335