### PR TITLE
feat: add command-line interface for headless automation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,7 +51,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Privacy & Security | `PrivacyViewModel` · `FileShredderViewModel` · `AppBlockerViewModel` · `DebloaterViewModel` · `BrowserCleanerViewModel` · `DefenderViewModel` · `PlaceholderViewModel` (Edge/OneDrive Remover · Notification Blocker) |
 | Customization | `ContextMenuViewModel` · `DarkModeViewModel` · `PlaceholderViewModel` (Volume Control) |
 | Info | `DriversViewModel` · `BatteryHealthViewModel` · `LogsViewModel` · `SystemReportViewModel` · `LegacyPanelsViewModel` · `AboutViewModel` |
-| Advanced | `ProfileViewModel` · `EnvironmentVariablesViewModel` · `PlaceholderViewModel` (CLI Interface) |
+| Advanced | `ProfileViewModel` · `EnvironmentVariablesViewModel` · `CliInterfaceViewModel` |
 
 - `DashboardViewModel` — real-time system vitals (CPU/RAM/GPU at 300ms polling),
   temperatures (LibreHardwareMonitor + NvAPIWrapper), storage overview, system
@@ -89,6 +89,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `ContextMenuViewModel` — scan and manage Explorer right-click context menu entries.
 - `SystemReportViewModel` — generate a read-only full-system snapshot and export it as text, HTML, or JSON.
 - `EnvironmentVariablesViewModel` — view/edit User and System environment variables with a dedicated PATH editor (reorder, dedupe, missing-folder detection); staged edits with a one-time backup.
+- `CliInterfaceViewModel` — read-only reference tab listing the headless CLI commands (sourced from `CliRunner.Commands`) with copy-to-clipboard; documents the flags, runs nothing itself.
 - `RestorePointsViewModel` — list, create, and restore Windows System Restore points (admin for create/restore; restore reboots, gated by confirmation).
 - `LegacyPanelsViewModel` — one-click launcher for the fixed catalog of classic Windows applets (pure launchers, no system modification).
 - `SystemFixesViewModel` — consolidated one-click repairs (Windows Update reset, network reset, WinGet reinstall) with per-fix confirmation + live output; opens netplwiz for secure auto-logon.
@@ -302,6 +303,13 @@ Key services:
   live registry against it and restores drifted values on request. `DetectChanges` is a
   pure, unit-tested diff; registry access reuses the validated HKCU/HKLM helper pattern
   from `PrivacyService`. Reads/writes only well-known values; nothing leaves the machine.
+- `CliRunner` — the headless command-line entry point (dispatched from `App.OnStartup`
+  before the single-instance mutex, attaching to the parent console). Exposes only
+  read-only/safe verbs (`--health`, `--cleanup`, `--trim-ram`, `--version/--help/--list`)
+  with `--json`/`--silent` modifiers and conventional exit codes (0/1/2). `Parse` and
+  `ExecuteAsync` are pure/return-value-based, so the whole CLI is unit-tested without
+  launching the process; `IsCliInvocation` is strict so the elevation/update-applier args
+  never trigger CLI mode.
 - `SafetyDatabase` — curated safety ratings for Windows services.
 - `ThemeService` — runtime theme switching with 12 presets and persistence.
 - `ToastService` — global glass-style toast notifications.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.49.0] - 2026-06-29
+
+### Added
+- **Command-line interface (Preview).** SysManager now accepts command-line flags so you can automate the safe maintenance actions from scripts, Task Scheduler, or deployment tools — it runs headless (no window) and writes to the launching console. Commands: `--health` (read-only health score), `--cleanup` (temp-file cleanup), `--trim-ram` (purge the standby list), plus `--version`, `--help`, and `--list`; add `--json` for machine-readable output or `--silent` for scripting, with conventional exit codes (0 success · 1 error · 2 usage). Only read-only or non-destructive actions are exposed — anything that changes the system irreversibly stays in the GUI behind a confirmation. A new **CLI Interface** tab lists every command with one-click copy. Closes #342.
+
 ## [1.48.0] - 2026-06-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ fully open source.
 
 ### Sidebar navigation
 The sidebar organises 57 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 50 tabs are fully
-implemented; 7 are work-in-progress placeholders marked with ⚙️:
+find what you need without scrolling through a flat list. 51 tabs are fully
+implemented; 6 are work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |
 |-------|------|
@@ -90,7 +90,7 @@ implemented; 7 are work-in-progress placeholders marked with ⚙️:
 | 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover ⚙️ · Defender Tweaks · Notification Blocker ⚙️ |
 | 🎨 Customization | Context Menu · Dark Mode Scheduler · Volume Control ⚙️ |
 | ℹ️ Info | Drivers · Battery Health · System Logs · System Report · Legacy Panels · About |
-| ⚙️ Advanced | Profile Export/Import · CLI Interface ⚙️ · Environment Variables |
+| ⚙️ Advanced | Profile Export/Import · CLI Interface · Environment Variables |
 
 > ⚙️ = Work in Progress — placeholder tab visible in the sidebar, implementation coming in future updates.
 
@@ -637,6 +637,21 @@ Manage Microsoft Defender without digging through Windows Security:
 - **Version-aware** — refuses profiles created by a newer, incompatible build
 - Only SysManager's own config is ever touched (never system settings), so an
   import is fully reversible — just import a different profile
+
+### CLI Interface
+- **Automate the safe actions from scripts, Task Scheduler, or deployment tools** —
+  SysManager accepts command-line flags and runs headless (no window), writing its
+  output to the launching console
+- Commands: `--health` (read-only health score), `--cleanup` (temp-file cleanup,
+  never follows junctions), `--trim-ram` (purge the standby list), plus `--version`,
+  `--help`, and `--list`
+- `--json` emits machine-readable output; `--silent` suppresses chatter for
+  scripting; conventional **exit codes** (0 success · 1 error · 2 usage) let a script
+  branch on the result
+- Only read-only or non-destructive actions are exposed on the CLI — anything that
+  changes the system irreversibly stays in the GUI behind a confirmation dialog
+- The in-app **CLI Interface** tab is a reference: it lists every command with a
+  one-click copy button. Example: `SysManager.exe --cleanup --silent`
 
 ## Screenshots
 

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -456,4 +456,15 @@ public class MainWindowViewModelTests
         Assert.IsType<SettingsWatchdogViewModel>(item.Content);
         Assert.True(item.IsInDevelopment);
     }
+
+    // CLI Interface (#342) — implemented reference tab, wired to a real view/VM, flagged PREVIEW.
+    [Fact]
+    public void NavLeaf_CliInterface_IsImplementedAndInPreview()
+    {
+        var vm = new MainWindowViewModel();
+        var item = vm.NavItems.First(n => n.Id == "nav-cli-interface");
+        Assert.Equal(typeof(SysManager.Views.CliInterfaceView), item.ViewType);
+        Assert.IsType<CliInterfaceViewModel>(item.Content);
+        Assert.True(item.IsInDevelopment);
+    }
 }

--- a/SysManager/SysManager.Tests/CliRunnerTests.cs
+++ b/SysManager/SysManager.Tests/CliRunnerTests.cs
@@ -1,0 +1,168 @@
+// SysManager · CliRunnerTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+public class CliRunnerTests
+{
+    // ── Parse ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_NoArgs_IsNone()
+        => Assert.Equal(CliCommand.None, CliRunner.Parse([]).Command);
+
+    [Theory]
+    [InlineData("--help", CliCommand.Help)]
+    [InlineData("-h", CliCommand.Help)]
+    [InlineData("/?", CliCommand.Help)]
+    [InlineData("--version", CliCommand.Version)]
+    [InlineData("-v", CliCommand.Version)]
+    [InlineData("--list", CliCommand.List)]
+    [InlineData("--health", CliCommand.Health)]
+    [InlineData("--cleanup", CliCommand.Cleanup)]
+    [InlineData("--trim-ram", CliCommand.TrimRam)]
+    public void Parse_RecognizesVerbs(string arg, CliCommand expected)
+        => Assert.Equal(expected, CliRunner.Parse([arg]).Command);
+
+    [Fact]
+    public void Parse_IsCaseInsensitive()
+        => Assert.Equal(CliCommand.Cleanup, CliRunner.Parse(["--CLEANUP"]).Command);
+
+    [Fact]
+    public void Parse_ModifiersSetFlags()
+    {
+        var r = CliRunner.Parse(["--cleanup", "--json", "--silent"]);
+        Assert.Equal(CliCommand.Cleanup, r.Command);
+        Assert.True(r.Json);
+        Assert.True(r.Silent);
+    }
+
+    [Fact]
+    public void Parse_FirstVerbWins()
+    {
+        // A single invocation does one thing; the first explicit verb is kept.
+        var r = CliRunner.Parse(["--health", "--cleanup"]);
+        Assert.Equal(CliCommand.Health, r.Command);
+    }
+
+    [Fact]
+    public void Parse_UnknownFlag_IsUnknownWithArgCaptured()
+    {
+        var r = CliRunner.Parse(["--frobnicate"]);
+        Assert.Equal(CliCommand.Unknown, r.Command);
+        Assert.Equal("--frobnicate", r.UnknownArg);
+    }
+
+    [Fact]
+    public void Parse_BareTokens_AreIgnored_NotUnknown()
+    {
+        // Non-flag tokens (no leading - or /) are not usage errors.
+        Assert.Equal(CliCommand.None, CliRunner.Parse(["foo", "bar"]).Command);
+    }
+
+    // ── IsCliInvocation: must NOT hijack the elevation sentinel ─────────────
+
+    [Fact]
+    public void IsCliInvocation_TrueForKnownVerb()
+        => Assert.True(CliRunner.IsCliInvocation(["--health"]));
+
+    [Fact]
+    public void IsCliInvocation_FalseForNoArgs()
+        => Assert.False(CliRunner.IsCliInvocation([]));
+
+    [Fact]
+    public void IsCliInvocation_FalseForElevationSentinel()
+    {
+        // The elevation relaunch arg must route to its own startup branch, NOT CLI mode.
+        Assert.False(CliRunner.IsCliInvocation(["--relaunched-elevated"]));
+    }
+
+    [Fact]
+    public void IsCliInvocation_FalseForUpdateApplierArg()
+        => Assert.False(CliRunner.IsCliInvocation(["--apply-update", @"C:\x.exe", "1234"]));
+
+    // ── ExecuteAsync (read-only commands only — no system mutation) ─────────
+
+    [Fact]
+    public async Task Execute_Version_ReturnsVersionAndOk()
+    {
+        var r = await new CliRunner().ExecuteAsync(new CliRequest(CliCommand.Version));
+        Assert.Equal(CliResult.Ok, r.ExitCode);
+        Assert.Equal(CliRunner.CurrentVersion, r.Output);
+    }
+
+    [Fact]
+    public async Task Execute_VersionJson_IsJson()
+    {
+        var r = await new CliRunner().ExecuteAsync(new CliRequest(CliCommand.Version, Json: true));
+        Assert.Equal(CliResult.Ok, r.ExitCode);
+        Assert.Contains("\"version\"", r.Output);
+        Assert.Contains(CliRunner.CurrentVersion, r.Output);
+    }
+
+    [Fact]
+    public async Task Execute_Help_ListsEveryCommand()
+    {
+        var r = await new CliRunner().ExecuteAsync(new CliRequest(CliCommand.Help));
+        Assert.Equal(CliResult.Ok, r.ExitCode);
+        foreach (var (flags, _) in CliRunner.Commands)
+        {
+            // The first flag of each command must appear in the help text.
+            var primary = flags.Split(',')[0].Trim();
+            Assert.Contains(primary, r.Output);
+        }
+    }
+
+    [Fact]
+    public async Task Execute_Unknown_IsUsageError()
+    {
+        var r = await new CliRunner().ExecuteAsync(new CliRequest(CliCommand.Unknown, UnknownArg: "--nope"));
+        Assert.Equal(CliResult.UsageError, r.ExitCode);
+        Assert.Contains("--nope", r.Output);
+    }
+
+    [Fact]
+    public async Task Execute_None_IsUsageErrorWithHelp()
+    {
+        var r = await new CliRunner().ExecuteAsync(new CliRequest(CliCommand.None));
+        Assert.Equal(CliResult.UsageError, r.ExitCode);
+        Assert.Contains("Usage:", r.Output);
+    }
+
+    // ── Help text / command catalog ─────────────────────────────────────────
+
+    [Fact]
+    public void Commands_NonEmpty_AllHaveFlagsAndDescription()
+    {
+        Assert.NotEmpty(CliRunner.Commands);
+        Assert.All(CliRunner.Commands, c =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(c.Flags));
+            Assert.False(string.IsNullOrWhiteSpace(c.Description));
+        });
+    }
+
+    [Fact]
+    public void BuildHelp_Text_MentionsExitCodes()
+        => Assert.Contains("Exit codes", CliRunner.BuildHelp(json: false));
+
+    [Fact]
+    public void BuildHelp_Json_IsMachineReadable()
+    {
+        var json = CliRunner.BuildHelp(json: true);
+        Assert.Contains("\"commands\"", json);
+        Assert.Contains("\"version\"", json);
+    }
+
+    [Fact]
+    public void ExitCodeConstants_AreConventional()
+    {
+        Assert.Equal(0, CliResult.Ok);
+        Assert.Equal(1, CliResult.Error);
+        Assert.Equal(2, CliResult.UsageError);
+    }
+}

--- a/SysManager/SysManager/App.xaml.cs
+++ b/SysManager/SysManager/App.xaml.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Threading;
 using Microsoft.Extensions.DependencyInjection;
+using SysManager.Models;
 using SysManager.Services;
 
 namespace SysManager;
@@ -42,6 +43,17 @@ public partial class App : Application
     [return: MarshalAs(UnmanagedType.Bool)]
     private static partial bool IsIconic(IntPtr hWnd);
 
+    // Console attach for headless CLI mode: a WinExe has no console of its own, so
+    // attach to the parent (the cmd/PowerShell that launched it) to write output there.
+    [LibraryImport("kernel32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool AttachConsole(int dwProcessId);
+
+    [LibraryImport("kernel32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool FreeConsole();
+
+    private const int AttachParentProcess = -1;
     private const int SW_RESTORE = 9;
 
     protected override void OnStartup(StartupEventArgs e)
@@ -61,6 +73,15 @@ public partial class App : Application
         // Register OEM/ANSI code pages (437, 852, etc.) required by system
         // tools like chkdsk.exe, sfc.exe, and DISM.exe on .NET 8+.
         System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+
+        // Headless CLI mode: when launched with a recognized CLI verb, run it and exit
+        // without a window, mutex, or DI graph. Runs before the single-instance guard so
+        // a script can run `SysManager.exe --cleanup` while the GUI is already open.
+        if (CliRunner.IsCliInvocation(e.Args))
+        {
+            RunCliAndExit(e.Args);
+            return;
+        }
 
         _instanceMutex = new Mutex(true, MutexName, out bool createdNew);
         if (!createdNew)
@@ -111,6 +132,33 @@ public partial class App : Application
         // Fire-and-forget is intentional — the listener loop runs for the app
         // lifetime and is cancelled via _pipeCts on OnExit.
         _ = StartPipeListenerAsync();
+    }
+
+    /// <summary>
+    /// Runs the headless CLI and exits with the command's exit code. Attaches to the parent
+    /// console so output appears in the launching shell; output is written there, not to a
+    /// window. No DI container or window is created. <c>--silent</c> suppresses stdout for
+    /// successful commands (the exit code still conveys the result to scripts).
+    /// </summary>
+    private void RunCliAndExit(string[] args)
+    {
+        var request = CliRunner.Parse(args);
+        bool attached = AttachConsole(AttachParentProcess);
+        int exitCode = CliResult.UsageError;
+        try
+        {
+            var result = new CliRunner().ExecuteAsync(request).GetAwaiter().GetResult();
+            exitCode = result.ExitCode;
+            bool suppress = request.Silent && result.ExitCode == CliResult.Ok;
+            if (attached && !suppress && !string.IsNullOrEmpty(result.Output))
+                Console.Out.WriteLine(result.Output);
+        }
+        finally
+        {
+            if (attached) FreeConsole();
+            Shutdown(exitCode);
+            Environment.Exit(exitCode);
+        }
     }
 
     /// <summary>

--- a/SysManager/SysManager/Models/CliRequest.cs
+++ b/SysManager/SysManager/Models/CliRequest.cs
@@ -1,0 +1,34 @@
+// SysManager · CliRequest — a parsed command-line invocation
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>The headless command requested on the command line.</summary>
+public enum CliCommand
+{
+    /// <summary>No CLI verb present — launch the normal GUI.</summary>
+    None,
+    Help,
+    Version,
+    List,
+    Health,
+    Cleanup,
+    TrimRam,
+    /// <summary>A <c>--flag</c> that isn't a recognized verb — usage error.</summary>
+    Unknown,
+}
+
+/// <summary>
+/// A parsed CLI invocation: the verb plus output modifiers. Produced by the pure
+/// <see cref="Services.CliRunner.Parse"/>; carries no behavior of its own.
+/// </summary>
+public sealed record CliRequest(CliCommand Command, bool Json = false, bool Silent = false, string? UnknownArg = null);
+
+/// <summary>The outcome of running a CLI command: a process exit code and the text to print.</summary>
+public sealed record CliResult(int ExitCode, string Output)
+{
+    public const int Ok = 0;
+    public const int Error = 1;
+    public const int UsageError = 2;
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -136,6 +136,7 @@ public static class ServiceRegistration
         services.AddSingleton<StandbyMemoryViewModel>();
         services.AddSingleton<ResourceHistoryViewModel>();
         services.AddSingleton<SettingsWatchdogViewModel>();
+        services.AddSingleton<CliInterfaceViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/CliRunner.cs
+++ b/SysManager/SysManager/Services/CliRunner.cs
@@ -1,0 +1,190 @@
+// SysManager · CliRunner — headless command-line entry point for scripting/automation
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Parses and runs SysManager's command-line interface, so power users and sysadmins can
+/// automate the safe maintenance actions from scripts, Task Scheduler, or deployment tools
+/// (e.g. <c>SysManager.exe --cleanup --silent</c> or <c>SysManager.exe --health --json</c>).
+///
+/// Only read-only or safe, non-destructive actions are exposed on the CLI — temp cleanup
+/// (never follows reparse points), standby-list trim (non-destructive cache drop), and
+/// read-only health/inventory. Anything that mutates the system irreversibly stays
+/// GUI-only behind a confirmation dialog. <see cref="Parse"/> is pure; <see cref="ExecuteAsync"/>
+/// returns the output text rather than writing it, so both are fully unit-testable.
+/// </summary>
+public sealed class CliRunner
+{
+    private const string Version = "1.49.0";
+
+    // CLI verbs that put startup into headless mode. The elevation sentinel
+    // (--relaunched-elevated) and the update-applier arg are deliberately absent, so they
+    // route to their own startup branches and never get treated as a CLI command.
+    private static readonly HashSet<string> CliVerbs = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "--help", "-h", "-?", "/?", "--version", "-v", "--list", "--health", "--cleanup", "--trim-ram",
+    };
+
+    /// <summary>True only when a recognized CLI verb is present — used by startup to choose
+    /// headless mode over the GUI. Deliberately strict: an unrecognized flag (e.g. the
+    /// elevation sentinel) does NOT trigger CLI mode, so other startup branches still run.</summary>
+    public static bool IsCliInvocation(string[] args) => args.Any(a => CliVerbs.Contains(a.Trim()));
+
+    /// <summary>
+    /// Parses the argument list into a <see cref="CliRequest"/>. The first recognized verb
+    /// wins; <c>--json</c> and <c>--silent</c> are modifiers. An unrecognized leading
+    /// <c>--flag</c> becomes <see cref="CliCommand.Unknown"/> (usage error). Pure.
+    /// </summary>
+    public static CliRequest Parse(string[] args)
+    {
+        bool json = false, silent = false;
+        CliCommand command = CliCommand.None;
+        string? unknown = null;
+
+        foreach (var raw in args)
+        {
+            var arg = raw.Trim().ToLowerInvariant();
+            switch (arg)
+            {
+                case "--json": json = true; break;
+                case "--silent" or "-s" or "/silent": silent = true; break;
+                case "--help" or "-h" or "-?" or "/?": command = Pick(command, CliCommand.Help); break;
+                case "--version" or "-v": command = Pick(command, CliCommand.Version); break;
+                case "--list": command = Pick(command, CliCommand.List); break;
+                case "--health": command = Pick(command, CliCommand.Health); break;
+                case "--cleanup": command = Pick(command, CliCommand.Cleanup); break;
+                case "--trim-ram": command = Pick(command, CliCommand.TrimRam); break;
+                default:
+                    // An unrecognized option flag is a usage error; bare tokens are ignored.
+                    if (arg.StartsWith('-') || arg.StartsWith('/'))
+                    {
+                        command = CliCommand.Unknown;
+                        unknown ??= raw.Trim();
+                    }
+                    break;
+            }
+        }
+        return new CliRequest(command, json, silent, unknown);
+    }
+
+    // First explicit verb wins; later verbs are ignored (a single invocation does one thing).
+    private static CliCommand Pick(CliCommand current, CliCommand next)
+        => current is CliCommand.None or CliCommand.Unknown ? next : current;
+
+    /// <summary>The recognized commands and one-line help, single source for help text and the in-app reference tab.</summary>
+    public static IReadOnlyList<(string Flags, string Description)> Commands { get; } =
+    [
+        ("--help, -h", "Show this help and exit."),
+        ("--version, -v", "Print the SysManager version and exit."),
+        ("--list", "List the available CLI commands."),
+        ("--health", "Print a system health score (read-only)."),
+        ("--cleanup", "Delete temporary files from user and Windows TEMP (safe, never follows junctions)."),
+        ("--trim-ram", "Purge the standby memory list (non-destructive; needs administrator)."),
+        ("--json", "Modifier: emit machine-readable JSON instead of text."),
+        ("--silent, -s", "Modifier: suppress non-essential output."),
+    ];
+
+    /// <summary>
+    /// Executes a parsed request and returns the exit code plus the text to print. Side effects
+    /// are limited to the safe actions described on each command. Never throws for a known
+    /// command — failures are reported in the result.
+    /// </summary>
+    public async Task<CliResult> ExecuteAsync(CliRequest request, CancellationToken ct = default)
+    {
+        return request.Command switch
+        {
+            CliCommand.Help or CliCommand.List => new CliResult(CliResult.Ok, BuildHelp(request.Json)),
+            CliCommand.Version => new CliResult(CliResult.Ok, request.Json ? Json(new { version = Version }) : Version),
+            CliCommand.Health => await RunHealthAsync(request, ct).ConfigureAwait(false),
+            CliCommand.Cleanup => await RunCleanupAsync(request, ct).ConfigureAwait(false),
+            CliCommand.TrimRam => RunTrimRam(request),
+            CliCommand.Unknown => new CliResult(CliResult.UsageError,
+                $"Unknown option '{request.UnknownArg}'.\n\n{BuildHelp(false)}"),
+            _ => new CliResult(CliResult.UsageError, BuildHelp(false)),
+        };
+    }
+
+    // ── Command implementations ────────────────────────────────────────────
+
+    private static async Task<CliResult> RunHealthAsync(CliRequest request, CancellationToken ct)
+    {
+        try
+        {
+            var svc = new HealthScoreService(new SystemInfoService(), new DiskHealthService(), new BatteryService());
+            var r = await svc.ComputeAsync(ct).ConfigureAwait(false);
+            return request.Json
+                ? new CliResult(CliResult.Ok, Json(new { score = r.Score, label = r.Label, disk = r.DiskScore, ram = r.RamScore, uptime = r.UptimeScore }))
+                : new CliResult(CliResult.Ok, $"Health score: {r.Score}/100 ({r.Label})");
+        }
+        catch (Exception ex) when (ex is System.Management.ManagementException or InvalidOperationException)
+        {
+            return new CliResult(CliResult.Error, request.Json ? Json(new { error = ex.Message }) : $"Health check failed: {ex.Message}");
+        }
+    }
+
+    private static async Task<CliResult> RunCleanupAsync(CliRequest request, CancellationToken ct)
+    {
+        try
+        {
+            var (bytes, files, errors) = await TuneUpService.CleanTempFilesAsync(ct).ConfigureAwait(false);
+            double mb = bytes / 1024.0 / 1024.0;
+            return request.Json
+                ? new CliResult(CliResult.Ok, Json(new { freedBytes = bytes, freedMB = Math.Round(mb, 1), filesDeleted = files, errors }))
+                : new CliResult(CliResult.Ok, request.Silent
+                    ? $"{mb:F0} MB freed"
+                    : $"Cleanup complete: freed {mb:F1} MB across {files} file(s){(errors > 0 ? $", {errors} skipped" : "")}.");
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return new CliResult(CliResult.Error, request.Json ? Json(new { error = ex.Message }) : $"Cleanup failed: {ex.Message}");
+        }
+    }
+
+    private static CliResult RunTrimRam(CliRequest request)
+    {
+        var svc = new StandbyMemoryService();
+        var before = svc.GetMemoryStatus();
+        bool ok = svc.TryPurgeStandbyList(out var error);
+        if (!ok)
+            return new CliResult(CliResult.Error, request.Json ? Json(new { error }) : $"Standby trim failed: {error}");
+
+        var after = svc.GetMemoryStatus();
+        return request.Json
+            ? new CliResult(CliResult.Ok, Json(new { freedMB = Math.Round((after.AvailableBytes - before.AvailableBytes) / 1024.0 / 1024.0, 0), loadPercentAfter = after.LoadPercent }))
+            : new CliResult(CliResult.Ok, request.Silent ? "Standby list purged" : $"Standby list purged. Memory load now {after.LoadPercent}%.");
+    }
+
+    // ── Help / formatting ───────────────────────────────────────────────────
+
+    /// <summary>Builds the help text (or a JSON command list). Pure.</summary>
+    public static string BuildHelp(bool json)
+    {
+        if (json)
+            return Json(new { version = Version, commands = Commands.Select(c => new { flags = c.Flags, description = c.Description }) });
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"SysManager {Version} — command-line interface");
+        sb.AppendLine();
+        sb.AppendLine("Usage: SysManager.exe <command> [--json] [--silent]");
+        sb.AppendLine();
+        sb.AppendLine("Commands:");
+        int width = Commands.Max(c => c.Flags.Length);
+        foreach (var (flags, description) in Commands)
+            sb.AppendLine($"  {flags.PadRight(width)}  {description}");
+        sb.AppendLine();
+        sb.AppendLine("Exit codes: 0 success · 1 error · 2 usage error.");
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string Json(object value)
+        => JsonSerializer.Serialize(value, new JsonSerializerOptions { WriteIndented = true });
+
+    internal static string CurrentVersion => Version;
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.48.0</Version>
-    <FileVersion>1.48.0.0</FileVersion>
-    <AssemblyVersion>1.48.0.0</AssemblyVersion>
+    <Version>1.49.0</Version>
+    <FileVersion>1.49.0.0</FileVersion>
+    <AssemblyVersion>1.49.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/CliInterfaceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CliInterfaceViewModel.cs
@@ -1,0 +1,59 @@
+// SysManager · CliInterfaceViewModel
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using SysManager.Helpers;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// Reference tab for the command-line interface. Lists the available CLI commands (the
+/// single source of truth is <see cref="CliRunner.Commands"/>) so a user can discover and
+/// copy them for use in scripts or Task Scheduler. Read-only: this tab runs nothing, it
+/// just documents the headless commands the executable accepts.
+/// </summary>
+public sealed partial class CliInterfaceViewModel : ViewModelBase
+{
+    public sealed record CommandRow(string Flags, string Description);
+
+    public BulkObservableCollection<CommandRow> Commands { get; } = new();
+
+    /// <summary>A ready-to-paste example invocation shown at the top of the tab.</summary>
+    public string Example => "SysManager.exe --cleanup --silent";
+
+    public CliInterfaceViewModel()
+    {
+        Commands.ReplaceWith(CliRunner.Commands.Select(c => new CommandRow(c.Flags, c.Description)));
+        StatusMessage = "Use these from a script, Task Scheduler, or a deployment tool. Add --json for machine-readable output.";
+    }
+
+    [RelayCommand]
+    private void CopyExample() => TryCopy(Example);
+
+    [RelayCommand]
+    private void CopyCommand(CommandRow? row)
+    {
+        if (row is null) return;
+        // Copy just the primary flag (the part before the first comma) so it pastes clean.
+        var primary = row.Flags.Split(',', 2)[0].Trim();
+        TryCopy($"SysManager.exe {primary}");
+    }
+
+    private void TryCopy(string text)
+    {
+        try
+        {
+            Clipboard.SetText(text);
+            StatusMessage = $"Copied: {text}";
+        }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            // The clipboard can be transiently locked by another process; report, don't crash.
+            StatusMessage = "Could not access the clipboard — try again.";
+        }
+    }
+}

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -67,6 +67,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public StandbyMemoryViewModel StandbyMemory { get; }
     public ResourceHistoryViewModel ResourceHistory { get; }
     public SettingsWatchdogViewModel SettingsWatchdog { get; }
+    public CliInterfaceViewModel CliInterface { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -98,9 +99,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
     // System group (additions)
     public PlaceholderViewModel WipTaskScheduler { get; private set; } = null!;
-
-    // Advanced group
-    public PlaceholderViewModel WipCliInterface { get; private set; } = null!;
 
     /// <summary>Grouped sidebar tree (12 categories).</summary>
     public ObservableCollection<NavGroup> NavGroups { get; } = new();
@@ -177,6 +175,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             StandbyMemory = sp.GetRequiredService<StandbyMemoryViewModel>();
             ResourceHistory = sp.GetRequiredService<ResourceHistoryViewModel>();
             SettingsWatchdog = sp.GetRequiredService<SettingsWatchdogViewModel>();
+            CliInterface = sp.GetRequiredService<CliInterfaceViewModel>();
         }
         else
         {
@@ -248,6 +247,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             StandbyMemory = new StandbyMemoryViewModel(new StandbyMemoryService());
             ResourceHistory = new ResourceHistoryViewModel(new ResourceHistoryService(sysInfo, new TemperatureService(diskHealth)));
             SettingsWatchdog = new SettingsWatchdogViewModel(new SettingsWatchdogService());
+            CliInterface = new CliInterfaceViewModel();
         }
 
         InitPlaceholders();
@@ -289,7 +289,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         WipTaskScheduler = new PlaceholderViewModel("Task Scheduler", "Browse and toggle scheduled tasks with color-coded safety indicators.", "#334");
 
         // Advanced group
-        WipCliInterface = new PlaceholderViewModel("CLI Interface", "Command-line control: sysmanager --cleanup --apply-profile Gaming --silent.", "#342");
     }
 
     private void InitNavigation()
@@ -392,7 +391,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
         Group("grp-advanced", "Advanced", "",
             Item("nav-profile-export", "Profile Export/Import", "", Profile,               typeof(Views.ProfileView)),
-            Item("nav-cli-interface",  "CLI Interface",         "", WipCliInterface,        typeof(Views.PlaceholderView)),
+            Item("nav-cli-interface",  "CLI Interface",         "", CliInterface,           typeof(Views.CliInterfaceView), inDevelopment: true),
             Item("nav-env-variables",  "Environment Variables", "", EnvironmentVariables, typeof(Views.EnvironmentVariablesView))),
     ];
 
@@ -508,6 +507,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         StandbyMemory?.Dispose();
         ResourceHistory?.Dispose();
         SettingsWatchdog?.Dispose();
+        CliInterface?.Dispose();
 
         // WIP placeholders
         WipFileLockDetector?.Dispose();
@@ -536,7 +536,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         WipDarkModeScheduler?.Dispose();
         WipVolumeControl?.Dispose();
         WipTaskScheduler?.Dispose();
-        WipCliInterface?.Dispose();
 
         GC.SuppressFinalize(this);
     }

--- a/SysManager/SysManager/Views/CliInterfaceView.xaml
+++ b/SysManager/SysManager/Views/CliInterfaceView.xaml
@@ -1,0 +1,76 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.CliInterfaceView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:CliInterfaceViewModel}"
+             Background="{DynamicResource Surface0}">
+
+    <Grid Margin="28,24,28,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Preview banner -->
+        <v:DevelopmentBanner Grid.Row="0" Margin="0,0,0,12"/>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="1" Margin="0,0,0,16">
+            <TextBlock Text="CLI Interface" Style="{StaticResource Display}"/>
+            <TextBlock Text="SysManager accepts command-line flags so you can automate safe maintenance from scripts, Task Scheduler, or deployment tools. Read-only or non-destructive actions only — anything that changes the system irreversibly stays in the app behind a confirmation."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap" MaxWidth="820"/>
+        </StackPanel>
+
+        <!-- Example -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="14">
+            <DockPanel>
+                <Button Content="Copy" Command="{Binding CopyExampleCommand}" DockPanel.Dock="Right"
+                        Style="{StaticResource SecondaryButton}" VerticalAlignment="Center"
+                        AutomationProperties.Name="Copy example command"/>
+                <StackPanel>
+                    <TextBlock Text="EXAMPLE" Style="{StaticResource SectionLabel}"/>
+                    <TextBlock Text="{Binding Example}" FontFamily="Consolas,Cascadia Mono,monospace"
+                               FontSize="14" Foreground="{DynamicResource Info}" Margin="0,4,0,0"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- Command reference -->
+        <Border Grid.Row="3" Style="{StaticResource Card}">
+            <DataGrid ItemsSource="{Binding Commands}" AutoGenerateColumns="False" IsReadOnly="True"
+                      HeadersVisibility="Column" GridLinesVisibility="None" Background="Transparent"
+                      BorderThickness="0" CanUserAddRows="False"
+                      VirtualizingPanel.IsVirtualizing="True"
+                      AutomationProperties.Name="Available CLI commands">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Command" Binding="{Binding Flags}" Width="Auto" MinWidth="160"
+                                        FontFamily="Consolas,Cascadia Mono,monospace"/>
+                    <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="*"/>
+                    <DataGridTemplateColumn Header="" Width="Auto">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Button Content="Copy" Padding="10,3" FontSize="11"
+                                        Style="{StaticResource GhostButton}"
+                                        AutomationProperties.Name="{Binding Flags, StringFormat='Copy {0}'}"
+                                        Command="{Binding DataContext.CopyCommandCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                        CommandParameter="{Binding}"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                </DataGrid.Columns>
+            </DataGrid>
+        </Border>
+
+        <!-- Status -->
+        <TextBlock Grid.Row="4" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+                   Margin="0,12,0,0" TextWrapping="Wrap"/>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/CliInterfaceView.xaml.cs
+++ b/SysManager/SysManager/Views/CliInterfaceView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · CliInterfaceView
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class CliInterfaceView : UserControl
+{
+    public CliInterfaceView() => InitializeComponent();
+}


### PR DESCRIPTION
## What

Implements **#342 — CLI / Automation Interface**: SysManager now accepts command-line flags and runs **headless** (no window), so power users and sysadmins can automate the safe maintenance actions from scripts, Task Scheduler, or deployment tools.

```
SysManager.exe --health --json
SysManager.exe --cleanup --silent
```

## How

- **`CliRunner`** — `Parse(args)` (pure) → `CliRequest`; `ExecuteAsync` → `CliResult { ExitCode, Output }` (returns text, doesn't write it). Verbs: `--health`, `--cleanup`, `--trim-ram`, `--version`, `--help`, `--list`; modifiers `--json` / `--silent`. Reuses existing services (`HealthScoreService`, `TuneUpService.CleanTempFilesAsync`, `StandbyMemoryService`).
- **`App.OnStartup`** — a headless branch dispatched **before the single-instance mutex** (so a script can run while the GUI is open), attaches to the parent console via `AttachConsole`, runs, prints, and exits with the command's code. Gated by `IsCliInvocation` — a **strict verb whitelist** so the elevation sentinel (`--relaunched-elevated`) and update-applier args never get hijacked into CLI mode.
- **`CliInterfaceViewModel` / `CliInterfaceView`** — graduates the placeholder to a real **Preview reference tab** listing every command with one-click copy (Strategy-1 layout).

## Safety

- **Only read-only or non-destructive verbs** are exposed (health read, temp cleanup that never follows junctions, non-destructive standby purge). Anything that mutates the system irreversibly stays GUI-only behind `DialogService.Confirm`.
- Exit codes: **0 success · 1 error · 2 usage**. No network, no telemetry.

## Tests

- `CliRunnerTests` — Parse (verbs, case-insensitive, modifiers, first-verb-wins, unknown flag, bare tokens), **IsCliInvocation does NOT hijack** the elevation sentinel or update-applier args, ExecuteAsync (version/help/unknown/none), help text + JSON, exit-code constants.
- `MainWindowViewModelTests.NavLeaf_CliInterface_IsImplementedAndInPreview`.
- Whole CLI is unit-tested **without launching the process**.

## Docs

README (sidebar table, counts 51 impl / 6 WIP, feature section), ARCHITECTURE (Advanced row + CliRunner & CliInterfaceViewModel entries), CHANGELOG (1.49.0), version bump to 1.49.0 — all in this PR.

Closes #342