### PR TITLE
feat: add Scheduled Maintenance tab for recurring automated maintenance

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,7 +44,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `TaskSchedulerViewModel` · `BootAnalyzerViewModel` · `SystemFixesViewModel` |
 | Gaming & Profiles | `TimerResolutionViewModel` · `DisplayProfileViewModel` · `CpuAffinityViewModel` · `StandbyMemoryViewModel` · `PlaceholderViewModel` (Gaming Profile) |
 | Monitor | `ProcessManagerViewModel` · `ResourceHistoryViewModel` · `PrivacyMonitorViewModel` · `AppAlertsViewModel` · `FileLockViewModel` · `SettingsWatchdogViewModel` · `PlaceholderViewModel` (Bandwidth Monitor) |
-| Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `PlaceholderViewModel` (Scheduled Maintenance) |
+| Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `ScheduledMaintenanceViewModel` |
 | Storage | `DiskAnalyzerViewModel` · `DuplicateFileViewModel` |
 | Network | `PingViewModel` · `TracerouteViewModel` · `SpeedTestViewModel` · `NetworkRepairViewModel` (shared: `NetworkSharedState`) · `DnsHostsViewModel` |
 | Apps | `AppUpdatesViewModel` · `BulkInstallerViewModel` · `UninstallerViewModel` |
@@ -90,6 +90,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `SystemReportViewModel` — generate a read-only full-system snapshot and export it as text, HTML, or JSON.
 - `EnvironmentVariablesViewModel` — view/edit User and System environment variables with a dedicated PATH editor (reorder, dedupe, missing-folder detection); staged edits with a one-time backup.
 - `CliInterfaceViewModel` — read-only reference tab listing the headless CLI commands (sourced from `CliRunner.Commands`) with copy-to-clipboard; documents the flags, runs nothing itself.
+- `ScheduledMaintenanceViewModel` — register/update/remove a single recurring Windows task that runs SysManager headless (temp cleanup or standby trim) daily/weekly; shows last/next run + last result. Create and remove are confirmed; only SysManager's own task is touched.
 - `RestorePointsViewModel` — list, create, and restore Windows System Restore points (admin for create/restore; restore reboots, gated by confirmation).
 - `LegacyPanelsViewModel` — one-click launcher for the fixed catalog of classic Windows applets (pure launchers, no system modification).
 - `SystemFixesViewModel` — consolidated one-click repairs (Windows Update reset, network reset, WinGet reinstall) with per-fix confirmation + live output; opens netplwiz for secure auto-logon.
@@ -310,6 +311,13 @@ Key services:
   `ExecuteAsync` are pure/return-value-based, so the whole CLI is unit-tested without
   launching the process; `IsCliInvocation` is strict so the elevation/update-applier args
   never trigger CLI mode.
+- `MaintenanceSchedulerService` — registers/reads/removes a single SysManager-owned Windows
+  scheduled task (`\SysManager\Scheduled Maintenance`) that launches the app's own exe with a
+  whitelisted CLI verb on a daily/weekly trigger, via the `ScheduledTasks` module through the
+  `IPowerShellRunner` seam. Registered in the current-user context (no admin); only ever
+  touches its own task — never enumerates or modifies others. The command is built from a
+  fixed argument whitelist (`MaintenanceSchedule.CliArguments`), so no free-form input reaches
+  the scheduler; result-code description is a pure, unit-tested helper.
 - `SafetyDatabase` — curated safety ratings for Windows services.
 - `ThemeService` — runtime theme switching with 12 presets and persistence.
 - `ToastService` — global glass-style toast notifications.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.50.0] - 2026-06-29
+
+### Added
+- **Scheduled Maintenance tab (Preview).** Automate maintenance on a schedule: register one Windows scheduled task that runs SysManager in the background (via its CLI) to clean temporary files or purge standby memory, daily or weekly at a time you pick. The tab shows the task's last run, next run, and last result, and lets you update or remove the schedule (each confirmed first). It runs in your user context — no admin required — and only ever touches its own task at `\SysManager\Scheduled Maintenance`, never any other scheduled task. Built on the same safe CLI verbs, so nothing destructive is automated. Closes #10.
+
 ## [1.49.0] - 2026-06-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ fully open source.
 
 ### Sidebar navigation
 The sidebar organises 57 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 51 tabs are fully
-implemented; 6 are work-in-progress placeholders marked with ⚙️:
+find what you need without scrolling through a flat list. 52 tabs are fully
+implemented; 5 are work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |
 |-------|------|
@@ -83,7 +83,7 @@ implemented; 6 are work-in-progress placeholders marked with ⚙️:
 | 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Task Scheduler · Boot Analyzer · System Fixes |
 | 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner · Timer Resolution · CPU Core Affinity · Display Profiles |
 | 📊 Monitor | Process Manager · Resource History · Camera/Mic/Location · App Alerts · File Lock Detector · Settings Watchdog · Bandwidth Monitor ⚙️ |
-| 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance ⚙️ |
+| 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance |
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS & Hosts |
 | 📦 Apps | App Updates · Bulk Installer · Uninstaller |
@@ -403,6 +403,16 @@ a confirmation before it runs:
 - Select all / deselect individual items
 - Move to Recycle Bin or permanent delete, with confirmation dialog
 - COM-based IShellLink resolution for accurate target validation
+
+### Scheduled Maintenance
+- **Automate maintenance on a schedule** — register one Windows scheduled task that
+  runs SysManager in the background (via its CLI) to clean temporary files or purge
+  standby memory, daily or weekly at a time you pick
+- See the **last run, next run, and last result** of the task at a glance
+- Update or remove the schedule any time, each with a confirmation
+- Runs in your user context (no admin required) and only ever touches its own task
+  at `\SysManager\Scheduled Maintenance` — no other scheduled tasks are affected
+- Built on the same safe CLI verbs; nothing destructive is automated
 
 ### Privacy & Telemetry
 - 12 registry-based toggles across 3 categories (Telemetry, UI Declutter, Features)

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -467,4 +467,15 @@ public class MainWindowViewModelTests
         Assert.IsType<CliInterfaceViewModel>(item.Content);
         Assert.True(item.IsInDevelopment);
     }
+
+    // Scheduled Maintenance (#10) — implemented, wired to a real view/VM, flagged PREVIEW.
+    [Fact]
+    public void NavLeaf_ScheduledMaintenance_IsImplementedAndInPreview()
+    {
+        var vm = new MainWindowViewModel();
+        var item = vm.NavItems.First(n => n.Id == "nav-scheduled-maintenance");
+        Assert.Equal(typeof(SysManager.Views.ScheduledMaintenanceView), item.ViewType);
+        Assert.IsType<ScheduledMaintenanceViewModel>(item.Content);
+        Assert.True(item.IsInDevelopment);
+    }
 }

--- a/SysManager/SysManager.Tests/MaintenanceScheduleTests.cs
+++ b/SysManager/SysManager.Tests/MaintenanceScheduleTests.cs
@@ -1,0 +1,83 @@
+// SysManager · MaintenanceScheduleTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+public class MaintenanceScheduleTests
+{
+    // ── CliArguments: must map to the whitelisted CLI verbs, never free text ──
+
+    [Theory]
+    [InlineData(MaintenanceAction.Cleanup, "--cleanup --silent")]
+    [InlineData(MaintenanceAction.TrimRam, "--trim-ram --silent")]
+    public void CliArguments_MapToWhitelistedVerbs(MaintenanceAction action, string expected)
+    {
+        var s = new MaintenanceSchedule(action, MaintenanceFrequency.Daily, 3, 0);
+        Assert.Equal(expected, s.CliArguments);
+    }
+
+    [Fact]
+    public void CliArguments_AreAlwaysSilentFlags_NeverArbitraryText()
+    {
+        // Every action's argument string is one of the fixed, known-safe forms — this
+        // guards the "no free-form input reaches the scheduler" invariant.
+        foreach (MaintenanceAction action in Enum.GetValues<MaintenanceAction>())
+        {
+            var args = new MaintenanceSchedule(action, MaintenanceFrequency.Daily, 1, 0).CliArguments;
+            Assert.Matches(@"^--[a-z-]+( --silent)?$", args);
+        }
+    }
+
+    // ── Summary: plain-language schedule description ──────────────────────
+
+    [Fact]
+    public void Summary_Daily_OmitsDay()
+    {
+        var s = new MaintenanceSchedule(MaintenanceAction.Cleanup, MaintenanceFrequency.Daily, 3, 5);
+        Assert.Equal("Every day at 03:05", s.Summary);
+    }
+
+    [Fact]
+    public void Summary_Weekly_NamesDay()
+    {
+        var s = new MaintenanceSchedule(MaintenanceAction.TrimRam, MaintenanceFrequency.Weekly, 22, 30, DayOfWeek.Friday);
+        Assert.Equal("Every Friday at 22:30", s.Summary);
+    }
+
+    [Fact]
+    public void ActionLabel_IsHumanReadable()
+    {
+        Assert.Equal("Clean temporary files", new MaintenanceSchedule(MaintenanceAction.Cleanup, MaintenanceFrequency.Daily, 0, 0).ActionLabel);
+        Assert.Equal("Purge standby memory", new MaintenanceSchedule(MaintenanceAction.TrimRam, MaintenanceFrequency.Daily, 0, 0).ActionLabel);
+    }
+
+    // ── DescribeResultCode: last-run status in plain language ─────────────
+
+    [Theory]
+    [InlineData(null, "Not run yet")]
+    [InlineData(0, "Last run succeeded")]
+    [InlineData(267009, "Currently running")]
+    [InlineData(267011, "Not run yet")]
+    public void DescribeResultCode_KnownCodes(int? code, string expected)
+        => Assert.Equal(expected, MaintenanceSchedulerService.DescribeResultCode(code));
+
+    [Fact]
+    public void DescribeResultCode_UnknownCode_FallsBackToHex()
+    {
+        var msg = MaintenanceSchedulerService.DescribeResultCode(unchecked((int)0x80070005));
+        Assert.Contains("0x80070005", msg);
+    }
+
+    // ── Task identity constants ───────────────────────────────────────────
+
+    [Fact]
+    public void TaskIdentity_IsSysManagerOwnedFolder()
+    {
+        Assert.Equal(@"\SysManager\", MaintenanceSchedulerService.TaskFolder);
+        Assert.Equal("Scheduled Maintenance", MaintenanceSchedulerService.TaskName);
+    }
+}

--- a/SysManager/SysManager/Models/MaintenanceSchedule.cs
+++ b/SysManager/SysManager/Models/MaintenanceSchedule.cs
@@ -1,0 +1,64 @@
+// SysManager · MaintenanceSchedule — a recurring maintenance task definition
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>How often the scheduled maintenance runs.</summary>
+public enum MaintenanceFrequency
+{
+    Daily,
+    Weekly,
+}
+
+/// <summary>Which maintenance action the schedule performs (maps to a safe CLI verb).</summary>
+public enum MaintenanceAction
+{
+    /// <summary>Delete temporary files (CLI <c>--cleanup</c>).</summary>
+    Cleanup,
+    /// <summary>Purge the standby memory list (CLI <c>--trim-ram</c>).</summary>
+    TrimRam,
+}
+
+/// <summary>
+/// A user-defined recurring maintenance schedule. The watchdog registers a single Windows
+/// scheduled task from this definition that launches SysManager headless with the matching
+/// CLI verb. Only the fields here are configurable — the command itself is built from a
+/// fixed whitelist, so no free-form text ever reaches the scheduler.
+/// </summary>
+public sealed record MaintenanceSchedule(
+    MaintenanceAction Action,
+    MaintenanceFrequency Frequency,
+    int Hour,
+    int Minute,
+    // Day of week for weekly schedules (ignored for daily). Sunday = 0.
+    DayOfWeek DayOfWeek = DayOfWeek.Sunday)
+{
+    /// <summary>The CLI argument string this schedule runs (whitelisted, no user text).</summary>
+    public string CliArguments => Action switch
+    {
+        MaintenanceAction.Cleanup => "--cleanup --silent",
+        MaintenanceAction.TrimRam => "--trim-ram --silent",
+        _ => "--help",
+    };
+
+    public string ActionLabel => Action switch
+    {
+        MaintenanceAction.Cleanup => "Clean temporary files",
+        MaintenanceAction.TrimRam => "Purge standby memory",
+        _ => "Unknown",
+    };
+
+    /// <summary>A plain-language summary of when this runs (e.g. "Every Sunday at 03:00").</summary>
+    public string Summary => Frequency == MaintenanceFrequency.Daily
+        ? $"Every day at {Hour:D2}:{Minute:D2}"
+        : $"Every {DayOfWeek} at {Hour:D2}:{Minute:D2}";
+}
+
+/// <summary>The live state of the registered maintenance task, read back from Windows.</summary>
+public sealed record MaintenanceStatus(
+    bool Exists,
+    string? State,
+    DateTime? LastRun,
+    DateTime? NextRun,
+    string? LastResultDescription);

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -82,6 +82,7 @@ public static class ServiceRegistration
         services.AddSingleton<StandbyMemoryService>();
         services.AddSingleton<ResourceHistoryService>();
         services.AddSingleton<SettingsWatchdogService>();
+        services.AddSingleton<MaintenanceSchedulerService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
         services.AddSingleton<DashboardViewModel>();
@@ -137,6 +138,7 @@ public static class ServiceRegistration
         services.AddSingleton<ResourceHistoryViewModel>();
         services.AddSingleton<SettingsWatchdogViewModel>();
         services.AddSingleton<CliInterfaceViewModel>();
+        services.AddSingleton<ScheduledMaintenanceViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/MaintenanceSchedulerService.cs
+++ b/SysManager/SysManager/Services/MaintenanceSchedulerService.cs
@@ -1,0 +1,176 @@
+// SysManager · MaintenanceSchedulerService — registers a recurring maintenance task
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Management.Automation;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Creates, reads, and removes a single SysManager-owned Windows scheduled task that runs
+/// the app headless (via its CLI) on a recurring schedule. Uses the <c>ScheduledTasks</c>
+/// PowerShell module through the shared <see cref="IPowerShellRunner"/> seam.
+///
+/// Safety: this service only ever touches the one task at <see cref="TaskFolder"/> +
+/// <see cref="TaskName"/> — it never enumerates or modifies other tasks. The command it
+/// registers is built from a whitelisted CLI argument string (no free-form user input),
+/// pointed at the running executable's own path, and registered in the current user's
+/// context (no admin required, runs only when that user is logged on).
+/// </summary>
+public sealed class MaintenanceSchedulerService
+{
+    public const string TaskFolder = @"\SysManager\";
+    public const string TaskName = "Scheduled Maintenance";
+
+    private readonly IPowerShellRunner _ps;
+
+    public MaintenanceSchedulerService(IPowerShellRunner ps) => _ps = ps;
+
+    /// <summary>Registers (or replaces) the maintenance task from the given schedule.
+    /// Returns true on success. The executable path defaults to the running process.</summary>
+    public async Task<bool> RegisterAsync(MaintenanceSchedule schedule, string? exePath = null, CancellationToken ct = default)
+    {
+        exePath ??= Environment.ProcessPath;
+        if (string.IsNullOrEmpty(exePath))
+        {
+            Log.Warning("Maintenance schedule not registered — could not resolve executable path.");
+            return false;
+        }
+
+        try
+        {
+            var parameters = new Dictionary<string, object?>
+            {
+                ["Exe"] = exePath,
+                ["Args"] = schedule.CliArguments,
+                ["Folder"] = TaskFolder,
+                ["Name"] = TaskName,
+                ["Daily"] = schedule.Frequency == MaintenanceFrequency.Daily,
+                ["At"] = $"{schedule.Hour:D2}:{schedule.Minute:D2}",
+                ["DayOfWeek"] = schedule.DayOfWeek.ToString(),
+            };
+            Collection<PSObject> results = await _ps.RunAsync(RegisterScript, parameters, ct).ConfigureAwait(false);
+            // The script emits the registered task's state; one row back == success.
+            return results.Count == 1 && Str(results[0], "State") is not null;
+        }
+        catch (RuntimeException ex)
+        {
+            Log.Warning("Maintenance schedule registration failed: {Error}", ex.Message);
+            return false;
+        }
+    }
+
+    /// <summary>Reads the current state of the maintenance task (Exists=false if not registered).</summary>
+    public async Task<MaintenanceStatus> GetStatusAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var parameters = new Dictionary<string, object?> { ["Folder"] = TaskFolder, ["Name"] = TaskName };
+            Collection<PSObject> results = await _ps.RunAsync(StatusScript, parameters, ct).ConfigureAwait(false);
+            if (results.Count == 0) return new MaintenanceStatus(false, null, null, null, null);
+
+            var row = results[0];
+            return new MaintenanceStatus(
+                Exists: true,
+                State: Str(row, "State"),
+                LastRun: Date(row, "LastRunTime"),
+                NextRun: Date(row, "NextRunTime"),
+                LastResultDescription: DescribeResult(row));
+        }
+        catch (RuntimeException ex)
+        {
+            Log.Debug("Maintenance status read failed: {Error}", ex.Message);
+            return new MaintenanceStatus(false, null, null, null, null);
+        }
+    }
+
+    /// <summary>Removes the maintenance task. Returns true if it no longer exists afterwards.</summary>
+    public async Task<bool> RemoveAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var parameters = new Dictionary<string, object?> { ["Folder"] = TaskFolder, ["Name"] = TaskName };
+            await _ps.RunAsync(RemoveScript, parameters, ct).ConfigureAwait(false);
+            var status = await GetStatusAsync(ct).ConfigureAwait(false);
+            return !status.Exists;
+        }
+        catch (RuntimeException ex)
+        {
+            Log.Warning("Maintenance schedule removal failed: {Error}", ex.Message);
+            return false;
+        }
+    }
+
+    // ── PowerShell scripts (parameterised; no string interpolation of user input) ──
+
+    // Register-ScheduledTask with -Force replaces any existing task of the same name, so
+    // re-registering just updates the schedule. The action runs the app's own exe with the
+    // whitelisted CLI args; the trigger is daily or weekly at the chosen time. Registered
+    // for the current user (-User $env:USERNAME), runs only when logged on — no admin needed.
+    private const string RegisterScript = """
+        param([string]$Exe, [string]$Args, [string]$Folder, [string]$Name,
+              [bool]$Daily, [string]$At, [string]$DayOfWeek)
+        $action = New-ScheduledTaskAction -Execute $Exe -Argument $Args
+        if ($Daily) {
+            $trigger = New-ScheduledTaskTrigger -Daily -At $At
+        } else {
+            $trigger = New-ScheduledTaskTrigger -Weekly -DaysOfWeek $DayOfWeek -At $At
+        }
+        $settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -DontStopOnIdleEnd
+        Register-ScheduledTask -TaskName $Name -TaskPath $Folder -Action $action -Trigger $trigger `
+            -Settings $settings -Description "SysManager automated maintenance." -Force -ErrorAction Stop |
+            Select-Object @{ n='State'; e={ [string]$_.State } } | Out-Null
+        Get-ScheduledTask -TaskName $Name -TaskPath $Folder -ErrorAction Stop |
+            Select-Object @{ n='State'; e={ [string]$_.State } }
+        """;
+
+    private const string StatusScript = """
+        param([string]$Folder, [string]$Name)
+        $task = Get-ScheduledTask -TaskName $Name -TaskPath $Folder -ErrorAction SilentlyContinue
+        if ($null -eq $task) { return }
+        $info = Get-ScheduledTaskInfo -TaskName $Name -TaskPath $Folder -ErrorAction SilentlyContinue
+        [PSCustomObject]@{
+            State          = [string]$task.State
+            LastRunTime    = $info.LastRunTime
+            NextRunTime    = $info.NextRunTime
+            LastTaskResult = $info.LastTaskResult
+        }
+        """;
+
+    private const string RemoveScript = """
+        param([string]$Folder, [string]$Name)
+        Unregister-ScheduledTask -TaskName $Name -TaskPath $Folder -Confirm:$false -ErrorAction SilentlyContinue
+        """;
+
+    /// <summary>Plain-language description of the last task result code. Pure/testable.</summary>
+    public static string DescribeResultCode(int? code) => code switch
+    {
+        null => "Not run yet",
+        0 => "Last run succeeded",
+        267009 => "Currently running",
+        267011 => "Not run yet",
+        unchecked((int)0x80070002) => "Last run failed (file not found)",
+        _ => $"Last run returned 0x{unchecked((uint)code.Value):X8}",
+    };
+
+    private static string DescribeResult(PSObject row)
+    {
+        var v = row.Properties["LastTaskResult"]?.Value;
+        if (v is null) return DescribeResultCode(null);
+        if (v is int i) return DescribeResultCode(i);
+        return int.TryParse(v.ToString(), out var parsed) ? DescribeResultCode(parsed) : DescribeResultCode(null);
+    }
+
+    private static string? Str(PSObject? obj, string property) => obj?.Properties[property]?.Value?.ToString();
+
+    private static DateTime? Date(PSObject? obj, string property) => obj?.Properties[property]?.Value switch
+    {
+        DateTime dt => dt,
+        string s when DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.None, out var p) => p,
+        _ => null,
+    };
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.49.0</Version>
-    <FileVersion>1.49.0.0</FileVersion>
-    <AssemblyVersion>1.49.0.0</AssemblyVersion>
+    <Version>1.50.0</Version>
+    <FileVersion>1.50.0.0</FileVersion>
+    <AssemblyVersion>1.50.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -68,6 +68,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public ResourceHistoryViewModel ResourceHistory { get; }
     public SettingsWatchdogViewModel SettingsWatchdog { get; }
     public CliInterfaceViewModel CliInterface { get; }
+    public ScheduledMaintenanceViewModel ScheduledMaintenance { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -80,9 +81,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public PlaceholderViewModel WipTimerResolution { get; private set; } = null!;
     public PlaceholderViewModel WipCpuAffinity { get; private set; } = null!;
     public PlaceholderViewModel WipDisplayProfiles { get; private set; } = null!;
-
-    // Cleanup group (File Shredder is now fully implemented)
-    public PlaceholderViewModel WipScheduledMaintenance { get; private set; } = null!;
 
     // Network group — DNS Changer + Hosts Editor now fully implemented as DnsHosts
 
@@ -176,6 +174,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             ResourceHistory = sp.GetRequiredService<ResourceHistoryViewModel>();
             SettingsWatchdog = sp.GetRequiredService<SettingsWatchdogViewModel>();
             CliInterface = sp.GetRequiredService<CliInterfaceViewModel>();
+            ScheduledMaintenance = sp.GetRequiredService<ScheduledMaintenanceViewModel>();
         }
         else
         {
@@ -248,6 +247,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             ResourceHistory = new ResourceHistoryViewModel(new ResourceHistoryService(sysInfo, new TemperatureService(diskHealth)));
             SettingsWatchdog = new SettingsWatchdogViewModel(new SettingsWatchdogService());
             CliInterface = new CliInterfaceViewModel();
+            ScheduledMaintenance = new ScheduledMaintenanceViewModel(new MaintenanceSchedulerService(new PowerShellRunner()));
         }
 
         InitPlaceholders();
@@ -270,7 +270,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         WipDisplayProfiles = new PlaceholderViewModel("Display Profiles", "Quick-switch refresh rate, HDR, resolution presets (Gaming/Work/Movie).", "#328");
 
         // Cleanup group (File Shredder is now fully implemented)
-        WipScheduledMaintenance = new PlaceholderViewModel("Scheduled Maintenance", "Automate cleanup, RAM trim, and health checks on schedule or idle trigger.", "#10");
 
         // Network group — DNS Changer + Hosts Editor now fully implemented as DnsHosts
 
@@ -348,7 +347,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-cleanup",               "Quick Cleanup",         "", Cleanup,                 typeof(Views.CleanupView)),
             Item("nav-deep-cleanup",          "Deep Cleanup",          "", DeepCleanup,             typeof(Views.DeepCleanupView)),
             Item("nav-shortcut-cleaner",      "Shortcut Cleaner",      "", ShortcutCleaner,         typeof(Views.ShortcutCleanerView)),
-            Item("nav-scheduled-maintenance", "Scheduled Maintenance", "", WipScheduledMaintenance, typeof(Views.PlaceholderView))),
+            Item("nav-scheduled-maintenance", "Scheduled Maintenance", "", ScheduledMaintenance,    typeof(Views.ScheduledMaintenanceView), inDevelopment: true)),
 
         Group("grp-storage", "Storage", "",
             Item("nav-disk-analyzer", "Disk Analyzer",    "", DiskAnalyzer,  typeof(Views.DiskAnalyzerView)),
@@ -508,6 +507,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         ResourceHistory?.Dispose();
         SettingsWatchdog?.Dispose();
         CliInterface?.Dispose();
+        ScheduledMaintenance?.Dispose();
 
         // WIP placeholders
         WipFileLockDetector?.Dispose();
@@ -517,7 +517,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         WipTimerResolution?.Dispose();
         WipCpuAffinity?.Dispose();
         WipDisplayProfiles?.Dispose();
-        WipScheduledMaintenance?.Dispose();
         Privacy?.Dispose();
         ContextMenu?.Dispose();
         SystemReport?.Dispose();

--- a/SysManager/SysManager/ViewModels/ScheduledMaintenanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ScheduledMaintenanceViewModel.cs
@@ -1,0 +1,133 @@
+// SysManager · ScheduledMaintenanceViewModel
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the Scheduled Maintenance tab. Lets the user register a single recurring
+/// Windows task that runs SysManager headless (temp cleanup or standby trim) on a daily or
+/// weekly schedule, and shows its status / last run. Creating or removing the task is
+/// confirmed first; only SysManager's own task is ever touched (via
+/// <see cref="MaintenanceSchedulerService"/>).
+/// </summary>
+public sealed partial class ScheduledMaintenanceViewModel : ViewModelBase
+{
+    private readonly MaintenanceSchedulerService _service;
+
+    public IReadOnlyList<MaintenanceAction> Actions { get; } = [MaintenanceAction.Cleanup, MaintenanceAction.TrimRam];
+    public IReadOnlyList<MaintenanceFrequency> Frequencies { get; } = [MaintenanceFrequency.Daily, MaintenanceFrequency.Weekly];
+    public IReadOnlyList<DayOfWeek> Days { get; } = Enum.GetValues<DayOfWeek>();
+    public IReadOnlyList<int> Hours { get; } = [.. Enumerable.Range(0, 24)];
+    public IReadOnlyList<int> Minutes { get; } = [0, 15, 30, 45];
+
+    [ObservableProperty] private MaintenanceAction _selectedAction = MaintenanceAction.Cleanup;
+    [ObservableProperty] private MaintenanceFrequency _selectedFrequency = MaintenanceFrequency.Weekly;
+    [ObservableProperty] private DayOfWeek _selectedDay = DayOfWeek.Sunday;
+    [ObservableProperty] private int _selectedHour = 3;
+    [ObservableProperty] private int _selectedMinute = 0;
+    [ObservableProperty] private bool _isWeekly = true;
+
+    [ObservableProperty] private bool _isScheduled;
+    [ObservableProperty] private string _currentSummary = "";
+    [ObservableProperty] private string _lastRun = "";
+    [ObservableProperty] private string _nextRun = "";
+    [ObservableProperty] private string _lastResult = "";
+
+    public ScheduledMaintenanceViewModel(MaintenanceSchedulerService service)
+    {
+        _service = service;
+        InitializeAsync(RefreshAsync);
+    }
+
+    partial void OnSelectedFrequencyChanged(MaintenanceFrequency value)
+        => IsWeekly = value == MaintenanceFrequency.Weekly;
+
+    private MaintenanceSchedule BuildSchedule() =>
+        new(SelectedAction, SelectedFrequency, SelectedHour, SelectedMinute, SelectedDay);
+
+    [RelayCommand]
+    private async Task RefreshAsync()
+    {
+        IsBusy = true;
+        try
+        {
+            var status = await _service.GetStatusAsync();
+            IsScheduled = status.Exists;
+            if (status.Exists)
+            {
+                CurrentSummary = $"Maintenance is scheduled (state: {status.State}).";
+                LastRun = status.LastRun is { } lr ? lr.ToString("yyyy-MM-dd HH:mm") : "—";
+                NextRun = status.NextRun is { } nr ? nr.ToString("yyyy-MM-dd HH:mm") : "—";
+                LastResult = status.LastResultDescription ?? "";
+                StatusMessage = "A maintenance task is registered. You can update or remove it below.";
+            }
+            else
+            {
+                CurrentSummary = "No maintenance is scheduled yet.";
+                LastRun = NextRun = LastResult = "";
+                StatusMessage = "Pick an action and time, then Save schedule to automate it.";
+            }
+            RemoveScheduleCommand.NotifyCanExecuteChanged();
+        }
+        finally { IsBusy = false; }
+    }
+
+    [RelayCommand]
+    private async Task SaveScheduleAsync()
+    {
+        var schedule = BuildSchedule();
+        if (!DialogService.Instance.Confirm(
+                $"Schedule \"{schedule.ActionLabel}\" to run automatically?\n\n{schedule.Summary}\n\n" +
+                "This creates a Windows scheduled task that launches SysManager in the background.",
+                "Schedule Maintenance — Confirm"))
+            return;
+
+        IsBusy = true;
+        try
+        {
+            bool ok = await _service.RegisterAsync(schedule);
+            if (ok)
+            {
+                ActivityLogService.Instance.Log("Scheduled Maintenance", $"{schedule.ActionLabel} — {schedule.Summary}");
+                StatusMessage = $"Scheduled: {schedule.ActionLabel.ToLowerInvariant()}, {schedule.Summary.ToLowerInvariant()}.";
+                Log.Information("Maintenance scheduled: {Action} {Summary}", schedule.ActionLabel, schedule.Summary);
+            }
+            else
+            {
+                StatusMessage = "Could not register the scheduled task. Check the log for details.";
+            }
+            await RefreshAsync();
+        }
+        finally { IsBusy = false; }
+    }
+
+    private bool CanRemove() => IsScheduled;
+
+    [RelayCommand(CanExecute = nameof(CanRemove))]
+    private async Task RemoveScheduleAsync()
+    {
+        if (!DialogService.Instance.Confirm(
+                "Remove the scheduled maintenance task?\n\nSysManager will no longer run maintenance automatically.",
+                "Remove Schedule — Confirm"))
+            return;
+
+        IsBusy = true;
+        try
+        {
+            bool removed = await _service.RemoveAsync();
+            if (removed) ActivityLogService.Instance.Log("Scheduled Maintenance", "Removed the maintenance schedule");
+            StatusMessage = removed ? "Scheduled maintenance removed." : "Could not remove the task. Check the log.";
+            await RefreshAsync();
+        }
+        finally { IsBusy = false; }
+    }
+
+    partial void OnIsScheduledChanged(bool value) => RemoveScheduleCommand.NotifyCanExecuteChanged();
+}

--- a/SysManager/SysManager/Views/ScheduledMaintenanceView.xaml
+++ b/SysManager/SysManager/Views/ScheduledMaintenanceView.xaml
@@ -1,0 +1,119 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.ScheduledMaintenanceView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:ScheduledMaintenanceViewModel}"
+             Background="{DynamicResource Surface0}">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Preview banner -->
+        <v:DevelopmentBanner Grid.Row="0" Margin="28,24,28,0"/>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="1" Margin="28,16,28,0">
+            <TextBlock Text="Scheduled Maintenance" Style="{StaticResource Display}"/>
+            <TextBlock Text="Run maintenance automatically on a schedule. SysManager creates one Windows scheduled task that launches the app in the background to clean temporary files or purge standby memory — no need to remember to do it yourself."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap" MaxWidth="820"/>
+        </StackPanel>
+
+        <!-- Current status card -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,0">
+            <StackPanel>
+                <TextBlock Text="Current schedule" Style="{StaticResource SectionTitle}"/>
+                <TextBlock Text="{Binding CurrentSummary}" Foreground="{DynamicResource TextSecondary}"
+                           FontSize="13" Margin="0,6,0,0"/>
+                <Grid Margin="0,12,0,0" Visibility="{Binding IsScheduled, Converter={StaticResource FlexVis}}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Border Grid.Column="0" Style="{StaticResource CardInner}" Margin="0,0,6,0">
+                        <StackPanel>
+                            <TextBlock Text="LAST RUN" Style="{StaticResource SectionLabel}"/>
+                            <TextBlock Text="{Binding LastRun}" FontSize="14" FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextSecondary}" Margin="0,4,0,0"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Column="1" Style="{StaticResource CardInner}" Margin="6,0,6,0">
+                        <StackPanel>
+                            <TextBlock Text="NEXT RUN" Style="{StaticResource SectionLabel}"/>
+                            <TextBlock Text="{Binding NextRun}" FontSize="14" FontWeight="SemiBold"
+                                       Foreground="{DynamicResource Info}" Margin="0,4,0,0"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Column="2" Style="{StaticResource CardInner}" Margin="6,0,0,0">
+                        <StackPanel>
+                            <TextBlock Text="LAST RESULT" Style="{StaticResource SectionLabel}"/>
+                            <TextBlock Text="{Binding LastResult}" FontSize="13" FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextSecondary}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </StackPanel>
+        </Border>
+
+        <!-- Configure card -->
+        <Border Grid.Row="3" Style="{StaticResource Card}" Margin="28,16,28,0">
+            <StackPanel>
+                <TextBlock Text="Configure" Style="{StaticResource SectionTitle}" Margin="0,0,0,12"/>
+                <WrapPanel Orientation="Horizontal">
+                    <StackPanel Margin="0,0,20,12">
+                        <TextBlock Text="ACTION" Style="{StaticResource SectionLabel}"/>
+                        <ComboBox ItemsSource="{Binding Actions}" SelectedItem="{Binding SelectedAction}"
+                                  Width="200" Margin="0,4,0,0" AutomationProperties.Name="Maintenance action"/>
+                    </StackPanel>
+                    <StackPanel Margin="0,0,20,12">
+                        <TextBlock Text="FREQUENCY" Style="{StaticResource SectionLabel}"/>
+                        <ComboBox ItemsSource="{Binding Frequencies}" SelectedItem="{Binding SelectedFrequency}"
+                                  Width="120" Margin="0,4,0,0" AutomationProperties.Name="Frequency"/>
+                    </StackPanel>
+                    <StackPanel Margin="0,0,20,12" Visibility="{Binding IsWeekly, Converter={StaticResource FlexVis}}">
+                        <TextBlock Text="DAY" Style="{StaticResource SectionLabel}"/>
+                        <ComboBox ItemsSource="{Binding Days}" SelectedItem="{Binding SelectedDay}"
+                                  Width="120" Margin="0,4,0,0" AutomationProperties.Name="Day of week"/>
+                    </StackPanel>
+                    <StackPanel Margin="0,0,8,12">
+                        <TextBlock Text="HOUR" Style="{StaticResource SectionLabel}"/>
+                        <ComboBox ItemsSource="{Binding Hours}" SelectedItem="{Binding SelectedHour}"
+                                  Width="70" Margin="0,4,0,0" AutomationProperties.Name="Hour"/>
+                    </StackPanel>
+                    <StackPanel Margin="0,0,20,12">
+                        <TextBlock Text="MINUTE" Style="{StaticResource SectionLabel}"/>
+                        <ComboBox ItemsSource="{Binding Minutes}" SelectedItem="{Binding SelectedMinute}"
+                                  Width="70" Margin="0,4,0,0" AutomationProperties.Name="Minute"/>
+                    </StackPanel>
+                </WrapPanel>
+                <WrapPanel Orientation="Horizontal" Margin="0,4,0,0">
+                    <Button Content="Save schedule" Command="{Binding SaveScheduleCommand}"
+                            Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"
+                            AutomationProperties.Name="Save maintenance schedule"/>
+                    <Button Content="Remove schedule" Command="{Binding RemoveScheduleCommand}"
+                            Style="{StaticResource DangerButton}" Margin="0,0,8,0"
+                            AutomationProperties.Name="Remove maintenance schedule"/>
+                    <Button Content="Refresh" Command="{Binding RefreshCommand}"
+                            Style="{StaticResource GhostButton}"
+                            AutomationProperties.Name="Refresh schedule status"/>
+                </WrapPanel>
+            </StackPanel>
+        </Border>
+
+        <!-- Status -->
+        <TextBlock Grid.Row="5" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+                   Margin="28,12,28,24" TextWrapping="Wrap"/>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/ScheduledMaintenanceView.xaml.cs
+++ b/SysManager/SysManager/Views/ScheduledMaintenanceView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · ScheduledMaintenanceView
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class ScheduledMaintenanceView : UserControl
+{
+    public ScheduledMaintenanceView() => InitializeComponent();
+}


### PR DESCRIPTION
## What

Implements **#10 — Scheduled Maintenance**: register one Windows scheduled task that runs SysManager headless (temp cleanup or standby trim) on a daily/weekly schedule, so maintenance happens automatically. Builds directly on the safe CLI verbs from #342.

## How

- **`MaintenanceSchedulerService`** — `RegisterAsync` / `GetStatusAsync` / `RemoveAsync` wrap `Register/Get/Unregister-ScheduledTask` through the `IPowerShellRunner` seam. The task launches the running exe (`Environment.ProcessPath`) with a **whitelisted** CLI argument string (`MaintenanceSchedule.CliArguments` → `--cleanup --silent` / `--trim-ram --silent`), registered in the **current-user context (no admin)**.
- **`MaintenanceSchedule` / `MaintenanceStatus`** models — action + frequency + time + day; `CliArguments` and `Summary` are pure.
- **`ScheduledMaintenanceViewModel` / `ScheduledMaintenanceView`** — pick action/frequency/day/time, see last/next run + last result; Save and Remove are confirmed via `DialogService.Confirm`. Strategy-2 layout, `DevelopmentBanner`.
- Graduates the `WipScheduledMaintenance` placeholder to a real **PREVIEW** tab.

## Safety

- **Only ever touches its own task** at `\SysManager\Scheduled Maintenance` — never enumerates or modifies any other scheduled task.
- The command is built from a fixed whitelist (no free-form text reaches the scheduler), pointed at the app's own executable.
- Runs as the current user (no admin); only the safe CLI verbs are automated — nothing destructive. Create/remove are confirmed first.

## Tests

- `MaintenanceScheduleTests` — `CliArguments` maps to whitelisted verbs + matches a strict `^--[a-z-]+( --silent)?$` shape (the no-free-text invariant), `Summary` daily/weekly, `DescribeResultCode` (known + hex fallback), task-identity constants.
- `MainWindowViewModelTests.NavLeaf_ScheduledMaintenance_IsImplementedAndInPreview`.

## Docs

README (sidebar table, counts 52 impl / 5 WIP, feature section), ARCHITECTURE (Cleanup row + service & VM entries), CHANGELOG (1.50.0), version bump to 1.50.0 — all in this PR.

Closes #10