### PR TITLE
feat: add Tweaks Hub for unified reversible optimizations with selective undo

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,7 +41,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Group | View Models |
 |-------|-------------|
 | Dashboard | `DashboardViewModel` |
-| System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `TaskSchedulerViewModel` · `BootAnalyzerViewModel` · `SystemFixesViewModel` |
+| System | `SystemHealthViewModel` · `WindowsUpdateViewModel` · `PerformanceViewModel` · `ServicesViewModel` · `StartupViewModel` · `WindowsFeaturesViewModel` · `RestorePointsViewModel` · `TaskSchedulerViewModel` · `BootAnalyzerViewModel` · `SystemFixesViewModel` · `TweaksHubViewModel` |
 | Gaming & Profiles | `TimerResolutionViewModel` · `DisplayProfileViewModel` · `CpuAffinityViewModel` · `StandbyMemoryViewModel` · `PlaceholderViewModel` (Gaming Profile) |
 | Monitor | `ProcessManagerViewModel` · `ResourceHistoryViewModel` · `PrivacyMonitorViewModel` · `AppAlertsViewModel` · `FileLockViewModel` · `SettingsWatchdogViewModel` · `PlaceholderViewModel` (Bandwidth Monitor) |
 | Cleanup | `CleanupViewModel` · `DeepCleanupViewModel` · `ShortcutCleanerViewModel` · `ScheduledMaintenanceViewModel` |
@@ -94,6 +94,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `RestorePointsViewModel` — list, create, and restore Windows System Restore points (admin for create/restore; restore reboots, gated by confirmation).
 - `LegacyPanelsViewModel` — one-click launcher for the fixed catalog of classic Windows applets (pure launchers, no system modification).
 - `SystemFixesViewModel` — consolidated one-click repairs (Windows Update reset, network reset, WinGet reinstall) with per-fix confirmation + live output; opens netplwiz for secure auto-logon.
+- `TweaksHubViewModel` — unified front-end over the reversible privacy/UX tweaks, grouped Essential (per-user) / Advanced (machine-wide, needs admin), with selective Apply/Undo, a pending-change count, and an auto restore-point before the first change. Delegates to `TweaksHubService` (no parallel tweak implementation).
 - `BootAnalyzerViewModel` — read-only boot-time history + slow-component breakdown from the Diagnostics-Performance log, with a trend vs recent average; needs admin to read the log.
 - `TimerResolutionViewModel` — request the finest Windows timer resolution (≈0.5 ms) for lower game input latency, or release it; shows the live effective value.
 - `FileLockViewModel` — find which processes are holding a file/folder (Restart Manager) and optionally end a selected one after confirmation; critical processes are protected.
@@ -318,6 +319,11 @@ Key services:
   touches its own task — never enumerates or modifies others. The command is built from a
   fixed argument whitelist (`MaintenanceSchedule.CliArguments`), so no free-form input reaches
   the scheduler; result-code description is a pure, unit-tested helper.
+- `TweaksHubService` — thin orchestrator behind the Tweaks Hub tab: loads `PrivacyService`
+  toggles as tier-classified `TweakItem`s, applies/reverts a selected set via the same
+  reversible `PrivacyService.ApplyToggle`, and takes one `RestorePointService` snapshot before
+  the first change of a session (best-effort). It reimplements no tweak; `PendingApplyCount` /
+  `PendingUndoCount` / `TweakItem.ClassifyTier` are pure, unit-tested helpers.
 - `SafetyDatabase` — curated safety ratings for Windows services.
 - `ThemeService` — runtime theme switching with 12 presets and persistence.
 - `ToastService` — global glass-style toast notifications.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.51.0] - 2026-06-29
+
+### Added
+- **Tweaks Hub tab (Preview).** A single place to review and apply the safe, reversible optimizations that are otherwise spread across tabs. Tweaks are grouped into **Essential** (low-risk, per-user, apply without admin) and **Advanced** (higher-impact, machine-wide, need administrator). Tick the ones you want and **Apply Selected** or **Undo Selected** in bulk — a live counter shows pending changes, an automatic System Restore point is created before the first change, and every tweak is individually reversible. Each row shows whether it's currently Applied or at the Windows Default. It's a front-end over the same reversible operations as the Privacy & Telemetry tab — no tweak is reimplemented. Closes #907.
+
 ## [1.50.0] - 2026-06-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ fully open source.
 ## Features
 
 ### Sidebar navigation
-The sidebar organises 57 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 52 tabs are fully
+The sidebar organises 58 feature tabs into 12 collapsible groups so you can
+find what you need without scrolling through a flat list. 53 tabs are fully
 implemented; 5 are work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |
 |-------|------|
 | 🏠 Dashboard | Dashboard |
-| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Task Scheduler · Boot Analyzer · System Fixes |
+| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Task Scheduler · Boot Analyzer · System Fixes · Tweaks Hub |
 | 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner · Timer Resolution · CPU Core Affinity · Display Profiles |
 | 📊 Monitor | Process Manager · Resource History · Camera/Mic/Location · App Alerts · File Lock Detector · Settings Watchdog · Bandwidth Monitor ⚙️ |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance |
@@ -220,6 +220,20 @@ a confirmation before it runs:
 - Live output, honest success/failure reporting, admin elevation banner
 - *Network-stack reset (Winsock / TCP-IP / DNS flush) lives on the Network → Network
   Repair tab, which offers those as individual one-click tools.*
+
+### Tweaks Hub
+- **One place for safe, reversible optimizations** that are otherwise spread across
+  tabs — review them all in a single list, tick the ones you want, and apply or
+  undo in bulk
+- **Essential** group — low-risk, per-user tweaks that apply without administrator
+- **Advanced** group — higher-impact, machine-wide tweaks behind a caution banner
+  (need administrator)
+- **Apply Selected / Undo Selected** with a live count of pending changes — nothing
+  is written until you click, and each tweak is individually reversible
+- An automatic **System Restore point** is created before the first change in a
+  session, so you can always roll back
+- Each row shows whether it's currently **Applied** or at the Windows **Default**;
+  it's a front-end over the same reversible operations as the Privacy & Telemetry tab
 
 ### Boot Analyzer
 - Shows how long your PC takes to boot — total, core (main path), and

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -75,16 +75,16 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
-    public void NavItems_ContainAll57()
+    public void NavItems_ContainAll58()
     {
         var vm = new MainWindowViewModel();
-        Assert.Equal(57, vm.NavItems.Count);
+        Assert.Equal(58, vm.NavItems.Count);
         var ids = vm.NavItems.Select(n => n.Id).ToList();
 
         // Dashboard
         Assert.Contains("nav-dashboard", ids);
 
-        // System (10)
+        // System (11)
         Assert.Contains("nav-system-health", ids);
         Assert.Contains("nav-windows-update", ids);
         Assert.Contains("nav-performance", ids);
@@ -95,6 +95,7 @@ public class MainWindowViewModelTests
         Assert.Contains("nav-task-scheduler", ids);
         Assert.Contains("nav-boot-analyzer", ids);
         Assert.Contains("nav-system-fixes", ids);
+        Assert.Contains("nav-tweaks-hub", ids);
 
         // Gaming & Profiles (5)
         Assert.Contains("nav-gaming-profile", ids);
@@ -240,11 +241,11 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
-    public void NavGroups_SystemGroup_Contains10Items()
+    public void NavGroups_SystemGroup_Contains11Items()
     {
         var vm = new MainWindowViewModel();
         var sys = vm.NavGroups.First(g => g.Id == "grp-system");
-        Assert.Equal(10, sys.Children.Count);
+        Assert.Equal(11, sys.Children.Count);
         var ids = sys.Children.Select(c => c.Id).ToList();
         Assert.Contains("nav-system-health", ids);
         Assert.Contains("nav-windows-update", ids);
@@ -256,6 +257,7 @@ public class MainWindowViewModelTests
         Assert.Contains("nav-task-scheduler", ids);
         Assert.Contains("nav-boot-analyzer", ids);
         Assert.Contains("nav-system-fixes", ids);
+        Assert.Contains("nav-tweaks-hub", ids);
         // Legacy Panels is a read-only applet launcher — it lives in Info, not System.
         Assert.DoesNotContain("nav-legacy-panels", ids);
     }
@@ -476,6 +478,17 @@ public class MainWindowViewModelTests
         var item = vm.NavItems.First(n => n.Id == "nav-scheduled-maintenance");
         Assert.Equal(typeof(SysManager.Views.ScheduledMaintenanceView), item.ViewType);
         Assert.IsType<ScheduledMaintenanceViewModel>(item.Content);
+        Assert.True(item.IsInDevelopment);
+    }
+
+    // Tweaks Hub (#907) — a brand-new tab (not a graduated placeholder), real view/VM, PREVIEW.
+    [Fact]
+    public void NavLeaf_TweaksHub_IsImplementedAndInPreview()
+    {
+        var vm = new MainWindowViewModel();
+        var item = vm.NavItems.First(n => n.Id == "nav-tweaks-hub");
+        Assert.Equal(typeof(SysManager.Views.TweaksHubView), item.ViewType);
+        Assert.IsType<TweaksHubViewModel>(item.Content);
         Assert.True(item.IsInDevelopment);
     }
 }

--- a/SysManager/SysManager.Tests/TweaksHubServiceTests.cs
+++ b/SysManager/SysManager.Tests/TweaksHubServiceTests.cs
@@ -1,0 +1,75 @@
+// SysManager · TweaksHubServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+public class TweaksHubServiceTests
+{
+    private static PrivacyToggle Toggle(string name, string path, bool enabled) => new()
+    {
+        Name = name, Description = "d", Category = "c",
+        RegistryPath = path, ValueName = "v", EnabledValue = 1, DisabledValue = 0, IsEnabled = enabled,
+    };
+
+    private static TweakItem Item(string path, bool selected, bool applied)
+    {
+        var t = TweakItem.From(Toggle("n", path, applied));
+        t.IsSelected = selected;
+        return t;
+    }
+
+    // ── Tier classification (the real risk/elevation boundary) ─────────────
+
+    [Theory]
+    [InlineData(@"HKLM\SOFTWARE\Policies\Microsoft\Windows\DataCollection", TweakTier.Advanced)]
+    [InlineData(@"HKEY_LOCAL_MACHINE\SOFTWARE\Foo", TweakTier.Advanced)]
+    [InlineData(@"HKCU\Software\Microsoft\Windows\CurrentVersion\AdvertisingInfo", TweakTier.Essential)]
+    [InlineData(@"HKEY_CURRENT_USER\Software\Foo", TweakTier.Essential)]
+    public void ClassifyTier_ByHive(string path, TweakTier expected)
+        => Assert.Equal(expected, TweakItem.ClassifyTier(path));
+
+    [Fact]
+    public void From_CopiesAppliedStateFromToggle()
+    {
+        Assert.True(TweakItem.From(Toggle("n", @"HKCU\x", enabled: true)).IsApplied);
+        Assert.False(TweakItem.From(Toggle("n", @"HKCU\x", enabled: false)).IsApplied);
+    }
+
+    // ── Pending counts ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void PendingApplyCount_CountsSelectedNotYetApplied()
+    {
+        var items = new[]
+        {
+            Item(@"HKCU\a", selected: true,  applied: false), // would apply
+            Item(@"HKCU\b", selected: true,  applied: true),  // already applied → not pending-apply
+            Item(@"HKCU\c", selected: false, applied: false), // not selected
+        };
+        Assert.Equal(1, TweaksHubService.PendingApplyCount(items));
+    }
+
+    [Fact]
+    public void PendingUndoCount_CountsSelectedAlreadyApplied()
+    {
+        var items = new[]
+        {
+            Item(@"HKCU\a", selected: true,  applied: true),  // would undo
+            Item(@"HKCU\b", selected: true,  applied: true),  // would undo
+            Item(@"HKCU\c", selected: true,  applied: false), // not applied → not pending-undo
+            Item(@"HKCU\d", selected: false, applied: true),  // not selected
+        };
+        Assert.Equal(2, TweaksHubService.PendingUndoCount(items));
+    }
+
+    [Fact]
+    public void PendingCounts_EmptyInput_AreZero()
+    {
+        Assert.Equal(0, TweaksHubService.PendingApplyCount([]));
+        Assert.Equal(0, TweaksHubService.PendingUndoCount([]));
+    }
+}

--- a/SysManager/SysManager/Models/TweakItem.cs
+++ b/SysManager/SysManager/Models/TweakItem.cs
@@ -1,0 +1,55 @@
+// SysManager · TweakItem — a selectable, reversible optimization in the Tweaks Hub
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SysManager.Models;
+
+/// <summary>Risk tier for a tweak in the hub.</summary>
+public enum TweakTier
+{
+    /// <summary>Low-risk, broadly recommended, per-user (HKCU) — applies without admin.</summary>
+    Essential,
+    /// <summary>Higher-impact, machine-wide (HKLM) — needs administrator.</summary>
+    Advanced,
+}
+
+/// <summary>
+/// One reversible optimization shown in the Tweaks Hub, wrapping the underlying
+/// <see cref="PrivacyToggle"/> so the hub is a unified front-end over the same
+/// already-reversible registry operations (no parallel implementation). The tier is
+/// derived from the toggle's registry hive — the real risk/elevation boundary.
+/// <see cref="IsSelected"/> is the user's tick; <see cref="IsApplied"/> reflects the
+/// current system state read from the registry.
+/// </summary>
+public sealed partial class TweakItem : ObservableObject
+{
+    [ObservableProperty] private bool _isSelected;
+    [ObservableProperty] private bool _isApplied;
+
+    public required PrivacyToggle Toggle { get; init; }
+    public required TweakTier Tier { get; init; }
+
+    public string Name => Toggle.Name;
+    public string Description => Toggle.Description;
+    public string Category => Toggle.Category;
+
+    /// <summary>Builds a hub item from a privacy toggle, classifying its tier by registry hive.</summary>
+    public static TweakItem From(PrivacyToggle toggle) => new()
+    {
+        Toggle = toggle,
+        Tier = ClassifyTier(toggle.RegistryPath),
+        IsApplied = toggle.IsEnabled,
+    };
+
+    /// <summary>
+    /// Pure tier classification: HKLM (machine-wide, needs admin) is Advanced; everything
+    /// else (HKCU, per-user) is Essential. Unit-testable without the registry.
+    /// </summary>
+    public static TweakTier ClassifyTier(string registryPath) =>
+        registryPath.StartsWith("HKLM", StringComparison.OrdinalIgnoreCase) ||
+        registryPath.StartsWith("HKEY_LOCAL_MACHINE", StringComparison.OrdinalIgnoreCase)
+            ? TweakTier.Advanced
+            : TweakTier.Essential;
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -83,6 +83,7 @@ public static class ServiceRegistration
         services.AddSingleton<ResourceHistoryService>();
         services.AddSingleton<SettingsWatchdogService>();
         services.AddSingleton<MaintenanceSchedulerService>();
+        services.AddSingleton<TweaksHubService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
         services.AddSingleton<DashboardViewModel>();
@@ -139,6 +140,7 @@ public static class ServiceRegistration
         services.AddSingleton<SettingsWatchdogViewModel>();
         services.AddSingleton<CliInterfaceViewModel>();
         services.AddSingleton<ScheduledMaintenanceViewModel>();
+        services.AddSingleton<TweaksHubViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/TweaksHubService.cs
+++ b/SysManager/SysManager/Services/TweaksHubService.cs
@@ -1,0 +1,83 @@
+// SysManager · TweaksHubService — unified front-end over the reversible privacy/UX tweaks
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Aggregates SysManager's existing reversible optimizations into one reviewable list with
+/// selective apply/undo. It does NOT reimplement any tweak — it delegates to
+/// <see cref="PrivacyService"/> (the same registry operations the Privacy &amp; Telemetry tab
+/// uses, each individually reversible) and creates an automatic System Restore point (via
+/// <see cref="RestorePointService"/>) before the first change in a session. Nothing is
+/// written to the system without an explicit Apply/Undo from the user.
+/// </summary>
+public sealed class TweaksHubService
+{
+    private readonly PrivacyService _privacy;
+    private readonly RestorePointService _restore;
+    private bool _restorePointTakenThisSession;
+
+    public TweaksHubService(PrivacyService privacy, RestorePointService restore)
+    {
+        _privacy = privacy;
+        _restore = restore;
+    }
+
+    /// <summary>Loads every tweak with its current applied state, classified into tiers.</summary>
+    public IReadOnlyList<TweakItem> LoadTweaks()
+        => _privacy.LoadToggles().Select(TweakItem.From).ToList();
+
+    /// <summary>
+    /// Applies (enable=true) or reverts (enable=false) the given tweaks. Creates a restore
+    /// point before the first change in the session (best-effort — a failure to snapshot does
+    /// not block the change, it's logged). Returns the items that failed to write.
+    /// </summary>
+    public async Task<IReadOnlyList<TweakItem>> ApplyAsync(IReadOnlyList<TweakItem> tweaks, bool enable, CancellationToken ct = default)
+    {
+        if (tweaks.Count == 0) return [];
+
+        await EnsureRestorePointAsync(ct).ConfigureAwait(false);
+
+        var failed = new List<TweakItem>();
+        foreach (var item in tweaks)
+        {
+            item.Toggle.IsEnabled = enable;
+            if (_privacy.ApplyToggle(item.Toggle))
+                item.IsApplied = enable;
+            else
+                failed.Add(item);
+        }
+        return failed;
+    }
+
+    private async Task EnsureRestorePointAsync(CancellationToken ct)
+    {
+        if (_restorePointTakenThisSession) return;
+        // Mark first so a slow/failed snapshot isn't retried before every batch — the restore
+        // point is a best-effort safety net, not a hard gate (RestorePointService itself
+        // rate-limits to one per 24h and needs admin; a miss is logged, not surfaced as failure).
+        _restorePointTakenThisSession = true;
+        try
+        {
+            await _restore.CreateAsync("SysManager Tweaks Hub", ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or UnauthorizedAccessException)
+        {
+            Log.Debug("Tweaks Hub restore point skipped: {Error}", ex.Message);
+        }
+    }
+
+    // ── Pure helpers (unit-testable) ───────────────────────────────────────
+
+    /// <summary>Count of selected tweaks not yet applied (would be turned on by Apply Selected).</summary>
+    public static int PendingApplyCount(IEnumerable<TweakItem> tweaks)
+        => tweaks.Count(t => t.IsSelected && !t.IsApplied);
+
+    /// <summary>Count of selected tweaks currently applied (would be reverted by Undo Selected).</summary>
+    public static int PendingUndoCount(IEnumerable<TweakItem> tweaks)
+        => tweaks.Count(t => t.IsSelected && t.IsApplied);
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.50.0</Version>
-    <FileVersion>1.50.0.0</FileVersion>
-    <AssemblyVersion>1.50.0.0</AssemblyVersion>
+    <Version>1.51.0</Version>
+    <FileVersion>1.51.0.0</FileVersion>
+    <AssemblyVersion>1.51.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -69,6 +69,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     public SettingsWatchdogViewModel SettingsWatchdog { get; }
     public CliInterfaceViewModel CliInterface { get; }
     public ScheduledMaintenanceViewModel ScheduledMaintenance { get; }
+    public TweaksHubViewModel TweaksHub { get; }
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
@@ -175,6 +176,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             SettingsWatchdog = sp.GetRequiredService<SettingsWatchdogViewModel>();
             CliInterface = sp.GetRequiredService<CliInterfaceViewModel>();
             ScheduledMaintenance = sp.GetRequiredService<ScheduledMaintenanceViewModel>();
+            TweaksHub = sp.GetRequiredService<TweaksHubViewModel>();
         }
         else
         {
@@ -248,6 +250,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             SettingsWatchdog = new SettingsWatchdogViewModel(new SettingsWatchdogService());
             CliInterface = new CliInterfaceViewModel();
             ScheduledMaintenance = new ScheduledMaintenanceViewModel(new MaintenanceSchedulerService(new PowerShellRunner()));
+            TweaksHub = new TweaksHubViewModel(new TweaksHubService(new PrivacyService(), restorePoints));
         }
 
         InitPlaceholders();
@@ -325,7 +328,8 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Item("nav-restore-points",   "Restore Points",   "", RestorePoints,    typeof(Views.RestorePointsView)),
             Item("nav-task-scheduler",   "Task Scheduler",   "", TaskScheduler,    typeof(Views.TaskSchedulerView)),
             Item("nav-boot-analyzer",    "Boot Analyzer",    "", BootAnalyzer,     typeof(Views.BootAnalyzerView)),
-            Item("nav-system-fixes",     "System Fixes",     "", SystemFixes,      typeof(Views.SystemFixesView))),
+            Item("nav-system-fixes",     "System Fixes",     "", SystemFixes,      typeof(Views.SystemFixesView)),
+            Item("nav-tweaks-hub",      "Tweaks Hub",       "", TweaksHub,        typeof(Views.TweaksHubView), inDevelopment: true)),
 
         Group("grp-gaming", "Gaming & Profiles", "",
             Item("nav-gaming-profile",   "Gaming Profile",       "", WipGamingProfile,      typeof(Views.PlaceholderView)),
@@ -508,6 +512,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         SettingsWatchdog?.Dispose();
         CliInterface?.Dispose();
         ScheduledMaintenance?.Dispose();
+        TweaksHub?.Dispose();
 
         // WIP placeholders
         WipFileLockDetector?.Dispose();

--- a/SysManager/SysManager/ViewModels/TweaksHubViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TweaksHubViewModel.cs
@@ -1,0 +1,137 @@
+// SysManager · TweaksHubViewModel
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the Tweaks Hub tab — a unified front-end over SysManager's existing
+/// reversible optimizations, grouped into Essential (per-user, safe) and Advanced
+/// (machine-wide, needs admin). The user ticks tweaks and applies or reverts them in bulk;
+/// a restore point is taken before the first change. Nothing is written without an explicit
+/// Apply/Undo, each confirmed first. Delegates to <see cref="TweaksHubService"/>.
+/// </summary>
+public sealed partial class TweaksHubViewModel : ViewModelBase
+{
+    private readonly TweaksHubService _service;
+
+    public BulkObservableCollection<TweakItem> Essential { get; } = new();
+    public BulkObservableCollection<TweakItem> Advanced { get; } = new();
+
+    [ObservableProperty] private bool _isElevated;
+    [ObservableProperty] private int _pendingApply;
+    [ObservableProperty] private int _pendingUndo;
+
+    public TweaksHubViewModel(TweaksHubService service)
+    {
+        _service = service;
+        IsElevated = AdminHelper.IsElevated();
+        Load();
+    }
+
+    private IEnumerable<TweakItem> AllTweaks => Essential.Concat(Advanced);
+
+    [RelayCommand]
+    private void RelaunchAsAdmin()
+    {
+        if (AdminHelper.RelaunchAsAdmin())
+            System.Windows.Application.Current?.Shutdown();
+    }
+
+    [RelayCommand]
+    private void Refresh() => Load();
+
+    private void Load()
+    {
+        // Detach old selection-change handlers before replacing the items.
+        foreach (var t in AllTweaks) t.PropertyChanged -= OnTweakChanged;
+
+        var tweaks = _service.LoadTweaks();
+        Essential.ReplaceWith(tweaks.Where(t => t.Tier == TweakTier.Essential));
+        Advanced.ReplaceWith(tweaks.Where(t => t.Tier == TweakTier.Advanced));
+
+        foreach (var t in AllTweaks) t.PropertyChanged += OnTweakChanged;
+        RecountPending();
+        StatusMessage = $"{Essential.Count} essential · {Advanced.Count} advanced tweak(s). Tick the ones you want, then Apply or Undo.";
+    }
+
+    private void OnTweakChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(TweakItem.IsSelected) or nameof(TweakItem.IsApplied))
+            RecountPending();
+    }
+
+    private void RecountPending()
+    {
+        PendingApply = TweaksHubService.PendingApplyCount(AllTweaks);
+        PendingUndo = TweaksHubService.PendingUndoCount(AllTweaks);
+        ApplySelectedCommand.NotifyCanExecuteChanged();
+        UndoSelectedCommand.NotifyCanExecuteChanged();
+    }
+
+    private bool CanApply() => PendingApply > 0;
+    private bool CanUndo() => PendingUndo > 0;
+
+    [RelayCommand(CanExecute = nameof(CanApply))]
+    private async Task ApplySelectedAsync()
+    {
+        var toApply = AllTweaks.Where(t => t.IsSelected && !t.IsApplied).ToList();
+        if (toApply.Count == 0) return;
+
+        if (!DialogService.Instance.Confirm(
+                $"Apply {toApply.Count} selected tweak(s)?\n\n" +
+                "A System Restore point is created before the first change so you can roll back. " +
+                "Each tweak is individually reversible.",
+                "Apply Tweaks — Confirm"))
+            return;
+
+        await RunBatchAsync(toApply, enable: true, "Applied");
+    }
+
+    [RelayCommand(CanExecute = nameof(CanUndo))]
+    private async Task UndoSelectedAsync()
+    {
+        var toUndo = AllTweaks.Where(t => t.IsSelected && t.IsApplied).ToList();
+        if (toUndo.Count == 0) return;
+
+        if (!DialogService.Instance.Confirm(
+                $"Undo {toUndo.Count} selected tweak(s), restoring the Windows default?",
+                "Undo Tweaks — Confirm"))
+            return;
+
+        await RunBatchAsync(toUndo, enable: false, "Reverted");
+    }
+
+    private async Task RunBatchAsync(IReadOnlyList<TweakItem> items, bool enable, string verb)
+    {
+        IsBusy = true;
+        try
+        {
+            var failed = await _service.ApplyAsync(items, enable);
+            int ok = items.Count - failed.Count;
+            if (ok > 0) ActivityLogService.Instance.Log("Tweaks Hub", $"{verb} {ok} tweak(s)");
+            Log.Information("Tweaks Hub {Verb}: {Ok} ok, {Failed} failed", verb, ok, failed.Count);
+
+            StatusMessage = failed.Count == 0
+                ? $"{verb} {ok} tweak(s)."
+                : $"{verb} {ok} tweak(s) · {failed.Count} need administrator (run as admin and retry).";
+            RecountPending();
+        }
+        finally { IsBusy = false; }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+            foreach (var t in AllTweaks) t.PropertyChanged -= OnTweakChanged;
+        base.Dispose(disposing);
+    }
+}

--- a/SysManager/SysManager/Views/TweaksHubView.xaml
+++ b/SysManager/SysManager/Views/TweaksHubView.xaml
@@ -1,0 +1,137 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.TweaksHubView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:TweaksHubViewModel}"
+             Background="{DynamicResource Surface0}">
+
+    <UserControl.Resources>
+        <!-- One reviewable tweak row: select checkbox + name/description + applied-state pill. -->
+        <DataTemplate x:Key="TweakRow">
+            <Border Margin="0,2" Padding="12,10" CornerRadius="6" BorderThickness="1"
+                    Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <CheckBox Grid.Column="0" IsChecked="{Binding IsSelected}" VerticalAlignment="Center" Margin="0,0,12,0"
+                              AutomationProperties.Name="{Binding Name, StringFormat='Select tweak: {0}'}"/>
+                    <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13"/>
+                        <TextBlock Text="{Binding Description}" FontSize="11" Foreground="{DynamicResource TextMuted}"
+                                   TextWrapping="Wrap" Margin="0,2,16,0"/>
+                    </StackPanel>
+                    <Border Grid.Column="2" CornerRadius="4" Padding="8,2" VerticalAlignment="Center"
+                            Background="{DynamicResource Surface3}">
+                        <TextBlock FontSize="10" FontWeight="Bold">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Text" Value="DEFAULT"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextMuted}"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsApplied}" Value="True">
+                                            <Setter Property="Text" Value="APPLIED"/>
+                                            <Setter Property="Foreground" Value="{DynamicResource Success}"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </Border>
+                </Grid>
+            </Border>
+        </DataTemplate>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Preview banner -->
+        <v:DevelopmentBanner Grid.Row="0" Margin="28,24,28,0"/>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="1" Margin="28,16,28,0">
+            <TextBlock Text="Tweaks Hub" Style="{StaticResource Display}"/>
+            <TextBlock Text="One place to review and apply safe, reversible optimizations that are otherwise spread across tabs. Tick the ones you want, then Apply or Undo — a System Restore point is created before the first change, and every tweak is individually reversible."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap" MaxWidth="820"/>
+        </StackPanel>
+
+        <!-- Admin banner (only Advanced tweaks need it) -->
+        <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
+                        AutomationProperties.Name="Run as administrator"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
+                    <TextBlock Text="Essential tweaks apply as-is. Advanced (machine-wide) tweaks need administrator."
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- Tweaks: Essential + Advanced -->
+        <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto" Margin="28,16,28,0">
+            <StackPanel>
+                <!-- Essential -->
+                <Border Style="{StaticResource Card}" Margin="0,0,0,12">
+                    <StackPanel>
+                        <TextBlock Text="ESSENTIAL" Style="{StaticResource SectionLabel}" Margin="0,0,0,4"/>
+                        <TextBlock Text="Low-risk, broadly recommended, per-user — safe for most people."
+                                   Style="{StaticResource Subtle}" Margin="0,0,0,10"/>
+                        <ItemsControl ItemsSource="{Binding Essential}" ItemTemplate="{StaticResource TweakRow}"
+                                      AutomationProperties.Name="Essential tweaks"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Advanced -->
+                <Border Style="{StaticResource Card}">
+                    <StackPanel>
+                        <TextBlock Text="ADVANCED" Style="{StaticResource SectionLabel}" Margin="0,0,0,4"/>
+                        <Border Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
+                                BorderThickness="1" CornerRadius="8" Padding="10,8" Margin="0,0,0,10">
+                            <TextBlock Text="Higher-impact, machine-wide changes — review each one. Still fully reversible."
+                                       Foreground="{DynamicResource WarningText}" FontSize="12" TextWrapping="Wrap"/>
+                        </Border>
+                        <ItemsControl ItemsSource="{Binding Advanced}" ItemTemplate="{StaticResource TweakRow}"
+                                      AutomationProperties.Name="Advanced tweaks"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </ScrollViewer>
+
+        <!-- Action bar -->
+        <Border Grid.Row="4" Style="{StaticResource Card}" Margin="28,12,28,24" Padding="12">
+            <DockPanel>
+                <TextBlock DockPanel.Dock="Left" VerticalAlignment="Center"
+                           Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                    <Button Command="{Binding ApplySelectedCommand}" Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"
+                            Content="{Binding PendingApply, StringFormat='Apply Selected ({0})'}"
+                            AutomationProperties.Name="Apply selected tweaks"/>
+                    <Button Command="{Binding UndoSelectedCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"
+                            Content="{Binding PendingUndo, StringFormat='Undo Selected ({0})'}"
+                            AutomationProperties.Name="Undo selected tweaks"/>
+                    <Button Content="Refresh" Command="{Binding RefreshCommand}" Style="{StaticResource GhostButton}"
+                            AutomationProperties.Name="Refresh tweak states"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/TweaksHubView.xaml.cs
+++ b/SysManager/SysManager/Views/TweaksHubView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · TweaksHubView
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class TweaksHubView : UserControl
+{
+    public TweaksHubView() => InitializeComponent();
+}


### PR DESCRIPTION
## What

Implements **#907 — Tweaks Hub**: a single System tab that aggregates SysManager's existing reversible optimizations into one reviewable list, so a user who just wants to "optimize this PC" doesn't have to visit several tabs. Grouped into **Essential** (low-risk, per-user) and **Advanced** (machine-wide, needs admin), with bulk Apply / Undo and a review-before-write flow.

## How

- **`TweaksHubService`** — a thin orchestrator: `LoadTweaks` reads `PrivacyService` toggles as tier-classified `TweakItem`s; `ApplyAsync` enables/reverts a selected set via the **same reversible** `PrivacyService.ApplyToggle`, taking one `RestorePointService` snapshot before the first change of the session. **No tweak is reimplemented** — it's a front-end over the same operations as the Privacy & Telemetry tab.
- **`TweakItem`** — wraps a `PrivacyToggle`; tier is classified by registry hive (HKLM = Advanced/admin, HKCU = Essential) — the real risk/elevation boundary.
- **`TweaksHubViewModel` / `TweaksHubView`** — Essential/Advanced grouped lists, select checkboxes, an Applied/Default pill per row, **Apply Selected (n) / Undo Selected (n)** with live counts, both confirmed via `DialogService.Confirm`. Strategy-2 layout, `DevelopmentBanner`, admin banner.

## Safety

- **Automatic restore point** before the first change (best-effort); **every tweak individually reversible**.
- Nothing is written without an explicit Apply/Undo; each is confirmed first.
- Advanced (HKLM) tweaks that need admin fail cleanly and are reported ("n need administrator"), never crash.

## Tests

- `TweaksHubServiceTests` — `ClassifyTier` by hive (HKLM/HKEY_LOCAL_MACHINE → Advanced, HKCU → Essential), `From` copies applied state, `PendingApplyCount`/`PendingUndoCount` logic + empty input.
- `MainWindowViewModelTests` — count bumped to **58** + System group to **11**, new `NavLeaf_TweaksHub_IsImplementedAndInPreview`.

## Docs

README (sidebar table, total 58 / 53 impl, System group, feature section), ARCHITECTURE (System row + service & VM entries), CHANGELOG (1.51.0), version bump to 1.51.0 — all in this PR.

Closes #907