### PR TITLE
fix: harden Settings Watchdog against malformed baseline + surface admin requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.51.1] - 2026-06-29
+
+### Fixed
+- **Settings Watchdog no longer crashes on a malformed baseline file.** A `settings-baseline.json` that was valid JSON but missing its data could throw when checking for changes; it's now treated as "no baseline saved" so the tab stays usable.
+- **Settings Watchdog now shows a "Run as administrator" banner** when not elevated, since restoring machine-wide settings needs admin — previously you only found out after a restore silently failed.
+
 ## [1.51.0] - 2026-06-29
 
 ### Added

--- a/SysManager/SysManager.Tests/SettingsWatchdogServiceTests.cs
+++ b/SysManager/SysManager.Tests/SettingsWatchdogServiceTests.cs
@@ -23,6 +23,17 @@ public class SettingsWatchdogServiceTests
     // ── DetectChanges ─────────────────────────────────────────────────────
 
     [Fact]
+    public void DetectChanges_NullBaseline_ReturnsEmpty_DoesNotThrow()
+    {
+        // Regression: a baseline JSON file that parses but omits "Values" deserializes to a
+        // BaselineSnapshot with Values == null. DetectChanges must treat that as "nothing
+        // captured" rather than NRE-ing (which previously crashed the Refresh command).
+        var ex = Record.Exception(() =>
+            Assert.Empty(SettingsWatchdogService.DetectChanges(Catalog, null!, new Dictionary<string, int?>())));
+        Assert.Null(ex);
+    }
+
+    [Fact]
     public void DetectChanges_NoDifference_ReturnsEmpty()
     {
         var baseline = new Dictionary<string, int?> { ["a"] = 0, ["b"] = 0, ["c"] = 1 };

--- a/SysManager/SysManager.Tests/SettingsWatchdogViewModelTests.cs
+++ b/SysManager/SysManager.Tests/SettingsWatchdogViewModelTests.cs
@@ -1,0 +1,155 @@
+// SysManager · SettingsWatchdogViewModelTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using NSubstitute;
+using SysManager.Models;
+using SysManager.Services;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+// Serialized: the confirm-gate tests swap the static DialogService.Instance.
+[Collection("DialogService")]
+public class SettingsWatchdogViewModelTests
+{
+    private static WatchedSetting Setting(string key) => new(
+        key, $"Name {key}", "desc", "Privacy", $@"HKLM\SOFTWARE\Test\{key}", "Val",
+        new Dictionary<int, string> { [0] = "Off", [1] = "On" });
+
+    private static SettingDrift Drift(string key, bool canRestore = true) =>
+        new(Setting(key), BaselineValue: 0, CurrentValue: 1, CanRestore: canRestore);
+
+    private static ISettingsWatchdogService NewService(params SettingDrift[] drifts)
+    {
+        var svc = Substitute.For<ISettingsWatchdogService>();
+        svc.Catalog.Returns([]);
+        svc.LoadBaseline().Returns(new BaselineSnapshot(new DateTime(2026, 1, 1), []));
+        svc.HasBaseline.Returns(true);
+        svc.DetectDrift().Returns(drifts);
+        return svc;
+    }
+
+    // ── SaveBaseline confirm gate ──────────────────────────────────────────
+
+    [Fact]
+    public void SaveBaseline_WhenBaselineExists_AndUserDeclines_DoesNotSave()
+    {
+        var svc = NewService();
+        var vm = new SettingsWatchdogViewModel(svc);
+
+        var prev = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false); // user clicks No
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.SaveBaselineCommand.Execute(null);
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            svc.DidNotReceive().SaveBaseline(Arg.Any<DateTime>());
+        }
+        finally { DialogService.Instance = prev; }
+    }
+
+    [Fact]
+    public void SaveBaseline_WhenConfirmed_Saves()
+    {
+        var svc = NewService();
+        var vm = new SettingsWatchdogViewModel(svc);
+
+        var prev = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.SaveBaselineCommand.Execute(null);
+            svc.Received(1).SaveBaseline(Arg.Any<DateTime>());
+        }
+        finally { DialogService.Instance = prev; }
+    }
+
+    [Fact]
+    public void SaveBaseline_WhenNoBaseline_SkipsConfirm_AndSaves()
+    {
+        var svc = Substitute.For<ISettingsWatchdogService>();
+        svc.Catalog.Returns([]);
+        svc.LoadBaseline().Returns((BaselineSnapshot?)null);
+        svc.HasBaseline.Returns(false);
+        svc.DetectDrift().Returns([]);
+        var vm = new SettingsWatchdogViewModel(svc);
+
+        var prev = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.SaveBaselineCommand.Execute(null);
+            // First-time save shouldn't prompt to overwrite.
+            dialog.DidNotReceive().Confirm(Arg.Any<string>(), Arg.Any<string>());
+            svc.Received(1).SaveBaseline(Arg.Any<DateTime>());
+        }
+        finally { DialogService.Instance = prev; }
+    }
+
+    // ── RestoreSelected confirm gate ───────────────────────────────────────
+
+    [Fact]
+    public void RestoreSelected_WhenUserDeclines_DoesNotRestore()
+    {
+        var svc = NewService(Drift("a"));
+        var vm = new SettingsWatchdogViewModel(svc);
+
+        var prev = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.RestoreSelectedCommand.Execute(null);
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            svc.DidNotReceive().Restore(Arg.Any<SettingDrift>());
+        }
+        finally { DialogService.Instance = prev; }
+    }
+
+    [Fact]
+    public void RestoreSelected_WhenConfirmed_RestoresEachRestorableDrift()
+    {
+        var svc = NewService(Drift("a"), Drift("b"));
+        svc.Restore(Arg.Any<SettingDrift>()).Returns(true);
+        var vm = new SettingsWatchdogViewModel(svc);
+
+        var prev = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.RestoreSelectedCommand.Execute(null);
+            svc.Received(2).Restore(Arg.Any<SettingDrift>());
+        }
+        finally { DialogService.Instance = prev; }
+    }
+
+    [Fact]
+    public void RestoreSelected_CanExecute_FalseWhenNoRestorableDrift()
+    {
+        // A drift that can't be restored must not enable the command.
+        var svc = NewService(Drift("a", canRestore: false));
+        var vm = new SettingsWatchdogViewModel(svc);
+        Assert.False(vm.RestoreSelectedCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void Refresh_NoBaseline_SetsHasBaselineFalse()
+    {
+        var svc = Substitute.For<ISettingsWatchdogService>();
+        svc.Catalog.Returns([]);
+        svc.LoadBaseline().Returns((BaselineSnapshot?)null);
+        svc.DetectDrift().Returns([]);
+        var vm = new SettingsWatchdogViewModel(svc);
+        Assert.False(vm.HasBaseline);
+        Assert.False(vm.HasDrift);
+    }
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -81,7 +81,7 @@ public static class ServiceRegistration
         services.AddSingleton<IWindowsThemeService, WindowsThemeService>();
         services.AddSingleton<StandbyMemoryService>();
         services.AddSingleton<ResourceHistoryService>();
-        services.AddSingleton<SettingsWatchdogService>();
+        services.AddSingleton<ISettingsWatchdogService, SettingsWatchdogService>();
         services.AddSingleton<MaintenanceSchedulerService>();
         services.AddSingleton<TweaksHubService>();
 

--- a/SysManager/SysManager/Services/ISettingsWatchdogService.cs
+++ b/SysManager/SysManager/Services/ISettingsWatchdogService.cs
@@ -1,0 +1,23 @@
+// SysManager · ISettingsWatchdogService — testable seam for the Settings Watchdog
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Seam over <see cref="SettingsWatchdogService"/> so the ViewModel can be unit-tested with a
+/// substituted implementation (no real registry / baseline file). Mirrors the established
+/// interface-seam pattern (<see cref="IAppBlockerService"/>, <see cref="IPowerShellRunner"/>).
+/// </summary>
+public interface ISettingsWatchdogService
+{
+    IReadOnlyList<WatchedSetting> Catalog { get; }
+    bool HasBaseline { get; }
+    IReadOnlyDictionary<string, int?> ReadCurrent();
+    IReadOnlyDictionary<string, int?> SaveBaseline(DateTime takenAt);
+    BaselineSnapshot? LoadBaseline();
+    IReadOnlyList<SettingDrift> DetectDrift();
+    bool Restore(SettingDrift drift);
+}

--- a/SysManager/SysManager/Services/SettingsWatchdogService.cs
+++ b/SysManager/SysManager/Services/SettingsWatchdogService.cs
@@ -19,7 +19,7 @@ namespace SysManager.Services;
 /// settings. Strictly local — reads/writes only well-known registry values, nothing leaves
 /// the machine. Registry access mirrors <see cref="PrivacyService"/>'s validated helper.
 /// </summary>
-public sealed class SettingsWatchdogService
+public sealed class SettingsWatchdogService : ISettingsWatchdogService
 {
     private static readonly string BaselinePath = Path.Join(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
@@ -51,7 +51,12 @@ public sealed class SettingsWatchdogService
         try
         {
             if (!File.Exists(BaselinePath)) return null;
-            return JsonSerializer.Deserialize<BaselineSnapshot>(File.ReadAllText(BaselinePath));
+            var snapshot = JsonSerializer.Deserialize<BaselineSnapshot>(File.ReadAllText(BaselinePath));
+            // A baseline file that parses as JSON but omits the "Values" property deserializes
+            // with Values == null (System.Text.Json does not enforce non-null on positional
+            // record params). Normalize it to an empty map so downstream diffing never NREs on
+            // a malformed-but-parseable file.
+            return snapshot is { Values: null } ? snapshot with { Values = [] } : snapshot;
         }
         catch (Exception ex) when (ex is JsonException or IOException)
         {
@@ -109,6 +114,9 @@ public sealed class SettingsWatchdogService
         IReadOnlyDictionary<string, int?> baseline,
         IReadOnlyDictionary<string, int?> current)
     {
+        // Defensive: a malformed/legacy baseline can yield a null map. Treat it as "nothing
+        // captured" rather than throwing — this is the trust boundary for persisted state.
+        if (baseline is null) return [];
         var drifts = new List<SettingDrift>();
         foreach (var setting in catalog)
         {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.51.0</Version>
-    <FileVersion>1.51.0.0</FileVersion>
-    <AssemblyVersion>1.51.0.0</AssemblyVersion>
+    <Version>1.51.1</Version>
+    <FileVersion>1.51.1.0</FileVersion>
+    <AssemblyVersion>1.51.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/SettingsWatchdogViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SettingsWatchdogViewModel.cs
@@ -19,7 +19,7 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class SettingsWatchdogViewModel : ViewModelBase
 {
-    private readonly SettingsWatchdogService _service;
+    private readonly ISettingsWatchdogService _service;
 
     public BulkObservableCollection<DriftRow> Drifts { get; } = new();
     public BulkObservableCollection<WatchedSetting> Watched { get; } = new();
@@ -29,7 +29,7 @@ public sealed partial class SettingsWatchdogViewModel : ViewModelBase
     [ObservableProperty] private bool _hasDrift;
     [ObservableProperty] private bool _isElevated;
 
-    public SettingsWatchdogViewModel(SettingsWatchdogService service)
+    public SettingsWatchdogViewModel(ISettingsWatchdogService service)
     {
         _service = service;
         IsElevated = AdminHelper.IsElevated();

--- a/SysManager/SysManager/Views/SettingsWatchdogView.xaml
+++ b/SysManager/SysManager/Views/SettingsWatchdogView.xaml
@@ -16,6 +16,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -44,8 +45,25 @@
             </StackPanel>
         </DockPanel>
 
+        <!-- Elevation banner: not elevated (restoring HKLM-backed settings needs admin) -->
+        <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
+                        AutomationProperties.Name="Run as administrator"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
+                    <TextBlock Text="Some watched settings are machine-wide and need administrator to restore."
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
         <!-- Baseline status banner -->
-        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,12,28,0" Padding="14,10"
+        <Border Grid.Row="3" Style="{StaticResource Card}" Margin="28,12,28,0" Padding="14,10"
                 Visibility="{Binding HasBaseline, Converter={StaticResource FlexVis}}">
             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                 <TextBlock Text="&#xE73E;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
@@ -56,7 +74,7 @@
         </Border>
 
         <!-- Drift summary banner (warning) -->
-        <Border Grid.Row="3" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
+        <Border Grid.Row="4" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
                 BorderThickness="1" CornerRadius="10" Padding="12,10" Margin="28,12,28,0"
                 Visibility="{Binding HasDrift, Converter={StaticResource FlexVis}}">
             <StackPanel Orientation="Horizontal">
@@ -69,7 +87,7 @@
         </Border>
 
         <!-- Drift list -->
-        <Border Grid.Row="4" Style="{StaticResource Card}" Margin="28,16,28,0">
+        <Border Grid.Row="5" Style="{StaticResource Card}" Margin="28,16,28,0">
             <Grid>
                 <DataGrid ItemsSource="{Binding Drifts}" AutoGenerateColumns="False" IsReadOnly="True"
                           HeadersVisibility="Column" GridLinesVisibility="None" Background="Transparent"
@@ -92,7 +110,7 @@
         </Border>
 
         <!-- Status -->
-        <TextBlock Grid.Row="5" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+        <TextBlock Grid.Row="6" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
                    Margin="28,12,28,24" TextWrapping="Wrap"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## What

Three robustness fixes for the Settings Watchdog tab (#335), all surfaced by an exhaustive review of the recently-shipped features.

## Fixes

1. **Crash on malformed baseline (the only user-visible defect found).** A `settings-baseline.json` that's valid JSON but omits the `Values` property deserialized to a `BaselineSnapshot` with `Values == null`; `DetectChanges` then NRE'd, and the catch in `LoadBaseline` only covers `JsonException`/`IOException`, so it escaped and crashed the Check-now/Refresh command. **Fix:** `LoadBaseline` normalizes a null `Values` to an empty map, and `DetectChanges` null-guards its baseline argument (defense in depth at the pure trust boundary).
2. **No admin affordance (HIGH UX).** The view never bound `IsElevated`, although the VM already computed it and exposed `RelaunchAsAdminCommand`. Restoring a machine-wide (HKLM) setting needs admin, so a non-elevated user only learned it failed *after* the restore. **Fix:** added the standard not-elevated admin banner (matching CleanupView/TweaksHubView) with a Run-as-administrator button.
3. **Testability seam.** Extracted `ISettingsWatchdogService` so the VM's confirm-gate logic is unit-testable with a substituted service (no real registry/baseline file) — the established `IAppBlockerService`/`IPowerShellRunner` pattern.

## Tests

- `DetectChanges_NullBaseline_ReturnsEmpty_DoesNotThrow` — the crash regression.
- VM confirm-gate (new `SettingsWatchdogViewModelTests`): SaveBaseline declined → no write; first-time save skips overwrite-confirm; RestoreSelected declined → no write; RestoreSelected restores each restorable drift; CanExecute false with no restorable drift.

## Docs

CHANGELOG 1.51.1, version bump to 1.51.1. README/ARCHITECTURE unchanged (feature behavior is the same; this is internal robustness + an admin affordance).

Part of the post-feature audit remediation (Batch 1 of 6).