### PR TITLE
fix: keep Tweaks Hub apply on the UI thread and report the restore point honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.51.2] - 2026-06-29
+
+### Fixed
+- **Tweaks Hub now reports the restore point honestly.** It previously stated a System Restore point "is created before the first change" as a fact; creating one needs administrator and Windows only allows one per 24h, so it often silently didn't happen. The wording now says it's attempted (when running as administrator) and the status line confirms only when one was actually created — every tweak remains individually reversible regardless.
+- **Fixed a threading issue when applying tweaks.** The first apply of a session updated the on-screen state from a background thread; it now stays on the UI thread, avoiding a potential intermittent error.
+
 ## [1.51.1] - 2026-06-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -230,8 +230,10 @@ a confirmation before it runs:
   (need administrator)
 - **Apply Selected / Undo Selected** with a live count of pending changes — nothing
   is written until you click, and each tweak is individually reversible
-- An automatic **System Restore point** is created before the first change in a
-  session, so you can always roll back
+- SysManager **tries to create a System Restore point** before the first change in a
+  session (best-effort — needs administrator and Windows' once-per-24h limit); the
+  status line tells you when one was actually created. Every tweak is also
+  individually reversible regardless
 - Each row shows whether it's currently **Applied** or at the Windows **Default**;
   it's a front-end over the same reversible operations as the Privacy & Telemetry tab
 

--- a/SysManager/SysManager.Tests/TweaksHubViewModelTests.cs
+++ b/SysManager/SysManager.Tests/TweaksHubViewModelTests.cs
@@ -1,0 +1,139 @@
+// SysManager · TweaksHubViewModelTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using NSubstitute;
+using SysManager.Models;
+using SysManager.Services;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+// Serialized: the confirm-gate tests swap the static DialogService.Instance.
+[Collection("DialogService")]
+public class TweaksHubViewModelTests
+{
+    private static TweakItem Tweak(string name, string hive, bool applied)
+    {
+        var toggle = new PrivacyToggle
+        {
+            Name = name, Description = "d", Category = "c",
+            RegistryPath = $@"{hive}\Software\Test\{name}", ValueName = "v",
+            EnabledValue = 1, DisabledValue = 0, IsEnabled = applied,
+        };
+        return TweakItem.From(toggle);
+    }
+
+    private static ITweaksHubService NewService(params TweakItem[] tweaks)
+    {
+        var svc = Substitute.For<ITweaksHubService>();
+        svc.LoadTweaks().Returns(tweaks);
+        svc.ApplyAsync(Arg.Any<IReadOnlyList<TweakItem>>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(new TweakApplyResult([], false)));
+        return svc;
+    }
+
+    // ── Apply confirm gate ─────────────────────────────────────────────────
+
+    [Fact]
+    public void ApplySelected_WhenUserDeclines_DoesNotApply()
+    {
+        var item = Tweak("a", "HKCU", applied: false);
+        item.IsSelected = true;
+        var svc = NewService(item);
+        var vm = new TweaksHubViewModel(svc);
+
+        var prev = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.ApplySelectedCommand.Execute(null);
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            svc.DidNotReceive().ApplyAsync(Arg.Any<IReadOnlyList<TweakItem>>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        }
+        finally { DialogService.Instance = prev; }
+    }
+
+    [Fact]
+    public void ApplySelected_WhenConfirmed_AppliesOnlySelectedNotYetApplied()
+    {
+        var sel = Tweak("a", "HKCU", applied: false); sel.IsSelected = true;
+        var already = Tweak("b", "HKCU", applied: true); already.IsSelected = true; // applied → not pending-apply
+        var unsel = Tweak("c", "HKCU", applied: false); // not selected
+        var svc = NewService(sel, already, unsel);
+        var vm = new TweaksHubViewModel(svc);
+
+        var prev = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.ApplySelectedCommand.Execute(null);
+            // Only the selected, not-yet-applied item is sent to enable=true.
+            svc.Received(1).ApplyAsync(
+                Arg.Is<IReadOnlyList<TweakItem>>(l => l.Count == 1 && l[0] == sel),
+                true, Arg.Any<CancellationToken>());
+        }
+        finally { DialogService.Instance = prev; }
+    }
+
+    // ── Undo confirm gate ──────────────────────────────────────────────────
+
+    [Fact]
+    public void UndoSelected_WhenUserDeclines_DoesNotUndo()
+    {
+        var item = Tweak("a", "HKCU", applied: true); item.IsSelected = true;
+        var svc = NewService(item);
+        var vm = new TweaksHubViewModel(svc);
+
+        var prev = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.UndoSelectedCommand.Execute(null);
+            svc.DidNotReceive().ApplyAsync(Arg.Any<IReadOnlyList<TweakItem>>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        }
+        finally { DialogService.Instance = prev; }
+    }
+
+    // ── CanExecute tracks pending counts ───────────────────────────────────
+
+    [Fact]
+    public void ApplyCommand_CanExecute_FalseWhenNothingPending()
+    {
+        // An applied + selected item is pending-UNDO, not pending-APPLY.
+        var item = Tweak("a", "HKCU", applied: true); item.IsSelected = true;
+        var vm = new TweaksHubViewModel(NewService(item));
+        Assert.False(vm.ApplySelectedCommand.CanExecute(null));
+        Assert.True(vm.UndoSelectedCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void SelectingItem_UpdatesPendingApply_AndEnablesCommand()
+    {
+        var item = Tweak("a", "HKCU", applied: false);
+        var vm = new TweaksHubViewModel(NewService(item));
+        Assert.Equal(0, vm.PendingApply);
+        Assert.False(vm.ApplySelectedCommand.CanExecute(null));
+
+        item.IsSelected = true; // fires PropertyChanged → RecountPending
+
+        Assert.Equal(1, vm.PendingApply);
+        Assert.True(vm.ApplySelectedCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void Load_ClassifiesIntoEssentialAndAdvancedByHive()
+    {
+        var hkcu = Tweak("a", "HKCU", applied: false);
+        var hklm = Tweak("b", "HKLM", applied: false);
+        var vm = new TweaksHubViewModel(NewService(hkcu, hklm));
+        Assert.Single(vm.Essential);
+        Assert.Single(vm.Advanced);
+    }
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -83,7 +83,7 @@ public static class ServiceRegistration
         services.AddSingleton<ResourceHistoryService>();
         services.AddSingleton<ISettingsWatchdogService, SettingsWatchdogService>();
         services.AddSingleton<MaintenanceSchedulerService>();
-        services.AddSingleton<TweaksHubService>();
+        services.AddSingleton<ITweaksHubService, TweaksHubService>();
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────
         services.AddSingleton<DashboardViewModel>();

--- a/SysManager/SysManager/Services/ITweaksHubService.cs
+++ b/SysManager/SysManager/Services/ITweaksHubService.cs
@@ -1,0 +1,27 @@
+// SysManager · ITweaksHubService — testable seam for the Tweaks Hub
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Seam over <see cref="TweaksHubService"/> so the ViewModel can be unit-tested with a
+/// substituted implementation (no real registry writes / restore point). Mirrors the
+/// established interface-seam pattern (<see cref="IAppBlockerService"/>, <see cref="IPowerShellRunner"/>).
+/// </summary>
+public interface ITweaksHubService
+{
+    IReadOnlyList<TweakItem> LoadTweaks();
+
+    /// <summary>
+    /// Applies (enable=true) or reverts (enable=false) the given tweaks. Returns the result:
+    /// the items that failed to write, and whether a System Restore point was actually created
+    /// before the first change (so the UI can report honestly rather than over-promise).
+    /// </summary>
+    Task<TweakApplyResult> ApplyAsync(IReadOnlyList<TweakItem> tweaks, bool enable, CancellationToken ct = default);
+}
+
+/// <summary>Outcome of a Tweaks Hub apply/undo batch.</summary>
+public sealed record TweakApplyResult(IReadOnlyList<TweakItem> Failed, bool RestorePointCreated);

--- a/SysManager/SysManager/Services/TweaksHubService.cs
+++ b/SysManager/SysManager/Services/TweaksHubService.cs
@@ -15,11 +15,11 @@ namespace SysManager.Services;
 /// <see cref="RestorePointService"/>) before the first change in a session. Nothing is
 /// written to the system without an explicit Apply/Undo from the user.
 /// </summary>
-public sealed class TweaksHubService
+public sealed class TweaksHubService : ITweaksHubService
 {
     private readonly PrivacyService _privacy;
     private readonly RestorePointService _restore;
-    private bool _restorePointTakenThisSession;
+    private bool _restorePointAttemptedThisSession;
 
     public TweaksHubService(PrivacyService privacy, RestorePointService restore)
     {
@@ -32,15 +32,21 @@ public sealed class TweaksHubService
         => _privacy.LoadToggles().Select(TweakItem.From).ToList();
 
     /// <summary>
-    /// Applies (enable=true) or reverts (enable=false) the given tweaks. Creates a restore
+    /// Applies (enable=true) or reverts (enable=false) the given tweaks. Attempts a restore
     /// point before the first change in the session (best-effort — a failure to snapshot does
-    /// not block the change, it's logged). Returns the items that failed to write.
+    /// not block the change). Returns the items that failed to write AND whether a restore
+    /// point was actually created, so the caller can report honestly instead of over-promising.
     /// </summary>
-    public async Task<IReadOnlyList<TweakItem>> ApplyAsync(IReadOnlyList<TweakItem> tweaks, bool enable, CancellationToken ct = default)
+    public async Task<TweakApplyResult> ApplyAsync(IReadOnlyList<TweakItem> tweaks, bool enable, CancellationToken ct = default)
     {
-        if (tweaks.Count == 0) return [];
+        if (tweaks.Count == 0) return new TweakApplyResult([], false);
 
-        await EnsureRestorePointAsync(ct).ConfigureAwait(false);
+        // ConfigureAwait(true): this is invoked from a UI-thread command and the post-await
+        // loop mutates bound TweakItem.IsApplied (and the VM's pending counts + command
+        // CanExecute). Resuming on the captured UI context keeps those mutations on the UI
+        // thread — RestorePointService.CreateAsync hops to the thread pool internally, so
+        // without this the continuation would run off-thread (a real cross-thread defect).
+        bool restorePointCreated = await EnsureRestorePointAsync(ct).ConfigureAwait(true);
 
         var failed = new List<TweakItem>();
         foreach (var item in tweaks)
@@ -51,23 +57,27 @@ public sealed class TweaksHubService
             else
                 failed.Add(item);
         }
-        return failed;
+        return new TweakApplyResult(failed, restorePointCreated);
     }
 
-    private async Task EnsureRestorePointAsync(CancellationToken ct)
+    /// <summary>
+    /// Attempts a restore point once per session. Returns true only if one was actually
+    /// created. Best-effort: System Restore needs admin and is rate-limited by Windows to one
+    /// per 24h, so a "no" is normal and must not be presented as a guaranteed safety net.
+    /// </summary>
+    private async Task<bool> EnsureRestorePointAsync(CancellationToken ct)
     {
-        if (_restorePointTakenThisSession) return;
-        // Mark first so a slow/failed snapshot isn't retried before every batch — the restore
-        // point is a best-effort safety net, not a hard gate (RestorePointService itself
-        // rate-limits to one per 24h and needs admin; a miss is logged, not surfaced as failure).
-        _restorePointTakenThisSession = true;
+        if (_restorePointAttemptedThisSession) return false;
+        // Mark attempted first so a slow/failed snapshot isn't retried before every batch.
+        _restorePointAttemptedThisSession = true;
         try
         {
-            await _restore.CreateAsync("SysManager Tweaks Hub", ct).ConfigureAwait(false);
+            return await _restore.CreateAsync("SysManager Tweaks Hub", ct).ConfigureAwait(true);
         }
         catch (Exception ex) when (ex is InvalidOperationException or UnauthorizedAccessException)
         {
             Log.Debug("Tweaks Hub restore point skipped: {Error}", ex.Message);
+            return false;
         }
     }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.51.1</Version>
-    <FileVersion>1.51.1.0</FileVersion>
-    <AssemblyVersion>1.51.1.0</AssemblyVersion>
+    <Version>1.51.2</Version>
+    <FileVersion>1.51.2.0</FileVersion>
+    <AssemblyVersion>1.51.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/TweaksHubViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TweaksHubViewModel.cs
@@ -21,7 +21,7 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class TweaksHubViewModel : ViewModelBase
 {
-    private readonly TweaksHubService _service;
+    private readonly ITweaksHubService _service;
 
     public BulkObservableCollection<TweakItem> Essential { get; } = new();
     public BulkObservableCollection<TweakItem> Advanced { get; } = new();
@@ -30,7 +30,7 @@ public sealed partial class TweaksHubViewModel : ViewModelBase
     [ObservableProperty] private int _pendingApply;
     [ObservableProperty] private int _pendingUndo;
 
-    public TweaksHubViewModel(TweaksHubService service)
+    public TweaksHubViewModel(ITweaksHubService service)
     {
         _service = service;
         IsElevated = AdminHelper.IsElevated();
@@ -88,8 +88,8 @@ public sealed partial class TweaksHubViewModel : ViewModelBase
 
         if (!DialogService.Instance.Confirm(
                 $"Apply {toApply.Count} selected tweak(s)?\n\n" +
-                "A System Restore point is created before the first change so you can roll back. " +
-                "Each tweak is individually reversible.",
+                "SysManager will try to create a System Restore point first (when running as " +
+                "administrator), and each tweak is individually reversible from here.",
                 "Apply Tweaks — Confirm"))
             return;
 
@@ -115,14 +115,19 @@ public sealed partial class TweaksHubViewModel : ViewModelBase
         IsBusy = true;
         try
         {
-            var failed = await _service.ApplyAsync(items, enable);
-            int ok = items.Count - failed.Count;
+            var result = await _service.ApplyAsync(items, enable);
+            int failedCount = result.Failed.Count;
+            int ok = items.Count - failedCount;
             if (ok > 0) ActivityLogService.Instance.Log("Tweaks Hub", $"{verb} {ok} tweak(s)");
-            Log.Information("Tweaks Hub {Verb}: {Ok} ok, {Failed} failed", verb, ok, failed.Count);
+            Log.Information("Tweaks Hub {Verb}: {Ok} ok, {Failed} failed, restorePoint={Rp}",
+                verb, ok, failedCount, result.RestorePointCreated);
 
-            StatusMessage = failed.Count == 0
-                ? $"{verb} {ok} tweak(s)."
-                : $"{verb} {ok} tweak(s) · {failed.Count} need administrator (run as admin and retry).";
+            // Mention the restore point only when one was actually created — never claim a
+            // safety net that silently didn't materialize (non-admin / rate-limited / SR off).
+            var rp = enable && result.RestorePointCreated ? " Restore point created." : "";
+            StatusMessage = failedCount == 0
+                ? $"{verb} {ok} tweak(s).{rp}"
+                : $"{verb} {ok} tweak(s) · {failedCount} need administrator (run as admin and retry).{rp}";
             RecountPending();
         }
         finally { IsBusy = false; }

--- a/SysManager/SysManager/Views/TweaksHubView.xaml
+++ b/SysManager/SysManager/Views/TweaksHubView.xaml
@@ -65,7 +65,7 @@
         <!-- Header -->
         <StackPanel Grid.Row="1" Margin="28,16,28,0">
             <TextBlock Text="Tweaks Hub" Style="{StaticResource Display}"/>
-            <TextBlock Text="One place to review and apply safe, reversible optimizations that are otherwise spread across tabs. Tick the ones you want, then Apply or Undo — a System Restore point is created before the first change, and every tweak is individually reversible."
+            <TextBlock Text="One place to review and apply safe, reversible optimizations that are otherwise spread across tabs. Tick the ones you want, then Apply or Undo — SysManager tries to create a System Restore point before the first change (when running as administrator), and every tweak is individually reversible."
                        Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap" MaxWidth="820"/>
         </StackPanel>
 


### PR DESCRIPTION
## What

Two real defects in the Tweaks Hub (#907), from the post-feature audit (Batch 2 of 6).

## Fixes

1. **Cross-thread mutation on first Apply (threading).** `ApplyAsync` awaited the restore-point creation with `ConfigureAwait(false)`. `RestorePointService.CreateAsync` hops to the thread pool internally, so the continuation — the loop that mutates bound `TweakItem.IsApplied` and raises the Apply/Undo commands' `CanExecuteChanged` — ran **off the UI thread** on the first apply of a session (intermittent; subsequent applies resume inline). That's a real cross-thread access on WPF command infrastructure. **Fix:** `ConfigureAwait(true)` so the mutation loop resumes on the captured UI context (the registry writes are fast HKCU/HKLM `SetValue`s).
2. **Over-promised restore point (honesty/trust).** The confirm dialog, the view header, and the README all stated a System Restore point **is created** before the first change — but it needs admin and Windows rate-limits it to one per 24h, so on most runs it silently didn't happen. **Fix:** `ApplyAsync` now returns a `TweakApplyResult` carrying whether a restore point was *actually* created; the dialog/header say it's *attempted* (when elevated) and the status line confirms only a real one. Tweaks remain individually reversible regardless.
3. **Testability seam.** Extracted `ITweaksHubService` so the VM's apply/undo confirm-gate logic is unit-testable with a substituted service.

## Tests

New `TweaksHubViewModelTests`: ApplySelected/UndoSelected declined-confirm → no apply; applies only selected-and-not-yet-applied; CanExecute tracks pending counts; selecting an item enables Apply; Essential/Advanced tier split.

## Docs

CHANGELOG 1.51.2, version bump to 1.51.2, README restore-point claim corrected to best-effort.

Part of the post-feature audit remediation (Batch 2 of 6).