### PR TITLE
fix: lighten Resource History sampler, speed up loads, tidy shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.51.3] - 2026-06-29
+
+### Changed
+- **Resource History is lighter on the system.** The background sampler no longer runs a disk health/SMART query every 10 seconds just to label storage sensors it doesn't record — it now reads only the CPU/GPU temperatures it actually stores, cutting continuous background WMI work over a long session.
+- **Faster history loading.** Opening the tab or changing the range now reads only the samples in the selected window (reading the file from the newest end and stopping at the cutoff) instead of parsing the entire history file every time, which matters once weeks of history have accrued.
+
+### Fixed
+- **Cleaner shutdown for Resource History.** The sampler now stops fully before its file lock is released on exit, avoiding a harmless-but-noisy background error during shutdown.
+- **Temperature chart now shows a clear "no data" message** on machines without supported temperature sensors, instead of a blank chart.
+
 ## [1.51.2] - 2026-06-29
 
 ### Fixed

--- a/SysManager/SysManager.Tests/ResourceHistoryServiceTests.cs
+++ b/SysManager/SysManager.Tests/ResourceHistoryServiceTests.cs
@@ -94,6 +94,53 @@ public class ResourceHistoryServiceTests
     }
 
     [Fact]
+    public void Downsample_MaxPointsZero_ClampsToOne()
+    {
+        var now = new DateTime(2026, 6, 29);
+        var input = Enumerable.Range(0, 50).Select(i => Sample(now.AddSeconds(i), cpu: 10)).ToList();
+        var result = ResourceHistoryService.Downsample(input, 0);
+        Assert.Single(result); // clamped to 1 bucket, no divide-by-zero
+    }
+
+    [Fact]
+    public void Downsample_MaxPointsOne_AveragesEntireSeriesIntoOneBucket()
+    {
+        var now = new DateTime(2026, 6, 29);
+        var input = new[]
+        {
+            Sample(now, cpu: 20), Sample(now.AddSeconds(10), cpu: 40),
+            Sample(now.AddSeconds(20), cpu: 60), Sample(now.AddSeconds(30), cpu: 80),
+        };
+        var result = ResourceHistoryService.Downsample(input, 1);
+        Assert.Single(result);
+        Assert.Equal(50, result[0].CpuPercent); // (20+40+60+80)/4
+    }
+
+    [Fact]
+    public void Downsample_ExactlyMaxPoints_ReturnsUnchanged()
+    {
+        var now = new DateTime(2026, 6, 29);
+        var input = new[] { Sample(now), Sample(now.AddSeconds(10)), Sample(now.AddSeconds(20)) };
+        var result = ResourceHistoryService.Downsample(input, 3); // count == maxPoints
+        Assert.Same(input, result);
+    }
+
+    [Fact]
+    public void Downsample_PartialGpuNullsInBucket_AveragesOnlyPresentValues()
+    {
+        var now = new DateTime(2026, 6, 29);
+        // One bucket: two GPU=100, two GPU=null → expect avg 100 (over present only), not 50.
+        var input = new[]
+        {
+            Sample(now.AddSeconds(0), gpu: 100), Sample(now.AddSeconds(10), gpu: null),
+            Sample(now.AddSeconds(20), gpu: 100), Sample(now.AddSeconds(30), gpu: null),
+        };
+        var result = ResourceHistoryService.Downsample(input, 1);
+        Assert.Single(result);
+        Assert.Equal(100, result[0].GpuPercent);
+    }
+
+    [Fact]
     public void Downsample_AboveCap_ReducesToAtMostMaxPoints()
     {
         var now = new DateTime(2026, 6, 29);

--- a/SysManager/SysManager/Services/ResourceHistoryService.cs
+++ b/SysManager/SysManager/Services/ResourceHistoryService.cs
@@ -43,6 +43,7 @@ public sealed class ResourceHistoryService : IDisposable
     private readonly SemaphoreSlim _fileLock = new(1, 1);
 
     private CancellationTokenSource? _cts;
+    private Task? _loopTask;
     private bool _disposed;
     private int _samplesSincePrune;
 
@@ -70,7 +71,7 @@ public sealed class ResourceHistoryService : IDisposable
             if (clamped == _retentionDays) return;
             _retentionDays = clamped;
             SaveRetention(clamped);
-            _ = PruneAsync();
+            _ = PruneAsync(_cts?.Token ?? CancellationToken.None);
         }
     }
 
@@ -88,9 +89,9 @@ public sealed class ResourceHistoryService : IDisposable
         var ct = _cts.Token;
 
         // Prune stale/malformed lines from a previous session before accruing new ones.
-        _ = PruneAsync();
+        _ = PruneAsync(ct);
 
-        _ = Task.Run(async () =>
+        _loopTask = Task.Run(async () =>
         {
             while (!ct.IsCancellationRequested)
             {
@@ -103,7 +104,7 @@ public sealed class ResourceHistoryService : IDisposable
                     if (++_samplesSincePrune >= PruneEverySamples)
                     {
                         _samplesSincePrune = 0;
-                        await PruneAsync().ConfigureAwait(false);
+                        await PruneAsync(ct).ConfigureAwait(false);
                     }
 
                     await Task.Delay(TimeSpan.FromSeconds(SampleIntervalSeconds), ct).ConfigureAwait(false);
@@ -127,7 +128,9 @@ public sealed class ResourceHistoryService : IDisposable
         double? cpuTemp = null, gpuTemp = null;
         try
         {
-            var readings = await _temps.ReadAllAsync().ConfigureAwait(false);
+            // includeStorage:false — the sampler only needs CPU/GPU temps, so skip the
+            // heavy per-poll disk WMI + SMART enumeration that storage naming would trigger.
+            var readings = await _temps.ReadAllAsync(includeStorage: false).ConfigureAwait(false);
             cpuTemp = readings
                 .Where(r => r.Component == "CPU" && r.TemperatureC.HasValue)
                 .Select(r => r.TemperatureC).Max();
@@ -185,7 +188,7 @@ public sealed class ResourceHistoryService : IDisposable
             await File.AppendAllTextAsync(DataPath, Serialize(sample) + "\n", ct).ConfigureAwait(false);
         }
         catch (IOException ex) { Log.Debug("Resource history append failed: {Error}", ex.Message); }
-        finally { _fileLock.Release(); }
+        finally { if (!_disposed) _fileLock.Release(); }
     }
 
     /// <summary>
@@ -200,34 +203,41 @@ public sealed class ResourceHistoryService : IDisposable
             if (!File.Exists(DataPath)) return [];
             var lines = await File.ReadAllLinesAsync(DataPath, ct).ConfigureAwait(false);
             var cutoff = DateTime.Now - range;
-            var samples = new List<ResourceSample>(lines.Length);
-            foreach (var line in lines)
+            // The file is append-only and time-ordered, so the requested range is a suffix:
+            // walk from the END and stop at the first line older than the cutoff. This bounds
+            // work to the window (e.g. ~360 lines for "last hour") instead of parsing the whole
+            // file — which for a 30-day file is ~260k lines / ~260k allocations on every load.
+            var samples = new List<ResourceSample>();
+            for (int i = lines.Length - 1; i >= 0; i--)
             {
-                if (TryParse(line, out var s) && s!.Timestamp >= cutoff)
-                    samples.Add(s);
+                if (!TryParse(lines[i], out var s)) continue;   // skip blanks/malformed
+                if (s!.Timestamp < cutoff) break;                // older than the window — done
+                samples.Add(s);
             }
-            samples.Sort((a, b) => a.Timestamp.CompareTo(b.Timestamp));
+            samples.Reverse(); // collected newest-first; callers expect oldest-first
             return samples;
         }
         catch (IOException ex) { Log.Debug("Resource history load failed: {Error}", ex.Message); return []; }
-        finally { _fileLock.Release(); }
+        finally { if (!_disposed) _fileLock.Release(); }
     }
 
     /// <summary>Rewrites the file dropping samples older than the retention window and any malformed lines.</summary>
-    public async Task PruneAsync()
+    public async Task PruneAsync(CancellationToken ct = default)
     {
-        await _fileLock.WaitAsync().ConfigureAwait(false);
+        try { await _fileLock.WaitAsync(ct).ConfigureAwait(false); }
+        catch (OperationCanceledException) { return; }
         try
         {
             if (!File.Exists(DataPath)) return;
-            var lines = await File.ReadAllLinesAsync(DataPath).ConfigureAwait(false);
+            var lines = await File.ReadAllLinesAsync(DataPath, ct).ConfigureAwait(false);
             var kept = Prune(lines, DateTime.Now, TimeSpan.FromDays(_retentionDays));
             // Only rewrite when something actually changed, to avoid needless disk churn.
             if (kept.Count == lines.Length) return;
-            await File.WriteAllLinesAsync(DataPath, kept).ConfigureAwait(false);
+            await File.WriteAllLinesAsync(DataPath, kept, ct).ConfigureAwait(false);
         }
+        catch (OperationCanceledException) { /* shutdown */ }
         catch (IOException ex) { Log.Debug("Resource history prune failed: {Error}", ex.Message); }
-        finally { _fileLock.Release(); }
+        finally { if (!_disposed) _fileLock.Release(); }
     }
 
     // ── Pure helpers (unit-testable, no WPF / WMI / file IO) ───────────────
@@ -352,8 +362,13 @@ public sealed class ResourceHistoryService : IDisposable
     public void Dispose()
     {
         if (_disposed) return;
-        _disposed = true;
         _cts?.Cancel();
+        // Wait briefly for the sampler loop to observe cancellation and exit before we dispose
+        // the semaphore it may still hold/await — otherwise its finally-block Release() would
+        // hit a disposed SemaphoreSlim. Bounded so shutdown can't hang on a stuck IO call.
+        try { _loopTask?.Wait(TimeSpan.FromSeconds(2)); }
+        catch (AggregateException) { /* loop faulted/cancelled — fine, we're tearing down */ }
+        _disposed = true;
         _cts?.Dispose();
         _cts = null;
         _fileLock.Dispose();

--- a/SysManager/SysManager/Services/TemperatureService.cs
+++ b/SysManager/SysManager/Services/TemperatureService.cs
@@ -35,7 +35,14 @@ public sealed class TemperatureService : IDisposable
         _skipHardwareInit = skipHardwareInit;
     }
 
-    public async Task<List<TemperatureReading>> ReadAllAsync()
+    /// <summary>
+    /// Reads all available temperature sensors. When <paramref name="includeStorage"/> is
+    /// false, the disk-temperature paths are skipped — the storage-name WMI lookup and the
+    /// per-disk SMART enumeration (<see cref="DiskHealthService.CollectAsync"/>) are by far
+    /// the heaviest part of a read, so a fast caller that only needs CPU/GPU (e.g. the
+    /// always-on resource sampler polling every 10s) passes false to avoid that cost.
+    /// </summary>
+    public async Task<List<TemperatureReading>> ReadAllAsync(bool includeStorage = true)
     {
         if (_skipHardwareInit) return [];
 
@@ -44,15 +51,17 @@ public sealed class TemperatureService : IDisposable
 
         if (isAdmin)
         {
-            await Task.Run(() => ReadViaLibreHardwareMonitor(readings)).ConfigureAwait(false);
+            await Task.Run(() => ReadViaLibreHardwareMonitor(readings, includeStorage)).ConfigureAwait(false);
 
-            // LHM storage often has bad names — enrich from DiskHealthService
-            await EnrichStorageNamesAsync(readings).ConfigureAwait(false);
+            // LHM storage often has bad names — enrich from DiskHealthService (skipped on the fast path).
+            if (includeStorage)
+                await EnrichStorageNamesAsync(readings).ConfigureAwait(false);
         }
         else
         {
             await Task.Run(() => ReadNvidiaGpuTemperatures(readings)).ConfigureAwait(false);
-            await ReadDiskTemperaturesAsync(readings).ConfigureAwait(false);
+            if (includeStorage)
+                await ReadDiskTemperaturesAsync(readings).ConfigureAwait(false);
 
             readings.Add(new TemperatureReading("CPU", "CPU Package", null, RequiresAdmin: true));
         }
@@ -60,7 +69,7 @@ public sealed class TemperatureService : IDisposable
         return readings;
     }
 
-    private void ReadViaLibreHardwareMonitor(List<TemperatureReading> readings)
+    private void ReadViaLibreHardwareMonitor(List<TemperatureReading> readings, bool includeStorage = true)
     {
         lock (_lhmLock)
         {
@@ -71,8 +80,9 @@ public sealed class TemperatureService : IDisposable
                 // only Update() the already-enumerated hardware.
                 _computer ??= OpenComputer();
 
-                // Pre-fetch disk names from WMI for cross-reference
-                var diskNames = GetDiskNamesFromWmi();
+                // Pre-fetch disk names from WMI for cross-reference (skipped on the fast path —
+                // this WMI query runs every poll otherwise and the sampler doesn't need names).
+                var diskNames = includeStorage ? GetDiskNamesFromWmi() : [];
 
                 foreach (var hardware in _computer.Hardware)
                 {
@@ -152,6 +162,7 @@ public sealed class TemperatureService : IDisposable
                     }
                     else if (component == "Storage")
                     {
+                        if (!includeStorage) continue;
                         var diskTemp = tempSensors.FirstOrDefault();
                         if (diskTemp is not null)
                         {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.51.2</Version>
-    <FileVersion>1.51.2.0</FileVersion>
-    <AssemblyVersion>1.51.2.0</AssemblyVersion>
+    <Version>1.51.3</Version>
+    <FileVersion>1.51.3.0</FileVersion>
+    <AssemblyVersion>1.51.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
@@ -52,6 +52,7 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
     [ObservableProperty] private int _retentionDays;
     [ObservableProperty] private int _sampleCount;
     [ObservableProperty] private bool _hasData;
+    [ObservableProperty] private bool _hasTemperatureData;
     [ObservableProperty] private string _summary = "";
 
     // ── Charts (built once, buffers replaced on reload) ───────────────────
@@ -119,6 +120,9 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
 
             SampleCount = _loaded.Count;
             HasData = _loaded.Count > 0;
+            // The temperature chart is meaningful only if at least one sample carries a temp
+            // reading (sensors/admin dependent); otherwise show its empty state, not a blank.
+            HasTemperatureData = _loaded.Any(s => s.CpuTempC.HasValue || s.GpuTempC.HasValue);
             Summary = BuildSummary(_loaded);
             StatusMessage = HasData
                 ? $"Showing {_loaded.Count} sample(s) over {SelectedRange.Label.ToLowerInvariant()}."

--- a/SysManager/SysManager/Views/ResourceHistoryView.xaml
+++ b/SysManager/SysManager/Views/ResourceHistoryView.xaml
@@ -101,6 +101,9 @@
                                         LegendBackgroundPaint="{Binding LegendBackgroundPaint}"
                                         TooltipTextPaint="{Binding TooltipTextPaint}"
                                         TooltipBackgroundPaint="{Binding TooltipBackgroundPaint}"/>
+                    <v:EmptyState Grid.Row="1" Glyph="&#xE9CA;" Title="No temperature data"
+                                  Message="CPU/GPU temperatures need supported sensors (and admin for CPU). The chart fills in once readings are available."
+                                  Visibility="{Binding HasTemperatureData, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                 </Grid>
             </Border>
         </Grid>


### PR DESCRIPTION
## What

Performance + robustness fixes for Resource History (#13), from the post-feature audit (Batch 3 of 6).

## Fixes

1. **Always-on sampler no longer does per-poll disk WMI + SMART (perf, HIGH).** The 10s sampler called `TemperatureService.ReadAllAsync()`, which on an elevated machine runs a `Win32_DiskDrive` WMI query plus a full `DiskHealthService` SMART enumeration just to *name* storage sensors — data the sampler discards (it stores only CPU/GPU temps). Added `ReadAllAsync(includeStorage: false)` that skips that; the sampler uses it. ~8,640 needless WMI/SMART enumerations/day eliminated on a tray-minimized session. The Dashboard keeps the full read (default `true`) — no behavior change there.
2. **`LoadAsync` parsed the whole file every time (perf, HIGH).** Up to ~260k lines at 30-day retention, allocating a sample per line then discarding 99% for a "last hour" view. It now reads from the newest end and stops at the cutoff, bounding work to the requested window.
3. **Dispose race (robustness).** `Dispose` disposed `_fileLock` without awaiting the sampler loop, so an in-flight `Release()` could hit a disposed semaphore at shutdown (caught+logged, but a real race). `Dispose` now waits (bounded 2s) for the loop to cancel first, guards `Release` with `_disposed`, and `PruneAsync` takes a cancellation token.
4. **Temperature EmptyState (UX).** The temperature chart now shows a "no temperature data" message on sensorless machines instead of a blank chart.

## Tests

`Downsample` boundary tests: maxPoints 0 (clamp), 1 (averages whole series), exactly-N (unchanged), partial-GPU-nulls (averages over present values only).

## Docs

CHANGELOG 1.51.3, version bump to 1.51.3.

Part of the post-feature audit remediation (Batch 3 of 6).
