### PR TITLE
fix: derive CLI version from the build instead of a stale constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.51.4] - 2026-06-29
+
+### Fixed
+- **`SysManager.exe --version` now reports the real version.** The command-line interface printed a hardcoded version that had fallen behind the actual build; it now reads the version from the running app, so `--version` and `--help` always match the installed release.
+
 ## [1.51.3] - 2026-06-29
 
 ### Changed

--- a/SysManager/SysManager.Tests/CliRunnerTests.cs
+++ b/SysManager/SysManager.Tests/CliRunnerTests.cs
@@ -96,6 +96,15 @@ public class CliRunnerTests
     }
 
     [Fact]
+    public void CurrentVersion_MatchesBuildVersion_NeverDrifts()
+    {
+        // Regression: the CLI version was a hardcoded const that drifted two minor
+        // releases behind the build. It must now equal the running assembly version
+        // (the csproj single source of truth), so --version can never report stale data.
+        Assert.Equal(UpdateService.CurrentVersion.ToString(3), CliRunner.CurrentVersion);
+    }
+
+    [Fact]
     public async Task Execute_VersionJson_IsJson()
     {
         var r = await new CliRunner().ExecuteAsync(new CliRequest(CliCommand.Version, Json: true));

--- a/SysManager/SysManager/Services/CliRunner.cs
+++ b/SysManager/SysManager/Services/CliRunner.cs
@@ -22,7 +22,10 @@ namespace SysManager.Services;
 /// </summary>
 public sealed class CliRunner
 {
-    private const string Version = "1.49.0";
+    // Derived from the running assembly's version (the single source of truth set in the
+    // csproj), so the CLI's reported version can never drift from the build — a hardcoded
+    // const here had already gone stale by two minor releases.
+    private static readonly string Version = UpdateService.CurrentVersion.ToString(3);
 
     // CLI verbs that put startup into headless mode. The elevation sentinel
     // (--relaunched-elevated) and the update-applier arg are deliberately absent, so they

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.51.3</Version>
-    <FileVersion>1.51.3.0</FileVersion>
-    <AssemblyVersion>1.51.3.0</AssemblyVersion>
+    <Version>1.51.4</Version>
+    <FileVersion>1.51.4.0</FileVersion>
+    <AssemblyVersion>1.51.4.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## What

The CLI reported a stale version (Batch 4 of 6, post-feature audit).

## Fix

`CliRunner.Version` was a hardcoded `const = "1.49.0"` while the build had moved to 1.51.x — so `SysManager.exe --version`, `--version --json`, and the `--help` banner all printed the wrong version to any script parsing them. It now derives from `UpdateService.CurrentVersion` (the assembly version, set from the csproj single source of truth), formatted to 3 parts. The value can never drift from the build again.

## Test

`CurrentVersion_MatchesBuildVersion_NeverDrifts` asserts the CLI version equals the assembly version, so any future drift fails CI.

## Docs

CHANGELOG 1.51.4, version bump to 1.51.4.

Part of the post-feature audit remediation (Batch 4 of 6).
