### PR TITLE
fix: gate Scheduled Maintenance commands on busy + pin explicit task principal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.51.5] - 2026-06-29
+
+### Fixed
+- **Scheduled Maintenance buttons no longer double-fire.** Save / Remove / Refresh are now disabled while one of them is running, so a fast double-click can't start overlapping operations.
+
+### Changed
+- **Scheduled Maintenance task now pins an explicit user principal.** The recurring task is registered to run as the current interactive user at the standard (non-elevated) level via an explicit principal, rather than relying on the scheduler's default — making its "current user, no admin, only when logged on" behavior deliberate.
+
 ## [1.51.4] - 2026-06-29
 
 ### Fixed

--- a/SysManager/SysManager.Tests/MaintenanceSchedulerServiceTests.cs
+++ b/SysManager/SysManager.Tests/MaintenanceSchedulerServiceTests.cs
@@ -1,0 +1,137 @@
+// SysManager · MaintenanceSchedulerServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+using NSubstitute;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+public class MaintenanceSchedulerServiceTests
+{
+    private static PSObject StateRow(string state)
+    {
+        var o = new PSObject();
+        o.Properties.Add(new PSNoteProperty("State", state));
+        return o;
+    }
+
+    private static PSObject StatusRow(string state, object? lastResult)
+    {
+        var o = new PSObject();
+        o.Properties.Add(new PSNoteProperty("State", state));
+        o.Properties.Add(new PSNoteProperty("LastRunTime", new DateTime(2026, 6, 29, 3, 0, 0)));
+        o.Properties.Add(new PSNoteProperty("NextRunTime", new DateTime(2026, 6, 30, 3, 0, 0)));
+        o.Properties.Add(new PSNoteProperty("LastTaskResult", lastResult));
+        return o;
+    }
+
+    private static (MaintenanceSchedulerService svc, IPowerShellRunner ps) NewService(params PSObject[] rows)
+    {
+        var ps = Substitute.For<IPowerShellRunner>();
+        ps.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+          .Returns(new Collection<PSObject>(rows.ToList()));
+        return (new MaintenanceSchedulerService(ps), ps);
+    }
+
+    // ── RegisterAsync: only whitelisted args reach PowerShell (security invariant) ──
+
+    [Fact]
+    public async Task RegisterAsync_PassesWhitelistedArgs_NeverFreeText()
+    {
+        var (svc, ps) = NewService(StateRow("Ready"));
+        var schedule = new MaintenanceSchedule(MaintenanceAction.Cleanup, MaintenanceFrequency.Weekly, 3, 30, DayOfWeek.Sunday);
+
+        var ok = await svc.RegisterAsync(schedule, exePath: @"C:\Apps\SysManager.exe");
+
+        Assert.True(ok);
+        await ps.Received(1).RunAsync(
+            Arg.Any<string>(),
+            Arg.Is<IDictionary<string, object?>?>(p =>
+                p != null &&
+                (string)p["Exe"]! == @"C:\Apps\SysManager.exe" &&
+                (string)p["Args"]! == "--cleanup --silent" &&     // whitelisted, never arbitrary
+                (string)p["Folder"]! == MaintenanceSchedulerService.TaskFolder &&
+                (string)p["Name"]! == MaintenanceSchedulerService.TaskName &&
+                (bool)p["Daily"]! == false &&
+                (string)p["At"]! == "03:30" &&
+                (string)p["DayOfWeek"]! == "Sunday"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RegisterAsync_DailySchedule_SetsDailyTrue()
+    {
+        var (svc, ps) = NewService(StateRow("Ready"));
+        var schedule = new MaintenanceSchedule(MaintenanceAction.TrimRam, MaintenanceFrequency.Daily, 9, 0);
+        await svc.RegisterAsync(schedule, exePath: @"C:\x.exe");
+        await ps.Received(1).RunAsync(Arg.Any<string>(),
+            Arg.Is<IDictionary<string, object?>?>(p => (bool)p!["Daily"]! && (string)p["Args"]! == "--trim-ram --silent"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RegisterAsync_NullExePath_ReturnsFalse_AndDoesNotRun()
+    {
+        var (svc, ps) = NewService(StateRow("Ready"));
+        var schedule = new MaintenanceSchedule(MaintenanceAction.Cleanup, MaintenanceFrequency.Daily, 1, 0);
+        var ok = await svc.RegisterAsync(schedule, exePath: "");
+        Assert.False(ok);
+        await ps.DidNotReceive().RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RegisterAsync_EmptyResults_ReturnsFalse()
+    {
+        var (svc, _) = NewService(); // no rows back
+        var schedule = new MaintenanceSchedule(MaintenanceAction.Cleanup, MaintenanceFrequency.Daily, 1, 0);
+        Assert.False(await svc.RegisterAsync(schedule, exePath: @"C:\x.exe"));
+    }
+
+    [Fact]
+    public async Task RegisterAsync_PowerShellThrows_ReturnsFalse()
+    {
+        var ps = Substitute.For<IPowerShellRunner>();
+        ps.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+          .Returns<Collection<PSObject>>(_ => throw new RuntimeException("denied"));
+        var svc = new MaintenanceSchedulerService(ps);
+        var schedule = new MaintenanceSchedule(MaintenanceAction.Cleanup, MaintenanceFrequency.Daily, 1, 0);
+        Assert.False(await svc.RegisterAsync(schedule, exePath: @"C:\x.exe"));
+    }
+
+    // ── GetStatusAsync ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetStatusAsync_NoRows_ReturnsExistsFalse()
+    {
+        var (svc, _) = NewService();
+        var status = await svc.GetStatusAsync();
+        Assert.False(status.Exists);
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_MapsStateRunsAndResult()
+    {
+        var (svc, _) = NewService(StatusRow("Ready", 0));
+        var status = await svc.GetStatusAsync();
+        Assert.True(status.Exists);
+        Assert.Equal("Ready", status.State);
+        Assert.Equal(new DateTime(2026, 6, 29, 3, 0, 0), status.LastRun);
+        Assert.Equal(new DateTime(2026, 6, 30, 3, 0, 0), status.NextRun);
+        Assert.Equal("Last run succeeded", status.LastResultDescription);
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_PowerShellThrows_ReturnsExistsFalse()
+    {
+        var ps = Substitute.For<IPowerShellRunner>();
+        ps.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+          .Returns<Collection<PSObject>>(_ => throw new RuntimeException("boom"));
+        var svc = new MaintenanceSchedulerService(ps);
+        Assert.False((await svc.GetStatusAsync()).Exists);
+    }
+}

--- a/SysManager/SysManager/Services/MaintenanceSchedulerService.cs
+++ b/SysManager/SysManager/Services/MaintenanceSchedulerService.cs
@@ -109,8 +109,11 @@ public sealed class MaintenanceSchedulerService
 
     // Register-ScheduledTask with -Force replaces any existing task of the same name, so
     // re-registering just updates the schedule. The action runs the app's own exe with the
-    // whitelisted CLI args; the trigger is daily or weekly at the chosen time. Registered
-    // for the current user (-User $env:USERNAME), runs only when logged on — no admin needed.
+    // whitelisted CLI args; the trigger is daily or weekly at the chosen time. The task is
+    // pinned to the current interactive user at the LIMITED run level via an explicit
+    // principal — so it needs no admin to register and runs only when that user is logged on,
+    // never with elevation. (Previously this relied on the cmdlet's default principal; the
+    // explicit principal makes the security posture deliberate rather than implicit.)
     private const string RegisterScript = """
         param([string]$Exe, [string]$Args, [string]$Folder, [string]$Name,
               [bool]$Daily, [string]$At, [string]$DayOfWeek)
@@ -121,8 +124,10 @@ public sealed class MaintenanceSchedulerService
             $trigger = New-ScheduledTaskTrigger -Weekly -DaysOfWeek $DayOfWeek -At $At
         }
         $settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -DontStopOnIdleEnd
+        $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
         Register-ScheduledTask -TaskName $Name -TaskPath $Folder -Action $action -Trigger $trigger `
-            -Settings $settings -Description "SysManager automated maintenance." -Force -ErrorAction Stop |
+            -Settings $settings -Principal $principal -Description "SysManager automated maintenance." `
+            -Force -ErrorAction Stop |
             Select-Object @{ n='State'; e={ [string]$_.State } } | Out-Null
         Get-ScheduledTask -TaskName $Name -TaskPath $Folder -ErrorAction Stop |
             Select-Object @{ n='State'; e={ [string]$_.State } }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.51.4</Version>
-    <FileVersion>1.51.4.0</FileVersion>
-    <AssemblyVersion>1.51.4.0</AssemblyVersion>
+    <Version>1.51.5</Version>
+    <FileVersion>1.51.5.0</FileVersion>
+    <AssemblyVersion>1.51.5.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ScheduledMaintenanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ScheduledMaintenanceViewModel.cs
@@ -43,43 +43,65 @@ public sealed partial class ScheduledMaintenanceViewModel : ViewModelBase
     public ScheduledMaintenanceViewModel(MaintenanceSchedulerService service)
     {
         _service = service;
+        PropertyChanged += OnVmPropertyChanged;
         InitializeAsync(RefreshAsync);
     }
 
     partial void OnSelectedFrequencyChanged(MaintenanceFrequency value)
         => IsWeekly = value == MaintenanceFrequency.Weekly;
 
+    /// <summary>Gate for the async commands so a second click can't start an overlapping
+    /// Save/Remove/Refresh while one is in flight (which would race IsBusy + the read-back).</summary>
+    private bool NotBusy => !IsBusy;
+
+    // IsBusy lives in ViewModelBase, so the [ObservableProperty] partial hook isn't generated
+    // here — observe it via PropertyChanged to re-evaluate the gated commands' CanExecute.
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(IsBusy)) return;
+        RefreshCommand.NotifyCanExecuteChanged();
+        SaveScheduleCommand.NotifyCanExecuteChanged();
+        RemoveScheduleCommand.NotifyCanExecuteChanged();
+    }
+
     private MaintenanceSchedule BuildSchedule() =>
         new(SelectedAction, SelectedFrequency, SelectedHour, SelectedMinute, SelectedDay);
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task RefreshAsync()
     {
         IsBusy = true;
-        try
-        {
-            var status = await _service.GetStatusAsync();
-            IsScheduled = status.Exists;
-            if (status.Exists)
-            {
-                CurrentSummary = $"Maintenance is scheduled (state: {status.State}).";
-                LastRun = status.LastRun is { } lr ? lr.ToString("yyyy-MM-dd HH:mm") : "—";
-                NextRun = status.NextRun is { } nr ? nr.ToString("yyyy-MM-dd HH:mm") : "—";
-                LastResult = status.LastResultDescription ?? "";
-                StatusMessage = "A maintenance task is registered. You can update or remove it below.";
-            }
-            else
-            {
-                CurrentSummary = "No maintenance is scheduled yet.";
-                LastRun = NextRun = LastResult = "";
-                StatusMessage = "Pick an action and time, then Save schedule to automate it.";
-            }
-            RemoveScheduleCommand.NotifyCanExecuteChanged();
-        }
+        try { await LoadStatusAsync(); }
         finally { IsBusy = false; }
     }
 
-    [RelayCommand]
+    /// <summary>
+    /// Reads the task status and updates the bound state. Does NOT touch <see cref="IsBusy"/>,
+    /// so Save/Remove can call it without prematurely clearing their own busy flag (which would
+    /// re-enable the commands mid-operation).
+    /// </summary>
+    private async Task LoadStatusAsync()
+    {
+        var status = await _service.GetStatusAsync();
+        IsScheduled = status.Exists;
+        if (status.Exists)
+        {
+            CurrentSummary = $"Maintenance is scheduled (state: {status.State}).";
+            LastRun = status.LastRun is { } lr ? lr.ToString("yyyy-MM-dd HH:mm") : "—";
+            NextRun = status.NextRun is { } nr ? nr.ToString("yyyy-MM-dd HH:mm") : "—";
+            LastResult = status.LastResultDescription ?? "";
+            StatusMessage = "A maintenance task is registered. You can update or remove it below.";
+        }
+        else
+        {
+            CurrentSummary = "No maintenance is scheduled yet.";
+            LastRun = NextRun = LastResult = "";
+            StatusMessage = "Pick an action and time, then Save schedule to automate it.";
+        }
+        RemoveScheduleCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task SaveScheduleAsync()
     {
         var schedule = BuildSchedule();
@@ -93,6 +115,7 @@ public sealed partial class ScheduledMaintenanceViewModel : ViewModelBase
         try
         {
             bool ok = await _service.RegisterAsync(schedule);
+            await LoadStatusAsync(); // refresh state first, then set the outcome message so it isn't overwritten
             if (ok)
             {
                 ActivityLogService.Instance.Log("Scheduled Maintenance", $"{schedule.ActionLabel} — {schedule.Summary}");
@@ -103,12 +126,11 @@ public sealed partial class ScheduledMaintenanceViewModel : ViewModelBase
             {
                 StatusMessage = "Could not register the scheduled task. Check the log for details.";
             }
-            await RefreshAsync();
         }
         finally { IsBusy = false; }
     }
 
-    private bool CanRemove() => IsScheduled;
+    private bool CanRemove() => IsScheduled && !IsBusy;
 
     [RelayCommand(CanExecute = nameof(CanRemove))]
     private async Task RemoveScheduleAsync()
@@ -123,11 +145,17 @@ public sealed partial class ScheduledMaintenanceViewModel : ViewModelBase
         {
             bool removed = await _service.RemoveAsync();
             if (removed) ActivityLogService.Instance.Log("Scheduled Maintenance", "Removed the maintenance schedule");
+            await LoadStatusAsync(); // refresh state first, then set the outcome message
             StatusMessage = removed ? "Scheduled maintenance removed." : "Could not remove the task. Check the log.";
-            await RefreshAsync();
         }
         finally { IsBusy = false; }
     }
 
     partial void OnIsScheduledChanged(bool value) => RemoveScheduleCommand.NotifyCanExecuteChanged();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing) PropertyChanged -= OnVmPropertyChanged;
+        base.Dispose(disposing);
+    }
 }


### PR DESCRIPTION
## What

Two fixes for Scheduled Maintenance (#10), from the post-feature audit (Batch 5 of 6).

## Fixes

1. **Commands not gated on busy (re-entrancy).** Save / Remove / Refresh had no `!IsBusy` `CanExecute` gate, so a fast double-click (or Save-then-Remove) could start overlapping async operations and desync `IsBusy`. All three are now gated on `!IsBusy`, re-evaluated when `IsBusy` changes (observed via `PropertyChanged`, since `IsBusy` lives in `ViewModelBase`). Save/Remove refresh status via a new non-`IsBusy`-toggling `LoadStatusAsync`, so they no longer report not-busy mid-operation.
2. **Comment vs code drift on a privileged surface.** The `RegisterScript` comment claimed a `-User $env:USERNAME` principal the `Register-ScheduledTask` call never passed (it relied on the cmdlet default). It now builds an explicit `New-ScheduledTaskPrincipal` (current user, Interactive logon, **Limited** run level) — making the "current user, no admin, only when logged on" posture deliberate and matching the docs.

## Tests

`MaintenanceSchedulerServiceTests` (the service previously had **zero**): `RegisterAsync` passes only whitelisted args (the "no free-form text reaches the scheduler" security invariant), daily-flag mapping, null-exe → false + no run, empty results → false, PowerShell throws → false; `GetStatusAsync` no-rows / maps state+runs+result / throws → ExistsFalse.

## Docs

CHANGELOG 1.51.5, version bump to 1.51.5.

Part of the post-feature audit remediation (Batch 5 of 6).
