### PR TITLE
fix: add busy progress affordance to new tabs and remove dead placeholder fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.51.6] - 2026-06-29
+
+### Added
+- **Progress indicator while a tab is working.** Resource History, Scheduled Maintenance, and Tweaks Hub now show a small progress bar next to the status line during loads, applies, and schedule changes — so you can tell the app is busy instead of wondering if a click registered.
+
+### Changed
+- **Internal cleanup:** removed eight unused placeholder objects that were allocated on every launch but no longer shown anywhere (left over after those features graduated to real tabs). No user-visible change.
+
 ## [1.51.5] - 2026-06-29
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.51.5</Version>
-    <FileVersion>1.51.5.0</FileVersion>
-    <AssemblyVersion>1.51.5.0</AssemblyVersion>
+    <Version>1.51.6</Version>
+    <FileVersion>1.51.6.0</FileVersion>
+    <AssemblyVersion>1.51.6.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -73,15 +73,10 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
     // ── Placeholder ViewModels for planned features (WIP) ──────────
     // Monitor group
-    public PlaceholderViewModel WipFileLockDetector { get; private set; } = null!;
     public PlaceholderViewModel WipBandwidthMonitor { get; private set; } = null!;
 
     // Gaming & Profiles group
     public PlaceholderViewModel WipGamingProfile { get; private set; } = null!;
-    public PlaceholderViewModel WipStandbyListCleaner { get; private set; } = null!;
-    public PlaceholderViewModel WipTimerResolution { get; private set; } = null!;
-    public PlaceholderViewModel WipCpuAffinity { get; private set; } = null!;
-    public PlaceholderViewModel WipDisplayProfiles { get; private set; } = null!;
 
     // Network group — DNS Changer + Hosts Editor now fully implemented as DnsHosts
 
@@ -89,15 +84,10 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
     // Privacy & Security group (Privacy & Telemetry + Debloater + Browser Cleaner now fully implemented)
     public PlaceholderViewModel WipEdgeOneDriveRemover { get; private set; } = null!;
-    public PlaceholderViewModel WipDefenderTweaks { get; private set; } = null!;
     public PlaceholderViewModel WipNotificationBlocker { get; private set; } = null!;
 
     // Customization group (Context Menu is now fully implemented)
-    public PlaceholderViewModel WipDarkModeScheduler { get; private set; } = null!;
     public PlaceholderViewModel WipVolumeControl { get; private set; } = null!;
-
-    // System group (additions)
-    public PlaceholderViewModel WipTaskScheduler { get; private set; } = null!;
 
     /// <summary>Grouped sidebar tree (12 categories).</summary>
     public ObservableCollection<NavGroup> NavGroups { get; } = new();
@@ -262,15 +252,10 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         // ── WIP placeholders for planned features ──────────────────────
 
         // Monitor group
-        WipFileLockDetector = new PlaceholderViewModel("File Lock Detector", "Find which process is locking a file and optionally release the handle.", "#333");
         WipBandwidthMonitor = new PlaceholderViewModel("Bandwidth Monitor", "Real-time per-app network usage with history graphs and alerts.", "#337");
 
         // Gaming & Profiles group
         WipGamingProfile = new PlaceholderViewModel("Gaming Profile", "One-click game mode: kill background processes, clear RAM, set timer resolution, auto-revert on game exit.", "#324");
-        WipStandbyListCleaner = new PlaceholderViewModel("Standby List Cleaner", "Automatic standby memory purging when free RAM drops below threshold (ISLC-style).", "#325");
-        WipTimerResolution = new PlaceholderViewModel("Timer Resolution", "Set Windows timer to 0.5ms for reduced input lag in competitive games.", "#326");
-        WipCpuAffinity = new PlaceholderViewModel("CPU Core Affinity", "Set per-game CPU affinity with P-core/E-core awareness for Intel hybrid CPUs.", "#327");
-        WipDisplayProfiles = new PlaceholderViewModel("Display Profiles", "Quick-switch refresh rate, HDR, resolution presets (Gaming/Work/Movie).", "#328");
 
         // Cleanup group (File Shredder is now fully implemented)
 
@@ -280,15 +265,12 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
         // Privacy & Security group (Privacy & Telemetry is now fully implemented)
         WipEdgeOneDriveRemover = new PlaceholderViewModel("Edge/OneDrive Remover", "Safely remove or disable Edge and OneDrive with full restore capability.", "#339");
-        WipDefenderTweaks = new PlaceholderViewModel("Defender Tweaks", "Toggle SmartScreen, manage exclusions, configure PUA and cloud protection.", "#344");
         WipNotificationBlocker = new PlaceholderViewModel("Notification Blocker", "Suppress annoying app pop-ups (update nags, trial reminders) with allowlist.", "#340");
 
         // Customization group (Context Menu is now fully implemented)
-        WipDarkModeScheduler = new PlaceholderViewModel("Dark Mode Scheduler", "Auto light/dark theme + color temperature (f.lux-style) on schedule or sunset.", "#329");
         WipVolumeControl = new PlaceholderViewModel("Volume Control", "Per-app volume mixer with output device routing and profile presets.", "#332");
 
         // System group (additions)
-        WipTaskScheduler = new PlaceholderViewModel("Task Scheduler", "Browse and toggle scheduled tasks with color-coded safety indicators.", "#334");
 
         // Advanced group
     }
@@ -515,13 +497,8 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         TweaksHub?.Dispose();
 
         // WIP placeholders
-        WipFileLockDetector?.Dispose();
         WipBandwidthMonitor?.Dispose();
         WipGamingProfile?.Dispose();
-        WipStandbyListCleaner?.Dispose();
-        WipTimerResolution?.Dispose();
-        WipCpuAffinity?.Dispose();
-        WipDisplayProfiles?.Dispose();
         Privacy?.Dispose();
         ContextMenu?.Dispose();
         SystemReport?.Dispose();
@@ -535,11 +512,8 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         PrivacyMonitor?.Dispose();
         BootAnalyzer?.Dispose();
         WipEdgeOneDriveRemover?.Dispose();
-        WipDefenderTweaks?.Dispose();
         WipNotificationBlocker?.Dispose();
-        WipDarkModeScheduler?.Dispose();
         WipVolumeControl?.Dispose();
-        WipTaskScheduler?.Dispose();
 
         GC.SuppressFinalize(this);
     }

--- a/SysManager/SysManager/Views/ResourceHistoryView.xaml
+++ b/SysManager/SysManager/Views/ResourceHistoryView.xaml
@@ -109,7 +109,11 @@
         </Grid>
 
         <!-- Status -->
-        <TextBlock Grid.Row="4" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
-                   Margin="28,12,28,24" TextWrapping="Wrap"/>
+        <DockPanel Grid.Row="4" Margin="28,12,28,24">
+            <ProgressBar AutomationProperties.Name="Loading" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+                         IsIndeterminate="True"
+                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>
+        </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/ScheduledMaintenanceView.xaml
+++ b/SysManager/SysManager/Views/ScheduledMaintenanceView.xaml
@@ -113,7 +113,11 @@
         </Border>
 
         <!-- Status -->
-        <TextBlock Grid.Row="5" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
-                   Margin="28,12,28,24" TextWrapping="Wrap"/>
+        <DockPanel Grid.Row="5" Margin="28,12,28,24">
+            <ProgressBar AutomationProperties.Name="Working" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+                         IsIndeterminate="True"
+                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>
+        </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/TweaksHubView.xaml
+++ b/SysManager/SysManager/Views/TweaksHubView.xaml
@@ -119,6 +119,9 @@
         <!-- Action bar -->
         <Border Grid.Row="4" Style="{StaticResource Card}" Margin="28,12,28,24" Padding="12">
             <DockPanel>
+                <ProgressBar AutomationProperties.Name="Working" DockPanel.Dock="Left" Width="100" Height="4"
+                             VerticalAlignment="Center" Margin="0,0,12,0" IsIndeterminate="True"
+                             Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
                 <TextBlock DockPanel.Dock="Left" VerticalAlignment="Center"
                            Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">


### PR DESCRIPTION
## What

Final post-feature-audit cleanup (Batch 6 of 6).

## Changes

1. **Busy progress affordance (UX).** Resource History, Scheduled Maintenance, and Tweaks Hub set `IsBusy` around their async work but never surfaced it. Added the sibling `CleanupView` pattern — an indeterminate `ProgressBar` next to the status line, visible while `IsBusy` — so the user gets feedback during loads / applies / schedule changes instead of a silent pause.
2. **Dead-code removal.** Deleted 8 orphaned `Wip*` `PlaceholderViewModel` fields (FileLockDetector, StandbyListCleaner, TimerResolution, CpuAffinity, DisplayProfiles, DefenderTweaks, DarkModeScheduler, TaskScheduler) left behind after those features graduated to real tabs. They were declared, allocated in `InitPlaceholders`, and disposed every launch but referenced in **no nav group** (verified: zero usage outside the declarations). Pure cleanup, no behavior change.

## Tests

No new tests: the removal is covered by the existing nav-count integration tests (still 58 items / 12 groups, all green), and the ProgressBar is presentation-only.

## Docs

CHANGELOG 1.51.6, version bump to 1.51.6.

Completes the post-feature audit remediation (6 of 6).
