### PR TITLE
fix: report usage error for unknown CLI flags instead of opening the GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.51.7] - 2026-06-29
+
+### Fixed
+- **Unknown command-line flags now report a usage error instead of silently opening the app.** Running `SysManager.exe --bogus` (or any unrecognized `--flag`) used to fall through to launching the GUI and exit 0, contradicting the documented contract (`--help` states unknown options exit 2). Unrecognized flags are now treated as a headless usage error: they print "Unknown option" with the help text and exit 2, while the internal startup sentinels (the elevation relaunch and the in-process update applier) are explicitly excluded so they still route to their own startup paths. Bare non-flag arguments are still ignored.
+
 ## [1.51.6] - 2026-06-29
 
 ### Added

--- a/SysManager/SysManager.Tests/CliRunnerTests.cs
+++ b/SysManager/SysManager.Tests/CliRunnerTests.cs
@@ -71,6 +71,17 @@ public class CliRunnerTests
         => Assert.True(CliRunner.IsCliInvocation(["--health"]));
 
     [Fact]
+    public void IsCliInvocation_TrueForUnknownFlag_SoItReportsUsageError()
+        // Regression: an unrecognized flag (typo) must run headless and report a usage
+        // error (exit 2), NOT silently fall through and open the GUI window.
+        => Assert.True(CliRunner.IsCliInvocation(["--bogus"]));
+
+    [Fact]
+    public void IsCliInvocation_FalseForBareTokens()
+        // Non-flag tokens (no leading - or /) never trigger CLI mode.
+        => Assert.False(CliRunner.IsCliInvocation(["foo", "bar"]));
+
+    [Fact]
     public void IsCliInvocation_FalseForNoArgs()
         => Assert.False(CliRunner.IsCliInvocation([]));
 

--- a/SysManager/SysManager/Services/CliRunner.cs
+++ b/SysManager/SysManager/Services/CliRunner.cs
@@ -35,10 +35,32 @@ public sealed class CliRunner
         "--help", "-h", "-?", "/?", "--version", "-v", "--list", "--health", "--cleanup", "--trim-ram",
     };
 
-    /// <summary>True only when a recognized CLI verb is present — used by startup to choose
-    /// headless mode over the GUI. Deliberately strict: an unrecognized flag (e.g. the
-    /// elevation sentinel) does NOT trigger CLI mode, so other startup branches still run.</summary>
-    public static bool IsCliInvocation(string[] args) => args.Any(a => CliVerbs.Contains(a.Trim()));
+    // Internal startup sentinels that LOOK like CLI flags but are handled by their own
+    // OnStartup branches (elevation relaunch, in-process update applier). They must NEVER
+    // be treated as a CLI invocation, so an unknown-flag dispatch can't hijack them.
+    private static readonly HashSet<string> NonCliSentinels = new(StringComparer.OrdinalIgnoreCase)
+    {
+        Helpers.AdminHelper.RelaunchedElevatedArg, UpdateApplier.ApplyUpdateArg,
+    };
+
+    /// <summary>True when the args should run headlessly (CLI mode) rather than open the GUI.
+    /// That's any recognized verb, OR an unrecognized option flag (so a typo like
+    /// <c>--bogus</c> reports a usage error + exit 2 instead of silently opening the window) —
+    /// EXCEPT the internal startup sentinels (elevation relaunch, update applier), which route
+    /// to their own branches. Bare non-flag tokens never trigger CLI mode.</summary>
+    public static bool IsCliInvocation(string[] args)
+    {
+        foreach (var raw in args)
+        {
+            var a = raw.Trim();
+            if (NonCliSentinels.Contains(a)) return false;
+        }
+        return args.Any(a => IsCliToken(a.Trim()));
+    }
+
+    // A recognized verb, or any unrecognized option flag (leading - or /). Bare tokens aren't.
+    private static bool IsCliToken(string arg)
+        => CliVerbs.Contains(arg) || arg.StartsWith('-') || arg.StartsWith('/');
 
     /// <summary>
     /// Parses the argument list into a <see cref="CliRequest"/>. The first recognized verb

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.51.6</Version>
-    <FileVersion>1.51.6.0</FileVersion>
-    <AssemblyVersion>1.51.6.0</AssemblyVersion>
+    <Version>1.51.7</Version>
+    <FileVersion>1.51.7.0</FileVersion>
+    <AssemblyVersion>1.51.7.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Bug
`SysManager.exe --bogus` (or any unrecognized `--flag`) fell through to **launching the GUI and exiting 0**, contradicting the documented contract — the app's own `--help` says "Exit codes: 0 success · 1 error · 2 usage error", and TC-4 / cli-smoke.ps1 both expect unknown flags to exit 2.

## Root cause
`CliRunner.IsCliInvocation` matched only a **known-verb allowlist**, so a typo'd flag wasn't recognized as CLI input and startup proceeded to the GUI. The `Parse`/`ExecuteAsync` path already maps unknown flags to `CliCommand.Unknown` → usage error (exit 2 + help) — it just never got reached.

## Fix
`IsCliInvocation` now also returns true for any unrecognized option flag (leading `-`/`/`), **except** the internal startup sentinels `--relaunched-elevated` and `--apply-update`, which must keep routing to their own `OnStartup` branches (elevation relaunch / in-process updater). Bare non-flag tokens still never trigger CLI mode.

## Verification
- Found by running the runtime test kit (`cli-smoke.ps1`) on the secondary workstation — it hung on the `--bogus` case.
- Verified live after the fix: `--bogus`/`--nope` → "Unknown option '…'" + help, **exit 2**; `--version` → exit 0; `--relaunched-elevated` → elevated GUI opens and stays alive (NOT treated as CLI).
- Full `cli-smoke.ps1`: **17/17 PASS** (incl. mutating `--cleanup`/`--trim-ram`).
- Regression tests added: `IsCliInvocation` true for an unknown flag, false for bare tokens (sentinel exclusions already covered).

Patch bump 1.51.7 + CHANGELOG entry.