### PR TITLE
fix: correct five visible-correctness defects (WIP tabs, disk health, app alerts, context menu, theme editor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.51.8] - 2026-06-30
+
+### Fixed
+- **Work-in-progress tabs no longer show a doubled hash in their issue reference.** The placeholder tabs (Bandwidth Monitor, Gaming Profile, Edge/OneDrive Remover, Notification Blocker, Volume Control) rendered "Tracked in issue ##337" because the template prepended a `#` to a value that already started with one. The duplicate is removed, so they now read "Tracked in issue #337".
+- **A drive with no SMART data is no longer painted red as if it were failing.** The disk-health percentage swatch fell through to the "failing" red when SMART health data was unavailable; it now shows the neutral grey used elsewhere for unknown readings, matching the temperature swatch.
+- **The App Alerts busy indicator no longer switches off while monitoring is active.** Running a manual "refresh installed apps" while monitoring was on forced the busy/monitoring affordance off in its cleanup step; the indicator now stays in sync with the monitoring state.
+- **The Context Menu search box now shows its placeholder text.** The "Search entries…" hint was wired through a `Tag` that the default text-box template never renders, so the field appeared blank; it now uses the same in-box placeholder pattern as the Bulk Installer search.
+- **One invalid custom-theme colour no longer discards the other three.** Entering a malformed hex value in the Appearance → Custom editor silently dropped all four colour edits; each field is now parsed independently, valid values still apply, and an invalid field is flagged with red text and a tooltip.
+
 ## [1.51.7] - 2026-06-29
 
 ### Fixed

--- a/SysManager/SysManager.Tests/AppAlertsViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppAlertsViewModelTests.cs
@@ -47,6 +47,33 @@ public class AppAlertsViewModelTests
     }
 
     [Fact]
+    public async Task RefreshInstalledApps_WhenNotMonitoring_LeavesBusyOff()
+    {
+        using var vm = new AppAlertsViewModel(new Services.AppAlertService());
+
+        await vm.RefreshInstalledAppsCommand.ExecuteAsync(null);
+
+        Assert.False(vm.IsMonitoring);
+        Assert.False(vm.IsBusy);
+    }
+
+    [Fact]
+    public async Task RefreshInstalledApps_WhileMonitoring_KeepsBusyInSyncWithMonitoring()
+    {
+        // Regression (idx 235): a manual refresh must not switch off the busy/monitoring
+        // affordance while monitoring is active — IsBusy has to track IsMonitoring.
+        using var vm = new AppAlertsViewModel(new Services.AppAlertService());
+        vm.StartMonitoringCommand.Execute(null);
+        Assert.True(vm.IsMonitoring);
+        Assert.True(vm.IsBusy);
+
+        await vm.RefreshInstalledAppsCommand.ExecuteAsync(null);
+
+        Assert.True(vm.IsMonitoring);
+        Assert.True(vm.IsBusy); // was incorrectly forced to false before the fix
+    }
+
+    [Fact]
     public void AppInstallEntry_DefaultValues()
     {
         var entry = new AppInstallEntry();

--- a/SysManager/SysManager.Tests/DiskHealthReportEdgeCaseTests.cs
+++ b/SysManager/SysManager.Tests/DiskHealthReportEdgeCaseTests.cs
@@ -118,10 +118,14 @@ public class DiskHealthReportEdgeCaseTests
     }
 
     [Fact]
-    public void HealthPercentColorHex_NullHealth_Red()
+    public void HealthPercentColorHex_NullHealth_IsNeutralGrey()
     {
+        // When no SMART data is available HealthPercent is null; the swatch must show
+        // the neutral "unknown" grey, not the failing red — consistent with
+        // TemperatureColorHex's null arm below.
         var report = new DiskHealthReport { HealthStatus = "SomethingUnknown" };
-        Assert.Equal("#EF4444", report.HealthPercentColorHex);
+        Assert.Null(report.HealthPercent);
+        Assert.Equal("#9AA0A6", report.HealthPercentColorHex);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/DiskHealthReportTests.cs
+++ b/SysManager/SysManager.Tests/DiskHealthReportTests.cs
@@ -128,6 +128,29 @@ public class DiskHealthReportTests
         Assert.Equal(0, r.HealthPercent);
     }
 
+    // ---------- Health-percent color ----------
+
+    [Theory]
+    [InlineData(0, "#22C55E")]   // 100% health (no wear) -> green
+    [InlineData(40, "#F59E0B")]  // 60% health -> amber
+    [InlineData(85, "#F87171")]  // 15% health (>=20 boundary excluded) -> light red
+    public void HealthPercentColorHex_ReturnsCorrectColor(int wear, string expected)
+    {
+        var r = new DiskHealthReport { WearPercent = wear, TemperatureC = 35, ReadErrors = 0, WriteErrors = 0 };
+        Assert.Equal(expected, r.HealthPercentColorHex);
+    }
+
+    [Fact]
+    public void HealthPercentColorHex_NoSmartData_IsNeutralGrey_NotRed()
+    {
+        // Regression: a disk with no SMART data (HealthPercent == null) must not be
+        // painted red as if it were failing — it shows the neutral "unknown" grey,
+        // consistent with TemperatureColorHex's null arm.
+        var r = new DiskHealthReport { HealthStatus = "" };
+        Assert.Null(r.HealthPercent);
+        Assert.Equal("#9AA0A6", r.HealthPercentColorHex);
+    }
+
     // ---------- Temperature color ----------
 
     [Theory]

--- a/SysManager/SysManager.Tests/DiskHealthReportTests.cs
+++ b/SysManager/SysManager.Tests/DiskHealthReportTests.cs
@@ -133,7 +133,8 @@ public class DiskHealthReportTests
     [Theory]
     [InlineData(0, "#22C55E")]   // 100% health (no wear) -> green
     [InlineData(40, "#F59E0B")]  // 60% health -> amber
-    [InlineData(85, "#F87171")]  // 15% health (>=20 boundary excluded) -> light red
+    [InlineData(75, "#F87171")]  // 25% health (>=20) -> light red
+    [InlineData(85, "#EF4444")]  // 15% health (<20) -> red
     public void HealthPercentColorHex_ReturnsCorrectColor(int wear, string expected)
     {
         var r = new DiskHealthReport { WearPercent = wear, TemperatureC = 35, ReadErrors = 0, WriteErrors = 0 };

--- a/SysManager/SysManager/Models/DiskHealthReport.cs
+++ b/SysManager/SysManager/Models/DiskHealthReport.cs
@@ -95,6 +95,7 @@ public sealed partial class DiskHealthReport : ObservableObject
     /// <summary>Color hex for the health percentage gauge.</summary>
     public string HealthPercentColorHex => HealthPercent switch
     {
+        null => "#9AA0A6",
         >= 80 => "#22C55E",
         >= 50 => "#F59E0B",
         >= 20 => "#F87171",

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.51.7</Version>
-    <FileVersion>1.51.7.0</FileVersion>
-    <AssemblyVersion>1.51.7.0</AssemblyVersion>
+    <Version>1.51.8</Version>
+    <FileVersion>1.51.8.0</FileVersion>
+    <AssemblyVersion>1.51.8.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
@@ -115,7 +115,9 @@ public sealed partial class AppAlertsViewModel : ViewModelBase
         }
         finally
         {
-            IsBusy = false;
+            // Keep the busy indicator in sync with the monitoring state: a manual
+            // refresh must not switch off the "monitoring active" affordance.
+            IsBusy = IsMonitoring;
             IsProgressIndeterminate = false;
         }
     }

--- a/SysManager/SysManager/Views/ContextMenuView.xaml
+++ b/SysManager/SysManager/Views/ContextMenuView.xaml
@@ -145,20 +145,14 @@
                               AutomationProperties.Name="Filter by location"
                               Width="160" Margin="0,0,8,0"
                               VerticalAlignment="Center"/>
-                    <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
-                             AutomationProperties.Name="Search entries"
-                             Width="200" Margin="0,0,8,0"
-                             VerticalAlignment="Center">
-                        <TextBox.Style>
-                            <Style TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
-                                <Style.Triggers>
-                                    <Trigger Property="Text" Value="">
-                                        <Setter Property="Tag" Value="Search entries..."/>
-                                    </Trigger>
-                                </Style.Triggers>
-                            </Style>
-                        </TextBox.Style>
-                    </TextBox>
+                    <Grid Width="200" Margin="0,0,8,0" VerticalAlignment="Center">
+                        <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
+                                 AutomationProperties.Name="Search entries"/>
+                        <TextBlock Text="Search entries…" IsHitTestVisible="False"
+                                   Foreground="{DynamicResource TextMuted}" Margin="6,0,0,0"
+                                   VerticalAlignment="Center" FontSize="12"
+                                   Visibility="{Binding FilterText, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                    </Grid>
                     <Button Content="Refresh" Command="{Binding RefreshCommand}"
                             AutomationProperties.Name="Refresh entries"
                             Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>

--- a/SysManager/SysManager/Views/PlaceholderView.xaml
+++ b/SysManager/SysManager/Views/PlaceholderView.xaml
@@ -30,7 +30,7 @@
             <!-- Issue reference -->
             <TextBlock FontSize="12" Foreground="{DynamicResource TextMuted}"
                        HorizontalAlignment="Center" Margin="0,12,0,0">
-                <Run Text="Tracked in issue #"/><Run Text="{Binding IssueNumber, Mode=OneTime}"/>
+                <Run Text="Tracked in issue "/><Run Text="{Binding IssueNumber, Mode=OneTime}"/>
             </TextBlock>
         </StackPanel>
     </Grid>

--- a/SysManager/SysManager/Views/ThemePopup.xaml.cs
+++ b/SysManager/SysManager/Views/ThemePopup.xaml.cs
@@ -217,23 +217,41 @@ public partial class ThemePopup : UserControl
 
     private void ApplyCustomFromInputs()
     {
+        // Parse each field independently so one invalid hex doesn't discard the
+        // other three valid edits. An unparseable field keeps its last-good colour
+        // (from its preview swatch) and is flagged visibly instead of failing silently.
+        var accent = ResolveHex(CustomAccentHex, CustomAccentPreview);
+        var bg = ResolveHex(CustomBgHex, CustomBgPreview);
+        var surface = ResolveHex(CustomSurfaceHex, CustomSurfacePreview);
+        var text = ResolveHex(CustomTextHex, CustomTextPreview);
+
+        CustomAccentPreview.Background = new SolidColorBrush(accent);
+        CustomBgPreview.Background = new SolidColorBrush(bg);
+        CustomSurfacePreview.Background = new SolidColorBrush(surface);
+        CustomTextPreview.Background = new SolidColorBrush(text);
+
+        ThemeService.Instance.SetCustom(accent, bg, surface, text);
+    }
+
+    /// <summary>
+    /// Parses a hex TextBox; on success clears the invalid flag and returns the colour,
+    /// on failure flags the box (red text + tooltip) and returns the swatch's current colour.
+    /// </summary>
+    private static Color ResolveHex(TextBox box, Border swatch)
+    {
         try
         {
-            var accent = (Color)ColorConverter.ConvertFromString(CustomAccentHex.Text);
-            var bg = (Color)ColorConverter.ConvertFromString(CustomBgHex.Text);
-            var surface = (Color)ColorConverter.ConvertFromString(CustomSurfaceHex.Text);
-            var text = (Color)ColorConverter.ConvertFromString(CustomTextHex.Text);
-
-            CustomAccentPreview.Background = new SolidColorBrush(accent);
-            CustomBgPreview.Background = new SolidColorBrush(bg);
-            CustomSurfacePreview.Background = new SolidColorBrush(surface);
-            CustomTextPreview.Background = new SolidColorBrush(text);
-
-            ThemeService.Instance.SetCustom(accent, bg, surface, text);
+            var color = (Color)ColorConverter.ConvertFromString(box.Text);
+            box.ClearValue(ForegroundProperty);
+            box.ClearValue(ToolTipProperty);
+            return color;
         }
         catch (FormatException ex)
         {
-            Serilog.Log.Debug(ex, "Theme custom hex parse failed");
+            Serilog.Log.Debug(ex, "Theme custom hex parse failed for {Field}", box.Tag);
+            box.Foreground = Brushes.IndianRed;
+            box.ToolTip = "Invalid colour — use a hex value like #1E2530.";
+            return (swatch.Background as SolidColorBrush)?.Color ?? Colors.Gray;
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes five confirmed visible-correctness defects surfaced by the full-repo audit and re-verified against current source. All are low-risk, user-facing, and isolated.

| Area | Before | After |
|---|---|---|
| WIP placeholder tabs | "Tracked in issue **##**337" | "Tracked in issue #337" |
| Disk health swatch (no SMART data) | painted **red** (implies failing) | neutral grey (unknown) |
| App Alerts busy indicator | switched **off** mid-monitoring on a manual refresh | stays in sync with monitoring state |
| Context Menu search box | **blank** (placeholder never rendered) | shows "Search entries…" |
| Custom theme editor | one bad hex **discarded all four** edits, silently | each field parsed independently; invalid field flagged |

## Details

- **PlaceholderView.xaml** — the template prepended `#` to an `IssueNumber` value that already began with `#`, producing a doubled hash on all five WIP tabs. Removed the literal `#`.
- **DiskHealthReport.cs** — `HealthPercentColorHex` lacked a `null` arm, so a disk with no SMART data (`HealthPercent == null`) fell through to the failing-red. Added the neutral-grey `null` arm, matching the sibling `TemperatureColorHex`.
- **AppAlertsViewModel.cs** — `RefreshInstalledAppsAsync`'s `finally` hard-set `IsBusy = false` even while monitoring was active; now `IsBusy = IsMonitoring`.
- **ContextMenuView.xaml** — the watermark was set via `Tag`, which the default TextBox template never renders. Replaced with the overlay-TextBlock placeholder pattern already used in BulkInstallerView.
- **ThemePopup.xaml.cs** — the four custom-theme hex fields were parsed in a single try; one malformed value threw and discarded the other three (Debug-log only). Each field is now parsed independently, keeps its last-good colour on failure, and is flagged with red text + a tooltip.

## Tests
- `DiskHealthReportTests` — added `HealthPercentColorHex` theory + a regression test asserting no-SMART-data → neutral grey, not red.
- `AppAlertsViewModelTests` — added two tests pinning the IsBusy↔IsMonitoring invariant across a manual refresh.

## Verification
- `dotnet build` (main + tests) — 0 warnings / 0 errors.
- Not run locally: `dotnet test` (CI runs the suite).
