### PR TITLE
fix: surface uninstall/Defender/restore operation failures as status instead of a crash dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.51.9] - 2026-06-30
+
+### Fixed
+- **A failed uninstaller launch no longer aborts the whole batch.** When uninstalling several apps at once, one app whose uninstaller executable could not be launched (missing, blocked, or corrupt) threw an error that stopped the entire run and surfaced a raw error dialog. The failure is now recorded on that app's row and the batch continues with the remaining apps.
+- **Defender toggles report failures cleanly instead of crashing to an error dialog.** Enabling/disabling PUA protection or Controlled Folder Access, and adding/removing scan exclusions, now catch a PowerShell runspace-level fault and show it as a status message — matching how the status refresh already behaved.
+- **System Restore actions report failures cleanly.** Creating or starting a restore now catches a runspace/WMI-level fault and shows it as a status message instead of letting it surface as a global error dialog.
+
 ## [1.51.8] - 2026-06-30
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DefenderViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DefenderViewModelTests.cs
@@ -116,4 +116,39 @@ public class DefenderViewModelTests
         Assert.Contains("was not changed", vm.StatusMessage, System.StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("updated", vm.StatusMessage, System.StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public async Task TogglePua_WhenRunspaceFaults_SurfacesStatus_DoesNotThrow()
+    {
+        // Regression (idx 74): a PowerShell runspace-level fault during a mutating
+        // command (not the script RuntimeException the service catches) must be caught
+        // and surfaced as a status message, like RefreshAsync — not escape the async
+        // command to the global handler. The first RunAsync (GetStatus at init) succeeds;
+        // the Set call faults.
+        var ps = Substitute.For<IPowerShellRunner>();
+        var calls = 0;
+        ps.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<System.Threading.CancellationToken>())
+          .Returns(_ => ++calls <= 1
+              ? new Collection<PSObject>()
+              : throw new System.InvalidOperationException("runspace is broken"));
+        var vm = new DefenderViewModel(new DefenderService(ps));
+        await vm.InitializationComplete;
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            // Must NOT throw — the fix adds the catch clauses.
+            await vm.TogglePuaCommand.ExecuteAsync(null);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+
+        Assert.False(vm.IsBusy);
+        Assert.Contains("could not change pua", vm.StatusMessage, System.StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.51.8</Version>
-    <FileVersion>1.51.8.0</FileVersion>
-    <AssemblyVersion>1.51.8.0</AssemblyVersion>
+    <Version>1.51.9</Version>
+    <FileVersion>1.51.9.0</FileVersion>
+    <AssemblyVersion>1.51.9.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DefenderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DefenderViewModel.cs
@@ -108,6 +108,8 @@ public sealed partial class DefenderViewModel : ViewModelBase
             Apply(status);
             ReportVerified("PUA protection", status, status.PuaProtection == target);
         }
+        catch (InvalidOperationException ex) { StatusMessage = $"Could not change PUA protection: {ex.Message}"; }
+        catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"Could not change PUA protection: {ex.Message}"; }
         finally { IsBusy = false; }
     }
 
@@ -123,6 +125,8 @@ public sealed partial class DefenderViewModel : ViewModelBase
             Apply(status);
             ReportVerified("Controlled Folder Access", status, status.ControlledFolderAccess == target);
         }
+        catch (InvalidOperationException ex) { StatusMessage = $"Could not change Controlled Folder Access: {ex.Message}"; }
+        catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"Could not change Controlled Folder Access: {ex.Message}"; }
         finally { IsBusy = false; }
     }
 
@@ -147,6 +151,8 @@ public sealed partial class DefenderViewModel : ViewModelBase
             Apply(status);
             ReportVerified("Exclusion", status, status.ExclusionPaths.Any(p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase)));
         }
+        catch (InvalidOperationException ex) { StatusMessage = $"Could not add the exclusion: {ex.Message}"; }
+        catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"Could not add the exclusion: {ex.Message}"; }
         finally { IsBusy = false; }
     }
 
@@ -164,6 +170,8 @@ public sealed partial class DefenderViewModel : ViewModelBase
             Apply(status);
             ReportVerified("Exclusion removal", status, !status.ExclusionPaths.Any(p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase)));
         }
+        catch (InvalidOperationException ex) { StatusMessage = $"Could not remove the exclusion: {ex.Message}"; }
+        catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"Could not remove the exclusion: {ex.Message}"; }
         finally { IsBusy = false; }
     }
 

--- a/SysManager/SysManager/ViewModels/RestorePointsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/RestorePointsViewModel.cs
@@ -114,6 +114,11 @@ public sealed partial class RestorePointsViewModel : ViewModelBase
             }
         }
         catch (OperationCanceledException) { StatusMessage = "Cancelled."; }
+        // CreateAsync runs PowerShell; a runspace/WMI-level fault would otherwise
+        // escape this async command unobserved. Surface it as a status message.
+        catch (System.Management.Automation.RuntimeException ex) { StatusMessage = $"Could not create a restore point: {ex.Message}"; }
+        catch (InvalidOperationException ex) { StatusMessage = $"Could not create a restore point: {ex.Message}"; }
+        catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"Could not create a restore point: {ex.Message}"; }
         finally
         {
             IsBusy = false;
@@ -152,6 +157,11 @@ public sealed partial class RestorePointsViewModel : ViewModelBase
             Log.Information("RestorePoint: restore to #{Seq} requested (ok={Ok})", point.SequenceNumber, ok);
         }
         catch (OperationCanceledException) { StatusMessage = "Cancelled."; }
+        // RestoreAsync runs PowerShell; a runspace/WMI-level fault would otherwise
+        // escape this async command unobserved. Surface it as a status message.
+        catch (System.Management.Automation.RuntimeException ex) { StatusMessage = $"Could not start the restore: {ex.Message}"; }
+        catch (InvalidOperationException ex) { StatusMessage = $"Could not start the restore: {ex.Message}"; }
+        catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"Could not start the restore: {ex.Message}"; }
         finally
         {
             IsBusy = false;

--- a/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
@@ -158,6 +158,10 @@ public sealed partial class UninstallerViewModel : ViewModelBase
                 }
                 catch (OperationCanceledException) { app.Status = "Cancelled"; break; }
                 catch (InvalidOperationException ex) { app.Status = $"Error: {ex.Message}"; }
+                // A failed uninstaller launch (missing/blocked exe) must not abort the
+                // whole batch — record it on the row and continue with the next app.
+                catch (System.ComponentModel.Win32Exception ex) { app.Status = $"Error: {ex.Message}"; }
+                catch (System.IO.IOException ex) { app.Status = $"Error: {ex.Message}"; }
                 done++;
             }
 


### PR DESCRIPTION
## Summary

Three error-handling fixes from the audit: privileged/batch operations that could escape an unhandled exception to the global crash dialog now surface the failure cleanly. All re-verified against current source; isolated to catch clauses.

| Area | Before | After |
|---|---|---|
| Uninstaller (batch) | one app's failed uninstaller launch **aborted the whole batch** + raw dialog | failure recorded on the row; batch continues |
| Defender toggles/exclusions | runspace fault **escaped** to the global error dialog | caught → status message (like the status refresh already did) |
| System Restore create/restore | runspace/WMI fault **escaped** to the global dialog | caught → status message |

## Details

- **UninstallerViewModel.cs** — the per-item `catch` handled `OperationCanceledException` + `InvalidOperationException`, but `Process.Start` for a missing/blocked uninstaller throws `Win32Exception` (or `IOException`), which escaped the per-item try and the `finally`-only outer try, aborting the batch. Added `Win32Exception`/`IOException` to the per-item catch so the run continues.
- **DefenderViewModel.cs** — `RefreshAsync` already caught `InvalidOperationException`/`Win32Exception` from a PowerShell runspace fault, but the four mutating commands (TogglePua, ToggleCfa, AddExclusion, RemoveExclusion) had only `finally { IsBusy = false; }`. Added the matching catches so a runspace fault becomes a status message, not a global dialog.
- **RestorePointsViewModel.cs** — `CreateAsync`/`RestoreAsync` caught only `OperationCanceledException`; a `RuntimeException`/`InvalidOperationException`/`Win32Exception` from the PowerShell-backed service escaped. Added the matching catches.

## Tests
- `DefenderViewModelTests` — added a regression test: a runspace fault (`InvalidOperationException`) during `TogglePua` is caught, `IsBusy` resets, and a "could not change PUA" status is shown — the command does not throw.

## Notes (honest scope)
- The Uninstaller fix has **no VM-level regression test**: `UninstallerViewModel` takes a concrete `UninstallerService` (no interface seam), so the mid-batch throw can't be mocked yet. Adding `IUninstallerService` is a separate architecture task (tracked in the audit backlog). The Defender test covers the same runspace-fault class on a seamed VM.
- The RestorePoints commands are gated on `IsElevated`, which is false on CI runners, so a VM-level execute test would be non-deterministic; the Defender test is the representative pin for this fix class.

## Verification
- `dotnet build` (main + tests) — 0 warnings / 0 errors. `dotnet test` not run locally (firewall); CI runs the suite.
