### PR TITLE
fix: preserve cached download on cancel, dedupe audio service entry, prefer physical gateway, drop dead catch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.51.10] - 2026-06-30
+
+### Fixed
+- **Cancelling an update download no longer deletes a previously-downloaded copy.** If a fresh download was cancelled, the cleanup step also removed any already-cached, still-valid installer, forcing an avoidable re-download on the next launch. Cancellation now only removes the partial in-progress file.
+- **A safe-to-disable service description is no longer silently dropped.** The service safety database held two entries for Windows Audio that differed only in capitalisation; in the case-insensitive lookup the second silently overwrote the first, losing the "only disable on headless servers" guidance. The duplicate was removed so the fuller description is always shown.
+- **The default-gateway detection prefers the real physical route.** Ping/monitoring picked the first active adapter's gateway, which on a machine with a VPN or virtual adapter could be the wrong one. Tunnel adapters are now skipped and physical adapters (Ethernet/Wi-Fi, fastest first) are preferred.
+
+### Changed
+- Removed an unreachable `catch` in the Recycle Bin helper: `SHEmptyRecycleBin` reports failure through its return code, not an exception, so the failure path now reads and logs the HRESULT directly.
+
 ## [1.51.9] - 2026-06-30
 
 ### Fixed

--- a/SysManager/SysManager.Tests/SafetyDatabaseTests.cs
+++ b/SysManager/SysManager.Tests/SafetyDatabaseTests.cs
@@ -51,6 +51,20 @@ public class SafetyDatabaseTests
     public void GetServiceSafety_KnownService_ReturnsNonEmptyDescription()
         => Assert.False(string.IsNullOrWhiteSpace(SafetyDatabase.GetServiceSafety("wuauserv").Description));
 
+    [Theory]
+    [InlineData("AudioSrv")]
+    [InlineData("Audiosrv")]
+    [InlineData("audiosrv")]
+    public void GetServiceSafety_AudioService_KeepsRicherDescription(string service)
+    {
+        // Regression (idx 173/308): the case-insensitive dictionary previously held both
+        // "AudioSrv" and "Audiosrv"; the second silently overwrote the first, dropping the
+        // "Only disable on headless servers" guidance. The duplicate was removed, so the
+        // richer description must survive for every casing.
+        var (_, description) = SafetyDatabase.GetServiceSafety(service);
+        Assert.Contains("headless servers", description, StringComparison.OrdinalIgnoreCase);
+    }
+
     // ---------- features ----------
 
     [Theory]

--- a/SysManager/SysManager/Helpers/GatewayHelper.cs
+++ b/SysManager/SysManager/Helpers/GatewayHelper.cs
@@ -8,28 +8,44 @@ using System.Net.Sockets;
 namespace SysManager.Helpers;
 
 /// <summary>
-/// Detects the default IPv4 gateway by scanning active network interfaces
-/// and returning the first usable gateway found.
+/// Detects the default IPv4 gateway by scanning active network interfaces. Tunnel
+/// (VPN) adapters are excluded and physical adapter types (Ethernet/Wi-Fi) are
+/// preferred over virtual ones, so a VPN or virtual adapter's gateway isn't picked
+/// over the real physical default route just because it enumerates first.
 /// </summary>
 public static class GatewayHelper
 {
     public static string? DetectDefaultGateway()
     {
-        var activeNics = NetworkInterface.GetAllNetworkInterfaces()
+        var candidates = NetworkInterface.GetAllNetworkInterfaces()
             .Where(nic => nic.OperationalStatus == OperationalStatus.Up
-                       && nic.NetworkInterfaceType != NetworkInterfaceType.Loopback);
+                       && nic.NetworkInterfaceType != NetworkInterfaceType.Loopback
+                       && nic.NetworkInterfaceType != NetworkInterfaceType.Tunnel)
+            .Select(nic => new
+            {
+                Gateway = nic.GetIPProperties().GatewayAddresses
+                    .Where(gw => gw?.Address != null
+                              && gw.Address.AddressFamily == AddressFamily.InterNetwork
+                              && gw.Address.ToString() != "0.0.0.0")
+                    .Select(gw => gw!.Address.ToString())
+                    .FirstOrDefault(),
+                Rank = TypeRank(nic.NetworkInterfaceType),
+                Speed = nic.Speed
+            })
+            .Where(x => x.Gateway != null)
+            .OrderBy(x => x.Rank)            // physical types first
+            .ThenByDescending(x => x.Speed); // then the fastest link
 
-        foreach (var nic in activeNics)
-        {
-            var gateway = nic.GetIPProperties().GatewayAddresses
-                .Where(gw => gw?.Address != null
-                          && gw.Address.AddressFamily == AddressFamily.InterNetwork
-                          && gw.Address.ToString() != "0.0.0.0")
-                .FirstOrDefault();
-
-            if (gateway != null)
-                return gateway.Address.ToString();
-        }
-        return null;
+        return candidates.FirstOrDefault()?.Gateway;
     }
+
+    // Lower rank = more likely to be the real default route.
+    private static int TypeRank(NetworkInterfaceType type) => type switch
+    {
+        NetworkInterfaceType.Ethernet or NetworkInterfaceType.GigabitEthernet
+            or NetworkInterfaceType.FastEthernetT or NetworkInterfaceType.FastEthernetFx => 0,
+        NetworkInterfaceType.Wireless80211 => 1,
+        NetworkInterfaceType.Ppp => 2,
+        _ => 3 // virtual / unknown
+    };
 }

--- a/SysManager/SysManager/Helpers/RecycleBinHelper.cs
+++ b/SysManager/SysManager/Helpers/RecycleBinHelper.cs
@@ -26,17 +26,14 @@ public static partial class RecycleBinHelper
     /// </summary>
     public static bool EmptyAllDrives()
     {
-        try
-        {
-            int hr = NativeMethods.SHEmptyRecycleBin(IntPtr.Zero, null, SuppressAllFlags);
-            // S_OK (>= 0) = success, ERROR_NO_MORE_FILES = bin already empty.
-            return hr >= 0 || unchecked((uint)hr) == ErrorNoMoreFiles;
-        }
-        catch (System.ComponentModel.Win32Exception ex)
-        {
-            Log.Warning("Empty recycle bin failed: {Error}", ex.Message);
-            return false;
-        }
+        // SHEmptyRecycleBin is a LibraryImport returning an HRESULT — it reports failure
+        // through the return code, not an exception, so there is nothing to catch here.
+        int hr = NativeMethods.SHEmptyRecycleBin(IntPtr.Zero, null, SuppressAllFlags);
+        // S_OK (>= 0) = success, ERROR_NO_MORE_FILES = bin already empty.
+        bool ok = hr >= 0 || unchecked((uint)hr) == ErrorNoMoreFiles;
+        if (!ok)
+            Log.Warning("Empty recycle bin failed: HRESULT 0x{Hr:X8}", hr);
+        return ok;
     }
 
     private static partial class NativeMethods

--- a/SysManager/SysManager/Services/SafetyDatabase.cs
+++ b/SysManager/SysManager/Services/SafetyDatabase.cs
@@ -61,7 +61,6 @@ public static class SafetyDatabase
         ["BITS"] = "Background Intelligent Transfer — used by Windows Update and Store. Disabling may break updates.",
         ["Themes"] = "Themes — provides visual themes. Disabling gives classic look but saves minimal resources.",
         ["AudioSrv"] = "Windows Audio — disabling removes all sound. Only disable on headless servers.",
-        ["Audiosrv"] = "Windows Audio — disabling removes all sound.",
         ["Dhcp"] = "DHCP Client — auto-assigns IP. Disable only with static IP configured.",
         ["Dnscache"] = "DNS Client — caches DNS lookups. Disabling slows browsing.",
         ["EventLog"] = "Windows Event Log — disabling prevents all logging. Bad for troubleshooting.",

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -234,8 +234,10 @@ public sealed class UpdateService
         }
         catch (OperationCanceledException)
         {
+            // Only clean the partial in-progress temp file. `target` may be a
+            // previously-downloaded, still-valid cached binary — deleting it on a
+            // cancelled re-download would force an avoidable re-download next launch.
             CleanupFile(tempFile);
-            CleanupFile(target);
             return null;
         }
         catch (HttpRequestException ex)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.51.9</Version>
-    <FileVersion>1.51.9.0</FileVersion>
-    <AssemblyVersion>1.51.9.0</AssemblyVersion>
+    <Version>1.51.10</Version>
+    <FileVersion>1.51.10.0</FileVersion>
+    <AssemblyVersion>1.51.10.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Four data/logic-correctness fixes from the audit (the trivial, low-risk subset of the "real bugs" tier). Each re-verified against current source.

- **UpdateService** (idx 190) — cancelling a fresh download also deleted any already-cached, still-valid installer (`CleanupFile(target)` in the `OperationCanceledException` handler), forcing an avoidable re-download. Now only the partial temp file is cleaned, matching the network/IO handlers.
- **SafetyDatabase** (idx 173/308) — the case-insensitive `CautionServices` dictionary held both `"AudioSrv"` and `"Audiosrv"`; the second silently overwrote the first, dropping the "Only disable on headless servers" guidance. Removed the duplicate.
- **GatewayHelper** (idx 207) — `DetectDefaultGateway` returned the first active non-loopback NIC's gateway, so on a machine with a VPN/virtual adapter up it could pick the wrong gateway as the ping/monitor target. Now skips tunnel adapters and prefers physical types (Ethernet/Wi-Fi), fastest link first.
- **RecycleBinHelper** (idx 210) — removed an unreachable `catch (Win32Exception)`: `SHEmptyRecycleBin` is a `LibraryImport` returning an HRESULT and never throws. The failure path now reads and logs the HRESULT directly.

## Tests
- `SafetyDatabaseTests` — added a theory asserting the Windows Audio description retains "headless servers" guidance for `AudioSrv`/`Audiosrv`/`audiosrv` (the dedup kept the richer entry).

## Notes
- The UpdateService cancel path and GatewayHelper multi-NIC selection are environment-dependent (cancellation timing / live adapter topology), so they have no isolated unit test; the change is a minimal, behavior-preserving correction verified by reading the surrounding logic.

## Verification
- `dotnet build` (main + tests) — 0 warnings / 0 errors. `dotnet test` not run locally (firewall); CI runs the suite.
