### PR TITLE
fix: free Known-Folder native buffer, gate power-plan writers, thread-safe winget-list collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.51.11] - 2026-06-30
+
+### Fixed
+- **A native string buffer was leaked on every Known-Folder lookup.** The Downloads/Documents/Desktop/Pictures/Music/Videos path resolver marshalled the Win32 result as a managed string but never freed the underlying COM-allocated buffer; it now takes the raw pointer and frees it, so repeated lookups (cleanup scans, etc.) no longer leak memory.
+- **Two power-plan changes could corrupt a concurrent power-query's output.** The power-plan/processor-state/hibernation writers shared the same process runner as the readers that parse `powercfg` output, but ran without the reader's serialization gate; a write running during a read could interleave the output stream. The writers now take the same gate.
+- **Listing installed apps could drop or corrupt a line under a thread race.** The winget-list output collector used a plain list that both the stdout and stderr reader threads wrote to concurrently; it now uses a thread-safe queue, matching the upgrade-list path.
+
 ## [1.51.10] - 2026-06-30
 
 ### Fixed

--- a/SysManager/SysManager.Tests/KnownFoldersTests.cs
+++ b/SysManager/SysManager.Tests/KnownFoldersTests.cs
@@ -1,0 +1,49 @@
+// SysManager · KnownFoldersTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Helpers;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="KnownFolders"/> — verifies the SHGetKnownFolderPath wrapper
+/// still resolves real, rooted folder paths after switching to manual PWSTR
+/// marshalling (the previous <c>out string</c> form leaked the CoTaskMem buffer per
+/// call; the wrapper now frees it itself). Assertions stay environment-independent:
+/// every Windows profile resolves these to a non-empty rooted path (either the
+/// relocated Known Folder or the SpecialFolder fallback), so they don't depend on a
+/// particular folder existing on a headless CI runner.
+/// </summary>
+public class KnownFoldersTests
+{
+    public static IEnumerable<object[]> Resolvers =>
+    [
+        [() => KnownFolders.GetDownloadsPath()],
+        [() => KnownFolders.GetDocumentsPath()],
+        [() => KnownFolders.GetDesktopPath()],
+        [() => KnownFolders.GetPicturesPath()],
+        [() => KnownFolders.GetMusicPath()],
+        [() => KnownFolders.GetVideosPath()],
+    ];
+
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void GetKnownPath_ReturnsNonEmptyRootedPath(Func<string> resolve)
+    {
+        var path = resolve();
+        Assert.False(string.IsNullOrWhiteSpace(path));
+        Assert.True(Path.IsPathRooted(path), $"expected a rooted path, got: {path}");
+    }
+
+    [Fact]
+    public void GetDownloadsPath_IsStableAcrossManyCalls()
+    {
+        // Repeated calls must return the same path and must not crash — exercises the
+        // marshal/free path many times (the leak fix runs on every call).
+        var first = KnownFolders.GetDownloadsPath();
+        for (var i = 0; i < 50; i++)
+            Assert.Equal(first, KnownFolders.GetDownloadsPath());
+    }
+}

--- a/SysManager/SysManager/Helpers/KnownFolders.cs
+++ b/SysManager/SysManager/Helpers/KnownFolders.cs
@@ -22,12 +22,15 @@ internal static partial class KnownFolders
     private static readonly Guid Music = new("4BD8D571-6D19-48D3-BE97-422220080E43");
     private static readonly Guid Videos = new("18989B1D-99B5-455B-841C-AB7C74E4DDFC");
 
-    [LibraryImport("shell32.dll", StringMarshalling = StringMarshalling.Utf16)]
+    // Returns the path through a CoTaskMem-allocated PWSTR that the CALLER must free.
+    // Marshalling to `out string` would copy the buffer but never release it (a native
+    // leak per call), so we take the raw pointer and free it ourselves.
+    [LibraryImport("shell32.dll")]
     private static partial int SHGetKnownFolderPath(
         in Guid rfid,
         uint dwFlags,
         nint hToken,
-        out string pszPath);
+        out nint ppszPath);
 
     /// <summary>Gets the actual Downloads folder path (respects user relocation).</summary>
     public static string GetDownloadsPath() => GetPath(Downloads);
@@ -51,15 +54,26 @@ internal static partial class KnownFolders
     {
         // The import returns the HRESULT. Because this is a plain (non-COM-interface)
         // LibraryImport, a failure does NOT throw — it returns a non-zero HRESULT and a
-        // null/empty path. Check the HRESULT (and guard the path) and fall back to the
-        // SpecialFolder equivalent on any failure.
+        // null pointer. Check the HRESULT (and guard the path) and fall back to the
+        // SpecialFolder equivalent on any failure. The returned PWSTR is CoTaskMem and
+        // MUST be freed by us.
+        nint ptr = nint.Zero;
         try
         {
-            int hr = SHGetKnownFolderPath(folderId, 0, nint.Zero, out var path);
-            if (hr >= 0 && !string.IsNullOrEmpty(path))
-                return path;
+            int hr = SHGetKnownFolderPath(folderId, 0, nint.Zero, out ptr);
+            if (hr >= 0 && ptr != nint.Zero)
+            {
+                var path = Marshal.PtrToStringUni(ptr);
+                if (!string.IsNullOrEmpty(path))
+                    return path;
+            }
         }
         catch (COMException) { /* fall through to the SpecialFolder fallback below */ }
+        finally
+        {
+            if (ptr != nint.Zero)
+                Marshal.FreeCoTaskMem(ptr);
+        }
 
         return Fallback(folderId);
     }

--- a/SysManager/SysManager/Services/PerformanceService.cs
+++ b/SysManager/SysManager/Services/PerformanceService.cs
@@ -230,7 +230,15 @@ public sealed partial class PerformanceService : IDisposable
     /// <summary>Activate a power plan by GUID.</summary>
     public async Task SetActivePlanAsync(string guid, CancellationToken ct = default)
     {
-        await _ps.RunProcessAsync("powercfg.exe", $"/setactive {guid}", ct, PowerShellRunner.OemEncoding).ConfigureAwait(false);
+        // Serialize on the same gate the readers use: they own the shared
+        // _ps.LineReceived while parsing, and a concurrent powercfg call on the
+        // same runner would interleave their output stream.
+        await _psGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await _ps.RunProcessAsync("powercfg.exe", $"/setactive {guid}", ct, PowerShellRunner.OemEncoding).ConfigureAwait(false);
+        }
+        finally { _psGate.Release(); }
     }
 
     /// <summary>
@@ -528,11 +536,17 @@ public sealed partial class PerformanceService : IDisposable
     /// </summary>
     public async Task SetProcessorMinStateAsync(int percent, CancellationToken ct = default)
     {
-        await _ps.RunProcessAsync("powercfg.exe",
-            $"/setacvalueindex SCHEME_CURRENT SUB_PROCESSOR PROCTHROTTLEMIN {percent}", ct, PowerShellRunner.OemEncoding).ConfigureAwait(false);
-        await _ps.RunProcessAsync("powercfg.exe",
-            $"/setdcvalueindex SCHEME_CURRENT SUB_PROCESSOR PROCTHROTTLEMIN {percent}", ct, PowerShellRunner.OemEncoding).ConfigureAwait(false);
-        await _ps.RunProcessAsync("powercfg.exe", "/setactive SCHEME_CURRENT", ct, PowerShellRunner.OemEncoding).ConfigureAwait(false);
+        // Serialize on the shared gate — see SetActivePlanAsync.
+        await _psGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await _ps.RunProcessAsync("powercfg.exe",
+                $"/setacvalueindex SCHEME_CURRENT SUB_PROCESSOR PROCTHROTTLEMIN {percent}", ct, PowerShellRunner.OemEncoding).ConfigureAwait(false);
+            await _ps.RunProcessAsync("powercfg.exe",
+                $"/setdcvalueindex SCHEME_CURRENT SUB_PROCESSOR PROCTHROTTLEMIN {percent}", ct, PowerShellRunner.OemEncoding).ConfigureAwait(false);
+            await _ps.RunProcessAsync("powercfg.exe", "/setactive SCHEME_CURRENT", ct, PowerShellRunner.OemEncoding).ConfigureAwait(false);
+        }
+        finally { _psGate.Release(); }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -608,7 +622,13 @@ public sealed partial class PerformanceService : IDisposable
     public async Task SetHibernationAsync(bool enabled, CancellationToken ct = default)
     {
         var arg = enabled ? "/hibernate on" : "/hibernate off";
-        await _ps.RunProcessAsync("powercfg.exe", arg, ct, PowerShellRunner.OemEncoding).ConfigureAwait(false);
+        // Serialize on the shared gate — see SetActivePlanAsync.
+        await _psGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await _ps.RunProcessAsync("powercfg.exe", arg, ct, PowerShellRunner.OemEncoding).ConfigureAwait(false);
+        }
+        finally { _psGate.Release(); }
     }
 
     // ═══════════════════════════════════════════════════════════════

--- a/SysManager/SysManager/Services/UninstallerService.cs
+++ b/SysManager/SysManager/Services/UninstallerService.cs
@@ -28,10 +28,13 @@ public sealed partial class UninstallerService
     /// </summary>
     public async Task<List<InstalledApp>> ListInstalledAsync(CancellationToken ct = default)
     {
-        List<string> captured = [];
+        // LineReceived fires from both the stdout and stderr reader threads
+        // concurrently, so the sink must be thread-safe — a plain List<T>.Add can
+        // corrupt the backing array or drop a line under the race.
+        var captured = new System.Collections.Concurrent.ConcurrentQueue<string>();
         void Collect(PowerShellLine l)
         {
-            if (l.Kind == OutputKind.Output) captured.Add(l.Text);
+            if (l.Kind == OutputKind.Output) captured.Enqueue(l.Text);
         }
 
         _runner.LineReceived += Collect;
@@ -42,7 +45,7 @@ public sealed partial class UninstallerService
         }
         finally { _runner.LineReceived -= Collect; }
 
-        return ParseListTable(captured);
+        return ParseListTable(captured.ToList());
     }
 
     /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.51.10</Version>
-    <FileVersion>1.51.10.0</FileVersion>
-    <AssemblyVersion>1.51.10.0</AssemblyVersion>
+    <Version>1.51.11</Version>
+    <FileVersion>1.51.11.0</FileVersion>
+    <AssemblyVersion>1.51.11.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Three concurrency/resource-correctness fixes from the audit. Each re-verified against current source.

- **KnownFolders** (idx 208, resource-leak) — `SHGetKnownFolderPath` was marshalled as `out string`, which copies the COM-allocated PWSTR into a managed string but never frees the native buffer, leaking it on every Downloads/Documents/Desktop/Pictures/Music/Videos lookup. Now takes the raw `out nint`, marshals with `Marshal.PtrToStringUni`, and frees with `Marshal.FreeCoTaskMem` in a `finally`.
- **PerformanceService** (idx 61, concurrency) — the reader methods acquire `_psGate` and own the shared `_ps.LineReceived` while parsing `powercfg` output, but the writers (`SetActivePlanAsync`, `SetProcessorMinStateAsync`, `SetHibernationAsync`) called `RunProcessAsync` on the same runner without the gate, so a write running during a read could interleave its output stream. The three writers now take the same gate.
- **UninstallerService** (idx 63, concurrency) — the `winget list` output collector used a `List<string>` that `LineReceived` writes to from both the stdout and stderr reader threads concurrently, which can corrupt the backing array or drop a line. Switched to `ConcurrentQueue<string>`, matching the already-fixed `WingetService` upgrade path.

## Tests
- `KnownFoldersTests` (new) — environment-independent assertions that every Known-Folder resolver still returns a non-empty rooted path and is stable across 50 calls (exercising the marshal/free path repeatedly). Uses `InternalsVisibleTo`.

## Notes (honest scope)
- The two race fixes (PerformanceService gate, Uninstaller collector) have **no isolated unit test**: both services take a concrete `PowerShellRunner` (no `IPowerShellRunner` seam) and the race lives in a private collector closure / shared runner, so it can't be deterministically reproduced in a unit test. The fixes are correctness-by-construction — the Uninstaller one mirrors the proven `WingetService` `ConcurrentQueue` pattern, and the PerformanceService one reuses the existing reader gate. Adding the runner seam is a separate architecture task (audit backlog).

## Verification
- `dotnet build` (main + tests) — 0 warnings / 0 errors. `dotnet test` not run locally (firewall); CI runs the suite.
