### PR TITLE
fix: skip symlinked files in shredder, preserve hosts ACL on restore, stricter hostname validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.51.12] - 2026-06-30
+
+### Fixed
+- **File shredder no longer follows symlinked files out of the selected folder.** When shredding a folder, the file walk skipped reparse-point directories but still included reparse-point files, so a symlink/hardlink file could cause its link target — possibly outside the folder — to be overwritten. Symlinked files are now skipped, matching the existing directory behaviour.
+- **Restoring the hosts file backup preserves the file's security descriptor.** Restore used a plain overwrite-copy, which relinks a new file that inherits only the folder's default permissions; it now replaces the file in place (like Save does), keeping the hardened hosts-file ACL.
+- **Hostname validation for new hosts entries is stricter.** The validator accepted malformed names such as consecutive dots (`a..b`), a leading/trailing dot, and over-long labels. It now enforces proper DNS label rules (1–63 chars per label, no consecutive or edge dots).
+
 ## [1.51.11] - 2026-06-30
 
 ### Fixed

--- a/SysManager/SysManager.Tests/HostsFileServiceTests.cs
+++ b/SysManager/SysManager.Tests/HostsFileServiceTests.cs
@@ -182,9 +182,11 @@ public class HostsFileServiceTests
 
     [Theory]
     [InlineData("999.999.999.999")]   // out-of-range octets
-    [InlineData("1.2.3")]             // too few octets
+    [InlineData("256.1.1.1")]         // first octet out of range
     [InlineData("notanip")]
     [InlineData("")]
+    // NOTE: do NOT use "1.2.3" here — IPAddress.TryParse accepts dotted shorthand
+    // ("1.2.3" -> 1.2.0.3), so it is a VALID address, not a rejection case.
     public void AddEntry_InvalidIp_Throws(string ip)
     {
         var (svc, _, dir) = NewServiceWithTempHosts("127.0.0.1 localhost\n");

--- a/SysManager/SysManager.Tests/HostsFileServiceTests.cs
+++ b/SysManager/SysManager.Tests/HostsFileServiceTests.cs
@@ -149,6 +149,89 @@ public class HostsFileServiceTests
     }
 
     [Fact]
+    public void RestoreBackup_PreservesOriginalFileIdentity_NotJustContent()
+    {
+        // Regression (idx 158, ACL/attribute loss): RestoreBackup must replace the hosts
+        // file in place (File.Replace) so the hardened DACL is preserved, not relink a new
+        // inode (File.Copy overwrite). Same creation-time proxy as the SaveHosts test:
+        // File.Replace keeps the original creation time; a fresh copy would reset it.
+        const string original = "# ORIGINAL pristine hosts\n127.0.0.1 original\n";
+        var (svc, hosts, dir) = NewServiceWithTempHosts(original);
+        try
+        {
+            var stamp = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            File.SetCreationTimeUtc(hosts, stamp);
+
+            svc.SaveHosts(new List<HostsEntry>
+            {
+                new() { IpAddress = "9.9.9.9", Hostname = "managed", IsEnabled = true }
+            });
+            Assert.True(svc.RestoreBackup());
+
+            Assert.Equal(original, File.ReadAllText(hosts));
+            Assert.Equal(stamp, File.GetCreationTimeUtc(hosts));
+            Assert.False(File.Exists(hosts + ".sysmanager.restore.tmp"), "restore temp file left behind");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    // ---------- AddEntry validation (idx 156 + the missing negative tests) ----------
+
+    [Theory]
+    [InlineData("999.999.999.999")]   // out-of-range octets
+    [InlineData("1.2.3")]             // too few octets
+    [InlineData("notanip")]
+    [InlineData("")]
+    public void AddEntry_InvalidIp_Throws(string ip)
+    {
+        var (svc, _, dir) = NewServiceWithTempHosts("127.0.0.1 localhost\n");
+        try
+        {
+            Assert.Throws<ArgumentException>(() => svc.AddEntry(ip, "example.com"));
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    [Theory]
+    [InlineData("")]                  // empty
+    [InlineData("   ")]               // whitespace
+    [InlineData("bad host")]          // space
+    [InlineData("a..b")]              // consecutive dots — accepted by the old loose regex
+    [InlineData(".leadingdot")]       // leading dot
+    [InlineData("trailingdot.")]      // trailing dot
+    [InlineData("under_score")]       // underscore not allowed in DNS labels
+    [InlineData("-leadinghyphen.com")]
+    public void AddEntry_InvalidHostname_Throws(string hostname)
+    {
+        var (svc, _, dir) = NewServiceWithTempHosts("127.0.0.1 localhost\n");
+        try
+        {
+            Assert.Throws<ArgumentException>(() => svc.AddEntry("1.1.1.1", hostname));
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    [Theory]
+    [InlineData("example.com")]
+    [InlineData("sub.domain.example.com")]
+    [InlineData("localhost")]
+    [InlineData("a-b.example")]
+    public void AddEntry_ValidInput_Succeeds(string hostname)
+    {
+        var (svc, _, dir) = NewServiceWithTempHosts("127.0.0.1 localhost\n");
+        try
+        {
+            var entry = svc.AddEntry("1.1.1.1", hostname);
+            Assert.Equal(hostname, entry.Hostname);
+            Assert.Equal("1.1.1.1", entry.IpAddress);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    [Fact]
     public void SaveHosts_LeavesNoTempFileBehind()
     {
         // Regression (atomic write): SaveHosts writes to a temp file then moves it

--- a/SysManager/SysManager/Services/FileShredderService.cs
+++ b/SysManager/SysManager/Services/FileShredderService.cs
@@ -209,7 +209,10 @@ public sealed partial class FileShredderService
             catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Shredder: access denied enumerating {Dir}", dir.FullName); continue; }
             catch (IOException ex) { Log.Debug(ex, "Shredder: I/O error enumerating {Dir}", dir.FullName); continue; }
 
-            foreach (var file in files)
+            // Skip symlink/hardlink files: shredding would overwrite the LINK TARGET
+            // (which may live outside the selected folder), so only real files in the
+            // tree are collected — mirrors the reparse-point skip on directories below.
+            foreach (var file in files.Where(f => (f.Attributes & FileAttributes.ReparsePoint) == 0))
                 results.Add(file.FullName);
 
             DirectoryInfo[] subDirs;

--- a/SysManager/SysManager/Services/HostsFileService.cs
+++ b/SysManager/SysManager/Services/HostsFileService.cs
@@ -32,7 +32,11 @@ public sealed partial class HostsFileService
         BackupPath = HostsPath + ".bak";
     }
 
-    [GeneratedRegex(@"^[a-zA-Z0-9]([a-zA-Z0-9\-\.]*[a-zA-Z0-9])?$")]
+    // One or more DNS labels separated by single dots. Each label is 1–63 chars,
+    // alphanumeric with internal hyphens only (no leading/trailing hyphen). This
+    // rejects consecutive dots ("a..b"), a leading/trailing dot, and over-long labels
+    // that the previous looser pattern accepted.
+    [GeneratedRegex(@"^(?=.{1,253}$)[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$")]
     private static partial Regex HostnameRegex();
 
     /// <summary>
@@ -165,7 +169,31 @@ public sealed partial class HostsFileService
     public bool RestoreBackup()
     {
         if (!File.Exists(BackupPath)) return false;
-        File.Copy(BackupPath, HostsPath, overwrite: true);
+
+        // Preserve the hardened hosts-file DACL the same way SaveHosts does: stage the
+        // backup content in a temp file then File.Replace it in, which copies the
+        // existing target's security descriptor onto the replacement. A plain
+        // File.Copy(overwrite:true) would relink a new inode that inherits only the
+        // directory's default ACL, silently weakening the file.
+        var tempPath = HostsPath + ".sysmanager.restore.tmp";
+        try
+        {
+            File.Copy(BackupPath, tempPath, overwrite: true);
+
+            if (File.Exists(HostsPath))
+                File.Replace(tempPath, HostsPath, destinationBackupFileName: null);
+            else
+                File.Move(tempPath, HostsPath, overwrite: false);
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+            {
+                try { File.Delete(tempPath); }
+                catch (IOException) { /* best-effort temp cleanup */ }
+                catch (UnauthorizedAccessException) { /* best-effort temp cleanup */ }
+            }
+        }
         return true;
     }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.51.11</Version>
-    <FileVersion>1.51.11.0</FileVersion>
-    <AssemblyVersion>1.51.11.0</AssemblyVersion>
+    <Version>1.51.12</Version>
+    <FileVersion>1.51.12.0</FileVersion>
+    <AssemblyVersion>1.51.12.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Three security-hardening fixes from the audit. Each re-verified against current source; isolated and behavior-preserving for valid input.

- **FileShredderService** (idx 60) — `EnumerateFilesSafe` skipped reparse-point *directories* but added all *files*, so a symlink/hardlink file in the shredded folder caused its link target (possibly outside the folder) to be overwritten. Now skips reparse-point files too, matching the directory behaviour. `ValidatePath` still blocks system-protected targets; this closes the in-tree symlink-file case.
- **HostsFileService.RestoreBackup** (idx 158) — used `File.Copy(overwrite:true)`, which relinks a new inode that inherits only the directory's default ACL, dropping the hardened hosts-file DACL. Now stages the backup to a temp file and `File.Replace`s it in place, preserving the security descriptor — exactly what `SaveHosts` already does.
- **HostsFileService.HostnameRegex** (idx 156) — the old pattern `^[a-zA-Z0-9]([a-zA-Z0-9\-\.]*[a-zA-Z0-9])?$` accepted consecutive dots (`a..b`), and over-long labels. Replaced with a proper DNS pattern (1–63-char labels, single-dot separators, no leading/trailing dot, ≤253 total).

## Tests
- `HostsFileServiceTests` — added:
  - `AddEntry_InvalidIp_Throws` / `AddEntry_InvalidHostname_Throws` (incl. `a..b`, `.x`, `x.`, underscore, leading hyphen) / `AddEntry_ValidInput_Succeeds` — these also close the previously-missing negative-test gap for the sole input-validation seam.
  - `RestoreBackup_PreservesOriginalFileIdentity_NotJustContent` — uses the creation-time proxy (File.Replace preserves it; a fresh copy resets it) to prove the in-place replace path, and asserts no restore temp file is left behind.

## Notes
- The FileShredder symlink-file skip has no isolated unit test (creating a symlink needs admin/developer mode on CI); it's a one-line guard mirroring the already-tested directory skip. The existing FileShredder symlink/junction *path-validation* tests remain the coverage for the protected-target case.

## Deferred to backlog (need design, not "safe isolated")
Registry-write allowlist helper (idx 175/306), Defender exclusion-path validation (151), Ookla signature chain validation (62), named-pipe ACL (206), EventLog XPath strip robustness (214).

## Verification
- `dotnet build` (main + tests) — 0 warnings / 0 errors. `dotnet test` not run locally (firewall); CI runs the suite.
