### PR TITLE
docs: refresh supported version, mark Preview tabs, fix stale smoke-test nav id

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,18 +85,19 @@ implemented; 5 are work-in-progress placeholders marked with ⚙️:
 | Group | Tabs |
 |-------|------|
 | 🏠 Dashboard | Dashboard |
-| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Task Scheduler · Boot Analyzer · System Fixes · Tweaks Hub |
+| 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Task Scheduler · Boot Analyzer · System Fixes · Tweaks Hub 🔬 |
 | 🎮 Gaming & Profiles | Gaming Profile ⚙️ · Standby List Cleaner · Timer Resolution · CPU Core Affinity · Display Profiles |
-| 📊 Monitor | Process Manager · Resource History · Camera/Mic/Location · App Alerts · File Lock Detector · Settings Watchdog · Bandwidth Monitor ⚙️ |
-| 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance |
+| 📊 Monitor | Process Manager · Resource History 🔬 · Camera/Mic/Location · App Alerts · File Lock Detector · Settings Watchdog 🔬 · Bandwidth Monitor ⚙️ |
+| 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance 🔬 |
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS & Hosts |
 | 📦 Apps | App Updates · Bulk Installer · Uninstaller |
 | 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover ⚙️ · Defender Tweaks · Notification Blocker ⚙️ |
 | 🎨 Customization | Context Menu · Dark Mode Scheduler · Volume Control ⚙️ |
 | ℹ️ Info | Drivers · Battery Health · System Logs · System Report · Legacy Panels · About |
-| ⚙️ Advanced | Profile Export/Import · CLI Interface · Environment Variables |
+| ⚙️ Advanced | Profile Export/Import · CLI Interface 🔬 · Environment Variables |
 
+> 🔬 = Preview — fully implemented and usable, marked in-app while it settles in.
 > ⚙️ = Work in Progress — placeholder tab visible in the sidebar, implementation coming in future updates.
 
 Groups expand and collapse with a click. Collapsed groups show a child count

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.42.x   | :white_check_mark: |
-| < 1.42   | :x:                |
+| 1.51.x   | :white_check_mark: |
+| < 1.51   | :x:                |
 
 ## Reporting a vulnerability
 

--- a/docs/manual-smoke.ps1
+++ b/docs/manual-smoke.ps1
@@ -32,7 +32,8 @@ $navIds = @(
     'nav-system-health',
     'nav-cleanup',
     'nav-deep-cleanup',
-    'nav-network',
+    'nav-ping',
+    'nav-network-repair',
     'nav-drivers',
     'nav-logs',
     'nav-about'


### PR DESCRIPTION
## Summary

Documentation/script-accuracy fixes from the audit. Docs + a helper script only — no shipped code, no release.

- **SECURITY.md** (idx 56) — supported-versions table was stuck at `1.42.x` (nine minor releases stale); bumped to `1.51.x` / `< 1.51`.
- **README** (idx 80) — the five tabs that ship with an in-app **PREVIEW** banner (Tweaks Hub, Resource History, Settings Watchdog, Scheduled Maintenance, CLI Interface) were listed as fully-shipped features. Added a 🔬 Preview marker + legend, distinct from the existing `⚙️` Work-in-Progress placeholder marker, so the docs match the UI.
- **docs/manual-smoke.ps1** (idx 0) — the manual smoke test iterated a hardcoded `nav-network` AutomationId that no longer exists (the network section was split into `nav-ping`/`nav-traceroute`/`nav-speed-test`/`nav-network-repair`/`nav-dns-hosts`), so the script always failed on a healthy build. Replaced with real ids (`nav-ping`, `nav-network-repair`).

## Verification
- The two new smoke-test nav ids (`nav-ping`, `nav-network-repair`) verified present in `MainWindowViewModel`.
- No `.cs`/`.csproj` touched → `docs:` (no version bump, no release).
