### PR TITLE
fix: registry-restore allowlist, Defender exclusion validation, Ookla cert chain, event-log filter allowlist, pipe ACL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.51.13] - 2026-06-30
+
+### Security
+- **Settings Watchdog restore is now allowlisted to its own catalog.** The restore path verified the hive but not the full setting; it now only ever writes a setting present in the watchdog's curated catalog (matched by exact path and value name), so it can never be repurposed to write an arbitrary registry key.
+- **Defender exclusion paths are validated at the service boundary.** Adding a scan exclusion now rejects empty, non-rooted, and wildcard (`*`/`?`) paths at the service itself (not just the UI), so an over-broad exclusion can't weaken Defender via any caller.
+- **The downloaded Ookla speed-test CLI now has its full certificate chain validated.** Verification previously checked only that the Authenticode subject contained "Ookla"; it now also builds and validates the certificate chain to a trusted root with online revocation, failing closed (and deleting the binary) if the chain is not valid.
+- **Event-log provider filtering uses an allowlist instead of character stripping.** A provider name with unexpected characters is now rejected outright rather than silently stripped (which could mangle a legitimate name into a different, wrong filter); injection remains blocked.
+- **The single-instance named pipe is restricted to the current user.** The activation pipe is now created with an explicit ACL granting only the current user connect rights, instead of relying on the default permissions.
+
 ## [1.51.12] - 2026-06-30
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DefenderServiceTests.cs
+++ b/SysManager/SysManager.Tests/DefenderServiceTests.cs
@@ -51,6 +51,24 @@ public class DefenderServiceTests
     public void ClampTri_KeepsZeroToTwo(int input, int expected)
         => Assert.Equal(expected, DefenderService.ClampTri(input));
 
+    // ── Exclusion-path validation at the service boundary (idx 151) ───────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("relative\\path")]   // not rooted
+    [InlineData(@"C:\Games\*")]       // wildcard
+    [InlineData(@"C:\Games\?")]       // wildcard
+    public void IsValidExclusionPath_RejectsBadInput(string? path)
+        => Assert.False(DefenderService.IsValidExclusionPath(path!));
+
+    [Theory]
+    [InlineData(@"C:\Games")]
+    [InlineData(@"D:\Steam\steamapps")]
+    public void IsValidExclusionPath_AcceptsRootedNonWildcardPath(string path)
+        => Assert.True(DefenderService.IsValidExclusionPath(path));
+
     [Fact]
     public void ParseStatus_NormalizesInvertedRealtimeBoolean()
     {

--- a/SysManager/SysManager.Tests/EventLogServiceTests.cs
+++ b/SysManager/SysManager.Tests/EventLogServiceTests.cs
@@ -99,12 +99,26 @@ public class EventLogServiceTests
     }
 
     [Fact]
-    public void BuildXPath_ProviderWithQuotes_SanitizesInput()
+    public void BuildXPath_ProviderWithMetacharacters_IsRejectedNotMangled()
     {
+        // idx 214: a provider name containing XPath metacharacters is now REJECTED via
+        // an allowlist (the clause is dropped) rather than silently stripped into a
+        // different name. Injection is still impossible AND we never build a wrong filter.
         var opt = new EventLogQueryOptions { ProviderName = "test'injection" };
         var result = InvokeBuildXPath(opt);
-        Assert.DoesNotContain("'injection", result);
-        Assert.Contains("testinjection", result);
+        Assert.DoesNotContain("'injection", result);   // no injection
+        Assert.DoesNotContain("Provider", result);      // clause dropped, not mangled-in
+        Assert.DoesNotContain("testinjection", result); // not silently rewritten
+    }
+
+    [Fact]
+    public void BuildXPath_ProviderWithSpacesAndDots_IsAccepted()
+    {
+        // Real provider names like "Microsoft-Windows-Kernel-Power" or "Service Control
+        // Manager" must pass the allowlist verbatim.
+        var opt = new EventLogQueryOptions { ProviderName = "Microsoft-Windows-Kernel-Power" };
+        var result = InvokeBuildXPath(opt);
+        Assert.Contains("Provider[@Name='Microsoft-Windows-Kernel-Power']", result);
     }
 
     // ---------- MapLevel ----------

--- a/SysManager/SysManager.Tests/SettingsWatchdogServiceTests.cs
+++ b/SysManager/SysManager.Tests/SettingsWatchdogServiceTests.cs
@@ -108,4 +108,33 @@ public class SettingsWatchdogServiceTests
             Assert.Matches(@"^(HKCU|HKLM)\\", s.RegistryPath);
         });
     }
+
+    // ── Restore allowlist guard (idx 175) ────────────────────────────────────
+
+    [Fact]
+    public void Restore_OutOfCatalogSetting_IsRefused_AndWritesNothing()
+    {
+        // Regression (idx 175): Restore must only ever write a setting that is part of
+        // its own curated catalog. A hand-built drift pointing at an arbitrary registry
+        // path must be refused BEFORE any registry write — so this returns false without
+        // ever touching the registry (the path below is never opened).
+        var svc = new SettingsWatchdogService();
+        var rogue = new WatchedSetting(
+            "rogue", "Rogue", "Not in catalog", "Cat",
+            @"HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run", "Evil",
+            new Dictionary<int, string>());
+        var drift = new SettingDrift(rogue, BaselineValue: 1, CurrentValue: 0, CanRestore: true);
+
+        Assert.False(svc.Restore(drift));
+    }
+
+    [Fact]
+    public void Restore_NonRestorableOrNoBaseline_ReturnsFalse()
+    {
+        var svc = new SettingsWatchdogService();
+        var known = svc.Catalog[0];
+        // CanRestore=false and null baseline are both early-out false paths.
+        Assert.False(svc.Restore(new SettingDrift(known, BaselineValue: 1, CurrentValue: 0, CanRestore: false)));
+        Assert.False(svc.Restore(new SettingDrift(known, BaselineValue: null, CurrentValue: 0, CanRestore: true)));
+    }
 }

--- a/SysManager/SysManager/App.xaml.cs
+++ b/SysManager/SysManager/App.xaml.cs
@@ -246,9 +246,14 @@ public partial class App : Application
         {
             while (!ct.IsCancellationRequested)
             {
-                await using var server = new NamedPipeServerStream(
+                // Restrict the single-instance pipe to the current user only. The
+                // connection carries no payload (it is a pure "activate the window"
+                // signal), but an explicit DACL stops any other local account from
+                // poking the server, rather than relying on the default ACL.
+                await using var server = NamedPipeServerStreamAcl.Create(
                     PipeName, PipeDirection.In, 1, PipeTransmissionMode.Byte,
-                    PipeOptions.Asynchronous);
+                    PipeOptions.Asynchronous, inBufferSize: 0, outBufferSize: 0,
+                    CreateCurrentUserPipeSecurity());
                 await server.WaitForConnectionAsync(ct).ConfigureAwait(false);
 
                 // A second instance connected — activate our window on the UI thread
@@ -264,6 +269,27 @@ public partial class App : Application
         }
         catch (OperationCanceledException) { /* shutdown */ }
         catch (IOException) { /* pipe broken during shutdown */ }
+    }
+
+    /// <summary>
+    /// Builds a <see cref="PipeSecurity"/> that grants only the current user the right
+    /// to read/write/connect to the single-instance pipe, so no other local account can
+    /// interact with it. Returns null if the current identity can't be resolved, in
+    /// which case the caller falls back to the default ACL.
+    /// </summary>
+    private static System.IO.Pipes.PipeSecurity CreateCurrentUserPipeSecurity()
+    {
+        var security = new System.IO.Pipes.PipeSecurity();
+        using var identity = System.Security.Principal.WindowsIdentity.GetCurrent();
+        var user = identity.User;
+        if (user is not null)
+        {
+            security.AddAccessRule(new System.IO.Pipes.PipeAccessRule(
+                user,
+                System.IO.Pipes.PipeAccessRights.ReadWrite,
+                System.Security.AccessControl.AccessControlType.Allow));
+        }
+        return security;
     }
 
     private static void OnUi(object s, DispatcherUnhandledExceptionEventArgs e)

--- a/SysManager/SysManager/Services/DefenderService.cs
+++ b/SysManager/SysManager/Services/DefenderService.cs
@@ -90,7 +90,25 @@ public sealed class DefenderService
 
     /// <summary>Add a folder exclusion (additive — never replaces the array). Verifies.</summary>
     public Task<DefenderStatus> AddExclusionPathAsync(string path, CancellationToken ct = default)
-        => ApplyAndVerifyAsync("Add-MpPreference -ExclusionPath $Path", new() { ["Path"] = path }, ct);
+    {
+        // Trust-boundary validation at the service (the UI validates too, but the service
+        // is public): reject empty, non-rooted, and wildcard paths so an over-broad
+        // exclusion ("*", "C:\?") can never weaken Defender, even via a non-UI caller.
+        if (!IsValidExclusionPath(path))
+            throw new ArgumentException("Exclusion path must be a rooted path without wildcards.", nameof(path));
+        return ApplyAndVerifyAsync("Add-MpPreference -ExclusionPath $Path", new() { ["Path"] = path }, ct);
+    }
+
+    /// <summary>
+    /// A valid exclusion path is non-empty, rooted, free of wildcards, and within the
+    /// Win32 path length limit. Existence is intentionally NOT required here — the path
+    /// may legitimately not exist yet on the service boundary; the UI checks existence.
+    /// </summary>
+    internal static bool IsValidExclusionPath(string path)
+        => !string.IsNullOrWhiteSpace(path)
+           && System.IO.Path.IsPathRooted(path)
+           && !path.Contains('*') && !path.Contains('?')
+           && path.Length <= 260;
 
     /// <summary>Remove a folder exclusion. Verifies.</summary>
     public Task<DefenderStatus> RemoveExclusionPathAsync(string path, CancellationToken ct = default)

--- a/SysManager/SysManager/Services/EventLogService.cs
+++ b/SysManager/SysManager/Services/EventLogService.cs
@@ -4,6 +4,7 @@
 
 using System.Buffers;
 using System.Diagnostics.Eventing.Reader;
+using System.Text.RegularExpressions;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -14,8 +15,13 @@ namespace SysManager.Services;
 /// FriendlyEventEntry model. Filtering is done with XPath to keep the OS-side
 /// query fast and avoid pulling millions of rows into memory.
 /// </summary>
-public sealed class EventLogService
+public sealed partial class EventLogService
 {
+    // Conservative allowlist for Windows event-log provider names:
+    // letters, digits, space, dot, dash, underscore. Anything else is rejected.
+    [GeneratedRegex(@"^[A-Za-z0-9 ._-]{1,255}$")]
+    private static partial Regex ProviderNameRegex();
+
     /// <summary>
     /// Queries a single log. Security requires admin; we silently skip on
     /// UnauthorizedAccessException so the rest of the dashboard still works.
@@ -157,22 +163,13 @@ public sealed class EventLogService
 
         if (!string.IsNullOrWhiteSpace(opt.ProviderName))
         {
-            // SEC-003: Strip XPath metacharacters to prevent injection.
-            var safe = opt.ProviderName
-                .Replace("'", "")
-                .Replace("\"", "")
-                .Replace("[", "")
-                .Replace("]", "")
-                .Replace("/", "")
-                .Replace("\\", "")
-                .Replace("|", "")
-                .Replace("(", "")
-                .Replace(")", "")
-                .Replace("@", "")
-                .Replace("*", "")
-                .Replace("<", "")
-                .Replace(">", "");
-            clauses.Add($"Provider[@Name='{safe}']");
+            // SEC-003: Allowlist rather than strip. A real Windows provider name is
+            // letters/digits/dot/dash/underscore plus spaces. If it matches, use it
+            // verbatim; if not, skip the provider clause entirely instead of silently
+            // deleting metacharacters — which could mangle a legitimate name into a
+            // different, wrong filter that quietly returns zero rows.
+            if (ProviderNameRegex().IsMatch(opt.ProviderName))
+                clauses.Add($"Provider[@Name='{opt.ProviderName}']");
         }
 
         if (opt.EventId.HasValue)

--- a/SysManager/SysManager/Services/SettingsWatchdogService.cs
+++ b/SysManager/SysManager/Services/SettingsWatchdogService.cs
@@ -87,6 +87,20 @@ public sealed class SettingsWatchdogService : ISettingsWatchdogService
         ArgumentNullException.ThrowIfNull(drift);
         if (!drift.CanRestore || drift.BaselineValue is null) return false;
 
+        // Allowlist guard: only ever write a setting that is part of our own curated
+        // catalog (matched by exact hive+path AND value name). The catalog is the single
+        // source of truth, so the writer can never be repurposed for an arbitrary
+        // registry path even if a caller hands us a hand-built drift.
+        var inCatalog = Catalog.Any(s =>
+            string.Equals(s.RegistryPath, drift.Setting.RegistryPath, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(s.ValueName, drift.Setting.ValueName, StringComparison.OrdinalIgnoreCase));
+        if (!inCatalog)
+        {
+            Log.Warning("Settings Watchdog refused to restore an out-of-catalog setting: {Path}\\{Value}",
+                drift.Setting.RegistryPath, drift.Setting.ValueName);
+            return false;
+        }
+
         try
         {
             using var key = OpenOrCreateKey(drift.Setting.RegistryPath, writable: true);

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -423,16 +423,34 @@ public sealed class SpeedTestService
         try
         {
 #pragma warning disable SYSLIB0057 // CreateFromSignedFile is obsolete — no direct replacement for Authenticode verification
-            var cert = System.Security.Cryptography.X509Certificates.X509Certificate.CreateFromSignedFile(exe);
+            var signer = System.Security.Cryptography.X509Certificates.X509Certificate.CreateFromSignedFile(exe);
 #pragma warning restore SYSLIB0057
-            if (cert is null || !cert.Subject.Contains("Ookla", StringComparison.OrdinalIgnoreCase))
+            using var cert = new System.Security.Cryptography.X509Certificates.X509Certificate2(signer);
+
+            if (!cert.Subject.Contains("Ookla", StringComparison.OrdinalIgnoreCase))
             {
-                Log.Warning("Ookla speedtest.exe Authenticode subject mismatch: {Subject}", cert?.Subject ?? "none");
+                Log.Warning("Ookla speedtest.exe Authenticode subject mismatch: {Subject}", cert.Subject);
                 TryDeleteExe(exe);
                 throw new InvalidOperationException(
-                    $"Ookla speedtest.exe failed Authenticode verification (subject: {cert?.Subject ?? "none"}). Binary deleted for security.");
+                    $"Ookla speedtest.exe failed Authenticode verification (subject: {cert.Subject}). Binary deleted for security.");
             }
-            Log.Information("Ookla speedtest.exe Authenticode verified: {Subject}", cert.Subject);
+
+            // Subject alone is forgeable (anyone can issue a self-signed "Ookla" cert),
+            // so also build and validate the full certificate chain to a trusted root,
+            // with online revocation. Fail closed if the chain does not validate.
+            using var chain = new System.Security.Cryptography.X509Certificates.X509Chain();
+            chain.ChainPolicy.RevocationMode = System.Security.Cryptography.X509Certificates.X509RevocationMode.Online;
+            chain.ChainPolicy.RevocationFlag = System.Security.Cryptography.X509Certificates.X509RevocationFlag.ExcludeRoot;
+            chain.ChainPolicy.VerificationFlags = System.Security.Cryptography.X509Certificates.X509VerificationFlags.NoFlag;
+            if (!chain.Build(cert))
+            {
+                var statuses = string.Join(", ", chain.ChainStatus.Select(s => s.Status.ToString()));
+                Log.Warning("Ookla speedtest.exe certificate chain did not validate: {Status}", statuses);
+                TryDeleteExe(exe);
+                throw new InvalidOperationException(
+                    $"Ookla speedtest.exe certificate chain failed validation ({statuses}). Binary deleted for security.");
+            }
+            Log.Information("Ookla speedtest.exe Authenticode chain verified: {Subject}", cert.Subject);
         }
         catch (System.Security.Cryptography.CryptographicException ex)
         {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.51.12</Version>
-    <FileVersion>1.51.12.0</FileVersion>
-    <AssemblyVersion>1.51.12.0</AssemblyVersion>
+    <Version>1.51.13</Version>
+    <FileVersion>1.51.13.0</FileVersion>
+    <AssemblyVersion>1.51.13.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Five deferred-but-real security-hardening fixes from the audit (the "safe, isolated" subset). Each re-verified against current source.

- **SettingsWatchdogService.Restore** (idx 175) — verified the hive but not the full setting; now only writes a setting present in its own curated `Catalog` (exact path + value name), so the writer can't be repurposed for an arbitrary registry key.
- **DefenderService.AddExclusionPathAsync** (idx 151) — forwarded the path straight to `Add-MpPreference` (bound param, no injection, but no boundary validation). Now rejects empty/non-rooted/wildcard paths at the **service** boundary (`internal static IsValidExclusionPath`), not just the UI.
- **SpeedTestService.VerifyOoklaSignature** (idx 62) — checked only that the Authenticode subject contained "Ookla" (forgeable). Now also builds and validates the full certificate chain to a trusted root with online revocation, failing closed (and deleting the binary) if invalid.
- **EventLogService.BuildXPath** (idx 214) — hand-rolled XPath escaping by stripping metacharacters, which could silently mangle a legitimate provider name into a different filter. Now allowlists the provider name (`^[A-Za-z0-9 ._-]{1,255}$`) and skips the clause if it doesn't match; injection stays blocked.
- **App single-instance pipe** (idx 206) — `NamedPipeServerStream` used the default ACL. Now created via `NamedPipeServerStreamAcl.Create` with an explicit `PipeSecurity` granting only the current user connect rights.

## Tests
- `SettingsWatchdogServiceTests` — `Restore_OutOfCatalogSetting_IsRefused_AndWritesNothing` (refused before any registry write) + non-restorable/no-baseline early-out.
- `DefenderServiceTests` — `IsValidExclusionPath` rejects null/empty/relative/wildcard, accepts rooted non-wildcard paths.

## Notes (honest scope)
- The Ookla chain validation and the pipe ACL have no isolated unit test (they need a real signed binary / a live pipe handshake); both use the standard BCL APIs (`X509Chain.Build`, `NamedPipeServerStreamAcl`) and are verified by build + reading.

## Verification
- `dotnet build` (main + tests) — 0 warnings / 0 errors. `dotnet test` not run locally (firewall); CI runs the suite.
