### PR TITLE
fix: reject trailing-newline injection in 9 boundary validators (+ injection negative tests)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.51.14] - 2026-06-30
+
+### Security
+- **Input validators that feed a command/registry boundary now reject a trailing newline.** Nine allowlist patterns (winget package IDs, service names, blocked-executable names, Appx package names, environment-variable names, Windows-feature names, event-log provider names, and hostnames) used `^…$` anchors, which in .NET match before a trailing newline — so a value like `pkg\n` slipped through and could smuggle a second line into the command. They now use absolute `\A…\z` anchors. The winget package-ID pattern additionally dropped `\s` (which allowed tabs/newlines mid-string) in favour of a literal space.
+
+### Tests
+- Added injection-rejection negative tests for the winget package-ID validators (`UpgradeAsync`, `UninstallAsync`) and the service-name/start-type validator (`SetStartupTypeAsync`), covering command separators, chaining, substitution, quotes, newlines, and over-length input.
+
 ## [1.51.13] - 2026-06-30
 
 ### Security

--- a/SysManager/SysManager.Tests/ServiceManagerServiceTests.cs
+++ b/SysManager/SysManager.Tests/ServiceManagerServiceTests.cs
@@ -107,4 +107,38 @@ public class ServiceManagerServiceTests
         Assert.Contains("Status", changed);
         Assert.Contains("StartType", changed);
     }
+
+    // ── SetStartupTypeAsync input validation (idx 174 — negative tests) ───────
+    // The validation throws BEFORE sc.exe is ever launched, so a real runner can be
+    // passed safely: these rejection paths never spawn a process.
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("bad;name")]      // command separator
+    [InlineData("name&calc")]     // command chaining
+    [InlineData("name|pipe")]
+    [InlineData("name\"quote")]
+    [InlineData("name\nnewline")]
+    public async Task SetStartupTypeAsync_InvalidServiceName_Throws(string serviceName)
+    {
+        var ps = new PowerShellRunner();
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => ServiceManagerService.SetStartupTypeAsync(serviceName, "demand", ps));
+    }
+
+    [Theory]
+    [InlineData("totally-bogus")]
+    [InlineData("AUTOMATIC")]   // the sc.exe token is "auto", not the .NET name
+    [InlineData("")]
+    [InlineData("enabled")]
+    public async Task SetStartupTypeAsync_InvalidStartType_Throws(string startType)
+    {
+        // Valid service name, invalid start type → rejected before sc.exe is launched.
+        // (We deliberately never call it with a VALID type here — that would spawn
+        // sc.exe and mutate a real service.)
+        var ps = new PowerShellRunner();
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => ServiceManagerService.SetStartupTypeAsync("Winmgmt", startType, ps));
+    }
 }

--- a/SysManager/SysManager.Tests/WingetServiceValidationTests.cs
+++ b/SysManager/SysManager.Tests/WingetServiceValidationTests.cs
@@ -1,0 +1,65 @@
+// SysManager · WingetServiceValidationTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Negative tests for the package-ID allowlist on the winget-backed commands
+/// (idx 66). The ID is validated BEFORE winget.exe is ever launched, so a real
+/// runner can be passed safely — the rejection paths never spawn a process. This
+/// is the sole defense against command-injection through a crafted package ID, so
+/// it must be explicitly tested (project rule: a validation that is the only
+/// barrier against bad input must have a negative test).
+/// </summary>
+public class WingetServiceValidationTests
+{
+    // Strings that must be rejected: command separators / chaining / substitution /
+    // quoting / newlines, plus empty/whitespace and an over-length id.
+    public static IEnumerable<object[]> InvalidIds =>
+    [
+        [""],
+        ["   "],
+        ["pkg; calc.exe"],
+        ["pkg && calc"],
+        ["pkg | more"],
+        ["pkg`whoami`"],
+        ["pkg$(whoami)"],
+        ["pkg\"quote"],
+        ["pkg\nnewline"],
+        [new string('a', 257)],   // exceeds the 256-char cap
+    ];
+
+    [Theory]
+    [MemberData(nameof(InvalidIds))]
+    public async Task WingetService_UpgradeAsync_RejectsInvalidId(string id)
+    {
+        var ps = new PowerShellRunner();
+        var svc = new WingetService(ps);
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.UpgradeAsync(id));
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidIds))]
+    public async Task UninstallerService_UninstallAsync_RejectsInvalidId(string id)
+    {
+        var ps = new PowerShellRunner();
+        var svc = new UninstallerService(ps);
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.UninstallAsync(id));
+    }
+
+    [Theory]
+    [InlineData("Microsoft.VisualStudioCode")]
+    [InlineData("Notepad++.Notepad++")]
+    [InlineData("Microsoft.VisualStudio.2022.Community")]
+    [InlineData("7zip.7zip")]
+    public void PackageIdShape_AcceptsRealWorldIds(string id)
+    {
+        // These valid winget IDs must NOT be rejected by the allowlist shape. We can't
+        // call UpgradeAsync here (it would spawn winget); instead assert the IDs only
+        // use the allowed character class, which is exactly what the validator checks.
+        Assert.Matches(@"^[\w.\-/+ ]{1,256}$", id);
+    }
+}

--- a/SysManager/SysManager/Services/AppBlockerService.cs
+++ b/SysManager/SysManager/Services/AppBlockerService.cs
@@ -249,6 +249,7 @@ public sealed partial class AppBlockerService : IAppBlockerService
         return blocked;
     }
 
-    [System.Text.RegularExpressions.GeneratedRegex(@"^[A-Za-z0-9_\-. ]+\.exe$", System.Text.RegularExpressions.RegexOptions.IgnoreCase)]
+    // \A…\z (absolute anchors): ^…$ would accept a trailing newline after ".exe".
+    [System.Text.RegularExpressions.GeneratedRegex(@"\A[A-Za-z0-9_\-. ]+\.exe\z", System.Text.RegularExpressions.RegexOptions.IgnoreCase)]
     private static partial System.Text.RegularExpressions.Regex ExeNamePattern();
 }

--- a/SysManager/SysManager/Services/BulkInstallerService.cs
+++ b/SysManager/SysManager/Services/BulkInstallerService.cs
@@ -39,6 +39,7 @@ public sealed partial class BulkInstallerService
     /// Matches valid winget package IDs: alphanumeric, dots, hyphens,
     /// underscores, forward slashes, plus signs, and spaces. Max 256 chars.
     /// </summary>
-    [GeneratedRegex(@"^[\w.\-/+ ]{1,256}$")]
+    // \A…\z (absolute anchors): ^…$ would accept a trailing newline ("pkg\n").
+    [GeneratedRegex(@"\A[\w.\-/+ ]{1,256}\z")]
     private static partial Regex PackageIdPattern();
 }

--- a/SysManager/SysManager/Services/DebloaterService.cs
+++ b/SysManager/SysManager/Services/DebloaterService.cs
@@ -29,7 +29,9 @@ public sealed partial class DebloaterService
 
     // PackageFullName shape: letters/digits/dot/dash/underscore/tilde, plus we accept the
     // version and publisher-hash segments. Validated before being embedded in a script.
-    [GeneratedRegex(@"^[A-Za-z0-9][A-Za-z0-9._~-]{0,255}$")]
+    // \A…\z (absolute anchors): ^…$ would accept a trailing newline before the package
+    // name is embedded into the Remove-AppxPackage script.
+    [GeneratedRegex(@"\A[A-Za-z0-9][A-Za-z0-9._~-]{0,255}\z")]
     private static partial Regex PackageFullNameRegex();
 
     /// <summary>

--- a/SysManager/SysManager/Services/EnvironmentVariableService.cs
+++ b/SysManager/SysManager/Services/EnvironmentVariableService.cs
@@ -61,7 +61,9 @@ public sealed partial class EnvironmentVariableService
     // Variable names: letters, digits, underscore and a few shell-safe punctuation
     // characters; no '=', no whitespace, no control chars. Rejects the leading '='
     // used by hidden drive-current-directory pseudo-variables (=C:, =ExitCode).
-    [GeneratedRegex(@"^[A-Za-z_][A-Za-z0-9_.()\-]*$")]
+    // \A…\z (absolute anchors): ^…$ would accept a trailing newline in the variable
+    // name before it is used as a registry value name.
+    [GeneratedRegex(@"\A[A-Za-z_][A-Za-z0-9_.()\-]*\z")]
     private static partial Regex VariableNameRegex();
 
     /// <summary>Validates an environment-variable name. Throws <see cref="ArgumentException"/> on invalid input.</summary>

--- a/SysManager/SysManager/Services/EventLogService.cs
+++ b/SysManager/SysManager/Services/EventLogService.cs
@@ -19,7 +19,7 @@ public sealed partial class EventLogService
 {
     // Conservative allowlist for Windows event-log provider names:
     // letters, digits, space, dot, dash, underscore. Anything else is rejected.
-    [GeneratedRegex(@"^[A-Za-z0-9 ._-]{1,255}$")]
+    [GeneratedRegex(@"\A[A-Za-z0-9 ._-]{1,255}\z")]
     private static partial Regex ProviderNameRegex();
 
     /// <summary>

--- a/SysManager/SysManager/Services/HostsFileService.cs
+++ b/SysManager/SysManager/Services/HostsFileService.cs
@@ -36,7 +36,7 @@ public sealed partial class HostsFileService
     // alphanumeric with internal hyphens only (no leading/trailing hyphen). This
     // rejects consecutive dots ("a..b"), a leading/trailing dot, and over-long labels
     // that the previous looser pattern accepted.
-    [GeneratedRegex(@"^(?=.{1,253}$)[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$")]
+    [GeneratedRegex(@"\A(?=.{1,253}\z)[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*\z")]
     private static partial Regex HostnameRegex();
 
     /// <summary>

--- a/SysManager/SysManager/Services/ServiceManagerService.cs
+++ b/SysManager/SysManager/Services/ServiceManagerService.cs
@@ -221,6 +221,8 @@ public sealed partial class ServiceManagerService
         catch (UnauthorizedAccessException) { return ""; }
     }
 
-    [System.Text.RegularExpressions.GeneratedRegex(@"^[\w \-.$]+$")]
+    // \A…\z (absolute anchors): ^…$ would accept a trailing newline in the service
+    // name, which is then interpolated into the sc.exe command line.
+    [System.Text.RegularExpressions.GeneratedRegex(@"\A[\w \-.$]+\z")]
     private static partial System.Text.RegularExpressions.Regex ServiceNamePattern();
 }

--- a/SysManager/SysManager/Services/UninstallerService.cs
+++ b/SysManager/SysManager/Services/UninstallerService.cs
@@ -68,7 +68,9 @@ public sealed partial class UninstallerService
     /// Matches valid winget package IDs: alphanumeric, dots, hyphens,
     /// underscores, forward slashes, plus signs, and spaces. Max 256 chars.
     /// </summary>
-    [GeneratedRegex(@"^[\w.\-/+ ]{1,256}$")]
+    // \A…\z (absolute anchors): ^…$ would accept a trailing newline ("pkg\n"),
+    // which could smuggle a second line into the winget argument.
+    [GeneratedRegex(@"\A[\w.\-/+ ]{1,256}\z")]
     private static partial Regex PackageIdPattern();
 
     [GeneratedRegex(@"^\s*Name\s+Id\s+Version", RegexOptions.IgnoreCase)]

--- a/SysManager/SysManager/Services/WindowsFeaturesService.cs
+++ b/SysManager/SysManager/Services/WindowsFeaturesService.cs
@@ -168,6 +168,8 @@ public sealed partial class WindowsFeaturesService
     /// in Enable/DisableFeatureAsync where featureName is interpolated into a command.
     /// Do NOT relax this pattern without reviewing injection implications.
     /// </summary>
-    [GeneratedRegex(@"^[\w.\-]{1,128}$")]
+    // \A…\z (absolute anchors): ^…$ would accept a trailing newline in the feature
+    // name before it is embedded into the PowerShell command.
+    [GeneratedRegex(@"\A[\w.\-]{1,128}\z")]
     private static partial Regex FeatureNamePattern();
 }

--- a/SysManager/SysManager/Services/WingetService.cs
+++ b/SysManager/SysManager/Services/WingetService.cs
@@ -89,7 +89,11 @@ public sealed partial class WingetService
     /// Matches valid winget package IDs: alphanumeric, dots, hyphens,
     /// underscores, forward slashes, plus signs, and spaces. Max 256 chars.
     /// </summary>
-    [GeneratedRegex(@"^[\w.\-/+\s]{1,256}$")]
+    // \A…\z (absolute anchors) rather than ^…$: ^/$ would let a trailing newline
+    // through ("pkg\n" matches as "pkg"), which could smuggle a second line into the
+    // argument. \z anchors at the true end of input. Also dropped \s (which allowed
+    // tabs/newlines mid-string) in favour of a literal space.
+    [GeneratedRegex(@"\A[\w.\-/+ ]{1,256}\z")]
     private static partial Regex PackageIdPattern();
 
     [GeneratedRegex(@"^\s*Name\s+Id\s+Version\s+Available", RegexOptions.IgnoreCase)]

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.51.13</Version>
-    <FileVersion>1.51.13.0</FileVersion>
-    <AssemblyVersion>1.51.13.0</AssemblyVersion>
+    <Version>1.51.14</Version>
+    <FileVersion>1.51.14.0</FileVersion>
+    <AssemblyVersion>1.51.14.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Started as negative-test additions (idx 66, idx 174) — and the new tests **surfaced a real injection-hardening gap**, so this PR now also fixes it (class-wide).

### Security fix
Nine input-validation allowlists that feed a process/registry/PowerShell boundary used `^…$` anchors. In .NET, `$` matches **before a trailing newline**, so a value like `pkg\n` was accepted (matched as `pkg`) — letting a second line be smuggled into the command. Switched all nine to absolute `\A…\z` anchors:

- `WingetService` / `BulkInstallerService` / `UninstallerService` — winget package IDs (WingetService also dropped `\s`, which allowed tabs/newlines mid-string, for a literal space — this was the exact case the new test caught)
- `ServiceManagerService` — service names (→ `sc.exe`)
- `AppBlockerService` — blocked-executable names (→ IFEO registry)
- `DebloaterService` — Appx package names (→ `Remove-AppxPackage`)
- `EnvironmentVariableService` — variable names (→ registry value name)
- `WindowsFeaturesService` — feature names (→ PowerShell)
- `EventLogService` — provider names (→ XPath)
- `HostsFileService` — hostnames (→ hosts file)

### Tests
- `WingetServiceValidationTests` (new) — `UpgradeAsync`/`UninstallAsync` reject empty/whitespace, `;`, `&&`, `|`, `` `…` ``, `$(…)`, quotes, **newlines**, and over-length IDs; accept real IDs.
- `ServiceManagerServiceTests` — `SetStartupTypeAsync` rejects injection-style service names and invalid start types before `sc.exe` runs.

All rejections happen before any process/registry write, so the tests are deterministic.

## Verification
- `dotnet build` (main + tests) 0/0. Every pattern re-verified in real .NET against newline/real-ID cases. `dotnet test` runs in CI.
