### PR TITLE
chore: centralize data-layer status colours into a single StatusColors source

### DIFF
--- a/SysManager/SysManager/Helpers/StatusColors.cs
+++ b/SysManager/SysManager/Helpers/StatusColors.cs
@@ -1,0 +1,33 @@
+// SysManager · StatusColors — single source of truth for status hex colours
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Helpers;
+
+/// <summary>
+/// Canonical status-colour hex strings shared by the models and view-models that
+/// expose a <c>*ColorHex</c> property (disk health, temperature, health score,
+/// tune-up results, cleanup categories, etc.). These were previously copy-pasted as
+/// bare hex literals across ~10 files; centralising them here keeps the palette from
+/// drifting between copies. The values are byte-identical to the previous literals.
+/// </summary>
+internal static class StatusColors
+{
+    /// <summary>Good / healthy / safe — green.</summary>
+    public const string Good = "#22C55E";
+
+    /// <summary>Caution / warning — amber.</summary>
+    public const string Warning = "#F59E0B";
+
+    /// <summary>Informational / nominal — blue.</summary>
+    public const string Info = "#3B82F6";
+
+    /// <summary>Elevated concern — light red.</summary>
+    public const string Elevated = "#F87171";
+
+    /// <summary>Bad / critical / failing — red.</summary>
+    public const string Bad = "#EF4444";
+
+    /// <summary>Unknown / no data / neutral — grey.</summary>
+    public const string Neutral = "#9AA0A6";
+}

--- a/SysManager/SysManager/Models/DiskHealthReport.cs
+++ b/SysManager/SysManager/Models/DiskHealthReport.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;
+using SysManager.Helpers;
 
 namespace SysManager.Models;
 
@@ -52,7 +53,7 @@ public sealed partial class DiskHealthReport : ObservableObject
     private long? _writeErrors;
     [ObservableProperty] private long? _startStopCount;
     [ObservableProperty] private string _verdict = "";         // plain-English summary
-    [ObservableProperty] private string _verdictColorHex = "#9AA0A6";
+    [ObservableProperty] private string _verdictColorHex = StatusColors.Neutral;
 
     /// <summary>
     /// Overall health score 0–100 (100 = perfect). Computed from wear, temperature,
@@ -95,21 +96,21 @@ public sealed partial class DiskHealthReport : ObservableObject
     /// <summary>Color hex for the health percentage gauge.</summary>
     public string HealthPercentColorHex => HealthPercent switch
     {
-        null => "#9AA0A6",
-        >= 80 => "#22C55E",
-        >= 50 => "#F59E0B",
-        >= 20 => "#F87171",
-        _ => "#EF4444"
+        null => StatusColors.Neutral,
+        >= 80 => StatusColors.Good,
+        >= 50 => StatusColors.Warning,
+        >= 20 => StatusColors.Elevated,
+        _ => StatusColors.Bad
     };
 
     /// <summary>Color hex for the temperature reading.</summary>
     public string TemperatureColorHex => TemperatureC switch
     {
-        null => "#9AA0A6",
-        <= 40 => "#22C55E",
-        <= 50 => "#F59E0B",
-        <= 60 => "#F87171",
-        _ => "#EF4444"
+        null => StatusColors.Neutral,
+        <= 40 => StatusColors.Good,
+        <= 50 => StatusColors.Warning,
+        <= 60 => StatusColors.Elevated,
+        _ => StatusColors.Bad
     };
 
     /// <summary>Temperature as a 0–100 gauge value (0 °C = 0, 80 °C = 100).</summary>
@@ -125,11 +126,11 @@ public sealed partial class DiskHealthReport : ObservableObject
     /// <summary>Color hex for the wear gauge.</summary>
     public string WearColorHex => WearPercent switch
     {
-        null => "#9AA0A6",
-        <= 20 => "#22C55E",
-        <= 50 => "#F59E0B",
-        <= 80 => "#F87171",
-        _ => "#EF4444"
+        null => StatusColors.Neutral,
+        <= 20 => StatusColors.Good,
+        <= 50 => StatusColors.Warning,
+        <= 80 => StatusColors.Elevated,
+        _ => StatusColors.Bad
     };
 
     /// <summary>Friendly power-on time display.</summary>

--- a/SysManager/SysManager/Models/HealthScoreResult.cs
+++ b/SysManager/SysManager/Models/HealthScoreResult.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
+
 namespace SysManager.Models;
 
 /// <summary>
@@ -16,9 +18,9 @@ public sealed class HealthScoreResult
     /// <summary>Color hex for the gauge arc.</summary>
     public string ColorHex => Score switch
     {
-        >= 80 => "#22C55E",  // green
-        >= 50 => "#F59E0B",  // amber
-        _ => "#EF4444"       // red
+        >= 80 => StatusColors.Good,  // green
+        >= 50 => StatusColors.Warning,  // amber
+        _ => StatusColors.Bad       // red
     };
 
     /// <summary>Human-readable label for the score.</summary>
@@ -50,5 +52,5 @@ public sealed class HealthRecommendation
     public required string Severity { get; init; }  // "warning" or "critical"
 
     public string IconGlyph => Severity == "critical" ? "\uE783" : "\uE7BA";
-    public string ColorHex => Severity == "critical" ? "#EF4444" : "#F59E0B";
+    public string ColorHex => Severity == "critical" ? StatusColors.Bad : StatusColors.Warning;
 }

--- a/SysManager/SysManager/Models/TemperatureReading.cs
+++ b/SysManager/SysManager/Models/TemperatureReading.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
+
 namespace SysManager.Models;
 
 public sealed record TemperatureReading(
@@ -17,9 +19,9 @@ public sealed record TemperatureReading(
     public string ColorHex => TemperatureC switch
     {
         null => "#6B7B8F",
-        <= 45 => "#22C55E",
-        <= 65 => "#3B82F6",
-        <= 80 => "#F59E0B",
-        _ => "#EF4444"
+        <= 45 => StatusColors.Good,
+        <= 65 => StatusColors.Info,
+        <= 80 => StatusColors.Warning,
+        _ => StatusColors.Bad
     };
 }

--- a/SysManager/SysManager/Models/TuneUpResult.cs
+++ b/SysManager/SysManager/Models/TuneUpResult.cs
@@ -62,9 +62,9 @@ public sealed class TuneUpResult
 
     public string OverallColorHex => WarningCount switch
     {
-        0 => "#22C55E",
-        <= 2 => "#F59E0B",
-        _ => "#EF4444"
+        0 => StatusColors.Good,
+        <= 2 => StatusColors.Warning,
+        _ => StatusColors.Bad
     };
 }
 

--- a/SysManager/SysManager/Services/DiskHealthService.cs
+++ b/SysManager/SysManager/Services/DiskHealthService.cs
@@ -6,6 +6,8 @@ using System.Management;
 using Serilog;
 using SysManager.Models;
 
+using SysManager.Helpers;
+
 namespace SysManager.Services;
 
 /// <summary>
@@ -136,13 +138,13 @@ public sealed class DiskHealthService
         if (r.HealthStatus == "Unhealthy")
         {
             r.Verdict = "Drive is failing — back up now and replace it.";
-            r.VerdictColorHex = "#EF4444";
+            r.VerdictColorHex = StatusColors.Bad;
             return;
         }
         if (r.HealthStatus == "Warning")
         {
             r.Verdict = "Drive is warning of problems. Back up soon.";
-            r.VerdictColorHex = "#F59E0B";
+            r.VerdictColorHex = StatusColors.Warning;
             return;
         }
 
@@ -150,19 +152,19 @@ public sealed class DiskHealthService
         if (r.WearPercent is >= 90)
         {
             r.Verdict = $"SSD {r.WearPercent}% worn out — plan a replacement.";
-            r.VerdictColorHex = "#F59E0B";
+            r.VerdictColorHex = StatusColors.Warning;
             return;
         }
         if (r.TemperatureC is >= 70)
         {
             r.Verdict = $"Running hot ({r.TemperatureC:F0} °C). Check cooling / airflow.";
-            r.VerdictColorHex = "#F59E0B";
+            r.VerdictColorHex = StatusColors.Warning;
             return;
         }
         if ((r.ReadErrors ?? 0) > 0 || (r.WriteErrors ?? 0) > 0)
         {
             r.Verdict = $"{(r.ReadErrors ?? 0) + (r.WriteErrors ?? 0)} I/O errors logged. Monitor closely.";
-            r.VerdictColorHex = "#F59E0B";
+            r.VerdictColorHex = StatusColors.Warning;
             return;
         }
 
@@ -174,7 +176,7 @@ public sealed class DiskHealthService
         r.Verdict = bits.Count > 0
             ? "Healthy — " + string.Join(" · ", bits)
             : "Healthy.";
-        r.VerdictColorHex = "#22C55E";
+        r.VerdictColorHex = StatusColors.Good;
     }
 
     // ---------- helpers ----------


### PR DESCRIPTION
## Summary

Status-colour hex strings were copy-pasted as bare literals across the data layer (`DiskHealthReport`, `HealthScoreResult`, `TemperatureReading`, `TuneUpResult`, `DiskHealthService`). Introduced `Helpers/StatusColors` with named constants and referenced them instead, so the palette has one source of truth.

| Constant | Value |
|---|---|
| Good | #22C55E |
| Warning | #F59E0B |
| Info | #3B82F6 |
| Elevated | #F87171 |
| Bad | #EF4444 |
| Neutral | #9AA0A6 |

## Behaviour
Byte-identical — the constants hold the exact previous hex strings, so every `*ColorHex` property returns the same value. `chore:` → no release.

## Scope / not touched
- **ThemeService is intentionally excluded** — its hex literals are theme-preset accent/background colours, not status colours; replacing them would change theme appearance.
- The view-model status-colour call sites (Dashboard, Cleanup, ResourceHistory, SystemHealth) are a follow-up slice.

## Verification
- `dotnet build` (main + tests) 0/0. Existing tests assert the string values (`#9AA0A6` etc.), which are unchanged, so they still pass. No production behaviour change.