### PR TITLE
feat: make Bulk Installer web icons opt-in (honour no-cloud promise)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.0] - 2026-06-30
+
+### Changed
+- **App icons in the Bulk Installer are now opt-in.** SysManager no longer contacts the web for app icons by default — this keeps the "no cloud, no telemetry" promise intact out of the box. A new "Load app icons from the web" checkbox in the Bulk Installer toolbar turns the feature on; only then are icons fetched from Google's favicon service (the choice is remembered). Already-cached icons still load offline. The README now documents exactly when the app uses the network.
+
 ## [1.51.14] - 2026-06-30
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Event Log viewer into a single tabbed WPF app.
 
 Everything runs on the machine itself. No cloud, no telemetry, no account.
 
+> **When SysManager uses the network.** There is no background phone-home — the app
+> never sends usage data. Network access only happens for features you explicitly
+> use: the network diagnostics (ping / traceroute / speed test), checking GitHub for
+> a new release on the About tab, and downloading an app you chose to install via
+> winget. App icons in the Bulk Installer are an **opt-in** extra — off by default, and
+> only when you tick "Load app icons from the web" does it fetch them from Google's
+> favicon service. Nothing else leaves your PC.
+
 Built with gamers in mind — live ping overlays for CS2, FACEIT, PUBG and streaming
 endpoints, Steam/Epic/Battle.net/Riot/GOG/EA launcher cache cleanup, and
 an honest "is it my PC, my ISP, or the server?" verdict.

--- a/SysManager/SysManager.Tests/AppIconServiceTests.cs
+++ b/SysManager/SysManager.Tests/AppIconServiceTests.cs
@@ -49,6 +49,7 @@ public class AppIconServiceTests
     {
         var handler = new StubHandler((_, _) => throw new HttpRequestException("simulated offline"));
         var svc = new AppIconService(handler);
+        svc.SetNetworkFetchEnabled(true); // opt in so the download path is reached
 
         // A known mapped ID so the download path is reached, then the handler fails.
         var ex = await Record.ExceptionAsync(() => svc.GetIconAsync("Git.Git"));
@@ -65,12 +66,39 @@ public class AppIconServiceTests
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
         var svc = new AppIconService(handler);
+        svc.SetNetworkFetchEnabled(true); // opt in so the download path is reached
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
         var ex = await Record.ExceptionAsync(() => svc.GetIconAsync("Git.Git", cts.Token));
 
         Assert.Null(ex); // TaskCanceledException is caught and turned into a null result
+    }
+
+    // ── Network-fetch opt-in (idx 9/10/13/14: honour the no-cloud promise) ────
+
+    [Fact]
+    public async Task GetIconAsync_WhenFetchDisabled_MakesNoNetworkRequest()
+    {
+        var handler = new StubHandler((_, _) => new HttpResponseMessage(HttpStatusCode.OK));
+        var svc = new AppIconService(handler);
+        svc.SetNetworkFetchEnabled(false); // explicit: opt-out
+
+        // A known-mapped ID that is NOT cached must still make zero network calls.
+        var icon = await svc.GetIconAsync("Git.Git." + Guid.NewGuid().ToString("N"));
+
+        Assert.Null(icon);
+        Assert.Equal(0, handler.Calls);
+    }
+
+    [Fact]
+    public void SetNetworkFetchEnabled_TogglesAndReportsValue()
+    {
+        var svc = new AppIconService(new StubHandler((_, _) => new HttpResponseMessage(HttpStatusCode.OK)));
+        Assert.True(svc.SetNetworkFetchEnabled(true));
+        Assert.True(svc.NetworkFetchEnabled);
+        Assert.False(svc.SetNetworkFetchEnabled(false));
+        Assert.False(svc.NetworkFetchEnabled);
     }
 
     [Fact]

--- a/SysManager/SysManager/Services/AppIconService.cs
+++ b/SysManager/SysManager/Services/AppIconService.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Net.Http;
+using System.Text.Json;
 using System.Windows.Media.Imaging;
 using Serilog;
 
@@ -24,7 +25,20 @@ public sealed class AppIconService
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "SysManager", "IconCache");
 
+    private static readonly string SettingsPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "SysManager", "icon-fetch.json");
+
     private readonly HttpClient _http;
+
+    /// <summary>
+    /// Whether the service may fetch icons over the network (from the Google favicon
+    /// service). Defaults to <c>false</c> to honour the app's local-first / no-cloud
+    /// promise — the Bulk Installer renders without web icons unless the user opts in.
+    /// Cached icons (already on disk) are always loaded regardless of this flag, since
+    /// reading them touches no network. Persisted so the choice survives restarts.
+    /// </summary>
+    public bool NetworkFetchEnabled { get; private set; }
 
     /// <summary>
     /// Creates the service. Pass a custom <paramref name="handler"/> (e.g. a stub)
@@ -36,7 +50,45 @@ public sealed class AppIconService
         _http = handler is null ? new HttpClient() : new HttpClient(handler);
         _http.Timeout = TimeSpan.FromSeconds(5);
         _http.DefaultRequestHeaders.UserAgent.ParseAdd("SysManager/1.0");
+        NetworkFetchEnabled = LoadPreference();
     }
+
+    /// <summary>
+    /// Enables or disables network icon fetching and persists the choice. Returns the
+    /// effective value. Disabling does not delete already-cached icons.
+    /// </summary>
+    public bool SetNetworkFetchEnabled(bool enabled)
+    {
+        NetworkFetchEnabled = enabled;
+        SavePreference(enabled);
+        return NetworkFetchEnabled;
+    }
+
+    private static bool LoadPreference()
+    {
+        try
+        {
+            if (!File.Exists(SettingsPath)) return false; // default: no network
+            var pref = JsonSerializer.Deserialize<IconFetchPreference>(File.ReadAllText(SettingsPath));
+            return pref?.NetworkFetchEnabled ?? false;
+        }
+        catch (IOException ex) { Log.Debug(ex, "Icon-fetch preference read failed"); return false; }
+        catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Icon-fetch preference read denied"); return false; }
+        catch (JsonException ex) { Log.Debug(ex, "Icon-fetch preference malformed"); return false; }
+    }
+
+    private static void SavePreference(bool enabled)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(SettingsPath)!);
+            File.WriteAllText(SettingsPath, JsonSerializer.Serialize(new IconFetchPreference(enabled)));
+        }
+        catch (IOException ex) { Log.Debug(ex, "Icon-fetch preference write failed"); }
+        catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Icon-fetch preference write denied"); }
+    }
+
+    private sealed record IconFetchPreference(bool NetworkFetchEnabled);
 
     /// <summary>
     /// Gets the icon for an application by its winget ID.
@@ -59,6 +111,11 @@ public sealed class AppIconService
             catch (IOException ex) { Log.Debug(ex, "Could not delete corrupt icon cache for {AppId}", appId); }
             catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Could not delete corrupt icon cache for {AppId}", appId); }
         }
+
+        // No cached copy. A network fetch only happens when the user has opted in —
+        // otherwise we return null and the list renders without a web icon, keeping the
+        // local-first / no-cloud promise intact.
+        if (!NetworkFetchEnabled) return null;
 
         // Determine the download URL
         var url = GetFaviconUrl(appId);

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.51.14</Version>
-    <FileVersion>1.51.14.0</FileVersion>
-    <AssemblyVersion>1.51.14.0</AssemblyVersion>
+    <Version>1.52.0</Version>
+    <FileVersion>1.52.0.0</FileVersion>
+    <AssemblyVersion>1.52.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
@@ -32,6 +32,13 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
     [ObservableProperty] private string _selectedCategory = "All";
     [ObservableProperty] private bool _isElevated;
 
+    /// <summary>
+    /// When on, app icons are fetched from the Google favicon service. Off by default
+    /// to honour the no-cloud promise; the user opts in via the checkbox. Toggling it
+    /// persists the choice and (when enabled) loads the icons.
+    /// </summary>
+    [ObservableProperty] private bool _loadWebIcons;
+
     public List<string> Categories { get; } =
     [
         "All",
@@ -59,6 +66,15 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
     partial void OnFilterTextChanged(string value) => ApplyFilter();
     partial void OnSelectedCategoryChanged(string value) => ApplyFilter();
 
+    partial void OnLoadWebIconsChanged(bool value)
+    {
+        // Persist the opt-in, then (when turning it on) fetch the icons now so the
+        // change is visible immediately rather than only after the next visit.
+        _iconService.SetNetworkFetchEnabled(value);
+        if (value)
+            InitializeAsync(LoadIconsAsync);
+    }
+
     public BulkInstallerViewModel(BulkInstallerService service, AppIconService iconService)
     {
         _service = service;
@@ -68,6 +84,8 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
         // click would otherwise dispose the shared CTS mid-flight).
         PropertyChanged += OnVmPropertyChanged;
         IsElevated = AdminHelper.IsElevated();
+        // Reflect the persisted opt-in WITHOUT triggering a save/reload during ctor init.
+        _loadWebIcons = _iconService.NetworkFetchEnabled;
         Apps.ReplaceWith(BuildCuratedApps());
         ApplyFilter();
 

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -85,6 +85,10 @@
                 <Button Content="Cancel" Command="{Binding CancelCommand}"
                         Style="{StaticResource GhostButton}"
                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+                <CheckBox Content="Load app icons from the web" IsChecked="{Binding LoadWebIcons}"
+                          VerticalAlignment="Center" Margin="12,0,0,0"
+                          AutomationProperties.Name="Load app icons from the web"
+                          ToolTip="Off by default to keep SysManager fully local. When on, app icons are fetched from Google's favicon service (google.com/s2/favicons), which reveals the queried app domains to Google."/>
             </WrapPanel>
         </Border>
 


### PR DESCRIPTION
## Summary

Closes the audit's privacy-claim finding (idx 9/10/13/14): the Bulk Installer silently fetched app icons from Google's favicon service on every visit, contradicting the headline "no cloud, no telemetry" promise.

- **AppIconService** — added a persisted `NetworkFetchEnabled` flag (default **off**, stored in `%LocalAppData%\SysManager\icon-fetch.json`). `GetIconAsync` returns null (no network) when disabled; already-cached icons still load offline regardless.
- **BulkInstallerViewModel** — `LoadWebIcons` observable bound to a new toolbar checkbox; toggling persists the choice and (when enabled) loads icons immediately.
- **BulkInstallerView** — "Load app icons from the web" checkbox with a tooltip disclosing the Google contact.
- **README** — new "When SysManager uses the network" note listing every user-initiated network use (diagnostics, GitHub update check, winget installs, opt-in icons).

## Behaviour change
Out of the box, the app now makes **zero** network calls for icons — restoring the no-cloud claim. Users who want icons tick one box.

## Tests
- `GetIconAsync_WhenFetchDisabled_MakesNoNetworkRequest` (0 handler calls), `SetNetworkFetchEnabled_TogglesAndReportsValue`, and the two existing network-path tests updated to opt in first.

## Verification
- `dotnet build` (main + tests) 0/0. `dotnet test` runs in CI.