### PR TITLE
fix: add a use-at-your-own-risk / back-up-first safety note to the About tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.1] - 2026-06-30
+
+### Added
+- **Safety note in the About tab.** The legal section now explicitly states that some tools change system settings, the registry, or delete files — use them at your own risk, review each action before confirming, and back up important data first — alongside the existing reminder that SysManager creates a System Restore point where it can and keeps changes reversible.
+
 ## [1.52.0] - 2026-06-30
 
 ### Changed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.0</Version>
-    <FileVersion>1.52.0.0</FileVersion>
-    <AssemblyVersion>1.52.0.0</AssemblyVersion>
+    <Version>1.52.1</Version>
+    <FileVersion>1.52.1.0</FileVersion>
+    <AssemblyVersion>1.52.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AboutView.xaml
+++ b/SysManager/SysManager/Views/AboutView.xaml
@@ -186,6 +186,11 @@
                             All operations are local to your machine — no telemetry, no accounts. Updates are fetched from the public
                             GitHub Releases API and downloaded directly from GitHub.
                         </TextBlock>
+                        <TextBlock TextWrapping="Wrap" Margin="0,8,0,0" Foreground="{DynamicResource TextSecondary}" FontSize="12">
+                            Some tools change system settings, the registry, or delete files. Use them at your own risk: review each
+                            action before confirming, and back up important data first. Where it can, SysManager creates a System
+                            Restore point before a system-altering operation and makes changes individually reversible.
+                        </TextBlock>
                     </StackPanel>
                 </Border>
 


### PR DESCRIPTION
## Summary

Closes audit idx 86. The About → Legal section stated MIT / "AS IS" but didn't give the user an operational safety note for a tool that edits the registry, changes system settings, and deletes files. Added one concise paragraph: use at your own risk, review each action before confirming, back up important data first — next to the existing reminder that SysManager creates a System Restore point where it can and keeps changes reversible.

In-app text only, no logic change. `fix:` → 1.52.1.

## Verification
- `dotnet build` 0/0. Leak scan clean.