### PR TITLE
chore: freeze static read-only lookup tables into FrozenDictionary

### DIFF
--- a/SysManager/SysManager/Services/AppIconService.cs
+++ b/SysManager/SysManager/Services/AppIconService.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Collections.Frozen;
 using System.IO;
 using System.Net.Http;
 using System.Text.Json;
@@ -184,7 +185,7 @@ public sealed class AppIconService
     /// <summary>
     /// Maps winget package IDs to their associated website domain for favicon retrieval.
     /// </summary>
-    private static readonly Dictionary<string, string> AppDomains = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly FrozenDictionary<string, string> AppDomains = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
         // Browsers
         ["Google.Chrome"] = "google.com/chrome",
@@ -253,5 +254,5 @@ public sealed class AppIconService
         ["Microsoft.VCRedist.2015+.x64"] = "microsoft.com",
         ["Oracle.JavaRuntimeEnvironment"] = "java.com",
         ["Microsoft.DirectX"] = "microsoft.com",
-    };
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 }

--- a/SysManager/SysManager/Services/ContextMenuService.cs
+++ b/SysManager/SysManager/Services/ContextMenuService.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Collections.Frozen;
 using System.Diagnostics;
 using System.IO;
 using System.Security;
@@ -371,7 +372,7 @@ public sealed partial class ContextMenuService
     /// Human-readable explanations for common context menu entries.
     /// Keyed by raw registry name (case-insensitive).
     /// </summary>
-    private static readonly Dictionary<string, string> KnownExplanations = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly FrozenDictionary<string, string> KnownExplanations = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
         ["open"] = "Opens the file with its default associated application",
         ["edit"] = "Opens the file in the default text editor (Notepad)",
@@ -398,12 +399,12 @@ public sealed partial class ContextMenuService
         ["Troubleshoot compatibility"] = "Runs the Program Compatibility Troubleshooter for older apps",
         ["git_bash"] = "Opens a Git Bash terminal in the current directory",
         ["git_gui"] = "Opens Git GUI for visual staging, committing and history browsing",
-    };
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Explanations keyed by executable name (for entries resolved via command path).
     /// </summary>
-    private static readonly Dictionary<string, string> KnownExeExplanations = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly FrozenDictionary<string, string> KnownExeExplanations = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
         ["code"] = "Opens the file or folder in Visual Studio Code editor",
         ["notepad++"] = "Opens the file in Notepad++ text editor",
@@ -416,7 +417,7 @@ public sealed partial class ContextMenuService
         ["pwsh"] = "Opens PowerShell 7 in the current folder",
         ["git-bash"] = "Opens a Git Bash terminal in the current directory",
         ["git-gui"] = "Opens Git GUI for visual staging and committing",
-    };
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Gets the human-readable explanation for an entry based on its raw name and command.
@@ -446,7 +447,7 @@ public sealed partial class ContextMenuService
     }
 
     // Well-known registry entry names mapped to user-friendly display names
-    private static readonly Dictionary<string, string> KnownNames = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly FrozenDictionary<string, string> KnownNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
         ["cmd"] = "Command Prompt",
         ["powershell"] = "PowerShell",
@@ -471,10 +472,10 @@ public sealed partial class ContextMenuService
         ["paste"] = "Paste",
         ["delete"] = "Delete",
         ["rename"] = "Rename",
-    };
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     // Known DLL resource strings mapped to friendly names
-    private static readonly Dictionary<string, string> KnownResourceStrings = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly FrozenDictionary<string, string> KnownResourceStrings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
         ["@shell32.dll,-8506"] = "Open Command Prompt",
         ["@shell32.dll,-8508"] = "Open PowerShell",
@@ -482,10 +483,10 @@ public sealed partial class ContextMenuService
         ["@shell32.dll,-8518"] = "Open PowerShell as Administrator",
         ["@shell32.dll,-31328"] = "Share",
         ["@shell32.dll,-37400"] = "Pin to Quick Access",
-    };
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     // Known executable names mapped to friendly application names
-    private static readonly Dictionary<string, string> KnownExeNames = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly FrozenDictionary<string, string> KnownExeNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
         ["git-bash"] = "Git Bash",
         ["git-gui"] = "Git GUI",
@@ -502,7 +503,7 @@ public sealed partial class ContextMenuService
         ["pwsh"] = "PowerShell",
         ["cmd"] = "Command Prompt",
         ["wt"] = "Windows Terminal",
-    };
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Resolves a raw registry entry name into a user-friendly display name.

--- a/SysManager/SysManager/Services/DebloaterService.cs
+++ b/SysManager/SysManager/Services/DebloaterService.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Collections.Frozen;
 using System.Collections.ObjectModel;
 using System.Management.Automation;
 using System.Text.RegularExpressions;
@@ -71,8 +72,8 @@ public sealed partial class DebloaterService
     /// Curated "commonly removed bloat" families — pre-checked safe items the preset selects.
     /// Each entry maps a name prefix to a friendly label + one-line description.
     /// </summary>
-    private static readonly Dictionary<string, (string Display, string Description)> Catalog =
-        new(StringComparer.OrdinalIgnoreCase)
+    private static readonly FrozenDictionary<string, (string Display, string Description)> Catalog =
+        new Dictionary<string, (string Display, string Description)>(StringComparer.OrdinalIgnoreCase)
         {
             ["Microsoft.BingNews"] = ("Microsoft News", "Bing-powered news app."),
             ["Microsoft.BingWeather"] = ("Weather", "Bing-powered weather app."),
@@ -100,7 +101,7 @@ public sealed partial class DebloaterService
             ["Microsoft.SkypeApp"] = ("Skype", "Bundled Skype app."),
             ["Microsoft.WindowsMaps"] = ("Maps", "Offline maps app."),
             ["Microsoft.WindowsFeedbackHub"] = ("Feedback Hub", "Sends feedback to Microsoft."),
-        };
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Lists installed Store apps for the current user, newest catalog matches first.

--- a/SysManager/SysManager/Services/EventExplainer.cs
+++ b/SysManager/SysManager/Services/EventExplainer.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Collections.Frozen;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -16,7 +17,7 @@ public static class EventExplainer
 {
     private readonly record struct Key(string Provider, int EventId);
 
-    private static readonly Dictionary<Key, (string Explanation, string Recommendation)> Known = new()
+    private static readonly FrozenDictionary<Key, (string Explanation, string Recommendation)> Known = new Dictionary<Key, (string Explanation, string Recommendation)>
     {
         // ---------- Kernel / crashes ----------
         [new("Microsoft-Windows-Kernel-Power", 41)] = (
@@ -131,10 +132,10 @@ public static class EventExplainer
         [new("Microsoft-Windows-Power-Troubleshooter", 1)] = (
             "The system resumed from sleep.",
             "Informational."),
-    };
+    }.ToFrozenDictionary();
 
     // Fallbacks by EventId only (when provider varies or isn't known)
-    private static readonly Dictionary<int, (string Explanation, string Recommendation)> KnownById = new()
+    private static readonly FrozenDictionary<int, (string Explanation, string Recommendation)> KnownById = new Dictionary<int, (string Explanation, string Recommendation)>
     {
         [41] = ("The PC wasn't shut down cleanly — crash, freeze, or power loss.",
                 "See Reliability Monitor. Frequent = hardware/driver issue."),
@@ -142,7 +143,7 @@ public static class EventExplainer
         [1001] = ("A crash report was filed.", "See the related Application Error for details."),
         [6008] = ("The previous system shutdown was unexpected.",
                   "Often a duplicate of Kernel-Power 41. Look for a BSOD or power loss around that time."),
-    };
+    }.ToFrozenDictionary();
 
     public static void Enrich(FriendlyEventEntry entry)
     {

--- a/SysManager/SysManager/Services/SafetyDatabase.cs
+++ b/SysManager/SysManager/Services/SafetyDatabase.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Collections.Frozen;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -30,7 +31,7 @@ public static class SafetyDatabase
         return (SafetyLevel.Caution, "Check documentation before modifying.");
     }
 
-    private static readonly Dictionary<string, string> SafeServices = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly FrozenDictionary<string, string> SafeServices = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
         ["DiagTrack"] = "Connected User Experiences and Telemetry — sends diagnostic data to Microsoft. Disabling stops all telemetry.",
         ["dmwappushservice"] = "WAP Push Message Routing — used for telemetry delivery. Safe to disable.",
@@ -52,9 +53,9 @@ public static class SafetyDatabase
         ["TrkWks"] = "Distributed Link Tracking Client — tracks NTFS links across network. Rarely needed.",
         ["WerSvc"] = "Windows Error Reporting — sends crash reports to Microsoft.",
         ["PhoneSvc"] = "Phone Service — manages telephony state. Not needed on desktops.",
-    };
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
-    private static readonly Dictionary<string, string> CautionServices = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly FrozenDictionary<string, string> CautionServices = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
         ["wuauserv"] = "Windows Update — handles updates. Disabling prevents security patches. Only disable temporarily.",
         ["Spooler"] = "Print Spooler — required for printing. Disable only if you never print.",
@@ -67,9 +68,9 @@ public static class SafetyDatabase
         ["LanmanServer"] = "Server — SMB file sharing. Disable if you don't share files on network.",
         ["LanmanWorkstation"] = "Workstation — SMB client. Disable if you don't access network shares.",
         ["Schedule"] = "Task Scheduler — many system tasks depend on this. Disabling can break maintenance.",
-    };
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
-    private static readonly Dictionary<string, string> CriticalServices = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly FrozenDictionary<string, string> CriticalServices = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
         ["RpcSs"] = "Remote Procedure Call — core Windows IPC. System will not function without it.",
         ["RpcEptMapper"] = "RPC Endpoint Mapper — required by RPC. Do not disable.",
@@ -86,9 +87,9 @@ public static class SafetyDatabase
         ["Power"] = "Power — manages power policy. Disabling causes unpredictable behavior.",
         ["ProfSvc"] = "User Profile Service — loads user profiles. Disabling prevents login.",
         ["nsi"] = "Network Store Interface — network connectivity core.",
-    };
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
-    private static readonly Dictionary<string, string> SafeFeatures = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly FrozenDictionary<string, string> SafeFeatures = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
         ["Internet-Explorer-Optional-amd64"] = "Legacy IE compatibility in Edge. Not needed unless you use old enterprise sites.",
         ["MediaPlayback"] = "Windows Media Player legacy — replaced by modern Media Player app.",
@@ -104,9 +105,9 @@ public static class SafetyDatabase
         ["DirectPlay"] = "DirectPlay — legacy gaming API. Only needed for very old games.",
         ["SimpleTCP"] = "Simple TCP/IP Services — echo, daytime servers. Never needed on workstations.",
         ["SMB1Protocol"] = "SMB 1.0 — insecure file sharing protocol. Disable unless connecting to ancient NAS.",
-    };
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
-    private static readonly Dictionary<string, string> CautionFeatures = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly FrozenDictionary<string, string> CautionFeatures = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
         ["NetFx4-AdvSrvs"] = ".NET Framework 4.x Advanced Services — some apps depend on this.",
         ["NetFx3"] = ".NET Framework 3.5 — needed by some older applications.",
@@ -115,9 +116,9 @@ public static class SafetyDatabase
         ["SmbDirect"] = "SMB Direct (RDMA) — high-speed file transfer. Only needed with RDMA NICs.",
         ["WCF-Services45"] = "WCF Services — .NET communication framework. Some enterprise apps need it.",
         ["Microsoft-Windows-Subsystem-Linux"] = "WSL — Windows Subsystem for Linux. Needed by developers using Linux tools.",
-    };
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
-    private static readonly Dictionary<string, string> CriticalFeatures = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly FrozenDictionary<string, string> CriticalFeatures = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
         ["Microsoft-Hyper-V-All"] = "Hyper-V — virtualization platform. Required by Docker, WSL2, Android Emulator.",
         ["Microsoft-Hyper-V"] = "Hyper-V core. Disabling breaks all VM-based tools.",
@@ -125,5 +126,5 @@ public static class SafetyDatabase
         ["HypervisorPlatform"] = "Windows Hypervisor Platform — needed by third-party VMs (VirtualBox, etc).",
         ["Containers"] = "Windows Containers — used by Docker. Disabling breaks container workloads.",
         ["Microsoft-Windows-Client-EmbeddedExp-Package"] = "Windows Sandbox — isolated test environment. Useful for security.",
-    };
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 }

--- a/SysManager/SysManager/Services/ServiceManagerService.cs
+++ b/SysManager/SysManager/Services/ServiceManagerService.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Collections.Frozen;
 using System.ServiceProcess;
 using SysManager.Models;
 
@@ -17,7 +18,7 @@ public sealed partial class ServiceManagerService
     /// Gaming-oriented recommendations for common Windows services.
     /// Key = service name (case-insensitive), Value = (recommendation, reason).
     /// </summary>
-    internal static readonly Dictionary<string, (string Rec, string Reason)> GamingGuide = new(StringComparer.OrdinalIgnoreCase)
+    internal static readonly FrozenDictionary<string, (string Rec, string Reason)> GamingGuide = new Dictionary<string, (string Rec, string Reason)>(StringComparer.OrdinalIgnoreCase)
     {
         ["SysMain"] = ("safe-to-disable", "Superfetch — preloads apps into RAM. Disabling frees RAM for games and reduces disk I/O."),
         ["DiagTrack"] = ("safe-to-disable", "Connected User Experiences and Telemetry — sends usage data to Microsoft. No impact on functionality."),
@@ -44,7 +45,7 @@ public sealed partial class ServiceManagerService
         ["nsi"] = ("keep-enabled", "Network Store Interface — required for network connectivity."),
         ["Winmgmt"] = ("keep-enabled", "Windows Management Instrumentation — required by many apps and system tools."),
         ["wuauserv"] = ("keep-enabled", "Windows Update — keeps your system secure and up to date."),
-    };
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Enumerate all Windows services with their current state and gaming recommendations.


### PR DESCRIPTION
## What

Converts the static, build-once / read-many lookup tables that are queried per item during scans from `Dictionary` to `FrozenDictionary` (.NET 8+).

| File | Tables |
|---|---|
| `SafetyDatabase` | Safe/Caution/Critical **Services** + **Features** (6) |
| `ContextMenuService` | Known explanations / exe-explanations / names / resource-strings / exe-names (5) |
| `ServiceManagerService` | `GamingGuide` (1) |
| `AppIconService` | `AppDomains` (1) |
| `DebloaterService` | `Catalog` (1) |
| `EventExplainer` | `Known` + `KnownById` (2) |

## Why

`FrozenDictionary` trades a one-time construction cost for faster steady-state reads — the exact access pattern of these tables (built once at type-init, then read once per scanned service / event / app). Matches the existing `FrozenSet` idiom already used in `TaskSchedulerService`.

## Correctness — comparer preserved exactly

The case-insensitive trap: dropping the comparer would silently make lookups case-sensitive. Every case-insensitive table is converted through `.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase)`. `EventExplainer`'s two maps keep the default comparer (struct / int keys). Behaviour is identical — confirmed by the existing `GamingGuide_CaseInsensitive` test (`sysmain` / `SYSMAIN`) still passing.

## Deliberately left as plain Dictionary

`ThemeService` dark↔light maps (6 entries, read rarely) and `ContextMenuPreset.All` (3 entries, **public `IReadOnlyDictionary` contract**). Freezing those would be cargo-cult with no measurable benefit.

## Verification
- `dotnet build -c Release` (main + tests) → 0 warnings, 0 errors
- `chore:` → no release, no version bump