### PR TITLE
chore: consolidate the winget package-ID validator into one shared helper

### DIFF
--- a/SysManager/SysManager.Tests/WingetIdTests.cs
+++ b/SysManager/SysManager.Tests/WingetIdTests.cs
@@ -1,0 +1,50 @@
+// SysManager · WingetIdTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Helpers;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Pins the shared winget package-ID validator (<see cref="WingetId.IsValid"/>),
+/// which is the single source of truth used by WingetService, UninstallerService
+/// and BulkInstallerService before a package ID is interpolated into a winget
+/// command line. This is a security boundary (the sole barrier against
+/// command-injection through a crafted ID), so both the accept and reject paths
+/// are asserted directly here rather than only through the services.
+/// </summary>
+public class WingetIdTests
+{
+    [Theory]
+    [InlineData("Microsoft.VisualStudioCode")]
+    [InlineData("Notepad++.Notepad++")]
+    [InlineData("Microsoft.VisualStudio.2022.Community")]
+    [InlineData("7zip.7zip")]
+    [InlineData("Mozilla.Firefox")]
+    public void IsValid_AcceptsRealWorldIds(string id) =>
+        Assert.True(WingetId.IsValid(id));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("pkg; calc.exe")]
+    [InlineData("pkg && calc")]
+    [InlineData("pkg | more")]
+    [InlineData("pkg`whoami`")]
+    [InlineData("pkg$(whoami)")]
+    [InlineData("pkg\"quote")]
+    [InlineData("pkg\nnewline")]      // trailing/embedded newline — the \z anchor must reject
+    [InlineData("pkg\ttab")]
+    public void IsValid_RejectsInjectionAndBlank(string? id) =>
+        Assert.False(WingetId.IsValid(id));
+
+    [Fact]
+    public void IsValid_RejectsOverLengthId() =>
+        Assert.False(WingetId.IsValid(new string('a', 257)));
+
+    [Fact]
+    public void IsValid_AcceptsMaxLengthId() =>
+        Assert.True(WingetId.IsValid(new string('a', 256)));
+}

--- a/SysManager/SysManager/Helpers/WingetId.cs
+++ b/SysManager/SysManager/Helpers/WingetId.cs
@@ -1,0 +1,33 @@
+// SysManager · WingetId — single source of truth for winget package-ID validation
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Text.RegularExpressions;
+
+namespace SysManager.Helpers;
+
+/// <summary>
+/// Validates winget package IDs before they are interpolated into a winget
+/// command line. This is a security boundary: the same allowlist was previously
+/// copy-pasted into WingetService, UninstallerService and BulkInstallerService,
+/// where three copies could drift apart. Centralising it here keeps the rule in
+/// one place.
+/// </summary>
+public static partial class WingetId
+{
+    /// <summary>
+    /// True if <paramref name="packageId"/> is a valid winget package ID: a
+    /// non-blank string of alphanumerics, dots, hyphens, underscores, forward
+    /// slashes (scoped IDs like "Microsoft.VisualStudio.2022.Community"), plus
+    /// signs (e.g. "Notepad++.Notepad++") and spaces, up to 256 characters.
+    /// </summary>
+    public static bool IsValid(string? packageId) =>
+        !string.IsNullOrWhiteSpace(packageId) && Pattern().IsMatch(packageId);
+
+    // \A…\z (absolute anchors) rather than ^…$: ^/$ would let a trailing newline
+    // through ("pkg\n" matches as "pkg"), which could smuggle a second line into
+    // the winget argument. \z anchors at the true end of input. A literal space is
+    // used instead of \s (which would also allow tabs/newlines mid-string).
+    [GeneratedRegex(@"\A[\w.\-/+ ]{1,256}\z")]
+    private static partial Regex Pattern();
+}

--- a/SysManager/SysManager/Services/BulkInstallerService.cs
+++ b/SysManager/SysManager/Services/BulkInstallerService.cs
@@ -2,7 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.Text.RegularExpressions;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -10,7 +10,7 @@ namespace SysManager.Services;
 /// <summary>
 /// Wraps winget.exe to install packages by their winget ID.
 /// </summary>
-public sealed partial class BulkInstallerService
+public sealed class BulkInstallerService
 {
     private readonly IPowerShellRunner _runner;
 
@@ -27,19 +27,11 @@ public sealed partial class BulkInstallerService
     /// </summary>
     public async Task<int> InstallAsync(string wingetId, CancellationToken ct = default)
     {
-        if (string.IsNullOrWhiteSpace(wingetId)
-            || !PackageIdPattern().IsMatch(wingetId))
+        // Validate wingetId before interpolating it into the winget command line.
+        if (!WingetId.IsValid(wingetId))
             throw new ArgumentException("Invalid package ID.", nameof(wingetId));
 
         var args = $"install --id \"{wingetId}\" -e --silent --accept-source-agreements --accept-package-agreements --disable-interactivity";
         return await _runner.RunProcessAsync("winget", args, ct).ConfigureAwait(false);
     }
-
-    /// <summary>
-    /// Matches valid winget package IDs: alphanumeric, dots, hyphens,
-    /// underscores, forward slashes, plus signs, and spaces. Max 256 chars.
-    /// </summary>
-    // \A…\z (absolute anchors): ^…$ would accept a trailing newline ("pkg\n").
-    [GeneratedRegex(@"\A[\w.\-/+ ]{1,256}\z")]
-    private static partial Regex PackageIdPattern();
 }

--- a/SysManager/SysManager/Services/UninstallerService.cs
+++ b/SysManager/SysManager/Services/UninstallerService.cs
@@ -4,6 +4,7 @@
 
 using System.Text.RegularExpressions;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -53,25 +54,13 @@ public sealed partial class UninstallerService
     /// </summary>
     public async Task<int> UninstallAsync(string packageId, CancellationToken ct = default)
     {
-        // Validate packageId: allowlist alphanumeric, dots, hyphens, underscores,
-        // forward slashes (scoped IDs like "Microsoft.VisualStudio.2022.Community"),
-        // and plus signs (e.g. "Notepad++.Notepad++").
-        if (string.IsNullOrWhiteSpace(packageId)
-            || !PackageIdPattern().IsMatch(packageId))
+        // Validate packageId before interpolating it into the winget command line.
+        if (!WingetId.IsValid(packageId))
             throw new ArgumentException("Invalid package ID.", nameof(packageId));
 
         var args = $"uninstall --id \"{packageId}\" -e --silent --accept-source-agreements --disable-interactivity";
         return await _runner.RunProcessAsync("winget", args, ct).ConfigureAwait(false);
     }
-
-    /// <summary>
-    /// Matches valid winget package IDs: alphanumeric, dots, hyphens,
-    /// underscores, forward slashes, plus signs, and spaces. Max 256 chars.
-    /// </summary>
-    // \A…\z (absolute anchors): ^…$ would accept a trailing newline ("pkg\n"),
-    // which could smuggle a second line into the winget argument.
-    [GeneratedRegex(@"\A[\w.\-/+ ]{1,256}\z")]
-    private static partial Regex PackageIdPattern();
 
     [GeneratedRegex(@"^\s*Name\s+Id\s+Version", RegexOptions.IgnoreCase)]
     private static partial Regex ListHeaderPattern();

--- a/SysManager/SysManager/Services/WingetService.cs
+++ b/SysManager/SysManager/Services/WingetService.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Text.RegularExpressions;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -72,10 +73,8 @@ public sealed partial class WingetService
 
     public async Task<WingetResult> UpgradeAsync(string packageId, CancellationToken ct = default)
     {
-        // Validate packageId: allowlist alphanumeric, dots, hyphens, underscores,
-        // forward slashes (scoped IDs), and plus signs (e.g. "Notepad++.Notepad++").
-        if (string.IsNullOrWhiteSpace(packageId)
-            || !PackageIdPattern().IsMatch(packageId))
+        // Validate packageId before interpolating it into the winget command line.
+        if (!WingetId.IsValid(packageId))
             throw new ArgumentException("Invalid package ID.", nameof(packageId));
 
         // --no-progress suppresses winget's animated block-character progress bar, which
@@ -84,17 +83,6 @@ public sealed partial class WingetService
         int code = await _runner.RunProcessAsync("winget", args, ct).ConfigureAwait(false);
         return WingetResult.From(code);
     }
-
-    /// <summary>
-    /// Matches valid winget package IDs: alphanumeric, dots, hyphens,
-    /// underscores, forward slashes, plus signs, and spaces. Max 256 chars.
-    /// </summary>
-    // \A…\z (absolute anchors) rather than ^…$: ^/$ would let a trailing newline
-    // through ("pkg\n" matches as "pkg"), which could smuggle a second line into the
-    // argument. \z anchors at the true end of input. Also dropped \s (which allowed
-    // tabs/newlines mid-string) in favour of a literal space.
-    [GeneratedRegex(@"\A[\w.\-/+ ]{1,256}\z")]
-    private static partial Regex PackageIdPattern();
 
     [GeneratedRegex(@"^\s*Name\s+Id\s+Version\s+Available", RegexOptions.IgnoreCase)]
     private static partial Regex UpgradeHeaderPattern();


### PR DESCRIPTION
## What

The winget package-ID allowlist regex `\A[\w.\-/+ ]{1,256}\z` was copy-pasted **identically** into three services. This consolidates it into a single `Helpers/WingetId.cs`.

| Before | After |
|---|---|
| `WingetService.PackageIdPattern()` | → `WingetId.IsValid(id)` |
| `UninstallerService.PackageIdPattern()` | → `WingetId.IsValid(id)` |
| `BulkInstallerService.PackageIdPattern()` | → `WingetId.IsValid(id)` |

## Why

This is a **security boundary** — the sole barrier against command-injection through a crafted package ID (the ID is interpolated straight into the winget command line). Three copies of a security rule can drift apart; one copy can't. (The `\A…\z` anchors here are the exact newline-injection hardening from #1179 — now in one place.)

## Design

`WingetId.IsValid(string?)` folds in the `IsNullOrWhiteSpace` guard that all three call-sites already had (a lone space matches the char class but must still be rejected). `BulkInstallerService` loses its only `[GeneratedRegex]`, so it's no longer `partial`.

## Tests

New `WingetIdTests` pins the validator directly: real-world IDs accepted; separators / chaining / substitution / quoting / **newline** / tab / blank / over-length rejected; 256 chars accepted, 257 rejected. The existing service-level negative tests still pass unchanged — proof the behaviour is identical.

## Verification
- `dotnet build -c Release` (app + tests) → 0 warnings, 0 errors
- 0 leftover `PackageIdPattern` references (grep-verified)
- `chore:` → no release