### PR TITLE
chore: drop dead clamp in TimerResolutionService.Enable

### DIFF
--- a/SysManager/SysManager/Services/TimerResolutionService.cs
+++ b/SysManager/SysManager/Services/TimerResolutionService.cs
@@ -27,9 +27,6 @@ public sealed partial class TimerResolutionService : ITimerResolutionService
 {
     private bool _enabledByApp;
 
-    /// <summary>0.5 ms expressed in 100-nanosecond units — the common gaming target.</summary>
-    public const uint HalfMilliInHundredNs = 5000;
-
     /// <summary>Read the achievable range and the resolution currently in effect.</summary>
     public TimerResolutionStatus Query()
     {
@@ -51,17 +48,17 @@ public sealed partial class TimerResolutionService : ITimerResolutionService
     }
 
     /// <summary>
-    /// Request the finest achievable timer resolution (clamped to the device's
-    /// reported minimum). Returns the status after re-querying the effective value.
+    /// Request the finest achievable timer resolution reported by the device.
+    /// Returns the status after re-querying the effective value.
     /// </summary>
     public TimerResolutionStatus Enable()
     {
         var status = Query();
         if (status.FinestHundredNs == 0) return status; // query failed; nothing to set
 
-        // Never request finer than the hardware allows.
-        uint target = Math.Max(status.FinestHundredNs, HalfMilliInHundredNs);
-        if (target > status.FinestHundredNs) target = status.FinestHundredNs;
+        // FinestHundredNs is the smallest (finest) interval the hardware reports, so
+        // it is already the finest we can legitimately request.
+        uint target = status.FinestHundredNs;
 
         try
         {


### PR DESCRIPTION
## What

`Enable()` computed `target = Math.Max(finest, HalfMilliInHundredNs)` and then immediately `if (target > finest) target = finest`. That pair **always** collapses to `target = finest` — so the `Math.Max` branch and the `HalfMilliInHundredNs` (0.5 ms) constant were dead: the finer 0.5 ms request could never actually be issued.

## Fix

`target = status.FinestHundredNs` (byte-identical to what the code already resolved to) + removed the unused public constant.

## Not in scope (deliberately)

Actually *honouring* a 0.5 ms gaming target instead of the hardware finest **changes the requested resolution** — a power/latency tradeoff that needs real-hardware validation. That's a feature decision, not a dead-code cleanup, so it is intentionally left out.

## Verification
- `dotnet build -c Release` (app + tests) → 0 warnings, 0 errors
- `HalfMilliInHundredNs` has 0 remaining references (grep-verified)
- Existing `TimerResolutionStatusTests`/`TimerResolutionViewModelTests` exercise the status record's ms-conversion (the `5000` there is FinestHundredNs test data, unrelated to the removed const) — unaffected
- `chore:` → no release