### PR TITLE
fix: route winget parsing through the shared table parser (Dashboard count + Bulk Installer search)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.2] - 2026-06-30
+
+### Fixed
+- **App-update count on the Dashboard is now accurate.** The dashboard alert used a fragile "count non-blank winget lines minus two" heuristic that mis-counted whenever winget's header/footer layout shifted. It now reuses the same parsed upgrade list the App Updates tab shows (rows that actually have an available version), so the two surfaces always agree.
+- **Bulk Installer search results parse reliably for wide or non-Latin app names.** The search parser previously used fixed character offsets that mis-sliced rows containing wide/CJK characters. It now routes through the shared winget table parser (the same one the upgrade list uses), so column detection is handled in one place.
+
 ## [1.52.1] - 2026-06-30
 
 ### Added

--- a/SysManager/SysManager.IntegrationTests/AllViewModelsSweepTests.cs
+++ b/SysManager/SysManager.IntegrationTests/AllViewModelsSweepTests.cs
@@ -16,7 +16,7 @@ namespace SysManager.IntegrationTests;
 [Collection("Network")]
 public class AllViewModelsSweepTests
 {
-    [Fact] public void Dashboard_Constructs() => Assert.NotNull(new DashboardViewModel(new SystemInfoService(), new TuneUpService(new ShortcutCleanerService(), new DiskHealthService(), new SystemInfoService()), new HealthScoreService(new SystemInfoService(), new DiskHealthService(), new BatteryService()), new TemperatureService(new DiskHealthService(), skipHardwareInit: true)));
+    [Fact] public void Dashboard_Constructs() => Assert.NotNull(new DashboardViewModel(new SystemInfoService(), new TuneUpService(new ShortcutCleanerService(), new DiskHealthService(), new SystemInfoService()), new HealthScoreService(new SystemInfoService(), new DiskHealthService(), new BatteryService()), new TemperatureService(new DiskHealthService(), skipHardwareInit: true), new WingetService(new PowerShellRunner())));
     [Fact] public void AppUpdates_Constructs() => Assert.NotNull(new AppUpdatesViewModel(new WingetService(new PowerShellRunner())));
     [Fact] public void WindowsUpdate_Constructs() => Assert.NotNull(new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService(), new WindowsUpdatePolicyService()));
     [Fact] public void SystemHealth_Constructs() => Assert.NotNull(new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService()));
@@ -29,7 +29,7 @@ public class AllViewModelsSweepTests
 
     [Fact]
     public void Dashboard_HasNonEmptySummaryOrEmpty()
-        => Assert.NotNull(new DashboardViewModel(new SystemInfoService(), new TuneUpService(new ShortcutCleanerService(), new DiskHealthService(), new SystemInfoService()), new HealthScoreService(new SystemInfoService(), new DiskHealthService(), new BatteryService()), new TemperatureService(new DiskHealthService(), skipHardwareInit: true)));
+        => Assert.NotNull(new DashboardViewModel(new SystemInfoService(), new TuneUpService(new ShortcutCleanerService(), new DiskHealthService(), new SystemInfoService()), new HealthScoreService(new SystemInfoService(), new DiskHealthService(), new BatteryService()), new TemperatureService(new DiskHealthService(), skipHardwareInit: true), new WingetService(new PowerShellRunner())));
 
     [Fact]
     public void AppUpdates_HasCollections()

--- a/SysManager/SysManager.IntegrationTests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DashboardViewModelTests.cs
@@ -18,7 +18,8 @@ public class DashboardViewModelTests
             sys,
             new TuneUpService(new ShortcutCleanerService(), diskHealth, sys),
             new HealthScoreService(sys, diskHealth, new BatteryService()),
-            new TemperatureService(diskHealth, skipHardwareInit: true));
+            new TemperatureService(diskHealth, skipHardwareInit: true),
+            new WingetService(new PowerShellRunner()));
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/BulkInstallerSearchParseTests.cs
+++ b/SysManager/SysManager.Tests/BulkInstallerSearchParseTests.cs
@@ -1,0 +1,87 @@
+// SysManager · BulkInstallerSearchParseTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Text;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Pins <see cref="BulkInstallerViewModel.ParseSearchResults"/>, which routes
+/// <c>winget search</c> output through the shared column parser instead of the
+/// old hand-rolled character-offset slicing. The parser locates columns by the
+/// header word positions, so the fixtures here are built from explicit column
+/// widths — Id/Version values are guaranteed to line up under the "Id"/"Version"
+/// header words exactly as winget's fixed-width output does.
+/// </summary>
+public class BulkInstallerSearchParseTests
+{
+    // Column start offsets, matching winget search's fixed-width layout.
+    private const int IdCol = 29;
+    private const int VersionCol = 60;
+
+    /// <summary>Builds one fixed-width row with values under the correct columns.</summary>
+    private static string Row(string name, string id, string version)
+    {
+        var sb = new StringBuilder();
+        sb.Append(name.PadRight(IdCol));
+        sb.Append(id.PadRight(VersionCol - IdCol));
+        sb.Append(version);
+        return sb.ToString();
+    }
+
+    private static string Table(params string[] rows)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(Row("Name", "Id", "Version") + "   Match       Source");
+        sb.AppendLine(new string('-', 90));
+        foreach (var r in rows) sb.AppendLine(r);
+        return sb.ToString();
+    }
+
+    [Fact]
+    public void ParseSearchResults_ExtractsNameAndId()
+    {
+        var output = Table(
+            Row("Visual Studio", "Microsoft.VisualStudio", "17.9.0"),
+            Row("7-Zip", "7zip.7zip", "23.01"));
+
+        var apps = BulkInstallerViewModel.ParseSearchResults(output);
+
+        Assert.Equal(2, apps.Count);
+        Assert.Equal("Visual Studio", apps[0].Name);
+        Assert.Equal("Microsoft.VisualStudio", apps[0].WingetId);
+        Assert.Equal("7-Zip", apps[1].Name);
+        Assert.Equal("7zip.7zip", apps[1].WingetId);
+    }
+
+    [Fact]
+    public void ParseSearchResults_TagsEveryRowAsCustomCategory()
+    {
+        var output = Table(Row("Firefox", "Mozilla.Firefox", "128.0"));
+        var apps = BulkInstallerViewModel.ParseSearchResults(output);
+
+        Assert.NotEmpty(apps);
+        Assert.All(apps, a => Assert.Equal("Custom", a.Category));
+    }
+
+    [Fact]
+    public void ParseSearchResults_EmptyOutput_ReturnsEmpty() =>
+        Assert.Empty(BulkInstallerViewModel.ParseSearchResults(string.Empty));
+
+    [Fact]
+    public void ParseSearchResults_HeaderOnly_ReturnsEmpty() =>
+        Assert.Empty(BulkInstallerViewModel.ParseSearchResults(Table()));
+
+    [Fact]
+    public void ParseSearchResults_CapsAtThirtyRows()
+    {
+        var rows = new string[50];
+        for (var i = 0; i < rows.Length; i++)
+            rows[i] = Row($"App{i}", $"Publisher.App{i}", "1.0.0");
+
+        var apps = BulkInstallerViewModel.ParseSearchResults(Table(rows));
+        Assert.Equal(30, apps.Count);
+    }
+}

--- a/SysManager/SysManager.Tests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DashboardViewModelTests.cs
@@ -25,7 +25,8 @@ public class DashboardViewModelTests
         return new DashboardViewModel(sys,
             new TuneUpService(new ShortcutCleanerService(), diskHealth, sys),
             new HealthScoreService(sys, diskHealth, new BatteryService()),
-            new TemperatureService(diskHealth, skipHardwareInit: true));
+            new TemperatureService(diskHealth, skipHardwareInit: true),
+            new WingetService(new PowerShellRunner()));
     }
 
     // ---------- construction & defaults ----------

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.1</Version>
-    <FileVersion>1.52.1.0</FileVersion>
-    <AssemblyVersion>1.52.1.0</AssemblyVersion>
+    <Version>1.52.2</Version>
+    <FileVersion>1.52.2.0</FileVersion>
+    <AssemblyVersion>1.52.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Text.RegularExpressions;
 using System.Windows.Data;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -325,54 +326,47 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
         var output = proc.StandardOutput.ReadToEnd();
         proc.WaitForExit(30_000);
 
-        // Parse the tabular output from winget search.
-        // The output has a header line with column names, a separator line of dashes,
-        // then data rows. Columns are: Name, Id, Version, [Match], Source
-        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        return ParseSearchResults(output);
+    }
 
-        // Find the separator line (all dashes and spaces)
-        var separatorIndex = -1;
-        for (var i = 0; i < lines.Length; i++)
+    /// <summary>
+    /// Parses <c>winget search</c> tabular output into installable-app rows. Pure and
+    /// process-free so it can be unit-tested with captured payloads. Routes through the
+    /// shared <see cref="WingetTableParser"/> instead of re-implementing column slicing,
+    /// so a header-layout change (wide/CJK names, extra columns) is handled in one place.
+    /// </summary>
+    internal static List<InstallableApp> ParseSearchResults(string output)
+    {
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries).ToList();
+        var rows = WingetTableParser.Parse(lines, SearchHeaderPattern(), SearchSummaryPattern());
+
+        List<InstallableApp> results = [];
+        foreach (var row in rows)
         {
-            if (lines[i].TrimEnd().All(c => c == '-' || c == ' ') && lines[i].Contains("--"))
-            {
-                separatorIndex = i;
-                break;
-            }
-        }
-
-        if (separatorIndex < 1 || separatorIndex + 1 >= lines.Length) return results;
-
-        // Determine column positions from the header line
-        var header = lines[separatorIndex - 1];
-        var idStart = header.IndexOf("Id", StringComparison.Ordinal);
-        var versionStart = header.IndexOf("Version", StringComparison.Ordinal);
-
-        if (idStart < 0 || versionStart < 0) return results;
-
-        // Parse data rows
-        for (var i = separatorIndex + 1; i < lines.Length && results.Count < 30; i++)
-        {
-            var line = lines[i];
-            if (line.Length < versionStart) continue;
-
-            var name = line[..idStart].TrimEnd();
-            var id = line[idStart..versionStart].TrimEnd();
-
-            if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(id)) continue;
+            if (results.Count >= 30) break;
+            if (string.IsNullOrWhiteSpace(row.Name) || string.IsNullOrWhiteSpace(row.Id)) continue;
 
             results.Add(new InstallableApp
             {
-                Name = name,
-                WingetId = id,
+                Name = row.Name,
+                WingetId = row.Id,
                 Category = "Custom",
-                Description = $"winget: {id}",
+                Description = $"winget: {row.Id}",
                 IconGlyph = GlyphForCategory("Custom"),
             });
         }
 
         return results;
     }
+
+    // winget search header: "Name  Id  Version  [Match]  Source".
+    [GeneratedRegex(@"^\s*Name\s+Id\s+Version", RegexOptions.IgnoreCase)]
+    private static partial Regex SearchHeaderPattern();
+
+    // winget search has no numeric footer, so this pattern is intentionally
+    // unmatchable — parsing runs to the end of the captured lines.
+    [GeneratedRegex(@"(?!)")]
+    private static partial Regex SearchSummaryPattern();
 
     private void ApplyFilter()
     {

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -19,6 +19,7 @@ public sealed partial class DashboardViewModel : ViewModelBase
     private readonly TuneUpService _tuneUp;
     private readonly HealthScoreService _healthScore;
     private readonly TemperatureService _temps;
+    private readonly WingetService _winget;
     private CancellationTokenSource? _tuneUpCts;
     private CancellationTokenSource? _pollingCts;
 
@@ -86,12 +87,13 @@ public sealed partial class DashboardViewModel : ViewModelBase
     [ObservableProperty] private bool _isActive;
 
     public DashboardViewModel(SystemInfoService sys, TuneUpService tuneUp,
-        HealthScoreService healthScore, TemperatureService temps)
+        HealthScoreService healthScore, TemperatureService temps, WingetService winget)
     {
         _sys = sys;
         _tuneUp = tuneUp;
         _healthScore = healthScore;
         _temps = temps;
+        _winget = winget;
         IsElevated = AdminHelper.IsElevated();
         InitializeAsync(InitAsync);
     }
@@ -427,16 +429,11 @@ public sealed partial class DashboardViewModel : ViewModelBase
     {
         try
         {
-            var runner = new PowerShellRunner();
-            var output = new System.Text.StringBuilder();
-            runner.LineReceived += l => { if (l.Kind == OutputKind.Output) output.AppendLine(l.Text); };
-
-            await runner.RunScriptViaPwshAsync(
-                "winget upgrade --include-unknown 2>$null | Select-String -Pattern '^\\S' | Measure-Object | Select-Object -ExpandProperty Count",
-                CancellationToken.None);
-
-            var countText = output.ToString().Trim();
-            var count = int.TryParse(countText, out var n) ? Math.Max(n - 2, 0) : 0;
+            // Reuse the shared, column-parsed upgrade list instead of a fragile
+            // "count non-blank lines minus the header/separator" heuristic — the
+            // latter mis-counted whenever winget's header/footer layout shifted.
+            var upgradable = await _winget.ListUpgradableAsync(CancellationToken.None);
+            var count = upgradable.Count;
 
             var (title, severity) = ClassifyAppUpdates(count);
             System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -186,7 +186,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             var speedTest = new SpeedTestService();
             var netRepair = new NetworkRepairService(runner);
 
-            Dashboard = new DashboardViewModel(sysInfo, tuneUp, healthScore, new TemperatureService(diskHealth));
+            Dashboard = new DashboardViewModel(sysInfo, tuneUp, healthScore, new TemperatureService(diskHealth), winget);
             AppUpdates = new AppUpdatesViewModel(winget);
             WindowsUpdate = new WindowsUpdateViewModel(runner, new WindowsUpdateService(), new WindowsUpdatePolicyService());
             SystemHealth = new SystemHealthViewModel(sysInfo, diskHealth, new MemoryTestService(), fixedDrives, runner, new BiosService());


### PR DESCRIPTION
## What

Two winget surfaces bypassed the canonical `WingetTableParser` and rolled their own fragile parsing. Both now reuse the shared parser.

### idx 245 — Dashboard app-update count
`ScanAppUpdatesAsync` counted updates with a `winget upgrade … | Measure-Object` line-count then `Math.Max(n - 2, 0)` to guess-strip the header/separator. That mis-counted whenever winget's header/footer layout shifted. It now injects `WingetService` and uses `ListUpgradableAsync().Count` — the **same parsed list the App Updates tab shows** (only rows with an actual `Available` version), so the dashboard alert and the tab always agree.

### idx 239 — Bulk Installer search
`SearchWingetPackages` sliced each row by fixed character offsets derived from `IndexOf("Id")`/`IndexOf("Version")`, which mis-sliced rows containing wide/CJK characters. The parse is extracted into a **pure, testable** `ParseSearchResults` that routes through `WingetTableParser` (column detection handled in one place).

## Tests

New `BulkInstallerSearchParseTests`: name/id extraction, Custom-category tagging, empty output, header-only, and the 30-row cap — fixtures built from explicit column widths so header/data alignment can't drift.

## Ctor change

`DashboardViewModel` gained a `WingetService` parameter (already a DI singleton, so runtime resolution is automatic). All four construction sites updated: the manual test/designer graph in `MainWindowViewModel` + three test constructors.

## Not fixed (verified, deliberately left)

idx 223 (storage temp/disk-name pairing) — the audit is right that positional-index pairing can mislabel on 2+ disks, but LHM storage sensors expose **no reliable key** (serial/index) to join to WMI `Win32_DiskDrive`. Any alternative is another unprovable heuristic that could regress the common single-disk case, so it's left as-is.

## Verification
- `dotnet build -c Release` on app + all three test projects → 0 errors
- `fix:` → patch bump to **1.52.2**; CHANGELOG entry added; csproj version matches