### PR TITLE
docs: correct supported-version table and 1.52.2 changelog date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 - **Performance tab "Restore" no longer mis-reverts Xbox Game Bar.** Restore captured the Game Bar overlay (`AppCaptureEnabled`) and per-game DVR (`GameDVR_Enabled`) as two independent settings but then wrote a single combined value to both keys — so if you had one on and the other off, restoring forced both off and silently lost the on state. Each setting is now restored to exactly what the snapshot captured.
 
-## [1.52.2] - 2026-06-30
+## [1.52.2] - 2026-07-01
 
 ### Fixed
 - **App-update count on the Dashboard is now accurate.** The dashboard alert used a fragile "count non-blank winget lines minus two" heuristic that mis-counted whenever winget's header/footer layout shifted. It now reuses the same parsed upgrade list the App Updates tab shows (rows that actually have an available version), so the two surfaces always agree.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.51.x   | :white_check_mark: |
-| < 1.51   | :x:                |
+| 1.52.x   | :white_check_mark: |
+| < 1.52   | :x:                |
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
Two doc-drift fixes surfaced by the full-repo audit.

- **SECURITY.md** — the supported-versions table listed `1.51.x` while the latest minor is now `1.52.x` (v1.52.2 shipped). By the doc's own *"latest minor release only"* policy, updated the supported row to `1.52.x` and the cutoff to `< 1.52`.
- **CHANGELOG.md** — the `1.52.2` entry was dated `2026-06-30` but the release published `2026-07-01`. Corrected to the tag date.

`docs:` → no release.