### PR TITLE
chore: normalize author headers (9 test files + App/MainWindow) + CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,4 +22,5 @@
 # Source code
 /SysManager/SysManager/                 @laurentiu021
 /SysManager/SysManager.Tests/           @laurentiu021
+/SysManager/SysManager.IntegrationTests/ @laurentiu021
 /SysManager/SysManager.UITests/         @laurentiu021

--- a/SysManager/SysManager.Tests/AppBlockerServiceValidationTests.cs
+++ b/SysManager/SysManager.Tests/AppBlockerServiceValidationTests.cs
@@ -1,4 +1,6 @@
-// SysManager · AppBlockerService input validation tests (no registry access)
+// SysManager · AppBlockerServiceValidationTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
 using SysManager.Services;
 
 namespace SysManager.Tests;

--- a/SysManager/SysManager.Tests/BatteryInfoEdgeCaseTests.cs
+++ b/SysManager/SysManager.Tests/BatteryInfoEdgeCaseTests.cs
@@ -1,4 +1,6 @@
-// SysManager · BatteryInfo computed property edge-case tests
+// SysManager · BatteryInfoEdgeCaseTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
 using SysManager.Models;
 
 namespace SysManager.Tests;

--- a/SysManager/SysManager.Tests/CleanupCategoryHumanSizeExtendedTests.cs
+++ b/SysManager/SysManager.Tests/CleanupCategoryHumanSizeExtendedTests.cs
@@ -1,4 +1,6 @@
-// SysManager · FormatHelper.FormatSize extended boundary tests
+// SysManager · CleanupCategoryHumanSizeExtendedTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
 using SysManager.Helpers;
 using SysManager.Models;
 

--- a/SysManager/SysManager.Tests/DiskHealthReportEdgeCaseTests.cs
+++ b/SysManager/SysManager.Tests/DiskHealthReportEdgeCaseTests.cs
@@ -1,4 +1,6 @@
-// SysManager · DiskHealthReport edge-case tests
+// SysManager · DiskHealthReportEdgeCaseTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
 using SysManager.Models;
 
 namespace SysManager.Tests;

--- a/SysManager/SysManager.Tests/EventExplainerEdgeCaseTests.cs
+++ b/SysManager/SysManager.Tests/EventExplainerEdgeCaseTests.cs
@@ -1,4 +1,6 @@
-// SysManager · EventExplainer — coverage for generic fallback and known lookups
+// SysManager · EventExplainerEdgeCaseTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
 using SysManager.Models;
 using SysManager.Services;
 

--- a/SysManager/SysManager.Tests/HealthAnalyzerEdgeCaseTests.cs
+++ b/SysManager/SysManager.Tests/HealthAnalyzerEdgeCaseTests.cs
@@ -1,4 +1,6 @@
-// SysManager · HealthAnalyzer edge-case and boundary tests
+// SysManager · HealthAnalyzerEdgeCaseTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
 using SysManager.Models;
 using SysManager.Services;
 using static SysManager.Services.HealthAnalyzer;

--- a/SysManager/SysManager.Tests/LogServiceSanitizeEdgeCaseTests.cs
+++ b/SysManager/SysManager.Tests/LogServiceSanitizeEdgeCaseTests.cs
@@ -1,4 +1,6 @@
-// SysManager · LogService.SanitizePath edge-case tests
+// SysManager · LogServiceSanitizeEdgeCaseTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
 using SysManager.Services;
 
 namespace SysManager.Tests;

--- a/SysManager/SysManager.Tests/OperationLockServiceEdgeCaseTests.cs
+++ b/SysManager/SysManager.Tests/OperationLockServiceEdgeCaseTests.cs
@@ -1,4 +1,6 @@
-// SysManager · OperationLockService concurrency and edge-case tests
+// SysManager · OperationLockServiceEdgeCaseTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
 using SysManager.Services;
 
 namespace SysManager.Tests;

--- a/SysManager/SysManager.Tests/ViewModelBaseExtendedTests.cs
+++ b/SysManager/SysManager.Tests/ViewModelBaseExtendedTests.cs
@@ -1,4 +1,6 @@
-// SysManager · ViewModelBase dispose and state transition tests
+// SysManager · ViewModelBaseExtendedTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
 using SysManager.ViewModels;
 
 namespace SysManager.Tests;

--- a/SysManager/SysManager/App.xaml.cs
+++ b/SysManager/SysManager/App.xaml.cs
@@ -1,4 +1,4 @@
-// SysManager — Windows system monitoring toolkit
+// SysManager · App
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-// SysManager — MainWindow shell
+// SysManager · MainWindow
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 


### PR DESCRIPTION
Repo-hygiene items from the full-repo audit.

- **9 SysManager.Tests files** carried only a descriptive `// SysManager · <desc>` first line and were **missing the mandatory Author + License lines**. All now use the standard 3-line header (`// SysManager · <ClassName>` / Author / License), matching the other ~160 .cs files: AppBlockerServiceValidationTests, BatteryInfoEdgeCaseTests, CleanupCategoryHumanSizeExtendedTests, DiskHealthReportEdgeCaseTests, EventExplainerEdgeCaseTests, HealthAnalyzerEdgeCaseTests, LogServiceSanitizeEdgeCaseTests, OperationLockServiceEdgeCaseTests, ViewModelBaseExtendedTests.
- **App.xaml.cs / MainWindow.xaml.cs** used a `// SysManager — <desc>` em-dash first line instead of `// SysManager · <ClassName>` (Author + License were already correct). Normalized.
- **CODEOWNERS** listed Tests + UITests but omitted IntegrationTests; added it (default `* @laurentiu021` already covered it — now the explicit list is consistent).

Build 0/0 (main + tests). `chore:` → no release.