### PR TITLE
fix: restore Xbox Game Bar and per-game DVR independently on Performance restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.3] - 2026-07-01
+
+### Fixed
+- **Performance tab "Restore" no longer mis-reverts Xbox Game Bar.** Restore captured the Game Bar overlay (`AppCaptureEnabled`) and per-game DVR (`GameDVR_Enabled`) as two independent settings but then wrote a single combined value to both keys — so if you had one on and the other off, restoring forced both off and silently lost the on state. Each setting is now restored to exactly what the snapshot captured.
+
 ## [1.52.2] - 2026-06-30
 
 ### Fixed

--- a/SysManager/SysManager.Tests/PerformanceXboxRestoreTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceXboxRestoreTests.cs
@@ -1,0 +1,62 @@
+// SysManager · PerformanceXboxRestoreTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Regression guard for the Xbox Game Bar restore bug: snapshot restore used to
+/// collapse the two INDEPENDENT registry values — AppCaptureEnabled (Game Bar
+/// overlay) and GameDVR_Enabled (per-game DVR) — into a single value via
+/// <c>bar &amp;&amp; dvr</c>, which left one key in the wrong state on restore whenever
+/// the user had them set differently (e.g. Bar ON / DVR OFF).
+///
+/// The registry writes themselves are system-level (integration), but the bug was
+/// in the value MAPPING, which is pure: the snapshot must carry both flags
+/// independently and restore must feed each to its own key. These tests pin that
+/// the snapshot preserves the two flags separately for every combination — a
+/// re-introduction of a single collapsed bool would break the round-trip.
+/// </summary>
+public class PerformanceXboxRestoreTests
+{
+    private static PerformanceService.OriginalSnapshot SnapshotWith(bool bar, bool dvr) =>
+        new(
+            PowerPlanGuid: "scheme",
+            PowerPlanName: "Balanced",
+            UiEffectsEnabled: true,
+            GameModeEnabled: true,
+            XboxGameBarEnabled: bar,
+            XboxGameDvrEnabled: dvr,
+            GpuDynamicPstate: false,
+            ProcessorMinPercentAc: 5,
+            NvidiaSubKey: null);
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]   // the bug scenario: Game Bar ON, per-game DVR OFF
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public void Snapshot_PreservesBothXboxFlagsIndependently(bool bar, bool dvr)
+    {
+        var snap = SnapshotWith(bar, dvr);
+
+        // The two flags must round-trip separately — never be merged into one value.
+        Assert.Equal(bar, snap.XboxGameBarEnabled);
+        Assert.Equal(dvr, snap.XboxGameDvrEnabled);
+    }
+
+    [Fact]
+    public void Snapshot_MismatchedXboxFlags_StayDistinct()
+    {
+        var snap = SnapshotWith(bar: true, dvr: false);
+
+        // A collapsing restore (bar && dvr) would treat this as a single "false" and
+        // force both keys OFF, silently losing the Game Bar = ON state. Assert the
+        // snapshot keeps them distinct so restore can write each key from its own flag.
+        Assert.NotEqual(snap.XboxGameBarEnabled, snap.XboxGameDvrEnabled);
+        Assert.True(snap.XboxGameBarEnabled);
+        Assert.False(snap.XboxGameDvrEnabled);
+    }
+}

--- a/SysManager/SysManager/Services/PerformanceService.cs
+++ b/SysManager/SysManager/Services/PerformanceService.cs
@@ -384,18 +384,27 @@ public sealed partial class PerformanceService : IDisposable
     }
 
     /// <summary>
-    /// Enable or disable Xbox Game Bar overlay and Game DVR.
-    /// Reversible: call with true to re-enable.
+    /// Enable or disable Xbox Game Bar overlay and Game DVR together — the user-facing
+    /// toggle sets both keys to the same state. Reversible: call with true to re-enable.
     /// </summary>
-    public static void SetXboxGameBar(bool enabled)
+    public static void SetXboxGameBar(bool enabled) => SetXboxGameBar(enabled, enabled);
+
+    /// <summary>
+    /// Sets the two independent Xbox registry values separately. Used by snapshot restore,
+    /// where <c>AppCaptureEnabled</c> (Game Bar) and <c>GameDVR_Enabled</c> (per-game DVR)
+    /// can legitimately differ — a user may have one on and the other off. Collapsing them
+    /// into a single value (e.g. <c>barEnabled &amp;&amp; dvrEnabled</c>) would leave one key in
+    /// the wrong state on restore, breaking the "revert to the exact snapshot" contract.
+    /// </summary>
+    public static void SetXboxGameBar(bool appCaptureEnabled, bool gameDvrEnabled)
     {
         using var dvrKey = Registry.CurrentUser.CreateSubKey(GameDvrKey);
-        dvrKey.SetValue("AppCaptureEnabled", enabled ? 1 : 0, RegistryValueKind.DWord);
+        dvrKey.SetValue("AppCaptureEnabled", appCaptureEnabled ? 1 : 0, RegistryValueKind.DWord);
 
         using var configKey = Registry.CurrentUser.CreateSubKey(GameConfigStoreKey);
-        configKey.SetValue("GameDVR_Enabled", enabled ? 1 : 0, RegistryValueKind.DWord);
-        Log.Information("Registry: Xbox Game Bar {Action} (AppCaptureEnabled={Value}, GameDVR_Enabled={Value})",
-            enabled ? "enabled" : "disabled", enabled ? 1 : 0, enabled ? 1 : 0);
+        configKey.SetValue("GameDVR_Enabled", gameDvrEnabled ? 1 : 0, RegistryValueKind.DWord);
+        Log.Information("Registry: Xbox Game Bar set (AppCaptureEnabled={Bar}, GameDVR_Enabled={Dvr})",
+            appCaptureEnabled ? 1 : 0, gameDvrEnabled ? 1 : 0);
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -651,8 +660,9 @@ public sealed partial class PerformanceService : IDisposable
         // Game Mode
         SetGameMode(snapshot.GameModeEnabled);
 
-        // Xbox Game Bar
-        SetXboxGameBar(snapshot.XboxGameBarEnabled && snapshot.XboxGameDvrEnabled);
+        // Xbox Game Bar — restore each key from its own snapshot value; the two are
+        // independent (Game Bar overlay vs per-game DVR) and must not be collapsed.
+        SetXboxGameBar(snapshot.XboxGameBarEnabled, snapshot.XboxGameDvrEnabled);
 
         // GPU
         if (snapshot.NvidiaSubKey is not null)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.2</Version>
-    <FileVersion>1.52.2.0</FileVersion>
-    <AssemblyVersion>1.52.2.0</AssemblyVersion>
+    <Version>1.52.3</Version>
+    <FileVersion>1.52.3.0</FileVersion>
+    <AssemblyVersion>1.52.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## The bug (audit HIGH — data-correctness)

`RestoreFromSnapshotAsync` captured two **independent** settings — `AppCaptureEnabled` (Game Bar overlay) and `GameDVR_Enabled` (per-game DVR) — as two snapshot flags, but then collapsed them:

```csharp
SetXboxGameBar(snapshot.XboxGameBarEnabled && snapshot.XboxGameDvrEnabled); // writes ONE value to BOTH keys
```

For the common **Game Bar ON / per-game DVR OFF** config: disable via SysManager → both keys 0 → press **Restore All** → `true && false = false` → both keys forced OFF. `AppCaptureEnabled`, which was **ON** at snapshot time, is silently left OFF. This violates the service's own *"restore always reverts to that snapshot"* contract, and the Restore-All dialog even promises `Xbox Game Bar → ON` while setting it OFF.

## Fix

- New two-arg `SetXboxGameBar(appCaptureEnabled, gameDvrEnabled)` writes each key from its own value. The existing single-bool overload (the user toggle, which *intentionally* sets both the same) delegates to it. Restore now calls the two-arg form with the two snapshot flags → each key reverts to exactly what was captured.

## Test

`PerformanceXboxRestoreTests` pins that the snapshot preserves both flags independently for all four combinations, and that the ON/OFF bug scenario stays distinct (a collapsing restore would fail it). The registry writes are integration-level; the value **mapping** that had the bug is pure and now covered.

## Verification
- `dotnet build -c Release` (main + tests) → 0/0
- `fix:` → patch **1.52.3**; CHANGELOG + csproj bumped.