### PR TITLE
fix: in-app updater no longer rejects unsigned builds as tampering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.4] - 2026-07-01
+
+### Fixed
+- **In-app updater no longer aborts every update as "possible tampering."** The Authenticode check treated an *unsigned* download as an invalid signature and cancelled the install — but SysManager ships unsigned builds, so the About-tab "Download → Install" flow was blocked for every release. (Most people update through winget, so this went unnoticed.) An unsigned binary is now correctly accepted; file integrity is still enforced by the SHA256 verification that runs first, and the check now only rejects a file whose signature data is genuinely unreadable.
+
 ## [1.52.3] - 2026-07-01
 
 ### Fixed

--- a/SysManager/SysManager.Tests/UpdateServiceAuthenticodeTests.cs
+++ b/SysManager/SysManager.Tests/UpdateServiceAuthenticodeTests.cs
@@ -1,0 +1,89 @@
+// SysManager · UpdateServiceAuthenticodeTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Regression tests for <see cref="UpdateService.VerifyAuthenticode"/>.
+///
+/// The bug: <c>X509Certificate.CreateFromSignedFile</c> THROWS
+/// <c>CryptographicException</c> (HResult 0x80092009, CRYPT_E_NO_MATCH) on a file
+/// with no embedded Authenticode signature — it does not return null. The old code
+/// only returned <c>true</c> from the null branch (which is unreachable) and turned
+/// every unsigned file into <c>false</c> via the catch. Since SysManager ships
+/// unsigned builds, that made the in-app updater abort EVERY install with
+/// "invalid digital signature — possible tampering". These tests pin that an
+/// unsigned file is now accepted (true), so the update flow is no longer blocked.
+///
+/// (File integrity is enforced separately by the SHA256 check, which runs first.)
+/// </summary>
+public class UpdateServiceAuthenticodeTests
+{
+    private static string WriteTempFile(byte[] bytes)
+    {
+        var path = Path.Combine(Path.GetTempPath(), "sysmgr_authtest_" + Guid.NewGuid().ToString("N") + ".bin");
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    [Fact]
+    public void VerifyAuthenticode_UnsignedFile_ReturnsTrue()
+    {
+        // A plain file has no embedded Authenticode signature → CreateFromSignedFile
+        // throws CRYPT_E_NO_MATCH. This MUST be treated as "unsigned, allowed", not tampering.
+        var path = WriteTempFile("not a signed PE, just bytes"u8.ToArray());
+        try
+        {
+            Assert.True(UpdateService.VerifyAuthenticode(path),
+                "An unsigned file must be accepted — SysManager ships unsigned builds and the " +
+                "SHA256 check is the integrity gate; rejecting here blocks every in-app update.");
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void VerifyAuthenticode_TinyUnsignedFile_ReturnsTrue()
+    {
+        // A 1-byte file still reports "no signature" (CRYPT_E_NO_MATCH) → allowed.
+        var path = WriteTempFile([0x41]);
+        try
+        {
+            Assert.True(UpdateService.VerifyAuthenticode(path));
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void VerifyAuthenticode_EmptyFile_ReturnsFalse()
+    {
+        // An empty file cannot be read as a PE at all (surfaces as E_FAIL, not
+        // "no signature"), so it is correctly rejected. A real update is never empty —
+        // and the SHA256 step rejects a truncated download before this runs — so this
+        // only documents that a malformed/unreadable file is not silently accepted.
+        var path = WriteTempFile([]);
+        try
+        {
+            Assert.False(UpdateService.VerifyAuthenticode(path));
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void VerifyAuthenticode_RandomBinaryContent_ReturnsTrue()
+    {
+        // Bytes that vaguely resemble a PE header but carry no signature directory.
+        var bytes = new byte[512];
+        bytes[0] = (byte)'M';
+        bytes[1] = (byte)'Z';
+        var path = WriteTempFile(bytes);
+        try
+        {
+            Assert.True(UpdateService.VerifyAuthenticode(path));
+        }
+        finally { File.Delete(path); }
+    }
+}

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -316,10 +316,24 @@ public sealed class UpdateService
         }
     }
 
+    // CryptographicException HResult raised by CreateFromSignedFile when the file
+    // carries NO embedded Authenticode signature at all. On .NET this surfaces as
+    // CRYPT_E_NO_MATCH (0x80092009) — "Cannot find the requested object". SysManager's
+    // own builds are unsigned (no code-signing certificate yet), so this is the normal,
+    // expected case and must NOT be treated as tampering.
+    private const int CryptENoMatch = unchecked((int)0x80092009);
+
     /// <summary>
-    /// Verifies the Authenticode signature on a downloaded update binary.
-    /// Returns true if the binary is signed or unsigned (open-source builds).
-    /// Returns false only if the signature is present but INVALID (tampered).
+    /// Reports the Authenticode state of a downloaded update binary. Returns true when
+    /// the binary is validly embedded-signed OR carries no signature at all (SysManager
+    /// ships unsigned open-source builds). Returns false only when reading the signature
+    /// fails for a reason other than "no signature present".
+    ///
+    /// This is NOT the integrity gate: file integrity is enforced by the SHA256 check
+    /// (<see cref="VerifyHashAsync"/>) against the published .sha256, which runs first in
+    /// the install flow. <c>CreateFromSignedFile</c> extracts the signer certificate but
+    /// does not by itself validate the file against the signature, so it cannot detect a
+    /// tampered signed binary — the SHA256 comparison is what catches a modified download.
     /// </summary>
     public static bool VerifyAuthenticode(string filePath)
     {
@@ -329,19 +343,24 @@ public sealed class UpdateService
             var cert = System.Security.Cryptography.X509Certificates.X509Certificate
                 .CreateFromSignedFile(filePath);
 #pragma warning restore SYSLIB0057
-            if (cert is not null)
-            {
-                Serilog.Log.Information("Update binary Authenticode verified: {Subject}", cert.Subject);
-                return true;
-            }
-            // Unsigned binary — acceptable for open-source GitHub Actions builds.
+            // A non-null cert means an embedded Authenticode signature was found and its
+            // signer certificate could be read. (Unsigned files throw below rather than
+            // returning null, so this branch is the signed case.)
+            Serilog.Log.Information("Update binary is Authenticode-signed: {Subject}", cert.Subject);
+            return true;
+        }
+        catch (System.Security.Cryptography.CryptographicException ex) when (ex.HResult == CryptENoMatch)
+        {
+            // No embedded signature — expected for SysManager's unsigned builds. Allow it;
+            // integrity is already guaranteed by the SHA256 verification step.
             Serilog.Log.Information("Update binary has no Authenticode signature (expected for unsigned builds)");
             return true;
         }
-        catch (System.Security.Cryptography.CryptographicException)
+        catch (System.Security.Cryptography.CryptographicException ex)
         {
-            // Invalid/tampered signature — file HAS a signature but it's broken.
-            Serilog.Log.Warning("Update binary has INVALID Authenticode signature — possible tampering: {File}", LogService.SanitizePath(filePath));
+            // Signature data present but could not be read/parsed — treat as suspect.
+            Serilog.Log.Warning(ex, "Update binary Authenticode signature could not be read (HResult 0x{HResult:X8}): {File}",
+                ex.HResult, LogService.SanitizePath(filePath));
             return false;
         }
     }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.3</Version>
-    <FileVersion>1.52.3.0</FileVersion>
-    <AssemblyVersion>1.52.3.0</AssemblyVersion>
+    <Version>1.52.4</Version>
+    <FileVersion>1.52.4.0</FileVersion>
+    <AssemblyVersion>1.52.4.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -504,10 +504,12 @@ public sealed partial class AboutViewModel : ViewModelBase
             return;
         }
 
-        // Step 1b: Verify Authenticode signature (detects tampered binaries).
+        // Step 1b: Authenticode check. Integrity is already guaranteed by the SHA256
+        // step above; this only rejects a file whose signature data is present but
+        // unreadable. Unsigned builds (SysManager ships unsigned) are allowed.
         if (!UpdateService.VerifyAuthenticode(DownloadedPath))
         {
-            DownloadStatus = "Update binary has an invalid digital signature — possible tampering. Download aborted.";
+            DownloadStatus = "Update binary's signature could not be read. Download aborted.";
             return;
         }
 


### PR DESCRIPTION
## The bug (validated HIGH — live functional break)

The audit flagged `UpdateService.VerifyAuthenticode` as a *test-coverage gap*. Probing the real .NET 10 behaviour proved it's worse — a **live functional bug**:

`X509Certificate.CreateFromSignedFile` **throws `CryptographicException`** on an unsigned file (HResult `0x80092009`, CRYPT_E_NO_MATCH) — it does **not** return null. The old `catch` turned that into `return false`, and `AboutViewModel` then aborted:

> "Update binary has an invalid digital signature — possible tampering. Download aborted."

**SysManager ships unsigned builds**, so the in-app **About → Download → Install** updater was broken for *every* release. It went unnoticed because most users update via winget, not the in-app button.

## Validation (probe, not assumption)

Ran a throwaway probe against .NET 10:
| Input | Result |
|---|---|
| unsigned file / 1-byte file | throws `0x80092009` (no signature) |
| empty / unreadable file | throws `0x80004005` (E_FAIL) |
| validly embedded-signed PE (dotnet.exe) | returns cert |
| **byte-flipped signed PE** | **still returns its cert** |

That last row proves `CreateFromSignedFile` never validated integrity anyway — so it was never a real tamper detector. The **SHA256 check (runs first)** is the actual integrity gate.

## Fix

- `VerifyAuthenticode` returns `true` for the no-signature case (unsigned builds) and `false` only when signature data is present but unreadable. Docs corrected to stop claiming tamper detection.
- `AboutViewModel` message + comment updated (SHA256 is the integrity gate; unsigned is allowed).
- `UpdateServiceAuthenticodeTests`: unsigned / 1-byte / MZ-header → accepted; empty → rejected. **Expectations validated against the real compiled method** (caught my own wrong empty-file assertion before pushing).

## Verification
- `dotnet build -c Release` (main + tests) → 0/0
- `fix:` → patch **1.52.4**; CHANGELOG + csproj bumped.