### PR TITLE
fix: cache RAM DIMM inventory so Dashboard 300ms poll stops re-scanning it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.5] - 2026-07-01
+
+### Fixed
+- **Dashboard vitals polling no longer re-scans the RAM hardware inventory every 300 ms.** The live CPU/RAM/GPU snapshot the Dashboard refreshes ~3× a second was re-enumerating the physical memory modules (bank, manufacturer, capacity, speed, part number) via WMI on every tick, even though that inventory is fixed hardware that never changes while the app runs. The DIMM list is now read once and cached — matching how OS, CPU, and disk info were already cached — so only the dynamic RAM totals are refreshed per poll. Lower background CPU/WMI overhead with no change to what's displayed.
+
 ## [1.52.4] - 2026-07-01
 
 ### Fixed

--- a/SysManager/SysManager.IntegrationTests/SystemInfoServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/SystemInfoServiceTests.cs
@@ -67,6 +67,31 @@ public class SystemInfoServiceTests
     }
 
     [Fact]
+    public async Task CaptureAsync_ReusesCachedMemoryModules()
+    {
+        // The physical DIMM inventory is static hardware — it must be enumerated once
+        // and reused, so the Dashboard's 300 ms vitals poll never re-scans
+        // Win32_PhysicalMemory. Same instance across calls proves the cache holds.
+        var svc = new SystemInfoService();
+        var a = await svc.CaptureAsync();
+        var b = await svc.CaptureAsync();
+        Assert.Same(a.Memory.Modules, b.Memory.Modules);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_MemoryTotalsStillRefreshPerCall()
+    {
+        // Caching the modules must NOT freeze the dynamic RAM totals — each snapshot
+        // still carries a freshly-queried total/available/used so live vitals stay real.
+        var svc = new SystemInfoService();
+        var a = await svc.CaptureAsync();
+        var b = await svc.CaptureAsync();
+        Assert.True(a.Memory.TotalGB > 0);
+        Assert.True(b.Memory.TotalGB > 0);
+        Assert.Equal(a.Memory.TotalGB, b.Memory.TotalGB, 3); // total RAM is stable within a session
+    }
+
+    [Fact]
     public async Task CaptureAsync_RespectsCancellation()
     {
         var svc = new SystemInfoService();

--- a/SysManager/SysManager/Services/SystemInfoService.cs
+++ b/SysManager/SysManager/Services/SystemInfoService.cs
@@ -18,6 +18,7 @@ public sealed class SystemInfoService
     private OsInfo? _cachedOs;
     private CpuInfo? _cachedCpuStatic;
     private List<DiskInfo>? _cachedDisks;
+    private IReadOnlyList<MemoryModule>? _cachedModules;
     private readonly Lock _cacheLock = new();
 
     public Task<SystemSnapshot> CaptureAsync(CancellationToken ct = default)
@@ -43,9 +44,14 @@ public sealed class SystemInfoService
             // Disk info is static (models don't change at runtime).
             _cachedDisks ??= QueryDisks();
             disks = _cachedDisks;
+
+            // Physical memory modules (bank/manufacturer/capacity/speed/part) are static
+            // hardware — enumerate the DIMMs once. Only the dynamic totals refresh below,
+            // so the Dashboard's 300 ms vitals poll no longer re-queries Win32_PhysicalMemory.
+            _cachedModules ??= QueryMemoryModules();
         }
 
-        var mem = QueryMemory();
+        var mem = QueryMemory(_cachedModules);
         return new SystemSnapshot(os, cpu, mem, disks, DateTime.Now);
     }
 
@@ -128,7 +134,9 @@ public sealed class SystemInfoService
         return 0;
     }
 
-    private static MemoryInfo QueryMemory()
+    // Dynamic RAM totals (refreshed every poll) combined with the pre-enumerated,
+    // cached static DIMM modules. Only Win32_OperatingSystem is queried here.
+    private static MemoryInfo QueryMemory(IReadOnlyList<MemoryModule> modules)
     {
         double totalKb = 0, freeKb = 0;
         using (var s = new ManagementObjectSearcher("SELECT TotalVisibleMemorySize,FreePhysicalMemory FROM Win32_OperatingSystem"))
@@ -148,25 +156,30 @@ public sealed class SystemInfoService
         double usedGB = totalGB - freeGB;
         double pct = totalGB > 0 ? usedGB / totalGB * 100.0 : 0;
 
+        return new MemoryInfo(totalGB, freeGB, usedGB, pct, modules);
+    }
+
+    // Physical DIMM inventory — static hardware, enumerated once and cached. Kept
+    // separate from QueryMemory so the per-poll path never re-scans Win32_PhysicalMemory.
+    private static List<MemoryModule> QueryMemoryModules()
+    {
         List<MemoryModule> modules = [];
-        using (var s = new ManagementObjectSearcher("SELECT BankLabel,Manufacturer,Capacity,Speed,PartNumber FROM Win32_PhysicalMemory"))
+        using var s = new ManagementObjectSearcher("SELECT BankLabel,Manufacturer,Capacity,Speed,PartNumber FROM Win32_PhysicalMemory");
+        using var modCollection = s.Get();
+        foreach (ManagementObject mo in modCollection)
         {
-            using var modCollection = s.Get();
-            foreach (ManagementObject mo in modCollection)
+            using (mo)
             {
-                using (mo)
-                {
-                    double capBytes = Convert.ToDouble(mo["Capacity"] ?? 0);
-                    modules.Add(new MemoryModule(
-                        mo["BankLabel"]?.ToString() ?? "",
-                        mo["Manufacturer"]?.ToString()?.Trim() ?? "",
-                        capBytes / 1024d / 1024d / 1024d,
-                        Convert.ToUInt32(mo["Speed"] ?? 0u),
-                        mo["PartNumber"]?.ToString()?.Trim() ?? ""));
-                }
+                double capBytes = Convert.ToDouble(mo["Capacity"] ?? 0);
+                modules.Add(new MemoryModule(
+                    mo["BankLabel"]?.ToString() ?? "",
+                    mo["Manufacturer"]?.ToString()?.Trim() ?? "",
+                    capBytes / 1024d / 1024d / 1024d,
+                    Convert.ToUInt32(mo["Speed"] ?? 0u),
+                    mo["PartNumber"]?.ToString()?.Trim() ?? ""));
             }
         }
-        return new MemoryInfo(totalGB, freeGB, usedGB, pct, modules);
+        return modules;
     }
 
     private static List<DiskInfo> QueryDisks()

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.4</Version>
-    <FileVersion>1.52.4.0</FileVersion>
-    <AssemblyVersion>1.52.4.0</AssemblyVersion>
+    <Version>1.52.5</Version>
+    <FileVersion>1.52.5.0</FileVersion>
+    <AssemblyVersion>1.52.5.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem
The Dashboard's real-time vitals loop polls `SystemInfoService.CaptureAsync()` every **300 ms** (`DashboardViewModel.cs:159`). `Capture()` already caches static data — OS caption, CPU name/cores, disk models — with `??=`, but `QueryMemory()` was called **unconditionally on every poll** and re-enumerated `Win32_PhysicalMemory` (bank label, manufacturer, capacity, speed, part number). That's fixed hardware that never changes during a session, so it was ~3 WMI object-enumerations/second of pure waste on the background poll.

## Fix
Split the memory query:
- `QueryMemoryModules()` — the static DIMM inventory, enumerated **once** and cached in `_cachedModules` (same pattern as `_cachedCpuStatic` / `_cachedDisks`).
- `QueryMemory(modules)` — only the **dynamic** totals (`Win32_OperatingSystem` total/free), refreshed per poll, combined with the cached modules.

`MemoryInfo` record shape is unchanged, so all three consumers (SystemReportService, DashboardViewModel, SystemHealthViewModel) still receive the module list — identical content, now cached. The list is never mutated, so sharing the cached instance is safe.

## Behavior
Identical displayed data. Lower background CPU/WMI overhead.

## Tests
- `CaptureAsync_ReusesCachedMemoryModules` — same `Modules` instance across two captures (pins the cache).
- `CaptureAsync_MemoryTotalsStillRefreshPerCall` — totals still queried live per call (guards against over-caching).

Build: main + integration tests, 0 warnings / 0 errors.