### PR TITLE
fix: keep CLI --json machine-readable on errors and harden startup logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.6] - 2026-07-01
+
+### Fixed
+- **`--json` now stays machine-readable on CLI errors.** When an unknown flag or a bare usage error was hit together with `--json`, the CLI printed the human help text instead of JSON — so piping the output to a JSON parser (`SysManager.exe --bogus --json | ConvertFrom-Json`) broke. Both error paths now emit valid JSON: an unknown flag returns `{"error": "..."}` and a bare usage error returns the machine-readable command catalog.
+- **Headless CLI reports a runtime fault as an error (exit 1), not a usage error (exit 2).** If a CLI command threw unexpectedly the process exited with code 2, which conventionally means "you typed the command wrong." An unexpected fault is now logged and exits with code 1 (general error), so scripts can distinguish a bad invocation from a genuine failure.
+- **Startup crashes are now logged instead of vanishing.** The unhandled-exception handlers were registered *after* the dependency container, tray icon, and resource-history sampler were built — so a failure during that early startup surfaced as a bare Windows crash with no log entry. The handlers are now wired first, so any startup fault is captured in the log.
+- **Resource-history retention config load no longer risks an unhandled exception at startup.** Reading the retention setting caught malformed JSON and I/O errors but not an access-denied error; since it runs during construction, that gap could throw in the unprotected startup window. It now degrades to the 7-day default on access-denied too.
+
 ## [1.52.5] - 2026-07-01
 
 ### Fixed

--- a/SysManager/SysManager.Tests/CliRunnerTests.cs
+++ b/SysManager/SysManager.Tests/CliRunnerTests.cs
@@ -153,6 +153,30 @@ public class CliRunnerTests
         Assert.Contains("Usage:", r.Output);
     }
 
+    [Fact]
+    public async Task Execute_UnknownJson_EmitsParseableJsonError()
+    {
+        // Regression: the usage-error arm ignored --json and emitted plain help text, so
+        // `--bogus --json | ConvertFrom-Json` fed a JSON consumer non-JSON. It must now
+        // return a structured {"error": ...} and NOT leak the help prose.
+        var r = await new CliRunner().ExecuteAsync(new CliRequest(CliCommand.Unknown, Json: true, UnknownArg: "--nope"));
+        Assert.Equal(CliResult.UsageError, r.ExitCode);
+        var doc = System.Text.Json.JsonDocument.Parse(r.Output); // throws if not valid JSON
+        Assert.Contains("--nope", doc.RootElement.GetProperty("error").GetString());
+        Assert.DoesNotContain("Usage:", r.Output);
+    }
+
+    [Fact]
+    public async Task Execute_NoneJson_EmitsMachineReadableHelp()
+    {
+        // The bare-usage arm must also honor --json (machine-readable command catalog),
+        // not dump the human help text to a JSON consumer.
+        var r = await new CliRunner().ExecuteAsync(new CliRequest(CliCommand.None, Json: true));
+        Assert.Equal(CliResult.UsageError, r.ExitCode);
+        var doc = System.Text.Json.JsonDocument.Parse(r.Output); // throws if not valid JSON
+        Assert.True(doc.RootElement.TryGetProperty("commands", out _));
+    }
+
     // ── Help text / command catalog ─────────────────────────────────────────
 
     [Fact]

--- a/SysManager/SysManager/App.xaml.cs
+++ b/SysManager/SysManager/App.xaml.cs
@@ -105,6 +105,13 @@ public partial class App : Application
 
         LogService.Init();
 
+        // Wire the crash handlers FIRST — before the DI build, tray, and resource-history
+        // start below — so a throw anywhere in the remaining startup is logged rather than
+        // surfacing as a bare Windows Error Reporting crash with no diagnostic trail.
+        DispatcherUnhandledException += OnUi;
+        AppDomain.CurrentDomain.UnhandledException += OnDomain;
+        TaskScheduler.UnobservedTaskException += OnTask;
+
         // ── Build DI container ─────────────────────────────────────────
         var serviceCollection = new ServiceCollection();
         serviceCollection.ConfigureServices();
@@ -121,9 +128,6 @@ public partial class App : Application
         // service is disposed with the DI container on exit (stops the loop).
         Services.GetRequiredService<ResourceHistoryService>().Start();
 
-        DispatcherUnhandledException += OnUi;
-        AppDomain.CurrentDomain.UnhandledException += OnDomain;
-        TaskScheduler.UnobservedTaskException += OnTask;
         base.OnStartup(e);
 
         ThemeService.Instance.Initialize();
@@ -144,7 +148,10 @@ public partial class App : Application
     {
         var request = CliRunner.Parse(args);
         bool attached = AttachConsole(AttachParentProcess);
-        int exitCode = CliResult.UsageError;
+        // Default to the error code (1), not the usage code (2): ExecuteAsync sets the
+        // real code for every known command, so the only way we keep this default is an
+        // unexpected throw — which is a runtime error, not a usage mistake.
+        int exitCode = CliResult.Error;
         try
         {
             var result = new CliRunner().ExecuteAsync(request).GetAwaiter().GetResult();
@@ -152,6 +159,17 @@ public partial class App : Application
             bool suppress = request.Silent && result.ExitCode == CliResult.Ok;
             if (attached && !suppress && !string.IsNullOrEmpty(result.Output))
                 Console.Out.WriteLine(result.Output);
+        }
+        catch (Exception ex)
+        {
+            // A known command never throws (CliRunner reports failures in the result),
+            // so reaching here means an unexpected fault. Report it as an error (exit 1)
+            // and, if a JSON payload was requested, keep the output machine-readable.
+            LogService.Logger?.Error(ex, "CLI command threw unexpectedly");
+            if (attached)
+                Console.Error.WriteLine(request.Json
+                    ? $"{{\"error\":\"{ex.Message.Replace("\\", "\\\\").Replace("\"", "\\\"")}\"}}"
+                    : $"Error: {ex.Message}");
         }
         finally
         {

--- a/SysManager/SysManager/Services/CliRunner.cs
+++ b/SysManager/SysManager/Services/CliRunner.cs
@@ -130,9 +130,10 @@ public sealed class CliRunner
             CliCommand.Health => await RunHealthAsync(request, ct).ConfigureAwait(false),
             CliCommand.Cleanup => await RunCleanupAsync(request, ct).ConfigureAwait(false),
             CliCommand.TrimRam => RunTrimRam(request),
-            CliCommand.Unknown => new CliResult(CliResult.UsageError,
-                $"Unknown option '{request.UnknownArg}'.\n\n{BuildHelp(false)}"),
-            _ => new CliResult(CliResult.UsageError, BuildHelp(false)),
+            CliCommand.Unknown => new CliResult(CliResult.UsageError, request.Json
+                ? Json(new { error = $"Unknown option '{request.UnknownArg}'." })
+                : $"Unknown option '{request.UnknownArg}'.\n\n{BuildHelp(false)}"),
+            _ => new CliResult(CliResult.UsageError, BuildHelp(request.Json)),
         };
     }
 

--- a/SysManager/SysManager/Services/ResourceHistoryService.cs
+++ b/SysManager/SysManager/Services/ResourceHistoryService.cs
@@ -342,7 +342,7 @@ public sealed class ResourceHistoryService : IDisposable
             var cfg = JsonSerializer.Deserialize<RetentionConfig>(File.ReadAllText(ConfigPath));
             return cfg is not null && RetentionOptions.Contains(cfg.RetentionDays) ? cfg.RetentionDays : 7;
         }
-        catch (Exception ex) when (ex is JsonException or IOException)
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
         {
             Log.Debug("Resource history config load failed: {Error}", ex.Message);
             return 7;

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.5</Version>
-    <FileVersion>1.52.5.0</FileVersion>
-    <AssemblyVersion>1.52.5.0</AssemblyVersion>
+    <Version>1.52.6</Version>
+    <FileVersion>1.52.6.0</FileVersion>
+    <AssemblyVersion>1.52.6.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Four small, independently-verified correctness/robustness fixes on the headless CLI and startup path. Each was validated against current source before changing anything.

## 1. `--json` broke on CLI errors (MED)
`CliRunner.ExecuteAsync` (`CliRunner.cs:133-135`): both usage-error arms returned `BuildHelp(false)`, ignoring `request.Json`. So `SysManager.exe --bogus --json | ConvertFrom-Json` fed **human help text** to a JSON parser.
- Unknown flag → `{"error": "Unknown option '...'."}`
- Bare usage error → the machine-readable command catalog (`BuildHelp(true)`).

## 2. Wrong exit code on unexpected fault (LOW)
`App.xaml.cs` `RunCliAndExit`: `exitCode` defaulted to `UsageError` (2). Since `ExecuteAsync` sets the real code for every known command, the only way that default survived was an unexpected throw — reported as "usage error" (2) instead of "error" (1). Now defaults to `Error` (1) with a top-level catch that logs the fault and, under `--json`, still writes a JSON error to stderr.

## 3. Early-startup crashes went unlogged (LOW)
`App.xaml.cs` `OnStartup`: the three unhandled-exception handlers were registered **after** the DI container build, tray-icon resolve, and `ResourceHistoryService.Start()`. A throw in that window surfaced as a bare WER crash with no log. Handlers are now wired immediately after `LogService.Init()`, before those steps. (Old registration site removed — verified handlers subscribe exactly once.)

## 4. LoadRetention missed access-denied (LOW)
`ResourceHistoryService.cs:345`: `LoadRetention()` runs in the constructor and caught `JsonException`/`IOException` but not `UnauthorizedAccessException` (which `File.ReadAllText` can throw). Added it — degrades to the 7-day default like the others.

## Tests
`CliRunnerTests`: `Execute_UnknownJson_EmitsParseableJsonError` and `Execute_NoneJson_EmitsMachineReadableHelp` — both parse the output with `JsonDocument` (fails if not valid JSON) and assert no help prose leaks.

Build: main + unit tests, 0 warnings / 0 errors. Bumps to 1.52.6.