### PR TITLE
test: replace vacuous asserts with real post-conditions in ping/browser tests

### DIFF
--- a/SysManager/SysManager.IntegrationTests/PingMonitorStressTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PingMonitorStressTests.cs
@@ -48,8 +48,11 @@ public class PingMonitorStressTests
         };
         svc.AddOrUpdate(new PingTarget("base", Unreachable, "#111"));
         svc.Start();
+        Assert.True(svc.IsRunning);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        // The churn deliberately never touches "base" — only 192.0.2.2-253 hosts — so
+        // it survives as a fixed point we can assert on after the storm settles.
         var churn = Task.Run(() =>
         {
             var rnd = new Random(42);
@@ -61,11 +64,18 @@ public class PingMonitorStressTests
             }
         });
 
+        // A concurrency fault inside the loop faults this Task, so awaiting it here
+        // rethrows and fails the test — no separate exception plumbing needed.
         await churn;
         svc.Stop();
 
-        // If we got here without an exception, the concurrent access is safe.
-        Assert.True(true);
+        // Concrete post-conditions after concurrent add/remove: the service stopped
+        // cleanly, its target map is still coherent, and the untouched "base" target
+        // is intact (a corrupt ConcurrentDictionary would drop or duplicate it).
+        Assert.False(svc.IsRunning);
+        Assert.True(svc.Targets.ContainsKey(Unreachable));
+        Assert.Equal("base", svc.Targets[Unreachable].Name);
+        Assert.All(svc.Targets.Keys, Assert.NotNull);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/BrowserCleanerServiceTests.cs
+++ b/SysManager/SysManager.Tests/BrowserCleanerServiceTests.cs
@@ -150,12 +150,17 @@ public sealed class BrowserCleanerServiceTests : IDisposable
 
         var items = await _svc.ScanAsync();
         var cache = items.FirstOrDefault(i => i.Browser == "Google Chrome" && i.Category == "Cache");
-        // The junctioned cache must not contribute the victim's bytes/files to the scan.
-        if (cache is not null)
-        {
-            Assert.Equal(0, cache.SizeBytes);
-            Assert.Equal(0, cache.FileCount);
-        }
+
+        // The reparse-point guard makes the junctioned cache measure as (0 bytes, 0 files),
+        // so the scan drops the empty category entirely (ScanAsync skips size==0 && files==0).
+        // Either way it must NEVER surface with the victim's 4096 bytes — a followed junction
+        // would show up here as a non-zero Cache item. Asserting null is correct-by-design.
+        Assert.Null(cache);
+
+        // No scanned item anywhere may have absorbed the victim's bytes through the junction.
+        Assert.DoesNotContain(items, i => i.SizeBytes >= 4096);
+
+        // And the out-of-tree victim data is untouched by the scan.
         Assert.True(File.Exists(Path.Combine(victimDir, "secret.dat")));
     }
 


### PR DESCRIPTION
Two existing tests asserted essentially nothing — they'd pass even if the behavior they claim to cover regressed. No production code changes.

## 1. `PingMonitorStressTests.ParallelAddRemoveWhileRunning_IsThreadSafe`
Ended with `Assert.True(true)` — a tautology. The test churns concurrent `AddOrUpdate`/`Remove` against a running monitor to prove the `ConcurrentDictionary` access is thread-safe, but asserted no state.

Now asserts concrete post-conditions after the storm settles:
- `svc.IsRunning` is `false` (stopped cleanly),
- the `"base"` target — which the churn deliberately never touches (it only mutates `192.0.2.2-253`) — is still present with its original name (a corrupted map would drop or duplicate it),
- every key is non-null.

A concurrency fault inside the churn task still fails the test via rethrow on `await churn` (unchanged).

## 2. `BrowserCleanerServiceTests.Scan_DoesNotFollowJunction_OutOfBrowserTree`
The cache assertions were wrapped in `if (cache is not null) { ... }`, so they were **silently skipped** whenever the item didn't surface — the common path — leaving only the victim-file check.

I adversarially verified the real `ScanAsync` behavior first: a junctioned cache leaf measures as (0 bytes, 0 files) via the reparse-point guard, and `ScanAsync` drops any `size==0 && files==0` category — so `cache` is **null by design**. (An `Assert.NotNull` here would have been wrong and would fail.) The correct, un-skippable assertions:
- `Assert.Null(cache)` — the empty junctioned category is dropped,
- `Assert.DoesNotContain(items, i => i.SizeBytes >= 4096)` — **no** scanned item absorbed the victim's bytes through the junction (the actual security property),
- victim `secret.dat` still exists (retained).

Build: unit + integration tests, 0 warnings / 0 errors. `test:` — no release.