### PR TITLE
docs: correct sidebar group count (11 collapsible + flat Dashboard, not 12 collapsible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,10 @@ fully open source.
 ## Features
 
 ### Sidebar navigation
-The sidebar organises 58 feature tabs into 12 collapsible groups so you can
-find what you need without scrolling through a flat list. 53 tabs are fully
-implemented; 5 are work-in-progress placeholders marked with ⚙️:
+The sidebar organises 58 feature tabs into 12 groups — 11 collapsible groups
+plus a flat top-level Dashboard entry — so you can find what you need without
+scrolling through a flat list. 53 tabs are fully implemented; 5 are
+work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |
 |-------|------|


### PR DESCRIPTION
## The problem
README line 89 claimed the sidebar has **"12 collapsible groups"** — but line 113 of the *same section* already says:

> Dashboard renders as a flat top-level entry without an expander arrow.

So the paragraph contradicts itself: it calls all 12 groups collapsible, then says one of them (Dashboard) is a flat entry that doesn't collapse.

## Verified against source (not just the doc)
- `ViewModels/NavGroup.cs:29` — `public bool IsSingleItem => Children.Count == 1;`
- `MainWindow.xaml:111` — the `<Expander>` (the collapsible chrome) is bound `Visibility="{Binding IsSingleItem, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"` — rendered **only** for groups that are *not* single-item.
- The Dashboard group (1 child) is single-item → no expander. So exactly **11** of the 12 groups collapse.

## Fix
Reworded line 89 to "12 groups — 11 collapsible groups plus a flat top-level Dashboard entry". The 58 / 53 implemented / 5 WIP / 5 Preview figures were all already correct — only the "12 collapsible" qualifier was wrong.

No release (`docs:`).