### PR TITLE
fix: make chart text and banner/toast follow the theme (readable on light presets)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.7] - 2026-07-01
+
+### Fixed
+- **Chart text is now readable on the light themes.** The Ping/Traceroute latency chart and the Resource History usage/temperature charts painted their axis labels, legend, and tooltip in a fixed near-white color that was set once and never updated when you switched themes. On any of the six light presets that meant white-on-white — the axis values, time labels, and legend were effectively invisible. The chart text now follows the active theme (dark-on-light on light presets, light-on-dark on dark presets) and repaints instantly when you change the theme. The previously-unused theme-change signal is now wired up to drive this.
+- **Update banner and toast notification follow the theme.** Both used a fixed dark background, so on a light preset the update banner was a dark box clashing with the light UI and the toast's title could render dark-on-dark. They now use the theme's elevated surface color and stay legible on every preset.
+
 ## [1.52.6] - 2026-07-01
 
 ### Fixed

--- a/SysManager/SysManager.Tests/ChartThemeTests.cs
+++ b/SysManager/SysManager.Tests/ChartThemeTests.cs
@@ -1,0 +1,93 @@
+// SysManager · ChartThemeTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Painting;
+using SkiaSharp;
+using SysManager.Helpers;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Regression tests for <see cref="ChartTheme"/>. The bug: chart axis/legend/tooltip paints
+/// were hardcoded near-white (E6E9EE) and set once, so on the six light presets the text
+/// rendered white-on-white and was invisible (measured 1.1–1.2:1 contrast). ChartTheme drives
+/// those paints from the active theme's foreground colors instead. These tests pin that
+/// <see cref="ChartTheme.Apply"/> repaints the supplied paints/axes to the current theme.
+/// </summary>
+public class ChartThemeTests
+{
+    [Fact]
+    public void Sk_PreservesRgbaChannels()
+    {
+        var c = System.Windows.Media.Color.FromArgb(0x12, 0x34, 0x56, 0x78);
+        var sk = ChartTheme.Sk(c);
+        Assert.Equal(0x34, sk.Red);
+        Assert.Equal(0x56, sk.Green);
+        Assert.Equal(0x78, sk.Blue);
+        Assert.Equal(0x12, sk.Alpha);
+    }
+
+    [Fact]
+    public void Apply_RepaintsTextToThemeForeground_NotHardcodedWhite()
+    {
+        // Start every paint at a deliberately-wrong color so we can prove Apply overwrote it.
+        var legend = new SolidColorPaint(SKColors.Magenta);
+        var tooltipText = new SolidColorPaint(SKColors.Magenta);
+        var tooltipBg = new SolidColorPaint(SKColors.Magenta);
+        var axis = new Axis
+        {
+            LabelsPaint = new SolidColorPaint(SKColors.Magenta),
+            NamePaint = new SolidColorPaint(SKColors.Magenta),
+            SeparatorsPaint = new SolidColorPaint(SKColors.Magenta)
+        };
+
+        ChartTheme.Apply(legend, tooltipText, tooltipBg, [axis]);
+
+        var t = ThemeService.Instance.CurrentTheme;
+        Assert.Equal(ChartTheme.Sk(t.TextPrimary), legend.Color);
+        Assert.Equal(ChartTheme.Sk(t.TextPrimary), tooltipText.Color);
+        Assert.Equal(ChartTheme.Sk(t.Surface2), tooltipBg.Color);
+        Assert.Equal(ChartTheme.Sk(t.TextPrimary), ((SolidColorPaint)axis.LabelsPaint!).Color);
+        Assert.Equal(ChartTheme.Sk(t.TextSecondary), ((SolidColorPaint)axis.NamePaint!).Color);
+
+        // None of the repainted foregrounds may remain the sentinel magenta.
+        Assert.NotEqual(SKColors.Magenta, legend.Color);
+        Assert.NotEqual(SKColors.Magenta, ((SolidColorPaint)axis.LabelsPaint!).Color);
+    }
+
+    [Fact]
+    public void Apply_LabelContrastsAgainstBackground_OnCurrentTheme()
+    {
+        // The point of the fix: label text must be readable against the theme background.
+        // Assert a real luminance-contrast gap (not white-on-white) for the active theme.
+        var axis = new Axis { LabelsPaint = new SolidColorPaint(SKColors.Magenta) };
+        ChartTheme.Apply(new SolidColorPaint(SKColors.Black), new SolidColorPaint(SKColors.Black),
+            new SolidColorPaint(SKColors.Black), [axis]);
+
+        var t = ThemeService.Instance.CurrentTheme;
+        var text = ChartTheme.Sk(t.TextPrimary);
+        var bg = ChartTheme.Sk(t.Background);
+        Assert.True(ContrastRatio(text, bg) >= 4.5,
+            $"Chart label text must meet WCAG 4.5:1 against the theme background; got {ContrastRatio(text, bg):F2}:1.");
+    }
+
+    private static double ContrastRatio(SKColor a, SKColor b)
+    {
+        double la = RelLum(a), lb = RelLum(b);
+        var (hi, lo) = la >= lb ? (la, lb) : (lb, la);
+        return (hi + 0.05) / (lo + 0.05);
+    }
+
+    private static double RelLum(SKColor c)
+    {
+        static double Ch(byte v)
+        {
+            var s = v / 255.0;
+            return s <= 0.03928 ? s / 12.92 : Math.Pow((s + 0.055) / 1.055, 2.4);
+        }
+        return 0.2126 * Ch(c.Red) + 0.7152 * Ch(c.Green) + 0.0722 * Ch(c.Blue);
+    }
+}

--- a/SysManager/SysManager/Helpers/ChartTheme.cs
+++ b/SysManager/SysManager/Helpers/ChartTheme.cs
@@ -1,0 +1,57 @@
+// SysManager · ChartTheme — drives SkiaSharp chart paints from the active app theme
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Painting;
+using SkiaSharp;
+using SysManager.Services;
+using WpfColor = System.Windows.Media.Color;
+
+namespace SysManager.Helpers;
+
+/// <summary>
+/// Bridges the WPF <see cref="ThemeService"/> to the LiveCharts/SkiaSharp charts.
+///
+/// Chart labels, legends, and tooltips are painted with SkiaSharp <see cref="SolidColorPaint"/>
+/// objects, which — unlike WPF <c>DynamicResource</c> brushes — do NOT track a theme change.
+/// Historically the paints were hardcoded near-white (E6E9EE), so on any of the six light
+/// presets the axis text/legend/tooltip rendered white-on-white and was invisible.
+///
+/// This helper mutates the <c>.Color</c> of the existing paint instances (no rebuild, so the
+/// chart's bound Axis/paint references stay valid) using the current theme's foreground colors,
+/// giving readable contrast on both light and dark presets. Callers apply it once at
+/// construction and again on every <see cref="ThemeService.ThemeChanged"/>.
+/// </summary>
+internal static class ChartTheme
+{
+    /// <summary>WPF <see cref="WpfColor"/> → SkiaSharp <see cref="SKColor"/> (alpha preserved).</summary>
+    public static SKColor Sk(WpfColor c) => new(c.R, c.G, c.B, c.A);
+
+    /// <summary>
+    /// Repaints the supplied legend/tooltip paints and axes from the active theme. Separator
+    /// lines use the theme border at low alpha so the gridlines stay subtle on any background.
+    /// </summary>
+    public static void Apply(
+        SolidColorPaint legendText,
+        SolidColorPaint tooltipText,
+        SolidColorPaint tooltipBackground,
+        IEnumerable<Axis> axes)
+    {
+        var t = ThemeService.Instance.CurrentTheme;
+        var primary = Sk(t.TextPrimary);
+        var secondary = Sk(t.TextSecondary);
+        var separator = Sk(t.Border).WithAlpha(80);
+
+        legendText.Color = primary;
+        tooltipText.Color = primary;
+        tooltipBackground.Color = Sk(t.Surface2);
+
+        foreach (var axis in axes)
+        {
+            if (axis.LabelsPaint is SolidColorPaint labels) labels.Color = primary;
+            if (axis.NamePaint is SolidColorPaint name) name.Color = secondary;
+            if (axis.SeparatorsPaint is SolidColorPaint sep) sep.Color = separator;
+        }
+    }
+}

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -356,7 +356,7 @@
 
                 <!-- Update banner — only when a newer release is available. -->
                 <Border Grid.Row="0" Margin="24,16,24,0" Padding="14,10" CornerRadius="10"
-                        Background="#0F1A2E" BorderBrush="{DynamicResource Accent}" BorderThickness="1"
+                        Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Accent}" BorderThickness="1"
                         Visibility="{Binding About.UpdateAvailable, Converter={StaticResource FlexVis}}">
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -387,7 +387,7 @@
         <Border x:Name="ToastOverlay" Grid.Column="1"
                 HorizontalAlignment="Right" VerticalAlignment="Bottom"
                 Margin="0,0,20,20" Visibility="Collapsed">
-            <Border Background="#F0141B27" CornerRadius="10"
+            <Border Background="{DynamicResource Surface2}" CornerRadius="10"
                     BorderBrush="#4022C55E" BorderThickness="1"
                     Padding="14,12,18,12">
                 <Border.Effect>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.6</Version>
-    <FileVersion>1.52.6.0</FileVersion>
-    <AssemblyVersion>1.52.6.0</AssemblyVersion>
+    <Version>1.52.7</Version>
+    <FileVersion>1.52.7.0</FileVersion>
+    <AssemblyVersion>1.52.7.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/NetworkSharedState.cs
+++ b/SysManager/SysManager/ViewModels/NetworkSharedState.cs
@@ -105,6 +105,12 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
         TraceXAxes = [BuildHopAxis()];
         TraceYAxes = [BuildValueAxis("Latency (ms)")];
 
+        // Paint chart labels/legend/tooltip from the active theme and keep them in sync,
+        // so axis text stays readable on the light presets (a hardcoded near-white was
+        // invisible on a white background). The seam is unsubscribed in Dispose().
+        ApplyChartTheme();
+        ThemeService.Instance.ThemeChanged += ApplyChartTheme;
+
         Pinger.SampleReceived += OnSample;
         TraceMonitor.RouteCompleted += OnRouteCompleted;
 
@@ -527,6 +533,17 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
         else Dispatcher.BeginInvoke(DispatcherPriority.Background, action);
     }
 
+    // ── Chart theming ──
+
+    /// <summary>
+    /// Repaints the chart labels, legend, and tooltip from the current app theme. Wired to
+    /// <see cref="ThemeService.ThemeChanged"/> so switching to a light preset makes the axis
+    /// text dark-on-light (readable) instead of the previous hardcoded near-white.
+    /// </summary>
+    private void ApplyChartTheme() => Helpers.ChartTheme.Apply(
+        LegendTextPaint, TooltipTextPaint, TooltipBackgroundPaint,
+        [.. LatencyXAxes, .. LatencyYAxes, .. TraceXAxes, .. TraceYAxes]);
+
     // ── Axis factories ──
 
     internal static Axis BuildTimeAxis() => new()
@@ -567,6 +584,7 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
         if (_disposed) return;
         _disposed = true;
 
+        ThemeService.Instance.ThemeChanged -= ApplyChartTheme;
         Pinger.SampleReceived -= OnSample;
         TraceMonitor.RouteCompleted -= OnRouteCompleted;
         // Stop, do not Dispose: Pinger / TraceMonitor are DI singletons the container

--- a/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
@@ -86,6 +86,12 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
         TemperatureXAxes = [BuildTimeAxis()];
         TemperatureYAxes = [BuildTempAxis()];
 
+        // Paint chart labels/legend/tooltip from the active theme and keep them in sync,
+        // so axis text stays readable on the light presets (a hardcoded near-white was
+        // invisible on a white background). Unsubscribed in Dispose(bool).
+        ApplyChartTheme();
+        ThemeService.Instance.ThemeChanged += ApplyChartTheme;
+
         UsageSeries.Add(BuildLine("CPU", "#60A5FA", _cpuBuffer));
         UsageSeries.Add(BuildLine("RAM", "#A78BFA", _ramBuffer));
         UsageSeries.Add(BuildLine("GPU", "#34D399", _gpuBuffer));
@@ -223,10 +229,20 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
         NameTextSize = 14
     };
 
+    /// <summary>
+    /// Repaints the chart labels, legend, and tooltip from the current app theme. Wired to
+    /// <see cref="ThemeService.ThemeChanged"/> so switching to a light preset makes the axis
+    /// text dark-on-light (readable) instead of the previous hardcoded near-white.
+    /// </summary>
+    private void ApplyChartTheme() => ChartTheme.Apply(
+        LegendTextPaint, TooltipTextPaint, TooltipBackgroundPaint,
+        [.. UsageXAxes, .. UsageYAxes, .. TemperatureXAxes, .. TemperatureYAxes]);
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)
         {
+            ThemeService.Instance.ThemeChanged -= ApplyChartTheme;
             foreach (var s in UsageSeries) DisposeSeries(s);
             foreach (var s in TemperatureSeries) DisposeSeries(s);
             DisposeAxisPaints(UsageXAxes);


### PR DESCRIPTION
## The problem (HIGH — invisible text on light themes)
The Ping/Traceroute latency chart and the Resource History usage/temperature charts painted their **axis labels, legend, and tooltip** with a hardcoded near-white SkiaSharp color (`E6E9EE`), set once in the constructor. Unlike WPF `DynamicResource` brushes, Skia paints don't react to a theme change — so on all **six light presets** the chart text was white-on-white.

Measured contrast of `#E6E9EE` text against the light-preset backgrounds:

| Preset | bg | contrast | |
|---|---|---|---|
| Clean Indigo | #FFFFFF | 1.22:1 | invisible |
| Sky Breeze | #F8FAFC | 1.16:1 | invisible |
| Warm Sand | #FFFBEB | 1.17:1 | invisible |
| Mint Fresh | #F0FDF4 | 1.16:1 | invisible |
| Soft Blossom | #FDF2F8 | 1.11:1 | invisible |
| Lavender | #FAF5FF | 1.13:1 | invisible |

(WCAG needs ≥4.5:1.) A user on a light theme saw chart lines floating with no axis values, no time labels, and no legend.

## The fix
New `Helpers/ChartTheme` bridges `ThemeService.CurrentTheme` to the Skia paints. It **mutates the existing paint/axis `.Color`** (no rebuild — the bound Axis/paint references stay valid) from the theme's foreground colors, and both chart VMs:
- call it once at construction, and
- subscribe to `ThemeService.ThemeChanged` so the charts repaint instantly on a theme switch.

This **wires up the previously-dead `ThemeChanged` seam** (it was raised at `ThemeService.cs:161` but had zero subscribers). Both VMs are DI singletons and unsubscribe in `Dispose` — no leak.

After the fix, label-on-background contrast is 8.7–16:1 across the light presets; dark presets are unchanged.

Also swapped the **update banner** (`#0F1A2E`) and **toast** (`#F0141B27`) fixed dark backgrounds for the theme `Surface2` brush, so on a light preset the banner no longer renders as a dark box clashing with the UI and the toast title no longer risks dark-on-dark.

## Tests
`ChartThemeTests`: RGBA channel preservation; `Apply` repaints legend/tooltip/axis to the theme foreground (asserts the sentinel magenta is gone); and the active theme's label-vs-background meets WCAG 4.5:1.

Build: main + unit tests, 0 warnings / 0 errors. `fix:` → 1.52.7.