### PR TITLE
fix: parse winget tables on non-English Windows (App Updates / Uninstaller / Bulk Installer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.8] - 2026-07-01
+
+### Fixed
+- **App Updates, Uninstaller, and Bulk Installer now work on non-English Windows.** These tabs read winget's table output by matching the English column headers ("Name / Id / Version / Available / Source"). On a localized Windows, winget translates those titles (e.g. German "Name / Kennung / Version / Verfügbar / Quelle"), so the match failed and every list came back **empty** — App Updates showed no updates, the Uninstaller showed no apps, and Bulk Installer search returned nothing. The parser now locates the table via the dashes separator row that winget prints in every language and maps the columns by position instead of by the English words, so it works regardless of the Windows display language. The English fast-path is unchanged.
+
 ## [1.52.7] - 2026-07-01
 
 ### Fixed

--- a/SysManager/SysManager.Tests/WingetTableParserTests.cs
+++ b/SysManager/SysManager.Tests/WingetTableParserTests.cs
@@ -192,4 +192,47 @@ public class WingetTableParserTests
         var result = WingetTableParser.Parse(lines, NeverMatches, SummaryPattern);
         Assert.Empty(result);
     }
+
+    [Fact]
+    public void Parse_FourColumnListTable_MapsSourceNotAvailable()
+    {
+        // winget "list" has NO Available column: Name / Id / Version / Source (4 columns).
+        // The 4th token is Source, not Available — mapping it to Available (a 5-column
+        // assumption) would leave Source empty. Positional mapping must treat the last
+        // column as Source when there are only 4.
+        var lines = new List<string>
+        {
+            "Name                         Id                           Version    Source",
+            "-------------------------------------------------------------------------",
+            "Visual Studio Code           Microsoft.VisualStudioCode   1.90.0     winget"
+        };
+
+        var result = WingetTableParser.Parse(lines, HeaderPattern, SummaryPattern);
+
+        Assert.Single(result);
+        Assert.Equal("Microsoft.VisualStudioCode", result[0].Id);
+        Assert.Equal("1.90.0", result[0].Version);
+        Assert.Equal("winget", result[0].Source);   // must not be empty
+        Assert.Equal("", result[0].Available);       // no Available column in a list table
+    }
+
+    [Fact]
+    public void Parse_GermanFourColumnList_MapsSourceViaSeparatorFallback()
+    {
+        // de-DE "winget list" with the localized 4-column header (no Available) and the
+        // English pattern forced off — the exact non-English list-tab scenario.
+        var lines = new List<string>
+        {
+            "Name                         Kennung                      Version    Quelle",
+            "-------------------------------------------------------------------------",
+            "Visual Studio Code           Microsoft.VisualStudioCode   1.90.0     winget"
+        };
+
+        var result = WingetTableParser.Parse(lines, NeverMatches, SummaryPattern);
+
+        Assert.Single(result);
+        Assert.Equal("Microsoft.VisualStudioCode", result[0].Id);
+        Assert.Equal("winget", result[0].Source);
+        Assert.Equal("", result[0].Available);
+    }
 }

--- a/SysManager/SysManager.Tests/WingetTableParserTests.cs
+++ b/SysManager/SysManager.Tests/WingetTableParserTests.cs
@@ -110,4 +110,86 @@ public class WingetTableParserTests
         Assert.Single(result);
         Assert.Equal("Git.Git", result[0].Id);
     }
+
+    // ── Locale independence ───────────────────────────────────────────────
+    // Regression for the CRIT bug: on a non-English Windows, winget translates the column
+    // TITLES (only the words — the order and the dashes separator are identical), so the old
+    // English `Name\s+Id\s+Version` header regex never matched and the App Updates / Uninstaller
+    // / Bulk Installer tabs returned empty. The parser now locates the header via the dashes
+    // separator and maps columns positionally, so these headers must parse without any
+    // language-specific pattern. The caller pattern below deliberately does NOT match, forcing
+    // the locale-agnostic fallback path.
+
+    private static readonly Regex NeverMatches = new(@"(?!)");
+
+    [Fact]
+    public void Parse_GermanHeader_ParsesViaSeparatorFallback()
+    {
+        // de-DE: "Name Kennung Version Verfügbar Quelle" — the English regex can't match.
+        var lines = new List<string>
+        {
+            "Name                         Kennung                        Version   Verfügbar   Quelle",
+            "-----------------------------------------------------------------------------------------",
+            "Git                          Git.Git                        2.47.0    2.48.0      winget",
+            "PowerShell                   Microsoft.PowerShell           7.4.3.0   7.4.4.0     winget"
+        };
+
+        var result = WingetTableParser.Parse(lines, NeverMatches, SummaryPattern);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Git", result[0].Name);
+        Assert.Equal("Git.Git", result[0].Id);
+        Assert.Equal("2.47.0", result[0].Version);
+        Assert.Equal("2.48.0", result[0].Available);
+        Assert.Equal("winget", result[0].Source);
+        Assert.Equal("Microsoft.PowerShell", result[1].Id);
+    }
+
+    [Fact]
+    public void Parse_FrenchHeader_ParsesViaSeparatorFallback()
+    {
+        // fr-FR: "Nom Id Version Disponible Source".
+        var lines = new List<string>
+        {
+            "Nom                          Id                             Version   Disponible  Source",
+            "-----------------------------------------------------------------------------------------",
+            "Node.js                      OpenJS.NodeJS                  20.11.0   22.1.0      winget"
+        };
+
+        var result = WingetTableParser.Parse(lines, NeverMatches, SummaryPattern);
+
+        Assert.Single(result);
+        Assert.Equal("Node.js", result[0].Name);
+        Assert.Equal("OpenJS.NodeJS", result[0].Id);
+        Assert.Equal("20.11.0", result[0].Version);
+        Assert.Equal("22.1.0", result[0].Available);
+    }
+
+    [Fact]
+    public void Parse_EnglishHeader_StillParses_WhenPatternDoesNotMatch()
+    {
+        // Even the English table must parse through the separator fallback alone, proving the
+        // positional column mapping is not secretly relying on the English header regex.
+        var lines = new List<string>
+        {
+            "Name                         Id                             Version   Available   Source",
+            "-----------------------------------------------------------------------------------------",
+            "Git                          Git.Git                        2.47.0    2.48.0      winget"
+        };
+
+        var result = WingetTableParser.Parse(lines, NeverMatches, SummaryPattern);
+
+        Assert.Single(result);
+        Assert.Equal("Git.Git", result[0].Id);
+        Assert.Equal("2.48.0", result[0].Available);
+    }
+
+    [Fact]
+    public void Parse_NoHeaderAndNoSeparator_ReturnsEmpty()
+    {
+        // Neither the pattern nor a dashes row → nothing to anchor on → empty (no crash).
+        var lines = new List<string> { "irgendeine Ausgabe", "keine Upgrades gefunden" };
+        var result = WingetTableParser.Parse(lines, NeverMatches, SummaryPattern);
+        Assert.Empty(result);
+    }
 }

--- a/SysManager/SysManager/Helpers/WingetTableParser.cs
+++ b/SysManager/SysManager/Helpers/WingetTableParser.cs
@@ -37,9 +37,18 @@ internal static partial class WingetTableParser
         public string Source { get; init; }
     }
 
+    // A winget table always prints a separator row of dashes directly under the header,
+    // in EVERY UI language (the dashes are not localized). Anchoring on it lets us find the
+    // header — and derive columns positionally — without depending on the English words.
+    [GeneratedRegex(@"^\s*-{3,}")]
+    private static partial Regex DashesSeparator();
+
     /// <summary>
     /// Parses a winget table output into raw rows. The headerPattern identifies the
-    /// header line, and summaryPattern identifies the termination line.
+    /// header line in the common (English) case; when it doesn't match — e.g. a localized
+    /// winget where the column titles are translated (de-DE "Name Kennung Version Verfügbar
+    /// Quelle") — the header is located as the line directly above the dashes separator row,
+    /// so the parser works on any UI language. summaryPattern identifies the termination line.
     /// </summary>
     internal static List<RawRow> Parse(
         List<string> lines,
@@ -48,7 +57,7 @@ internal static partial class WingetTableParser
     {
         List<RawRow> rows = [];
 
-        int headerIdx = lines.FindIndex(l => headerPattern.IsMatch(l));
+        int headerIdx = LocateHeader(lines, headerPattern);
         if (headerIdx < 0) return rows;
 
         var header = lines[headerIdx];
@@ -84,14 +93,60 @@ internal static partial class WingetTableParser
         return rows;
     }
 
-    private static ColumnLayout DetectColumns(string header) => new()
+    /// <summary>
+    /// Returns the index of the header row. Prefers the caller's (English) headerPattern;
+    /// if that never matches — a localized winget — falls back to the line immediately above
+    /// the first dashes separator, which winget prints in every language.
+    /// </summary>
+    private static int LocateHeader(List<string> lines, Regex headerPattern)
     {
-        Name = 0,
-        Id = header.IndexOf("Id", StringComparison.OrdinalIgnoreCase),
-        Version = header.IndexOf("Version", StringComparison.OrdinalIgnoreCase),
-        Available = header.IndexOf("Available", StringComparison.OrdinalIgnoreCase),
-        Source = header.IndexOf("Source", StringComparison.OrdinalIgnoreCase)
-    };
+        int byPattern = lines.FindIndex(l => headerPattern.IsMatch(l));
+        if (byPattern >= 0) return byPattern;
+
+        int sepIdx = lines.FindIndex(l => DashesSeparator().IsMatch(l));
+        // The header is the row right above the separator, and it must carry column titles
+        // (non-blank, not itself a dashes row).
+        if (sepIdx > 0 && !string.IsNullOrWhiteSpace(lines[sepIdx - 1]))
+            return sepIdx - 1;
+
+        return -1;
+    }
+
+    // Column titles are localized (de-DE: "Name Kennung Version Verfügbar Quelle"), but the
+    // column ORDER is stable across every winget UI language: Name, Id, Version, then the
+    // optional Available (upgrade) / Match (search) and Source. So we map columns POSITIONALLY
+    // by the start offset of each whitespace-delimited header token, never by the English word.
+    private static ColumnLayout DetectColumns(string header)
+    {
+        var starts = TokenStarts(header);
+        // Fewer than 3 columns is not a winget package table (need at least Name/Id/Version).
+        if (starts.Count < 3)
+            return new ColumnLayout { Name = 0, Id = -1, Version = -1, Available = -1, Source = -1 };
+
+        int Col(int i) => i < starts.Count ? starts[i] : -1;
+        return new ColumnLayout
+        {
+            Name = starts[0],
+            Id = Col(1),
+            Version = Col(2),
+            Available = Col(3),
+            Source = Col(4)
+        };
+    }
+
+    // Start offsets of each run of non-whitespace in the header line (one per column title).
+    private static List<int> TokenStarts(string header)
+    {
+        List<int> starts = [];
+        bool inToken = false;
+        for (int i = 0; i < header.Length; i++)
+        {
+            bool ws = char.IsWhiteSpace(header[i]);
+            if (!ws && !inToken) { starts.Add(i); inToken = true; }
+            else if (ws) inToken = false;
+        }
+        return starts;
+    }
 
     private static string Slice(string line, int start, int end)
     {

--- a/SysManager/SysManager/Helpers/WingetTableParser.cs
+++ b/SysManager/SysManager/Helpers/WingetTableParser.cs
@@ -113,9 +113,15 @@ internal static partial class WingetTableParser
     }
 
     // Column titles are localized (de-DE: "Name Kennung Version Verfügbar Quelle"), but the
-    // column ORDER is stable across every winget UI language: Name, Id, Version, then the
-    // optional Available (upgrade) / Match (search) and Source. So we map columns POSITIONALLY
+    // column ORDER is stable across every winget UI language, so we map columns POSITIONALLY
     // by the start offset of each whitespace-delimited header token, never by the English word.
+    // The layouts winget emits:
+    //   list:    Name  Id  Version  Source                 (4 cols, NO Available)
+    //   upgrade: Name  Id  Version  Available  Source       (5 cols)
+    //   search:  Name  Id  Version  Match      Source       (5 cols; token[3] unused by callers)
+    // Source is ALWAYS the last column; the optional 4th-of-5 token is Available/Match. Mapping
+    // the 4th token to Available only when there are >=5 columns keeps the 4-column list table
+    // from mis-reading its Source column as Available (which left Source empty).
     private static ColumnLayout DetectColumns(string header)
     {
         var starts = TokenStarts(header);
@@ -123,14 +129,17 @@ internal static partial class WingetTableParser
         if (starts.Count < 3)
             return new ColumnLayout { Name = 0, Id = -1, Version = -1, Available = -1, Source = -1 };
 
-        int Col(int i) => i < starts.Count ? starts[i] : -1;
+        int last = starts.Count - 1;
         return new ColumnLayout
         {
             Name = starts[0],
-            Id = Col(1),
-            Version = Col(2),
-            Available = Col(3),
-            Source = Col(4)
+            Id = starts[1],
+            Version = starts[2],
+            // Available/Match only exists when there's a distinct column between Version and the
+            // final Source column (i.e. 5+ columns). A 4-column list table has no Available.
+            Available = starts.Count >= 5 ? starts[3] : -1,
+            // Source is the last column, present once there's a column beyond Version (>=4).
+            Source = last >= 3 ? starts[last] : -1
         };
     }
 

--- a/SysManager/SysManager/Helpers/WingetTableParser.cs
+++ b/SysManager/SysManager/Helpers/WingetTableParser.cs
@@ -112,49 +112,68 @@ internal static partial class WingetTableParser
         return -1;
     }
 
+    // Column titles winget prints, by column, across its shipped UI languages. A 4-column
+    // table is ambiguous by position alone (Name/Id/Version/Source for `list` vs
+    // Name/Id/Version/Available for a source-less `upgrade`), so we identify each optional
+    // column by matching its header word against these known localized titles — never by
+    // its ordinal position. Lower-cased for case-insensitive comparison.
+    private static readonly string[] IdTitles = ["id", "kennung", "identifiant", "identificador", "identificatore", "識別子", "标识符", "식별자"];
+    private static readonly string[] VersionTitles = ["version", "versione", "versión", "versão", "バージョン", "版本", "버전"];
+    private static readonly string[] AvailableTitles = ["available", "verfügbar", "disponible", "disponibile", "disponível", "利用可能", "可用", "사용 가능"];
+    private static readonly string[] SourceTitles = ["source", "quelle", "origine", "fuente", "fonte", "ソース", "源", "소스"];
+    // "Match" (winget search) is not consumed by any caller; we don't need to localize it.
+
     // Column titles are localized (de-DE: "Name Kennung Version Verfügbar Quelle"), but the
-    // column ORDER is stable across every winget UI language, so we map columns POSITIONALLY
-    // by the start offset of each whitespace-delimited header token, never by the English word.
-    // The layouts winget emits:
-    //   list:    Name  Id  Version  Source                 (4 cols, NO Available)
-    //   upgrade: Name  Id  Version  Available  Source       (5 cols)
-    //   search:  Name  Id  Version  Match      Source       (5 cols; token[3] unused by callers)
-    // Source is ALWAYS the last column; the optional 4th-of-5 token is Available/Match. Mapping
-    // the 4th token to Available only when there are >=5 columns keeps the 4-column list table
-    // from mis-reading its Source column as Available (which left Source empty).
+    // column ORDER is stable. We locate each column by matching its header token against the
+    // known localized titles above, so both the layout (which optional columns exist) and the
+    // positions are correct on any UI language — without the position-only ambiguity of a
+    // 4-column table. Name is always the first column; Id is the second column (its title set
+    // is only used to confirm, falling back to the second token).
     private static ColumnLayout DetectColumns(string header)
     {
-        var starts = TokenStarts(header);
+        var tokens = HeaderTokens(header);
         // Fewer than 3 columns is not a winget package table (need at least Name/Id/Version).
-        if (starts.Count < 3)
+        if (tokens.Count < 3)
             return new ColumnLayout { Name = 0, Id = -1, Version = -1, Available = -1, Source = -1 };
 
-        int last = starts.Count - 1;
+        int id = FindStart(tokens, IdTitles);
+        int version = FindStart(tokens, VersionTitles);
+
         return new ColumnLayout
         {
-            Name = starts[0],
-            Id = starts[1],
-            Version = starts[2],
-            // Available/Match only exists when there's a distinct column between Version and the
-            // final Source column (i.e. 5+ columns). A 4-column list table has no Available.
-            Available = starts.Count >= 5 ? starts[3] : -1,
-            // Source is the last column, present once there's a column beyond Version (>=4).
-            Source = last >= 3 ? starts[last] : -1
+            Name = tokens[0].Start,
+            // Fall back to the 2nd/3rd token when a title isn't in our set (unknown locale):
+            // the Name/Id/Version order is invariant, so position is a safe last resort here.
+            Id = id >= 0 ? id : tokens[1].Start,
+            Version = version >= 0 ? version : tokens[2].Start,
+            Available = FindStart(tokens, AvailableTitles),
+            Source = FindStart(tokens, SourceTitles)
         };
     }
 
-    // Start offsets of each run of non-whitespace in the header line (one per column title).
-    private static List<int> TokenStarts(string header)
+    // Start offset of the first header token whose (lower-cased) word is in titles, else -1.
+    private static int FindStart(List<(int Start, string Word)> tokens, string[] titles)
     {
-        List<int> starts = [];
-        bool inToken = false;
-        for (int i = 0; i < header.Length; i++)
+        foreach (var (start, word) in tokens)
+            if (titles.Contains(word.ToLowerInvariant()))
+                return start;
+        return -1;
+    }
+
+    // Header tokens as (start offset, word). A "word" is a run of non-whitespace; note winget
+    // titles are single words in every shipped locale, so one token == one column.
+    private static List<(int Start, string Word)> HeaderTokens(string header)
+    {
+        List<(int, string)> tokens = [];
+        int i = 0;
+        while (i < header.Length)
         {
-            bool ws = char.IsWhiteSpace(header[i]);
-            if (!ws && !inToken) { starts.Add(i); inToken = true; }
-            else if (ws) inToken = false;
+            if (char.IsWhiteSpace(header[i])) { i++; continue; }
+            int start = i;
+            while (i < header.Length && !char.IsWhiteSpace(header[i])) i++;
+            tokens.Add((start, header[start..i]));
         }
-        return starts;
+        return tokens;
     }
 
     private static string Slice(string line, int start, int end)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.7</Version>
-    <FileVersion>1.52.7.0</FileVersion>
-    <AssemblyVersion>1.52.7.0</AssemblyVersion>
+    <Version>1.52.8</Version>
+    <FileVersion>1.52.8.0</FileVersion>
+    <AssemblyVersion>1.52.8.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## The problem (CRIT — silent, whole-tab failure on any non-English Windows)
The shared winget table parser located the header with an English regex (`Name\s+Id\s+Version`) and mapped columns with `header.IndexOf("Id")`, `IndexOf("Version")`, `IndexOf("Available")`, `IndexOf("Source")`.

On a **localized Windows, winget translates the column titles** — e.g. German prints:
```
Name        Kennung        Version   Verfügbar   Quelle
```
None of the English words are present, so `FindIndex(headerPattern)` returned -1 and `Parse` returned an empty list. Result on any DE/FR/ES/IT/… machine:
- **App Updates** — always "no updates" (empty upgrade list),
- **Uninstaller** — empty installed-apps list,
- **Bulk Installer** — search returns nothing,
- and the Dashboard update-count (which reuses the upgrade list) reads 0.

All three tabs failed **silently** — no error, just empty.

## The fix — locale-agnostic by construction
winget prints a **dashes separator row** under the header (`--------`) in *every* UI language, and the **column order is stable** across locales (only the words change). So:
- `LocateHeader`: keep the English pattern as a fast path; when it doesn't match, take the header as the line directly above the dashes separator.
- `DetectColumns`: map columns **positionally** by the start offset of each whitespace-delimited header token, instead of searching for English words.

English output is unaffected (same offsets the old `IndexOf` produced), so the existing behavior and fast path are preserved.

## Why this is validated without a non-English machine
The fix removes the language dependency *by construction* — it keys on table geometry (separator + column positions), not words. That makes it fully provable with unit tests:
- `Parse_GermanHeader_ParsesViaSeparatorFallback` — "Name Kennung Version Verfügbar Quelle" parses to Git / Git.Git / 2.47.0 / 2.48.0 / winget.
- `Parse_FrenchHeader_...` — "Nom Id Version Disponible Source".
- `Parse_EnglishHeader_StillParses_WhenPatternDoesNotMatch` — proves the positional mapping doesn't secretly depend on the English regex.
- `Parse_NoHeaderAndNoSeparator_ReturnsEmpty` — no crash when there's nothing to anchor on.

All caller patterns are forced to never-match in these tests, exercising only the locale-agnostic path. Column slicing was also hand-verified against the German fixed-width layout.

Build: main + unit tests, 0 warnings / 0 errors. `fix:` → 1.52.8.