### PR TITLE
docs: correct ARCHITECTURE seam-interface list + add UpdateApplier

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -115,9 +115,13 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 ## Services
 
 Thin wrappers around the underlying platform. Each service is designed to be
-unit-testable. The key seam interfaces are `IPowerShellRunner` (PowerShellRunner),
-`IAppBlockerService` (AppBlockerService), and `IDialogService` (DialogService) —
-substitutable in tests (see `ServiceRegistration.cs`).
+unit-testable. Services that a view-model needs to substitute in tests sit behind
+an interface seam — currently `IPowerShellRunner` (PowerShellRunner),
+`IAppBlockerService` (AppBlockerService), `IDialogService` (DialogService),
+`ICpuAffinityService`, `IFileLockService`, `ISettingsWatchdogService`,
+`ITimerResolutionService`, `ITweaksHubService`, and `IWindowsThemeService` — each
+registered against its implementation and mock-substitutable (see
+`ServiceRegistration.cs`).
 
 Key services:
 - `PingMonitorService` / `TracerouteService` / `TracerouteMonitorService` —
@@ -159,6 +163,8 @@ Key services:
   pagefile, hiberfil, System Volume Information.
 - `UpdateService` — GitHub Releases API client with explicit
   `SocketsHttpHandler`, retry, and surfaced error messages.
+- `UpdateApplier` — runs on relaunch to swap the freshly-downloaded exe over the
+  old one and restart, before any DI/UI is built (see the Updates flow below).
 - `StartupService` — enumerate and toggle startup programs via registry
   Run / RunOnce keys.
 - `DuplicateFileService` — three-pass duplicate finder (size grouping →


### PR DESCRIPTION
Two accuracy fixes in ARCHITECTURE.md, both verified against the files on disk.

## 1. Seam-interface list was stale (said 3, there are 9)
The Services section stated *"The key seam interfaces are `IPowerShellRunner`, `IAppBlockerService`, and `IDialogService`"*. `ls Services/I*.cs` shows nine interface seams:
`IAppBlockerService`, `ICpuAffinityService`, `IDialogService`, `IFileLockService`, `IPowerShellRunner`, `ISettingsWatchdogService`, `ITimerResolutionService`, `ITweaksHubService`, `IWindowsThemeService`.
For a project that showcases a testable-seam architecture, the doc undersold the actual coverage. Updated to list all nine.

## 2. `UpdateApplier` was missing from the Services list
It's a real service (`Services/UpdateApplier.cs`) described in the Updates-flow prose ("hands off to `UpdateApplier`…") but absent from the Services bullet inventory. Added a bullet next to `UpdateService`.

No code change. `docs:` — no release.