### PR TITLE
docs: add missing Storage gallery section + move misfiled Disk Analyzer screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,7 +776,14 @@ Manage Microsoft Defender without digging through Windows Security:
 <a href="docs/screenshots/27-shortcut-cleaner.png"><img src="docs/screenshots/27-shortcut-cleaner.png" width="280" alt="Shortcut Cleaner"></a>
 </p>
 <p>
-<a href="docs/screenshots/28-scheduled-maintenance.png"><img src="docs/screenshots/28-scheduled-maintenance.png" width="280" alt="Scheduled Maintenance"></a>&nbsp;
+<a href="docs/screenshots/28-scheduled-maintenance.png"><img src="docs/screenshots/28-scheduled-maintenance.png" width="280" alt="Scheduled Maintenance"></a>
+</p>
+</details>
+
+<details>
+<summary><strong>💾 Storage</strong> — Disk Analyzer · Duplicate Finder</summary>
+<br>
+<p>
 <a href="docs/screenshots/29-disk-analyzer.png"><img src="docs/screenshots/29-disk-analyzer.png" width="280" alt="Disk Analyzer"></a>
 </p>
 </details>
@@ -804,7 +811,7 @@ Manage Microsoft Defender without digging through Windows Security:
 </details>
 
 <details>
-<summary><strong>🔒 Privacy &amp; Security</strong> — Privacy &amp; Telemetry · File Shredder · App Blocker · Debloater · Browser Cleaner · Defender</summary>
+<summary><strong>🛡️ Privacy &amp; Security</strong> — Privacy &amp; Telemetry · File Shredder · App Blocker · Debloater · Browser Cleaner · Defender</summary>
 <br>
 <p>
 <a href="docs/screenshots/39-privacy-telemetry.png"><img src="docs/screenshots/39-privacy-telemetry.png" width="280" alt="Privacy &amp; Telemetry"></a>&nbsp;


### PR DESCRIPTION
## The problem
The **Screenshots gallery had only 11 `<details>` sections for the 12 sidebar groups** — the **💾 Storage group was missing entirely**. Its Disk Analyzer screenshot (`29-disk-analyzer.png`) had been misfiled inside the **🧹 Cleanup** section, whose summary doesn't even list it. So a reader expanding *Cleanup* saw a Disk Analyzer screenshot it never named, while an entire group (Storage) had no gallery section at all.

Verified against the tab table:
- Line 100 (Cleanup) = Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance — **no Disk Analyzer**.
- Line 101 (Storage) = **Disk Analyzer** · Duplicate Finder.
- The 11 gallery summaries were: Dashboard, System, Gaming, Monitor, Cleanup, Network, Apps, Privacy, Customization, Info, Advanced — **Storage absent**.

## Fix
- Added a **💾 Storage** `<details>` section (Disk Analyzer · Duplicate Finder) in the correct group order (Cleanup → Storage → Network), matching the tab table.
- Moved `29-disk-analyzer.png` out of Cleanup into Storage.
- Unified the **Privacy & Security** gallery icon: it used 🔒 (padlock) in the gallery but 🛡️ (shield) in the tab table for the same group — now both 🛡️.

Gallery now has all 12 groups; every one of the 44 screenshot references still resolves. (Duplicate Finder has no screenshot yet — same as other implemented tabs pending a capture pass; the section header lists it for completeness.)

No release (`docs:`).