### PR TITLE
fix: guard non-positive Top in large-file scanner to prevent crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.9] - 2026-07-03
+
+### Fixed
+- **Disk Analyzer no longer crashes when "Top files" is set to 0.** The large-file scanner takes a "keep the top N" count from the Deep Cleanup input. If that value was 0 (or negative), the scan threw an internal error the moment it found its first file and the operation faulted. The scanner now treats a non-positive count as "nothing to keep" and returns an empty result instead of crashing.
+
 ## [1.52.8] - 2026-07-01
 
 ### Fixed

--- a/SysManager/SysManager.Tests/LargeFileScannerTests.cs
+++ b/SysManager/SysManager.Tests/LargeFileScannerTests.cs
@@ -151,6 +151,19 @@ public class LargeFileScannerTests : IDisposable
         Assert.Empty(result);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task Scan_NonPositiveTop_ReturnsEmpty(int top)
+    {
+        // Regression: a non-positive Top (reachable from the unvalidated TopCount
+        // textbox) used to reach the eviction path and throw ArgumentNullException
+        // via meta.Remove(null) once an eligible file was found. Now guarded → empty.
+        CreateFile("big.bin", 2000);
+        var result = await _scanner.ScanAsync(_root, minSizeBytes: 500, top: top);
+        Assert.Empty(result);
+    }
+
     // ---------- cancellation ----------
 
     [Fact]

--- a/SysManager/SysManager/Services/LargeFileScanner.cs
+++ b/SysManager/SysManager/Services/LargeFileScanner.cs
@@ -43,6 +43,14 @@ public sealed class LargeFileScanner
         if (string.IsNullOrWhiteSpace(rootPath) || !Directory.Exists(rootPath))
             return [];
 
+        // A non-positive Top has no meaning (nothing to keep) and would crash the
+        // eviction path: on the first eligible file, heap.Count (0) < top (<=0) is
+        // false, so heap.Min on the empty set returns default ((0, null)) and
+        // meta.Remove(null) throws ArgumentNullException. TopCount is bound from an
+        // unvalidated UI textbox, so guard it here at the boundary.
+        if (top <= 0)
+            return [];
+
         var heap = new SortedSet<(long Size, string Path)>(Comparer<(long, string)>.Create(
             (a, b) =>
             {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.8</Version>
-    <FileVersion>1.52.8.0</FileVersion>
-    <AssemblyVersion>1.52.8.0</AssemblyVersion>
+    <Version>1.52.9</Version>
+    <FileVersion>1.52.9.0</FileVersion>
+    <AssemblyVersion>1.52.9.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem
The large-file scanner (`LargeFileScanner.ScanAsync`) receives a "keep the top N" count from the Deep Cleanup **Top files** input, which is bound TwoWay from an unvalidated integer textbox. When that value is **0 or negative**, the scan crashed the moment it found its first eligible file:

- `heap.Count (0) < top (<=0)` is false, so the eviction branch runs
- `heap.Min` on an empty `SortedSet` returns `default` — `(0L, null)`
- `meta.Remove(null)` throws `ArgumentNullException`, faulting the scan

## Fix
Guard `top <= 0` at the boundary and return an empty result, matching the existing invalid-`rootPath` idiom a few lines above. A non-positive "keep top N" has no meaning (nothing to keep), so an empty result is the correct, non-crashing behavior.

## Test
Adds `Scan_NonPositiveTop_ReturnsEmpty` (`[Theory]` with 0 and -1) that creates an eligible file and asserts an empty result. It **faults with `ArgumentNullException` on the pre-fix code** and passes after the guard.

- Build: app + tests 0 errors / 0 warnings.
- Behavior: no change for `top >= 1`; existing tests unaffected.
