### PR TITLE
fix: Browser Cleaner now cleans Opera (was a silent no-op)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.10] - 2026-07-03
+
+### Fixed
+- **Browser Cleaner now actually cleans Opera.** Opera was listed as a supported browser but its cleanup silently did nothing: the paths were built for the Chromium `\Default\` profile layout that Chrome/Edge/Brave use, while Opera Stable stores its profile directly under `Opera Software\Opera Stable` (no `\Default\`) and keeps cookies/history/sessions under Roaming AppData rather than Local. Every Opera path missed, so scan found nothing and clean freed nothing. Opera now uses its real on-disk layout; Chrome, Edge, Brave, and Firefox are unchanged.
+
 ## [1.52.9] - 2026-07-03
 
 ### Fixed

--- a/SysManager/SysManager.Tests/BrowserCleanerServiceTests.cs
+++ b/SysManager/SysManager.Tests/BrowserCleanerServiceTests.cs
@@ -58,6 +58,13 @@ public sealed class BrowserCleanerServiceTests : IDisposable
         File.WriteAllBytes(full, new byte[bytes]);
     }
 
+    private void WriteRoamingFile(string relUnderRoaming, int bytes)
+    {
+        var full = Path.Combine(_roaming, relUnderRoaming);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllBytes(full, new byte[bytes]);
+    }
+
     [Fact]
     public async Task Scan_NoBrowsers_ReturnsEmpty()
         => Assert.Empty(await _svc.ScanAsync());
@@ -190,6 +197,38 @@ public sealed class BrowserCleanerServiceTests : IDisposable
 
         Assert.Equal(0, deleted);
         Assert.True(File.Exists(secret), "Clean must not delete files through a junction.");
+    }
+
+    // --- Opera: Chromium-based but no "\Default\" profile segment, and its Cookies/History/
+    // Sessions live under Roaming (only Cache is under Local). Regression for the silent no-op
+    // where Opera was routed through ChromiumDefs (all paths under a non-existent \Default\). ---
+
+    [Fact]
+    public async Task Scan_FindsOperaCache_UnderLocal_NoDefaultSegment()
+    {
+        // Real Opera layout: cache directly under "Opera Software\Opera Stable\Cache" in Local,
+        // with NO "\Default\" segment.
+        WriteFile(@"Opera Software\Opera Stable\Cache\data_0", 4096);
+
+        var items = await _svc.ScanAsync();
+        var cache = items.FirstOrDefault(i => i.Browser == "Opera" && i.Category == "Cache");
+        Assert.NotNull(cache);                       // was null before the fix (wrong \Default\ path)
+        Assert.Equal(4096, cache!.SizeBytes);
+        Assert.False(cache.IsSensitive);
+        Assert.All(cache.Paths, p => Assert.DoesNotContain(@"\Default\", p));
+    }
+
+    [Fact]
+    public async Task Scan_FindsOperaCookies_UnderRoaming_AndSensitive()
+    {
+        // Opera keeps Cookies/History/Sessions under Roaming AppData, not Local.
+        WriteRoamingFile(@"Opera Software\Opera Stable\Network\Cookies", 512);
+
+        var items = await _svc.ScanAsync();
+        var cookies = items.FirstOrDefault(i => i.Browser == "Opera" && i.Category == "Cookies");
+        Assert.NotNull(cookies);                     // was null before the fix
+        Assert.True(cookies!.IsSensitive);
+        Assert.False(cookies.IsSelected);            // never auto-selected
     }
 
     [Fact]

--- a/SysManager/SysManager/Services/BrowserCleanerService.cs
+++ b/SysManager/SysManager/Services/BrowserCleanerService.cs
@@ -30,7 +30,7 @@ public sealed class BrowserCleanerService
 
     private sealed record Def(string Browser, string Category, string Description, bool Sensitive, string[] RelativePaths, bool Roaming = false);
 
-    // Chromium "Default" profile layout is shared by Chrome/Edge/Brave/Opera.
+    // Chrome/Edge/Brave keep per-profile data under "<UserData>\Default\..." in LocalAppData.
     private static Def[] ChromiumDefs(string browser, string userDataRel) =>
     [
         new(browser, "Cache", "Cached images and files.", false,
@@ -43,13 +43,38 @@ public sealed class BrowserCleanerService
             [$@"{userDataRel}\Default\Sessions", $@"{userDataRel}\Default\Session Storage"]),
     ];
 
+    // Opera Stable is Chromium-based but does NOT use a "\Default\" profile segment: the
+    // profile lives directly under "Opera Software\Opera Stable". It also splits its data
+    // across two roots — the cache is under LocalAppData, but Cookies/History/Sessions live
+    // under Roaming AppData. Routing it through ChromiumDefs pointed every path at a
+    // "\Default\" folder Opera never creates, so scan/clean silently matched nothing.
+    // NOTE: each Def's Roaming flag applies to ALL its RelativePaths, so cache paths (local)
+    // and the roaming data paths must stay in separate Defs.
+    private static Def[] OperaDefs()
+    {
+        const string profileRel = @"Opera Software\Opera Stable";
+        return
+        [
+            // Cache lives under LocalAppData (Roaming: false).
+            new("Opera", "Cache", "Cached images and files.", false,
+                [$@"{profileRel}\Cache", $@"{profileRel}\Code Cache", $@"{profileRel}\GPUCache"]),
+            // Cookies/History/Sessions live under Roaming AppData (Roaming: true).
+            new("Opera", "History", "Browsing and download history.", false,
+                [$@"{profileRel}\History", $@"{profileRel}\History-journal"], Roaming: true),
+            new("Opera", "Cookies", "Cookies — clearing these signs you out of websites.", true,
+                [$@"{profileRel}\Network\Cookies", $@"{profileRel}\Network\Cookies-journal"], Roaming: true),
+            new("Opera", "Sessions", "Open tabs / session restore data.", true,
+                [$@"{profileRel}\Sessions", $@"{profileRel}\Session Storage"], Roaming: true),
+        ];
+    }
+
     private List<Def> BuildDefs()
     {
         List<Def> defs = [];
         defs.AddRange(ChromiumDefs("Google Chrome", @"Google\Chrome\User Data"));
         defs.AddRange(ChromiumDefs("Microsoft Edge", @"Microsoft\Edge\User Data"));
         defs.AddRange(ChromiumDefs("Brave", @"BraveSoftware\Brave-Browser\User Data"));
-        defs.AddRange(ChromiumDefs("Opera", @"Opera Software\Opera Stable"));
+        defs.AddRange(OperaDefs());
         // Firefox keeps profiles in roaming AppData, but the cache lives under LocalAppData
         // in per-profile "<profile>\cache2" folders. We target the cache2 subfolders only —
         // never the Profiles root, which holds prefs.js, logins.json, key4.db and bookmarks.

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.9</Version>
-    <FileVersion>1.52.9.0</FileVersion>
-    <AssemblyVersion>1.52.9.0</AssemblyVersion>
+    <Version>1.52.10</Version>
+    <FileVersion>1.52.10.0</FileVersion>
+    <AssemblyVersion>1.52.10.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem
Opera is advertised as a supported browser in Browser Cleaner (README: "Auto-detects Chrome, Edge, Brave, Opera, and Firefox"), but its cleanup was a **100% silent no-op**. Opera was routed through `ChromiumDefs`, which builds every path around the `\Default\` profile segment used by Chrome/Edge/Brave. But Opera Stable:

- stores its profile **directly** under `Opera Software\Opera Stable` — there is **no `\Default\`** segment, and
- keeps **Cookies / History / Sessions under Roaming AppData**, while only the cache is under Local.

So every Opera path pointed at a folder that never exists. Scan surfaced nothing and Clean freed nothing — for a browser the UI lists as supported.

## Fix
Add a dedicated `OperaDefs()` that models Opera's real on-disk layout:
- **Cache** → `Opera Software\Opera Stable\Cache` (+ `Code Cache`, `GPUCache`) under **Local**.
- **History / Cookies / Sessions** → under **Roaming** (`Roaming: true`).

`ChromiumDefs` (Chrome, Edge, Brave) and the Firefox handling are **untouched**.

## Safety
Scan is read-only (sizing). Clean only deletes files it discovered under the browser tree, with the existing reparse-point guards intact — so a wrong path can only ever clean *nothing* (the current bug), never touch unrelated data. This fix strictly makes previously-missed Opera paths resolve correctly.

## Test
Two regression tests via the injectable temp-tree seam:
- `Scan_FindsOperaCache_UnderLocal_NoDefaultSegment` — cache found under Local, asserts no `\Default\` in paths.
- `Scan_FindsOperaCookies_UnderRoaming_AndSensitive` — cookies found under Roaming, sensitive + unselected.

Both return **null (not found) on the pre-fix code** and pass after. Build: app + tests 0 errors / 0 warnings.
