### PR TITLE
fix: Performance tab reverts correctly on non-English Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.11] - 2026-07-03
+
+### Fixed
+- **Performance tab now reverts correctly on non-English Windows.** Two power settings were read by matching English text that Windows translates in other display languages, so on a non-English system the "Restore" path misbehaved:
+  - The **active power plan** was located by the English "GUID:" label. On a localized Windows that label is translated, so the plan couldn't be read and Restore silently skipped restoring it. The plan is now identified by its GUID (identical in every language), so it restores correctly regardless of display language.
+  - The **processor minimum state** was read by an English label and fell back to a fabricated 5% when the label didn't match — which then got **written back** as the "restored" value on non-English machines. It now returns "unknown" when it genuinely can't be read, and Restore leaves the setting untouched rather than forcing a wrong value. The English fast-path is unchanged.
+
 ## [1.52.10] - 2026-07-03
 
 ### Fixed

--- a/SysManager/SysManager.Tests/PerformanceServiceTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceServiceTests.cs
@@ -76,6 +76,25 @@ public class PerformanceServiceTests
         Assert.Equal("8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c", guid);
     }
 
+    [Fact]
+    public void ParseActivePlan_NonEnglishLabel_StillParsesGuid()
+    {
+        // Regression for the locale bug: the old parser keyed off the English "GUID:"
+        // substring, which is translated on non-English Windows, so it returned ("Unknown", "")
+        // and Restore then skipped the power-plan restore entirely. The parser now anchors on
+        // the canonical GUID token, which powercfg prints identically in every language.
+        // German example ("Energieschema-GUID:"):
+        var lines = new List<string>
+        {
+            "Energieschema-GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Ausbalanciert)"
+        };
+
+        var (name, guid) = PerformanceService.ParseActivePlan(lines);
+
+        Assert.Equal("381b4222-f694-41f0-9685-ff5bb260df2e", guid);
+        Assert.Equal("Ausbalanciert", name);
+    }
+
     // ── ParsePlanGuidByName ──
 
     [Fact]
@@ -160,18 +179,40 @@ public class PerformanceServiceTests
     }
 
     [Fact]
-    public void ParseProcessorMinPercent_EmptyInput_ReturnsDefault5()
+    public void ParseProcessorMinPercent_EmptyInput_ReturnsNull()
     {
+        // Behavior change (bug fix): the parser used to return a fabricated 5 when it
+        // couldn't read the value. That caused Restore to WRITE 5% back on machines where
+        // the read failed (non-English powercfg output). It now returns null = "unknown",
+        // and the snapshot/restore path treats null as "leave the setting untouched".
         var result = PerformanceService.ParseProcessorMinPercent(new List<string>());
-        Assert.Equal(5, result);
+        Assert.Null(result);
     }
 
     [Fact]
-    public void ParseProcessorMinPercent_NoMatchingLine_ReturnsDefault5()
+    public void ParseProcessorMinPercent_NoMatchingLine_ReturnsNull()
     {
         var lines = new List<string> { "some random text" };
         var result = PerformanceService.ParseProcessorMinPercent(lines);
-        Assert.Equal(5, result);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseProcessorMinPercent_NonEnglishLabel_StillParsesFirstHex()
+    {
+        // Regression for the locale bug: on non-English Windows the "Current AC Power
+        // Setting Index" label is translated, so the old English-label match failed and the
+        // parser returned the fabricated 5. powercfg still prints the AC value first as a
+        // "0x…" token in every language, so the fallback now reads it. German example:
+        var lines = new List<string>
+        {
+            "  Index für aktuelle Wechselstromeinstellung: 0x00000032",
+            "  Index für aktuelle Gleichstromeinstellung: 0x00000019",
+        };
+
+        var result = PerformanceService.ParseProcessorMinPercent(lines);
+
+        Assert.Equal(0x32, result); // 50 — the AC value, not the DC value, not a fabricated 5
     }
 
     [Fact]

--- a/SysManager/SysManager/Services/PerformanceService.cs
+++ b/SysManager/SysManager/Services/PerformanceService.cs
@@ -79,7 +79,7 @@ public sealed partial class PerformanceService : IDisposable
         bool XboxGameBarEnabled,
         bool XboxGameDvrEnabled,
         bool GpuDynamicPstate,       // true = dynamic (default), false = disabled
-        int ProcessorMinPercentAc,
+        int? ProcessorMinPercentAc,  // null = couldn't read (don't restore rather than guess)
         string? NvidiaSubKey);       // null = no NVIDIA GPU
 
     /// <summary>
@@ -179,7 +179,10 @@ public sealed partial class PerformanceService : IDisposable
             profile.GpuMaxPerformance = ReadGpuMaxPerformance(nvidiaKey);
         }
 
-        var minPct = await ReadProcessorMinPercentAsync(ct).ConfigureAwait(false);
+        // Display-only profile: if the value can't be read, fall back to the Windows default
+        // (5) for the UI — unchanged from before. The RESTORE path (snapshot) keeps the true
+        // null so it never writes back a guessed value.
+        var minPct = await ReadProcessorMinPercentAsync(ct).ConfigureAwait(false) ?? 5;
         profile.ProcessorMinPercent = minPct;
         profile.ProcessorMaxState = minPct >= 100;
 
@@ -203,24 +206,31 @@ public sealed partial class PerformanceService : IDisposable
         return ParseActivePlan(lines);
     }
 
+    // Canonical GUID token (8-4-4-4-12 hex). powercfg prints the active plan's GUID in this
+    // exact form in EVERY display language, so anchoring on it makes the parse locale-agnostic.
+    [System.Text.RegularExpressions.GeneratedRegex(
+        "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")]
+    private static partial System.Text.RegularExpressions.Regex PowerPlanGuidRegex();
+
     /// <summary>
-    /// Parses powercfg /getactivescheme output.
-    /// Format: "Power Scheme GUID: 381b4222-...  (Balanced)"
+    /// Parses powercfg /getactivescheme output. Example (en-US):
+    /// "Power Scheme GUID: 381b4222-...  (Balanced)".
+    /// Locale-agnostic: the English label ("Power Scheme GUID:") is translated on non-English
+    /// Windows, so we anchor on the canonical GUID token itself (stable in every language)
+    /// rather than the label. The friendly name is read from the trailing parentheses when
+    /// present (localized, display-only); otherwise the GUID stands in.
     /// </summary>
     internal static (string Name, string Guid) ParseActivePlan(IList<string> lines)
     {
         foreach (var line in lines)
         {
-            var guidIdx = line.IndexOf("GUID:", StringComparison.OrdinalIgnoreCase);
-            if (guidIdx < 0) continue;
-            var afterGuid = line[(guidIdx + 5)..].Trim();
-            var spaceIdx = afterGuid.IndexOf(' ');
-            if (spaceIdx < 0) continue;
-            var guid = afterGuid[..spaceIdx].Trim();
-            var parenStart = afterGuid.IndexOf('(');
-            var parenEnd = afterGuid.IndexOf(')');
+            var m = PowerPlanGuidRegex().Match(line);
+            if (!m.Success) continue;
+            var guid = m.Value;
+            var parenStart = line.IndexOf('(');
+            var parenEnd = line.IndexOf(')');
             var name = parenStart >= 0 && parenEnd > parenStart
-                ? afterGuid[(parenStart + 1)..parenEnd]
+                ? line[(parenStart + 1)..parenEnd].Trim()
                 : guid;
             return (name, guid);
         }
@@ -508,8 +518,12 @@ public sealed partial class PerformanceService : IDisposable
     //  PROCESSOR STATE — powercfg (instant, no reboot)
     // ═══════════════════════════════════════════════════════════════
 
-    /// <summary>Read the current processor minimum state percentage (AC).</summary>
-    internal async Task<int> ReadProcessorMinPercentAsync(CancellationToken ct = default)
+    /// <summary>
+    /// Read the current processor minimum state percentage (AC), or null if it can't be
+    /// parsed. Callers that persist it for restore MUST keep the null (never substitute a
+    /// default), so a snapshot on a machine we couldn't read doesn't write back a wrong value.
+    /// </summary>
+    internal async Task<int?> ReadProcessorMinPercentAsync(CancellationToken ct = default)
     {
         await _psGate.WaitAsync(ct).ConfigureAwait(false);
         List<string> lines = [];
@@ -525,18 +539,36 @@ public sealed partial class PerformanceService : IDisposable
         return ParseProcessorMinPercent(lines);
     }
 
-    internal static int ParseProcessorMinPercent(IList<string> lines)
+    internal static int? ParseProcessorMinPercent(IList<string> lines)
     {
-        // Look for "Current AC Power Setting Index: 0x00000064" (100 = 0x64)
+        // The query is PROCTHROTTLEMIN only, so powercfg prints exactly two hex values:
+        // "Current AC Power Setting Index: 0x…" then "Current DC Power Setting Index: 0x…"
+        // (AC always first, in every language). We want the AC value.
+        //
+        // Fast path (en-US, unchanged): match the English AC label exactly.
+        // Locale-agnostic fallback: the label is translated on non-English Windows, so fall
+        // back to the FIRST "0x…" token in the output — which is the AC index by powercfg's
+        // fixed AC-before-DC ordering. Return null when nothing parses: the caller must NOT
+        // invent a value, or a snapshot/restore would fabricate a wrong minimum (the bug this
+        // fixes — the old code returned 5, which "Restore" then wrote back on non-English boxes).
         foreach (var line in lines.Where(l => l.Contains("Current AC Power Setting Index", StringComparison.OrdinalIgnoreCase)))
         {
-            var hexIdx = line.IndexOf("0x", StringComparison.OrdinalIgnoreCase);
-            if (hexIdx < 0) continue;
-            var hex = line[(hexIdx + 2)..].Trim();
-            if (int.TryParse(hex, System.Globalization.NumberStyles.HexNumber, null, out var val))
-                return val;
+            if (TryParseHexToken(line, out var acVal)) return acVal;
         }
-        return 5; // Windows default
+        foreach (var line in lines)
+        {
+            if (TryParseHexToken(line, out var val)) return val;
+        }
+        return null; // couldn't read — do not guess
+    }
+
+    private static bool TryParseHexToken(string line, out int value)
+    {
+        value = 0;
+        var hexIdx = line.IndexOf("0x", StringComparison.OrdinalIgnoreCase);
+        if (hexIdx < 0) return false;
+        var hex = line[(hexIdx + 2)..].Trim();
+        return int.TryParse(hex, System.Globalization.NumberStyles.HexNumber, null, out value);
     }
 
     /// <summary>
@@ -668,8 +700,11 @@ public sealed partial class PerformanceService : IDisposable
         if (snapshot.NvidiaSubKey is not null)
             SetGpuMaxPerformance(snapshot.NvidiaSubKey, !snapshot.GpuDynamicPstate);
 
-        // Processor state
-        await SetProcessorMinStateAsync(snapshot.ProcessorMinPercentAc, ct).ConfigureAwait(false);
+        // Processor state — only restore if we captured a real value. A null means the
+        // snapshot couldn't read the original minimum (e.g. an unparseable powercfg output),
+        // so writing anything would fabricate state; leaving it untouched is the safe choice.
+        if (snapshot.ProcessorMinPercentAc is int minPct)
+            await SetProcessorMinStateAsync(minPct, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.10</Version>
-    <FileVersion>1.52.10.0</FileVersion>
-    <AssemblyVersion>1.52.10.0</AssemblyVersion>
+    <Version>1.52.11</Version>
+    <FileVersion>1.52.11.0</FileVersion>
+    <AssemblyVersion>1.52.11.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
@@ -363,7 +363,9 @@ public sealed partial class PerformanceViewModel : ViewModelBase
         try
         {
             await EnsureSnapshotAsync();
-            var target = WantProcessorMaxState ? 100 : _snapshot!.ProcessorMinPercentAc;
+            // "Restore default" targets the captured original; if it couldn't be read
+            // (null), fall back to the Windows default of 5% for this explicit user action.
+            var target = WantProcessorMaxState ? 100 : (_snapshot!.ProcessorMinPercentAc ?? 5);
             await _service.SetProcessorMinStateAsync(target);
             await RefreshAsync();
             StatusMessage = $"Processor min state set to {target}%.";
@@ -500,7 +502,7 @@ public sealed partial class PerformanceViewModel : ViewModelBase
             + $"• Visual effects → {(_snapshot.UiEffectsEnabled ? "Normal" : "Reduced")}\n"
             + $"• Game Mode → {(_snapshot.GameModeEnabled ? "ON" : "OFF")}\n"
             + $"• Xbox Game Bar → {(_snapshot.XboxGameBarEnabled ? "ON" : "OFF")}\n"
-            + $"• Processor min state → {_snapshot.ProcessorMinPercentAc}%\n"
+            + $"• Processor min state → {(_snapshot.ProcessorMinPercentAc is int p ? $"{p}%" : "unchanged")}\n"
             + (gpuWasChanged ? "• GPU → Dynamic P-state (reboot needed)\n" : "")
             + "\nContinue?",
             "Restore Original Settings — Confirm")) return;


### PR DESCRIPTION
## Problem
The Performance tab's snapshot/restore read two power settings by matching **English** text that Windows translates in other display languages. On a non-English Windows the "Restore" path misbehaved:

1. **Active power plan** — `ParseActivePlan` located the plan by the English `"GUID:"` label. On a localized Windows (e.g. German `Energieschema-GUID:`) that substring never matched, so the plan came back `("Unknown", "")` and Restore **silently skipped restoring the power plan**.
2. **Processor minimum state** — `ParseProcessorMinPercent` matched the English `"Current AC Power Setting Index"` label and, when it didn't match, returned a **fabricated 5%**. That 5 was then captured in the snapshot and **written back** by Restore — so on a non-English machine "Restore" forced the CPU minimum to 5% instead of the user's real original value. Broken reversibility.

## Fix
- **Power plan:** anchor on the canonical GUID token (`8-4-4-4-12` hex), which powercfg prints identically in every language, via a `[GeneratedRegex]`. The friendly name is still read from the trailing parentheses (display-only). English output parses exactly as before.
- **Processor min %:** `ParseProcessorMinPercent` now returns `int?` — `null` when it genuinely can't read the value instead of inventing 5. The English label stays as the fast path; a locale-agnostic fallback reads the first `0x…` token (AC is printed before DC in every language). The snapshot keeps the `int?`, and Restore **skips the write-back when null** (leaves the setting untouched) rather than fabricating one. The display path still shows 5 as a fallback, unchanged.

Snapshot record field `ProcessorMinPercentAc` is now `int?`; the two ViewModel sites (restore-default target, Restore-All confirm dialog) and the restore path handle null.

## Scope
EU/non-English Windows (German/French/Spanish/Italian) is the real target here. English behavior is byte-identical.

## Tests
- Updated `ParseProcessorMinPercent_EmptyInput`/`_NoMatchingLine` to assert `null` (the old "returns 5" WAS the bug).
- Added `ParseActivePlan_NonEnglishLabel_StillParsesGuid` (German `Energieschema-GUID:`).
- Added `ParseProcessorMinPercent_NonEnglishLabel_StillParsesFirstHex` (German AC/DC labels; asserts the AC value, not DC, not a fabricated 5).

Build: app + tests 0 errors / 0 warnings.
