### PR TITLE
fix: reverting a privacy toggle removes the value instead of enforcing the opposite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.12] - 2026-07-03
+
+### Fixed
+- **Turning a privacy toggle off now removes the setting instead of forcing the opposite.** When you switched a privacy protection back off (or used Undo in the Tweaks hub), SysManager wrote the "off" value into the registry — for the policy-backed toggles this **created an enforced Group Policy the machine may never have had**. The worst case was "Disable diagnostic data": reverting it wrote `AllowTelemetry = 3`, which is *enforced Full telemetry* — strictly worse than the value simply being absent. Reverting a toggle now **deletes** our registry value so Windows falls back to its own default, which is the correct meaning of "undo". This applies to both the Privacy & Telemetry tab and the Tweaks hub's Undo.
+
 ## [1.52.11] - 2026-07-03
 
 ### Fixed

--- a/SysManager/SysManager.Tests/PrivacyServiceTests.cs
+++ b/SysManager/SysManager.Tests/PrivacyServiceTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using Microsoft.Win32;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -54,5 +55,80 @@ public class PrivacyServiceTests
     {
         var svc = new PrivacyService();
         Assert.Throws<ArgumentNullException>(() => svc.ApplyToggle(null!));
+    }
+
+    // ── Revert behavior (F07 regression) ──────────────────────────────────
+    // Turning a toggle OFF must REMOVE our value (so Windows falls back to its own
+    // default), NOT write DisabledValue — which for policy toggles would materialise
+    // an enforced GPO the machine never had (e.g. AllowTelemetry=3 = Full telemetry).
+    // These use a throwaway HKCU subkey: per-user, no elevation, deleted on dispose.
+
+    private sealed class HkcuTestKey : IDisposable
+    {
+        // Relative to HKCU. "AllowTelemetry"-style value with an enforcing DisabledValue.
+        public string SubPath { get; } = @"Software\SysManagerTests\Privacy_" + Guid.NewGuid().ToString("N");
+        public string FullPath => @"HKCU\" + SubPath;
+
+        public PrivacyToggle Toggle(bool isEnabled) => new()
+        {
+            Name = "test",
+            Description = "revert test",
+            Category = "Telemetry",
+            RegistryPath = FullPath,
+            ValueName = "AllowTelemetry",
+            EnabledValue = 0,   // privacy ON
+            DisabledValue = 3,  // the dangerous "enforce Full telemetry" value we must NOT write on revert
+            IsEnabled = isEnabled,
+        };
+
+        public object? ReadValue()
+        {
+            using var k = Registry.CurrentUser.OpenSubKey(SubPath);
+            return k?.GetValue("AllowTelemetry");
+        }
+
+        public void Dispose()
+        {
+            try { Registry.CurrentUser.DeleteSubKeyTree(SubPath, throwOnMissingSubKey: false); } catch { /* best-effort cleanup */ }
+        }
+    }
+
+    [Fact]
+    public void ApplyToggle_On_WritesEnabledValue()
+    {
+        using var t = new HkcuTestKey();
+        var svc = new PrivacyService();
+
+        Assert.True(svc.ApplyToggle(t.Toggle(isEnabled: true)));
+        Assert.Equal(0, t.ReadValue()); // EnabledValue written
+    }
+
+    [Fact]
+    public void ApplyToggle_Off_RemovesValue_DoesNotWriteDisabledValue()
+    {
+        using var t = new HkcuTestKey();
+        var svc = new PrivacyService();
+
+        // First enable (writes 0), then revert (OFF).
+        Assert.True(svc.ApplyToggle(t.Toggle(isEnabled: true)));
+        Assert.Equal(0, t.ReadValue());
+
+        Assert.True(svc.ApplyToggle(t.Toggle(isEnabled: false)));
+
+        // Regression: the value must be GONE, not set to DisabledValue (3). The old code
+        // wrote 3 here — materialising an enforced "Full telemetry" policy on revert.
+        Assert.Null(t.ReadValue());
+    }
+
+    [Fact]
+    public void ApplyToggle_Off_WhenNeverSet_IsIdempotentNoOp()
+    {
+        using var t = new HkcuTestKey();
+        var svc = new PrivacyService();
+
+        // Revert with no prior value present: must succeed and leave the value absent
+        // (does not create the key-value with DisabledValue).
+        Assert.True(svc.ApplyToggle(t.Toggle(isEnabled: false)));
+        Assert.Null(t.ReadValue());
     }
 }

--- a/SysManager/SysManager/Services/PrivacyService.cs
+++ b/SysManager/SysManager/Services/PrivacyService.cs
@@ -42,8 +42,6 @@ public sealed class PrivacyService
     {
         ArgumentNullException.ThrowIfNull(toggle);
 
-        var valueToWrite = toggle.IsEnabled ? toggle.EnabledValue : toggle.DisabledValue;
-
         try
         {
             using var key = OpenOrCreateKey(toggle.RegistryPath, writable: true);
@@ -54,9 +52,26 @@ public sealed class PrivacyService
                 return false;
             }
 
-            key.SetValue(toggle.ValueName, valueToWrite, RegistryValueKind.DWord);
-            Log.Information("Privacy toggle applied: {Name} = {Value} at {Path}\\{ValueName}",
-                toggle.Name, valueToWrite, toggle.RegistryPath, toggle.ValueName);
+            if (toggle.IsEnabled)
+            {
+                // Privacy ON → enforce our protection value.
+                key.SetValue(toggle.ValueName, toggle.EnabledValue, RegistryValueKind.DWord);
+                Log.Information("Privacy toggle applied: {Name} = {Value} at {Path}\\{ValueName}",
+                    toggle.Name, toggle.EnabledValue, toggle.RegistryPath, toggle.ValueName);
+            }
+            else
+            {
+                // Privacy OFF (revert) → REMOVE our value so Windows falls back to its own
+                // default, rather than WRITING DisabledValue. Writing DisabledValue was wrong:
+                // for policy-backed toggles it materialises an enforced GPO the machine may
+                // never have had (e.g. AllowTelemetry=3 = Full telemetry ENFORCED), which is
+                // strictly worse than the value being absent. Deleting is the correct undo of
+                // an enforcement. DeleteValue(name, throwOnMissingValue: false) is a no-op when
+                // the value is already absent, so revert is idempotent.
+                key.DeleteValue(toggle.ValueName, throwOnMissingValue: false);
+                Log.Information("Privacy toggle reverted (value removed): {Name} at {Path}\\{ValueName}",
+                    toggle.Name, toggle.RegistryPath, toggle.ValueName);
+            }
             return true;
         }
         catch (UnauthorizedAccessException ex)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.11</Version>
-    <FileVersion>1.52.11.0</FileVersion>
-    <AssemblyVersion>1.52.11.0</AssemblyVersion>
+    <Version>1.52.12</Version>
+    <FileVersion>1.52.12.0</FileVersion>
+    <AssemblyVersion>1.52.12.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem
Turning a privacy toggle **off** — or using **Undo** in the Tweaks hub — wrote the toggle's `DisabledValue` into the registry. For the policy-backed toggles this **materialised an enforced Group Policy the machine may never have had**.

Worst case, "Disable diagnostic data": reverting it wrote `AllowTelemetry = 3` under `HKLM\SOFTWARE\Policies\Microsoft\Windows\DataCollection` — which is **enforced Full telemetry**, strictly worse than the value simply being absent. Once written, the "was-absent" original state was unrecoverable through the UI.

## Fix
`PrivacyService.ApplyToggle` now, on revert (toggle off), **deletes** our registry value instead of writing `DisabledValue`:

```
DeleteValue(ValueName, throwOnMissingValue: false)
```

so Windows falls back to its own default — which is the correct meaning of "undo an enforcement". `throwOnMissingValue: false` makes revert an idempotent no-op when the value is already absent. Turning a toggle **on** is unchanged (still writes `EnabledValue`).

This fixes the whole class in one place: both callers — the **Privacy & Telemetry** tab and **TweaksHubService.Undo** — route through `ApplyToggle`.

`ReadCurrentState` already treats an absent value as "privacy off", so after a revert the toggle reads back consistently as off.

## Tests
Regression tests against a throwaway `HKCU` subkey (per-user, no elevation, deleted on dispose — matching the existing `AppBlockerServiceRegistryTests`/`EnvironmentVariableServiceTests` convention):
- `ApplyToggle_On_WritesEnabledValue` — ON writes `EnabledValue`.
- `ApplyToggle_Off_RemovesValue_DoesNotWriteDisabledValue` — after enable→revert, the value is **gone**, asserted **not** set to the dangerous `DisabledValue = 3` (this is the bug the old code produced).
- `ApplyToggle_Off_WhenNeverSet_IsIdempotentNoOp` — reverting with no prior value succeeds and leaves the value absent.

Build: app + tests 0 errors / 0 warnings.
