### PR TITLE
fix: winget parser maps Available/Source positionally on unlisted locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.13] - 2026-07-03
+
+### Fixed
+- **App Updates now shows upgrades on Windows display languages we don't have column titles for.** The winget table parser identifies the "Available" and "Source" columns by matching their header word against a list of known translations. On a language not in that list (e.g. Russian, Korean), those two columns weren't found, so every upgrade row came back with a blank "Available" version and was silently dropped — App Updates showed **no upgrades at all**. For the standard five-column upgrade table the parser now falls back to the fixed column order when a title isn't recognized, so upgrades appear regardless of display language. Four-column tables stay ambiguous by design and are left untouched (they can't be disambiguated by position).
+
 ## [1.52.12] - 2026-07-03
 
 ### Fixed

--- a/SysManager/SysManager.Tests/WingetTableParserTests.cs
+++ b/SysManager/SysManager.Tests/WingetTableParserTests.cs
@@ -235,4 +235,58 @@ public class WingetTableParserTests
         Assert.Equal("winget", result[0].Source);
         Assert.Equal("", result[0].Available);
     }
+
+    // ── F03 regression: unlisted locale, 5-column upgrade table ──────────────
+    // The German/French tests above pass because those locales ARE in the title lists.
+    // The real gap: a locale whose Available/Source WORDS we don't know. Id/Version fell
+    // back to position, but Available/Source stayed -1 → every row's Available came back
+    // blank → WingetService dropped every row → App Updates showed ZERO upgrades. For the
+    // UNAMBIGUOUS 5-column shape we now map Available/Source positionally.
+
+    [Fact]
+    public void Parse_UnlistedLocale_FiveColumnUpgrade_MapsAvailableAndSourcePositionally()
+    {
+        // A fabricated locale whose column words are in NONE of the title lists. Only the
+        // Name/Id/Version/Available/Source ORDER (and the dashes separator) are relied on.
+        var lines = new List<string>
+        {
+            "Naimŭ                        Ident                        Verzia    Dostupny    Zdroj",
+            "-----------------------------------------------------------------------------------------",
+            "Git                          Git.Git                        2.47.0    2.48.0      winget",
+            "Node.js                      OpenJS.NodeJS                  20.11.0   22.1.0      winget"
+        };
+
+        var result = WingetTableParser.Parse(lines, NeverMatches, SummaryPattern);
+
+        Assert.Equal(2, result.Count);
+        // The whole point: Available is populated (not blank), so these upgrades are NOT dropped.
+        Assert.Equal("2.48.0", result[0].Available);
+        Assert.Equal("winget", result[0].Source);
+        Assert.Equal("Git.Git", result[0].Id);
+        Assert.Equal("22.1.0", result[1].Available);
+    }
+
+    [Fact]
+    public void Parse_UnlistedLocale_FourColumn_DoesNotGuessAvailableOrSource()
+    {
+        // A 4-column table in an unlisted locale is genuinely ambiguous by position
+        // (list=…/Source vs source-less upgrade=…/Available), so the positional fallback
+        // deliberately only fires at >=5 columns and does NOT guess the ambiguous 4th column.
+        // Id still resolves positionally so the row is not lost. (Version can bleed into the
+        // trailing column here — that's pre-existing 4-column behavior this fix doesn't touch.)
+        var lines = new List<string>
+        {
+            "Naimŭ                        Ident                        Verzia    Stĺpec4",
+            "-------------------------------------------------------------------------",
+            "Git                          Git.Git                        2.47.0    winget"
+        };
+
+        var result = WingetTableParser.Parse(lines, NeverMatches, SummaryPattern);
+
+        Assert.Single(result);
+        Assert.Equal("Git.Git", result[0].Id);
+        // The key invariant: neither ambiguous column is falsely populated.
+        Assert.Equal("", result[0].Available);
+        Assert.Equal("", result[0].Source);
+    }
 }

--- a/SysManager/SysManager/Helpers/WingetTableParser.cs
+++ b/SysManager/SysManager/Helpers/WingetTableParser.cs
@@ -138,6 +138,21 @@ internal static partial class WingetTableParser
 
         int id = FindStart(tokens, IdTitles);
         int version = FindStart(tokens, VersionTitles);
+        int available = FindStart(tokens, AvailableTitles);
+        int source = FindStart(tokens, SourceTitles);
+
+        // Positional fallback for the Available/Source columns on an unlisted locale, but ONLY
+        // for the UNAMBIGUOUS 5-column shape (Name Id Version Available Source). Without this,
+        // an upgrade table in a locale we don't have titles for leaves Available = -1, so every
+        // row's Available comes back blank and WingetService drops it — App Updates shows zero
+        // upgrades. A 4-column table is deliberately left alone: it's ambiguous by position
+        // (list = Name/Id/Version/Source vs source-less upgrade = Name/Id/Version/Available),
+        // and prior fixes proved position can't disambiguate it — so we don't guess there.
+        if (tokens.Count >= 5)
+        {
+            if (available < 0) available = tokens[3].Start;
+            if (source < 0) source = tokens[4].Start;
+        }
 
         return new ColumnLayout
         {
@@ -146,8 +161,8 @@ internal static partial class WingetTableParser
             // the Name/Id/Version order is invariant, so position is a safe last resort here.
             Id = id >= 0 ? id : tokens[1].Start,
             Version = version >= 0 ? version : tokens[2].Start,
-            Available = FindStart(tokens, AvailableTitles),
-            Source = FindStart(tokens, SourceTitles)
+            Available = available,
+            Source = source
         };
     }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.12</Version>
-    <FileVersion>1.52.12.0</FileVersion>
-    <AssemblyVersion>1.52.12.0</AssemblyVersion>
+    <Version>1.52.13</Version>
+    <FileVersion>1.52.13.0</FileVersion>
+    <AssemblyVersion>1.52.13.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem
The winget table parser locates the **Available** and **Source** columns by matching their header word against a list of known translations (`AvailableTitles`/`SourceTitles`). `Id`/`Version` additionally have a **positional** fallback (2nd/3rd token) for unknown locales — but `Available`/`Source` did not.

So on a Windows display language whose column words aren't in the lists (e.g. Russian, Korean), a standard five-column upgrade table left `Available = -1`. Every parsed row then had a **blank Available version**, and `WingetService.ParseUpgradeTable` drops any row with a blank Available (`WingetService.cs:59`) — so **App Updates showed zero upgrades** on those languages.

## Fix
In `DetectColumns`, after the title match, add a **positional fallback** for `Available` (token[3]) and `Source` (token[4]) — but **only for the unambiguous five-column shape** (`Name Id Version Available Source`).

A **four-column** table is deliberately left untouched: it is genuinely ambiguous by position (`list` = Name/Id/Version/**Source** vs a source-less `upgrade` = Name/Id/Version/**Available**), and prior fixes proved position can't disambiguate it. So the fallback only fires at `tokens.Count >= 5`, where the order is unambiguous.

## Scope
Complements the existing localized-title support (German/French/Spanish/Italian/CJK are matched by title). This catches every *other* language via order. English + already-listed locales are unchanged.

## Tests
- `Parse_UnlistedLocale_FiveColumnUpgrade_MapsAvailableAndSourcePositionally` — a fabricated locale whose column words are in **none** of the title lists; asserts `Available` is populated (so rows are **not** dropped) and `Source` maps correctly.
- `Parse_UnlistedLocale_FourColumn_DoesNotGuessAvailableOrSource` — an unlisted 4-column table does **not** falsely populate either ambiguous column.
- All existing tests (English, German/French 5-col, 4-col list) unchanged and still pass.

Build: app + tests 0 errors / 0 warnings.
