### PR TITLE
fix: File Shredder overwrites through one locked handle to close a path-swap race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.14] - 2026-07-03
+
+### Security
+- **File Shredder now overwrites through a single locked handle, closing a path-swap race.** The shredder validated the target path, then reopened the file by name for each overwrite pass and the final truncate. Between the validation and those reopens, a reparse point (junction/symlink) swapped in at the path could have redirected the overwrite to a different file — a time-of-check/time-of-use race. The shredder now opens the file once with an exclusive (no-sharing) handle, re-verifies *that handle's* real resolved path against the protected-folder denylist before writing anything, and reuses the same handle for every pass and the truncate — so nothing can redirect the operation once it starts. The existing symlink/junction protections are unchanged.
+
 ## [1.52.13] - 2026-07-03
 
 ### Fixed

--- a/SysManager/SysManager.Tests/FileShredderServiceTests.cs
+++ b/SysManager/SysManager.Tests/FileShredderServiceTests.cs
@@ -152,6 +152,29 @@ public class FileShredderServiceTests
     }
 
     [Fact]
+    public async Task ShredFileAsync_Thorough_MultiPass_OverwritesAndDeletes()
+    {
+        // Held-handle regression (F48): the shred now opens ONE exclusive handle and reuses
+        // it for every pass (rewinding Position=0) plus the final truncate, instead of
+        // reopening the file by path each pass. A 7-pass Thorough shred exercises that reuse
+        // across many passes and must still fully overwrite (multi-KB file spanning several
+        // 64 KB buffer writes) and delete the file.
+        var svc = NewService();
+        var file = Path.Combine(Path.GetTempPath(), "smtest_thorough_" + Guid.NewGuid().ToString("N") + ".dat");
+        await File.WriteAllBytesAsync(file, new byte[200_000]); // > buffer size, forces multiple chunks/pass
+
+        try
+        {
+            await svc.ShredFileAsync(file, ShredMethod.Thorough, null, CancellationToken.None);
+            Assert.False(File.Exists(file), "Thorough (7-pass) shred did not remove the file");
+        }
+        finally
+        {
+            if (File.Exists(file)) File.Delete(file);
+        }
+    }
+
+    [Fact]
     public async Task ShredFileAsync_ReportsProgressToCompletion()
     {
         var svc = NewService();

--- a/SysManager/SysManager/Services/FileShredderService.cs
+++ b/SysManager/SysManager/Services/FileShredderService.cs
@@ -57,61 +57,84 @@ public sealed partial class FileShredderService
         if (!File.Exists(filePath))
             throw new FileNotFoundException("File not found.", filePath);
 
-        var fileLength = new FileInfo(filePath).Length;
         var totalPasses = (int)method;
         var patterns = GetPatterns(method);
 
-        for (var pass = 0; pass < totalPasses; pass++)
+        // Open the file ONCE with an exclusive (FileShare.None) write handle and keep it open
+        // for every pass and the final truncate. This closes the validate-by-path/act-by-path
+        // TOCTOU: ValidatePath above checks a path STRING, but the destructive writes must act
+        // on the exact object we validated. By holding one exclusive handle and re-verifying
+        // THAT HANDLE's canonical path (GetFinalPathNameByHandle) against the protected roots
+        // before writing a byte, a reparse point swapped in after ValidatePath can no longer
+        // redirect the overwrite — the handle is already bound to the resolved object, and
+        // FileShare.None blocks anyone from moving/replacing it mid-shred.
+        var stream = new FileStream(
+            filePath,
+            FileMode.Open,
+            FileAccess.Write,
+            FileShare.None,
+            BufferSize,
+            FileOptions.WriteThrough | FileOptions.SequentialScan);
+
+        try
         {
-            ct.ThrowIfCancellationRequested();
+            // Re-validate the identity of the object we actually hold. If the resolved path
+            // sits under a protected root (a reparse point swapped in between ValidatePath and
+            // this open pointed us there), refuse — the exclusive handle guarantees this is the
+            // same object we will overwrite, so there is no residual race.
+            var heldCanonical = GetFinalPathFromHandle(stream.SafeFileHandle);
+            if (heldCanonical is not null)
+                ThrowIfProtected(ExpandShortPath(heldCanonical));
 
-            await using var stream = new FileStream(
-                filePath,
-                FileMode.Open,
-                FileAccess.Write,
-                FileShare.None,
-                BufferSize,
-                FileOptions.WriteThrough | FileOptions.SequentialScan);
+            var fileLength = stream.Length;
 
-            var buffer = new byte[BufferSize];
-            var pattern = patterns[pass];
-
-            if (pattern is null)
-            {
-                // Random pass — use cryptographic PRNG for secure overwrite
-                RandomNumberGenerator.Fill(buffer);
-            }
-            else
-            {
-                Array.Fill(buffer, pattern.Value);
-            }
-
-            var bytesRemaining = fileLength;
-            while (bytesRemaining > 0)
+            for (var pass = 0; pass < totalPasses; pass++)
             {
                 ct.ThrowIfCancellationRequested();
 
-                var writeSize = (int)Math.Min(BufferSize, bytesRemaining);
+                stream.Position = 0; // rewind for this pass (same handle, no reopen)
 
-                // Re-randomize buffer each chunk for random passes
+                var buffer = new byte[BufferSize];
+                var pattern = patterns[pass];
+
                 if (pattern is null)
-                    RandomNumberGenerator.Fill(buffer.AsSpan(0, writeSize));
+                {
+                    // Random pass — use cryptographic PRNG for secure overwrite
+                    RandomNumberGenerator.Fill(buffer);
+                }
+                else
+                {
+                    Array.Fill(buffer, pattern.Value);
+                }
 
-                await stream.WriteAsync(buffer.AsMemory(0, writeSize), ct).ConfigureAwait(false);
-                bytesRemaining -= writeSize;
+                var bytesRemaining = fileLength;
+                while (bytesRemaining > 0)
+                {
+                    ct.ThrowIfCancellationRequested();
+
+                    var writeSize = (int)Math.Min(BufferSize, bytesRemaining);
+
+                    // Re-randomize buffer each chunk for random passes
+                    if (pattern is null)
+                        RandomNumberGenerator.Fill(buffer.AsSpan(0, writeSize));
+
+                    await stream.WriteAsync(buffer.AsMemory(0, writeSize), ct).ConfigureAwait(false);
+                    bytesRemaining -= writeSize;
+                }
+
+                await stream.FlushAsync(ct).ConfigureAwait(false);
+
+                var overallProgress = (int)((pass + 1) * 100.0 / totalPasses);
+                progress?.Report(overallProgress);
             }
 
+            // Final truncate on the SAME held handle — no by-path reopen.
+            stream.SetLength(0);
             await stream.FlushAsync(ct).ConfigureAwait(false);
-
-            var overallProgress = (int)((pass + 1) * 100.0 / totalPasses);
-            progress?.Report(overallProgress);
         }
-
-        // Final cleanup: truncate, flush, close, then delete
-        await using (var finalStream = new FileStream(filePath, FileMode.Open, FileAccess.Write, FileShare.None))
+        finally
         {
-            finalStream.SetLength(0);
-            await finalStream.FlushAsync(ct).ConfigureAwait(false);
+            await stream.DisposeAsync().ConfigureAwait(false);
         }
 
         // The file contents are already securely overwritten and truncated to zero at
@@ -308,6 +331,17 @@ public sealed partial class FileShredderService
         if (handle.IsInvalid)
             return null;
 
+        return GetFinalPathFromHandle(handle);
+    }
+
+    /// <summary>
+    /// Returns the fully-resolved canonical path for an ALREADY-OPEN handle (every reparse
+    /// point collapsed), or null if the name can't be read. Used to verify the identity of the
+    /// exact handle we hold for the overwrite — closing the validate-by-path / act-by-path
+    /// TOCTOU window, since the check is on the same object we then write.
+    /// </summary>
+    private static string? GetFinalPathFromHandle(SafeFileHandle handle)
+    {
         // First call with a zero-length buffer returns the required length (incl. NUL).
         uint needed = NativeMethods.GetFinalPathNameByHandle(handle, [], 0, 0);
         if (needed == 0)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.13</Version>
-    <FileVersion>1.52.13.0</FileVersion>
-    <AssemblyVersion>1.52.13.0</AssemblyVersion>
+    <Version>1.52.14</Version>
+    <FileVersion>1.52.14.0</FileVersion>
+    <AssemblyVersion>1.52.14.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem (security — TOCTOU on a destructive path)
`FileShredderService.ShredFileAsync` validated the target path via `ValidatePath` (which resolves reparse points and checks the protected-folder denylist), but then **reopened the file by its path string** for every overwrite pass and again for the final truncate. Every by-path `CreateFile` follows whatever reparse point exists *at open time*.

Between the validation and those reopens, a junction/symlink swapped in at the path (a junction is creatable by an unprivileged user via `mklink /J`) could redirect the destructive multi-pass overwrite to a **different file** — including a protected one — defeating the denylist. Classic validate-by-path / act-by-path time-of-check/time-of-use race; for `ShredFolderAsync` it's iterated per file, widening the window.

## Fix
Open the file **once** with an exclusive `FileShare.None` write handle and keep it for the whole operation:
1. Re-verify **that handle's** canonical path (`GetFinalPathNameByHandle`) against the protected roots **before writing a byte** — the check is now on the exact object we hold, not a path string that can be re-pointed.
2. Reuse the same handle for every pass (rewinding `Position = 0`) and the final `SetLength(0)` — **no by-path reopen exists after validation**.
3. `FileShare.None` blocks anyone from moving/replacing the file mid-shred.

`FileShare.None` + `WriteThrough | SequentialScan` semantics are preserved. `ValidatePath` stays as the cheap first-line string check. Extracted `GetFinalPathFromHandle` (shared by `ResolveFinalPath` and the new handle check).

## Tests
- All existing guard tests are unchanged and must stay green — they prove the rewrite didn't weaken the denylist or the symlink/mid-path-junction protections (`ShredFileAsync_SymlinkToProtectedFile_ThrowsSecurityException`, `ShredFileAsync_FileBehindMidPathJunctionToProtected_ThrowsSecurityException`, sibling-allowed, cancel-before-delete).
- Adds `ShredFileAsync_Thorough_MultiPass_OverwritesAndDeletes` — a 7-pass shred of a >64 KB file, exercising the new single-handle reuse across many passes + chunks and asserting the file is fully overwritten and deleted.

Build: app + tests 0 errors / 0 warnings. (The race trigger itself isn't deterministically unit-testable without a timing seam; the fix removes the reopen that made it exploitable, and the existing reparse guards + happy-path multi-pass are covered.)
