### PR TITLE
fix: batch loops and single-instance listener survive per-item errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.15] - 2026-07-03
+
+### Fixed
+- **One invalid entry no longer aborts a whole batch upgrade or uninstall.** In App Updates and the Uninstaller, if a single package had an Id that failed validation (e.g. an Add/Remove-Programs GUID), the error thrown before that item even started would abort the entire remaining batch. Each item's error is now recorded on its own row and the batch continues with the rest.
+- **Single-instance activation is more robust.** The background listener that focuses the existing window when you launch a second copy wrapped its whole loop in one try/catch, so a single unexpected error could stop it permanently for the rest of the session. Each iteration now handles its own errors and keeps listening.
+
 ## [1.52.14] - 2026-07-03
 
 ### Security

--- a/SysManager/SysManager/App.xaml.cs
+++ b/SysManager/SysManager/App.xaml.cs
@@ -260,9 +260,9 @@ public partial class App : Application
     {
         _pipeCts = new CancellationTokenSource();
         var ct = _pipeCts.Token;
-        try
+        while (!ct.IsCancellationRequested)
         {
-            while (!ct.IsCancellationRequested)
+            try
             {
                 // Restrict the single-instance pipe to the current user only. The
                 // connection carries no payload (it is a pure "activate the window"
@@ -284,9 +284,17 @@ public partial class App : Application
                     }
                 });
             }
+            catch (OperationCanceledException) { break; }   // shutdown
+            catch (IOException) { break; }                  // pipe broken during shutdown
+            // A transient per-iteration fault (e.g. the OS refuses a pipe instance, or an
+            // ObjectDisposedException on a torn-down handle) must NOT permanently kill
+            // single-instance activation for the rest of the session — the old single-try
+            // wrapping the whole loop did exactly that. Log it and keep listening.
+            catch (Exception ex)
+            {
+                LogService.Logger?.Warning(ex, "Single-instance pipe listener iteration failed; continuing to listen");
+            }
         }
-        catch (OperationCanceledException) { /* shutdown */ }
-        catch (IOException) { /* pipe broken during shutdown */ }
     }
 
     /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.14</Version>
-    <FileVersion>1.52.14.0</FileVersion>
-    <AssemblyVersion>1.52.14.0</AssemblyVersion>
+    <Version>1.52.15</Version>
+    <FileVersion>1.52.15.0</FileVersion>
+    <AssemblyVersion>1.52.15.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
@@ -117,6 +117,10 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
                 }
                 catch (OperationCanceledException) { pkg.Status = "Cancelled"; break; }
                 catch (InvalidOperationException ex) { pkg.Status = $"Error: {ex.Message}"; failed++; }
+                // A single invalid package Id throws ArgumentException from UpgradeAsync
+                // BEFORE any process runs; record it on the row and keep upgrading the rest
+                // rather than aborting the whole batch.
+                catch (ArgumentException ex) { pkg.Status = $"Error: {ex.Message}"; failed++; }
                 attempted++;
             }
             Progress = 100;

--- a/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
@@ -162,6 +162,9 @@ public sealed partial class UninstallerViewModel : ViewModelBase
                 // whole batch — record it on the row and continue with the next app.
                 catch (System.ComponentModel.Win32Exception ex) { app.Status = $"Error: {ex.Message}"; }
                 catch (System.IO.IOException ex) { app.Status = $"Error: {ex.Message}"; }
+                // An unparseable package Id (e.g. an ARP GUID) throws ArgumentException from
+                // UninstallAsync before any process runs; record it and continue the batch.
+                catch (ArgumentException ex) { app.Status = $"Error: {ex.Message}"; }
                 done++;
             }
 


### PR DESCRIPTION
Three related error-handling robustness fixes (audit F18, F19, F33), all verified against current source.

## F18 / F19 — one bad Id no longer aborts a whole batch
`WingetService.UpgradeAsync` and `UninstallerService.UninstallAsync` validate the package Id and **throw `ArgumentException` before spawning any process** when it's invalid (e.g. an Add/Remove-Programs GUID that isn't a valid winget Id). The batch loops in **App Updates** and the **Uninstaller** caught `OperationCanceledException`/`InvalidOperationException` (and, for uninstall, `Win32Exception`/`IOException`) — but **not** `ArgumentException`. So a single invalid entry threw out of the loop and **aborted the entire remaining batch**. The Uninstaller's own comment says a bad item "must not abort the whole batch".

**Fix:** add a per-item `catch (ArgumentException)` arm to both loops — record the error on that row (`Error: …`) and continue with the next item.

## F33 — single-instance listener survives a transient fault
`App.StartPipeListenerAsync` wrapped its whole `while` loop in one `try` with only `OperationCanceledException`/`IOException` catches. Any other per-iteration fault (the OS refusing a pipe instance, an `ObjectDisposedException` on a torn-down handle) escaped the loop and **permanently killed single-instance activation** for the rest of the session — launching a second copy would no longer focus the running window.

**Fix:** move the `try` **inside** the loop. Shutdown exceptions (`OCE`/`IOException`) break cleanly; any other fault is logged (`LogService.Logger`) and the loop keeps listening. A broad per-iteration catch is the correct pattern for an accept-loop and it is logged.

## Tests
The `ArgumentException`-on-invalid-Id trigger is already covered at the service boundary (`WingetServiceValidationTests.WingetService_UpgradeAsync_RejectsInvalidId` / `UninstallerService_UninstallAsync_RejectsInvalidId`). The VM-level batch-continue and the startup pipe loop are not unit-testable here (the VMs wrap the non-mockable `PowerShellRunner`, and the pipe listener is a startup singleton) — so no new test is added rather than introducing a brittle seam mid-fix. Build: app + tests 0 errors / 0 warnings.
