### PR TITLE
fix: concurrency hardening (powercfg queue, cancel semantics, drivers gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.16] - 2026-07-03
+
+### Fixed
+- **Cancelling a Deep Cleanup scan or clean now reports "cancelled", not "complete".** A scan or clean stopped partway through cancellation still reported success (and fired a "complete" notification) with partial results. Cancelling now correctly ends the operation as cancelled.
+- **Driver list can't be started twice at once.** The "List drivers" button had no busy-guard (unlike the other scan tabs), so a second click during a scan could corrupt the collected output. It's now disabled while a scan is running, matching the App Updates / Uninstaller tabs.
+- **Hardened Performance-tab power queries against a threading race.** The four `powercfg` reads collected output into a plain list from a callback that fires on two reader threads at once, which could corrupt the captured lines. They now use a thread-safe queue, matching the winget service.
+
 ## [1.52.15] - 2026-07-03
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DeepCleanupServiceTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupServiceTests.cs
@@ -79,6 +79,28 @@ public class DeepCleanupServiceTests
     }
 
     [Fact]
+    public async Task ScanAsync_CancelledMidScan_Throws_DoesNotReturnPartial()
+    {
+        // Regression (F12): a scan cancelled AFTER it starts used to `break` out of its
+        // loops and fall through to report "Done" + return the partial category list, so
+        // the ViewModel showed a success toast for a cancelled scan. It must now throw
+        // OperationCanceledException instead. Deterministic (no wall-clock): the progress
+        // callback fires synchronously inside the scan loop, so cancelling on the first
+        // report cancels mid-scan reliably.
+        var s = new DeepCleanupService();
+        using var cts = new CancellationTokenSource();
+        var progress = new CancelOnFirstReport(cts);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => s.ScanAsync(progress, cts.Token));
+    }
+
+    private sealed class CancelOnFirstReport(CancellationTokenSource cts) : IProgress<DeepCleanupService.ScanProgress>
+    {
+        public void Report(DeepCleanupService.ScanProgress value) => cts.Cancel();
+    }
+
+    [Fact]
     public async Task ScanAsync_IncludesNvidiaCategory()
     {
         var s = new DeepCleanupService();

--- a/SysManager/SysManager/Services/DeepCleanupService.cs
+++ b/SysManager/SysManager/Services/DeepCleanupService.cs
@@ -243,6 +243,12 @@ public sealed class DeepCleanupService
             });
         }
 
+        // A cancelled scan exits the loops above with partial results; reporting "Done" and
+        // returning them would let the caller show a success toast for a cancelled op. Throw
+        // so the ViewModel's OperationCanceledException arm reports "cancelled" instead.
+        // Matches LargeFileScanner.
+        ct.ThrowIfCancellationRequested();
+
         progress?.Report(new ScanProgress(total, total, "Done"));
         return results;
     }
@@ -392,6 +398,12 @@ public sealed class DeepCleanupService
                 }
             }
         }
+
+        // A cancelled clean stops mid-way with partial deletions (already done + logged);
+        // reporting "Done" + returning a result would fire a success toast for a cancelled
+        // op. Throw so the ViewModel reports "Clean cancelled" instead. The work already
+        // performed is real and logged — throwing only changes the outcome message.
+        ct.ThrowIfCancellationRequested();
 
         progress?.Report(new ScanProgress(total, total, "Done"));
         return new CleanupResult { BytesFreed = freed, FilesDeleted = filesDeleted, Errors = errors };

--- a/SysManager/SysManager/Services/PerformanceService.cs
+++ b/SysManager/SysManager/Services/PerformanceService.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Collections.Concurrent;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Security;
@@ -197,13 +198,15 @@ public sealed partial class PerformanceService : IDisposable
     public async Task<(string Name, string Guid)> GetActivePlanAsync(CancellationToken ct = default)
     {
         await _psGate.WaitAsync(ct).ConfigureAwait(false);
-        List<string> lines = [];
-        void OnLine(PowerShellLine l) => lines.Add(l.Text);
+        // ConcurrentQueue: LineReceived fires from BOTH the stdout and stderr reader threads,
+        // so a plain List<string>.Add could interleave and corrupt/throw. Matches WingetService.
+        ConcurrentQueue<string> lines = new();
+        void OnLine(PowerShellLine l) => lines.Enqueue(l.Text);
         _ps.LineReceived += OnLine;
         try { await _ps.RunProcessAsync("powercfg.exe", "/getactivescheme", ct, PowerShellRunner.OemEncoding).ConfigureAwait(false); }
         finally { _ps.LineReceived -= OnLine; _psGate.Release(); }
 
-        return ParseActivePlan(lines);
+        return ParseActivePlan([.. lines]);
     }
 
     // Canonical GUID token (8-4-4-4-12 hex). powercfg prints the active plan's GUID in this
@@ -259,8 +262,10 @@ public sealed partial class PerformanceService : IDisposable
         var existingGuid = await FindPlanGuidByNameAsync("Ultimate Performance", ct).ConfigureAwait(false);
         if (!string.IsNullOrEmpty(existingGuid)) return existingGuid;
 
-        List<string> lines = [];
-        void OnLine(PowerShellLine l) => lines.Add(l.Text);
+        // ConcurrentQueue: LineReceived fires from BOTH the stdout and stderr reader threads,
+        // so a plain List<string>.Add could interleave and corrupt/throw. Matches WingetService.
+        ConcurrentQueue<string> lines = new();
+        void OnLine(PowerShellLine l) => lines.Enqueue(l.Text);
         await _psGate.WaitAsync(ct).ConfigureAwait(false);
         _ps.LineReceived += OnLine;
         try { await _ps.RunProcessAsync("powercfg.exe", $"-duplicatescheme {UltimatePerfScheme}", ct, PowerShellRunner.OemEncoding).ConfigureAwait(false); }
@@ -283,13 +288,15 @@ public sealed partial class PerformanceService : IDisposable
     public async Task<string?> FindPlanGuidByNameAsync(string nameSubstring, CancellationToken ct = default)
     {
         await _psGate.WaitAsync(ct).ConfigureAwait(false);
-        List<string> lines = [];
-        void OnLine(PowerShellLine l) => lines.Add(l.Text);
+        // ConcurrentQueue: LineReceived fires from BOTH the stdout and stderr reader threads,
+        // so a plain List<string>.Add could interleave and corrupt/throw. Matches WingetService.
+        ConcurrentQueue<string> lines = new();
+        void OnLine(PowerShellLine l) => lines.Enqueue(l.Text);
         _ps.LineReceived += OnLine;
         try { await _ps.RunProcessAsync("powercfg.exe", "/list", ct, PowerShellRunner.OemEncoding).ConfigureAwait(false); }
         finally { _ps.LineReceived -= OnLine; _psGate.Release(); }
 
-        return ParsePlanGuidByName(lines, nameSubstring);
+        return ParsePlanGuidByName([.. lines], nameSubstring);
     }
 
     internal static string? ParsePlanGuidByName(IList<string> lines, string nameSubstring)
@@ -526,8 +533,10 @@ public sealed partial class PerformanceService : IDisposable
     internal async Task<int?> ReadProcessorMinPercentAsync(CancellationToken ct = default)
     {
         await _psGate.WaitAsync(ct).ConfigureAwait(false);
-        List<string> lines = [];
-        void OnLine(PowerShellLine l) => lines.Add(l.Text);
+        // ConcurrentQueue: LineReceived fires from BOTH the stdout and stderr reader threads,
+        // so a plain List<string>.Add could interleave and corrupt/throw. Matches WingetService.
+        ConcurrentQueue<string> lines = new();
+        void OnLine(PowerShellLine l) => lines.Enqueue(l.Text);
         _ps.LineReceived += OnLine;
         try
         {
@@ -536,7 +545,7 @@ public sealed partial class PerformanceService : IDisposable
         }
         finally { _ps.LineReceived -= OnLine; _psGate.Release(); }
 
-        return ParseProcessorMinPercent(lines);
+        return ParseProcessorMinPercent([.. lines]);
     }
 
     internal static int? ParseProcessorMinPercent(IList<string> lines)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.15</Version>
-    <FileVersion>1.52.15.0</FileVersion>
-    <AssemblyVersion>1.52.15.0</AssemblyVersion>
+    <Version>1.52.16</Version>
+    <FileVersion>1.52.16.0</FileVersion>
+    <AssemblyVersion>1.52.16.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DriversViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DriversViewModel.cs
@@ -28,11 +28,25 @@ public sealed partial class DriversViewModel : ViewModelBase
     public DriversViewModel(PowerShellRunner runner)
     {
         _runner = runner;
+        // Re-evaluate ListDrivers' CanExecute when IsBusy flips. Without this gate a second
+        // click while a scan runs double-subscribes the LineReceived capture (concatenated
+        // JSON → JsonException) and recreates the shared _cts the first run is still awaiting.
+        // Mirrors AppUpdates/Uninstaller/WindowsUpdate.
+        PropertyChanged += OnVmPropertyChanged;
+    }
+
+    /// <summary>Gate for the long-running scan command; Cancel stays enabled.</summary>
+    private bool NotBusy => !IsBusy;
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(IsBusy)) return;
+        ListDriversCommand.NotifyCanExecuteChanged();
     }
 
     partial void OnHideSystemDriversChanged(bool value) => ApplyFilter();
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task ListDriversAsync()
     {
         IsBusy = true;
@@ -82,6 +96,7 @@ public sealed partial class DriversViewModel : ViewModelBase
     {
         if (disposing)
         {
+            PropertyChanged -= OnVmPropertyChanged;
             _cts?.Dispose();
         }
         base.Dispose(disposing);


### PR DESCRIPTION
Three verified concurrency/robustness fixes (audit F34, F12, F31), each re-checked against current source.

## F34 — powercfg captures use a thread-safe queue
`PerformanceService` has four `powercfg` reads that collect output into a plain `List<string>` from an `OnLine` handler subscribed to `_ps.LineReceived` — which fires from **both** the stdout and stderr reader threads. Concurrent `List.Add` can interleave and corrupt the list or throw. The sibling `WingetService` already uses `ConcurrentQueue` for exactly this.

**Fix:** all four sites now use `ConcurrentQueue<string>` (`Enqueue` is thread-safe); the parse methods still take `IList<string>` via `[.. lines]`.

## F12 — a cancelled Deep Cleanup no longer reports success
`DeepCleanupService.Scan` and `Clean` `break` out of their loops on cancellation, then fall through to `progress.Report(..., "Done")` and **return the partial result**. The ViewModel already had `catch (OperationCanceledException)` arms ("Scan/Clean cancelled") — but the service never threw, so a cancelled op showed a success status **and fired a "complete" toast** with partial results.

**Fix:** both methods now `ct.ThrowIfCancellationRequested()` before the "Done" report (matching `LargeFileScanner`), so the VM's existing cancel arms fire. Work already performed by a cancelled `Clean` is real and logged — throwing only corrects the outcome message.

## F31 — "List drivers" is busy-gated
`DriversViewModel.ListDriversAsync` was a bare `[RelayCommand]` with no `CanExecute` — the only scan VM without one. A second click during a scan double-subscribes the `LineReceived` capture (concatenated JSON → `JsonException`) and recreates the shared `_cts` the first run is still awaiting.

**Fix:** added `NotBusy` + `CanExecute = nameof(NotBusy)` + `NotifyCanExecuteChanged` on `IsBusy`, and unsubscribe in `Dispose` — mirroring the App Updates / Uninstaller / Windows Update tabs.

## Test
Adds `ScanAsync_CancelledMidScan_Throws_DoesNotReturnPartial` — cancels via the **synchronous** progress callback (fires inside the scan loop), so cancellation lands mid-scan deterministically (no wall-clock), and asserts the scan throws `OperationCanceledException` instead of returning a partial list. Build: app + tests 0 errors / 0 warnings.
