### PR TITLE
fix: Event Log time filter uses invariant culture (Logs empty on dot-separator locales)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.17] - 2026-07-03
+
+### Fixed
+- **System Logs no longer come back empty on some non-English regional settings.** The Event Log query built its time filter with the OS's regional time separator, so on a region that uses `.` instead of `:` in times (e.g. Finnish) the timestamp became invalid and the query silently failed — the Logs tab showed nothing. The timestamp is now always formatted in the culture-independent ISO form, so log filtering works regardless of regional settings.
+
 ## [1.52.16] - 2026-07-03
 
 ### Fixed

--- a/SysManager/SysManager.Tests/EventLogServiceTests.cs
+++ b/SysManager/SysManager.Tests/EventLogServiceTests.cs
@@ -66,6 +66,35 @@ public class EventLogServiceTests
     }
 
     [Fact]
+    public void BuildXPath_Since_UsesInvariantTimeSeparator_OnDotSeparatorCulture()
+    {
+        // Regression (F16): the SystemTime timestamp was formatted without a culture, so on a
+        // locale whose TimeSeparator is '.' (e.g. fi-FI) the ':' in the format became '.',
+        // producing an invalid SystemTime like "10.30.00" — EventLogQuery then threw and the
+        // Logs tab came back empty. Force such a culture and assert the ISO ':' survives.
+        var original = System.Globalization.CultureInfo.CurrentCulture;
+        try
+        {
+            System.Globalization.CultureInfo.CurrentCulture =
+                System.Globalization.CultureInfo.GetCultureInfo("fi-FI");
+
+            var opt = new EventLogQueryOptions
+            {
+                Since = new DateTime(2026, 1, 15, 10, 30, 45, DateTimeKind.Utc)
+            };
+            var result = InvokeBuildXPath(opt);
+
+            // Valid ISO 8601 time uses ':' regardless of the OS display language.
+            Assert.Contains("T10:30:45", result);
+            Assert.DoesNotContain("10.30.45", result);
+        }
+        finally
+        {
+            System.Globalization.CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
     public void BuildXPath_WithProvider_IncludesProviderName()
     {
         var opt = new EventLogQueryOptions { ProviderName = "disk" };

--- a/SysManager/SysManager/Services/EventLogService.cs
+++ b/SysManager/SysManager/Services/EventLogService.cs
@@ -157,7 +157,13 @@ public sealed partial class EventLogService
 
         if (opt.Since.HasValue)
         {
-            var iso = opt.Since.Value.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+            // InvariantCulture is REQUIRED: the ':' in the format string is replaced by the
+            // current culture's TimeSeparator, which is '.' on locales like fi-FI, producing
+            // "12.30.45" — an invalid SystemTime that makes EventLogQuery throw (caught → the
+            // Logs tab comes back empty). The Event Log XPath schema requires ISO-8601 with
+            // ':' regardless of the OS display language.
+            var iso = opt.Since.Value.ToUniversalTime()
+                .ToString("yyyy-MM-ddTHH:mm:ss.fffZ", System.Globalization.CultureInfo.InvariantCulture);
             clauses.Add($"TimeCreated[@SystemTime>='{iso}']");
         }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.16</Version>
-    <FileVersion>1.52.16.0</FileVersion>
-    <AssemblyVersion>1.52.16.0</AssemblyVersion>
+    <Version>1.52.17</Version>
+    <FileVersion>1.52.17.0</FileVersion>
+    <AssemblyVersion>1.52.17.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem
`EventLogService.BuildXPath` formatted the `SystemTime` bound with `ToString("yyyy-MM-ddTHH:mm:ss.fffZ")` and **no culture**. The `:` in the format string is rendered as the current culture's `TimeSeparator` — which is `.` on locales like Finnish (`fi-FI`) — producing an invalid timestamp such as `2026-01-15T10.30.45.000Z`. `EventLogQuery` then throws on the malformed XPath, the exception is caught, and the **Logs tab silently comes back empty** for those users.

## Fix
Format the timestamp with `CultureInfo.InvariantCulture`, so the ISO-8601 `:` separator is emitted regardless of the OS display language. One-line change at the format call.

## Test
`BuildXPath_Since_UsesInvariantTimeSeparator_OnDotSeparatorCulture` — forces `CurrentCulture = fi-FI` (a `.`-separator locale), builds the XPath, and asserts it contains `T10:30:45` and **not** `10.30.45`. Deterministic (no wall-clock), restores the culture in `finally`.

## Deferred from this locale group (not guessed)
- **F14** (Ultimate Performance plan matched by English name → orphan duplicate scheme on repeated non-EN applies): LOW impact (the plan still activates via GUID); `powercfg -duplicatescheme` makes a random-GUID localized copy with no locale-agnostic way to detect a prior duplicate — needs real non-EN `powercfg` output to fix safely.
- **F35** (SFC/DISM verdict matched on English phrases): SFC returns exit 0 for both "healthy" and "repaired", so exit-code can't distinguish them; the locale-robust fix is CBS.log parsing, which needs real non-EN SFC output to validate.

Build: app + tests 0 errors / 0 warnings.
