### PR TITLE
fix: correctness — honest Recycle Bin size, exact winget Id match, true >4GB VRAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.19] - 2026-07-03
+
+### Fixed
+- **Recycle Bin size estimates now match what emptying actually frees.** Both Quick Cleanup and Deep Cleanup summed the whole hidden `$Recycle.Bin` folder on every drive — which, on a shared PC (especially when running as administrator), also counts *other users'* deleted files. But emptying the bin only ever clears the current user's items, so the "X MB in Recycle Bin" figure could be far larger than what actually gets freed. The estimate now measures only the current user's Recycle Bin, so the number is honest.
+- **Installed-app detection no longer mislabels similarly-named apps.** In the Bulk Installer, an app was marked "Installed" if its winget Id appeared anywhere in a `winget list` row — so an app whose Id is a prefix of another (e.g. `Microsoft.Teams` vs. an installed `Microsoft.Teams.Classic`) was wrongly shown as already installed. Detection now compares exact winget Ids.
+- **System Report and About page now show the correct VRAM for GPUs over 4 GB.** Video memory was read from a 32-bit WMI field that caps at ~4 GiB, so an 8 GB or 12 GB card was reported as ~4 GB. The true size is now read from the graphics driver's 64-bit registry value, falling back to the old field only when that isn't available.
+
 ## [1.52.18] - 2026-07-03
 
 ### Fixed

--- a/SysManager/SysManager.Tests/BulkInstallerInstalledIdsTests.cs
+++ b/SysManager/SysManager.Tests/BulkInstallerInstalledIdsTests.cs
@@ -1,0 +1,95 @@
+// SysManager · BulkInstallerInstalledIdsTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Text;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Pins <see cref="BulkInstallerViewModel.ParseInstalledIds"/>, which decides the "Installed"
+/// badge from <c>winget list</c> output. The old code scanned each raw row with
+/// <c>line.Contains(id)</c>, so one curated Id that is a substring of an installed one (e.g.
+/// <c>Microsoft.Teams</c> ⊂ <c>Microsoft.Teams.Classic</c>) was falsely flagged installed.
+/// The parser now extracts exact Ids; detection is a set membership test.
+/// </summary>
+public class BulkInstallerInstalledIdsTests
+{
+    // winget list fixed-width layout: Name | Id | Version | Available | Source.
+    private const int IdCol = 30;
+    private const int VersionCol = 62;
+    private const int AvailableCol = 82;
+    private const int SourceCol = 96;
+
+    private static string Row(string name, string id, string version, string available = "", string source = "winget")
+    {
+        var sb = new StringBuilder();
+        sb.Append(name.PadRight(IdCol));
+        sb.Append(id.PadRight(VersionCol - IdCol));
+        sb.Append(version.PadRight(AvailableCol - VersionCol));
+        sb.Append(available.PadRight(SourceCol - AvailableCol));
+        sb.Append(source);
+        return sb.ToString();
+    }
+
+    private static string Table(params string[] rows)
+    {
+        var sb = new StringBuilder();
+        sb.Append("Name".PadRight(IdCol));
+        sb.Append("Id".PadRight(VersionCol - IdCol));
+        sb.Append("Version".PadRight(AvailableCol - VersionCol));
+        sb.Append("Available".PadRight(SourceCol - AvailableCol));
+        sb.AppendLine("Source");
+        sb.AppendLine(new string('-', 110));
+        foreach (var r in rows) sb.AppendLine(r);
+        sb.AppendLine($"{rows.Length} packages have available upgrades.");
+        return sb.ToString();
+    }
+
+    [Fact]
+    public void ParseInstalledIds_ExtractsExactIds()
+    {
+        var output = Table(
+            Row("Microsoft Teams classic", "Microsoft.Teams.Classic", "1.6.0"),
+            Row("7-Zip", "7zip.7zip", "23.01"));
+
+        var ids = BulkInstallerViewModel.ParseInstalledIds(output);
+
+        Assert.Contains("Microsoft.Teams.Classic", ids);
+        Assert.Contains("7zip.7zip", ids);
+    }
+
+    [Fact]
+    public void ParseInstalledIds_SubstringId_NotFalselyMatched()
+    {
+        // Regression (F20): only "Microsoft.Teams.Classic" is installed. A curated app whose Id
+        // is the *substring* "Microsoft.Teams" must NOT be reported installed — the old
+        // Contains() scan over the raw row flagged it.
+        var output = Table(Row("Microsoft Teams classic", "Microsoft.Teams.Classic", "1.6.0"));
+
+        var ids = BulkInstallerViewModel.ParseInstalledIds(output);
+
+        Assert.Contains("Microsoft.Teams.Classic", ids);
+        Assert.DoesNotContain("Microsoft.Teams", ids);
+    }
+
+    [Fact]
+    public void ParseInstalledIds_IsCaseInsensitive()
+    {
+        var output = Table(Row("Mozilla Firefox", "Mozilla.Firefox", "128.0"));
+
+        var ids = BulkInstallerViewModel.ParseInstalledIds(output);
+
+        // The set uses OrdinalIgnoreCase so a curated Id differing only in case still matches.
+        Assert.Contains("mozilla.firefox", ids);
+    }
+
+    [Fact]
+    public void ParseInstalledIds_EmptyOutput_ReturnsEmpty() =>
+        Assert.Empty(BulkInstallerViewModel.ParseInstalledIds(string.Empty));
+
+    [Fact]
+    public void ParseInstalledIds_HeaderOnly_ReturnsEmpty() =>
+        Assert.Empty(BulkInstallerViewModel.ParseInstalledIds(Table()));
+}

--- a/SysManager/SysManager.Tests/GpuVramHelperTests.cs
+++ b/SysManager/SysManager.Tests/GpuVramHelperTests.cs
@@ -1,0 +1,46 @@
+// SysManager · GpuVramHelperTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Helpers;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Pins <see cref="GpuVramHelper.SelectVramBytes"/> — the pure VRAM-source selection that both
+/// the System Report and the About-page diagnostics share (F27). <c>Win32_VideoController.AdapterRAM</c>
+/// is a uint32 that saturates near 4 GiB, so the 64-bit driver <c>qwMemorySize</c> must win when
+/// present; AdapterRAM is only a fallback. The registry-read path itself needs a live driver key
+/// and is not unit-tested.
+/// </summary>
+public class GpuVramHelperTests
+{
+    [Fact]
+    public void SelectVramBytes_PrefersRegistryQwordOverAdapterRam()
+    {
+        // Regression (F27): an 8 GB card reports ~4 GB via AdapterRAM's uint32 ceiling. The
+        // 64-bit qwMemorySize from the driver registry key must be reported instead.
+        const ulong eightGB = 8UL * 1024 * 1024 * 1024;
+        const ulong adapterRamCap = 4290772992UL; // AdapterRAM's ~4 GiB uint32 ceiling
+
+        var chosen = GpuVramHelper.SelectVramBytes(qwMemorySize: eightGB, adapterRam: adapterRamCap);
+
+        Assert.Equal(eightGB, chosen);
+    }
+
+    [Fact]
+    public void SelectVramBytes_FallsBackToAdapterRam_WhenRegistryMissing()
+    {
+        const ulong twoGB = 2UL * 1024 * 1024 * 1024;
+
+        Assert.Equal(twoGB, GpuVramHelper.SelectVramBytes(qwMemorySize: null, adapterRam: twoGB));
+        Assert.Equal(twoGB, GpuVramHelper.SelectVramBytes(qwMemorySize: 0UL, adapterRam: twoGB));
+    }
+
+    [Fact]
+    public void SelectVramBytes_ReturnsNull_WhenNeitherUsable()
+    {
+        Assert.Null(GpuVramHelper.SelectVramBytes(qwMemorySize: null, adapterRam: null));
+        Assert.Null(GpuVramHelper.SelectVramBytes(qwMemorySize: 0UL, adapterRam: 0UL));
+    }
+}

--- a/SysManager/SysManager/Helpers/GpuVramHelper.cs
+++ b/SysManager/SysManager/Helpers/GpuVramHelper.cs
@@ -1,0 +1,81 @@
+// SysManager · GpuVramHelper
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using Microsoft.Win32;
+
+namespace SysManager.Helpers;
+
+/// <summary>
+/// Single source of truth for resolving a GPU's true VRAM size.
+/// <c>Win32_VideoController.AdapterRAM</c> is a <c>uint32</c> (CIM_UINT32) that saturates near
+/// 4 GiB, so on its own it mis-reports every modern &gt;4 GB card. The full size is recorded in
+/// the driver's registry key as a 64-bit <c>qwMemorySize</c>; this helper prefers that and falls
+/// back to <c>AdapterRAM</c> only when the registry value is missing/zero. Both the System Report
+/// and the About-page diagnostics route through here so the two never drift apart.
+/// </summary>
+public static class GpuVramHelper
+{
+    // The display-adapter class node; each adapter is a numbered subkey (0000, 0001, …).
+    private const string ClassRoot =
+        @"SYSTEM\CurrentControlSet\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}";
+
+    /// <summary>
+    /// Resolves VRAM in gigabytes from the two WMI fields, or null when neither is usable.
+    /// </summary>
+    public static double? ResolveVramGB(string? pnpDeviceId, ulong? adapterRam)
+        => SelectVramBytes(ReadQwMemorySize(pnpDeviceId), adapterRam) is { } bytes
+            ? bytes / 1024.0 / 1024.0 / 1024.0
+            : null;
+
+    /// <summary>
+    /// Chooses the VRAM byte count: the driver's 64-bit <c>qwMemorySize</c> when present and
+    /// non-zero, otherwise the WMI <c>AdapterRAM</c> (uint32-capped) as a fallback. Returns null
+    /// when neither is a usable positive value. Pure so it is unit-testable.
+    /// </summary>
+    public static ulong? SelectVramBytes(ulong? qwMemorySize, ulong? adapterRam)
+    {
+        if (qwMemorySize is > 0) return qwMemorySize;
+        if (adapterRam is > 0) return adapterRam;
+        return null;
+    }
+
+    /// <summary>
+    /// Reads the true VRAM size (bytes) from the GPU's driver registry key. Windows records it as
+    /// a REG_QWORD <c>HardwareInformation.qwMemorySize</c> under the adapter's class node, matched
+    /// to this controller by a <c>MatchingDeviceId</c> that is a prefix of the WMI
+    /// <c>PNPDeviceID</c>. Returns null when the key/value is absent or unreadable — the caller
+    /// then falls back to AdapterRAM.
+    /// </summary>
+    public static ulong? ReadQwMemorySize(string? pnpDeviceId)
+    {
+        if (string.IsNullOrEmpty(pnpDeviceId)) return null;
+        try
+        {
+            using var classKey = Registry.LocalMachine.OpenSubKey(ClassRoot);
+            if (classKey is null) return null;
+
+            foreach (var sub in classKey.GetSubKeyNames())
+            {
+                using var adapter = classKey.OpenSubKey(sub);
+                if (adapter is null) continue;
+                if (adapter.GetValue("MatchingDeviceId") is not string match) continue;
+                if (!pnpDeviceId.StartsWith(match, StringComparison.OrdinalIgnoreCase)) continue;
+
+                if (adapter.GetValue("HardwareInformation.qwMemorySize") is { } qw)
+                {
+                    var bytes = Convert.ToUInt64(qw);
+                    return bytes > 0 ? bytes : null;
+                }
+                return null;
+            }
+        }
+        catch (System.Security.SecurityException) { /* registry ACL — fall back to AdapterRAM */ }
+        catch (UnauthorizedAccessException) { /* registry ACL — fall back to AdapterRAM */ }
+        catch (IOException) { /* transient registry error — fall back to AdapterRAM */ }
+        catch (FormatException) { /* unexpected value type — fall back to AdapterRAM */ }
+        catch (InvalidCastException) { /* unexpected value type — fall back to AdapterRAM */ }
+        return null;
+    }
+}

--- a/SysManager/SysManager/Helpers/RecycleBinHelper.cs
+++ b/SysManager/SysManager/Helpers/RecycleBinHelper.cs
@@ -2,7 +2,9 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using System.Runtime.InteropServices;
+using System.Security.Principal;
 using Serilog;
 
 namespace SysManager.Helpers;
@@ -34,6 +36,27 @@ public static partial class RecycleBinHelper
         if (!ok)
             Log.Warning("Empty recycle bin failed: HRESULT 0x{Hr:X8}", hr);
         return ok;
+    }
+
+    /// <summary>
+    /// The per-drive Recycle Bin folders that belong to the CURRENT user, i.e.
+    /// <c>&lt;drive&gt;\$Recycle.Bin\&lt;current-SID&gt;</c> on every fixed, ready drive. Sizing must
+    /// use these — not the whole <c>$Recycle.Bin</c> tree — because <see cref="EmptyAllDrives"/>
+    /// (SHEmptyRecycleBin) only empties the calling user's bin; summing all SIDs over-reports the
+    /// freeable bytes on a multi-user machine (especially when elevated, where the other users'
+    /// folders become readable). Returns an empty array when the current SID can't be resolved.
+    /// </summary>
+    public static string[] CurrentUserBinPaths()
+    {
+        string? sid;
+        try { sid = WindowsIdentity.GetCurrent().User?.Value; }
+        catch (System.Security.SecurityException) { sid = null; }
+        if (string.IsNullOrEmpty(sid)) return [];
+
+        return DriveInfo.GetDrives()
+            .Where(d => d.DriveType == DriveType.Fixed && d.IsReady)
+            .Select(d => Path.Combine(d.RootDirectory.FullName, "$Recycle.Bin", sid))
+            .ToArray();
     }
 
     private static partial class NativeMethods

--- a/SysManager/SysManager/Services/DeepCleanupService.cs
+++ b/SysManager/SysManager/Services/DeepCleanupService.cs
@@ -115,10 +115,7 @@ public sealed class DeepCleanupService
 
             new("Recycle Bin (all drives)",
                 "Emptying the recycle bin on every fixed drive.",
-                DriveInfo.GetDrives()
-                    .Where(d => d.DriveType == DriveType.Fixed && d.IsReady)
-                    .Select(d => Path.Combine(d.RootDirectory.FullName, "$Recycle.Bin"))
-                    .ToArray(),
+                RecycleBinHelper.CurrentUserBinPaths(),
                 IsRecycleBin: true),
 
             new("Steam — browser & depot cache",

--- a/SysManager/SysManager/Services/SystemReportService.cs
+++ b/SysManager/SysManager/Services/SystemReportService.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -101,20 +102,21 @@ public sealed class SystemReportService
         try
         {
             using var searcher = new ManagementObjectSearcher(
-                "SELECT Name, AdapterRAM, DriverVersion FROM Win32_VideoController");
+                "SELECT Name, AdapterRAM, DriverVersion, PNPDeviceID FROM Win32_VideoController");
             using var collection = searcher.Get();
             foreach (ManagementObject mo in collection)
             {
                 using (mo)
                 {
                     var name = mo["Name"]?.ToString()?.Trim() ?? "Unknown GPU";
-                    double? vram = null;
-                    if (mo["AdapterRAM"] is { } ram)
-                    {
-                        var bytes = Convert.ToUInt64(ram);
-                        if (bytes > 0) vram = bytes / 1024.0 / 1024.0 / 1024.0;
-                    }
+                    // Win32_VideoController.AdapterRAM is a uint32 (CIM_UINT32) and saturates
+                    // at ~4 GiB, so it mis-reports every modern >4 GB GPU. The true size lives
+                    // in the driver's registry key as a 64-bit qwMemorySize; prefer it and fall
+                    // back to AdapterRAM only when the registry value is missing/zero.
                     var driver = mo["DriverVersion"]?.ToString()?.Trim() ?? "";
+                    var pnpId = mo["PNPDeviceID"]?.ToString();
+                    ulong? adapterRam = mo["AdapterRAM"] is { } ram ? Convert.ToUInt64(ram) : null;
+                    var vram = GpuVramHelper.ResolveVramGB(pnpId, adapterRam);
                     gpus.Add(new GpuReportInfo(name, vram, driver));
                 }
             }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.18</Version>
-    <FileVersion>1.52.18.0</FileVersion>
-    <AssemblyVersion>1.52.18.0</AssemblyVersion>
+    <Version>1.52.19</Version>
+    <FileVersion>1.52.19.0</FileVersion>
+    <AssemblyVersion>1.52.19.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -326,16 +326,20 @@ public sealed partial class AboutViewModel : ViewModelBase
             try
             {
                 using var gpuSearch = new System.Management.ManagementObjectSearcher(
-                    "SELECT Name,DriverVersion,AdapterRAM FROM Win32_VideoController");
+                    "SELECT Name,DriverVersion,AdapterRAM,PNPDeviceID FROM Win32_VideoController");
                 using var gpuResults = gpuSearch.Get();
                 foreach (System.Management.ManagementObject mo in gpuResults)
                     using (mo)
                     {
                         var name = mo["Name"]?.ToString()?.Trim() ?? "unknown";
                         var driver = mo["DriverVersion"]?.ToString() ?? "";
-                        var vram = mo["AdapterRAM"] as uint? ?? 0;
+                        // AdapterRAM is a uint32 that caps near 4 GiB; the shared helper prefers the
+                        // driver's 64-bit qwMemorySize so >4 GB cards report their true VRAM.
+                        var pnpId = mo["PNPDeviceID"]?.ToString();
+                        ulong? adapterRam = mo["AdapterRAM"] is { } ram ? Convert.ToUInt64(ram) : null;
+                        var vramGB = SysManager.Helpers.GpuVramHelper.ResolveVramGB(pnpId, adapterRam);
                         sb.Append("GPU: ").Append(name);
-                        if (vram > 0) sb.Append($" ({vram / 1024.0 / 1024.0 / 1024.0:F1} GB VRAM)");
+                        if (vramGB is > 0) sb.Append($" ({vramGB:F1} GB VRAM)");
                         if (!string.IsNullOrEmpty(driver)) sb.Append($" driver {driver}");
                         sb.AppendLine();
                     }

--- a/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
@@ -139,13 +139,13 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
 
             if (string.IsNullOrWhiteSpace(output)) return;
 
-            var lines = output.Split('\n');
+            var installedIds = ParseInstalledIds(output);
 
             App.Current?.Dispatcher.Invoke(() =>
             {
                 foreach (var app in Apps)
                 {
-                    if (lines.Any(line => line.Contains(app.WingetId, StringComparison.OrdinalIgnoreCase)))
+                    if (installedIds.Contains(app.WingetId))
                         app.IsInstalled = true;
                 }
             });
@@ -155,6 +155,36 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
             Log.Debug(ex, "Could not determine installed apps via winget list");
         }
     }
+
+    /// <summary>
+    /// Extracts the exact package Ids from <c>winget list</c> output. Routes through the shared
+    /// <see cref="WingetTableParser"/> and returns Ids as a case-insensitive set, so installed
+    /// detection is an EXACT Id match rather than a substring scan of the raw row. The old
+    /// <c>line.Contains(id)</c> gave a false "Installed" badge whenever one curated Id was a
+    /// substring of an installed one (e.g. <c>Microsoft.Teams</c> ⊂ <c>Microsoft.Teams.Classic</c>).
+    /// Pure and process-free so it can be unit-tested with captured payloads.
+    /// </summary>
+    internal static HashSet<string> ParseInstalledIds(string output)
+    {
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries).ToList();
+        var rows = WingetTableParser.Parse(lines, ListHeaderPattern(), ListSummaryPattern());
+
+        HashSet<string> ids = new(StringComparer.OrdinalIgnoreCase);
+        foreach (var row in rows)
+            if (!string.IsNullOrWhiteSpace(row.Id))
+                ids.Add(row.Id);
+        return ids;
+    }
+
+    // winget list header: "Name  Id  Version  [Available]  Source". The parser also falls back
+    // to the dashes-separator line when this English pattern doesn't match a localized winget.
+    [GeneratedRegex(@"^\s*Name\s+Id\s+Version", RegexOptions.IgnoreCase)]
+    private static partial Regex ListHeaderPattern();
+
+    // winget list ends with a numeric footer ("N packages"/"N upgrades available"); stop there
+    // so the trailing summary line is never mistaken for a data row.
+    [GeneratedRegex(@"^\d+\s+(package|packages|upgrade|upgrades)\b", RegexOptions.IgnoreCase)]
+    private static partial Regex ListSummaryPattern();
 
     [RelayCommand]
     private void RelaunchAsAdmin()

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -121,12 +121,12 @@ public sealed partial class CleanupViewModel : ViewModelBase
                 try
                 {
                     long binBytes = 0;
-                    // The Recycle Bin lives in a hidden $Recycle.Bin folder on EVERY fixed
-                    // drive, not just C:. Sum them all so the estimate isn't drive-bound.
-                    foreach (var drive in DriveInfo.GetDrives())
+                    // The Recycle Bin lives in a hidden $Recycle.Bin folder on EVERY fixed drive,
+                    // one per-SID subfolder per user. Empty (SHEmptyRecycleBin) only clears the
+                    // CURRENT user's bin, so size only THIS user's per-SID folders — summing the
+                    // whole tree over-reports what emptying can actually free on a multi-user box.
+                    foreach (var recyclePath in RecycleBinHelper.CurrentUserBinPaths())
                     {
-                        if (drive.DriveType != DriveType.Fixed || !drive.IsReady) continue;
-                        var recyclePath = Path.Combine(drive.RootDirectory.FullName, "$Recycle.Bin");
                         if (!Directory.Exists(recyclePath)) continue;
                         foreach (var f in Directory.EnumerateFiles(recyclePath, "*", SearchOption.AllDirectories))
                         {


### PR DESCRIPTION
## Summary

Three Medium **correctness** findings from the 2026-07-03 audit, each re-verified against current source before fixing, plus their propagated siblings (fix the class, not the instance).

### F13 — Recycle Bin size over-reported on multi-user / elevated machines
Both Deep Cleanup and Quick Cleanup summed the whole hidden `$Recycle.Bin` tree on every drive — which counts *every user's* per-SID subfolder. But `SHEmptyRecycleBin` only empties the **calling user's** bin, so the reported "freeable" size could be far larger than what emptying actually removes (worse when elevated, where other users' folders become readable).
**Fix:** new `RecycleBinHelper.CurrentUserBinPaths()` (single source of truth) scopes sizing to `$Recycle.Bin\<current-SID>`. Applied in `DeepCleanupService` and the `CleanupViewModel` Quick Cleanup estimate (sibling).

### F20 — Bulk Installer false "Installed" badge on substring Ids
Installed-detection used `line.Contains(app.WingetId)` over the raw `winget list` row, so a curated Id that is a **substring** of an installed one (`Microsoft.Teams` ⊂ `Microsoft.Teams.Classic`) was wrongly flagged installed.
**Fix:** new pure `ParseInstalledIds()` routes through the shared `WingetTableParser` and matches **exact** Ids (case-insensitive set).

### F27 — VRAM mis-reported for GPUs over 4 GB
VRAM was read from `Win32_VideoController.AdapterRAM`, a `uint32` that saturates near 4 GiB — so an 8/12 GB card reported ~4 GB.
**Fix:** new `GpuVramHelper` prefers the driver's 64-bit registry `qwMemorySize`, falling back to `AdapterRAM` only when absent/zero. Applied in `SystemReportService` and the About-page diagnostics (sibling).

## Tests (regression)
- `BulkInstallerInstalledIdsTests` — exact-Id match; substring Id **not** falsely matched; case-insensitive; empty/header-only.
- `GpuVramHelperTests` — 64-bit qwMemorySize wins over uint32-capped AdapterRAM; fallback when registry missing/zero; null when neither usable.

## Verification
- `dotnet build -c Release` — main project **0 errors / 0 warnings**.
- `dotnet build -c Release` — tests project **0 errors / 0 warnings**.
- PROPAGATE: grepped all `AdapterRAM` / `$Recycle.Bin` / substring-Id sites; the two siblings above were the only other instances and are fixed here.
- `dotnet test` not run locally by policy; unit tests run on CI.
