### PR TITLE
fix: theming — legible metrics/severity on Light presets, theme popup opens on saved mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.52.19] - 2026-07-03
+## [1.52.20] - 2026-07-03
+
+### Fixed
+- **The theme picker now opens on your saved theme's presets.** If you'd set a Light or Custom theme, the theme popup initially built its preset list from the default Dark mode and only corrected itself once you clicked something — so it briefly showed the wrong set of presets. It now reads your saved mode first, so the correct presets appear immediately.
+- **Ping and System Logs numbers are now readable on the Light themes.** The average-ping / jitter / latency figures on the Network Ping tab and the severity counts (Critical, Errors, Warnings, Info) on the System Logs tab used fixed pale colors that nearly disappeared against the light preset backgrounds. They now use the app's semantic status colors, so they stay legible on every theme.
 
 ### Fixed
 - **Recycle Bin size estimates now match what emptying actually frees.** Both Quick Cleanup and Deep Cleanup summed the whole hidden `$Recycle.Bin` folder on every drive — which, on a shared PC (especially when running as administrator), also counts *other users'* deleted files. But emptying the bin only ever clears the current user's items, so the "X MB in Recycle Bin" figure could be far larger than what actually gets freed. The estimate now measures only the current user's Recycle Bin, so the number is honest.

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.19</Version>
-    <FileVersion>1.52.19.0</FileVersion>
-    <AssemblyVersion>1.52.19.0</AssemblyVersion>
+    <Version>1.52.20</Version>
+    <FileVersion>1.52.20.0</FileVersion>
+    <AssemblyVersion>1.52.20.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -56,7 +56,7 @@
                             </Ellipse.Effect>
                         </Ellipse>
                         <TextBlock Text="{Binding CriticalCount}" FontSize="20" FontWeight="Bold"
-                                   Foreground="#FF6B6B" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                                   Foreground="{DynamicResource Danger}" VerticalAlignment="Center" Margin="10,0,0,0"/>
                         <!-- Bold + ▲ glyph distinguish Critical from Error without relying on hue
                              (both are reds — a colorblind-safe, non-color cue). -->
                         <TextBlock FontSize="12" Foreground="#64748B" FontWeight="SemiBold"
@@ -79,7 +79,7 @@
                             </Ellipse.Effect>
                         </Ellipse>
                         <TextBlock Text="{Binding ErrorCount}" FontSize="20" FontWeight="Bold"
-                                   Foreground="#FCA5A5" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                                   Foreground="{DynamicResource Danger}" VerticalAlignment="Center" Margin="10,0,0,0"/>
                         <TextBlock FontSize="12" Foreground="#64748B"
                                    VerticalAlignment="Center" Margin="10,0,0,0">
                             <Run Text="&#x25CF; Errors"/>
@@ -104,7 +104,7 @@
                             </Ellipse.Effect>
                         </Ellipse>
                         <TextBlock Text="{Binding WarningCount}" FontSize="20" FontWeight="Bold"
-                                   Foreground="#FDE68A" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                                   Foreground="{DynamicResource Warning}" VerticalAlignment="Center" Margin="10,0,0,0"/>
                         <TextBlock Text="Warnings" FontSize="12" Foreground="#64748B"
                                    VerticalAlignment="Center" Margin="10,0,0,0"/>
                     </StackPanel>
@@ -123,7 +123,7 @@
                             </Ellipse.Effect>
                         </Ellipse>
                         <TextBlock Text="{Binding InfoCount}" FontSize="20" FontWeight="Bold"
-                                   Foreground="#7DD3FC" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                                   Foreground="{DynamicResource Info}" VerticalAlignment="Center" Margin="10,0,0,0"/>
                         <TextBlock Text="Info" FontSize="12" Foreground="#64748B"
                                    VerticalAlignment="Center" Margin="10,0,0,0"/>
                     </StackPanel>

--- a/SysManager/SysManager/Views/PingView.xaml
+++ b/SysManager/SysManager/Views/PingView.xaml
@@ -63,7 +63,7 @@
                         <StackPanel>
                             <TextBlock Text="AVG PING" Style="{StaticResource SectionLabel}"/>
                             <TextBlock Text="{Binding Shared.Health.AveragePingMs, StringFormat={}{0:F0} ms}"
-                                       Style="{StaticResource Metric}" Foreground="#60A5FA"/>
+                                       Style="{StaticResource Metric}" Foreground="{DynamicResource Info}"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource CardInner}" Margin="8,0" Padding="16,8" MinWidth="110">
@@ -77,7 +77,7 @@
                         <StackPanel>
                             <TextBlock Text="WORST JITTER" Style="{StaticResource SectionLabel}"/>
                             <TextBlock Text="{Binding Shared.Health.WorstJitterMs, StringFormat={}{0:F0} ms}"
-                                       Style="{StaticResource Metric}" Foreground="#F472B6"/>
+                                       Style="{StaticResource Metric}" Foreground="{DynamicResource Warning}"/>
                         </StackPanel>
                     </Border>
                 </StackPanel>
@@ -131,7 +131,7 @@
                                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
                                             <StackPanel Margin="0,0,16,0" HorizontalAlignment="Center">
                                                 <TextBlock Text="{Binding LastLatencyMs, StringFormat={}{0:F0} ms, FallbackValue=—}"
-                                                           Foreground="#60A5FA" FontWeight="Bold" FontSize="13" HorizontalAlignment="Center"/>
+                                                           Foreground="{DynamicResource Info}" FontWeight="Bold" FontSize="13" HorizontalAlignment="Center"/>
                                                 <TextBlock Text="LATENCY" Foreground="#475569" FontSize="9" HorizontalAlignment="Center" Margin="0,2,0,0"/>
                                             </StackPanel>
                                             <StackPanel Margin="0,0,16,0" HorizontalAlignment="Center">
@@ -141,7 +141,7 @@
                                             </StackPanel>
                                             <StackPanel Margin="0,0,16,0" HorizontalAlignment="Center">
                                                 <TextBlock Text="{Binding JitterMs, StringFormat={}{0:F0}, FallbackValue=—}"
-                                                           Foreground="#F472B6" FontWeight="Bold" FontSize="13" HorizontalAlignment="Center"/>
+                                                           Foreground="{DynamicResource Warning}" FontWeight="Bold" FontSize="13" HorizontalAlignment="Center"/>
                                                 <TextBlock Text="JITTER" Foreground="#475569" FontSize="9" HorizontalAlignment="Center" Margin="0,2,0,0"/>
                                             </StackPanel>
                                             <StackPanel HorizontalAlignment="Center">

--- a/SysManager/SysManager/Views/ThemePopup.xaml.cs
+++ b/SysManager/SysManager/Views/ThemePopup.xaml.cs
@@ -29,8 +29,12 @@ public partial class ThemePopup : UserControl
         if (_initialized) return;
         _initialized = true;
 
-        BuildPresetCards();
+        // Sync the mode radios to the persisted theme BEFORE building the preset cards:
+        // BuildPresetCards() reads DarkMode.IsChecked to decide which presets to list, and at
+        // Loaded time that is still the XAML default (Dark). A user who persisted a Light or
+        // Custom theme would otherwise see the Dark preset list until they interacted with the UI.
         SyncUiToService();
+        BuildPresetCards();
 
         DarkMode.Checked += Mode_Changed;
         LightMode.Checked += Mode_Changed;


### PR DESCRIPTION
## Summary

Three Medium **theming** findings from the 2026-07-03 audit, each verified against current source, plus the propagated per-target metric siblings. All fixes route hardcoded hex → the app's existing semantic theme brushes (`Info`/`Warning`/`Danger` in `App.xaml`), matching how ~30 other views already bind them (`DynamicResource`).

### F36 — Ping metrics washed out on Light presets
`AVG PING` (`#60A5FA`) and `WORST JITTER` (`#F472B6`) used hardcoded light accents that fall below 3:1 contrast on the six shipped Light presets. Bound to `{DynamicResource Info}` / `{DynamicResource Warning}` — consistent with `WORST LOSS`, which already used `WarningStripe`. **Propagate:** the per-target row `LATENCY`/`JITTER` numbers (same hexes, same class) were migrated too, so the tab isn't left half-fixed.

### F38 — Log severity counts near-invisible on Light presets
The four count numbers (Critical/Error `#FF6B6B`/`#FCA5A5`, Warning `#FDE68A`, Info `#7DD3FC`) composited to 1.2–2.5:1 on Light presets (Warning effectively invisible). Bound to `Danger`/`Warning`/`Info`. Critical vs Error remain distinguished by the existing ▲ glyph rather than hue (colorblind-safe cue is preserved).

### F39 — Theme popup showed the wrong presets for Light/Custom users
`BuildPresetCards()` reads `DarkMode.IsChecked` to pick which presets to list, but ran *before* `SyncUiToService()` set the radios to the persisted mode — so at `Loaded` it saw the XAML default (Dark). A user with a saved Light/Custom theme saw the Dark preset list until they interacted with the UI. `SyncUiToService()` now runs first; the mode handlers are still wired afterward, so setting the radios during sync fires no `Mode_Changed` (no re-entrancy).

## Note on testing
These are XAML color-binding and WPF init-order changes with no unit-testable seam. Visual/contrast regression is covered by the dedicated UI audit. The dark default shifts slightly (semantic brushes are shared across themes) — screenshots reviewed with the maintainer before merge.

## Verification
- `dotnet build -c Release` — main project **0 errors / 0 warnings**.
- PROPAGATE: grepped all six hardcoded hexes across `Views/`; the only remaining hits are separate LOW findings (F37 caption labels `#475569`, F60 DeepCleanup "Irreversible" pill), intentionally out of scope.
