### PR TITLE
fix: hosts file save preserves the user's standalone comments and blank lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.21] - 2026-07-03
+
+### Fixed
+- **Editing the hosts file no longer erases your own comments.** When you added, removed, or toggled an entry on the DNS & Hosts tab, SysManager rewrote the file from just the address mappings — silently dropping any standalone comment lines or blank spacing you'd written (section notes, documentation). Those comment and blank lines are now preserved through an edit, kept above the entries. Repeated saves stay stable (no duplicated headers), and a file with no comments is written exactly as before.
+
 ## [1.52.20] - 2026-07-03
 
 ### Fixed

--- a/SysManager/SysManager.Tests/HostsFileServiceTests.cs
+++ b/SysManager/SysManager.Tests/HostsFileServiceTests.cs
@@ -57,7 +57,7 @@ public class HostsFileServiceTests
     [Fact]
     public void RestoreBackup_RestoresPristineOriginal()
     {
-        const string original = "# ORIGINAL pristine hosts\n127.0.0.1 original\n";
+        const string original = "# ORIGINAL pristine hosts\n127.0.0.1 originalhost\n";
         var (svc, hosts, dir) = NewServiceWithTempHosts(original);
         try
         {
@@ -65,7 +65,10 @@ public class HostsFileServiceTests
             {
                 new() { IpAddress = "9.9.9.9", Hostname = "managed", IsEnabled = true }
             });
-            Assert.DoesNotContain("ORIGINAL pristine hosts", File.ReadAllText(hosts));
+            // The original IP MAPPING is replaced by the managed one. (The standalone comment is
+            // now legitimately preserved by F40, so we assert on the mapping, not the comment.)
+            Assert.DoesNotContain("originalhost", File.ReadAllText(hosts));
+            Assert.Contains("managed", File.ReadAllText(hosts));
 
             Assert.True(svc.HasBackup);
             Assert.True(svc.RestoreBackup());
@@ -229,6 +232,106 @@ public class HostsFileServiceTests
             var entry = svc.AddEntry("1.1.1.1", hostname);
             Assert.Equal(hostname, entry.Hostname);
             Assert.Equal("1.1.1.1", entry.IpAddress);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    // ---------- F40: standalone comment / blank-line preservation ----------
+
+    [Fact]
+    public async Task SaveHosts_PreservesStandaloneComments_ThroughReadEditSaveRoundTrip()
+    {
+        // Regression (F40): editing one entry through the UI rewrote the whole file from the
+        // parsed entries only, silently deleting the user's hand-written comments. A read →
+        // (edit) → save round trip must keep those comment lines.
+        const string original =
+            "# My custom block list\n" +
+            "# Managed by hand — do not delete\n" +
+            "0.0.0.0\tads.example.com\n";
+        var (svc, hosts, dir) = NewServiceWithTempHosts(original);
+        try
+        {
+            var entries = await svc.ReadHostsAsync();     // parses the one mapping
+            svc.SaveHosts(entries);                       // save without changing anything
+
+            var saved = File.ReadAllText(hosts);
+            Assert.Contains("# My custom block list", saved);
+            Assert.Contains("# Managed by hand — do not delete", saved);
+            Assert.Contains("ads.example.com", saved);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    [Fact]
+    public async Task SaveHosts_IsFixedPoint_RepeatedSavesDoNotAccumulate()
+    {
+        // The service is a singleton doing a canonical whole-file rewrite: preserving comments
+        // naively would re-capture SysManager's own header and blank lines every save, growing
+        // the file without bound. Two consecutive save cycles must produce identical output.
+        const string original =
+            "# Section A\n" +
+            "127.0.0.1\tlocalhost\n";
+        var (svc, hosts, dir) = NewServiceWithTempHosts(original);
+        try
+        {
+            var entries = await svc.ReadHostsAsync();
+            svc.SaveHosts(entries);
+            var afterFirst = File.ReadAllText(hosts);
+
+            var entries2 = await svc.ReadHostsAsync();
+            svc.SaveHosts(entries2);
+            var afterSecond = File.ReadAllText(hosts);
+
+            Assert.Equal(afterFirst, afterSecond);
+            // And the managed header appears exactly once, not once per save.
+            var headerCount = afterSecond.Split("# This file is managed by SysManager").Length - 1;
+            Assert.Equal(1, headerCount);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    [Fact]
+    public void SaveHosts_NoComments_OutputUnchangedFromCanonicalForm()
+    {
+        // A file with no standalone comments must produce exactly the canonical header + entries
+        // (byte-for-byte the previous behaviour) — the preservation logic adds nothing here.
+        var (svc, hosts, dir) = NewServiceWithTempHosts("127.0.0.1\tlocalhost\n");
+        try
+        {
+            svc.SaveHosts(new List<HostsEntry>
+            {
+                new() { IpAddress = "127.0.0.1", Hostname = "localhost", IsEnabled = true }
+            });
+            var expected =
+                "# This file is managed by SysManager" + Environment.NewLine +
+                "# Entries marked with # at the start are disabled" + Environment.NewLine +
+                Environment.NewLine +
+                "127.0.0.1\tlocalhost" + Environment.NewLine;
+            Assert.Equal(expected, File.ReadAllText(hosts));
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    [Fact]
+    public async Task SaveHosts_CommentedOutEntry_NotDuplicatedAsStandaloneComment()
+    {
+        // A disabled entry ("# 0.0.0.0 blocked") round-trips as a HostsEntry with IsEnabled=false,
+        // so it must NOT also be re-emitted as a standalone comment line — that would duplicate it.
+        const string original =
+            "# a real note\n" +
+            "# 0.0.0.0\tblocked.example.com\n";
+        var (svc, hosts, dir) = NewServiceWithTempHosts(original);
+        try
+        {
+            var entries = await svc.ReadHostsAsync();
+            Assert.Contains(entries, e => e.Hostname == "blocked.example.com" && !e.IsEnabled);
+
+            svc.SaveHosts(entries);
+            var saved = File.ReadAllText(hosts);
+
+            var blockedCount = saved.Split("blocked.example.com").Length - 1;
+            Assert.Equal(1, blockedCount);                 // exactly one (the disabled entry)
+            Assert.Contains("# a real note", saved);       // the genuine comment survives
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { } }
     }

--- a/SysManager/SysManager/Services/HostsFileService.cs
+++ b/SysManager/SysManager/Services/HostsFileService.cs
@@ -21,6 +21,13 @@ public sealed partial class HostsFileService
     private readonly string HostsPath;
     private readonly string BackupPath;
 
+    // SysManager's own managed-header lines. Kept as constants because SaveHosts both EMITS them
+    // and must EXCLUDE them when preserving the user's standalone comments — otherwise the header
+    // would be recaptured and re-emitted on every save, growing without bound (a singleton service
+    // rewrites the whole file each time). One source of truth keeps emit and capture in lock-step.
+    private const string ManagedHeaderLine1 = "# This file is managed by SysManager";
+    private const string ManagedHeaderLine2 = "# Entries marked with # at the start are disabled";
+
     /// <summary>
     /// Creates the service against the real system hosts file. The optional
     /// <paramref name="hostsPath"/> override exists for testing so the backup /
@@ -96,6 +103,55 @@ public sealed partial class HostsFileService
         return entries;
     }
 
+    /// <summary>
+    /// Extracts the user's standalone comment and blank lines from the current hosts file so
+    /// <see cref="SaveHosts"/> can re-emit them. A line is preserved when it is a pure comment
+    /// (starts with '#') that is NOT a commented-out IP entry (those round-trip as disabled
+    /// <see cref="HostsEntry"/> objects) and NOT one of SysManager's managed-header lines
+    /// (excluding them keeps repeated saves from accumulating duplicate headers). Interior blank
+    /// lines are kept for readability; leading/trailing blanks are trimmed so the block is a fixed
+    /// point. Returns an empty list when the file is absent — so a file with no comments produces
+    /// output byte-identical to the previous behaviour.
+    /// </summary>
+    private List<string> ReadStandaloneCommentLines()
+    {
+        List<string> preserved = [];
+        if (!File.Exists(HostsPath)) return preserved;
+
+        string[] rawLines;
+        try { rawLines = File.ReadAllLines(HostsPath); }
+        catch (IOException) { return preserved; }
+        catch (UnauthorizedAccessException) { return preserved; }
+
+        foreach (var raw in rawLines)
+        {
+            var line = raw.Trim();
+
+            if (line.Length == 0)
+            {
+                // Keep blank lines only once we've started collecting content, so leading blanks
+                // (and the gap under our header) are dropped; trailing blanks are trimmed below.
+                if (preserved.Count > 0) preserved.Add("");
+                continue;
+            }
+
+            if (!line.StartsWith('#')) continue;                       // an IP entry — carried by `entries`
+            if (line == ManagedHeaderLine1 || line == ManagedHeaderLine2) continue; // our own header
+
+            // A '#' followed by something IP-shaped is a disabled entry, already represented as a
+            // HostsEntry with IsEnabled=false — skip it here so it isn't duplicated.
+            if (LooksLikeIpStart(line[1..].TrimStart())) continue;
+
+            preserved.Add(line);
+        }
+
+        // Trim trailing blank lines so the preserved block ends cleanly (fixed point).
+        while (preserved.Count > 0 && preserved[^1].Length == 0)
+            preserved.RemoveAt(preserved.Count - 1);
+
+        return preserved;
+    }
+
     /// <summary>True if a pristine pre-SysManager backup of the hosts file exists.</summary>
     public bool HasBackup => File.Exists(BackupPath);
 
@@ -108,6 +164,11 @@ public sealed partial class HostsFileService
     /// overwritten on every save, which meant that after the first save the ".bak"
     /// already contained SysManager's own output — losing the pristine original and
     /// defeating <see cref="RestoreBackup"/>.
+    ///
+    /// Standalone comments and blank lines the user wrote (documentation, section headers)
+    /// are preserved verbatim above the entries, so an edit through the UI no longer strips
+    /// them. SysManager's own managed-header lines are excluded from that capture, making the
+    /// rewrite a fixed point — repeated saves don't accumulate duplicate headers or blanks.
     /// </remarks>
     public void SaveHosts(List<HostsEntry> entries)
     {
@@ -117,10 +178,20 @@ public sealed partial class HostsFileService
 
         var lines = new List<string>
         {
-            "# This file is managed by SysManager",
-            "# Entries marked with # at the start are disabled",
+            ManagedHeaderLine1,
+            ManagedHeaderLine2,
             ""
         };
+
+        // Re-emit the user's own standalone comments/blank lines (not IP mappings — those are
+        // carried by `entries`). Without this, editing one entry through the UI silently deleted
+        // every hand-written comment on the next save.
+        var preserved = ReadStandaloneCommentLines();
+        if (preserved.Count > 0)
+        {
+            lines.AddRange(preserved);
+            lines.Add("");
+        }
 
         foreach (var entry in entries)
         {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.20</Version>
-    <FileVersion>1.52.20.0</FileVersion>
-    <AssemblyVersion>1.52.20.0</AssemblyVersion>
+    <Version>1.52.21</Version>
+    <FileVersion>1.52.21.0</FileVersion>
+    <AssemblyVersion>1.52.21.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

**F40 (reversibility)** from the 2026-07-03 audit, verified against current source.

`SaveHosts` rewrote the hosts file from the parsed `HostsEntry` list only, so a **read → edit → save** round trip through the DNS & Hosts tab silently dropped every hand-written standalone comment and blank line (section notes, documentation). The IP mappings survived, but the write-once `.bak` can't recover comments added after the first save — so the loss was unrecoverable.

## Fix
New `ReadStandaloneCommentLines()` captures pure-comment and blank lines from the current file; `SaveHosts` re-emits them above the entries. It deliberately **excludes**:
- IP mappings (carried by `entries`),
- commented-out entries (they round-trip as disabled `HostsEntry`, so re-emitting would duplicate them),
- SysManager's own managed-header lines — recapturing those would grow the file on every save. The header is now a shared `const` used by both emit and capture, so the two can't drift.

Leading/trailing blank lines are trimmed, making repeated saves a **fixed point** (critical: the service is a singleton doing a whole-file rewrite).

## Tests (regression)
- Comments survive a read → save round trip.
- Repeated saves produce **identical** output; managed header appears exactly once.
- A comment-free file is written **byte-identical** to the previous behaviour.
- A commented-out entry is not duplicated as a standalone comment.
- Updated the existing `RestoreBackup_RestoresPristineOriginal` test to assert on the replaced **mapping** (the standalone comment is now legitimately preserved by this fix).

## Verification
- `dotnet build -c Release` — main **0/0**, tests **0/0**.
- PROPAGATE: `SaveHosts` is the only hosts-file writer (single call site in `DnsHostsViewModel`).
- `dotnet test` not run locally by policy; unit tests run on CI.
