### PR TITLE
fix: ghost-button borders visible on light themes + confirm before Startup Enable All

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.52.21] - 2026-07-03
+## [1.52.22] - 2026-07-03
+
+### Fixed
+- **Outline buttons are now visible on the light themes.** "Ghost" buttons (e.g. Export text / Copy on the System Report tab, and similar secondary actions elsewhere) drew their border in a translucent white that was invisible against the light presets' pale backgrounds — the buttons looked borderless. They now use the theme's own border color, so they're clearly outlined on every theme.
+- **Startup Manager asks before re-enabling everything.** The "Enable All" button immediately re-enabled every disabled startup item — a bulk system change that adds boot time — with no confirmation. It now asks first (showing how many items will be affected), matching the confirm-before-bulk-change behavior used elsewhere in the app.
 
 ### Fixed
 - **Editing the hosts file no longer erases your own comments.** When you added, removed, or toggled an entry on the DNS & Hosts tab, SysManager rewrote the file from just the address mappings — silently dropping any standalone comment lines or blank spacing you'd written (section notes, documentation). Those comment and blank lines are now preserved through an edit, kept above the entries. Repeated saves stay stable (no duplicated headers), and a file with no comments is written exactly as before.

--- a/SysManager/SysManager.Tests/StartupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/StartupViewModelTests.cs
@@ -2,6 +2,9 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using NSubstitute;
+using SysManager.Models;
+using SysManager.Services;
 using SysManager.ViewModels;
 
 namespace SysManager.Tests;
@@ -9,7 +12,10 @@ namespace SysManager.Tests;
 /// <summary>
 /// Tests for <see cref="StartupViewModel"/>. Verifies initial state,
 /// commands, and scan summary logic.
+/// Serialized under the DialogService collection: the confirm-gate test swaps the
+/// process-wide static <see cref="DialogService.Instance"/>.
 /// </summary>
+[Collection("DialogService")]
 public class StartupViewModelTests
 {
     [Fact]
@@ -124,6 +130,63 @@ public class StartupViewModelTests
     }
 
     // ── re-entrancy guard (regression: overlapping registry writes) ──
+
+    // ── confirmation gate (regression: bulk Enable All is a system change, must confirm) ──
+
+    [Fact]
+    public async Task EnableAll_WhenUserDeclinesConfirm_DoesNotEnableAndLeavesEntriesDisabled()
+    {
+        // Regression: "Enable All" re-arms every disabled startup item (registry/task writes)
+        // and adds boot time, so it must ask first. Declining must short-circuit BEFORE any
+        // write — proven here by the entry staying disabled (SetEnabledAsync is never reached).
+        var vm = new StartupViewModel(new StartupService());
+        // Let the ctor's auto-scan settle so it can't overwrite our seeded entry mid-test.
+        for (int i = 0; i < 30 && vm.IsBusy; i++) await Task.Delay(200);
+
+        vm.Entries.Clear();
+        var disabled = new StartupEntry { Name = "Seeded", Command = "c:\\x.exe", IsEnabled = false };
+        vm.Entries.Add(disabled);
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false); // user clicks "No"
+        DialogService.Instance = dialog;
+        try
+        {
+            await vm.EnableAllCommand.ExecuteAsync(null);
+
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            Assert.False(disabled.IsEnabled); // never enabled — the write path was not taken
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public async Task EnableAll_WithNoDisabledEntries_DoesNotPrompt()
+    {
+        // Nothing to enable → no confirmation dialog (and no write). Guards against nagging.
+        var vm = new StartupViewModel(new StartupService());
+        for (int i = 0; i < 30 && vm.IsBusy; i++) await Task.Delay(200);
+
+        vm.Entries.Clear();
+        vm.Entries.Add(new StartupEntry { Name = "On", Command = "c:\\y.exe", IsEnabled = true });
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        DialogService.Instance = dialog;
+        try
+        {
+            await vm.EnableAllCommand.ExecuteAsync(null);
+            dialog.DidNotReceive().Confirm(Arg.Any<string>(), Arg.Any<string>());
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
 
     [Fact]
     public void StateChangingCommands_DisabledWhileBusy()

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -316,16 +316,19 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="Button">
+                            <!-- Border uses the theme-adaptive Border1/Border2 brushes (updated per
+                                 preset by ThemeService.Apply) instead of hardcoded translucent white,
+                                 which was invisible on the six light presets (white border on white). -->
                             <Border x:Name="Bd" Background="Transparent" CornerRadius="8"
                                     Padding="{TemplateBinding Padding}"
-                                    BorderThickness="1" BorderBrush="#1AFFFFFF">
+                                    BorderThickness="1" BorderBrush="{DynamicResource Border1}">
                                 <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
                                                   TextBlock.Foreground="{TemplateBinding Foreground}"/>
                             </Border>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Surface3}"/>
-                                    <Setter TargetName="Bd" Property="BorderBrush" Value="#33FFFFFF"/>
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Border2}"/>
                                     <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                                 </Trigger>
                                 <Trigger Property="IsPressed" Value="True">
@@ -333,7 +336,7 @@
                                 </Trigger>
                                 <Trigger Property="IsKeyboardFocused" Value="True">
                                     <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Surface3}"/>
-                                    <Setter TargetName="Bd" Property="BorderBrush" Value="#33FFFFFF"/>
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Border2}"/>
                                     <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                                 </Trigger>
                                 <Trigger Property="IsEnabled" Value="False">

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.21</Version>
-    <FileVersion>1.52.21.0</FileVersion>
-    <AssemblyVersion>1.52.21.0</AssemblyVersion>
+    <Version>1.52.22</Version>
+    <FileVersion>1.52.22.0</FileVersion>
+    <AssemblyVersion>1.52.22.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/StartupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StartupViewModel.cs
@@ -150,16 +150,25 @@ public sealed partial class StartupViewModel : ViewModelBase
     [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task EnableAllAsync()
     {
+        var toEnable = Entries.Where(e => !e.IsEnabled).ToList();
+        if (toEnable.Count == 0)
+        {
+            StatusMessage = "All startup items are already enabled.";
+            return;
+        }
+
+        // Enabling every disabled item at once re-arms programs the user (or another tool)
+        // deliberately turned off, and each one adds boot time. Confirm the bulk change first —
+        // matching the confirm-before-bulk-write pattern used across the app (AppBlocker, Cleanup).
+        if (!DialogService.Instance.Confirm(
+                $"Re-enable {toEnable.Count} disabled startup item(s)?\n\n" +
+                "Each will run again at the next boot. You can disable any of them again individually.",
+                "Enable All Startup Items — Confirm"))
+            return;
+
         IsBusy = true;
         try
         {
-            var toEnable = Entries.Where(e => !e.IsEnabled).ToList();
-            if (toEnable.Count == 0)
-            {
-                StatusMessage = "All startup items are already enabled.";
-                return;
-            }
-
             // Report the outcome honestly: SetEnabledAsync returns false (and sets the
             // entry's StatusText) when a registry/task write fails, e.g. an item that
             // needs elevation. Previously every failure was swallowed and the status


### PR DESCRIPTION
## Summary

Two verified findings from the deep UI audit (dark + light themes, 288 screenshots, per-tab analysis + adversarial verification).

### S1 — Ghost buttons invisible on light themes (theming)
The `GhostButton` control template drew its border in hardcoded translucent white (`#1AFFFFFF`, hover/focus `#33FFFFFF`). On the six **light** presets that's white-on-white — the buttons looked borderless. Bound to the theme-adaptive `{DynamicResource Border1}` (default) and `{DynamicResource Border2}` (hover/focus) brushes, which `ThemeService.Apply()` rewrites per preset, so the outline is visible on **every** theme.
**Verified live**: System Report tab (Export HTML / Export JSON / Export text / Copy) in light mode now shows clear button outlines.

### M3 — Startup "Enable All" had no confirmation (behavior)
`EnableAllAsync` immediately re-enabled every disabled startup item (registry/task writes, adds boot time) with no prompt — contradicting the app's confirm-before-bulk-change convention. Now routes through `DialogService.Instance.Confirm` with the affected count, matching AppBlocker / Cleanup.

## Tests (regression)
- `EnableAll_WhenUserDeclinesConfirm_DoesNotEnableAndLeavesEntriesDisabled` — declining short-circuits before any write (entry stays disabled).
- `EnableAll_WithNoDisabledEntries_DoesNotPrompt` — no nag when there's nothing to enable.

## Adversarially rejected (NOT changed)
- **"Duplicate Finder ComboBox low contrast"** — all 25 ComboBoxes in the app use the WPF default with no `Style`; this one isn't special and renders fine. Fixing one would create inconsistency. False positive.
- **Blank WIP placeholder tabs (HIGH)** — confirmed real (content renders off-pane despite a correct layout tree), but the root cause resisted 3 fix attempts (`ContentControl` stretch did not resolve it). Per the 3-strike rule, deferred to a dedicated fix session with live WPF layout debugging rather than a blind 4th attempt. Impact is limited to 4 unimplemented PREVIEW tabs.

## Verification
- `dotnet build -c Release` — main **0/0**, tests **0/0**.
- GhostButton fix confirmed visually on a light preset; no dark-theme regression (Border1/Border2 already used across the app).
- `dotnet test` not run locally by policy; unit tests run on CI.
