### PR TITLE
fix: status banners (warning/success/info) legible on Light themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Warning, success and info banners are now readable on the Light themes.** Semantic status text (the amber "a finer timer wakes the CPU…" note on Timer Resolution, the "Running as administrator" banners, and similar warning/success/info messages across the app) used pale colors tuned for the dark themes. On the six light presets those washed out to near-invisible against the light banner — the amber warning text measured only ~1.4:1 contrast (WCAG AA needs 4.5:1). The theme engine now recomputes all status colors per theme, using darker, saturated tones on the light presets, so every banner stays legible on every theme. On the dark themes nothing changes.
+
 ## [1.52.22] - 2026-07-03
 
 ### Fixed

--- a/SysManager/SysManager.Tests/ThemeStatusBrushTests.cs
+++ b/SysManager/SysManager.Tests/ThemeStatusBrushTests.cs
@@ -1,0 +1,97 @@
+// SysManager · ThemeStatusBrushTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Media;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Regression tests for <see cref="ThemeService.StatusPalette"/>. The bug: the semantic status
+/// brushes (WarningText #FCD34D, SuccessText, InfoText, DangerText) were static in App.xaml and
+/// calibrated for dark surfaces; <see cref="ThemeService.Apply"/> repainted Surface/Text/Accent per
+/// preset but NEVER these, so on the six LIGHT presets the pale warning/info text rendered on a
+/// near-white banner and failed WCAG contrast (e.g. #FCD34D on #FFFFFF ≈ 1.4:1 — illegible).
+/// These tests pin that the light palette uses dark, saturated text that meets WCAG AA (4.5:1),
+/// while the dark palette stays legible on dark surfaces. They FAIL against the old static colors.
+/// </summary>
+public class ThemeStatusBrushTests
+{
+    // The brightest light-preset surface a status banner layers over (clean-indigo Surface = #FFFFFF)
+    // and the darkest dark-preset base (midnight-indigo Background = #070A0F). Text must contrast
+    // against the worst-case surface for its mode.
+    private static readonly Color LightSurface = C("#FFFFFF");
+    private static readonly Color DarkSurface = C("#070A0F");
+
+    [Theory]
+    [InlineData("WarningText")]
+    [InlineData("SuccessText")]
+    [InlineData("InfoText")]
+    [InlineData("DangerText")]
+    public void LightPalette_StatusText_MeetsWcagAaOnWhite(string key)
+    {
+        var color = Lookup(ThemeService.StatusPalette(isDark: false), key);
+        var ratio = ContrastRatio(color, LightSurface);
+        Assert.True(ratio >= 4.5,
+            $"Light-theme {key} must meet WCAG AA (4.5:1) against the near-white banner surface; got {ratio:F2}:1.");
+    }
+
+    [Theory]
+    [InlineData("WarningText")]
+    [InlineData("SuccessText")]
+    [InlineData("InfoText")]
+    [InlineData("DangerText")]
+    public void DarkPalette_StatusText_StaysLegibleOnDark(string key)
+    {
+        var color = Lookup(ThemeService.StatusPalette(isDark: true), key);
+        var ratio = ContrastRatio(color, DarkSurface);
+        Assert.True(ratio >= 4.5,
+            $"Dark-theme {key} must stay legible (4.5:1) on the dark surface; got {ratio:F2}:1.");
+    }
+
+    [Fact]
+    public void LightAndDark_ProduceDifferentWarningText()
+    {
+        // The whole point of the fix: the two modes must diverge. If they're equal, the palette was
+        // never actually mode-aware and the light-theme regression would silently return.
+        var light = Lookup(ThemeService.StatusPalette(false), "WarningText");
+        var dark = Lookup(ThemeService.StatusPalette(true), "WarningText");
+        Assert.NotEqual(dark, light);
+    }
+
+    [Fact]
+    public void Palette_CoversAllFourStatusTextKeys_InBothModes()
+    {
+        foreach (var mode in new[] { true, false })
+        {
+            var keys = ThemeService.StatusPalette(mode).Select(p => p.Key).ToHashSet();
+            Assert.Contains("WarningText", keys);
+            Assert.Contains("SuccessText", keys);
+            Assert.Contains("InfoText", keys);
+            Assert.Contains("DangerText", keys);
+        }
+    }
+
+    private static Color Lookup(IReadOnlyList<(string Key, Color Color)> palette, string key)
+        => palette.First(p => p.Key == key).Color;
+
+    private static Color C(string hex) => (Color)ColorConverter.ConvertFromString(hex);
+
+    private static double ContrastRatio(Color a, Color b)
+    {
+        double la = RelLum(a), lb = RelLum(b);
+        var (hi, lo) = la >= lb ? (la, lb) : (lb, la);
+        return (hi + 0.05) / (lo + 0.05);
+    }
+
+    private static double RelLum(Color c)
+    {
+        static double Ch(byte v)
+        {
+            var s = v / 255.0;
+            return s <= 0.03928 ? s / 12.92 : Math.Pow((s + 0.055) / 1.055, 2.4);
+        }
+        return 0.2126 * Ch(c.R) + 0.7152 * Ch(c.G) + 0.0722 * Ch(c.B);
+    }
+}

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -78,12 +78,18 @@
             <SolidColorBrush x:Key="WarningStripe" Color="#FBBF24"/>
             <SolidColorBrush x:Key="WarningText" Color="#FCD34D"/>
 
-            <!-- Info / Success category surfaces (low-alpha tints layer over any
-                 theme surface, so they stay readable on light and dark presets). -->
+            <!-- Info / Success / Danger category surfaces + text. These defaults are dark-calibrated;
+                 ThemeService.ApplyStatusBrushes() recomputes ALL of them per preset so light themes
+                 get WCAG-AA-legible text (pale dark-theme text washes out on near-white surfaces). -->
             <SolidColorBrush x:Key="InfoBgSubtle" Color="#1A38BDF8"/>
             <SolidColorBrush x:Key="InfoBorder" Color="#3338BDF8"/>
+            <SolidColorBrush x:Key="InfoText" Color="#7DD3FC"/>
             <SolidColorBrush x:Key="SuccessBgSubtle" Color="#1A22C55E"/>
             <SolidColorBrush x:Key="SuccessBorder" Color="#3322C55E"/>
+            <SolidColorBrush x:Key="SuccessText" Color="#4ADE80"/>
+            <SolidColorBrush x:Key="DangerBgSubtle" Color="#1AEF4444"/>
+            <SolidColorBrush x:Key="DangerBorder" Color="#33EF4444"/>
+            <SolidColorBrush x:Key="DangerText" Color="#F87171"/>
 
             <!-- Console output coloring (legacy) -->
             <SolidColorBrush x:Key="OutErrorBrush"   Color="#F87171" />

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -158,8 +158,51 @@ public sealed class ThemeService
         SetColor(res, "AccentHoverColor", Lighten(theme.Accent, 0.15));
         SetColor(res, "AccentPressedColor", Darken(theme.Accent, 0.12));
 
+        ApplyStatusBrushes(res, theme.IsDark);
+
         ThemeChanged?.Invoke();
     }
+
+    /// <summary>
+    /// Recomputes the semantic status brushes (Warning / Success / Info / Danger) for the current
+    /// mode. The App.xaml defaults are calibrated for dark surfaces — pale, high-lightness text
+    /// (e.g. WarningText #FCD34D) that reads on a near-black banner but washes out to illegible on a
+    /// light preset's near-white surface. On light themes we swap to darker, saturated text colors
+    /// that meet WCAG AA on white, and lift the subtle background tints so the banner is still
+    /// distinguishable. On dark themes we restore the original palette so nothing changes there.
+    /// This is the single seam that fixes every hardcoded-warning-banner contrast defect at once.
+    /// </summary>
+    private static void ApplyStatusBrushes(ResourceDictionary res, bool isDark)
+    {
+        foreach (var (key, color) in StatusPalette(isDark))
+            SetBrush(res, key, color);
+    }
+
+    /// <summary>
+    /// Pure color decision for the semantic status brushes, split out so it is unit-testable without
+    /// a WPF Application (the actual brush assignment writes into Application.Current.Resources).
+    /// Dark values mirror the App.xaml defaults; light values are darker, saturated text that meets
+    /// WCAG AA against a near-white surface, with tints lifted so the banner still reads as coloured.
+    /// </summary>
+    public static IReadOnlyList<(string Key, Color Color)> StatusPalette(bool isDark) => isDark
+        ?
+        [
+            ("WarningText", C("#FCD34D")), ("WarningBgSubtle", C("#1AFBBF24")),
+            ("WarningBg", C("#40FBBF24")), ("WarningStripe", C("#FBBF24")),
+            ("SuccessText", C("#4ADE80")), ("SuccessBgSubtle", C("#1A22C55E")), ("SuccessBorder", C("#3322C55E")),
+            ("InfoText", C("#7DD3FC")), ("InfoBgSubtle", C("#1A38BDF8")), ("InfoBorder", C("#3338BDF8")),
+            ("DangerText", C("#F87171")), ("DangerBgSubtle", C("#1AEF4444")), ("DangerBorder", C("#33EF4444")),
+        ]
+        :
+        [
+            ("WarningText", C("#92400E")), ("WarningBgSubtle", C("#26FBBF24")),   // amber-800 text — AA on white
+            ("WarningBg", C("#40FBBF24")), ("WarningStripe", C("#D97706")),
+            ("SuccessText", C("#15803D")), ("SuccessBgSubtle", C("#2622C55E")), ("SuccessBorder", C("#5522C55E")),
+            ("InfoText", C("#0369A1")), ("InfoBgSubtle", C("#2638BDF8")), ("InfoBorder", C("#5538BDF8")),
+            ("DangerText", C("#B91C1C")), ("DangerBgSubtle", C("#26EF4444")), ("DangerBorder", C("#55EF4444")),
+        ];
+
+    private static Color C(string hex) => (Color)ColorConverter.ConvertFromString(hex);
 
     private static void SetBrush(ResourceDictionary res, string key, Color color)
     {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.22</Version>
-    <FileVersion>1.52.22.0</FileVersion>
-    <AssemblyVersion>1.52.22.0</AssemblyVersion>
+    <Version>1.52.23</Version>
+    <FileVersion>1.52.23.0</FileVersion>
+    <AssemblyVersion>1.52.23.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem

The semantic status brushes (`WarningText` #FCD34D, `SuccessText`, `InfoText`, `DangerText`) were **static** in App.xaml, calibrated for the dark surfaces. `ThemeService.Apply()` repaints Surface/Text/Accent/Border per preset but **never** touched these — so on the six **light** presets the pale status text washed out against the near-white banners.

Measured contrast on white (WCAG AA requires 4.5:1):
- WarningText #FCD34D -> **1.44:1** (illegible)
- SuccessText #4ADE80 -> 1.74:1
- InfoText #7DD3FC -> 1.67:1
- DangerText #F87171 -> 2.77:1

This was the single root cause behind multiple audit findings (Timer Resolution, App Updates, DNS & Hosts, Shortcut Cleaner, Bulk Installer, File Lock warning banners).

## Fix

`Apply()` now recomputes **all** status-category brushes per mode via a new pure, unit-testable `ThemeService.StatusPalette(isDark)`:
- **Dark** keeps the original values (nothing changes on dark themes).
- **Light** uses darker, saturated text — amber-800 (#92400E), green-700 (#15803D), sky-700 (#0369A1), red-700 (#B91C1C) — all >=5:1 on white, with lifted background tints.

Adds the missing `SuccessText`/`InfoText`/`DangerText`/`DangerBgSubtle`/`DangerBorder` default brush keys to App.xaml so `{DynamicResource}` references resolve.

## Verification
- Built app + tests: **0 errors, 0 warnings**.
- Verified live on light theme (Timer Resolution + App Updates banners now clearly legible).
- Regression test `ThemeStatusBrushTests` asserts every light-mode status text meets 4.5:1 on #FFFFFF (**fails** against the old palette) and dark stays legible on #070A0F. Red-before/green-after confirmed by contrast calculation.
