### PR TITLE
docs: version the 1.52.23 changelog header so the release can publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.23] - 2026-07-03
+
 ### Fixed
 - **Warning, success and info banners are now readable on the Light themes.** Semantic status text (the amber "a finer timer wakes the CPU…" note on Timer Resolution, the "Running as administrator" banners, and similar warning/success/info messages across the app) used pale colors tuned for the dark themes. On the six light presets those washed out to near-invisible against the light banner — the amber warning text measured only ~1.4:1 contrast (WCAG AA needs 4.5:1). The theme engine now recomputes all status colors per theme, using darker, saturated tones on the light presets, so every banner stays legible on every theme. On the dark themes nothing changes.
 


### PR DESCRIPTION
## Problem

The v1.52.23 fix (light-theme status brushes, #1239) merged with its CHANGELOG entry left under `## [Unreleased]` instead of a versioned header. The release workflow extracts notes by matching `## [<tag-version>]`; it found no `## [1.52.23]` section and **failed** — the tag `v1.52.23` was created by auto-release, but the GitHub release never published (latest release is still v1.52.22).

## Fix

Move the entry under a versioned `## [1.52.23] - 2026-07-03` header (matching the convention every prior release uses), leaving `## [Unreleased]` empty above it. After merge, the release workflow is re-run for the existing `v1.52.23` tag and publishes.

CHANGELOG-only change — does **not** re-trigger auto-release (that workflow only fires on `SysManager/SysManager/**` paths).
