### PR TITLE
fix: theme-aware ComboBox style (readable dropdowns on Light themes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.24] - 2026-07-04
+
+### Fixed
+- **Dropdowns (combo boxes) now match the theme and stay readable on the Light themes.** The folder/path pickers on Duplicate Finder and Disk Analyzer, and other dropdowns across the app, used the default Windows combo-box look — a fixed white popup with near-black text that ignored the selected theme. On the dark themes it clashed; on the light themes the editable text and dropdown items were low-contrast. Combo boxes now use a theme-aware style (matching the app's text fields — themed surface, border, rounded corners, accent focus, and a properly styled dropdown list), so they look consistent and stay legible on every theme.
+
 ## [1.52.23] - 2026-07-03
 
 ### Fixed

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -564,6 +564,133 @@
                 </Setter>
             </Style>
 
+            <!-- ComboBox — theme-aware (the default WPF template uses fixed system
+                 colors: a white popup + near-black text that ignore the theme, so on
+                 the light presets the editable text and dropdown items rendered with
+                 poor contrast). This template drives every color from the theme
+                 brushes, matching the TextBox look (Surface2 field, Border2 outline,
+                 CornerRadius 8, Accent focus). Covers editable + non-editable. -->
+            <Style x:Key="ComboBoxToggleButton" TargetType="ToggleButton">
+                <Setter Property="Focusable" Value="False"/>
+                <Setter Property="ClickMode" Value="Press"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ToggleButton">
+                            <Border Background="Transparent"/>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <Style TargetType="ComboBox">
+                <Setter Property="Background" Value="{DynamicResource Surface2}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource Border2}"/>
+                <Setter Property="BorderThickness" Value="1"/>
+                <Setter Property="Padding" Value="10,7"/>
+                <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
+                <Setter Property="FontSize" Value="13"/>
+                <Setter Property="Height" Value="34"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ComboBox">
+                            <Grid>
+                                <Border x:Name="Bd"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        CornerRadius="8">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+
+                                        <!-- Editable text box (shown only when IsEditable) -->
+                                        <TextBox x:Name="PART_EditableTextBox" Grid.Column="0"
+                                                 Margin="{TemplateBinding Padding}"
+                                                 VerticalContentAlignment="Center"
+                                                 Background="Transparent" BorderThickness="0"
+                                                 Foreground="{DynamicResource TextPrimary}"
+                                                 CaretBrush="{DynamicResource Accent}"
+                                                 SelectionBrush="{DynamicResource Accent}"
+                                                 IsReadOnly="{TemplateBinding IsReadOnly}"
+                                                 Visibility="Hidden"/>
+                                        <!-- Selected item (shown when NOT editable) -->
+                                        <ContentPresenter x:Name="ContentSite" Grid.Column="0"
+                                                          Margin="{TemplateBinding Padding}"
+                                                          VerticalAlignment="Center"
+                                                          Content="{TemplateBinding SelectionBoxItem}"
+                                                          ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                                          IsHitTestVisible="False"/>
+
+                                        <ToggleButton x:Name="ToggleChevron" Grid.Column="1"
+                                                      Style="{StaticResource ComboBoxToggleButton}"
+                                                      IsChecked="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"/>
+                                        <TextBlock Grid.Column="1" Text="&#xE70D;" IsHitTestVisible="False"
+                                                   FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="11"
+                                                   Foreground="{DynamicResource TextSecondary}"
+                                                   VerticalAlignment="Center" Margin="0,0,12,0"/>
+                                    </Grid>
+                                </Border>
+
+                                <Popup x:Name="PART_Popup" AllowsTransparency="True"
+                                       Placement="Bottom" Focusable="False"
+                                       IsOpen="{TemplateBinding IsDropDownOpen}"
+                                       PopupAnimation="Fade">
+                                    <Border Background="{DynamicResource Surface1}"
+                                            BorderBrush="{DynamicResource Border2}" BorderThickness="1"
+                                            CornerRadius="8" Margin="0,4,0,0"
+                                            MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"
+                                            MaxHeight="{TemplateBinding MaxDropDownHeight}">
+                                        <ScrollViewer>
+                                            <ItemsPresenter/>
+                                        </ScrollViewer>
+                                    </Border>
+                                </Popup>
+                            </Grid>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsEditable" Value="True">
+                                    <Setter TargetName="PART_EditableTextBox" Property="Visibility" Value="Visible"/>
+                                    <Setter TargetName="ContentSite" Property="Visibility" Value="Collapsed"/>
+                                </Trigger>
+                                <Trigger Property="IsKeyboardFocusWithin" Value="True">
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Accent}"/>
+                                </Trigger>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource BorderAccent}"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <Style TargetType="ComboBoxItem">
+                <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
+                <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
+                <Setter Property="FontSize" Value="13"/>
+                <Setter Property="Padding" Value="10,7"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ComboBoxItem">
+                            <Border x:Name="Bd" Background="Transparent" CornerRadius="6"
+                                    Padding="{TemplateBinding Padding}" Margin="4,2">
+                                <ContentPresenter/>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsHighlighted" Value="True">
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Surface3}"/>
+                                </Trigger>
+                                <Trigger Property="IsSelected" Value="True">
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource AccentSoft}"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
             <!-- ============================================================ -->
             <!-- Typography helpers                                            -->
             <!-- ============================================================ -->

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.23</Version>
-    <FileVersion>1.52.23.0</FileVersion>
-    <AssemblyVersion>1.52.23.0</AssemblyVersion>
+    <Version>1.52.24</Version>
+    <FileVersion>1.52.24.0</FileVersion>
+    <AssemblyVersion>1.52.24.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem

The app's ~25 `ComboBox`es had **no explicit style**, so they fell back to the default WPF template — a fixed white popup with near-black text and system chrome that ignore the theme. On the light presets the editable text and dropdown items rendered low-contrast (Duplicate Finder folder picker, Disk Analyzer path, File Shredder algorithm selector, etc.); on the dark themes the white popup clashed.

The `App.xaml` "TextBox & ComboBox" section comment promised a ComboBox style, but only the TextBox style was ever implemented.

## Fix

Adds a global `ComboBox` + `ComboBoxItem` style to `App.xaml`, driven entirely by theme brushes and matching the existing TextBox look:
- Field: `Surface2` background, `Border2` outline, `CornerRadius=8`, `Accent` focus / `BorderAccent` hover.
- Popup: `Surface1` surface, `Border2` border, rounded, with a Fluent chevron glyph.
- Items: `TextPrimary` text, `Surface3` hover, `AccentSoft` selected.
- Covers both editable and non-editable modes.

## Verification
- Built app: **0 errors, 0 warnings** (BAML compile validates the ControlTemplate).
- Verified **live in both themes and both modes, including an open dropdown**:
  - Light: white themed field + popup, dark legible item text.
  - Dark: dark themed field + popup, light legible item text.
- No behavior change — purely a visual/theming style.
