### PR TITLE
fix: Task Scheduler task/path columns truncate with ellipsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.26] - 2026-07-04
+
+### Fixed
+- **Long task names and paths on the Task Scheduler tab now truncate with an ellipsis.** The Task and Path columns rendered long text clipped hard at the column edge with no "…" indicator, unlike the other data tables in the app (Services, Drivers, Uninstaller, etc.) which trim cleanly. Both columns now use the same character-ellipsis trimming, so overflowing text ends in "…" and the layout stays tidy.
+
 ## [1.52.25] - 2026-07-04
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.25</Version>
-    <FileVersion>1.52.25.0</FileVersion>
-    <AssemblyVersion>1.52.25.0</AssemblyVersion>
+    <Version>1.52.26</Version>
+    <FileVersion>1.52.26.0</FileVersion>
+    <AssemblyVersion>1.52.26.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/TaskSchedulerView.xaml
+++ b/SysManager/SysManager/Views/TaskSchedulerView.xaml
@@ -91,8 +91,20 @@
                       Background="Transparent" BorderThickness="0" GridLinesVisibility="None"
                       VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Header="Task" Binding="{Binding Name}" Width="2*"/>
-                    <DataGridTextColumn Header="Path" Binding="{Binding Path}" Width="2*"/>
+                    <DataGridTextColumn Header="Task" Binding="{Binding Name}" Width="2*">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Header="Path" Binding="{Binding Path}" Width="2*">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
                     <DataGridTextColumn Header="Type" Binding="{Binding CategoryLabel}" Width="110"/>
                     <DataGridTextColumn Header="State" Binding="{Binding State}" Width="90"/>
                     <DataGridTextColumn Header="Last run" Binding="{Binding LastRunDisplay}" Width="140"/>


### PR DESCRIPTION
## Problem

On the Task Scheduler tab, the **Task** and **Path** columns (`DataGridTextColumn` with `Width="2*"`) had no `ElementStyle`, so long task names/paths clipped hard at the column boundary with no `…` indicator. Every other data table in the app (Services, Drivers, Uninstaller, Process Manager, Windows Features, …) applies `TextTrimming="CharacterEllipsis"` to its free-text columns — this tab was the odd one out.

## Fix

Adds the same `CharacterEllipsis` `ElementStyle` to both wide free-text columns, matching the sibling idiom (e.g. ServicesView) exactly. Fixed-width columns (Type / State / Last run) are left as-is, consistent with the siblings.

## Verification
- Built app: **0 errors, 0 warnings**.
- Pure XAML style addition matching 10+ sibling views — no behavior/layout change beyond the intended trimming.
