### PR TITLE
fix: Dashboard metric colors as named theme brushes + themed admin pill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.27] - 2026-07-04
+
+### Fixed
+- **Dashboard "Run as admin" pill now follows the theme.** When SysManager isn't elevated, the small amber "Run as admin for all sensors" pill on the Dashboard used hardcoded amber tints that didn't adapt to the theme (and were tuned for dark). It now uses the app's theme-aware warning colors, so it stays legible on the light presets too.
+
+### Changed
+- **Dashboard metric colors are now named theme brushes.** The MEMORY (blue) and GPU (purple) accent colors were copy-pasted hex values repeated across the metric cards and quick-action list. They're now defined once as named `MetricBlue`/`MetricPurple` brushes and referenced everywhere — no visual change, just a single source of truth (matching how the CPU card already used a named brush).
+
 ## [1.52.26] - 2026-07-04
 
 ### Fixed

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -72,6 +72,12 @@
             <SolidColorBrush x:Key="Danger" Color="#EF4444"/>
             <SolidColorBrush x:Key="Info" Color="#38BDF8"/>
 
+            <!-- Dashboard metric identity colors (CPU=Success green, MEM=blue, GPU=purple).
+                 Named so the metric cards reference brushes instead of copy-pasting the same hex;
+                 the mid-tone blue/purple stay legible on both dark and light presets. -->
+            <SolidColorBrush x:Key="MetricBlue" Color="#3B82F6"/>
+            <SolidColorBrush x:Key="MetricPurple" Color="#A855F7"/>
+
             <!-- Warning category surface (admin elevation banner, etc.) -->
             <SolidColorBrush x:Key="WarningBgSubtle" Color="#1AFBBF24"/>
             <SolidColorBrush x:Key="WarningBg" Color="#40FBBF24"/>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.26</Version>
-    <FileVersion>1.52.26.0</FileVersion>
-    <AssemblyVersion>1.52.26.0</AssemblyVersion>
+    <Version>1.52.27</Version>
+    <FileVersion>1.52.27.0</FileVersion>
+    <AssemblyVersion>1.52.27.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -147,9 +147,9 @@
                         <DockPanel Margin="0,0,0,8">
                             <TextBlock Text="MEMORY" FontSize="11" FontWeight="SemiBold" Foreground="{DynamicResource TextMuted}"
                                        DockPanel.Dock="Left" VerticalAlignment="Center"/>
-                            <Ellipse Width="6" Height="6" Fill="#3B82F6" DockPanel.Dock="Right" VerticalAlignment="Center"/>
+                            <Ellipse Width="6" Height="6" Fill="{DynamicResource MetricBlue}" DockPanel.Dock="Right" VerticalAlignment="Center"/>
                         </DockPanel>
-                        <TextBlock FontSize="26" FontWeight="Bold" Foreground="#3B82F6">
+                        <TextBlock FontSize="26" FontWeight="Bold" Foreground="{DynamicResource MetricBlue}">
                             <Run Text="{Binding RamPercent, StringFormat='{}{0:F0}', Mode=OneWay}"/><Run Text="%"/>
                         </TextBlock>
                         <TextBlock FontSize="11" Foreground="{DynamicResource TextMuted}" Margin="0,4,0,0">
@@ -165,7 +165,7 @@
                             <Run Text="{Binding RamType, Mode=OneWay}"/>
                         </TextBlock>
                         <ProgressBar Height="4" Minimum="0" Maximum="100" Value="{Binding RamPercent, Mode=OneWay}"
-                                     Foreground="#3B82F6" Background="{DynamicResource Surface3}" Margin="0,10,0,0"/>
+                                     Foreground="{DynamicResource MetricBlue}" Background="{DynamicResource Surface3}" Margin="0,10,0,0"/>
                     </StackPanel>
                 </Border>
 
@@ -175,16 +175,16 @@
                         <DockPanel Margin="0,0,0,8">
                             <TextBlock Text="GPU" FontSize="11" FontWeight="SemiBold" Foreground="{DynamicResource TextMuted}"
                                        DockPanel.Dock="Left" VerticalAlignment="Center"/>
-                            <Ellipse Width="6" Height="6" Fill="#A855F7" DockPanel.Dock="Right" VerticalAlignment="Center"/>
+                            <Ellipse Width="6" Height="6" Fill="{DynamicResource MetricPurple}" DockPanel.Dock="Right" VerticalAlignment="Center"/>
                         </DockPanel>
-                        <TextBlock FontSize="26" FontWeight="Bold" Foreground="#A855F7">
+                        <TextBlock FontSize="26" FontWeight="Bold" Foreground="{DynamicResource MetricPurple}">
                             <Run Text="{Binding GpuPercent, StringFormat='{}{0:F0}', Mode=OneWay}"/><Run Text="%"/>
                         </TextBlock>
                         <TextBlock Text="{Binding GpuName}" FontSize="11" Foreground="{DynamicResource TextMuted}"
                                    TextTrimming="CharacterEllipsis" Margin="0,4,0,0"/>
                         <TextBlock Text="{Binding GpuVram}" FontSize="11" Foreground="{DynamicResource TextMuted}" Margin="0,2,0,0"/>
                         <ProgressBar Height="4" Minimum="0" Maximum="100" Value="{Binding GpuPercent, Mode=OneWay}"
-                                     Foreground="#A855F7" Background="{DynamicResource Surface3}" Margin="0,10,0,0"/>
+                                     Foreground="{DynamicResource MetricPurple}" Background="{DynamicResource Surface3}" Margin="0,10,0,0"/>
                     </StackPanel>
                 </Border>
             </Grid>
@@ -202,13 +202,13 @@
                                 <Button.Template>
                                     <ControlTemplate TargetType="Button">
                                         <Border x:Name="Bd" CornerRadius="4" Padding="{TemplateBinding Padding}"
-                                                Background="#10FBBF24" BorderBrush="#30FBBF24" BorderThickness="1">
+                                                Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningStripe}" BorderThickness="1">
                                             <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
                                         </Border>
                                         <ControlTemplate.Triggers>
                                             <Trigger Property="IsMouseOver" Value="True">
-                                                <Setter TargetName="Bd" Property="Background" Value="#20FBBF24"/>
-                                                <Setter TargetName="Bd" Property="BorderBrush" Value="#60FBBF24"/>
+                                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource WarningBg}"/>
+                                                <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource WarningStripe}"/>
                                             </Trigger>
                                         </ControlTemplate.Triggers>
                                     </ControlTemplate>
@@ -342,18 +342,18 @@
                                                DockPanel.Dock="Left" VerticalAlignment="Center"/>
                                     <TextBlock Text="{Binding QuickActionStatus}" FontSize="11"
                                                DockPanel.Dock="Right" HorizontalAlignment="Right" VerticalAlignment="Center"
-                                               Foreground="#3B82F6"/>
+                                               Foreground="{DynamicResource MetricBlue}"/>
                                 </DockPanel>
                                 <ProgressBar Height="4" Minimum="0" Maximum="100"
                                              Value="{Binding QuickActionProgress, Mode=OneWay}"
-                                             Foreground="#3B82F6" Background="{DynamicResource Surface3}" Margin="0,0,0,6"/>
+                                             Foreground="{DynamicResource MetricBlue}" Background="{DynamicResource Surface3}" Margin="0,0,0,6"/>
                                 <TextBlock Text="{Binding QuickActionDetail}" FontSize="11"
                                            Foreground="{DynamicResource TextMuted}" Margin="0,0,0,8"
                                            Visibility="{Binding QuickActionDetail, Converter={StaticResource FlexVis}}"/>
                                 <Button Content="{Binding QuickActionNavigateLabel}"
                                         Command="{Binding NavigateToQuickActionTabCommand}"
                                         Style="{StaticResource GhostButton}" Padding="8,4" FontSize="11"
-                                        Foreground="#3B82F6" HorizontalAlignment="Left"
+                                        Foreground="{DynamicResource MetricBlue}" HorizontalAlignment="Left"
                                         Visibility="{Binding IsQuickActionDone, Converter={StaticResource BoolToVis}}"/>
                             </StackPanel>
                         </Border>


### PR DESCRIPTION
## Problem

Two small consistency/theming gaps on the Dashboard:
1. **Metric colors copy-pasted.** The MEMORY (blue `#3B82F6`) and GPU (purple `#A855F7`) accent colors were hardcoded and repeated across the metric cards and the quick-action list, while the CPU card already used a named brush (`{DynamicResource Success}`).
2. **"Run as admin" pill off-theme.** When SysManager isn't elevated, the small amber "Run as admin for all sensors" pill used hardcoded amber tints (`#10FBBF24` / `#30FBBF24`) that didn't adapt to the theme.

## Fix

- Defines `MetricBlue` / `MetricPurple` once in `App.xaml` and references them everywhere — single source of truth, **no visual change** (matches how CPU already worked).
- Migrates the admin pill to the theme-aware `WarningBgSubtle` / `WarningBg` / `WarningStripe` brushes (which `ThemeService` recomputes per preset), so it stays legible on the light presets.

## Verification
- Built app: **0 errors, 0 warnings**.
- Propagate check: no hardcoded metric/status hex remains in `DashboardView`.
- Verified **live on the light theme**: Dashboard renders identically — CPU green, MEMORY blue, GPU purple, all legible; progress bars unchanged.
