### PR TITLE
fix: Ping cards + Context Menu tooltips use theme colors (Light-theme legibility)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.28] - 2026-07-04
+
+### Fixed
+- **Ping target cards and Context Menu preview tooltips are now theme-aware on the Light themes.** The per-target cards on the Ping tab used a hardcoded translucent-white border and fixed slate-gray metric labels (LATENCY/AVG/JITTER/LOSS) that were nearly invisible on the light presets; the Context Menu style-preview tooltips used fixed `Gray`/`DimGray` text. Both now use the app's theme text and border brushes, so they stay legible on every theme. On the dark themes the look is unchanged.
+
 ## [1.52.27] - 2026-07-04
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.27</Version>
-    <FileVersion>1.52.27.0</FileVersion>
-    <AssemblyVersion>1.52.27.0</AssemblyVersion>
+    <Version>1.52.28</Version>
+    <FileVersion>1.52.28.0</FileVersion>
+    <AssemblyVersion>1.52.28.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/ContextMenuView.xaml
+++ b/SysManager/SysManager/Views/ContextMenuView.xaml
@@ -75,18 +75,18 @@
                                 <StackPanel>
                                     <TextBlock Text="Classic Full Context Menu (Win10 Style)" FontWeight="SemiBold" FontSize="13" Margin="0,0,0,6"/>
                                     <TextBlock Text="This is actually the Win11 menu after clicking &quot;Show more options&quot; — but applied permanently. All entries visible on first right-click, no extra clicks needed."
-                                               Foreground="Gray" FontSize="11" Margin="0,0,0,8" TextWrapping="Wrap"/>
+                                               Foreground="{DynamicResource TextSecondary}" FontSize="11" Margin="0,0,0,8" TextWrapping="Wrap"/>
                                     <StackPanel Orientation="Horizontal">
                                         <StackPanel Margin="0,0,12,0">
-                                            <TextBlock Text="Default (clean)" FontSize="10" Foreground="Gray" HorizontalAlignment="Center" Margin="0,0,0,3"/>
+                                            <TextBlock Text="Default (clean)" FontSize="10" Foreground="{DynamicResource TextSecondary}" HorizontalAlignment="Center" Margin="0,0,0,3"/>
                                             <Image Source="/Resources/ctx-win10-default.png" MaxHeight="200" Stretch="Uniform"/>
                                         </StackPanel>
                                         <StackPanel>
-                                            <TextBlock Text="Custom (all entries ON)" FontSize="10" Foreground="Gray" HorizontalAlignment="Center" Margin="0,0,0,3"/>
+                                            <TextBlock Text="Custom (all entries ON)" FontSize="10" Foreground="{DynamicResource TextSecondary}" HorizontalAlignment="Center" Margin="0,0,0,3"/>
                                             <Image Source="/Resources/ctx-win10-custom-max.png" MaxHeight="200" Stretch="Uniform"/>
                                         </StackPanel>
                                     </StackPanel>
-                                    <TextBlock Text="ⓘ Hover for preview" FontSize="10" Foreground="DimGray" Margin="0,6,0,0" FontStyle="Italic"/>
+                                    <TextBlock Text="ⓘ Hover for preview" FontSize="10" Foreground="{DynamicResource TextMuted}" Margin="0,6,0,0" FontStyle="Italic"/>
                                 </StackPanel>
                             </ToolTip>
                         </Button.ToolTip>
@@ -101,22 +101,22 @@
                                 <StackPanel>
                                     <TextBlock Text="Modern Compact Context Menu (Win11 Style)" FontWeight="SemiBold" FontSize="13" Margin="0,0,0,6"/>
                                     <TextBlock Text="Compact menu with icons. Custom entries appear only after clicking &quot;Show more options&quot; at the bottom. The expanded view is identical to Win10 Default."
-                                               Foreground="Gray" FontSize="11" Margin="0,0,0,8" TextWrapping="Wrap"/>
+                                               Foreground="{DynamicResource TextSecondary}" FontSize="11" Margin="0,0,0,8" TextWrapping="Wrap"/>
                                     <StackPanel Orientation="Horizontal">
                                         <StackPanel Margin="0,0,12,0">
-                                            <TextBlock Text="Default (compact)" FontSize="10" Foreground="Gray" HorizontalAlignment="Center" Margin="0,0,0,3"/>
+                                            <TextBlock Text="Default (compact)" FontSize="10" Foreground="{DynamicResource TextSecondary}" HorizontalAlignment="Center" Margin="0,0,0,3"/>
                                             <Image Source="/Resources/ctx-win11-default.png" MaxHeight="200" Stretch="Uniform"/>
                                         </StackPanel>
                                         <StackPanel Margin="0,0,12,0">
-                                            <TextBlock Text="Custom (compact)" FontSize="10" Foreground="Gray" HorizontalAlignment="Center" Margin="0,0,0,3"/>
+                                            <TextBlock Text="Custom (compact)" FontSize="10" Foreground="{DynamicResource TextSecondary}" HorizontalAlignment="Center" Margin="0,0,0,3"/>
                                             <Image Source="/Resources/ctx-win11-custom-max.png" MaxHeight="200" Stretch="Uniform"/>
                                         </StackPanel>
                                         <StackPanel>
-                                            <TextBlock Text="After &quot;Show more options&quot;" FontSize="10" Foreground="Gray" HorizontalAlignment="Center" Margin="0,0,0,3"/>
+                                            <TextBlock Text="After &quot;Show more options&quot;" FontSize="10" Foreground="{DynamicResource TextSecondary}" HorizontalAlignment="Center" Margin="0,0,0,3"/>
                                             <Image Source="/Resources/ctx-win11-show-more.png" MaxHeight="200" Stretch="Uniform"/>
                                         </StackPanel>
                                     </StackPanel>
-                                    <TextBlock Text="ⓘ Hover for preview" FontSize="10" Foreground="DimGray" Margin="0,6,0,0" FontStyle="Italic"/>
+                                    <TextBlock Text="ⓘ Hover for preview" FontSize="10" Foreground="{DynamicResource TextMuted}" Margin="0,6,0,0" FontStyle="Italic"/>
                                 </StackPanel>
                             </ToolTip>
                         </Button.ToolTip>

--- a/SysManager/SysManager/Views/PingView.xaml
+++ b/SysManager/SysManager/Views/PingView.xaml
@@ -107,7 +107,7 @@
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Border Margin="0,0,10,10" Padding="14,12" CornerRadius="12"
-                                    Background="#0D6366F1" BorderBrush="#0AFFFFFF" BorderThickness="1">
+                                    Background="{DynamicResource AccentSoft}" BorderBrush="{DynamicResource Border1}" BorderThickness="1">
                                 <Grid>
                                     <Border Background="{Binding ColorHex, Converter={StaticResource HexBrush}}"
                                             Width="4" HorizontalAlignment="Left" CornerRadius="2"
@@ -132,22 +132,22 @@
                                             <StackPanel Margin="0,0,16,0" HorizontalAlignment="Center">
                                                 <TextBlock Text="{Binding LastLatencyMs, StringFormat={}{0:F0} ms, FallbackValue=—}"
                                                            Foreground="{DynamicResource Info}" FontWeight="Bold" FontSize="13" HorizontalAlignment="Center"/>
-                                                <TextBlock Text="LATENCY" Foreground="#475569" FontSize="9" HorizontalAlignment="Center" Margin="0,2,0,0"/>
+                                                <TextBlock Text="LATENCY" Foreground="{DynamicResource TextMuted}" FontSize="9" HorizontalAlignment="Center" Margin="0,2,0,0"/>
                                             </StackPanel>
                                             <StackPanel Margin="0,0,16,0" HorizontalAlignment="Center">
                                                 <TextBlock Text="{Binding AverageMs, StringFormat={}{0:F1}, FallbackValue=—}"
                                                            Foreground="{DynamicResource TextSecondary}" FontWeight="Bold" FontSize="13" HorizontalAlignment="Center"/>
-                                                <TextBlock Text="AVG" Foreground="#475569" FontSize="9" HorizontalAlignment="Center" Margin="0,2,0,0"/>
+                                                <TextBlock Text="AVG" Foreground="{DynamicResource TextMuted}" FontSize="9" HorizontalAlignment="Center" Margin="0,2,0,0"/>
                                             </StackPanel>
                                             <StackPanel Margin="0,0,16,0" HorizontalAlignment="Center">
                                                 <TextBlock Text="{Binding JitterMs, StringFormat={}{0:F0}, FallbackValue=—}"
                                                            Foreground="{DynamicResource Warning}" FontWeight="Bold" FontSize="13" HorizontalAlignment="Center"/>
-                                                <TextBlock Text="JITTER" Foreground="#475569" FontSize="9" HorizontalAlignment="Center" Margin="0,2,0,0"/>
+                                                <TextBlock Text="JITTER" Foreground="{DynamicResource TextMuted}" FontSize="9" HorizontalAlignment="Center" Margin="0,2,0,0"/>
                                             </StackPanel>
                                             <StackPanel HorizontalAlignment="Center">
                                                 <TextBlock Text="{Binding LossPercent, StringFormat={}{0:F0}%}"
                                                            Foreground="{DynamicResource WarningStripe}" FontWeight="Bold" FontSize="13" HorizontalAlignment="Center"/>
-                                                <TextBlock Text="LOSS" Foreground="#475569" FontSize="9" HorizontalAlignment="Center" Margin="0,2,0,0"/>
+                                                <TextBlock Text="LOSS" Foreground="{DynamicResource TextMuted}" FontSize="9" HorizontalAlignment="Center" Margin="0,2,0,0"/>
                                             </StackPanel>
                                         </StackPanel>
                                     </DockPanel>


### PR DESCRIPTION
## Problem

Two more hardcoded-color spots that broke on the light presets:
- **Ping** — the per-target cards used a hardcoded translucent-white border (`#0AFFFFFF`) and fixed slate-gray metric labels (`#475569` for LATENCY / AVG / JITTER / LOSS) that were nearly invisible on the light presets.
- **Context Menu** — the Win10/Win11 style-preview tooltips used fixed `Gray` / `DimGray` caption text.

## Fix

- Ping card → `AccentSoft` background + `Border1` border; the four metric labels → `TextMuted`.
- Context Menu tooltip captions → `TextSecondary` / `TextMuted`.

All theme brushes, so both stay legible on every preset; dark themes unchanged.

## Adversarial validation (refuted false positives — NOT changed)
Three sibling R1 findings were checked against source and refuted:
- **Browser Cleaner** "signs you out" badge — already uses `{DynamicResource WarningStripe}`.
- **System Report** description — uses the `Subtle` style (theme-aware); the finding's cited `ThemeService.cs:294` was the settings record, not a color mapping.
- **Gaming Profile** WIP badge — indigo-on-pale-indigo pill is legible (standard Fluent style), marginal at most.

## Verification
- Built app: **0 errors, 0 warnings**.
- Propagate check: no hardcoded hex / named-gray remains in either view.
