### PR TITLE
fix: ToggleSwitch + FilterChip styles theme-aware (Light-theme legibility)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.29] - 2026-07-04
+
+### Fixed
+- **Toggle switches and safety filter chips now follow the theme on the Light presets.** The "off" state of every toggle switch (Privacy toggles, feature switches, etc.) used a hardcoded dark-slate track that looked nearly black on the light themes; the safety filter chips (Safe / Caution / Critical) used hardcoded translucent status colors. Both now use the app's theme-aware brushes, so the off-toggle reads as a soft muted track and the chips stay legible on every theme. On the dark themes the look is unchanged.
+
 ## [1.52.28] - 2026-07-04
 
 ### Fixed

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -373,7 +373,7 @@
                     <Setter.Value>
                         <ControlTemplate TargetType="ToggleButton">
                             <Grid>
-                                <Border x:Name="Track" CornerRadius="11" Background="#374151"/>
+                                <Border x:Name="Track" CornerRadius="11" Background="{DynamicResource TextMuted}"/>
                                 <Border x:Name="Thumb" Width="18" Height="18" CornerRadius="9"
                                         Background="White" HorizontalAlignment="Left" Margin="2,2,0,2"
                                         VerticalAlignment="Center">
@@ -408,17 +408,17 @@
                     <Setter.Value>
                         <ControlTemplate TargetType="RadioButton">
                             <Border x:Name="Bd" CornerRadius="999" Padding="8,4"
-                                    Background="#1522C55E" BorderBrush="#3022C55E" BorderThickness="1"
+                                    Background="{DynamicResource SuccessBgSubtle}" BorderBrush="{DynamicResource SuccessBorder}" BorderThickness="1"
                                     Cursor="Hand">
                                 <StackPanel Orientation="Horizontal">
-                                    <Ellipse x:Name="Dot" Width="6" Height="6" Fill="#22C55E" Margin="0,0,5,0"/>
+                                    <Ellipse x:Name="Dot" Width="6" Height="6" Fill="{DynamicResource Success}" Margin="0,0,5,0"/>
                                     <ContentPresenter VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Border>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsChecked" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="#3022C55E"/>
-                                    <Setter TargetName="Bd" Property="BorderBrush" Value="#6022C55E"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource SuccessBorder}"/>
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Success}"/>
                                 </Trigger>
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter TargetName="Bd" Property="Background" Value="{DynamicResource AccentSoft}"/>
@@ -427,28 +427,28 @@
                         </ControlTemplate>
                     </Setter.Value>
                 </Setter>
-                <Setter Property="Foreground" Value="#4ADE80"/>
+                <Setter Property="Foreground" Value="{DynamicResource SuccessText}"/>
                 <Setter Property="FontSize" Value="11"/>
                 <Setter Property="FontWeight" Value="Medium"/>
             </Style>
 
             <Style x:Key="FilterChipCaution" TargetType="RadioButton" BasedOn="{StaticResource FilterChip}">
-                <Setter Property="Foreground" Value="#FBBF24"/>
+                <Setter Property="Foreground" Value="{DynamicResource WarningText}"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="RadioButton">
                             <Border x:Name="Bd" CornerRadius="999" Padding="8,4"
-                                    Background="#15F59E0B" BorderBrush="#30F59E0B" BorderThickness="1"
+                                    Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningStripe}" BorderThickness="1"
                                     Cursor="Hand">
                                 <StackPanel Orientation="Horizontal">
-                                    <Ellipse x:Name="Dot" Width="6" Height="6" Fill="#F59E0B" Margin="0,0,5,0"/>
+                                    <Ellipse x:Name="Dot" Width="6" Height="6" Fill="{DynamicResource Warning}" Margin="0,0,5,0"/>
                                     <ContentPresenter VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Border>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsChecked" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="#30F59E0B"/>
-                                    <Setter TargetName="Bd" Property="BorderBrush" Value="#60F59E0B"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource WarningBg}"/>
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource WarningStripe}"/>
                                 </Trigger>
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter TargetName="Bd" Property="Background" Value="{DynamicResource AccentSoft}"/>
@@ -460,22 +460,22 @@
             </Style>
 
             <Style x:Key="FilterChipCritical" TargetType="RadioButton" BasedOn="{StaticResource FilterChip}">
-                <Setter Property="Foreground" Value="#F87171"/>
+                <Setter Property="Foreground" Value="{DynamicResource DangerText}"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="RadioButton">
                             <Border x:Name="Bd" CornerRadius="999" Padding="8,4"
-                                    Background="#15EF4444" BorderBrush="#30EF4444" BorderThickness="1"
+                                    Background="{DynamicResource DangerBgSubtle}" BorderBrush="{DynamicResource DangerBorder}" BorderThickness="1"
                                     Cursor="Hand">
                                 <StackPanel Orientation="Horizontal">
-                                    <Ellipse x:Name="Dot" Width="6" Height="6" Fill="#EF4444" Margin="0,0,5,0"/>
+                                    <Ellipse x:Name="Dot" Width="6" Height="6" Fill="{DynamicResource Danger}" Margin="0,0,5,0"/>
                                     <ContentPresenter VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Border>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsChecked" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="#30EF4444"/>
-                                    <Setter TargetName="Bd" Property="BorderBrush" Value="#60EF4444"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource DangerBorder}"/>
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Danger}"/>
                                 </Trigger>
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter TargetName="Bd" Property="Background" Value="{DynamicResource AccentSoft}"/>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.28</Version>
-    <FileVersion>1.52.28.0</FileVersion>
-    <AssemblyVersion>1.52.28.0</AssemblyVersion>
+    <Version>1.52.29</Version>
+    <FileVersion>1.52.29.0</FileVersion>
+    <AssemblyVersion>1.52.29.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem

Two hardcoded-color spots in `App.xaml` that broke on the light presets:
1. **ToggleSwitch** — the "off" track was hardcoded `#374151` (dark slate). On the light themes every OFF toggle (Privacy toggles, feature switches, Ping targets, "Hide system", …) rendered as a near-black pill against the white cards.
2. **FilterChip** (Safe / Caution / Critical safety chips) — hardcoded translucent status hex (`#1522C55E` / `#15F59E0B` / `#15EF4444`) + text (`#4ADE80` / `#FBBF24` / `#F87171`).

## Fix

- ToggleSwitch off-track → `{DynamicResource TextMuted}` — recomputed per theme, so it's a soft muted track that reads on both themes and contrasts the white thumb. ON state already used `{DynamicResource Accent}`.
- FilterChips → the theme-aware `Success`/`Warning`/`Danger` `BgSubtle` / `Border` / `Text` brushes that `ThemeService` recomputes per preset (same family as the shipped status-brush fixes).

## Verification
- Built app: **0 errors, 0 warnings**.
- Verified **live on the light theme**: Privacy OFF toggles now render as a soft gray track (was near-black); Services safety filter chips + Safety-column badges are all legible. Dark themes unchanged (brushes restore their dark values).
