### PR TITLE
fix: Privacy Refresh reads registry off the UI thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.30] - 2026-07-04
+
+### Fixed
+- **Refreshing the Privacy & Telemetry tab no longer briefly freezes the window.** The "Refresh" button read every privacy registry key synchronously on the UI thread, so the app hitched while the toggles reloaded. The refresh now reads the registry on a background thread (matching how the tab loads initially) and updates the UI when done, keeping the window responsive.
+
 ## [1.52.29] - 2026-07-04
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.29</Version>
-    <FileVersion>1.52.29.0</FileVersion>
-    <AssemblyVersion>1.52.29.0</AssemblyVersion>
+    <Version>1.52.30</Version>
+    <FileVersion>1.52.30.0</FileVersion>
+    <AssemblyVersion>1.52.30.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/PrivacyViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PrivacyViewModel.cs
@@ -49,8 +49,6 @@ public sealed partial class PrivacyViewModel : ViewModelBase
         LoadToggles(loaded);
     }
 
-    private void LoadToggles() => LoadToggles(_service.LoadToggles());
-
     private void LoadToggles(List<PrivacyToggle> loaded)
     {
         // Unsubscribe from old toggles
@@ -171,9 +169,13 @@ public sealed partial class PrivacyViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void Refresh()
+    private async Task RefreshAsync()
     {
-        LoadToggles();
+        // Read the registry off the UI thread — the service reads every privacy key
+        // synchronously, which froze the UI when Refresh ran directly on the dispatcher.
+        // Mirrors the async initial load (LoadTogglesAsync).
+        var loaded = await Task.Run(_service.LoadToggles).ConfigureAwait(true);
+        LoadToggles(loaded);
         StatusMessage = "Toggles refreshed from registry.";
         Log.Information("Privacy: refreshed toggle states from registry");
     }


### PR DESCRIPTION
## Problem

The **Privacy & Telemetry** tab's "Refresh" button (`RefreshCommand`) called the synchronous `LoadToggles()` directly on the UI thread, which reads **every** privacy registry key synchronously — briefly freezing the window while the toggles reload.

The tab's **initial** load already does this correctly, off-thread: `LoadTogglesAsync()` → `await Task.Run(_service.LoadToggles).ConfigureAwait(true)`. Only Refresh regressed to the sync path.

## Fix

- `Refresh` is now `async Task RefreshAsync()` and reuses the same off-thread read (`await Task.Run(_service.LoadToggles)`), updating the UI on completion.
- Removed the now-unused synchronous `LoadToggles()` wrapper so the UI-thread-blocking path can't be reintroduced.
- `RefreshCommand` binding is unchanged — CommunityToolkit generates the same command name (it strips the `Async` suffix).

## Verification
- Built app **and** tests project: **0 errors, 0 warnings**.
- Matches the established async-load idiom already in the same VM; no behavior change beyond moving the registry read off the dispatcher.
