### PR TITLE
fix: add AutomationProperties.Name to action buttons (a11y)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.31] - 2026-07-04
+
+### Fixed
+- **Screen readers now announce a clear label for the action buttons on System Health, Network Repair and Windows Features.** Several buttons (Scan, Check memory errors, Run SMART check, chkdsk scan/cancel, Flush DNS, Reset Winsock, Reset TCP/IP, Run as administrator) had no accessibility name, so assistive tech only had the raw content to read. They now carry a descriptive `AutomationProperties.Name`, matching the pattern already used elsewhere in those views.
+
 ## [1.52.30] - 2026-07-04
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.30</Version>
-    <FileVersion>1.52.30.0</FileVersion>
-    <AssemblyVersion>1.52.30.0</AssemblyVersion>
+    <Version>1.52.31</Version>
+    <FileVersion>1.52.31.0</FileVersion>
+    <AssemblyVersion>1.52.31.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/NetworkRepairView.xaml
+++ b/SysManager/SysManager/Views/NetworkRepairView.xaml
@@ -20,6 +20,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        AutomationProperties.Name="Relaunch as administrator"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
@@ -72,6 +73,7 @@
                                        Text="When you visit a website, Windows caches its IP address. If the site moves or your DNS provider updates, the stale cache causes failures. This clears all cached lookups so fresh queries occur."/>
                         </StackPanel>
                         <Button Content="Flush DNS" Command="{Binding FlushDnsCommand}" Style="{StaticResource SecondaryButton}"
+                                AutomationProperties.Name="Flush DNS resolver cache"
                                 HorizontalAlignment="Right" DockPanel.Dock="Right" Padding="18,8"
                                 IsEnabled="{Binding IsRepairing, Converter={StaticResource BoolInvert}}"/>
                     </DockPanel>
@@ -98,6 +100,7 @@
                                        Text="Winsock is the low-level API all network applications use. Broken VPN drivers, malware, or corrupted LSP providers can break it. This resets the network catalog to factory defaults."/>
                         </StackPanel>
                         <Button Content="Reset Winsock" Command="{Binding ResetWinsockCommand}" Style="{StaticResource SecondaryButton}"
+                                AutomationProperties.Name="Reset Winsock catalog"
                                 HorizontalAlignment="Right" DockPanel.Dock="Right" Padding="18,8"
                                 IsEnabled="{Binding IsRepairing, Converter={StaticResource BoolInvert}}"/>
                     </DockPanel>
@@ -124,6 +127,7 @@
                                        Text="Completely rebuilds TCP/IP stack registry keys. Use only when other fixes fail — this resets all custom IP configurations, routes, and adapter settings to Windows defaults."/>
                         </StackPanel>
                         <Button Content="Reset TCP/IP" Command="{Binding ResetTcpIpCommand}" Style="{StaticResource SecondaryButton}"
+                                AutomationProperties.Name="Reset TCP/IP stack"
                                 HorizontalAlignment="Right" DockPanel.Dock="Right" Padding="18,8"
                                 IsEnabled="{Binding IsRepairing, Converter={StaticResource BoolInvert}}"/>
                     </DockPanel>

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -16,6 +16,7 @@
                                    Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
                     </StackPanel>
                     <Button Content="Scan" Command="{Binding ScanCommand}" Style="{StaticResource PrimaryButton}"
+                            AutomationProperties.Name="Scan system health"
                             HorizontalAlignment="Right" DockPanel.Dock="Right"/>
                 </DockPanel>
 
@@ -25,6 +26,7 @@
                         Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
                     <DockPanel>
                         <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                                AutomationProperties.Name="Relaunch as administrator"
                                 Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                             <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
@@ -104,8 +106,10 @@
                         </StackPanel>
                         <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
                             <Button Content="Check memory errors" Command="{Binding CheckMemoryErrorsCommand}"
+                                    AutomationProperties.Name="Check memory errors"
                                     Style="{StaticResource PrimaryButton}" Padding="14,8" Margin="0,0,8,0"/>
                             <Button Content="Run MemTest (reboot)" Command="{Binding ScheduleMemoryTestCommand}"
+                                    AutomationProperties.Name="Schedule a memory test on next reboot"
                                     Style="{StaticResource SecondaryButton}" Padding="14,8"/>
                         </StackPanel>
                     </Grid>
@@ -172,6 +176,7 @@
                         <DockPanel>
                             <TextBlock Text="Disk health (SMART)" Style="{StaticResource SectionTitle}"/>
                             <Button Content="Run SMART check" Command="{Binding CheckDiskHealthCommand}"
+                                    AutomationProperties.Name="Run SMART disk health check"
                                     Style="{StaticResource PrimaryButton}"
                                     HorizontalAlignment="Right" DockPanel.Dock="Right"/>
                         </DockPanel>
@@ -264,11 +269,14 @@
                             <TextBlock Text="File-system scan (chkdsk)" Style="{StaticResource SectionTitle}"/>
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Right">
                                 <Button Content="Refresh drives" Command="{Binding RefreshDrivesCommand}"
+                                        AutomationProperties.Name="Refresh drive list"
                                         Style="{StaticResource GhostButton}"/>
                                 <Button Content="Scan selected" Command="{Binding RunChkdskOnSelectedCommand}"
+                                        AutomationProperties.Name="Run chkdsk on selected drive"
                                         Style="{StaticResource PrimaryButton}" Margin="6,0,0,0"
                                         IsEnabled="{Binding IsChkdskRunning, Converter={StaticResource BoolInvert}}"/>
                                 <Button Content="Cancel" Command="{Binding CancelScanCommand}"
+                                        AutomationProperties.Name="Cancel disk scan"
                                         Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>
                             </StackPanel>
                         </DockPanel>
@@ -337,6 +345,7 @@
                                             <Button Grid.Column="3" Content="Scan"
                                                     Command="{Binding DataContext.RunChkdskCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                     CommandParameter="{Binding Letter}"
+                                                    AutomationProperties.Name="{Binding Letter, StringFormat='Run chkdsk on drive {0}'}"
                                                     Style="{StaticResource SecondaryButton}" Padding="12,6"
                                                     IsEnabled="{Binding DataContext.IsChkdskRunning, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource BoolInvert}}"/>
                                         </Grid>

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -57,6 +57,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        AutomationProperties.Name="Relaunch as administrator"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"


### PR DESCRIPTION
## Problem

Several action buttons across three views had no `AutomationProperties.Name`, so assistive tech only had the raw `Content` to announce (and some, like the per-drive "Scan", were ambiguous out of context):
- **System Health** — Scan, Check memory errors, Run MemTest, Run SMART check, Refresh drives, Scan selected, Cancel, per-drive chkdsk Scan, Run as administrator
- **Network Repair** — Flush DNS, Reset Winsock, Reset TCP/IP, Run as administrator
- **Windows Features** — Run as administrator

The same views already establish the pattern (e.g. the BIOS buttons on System Health carry `AutomationProperties.Name`), so this was an inconsistent a11y gap.

## Fix

Adds a descriptive `AutomationProperties.Name` to each (14 buttons), e.g. "Scan" → "Scan system health", the per-drive button → `"Run chkdsk on drive {0}"` bound to the drive letter.

## Verification
- Built app: **0 errors, 0 warnings**.
- Source-only accessibility metadata; no visual/behavior change.
