### PR TITLE
fix: System Logs severity cards + Env Variables tag theme-aware on Light

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.32] - 2026-07-04
+
+### Fixed
+- **System Logs severity cards and the "missing folder" tag stay legible on the Light themes.** The System Logs Critical/Errors/Warnings/Info cards used hardcoded translucent backgrounds, slate-gray labels and a fixed white card border; the Environment Variables "missing folder" tag used a fixed light-red. These now use the app's theme-aware brushes, so they render correctly on every theme. (The Critical card keeps its distinct brighter-red hue so it stays visually separable from Error, and the glow effects are unchanged.)
+
 ## [1.52.31] - 2026-07-04
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.31</Version>
-    <FileVersion>1.52.31.0</FileVersion>
-    <AssemblyVersion>1.52.31.0</AssemblyVersion>
+    <Version>1.52.32</Version>
+    <FileVersion>1.52.32.0</FileVersion>
+    <AssemblyVersion>1.52.32.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
+++ b/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
@@ -187,7 +187,7 @@
                                                 <TextBlock Text="{Binding Directory}" FontSize="12" TextWrapping="Wrap"
                                                            Foreground="{DynamicResource TextPrimary}"/>
                                                 <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
-                                                    <TextBlock Text="missing folder" FontSize="10" Foreground="#F87171" Margin="0,0,10,0"
+                                                    <TextBlock Text="missing folder" FontSize="10" Foreground="{DynamicResource DangerText}" Margin="0,0,10,0"
                                                                Visibility="{Binding IsMissing, Converter={StaticResource FlexVis}}"/>
                                                     <TextBlock Text="duplicate" FontSize="10" Foreground="{DynamicResource WarningStripe}"
                                                                Visibility="{Binding IsDuplicate, Converter={StaticResource FlexVis}}"/>

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -14,7 +14,7 @@
             <Setter Property="CornerRadius" Value="14"/>
             <Setter Property="Padding" Value="16,12"/>
             <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="BorderBrush" Value="#0FFFFFFF"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource Border1}"/>
         </Style>
     </UserControl.Resources>
 
@@ -59,7 +59,7 @@
                                    Foreground="{DynamicResource Danger}" VerticalAlignment="Center" Margin="10,0,0,0"/>
                         <!-- Bold + ▲ glyph distinguish Critical from Error without relying on hue
                              (both are reds — a colorblind-safe, non-color cue). -->
-                        <TextBlock FontSize="12" Foreground="#64748B" FontWeight="SemiBold"
+                        <TextBlock FontSize="12" Foreground="{DynamicResource TextMuted}" FontWeight="SemiBold"
                                    VerticalAlignment="Center" Margin="10,0,0,0">
                             <Run Text="&#x25B2; Critical"/>
                         </TextBlock>
@@ -67,20 +67,20 @@
                 </Grid>
             </Border>
             <!-- Errors -->
-            <Border Style="{StaticResource GlassCard}" Background="#14F87171" Margin="0,0,12,0"
+            <Border Style="{StaticResource GlassCard}" Background="{DynamicResource DangerBgSubtle}" Margin="0,0,12,0"
                     AutomationProperties.Name="{Binding ErrorCount, StringFormat='Errors: {0}'}">
                 <Grid>
-                    <Border Background="#F87171" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                    <Border Background="{DynamicResource Danger}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                             Margin="-16,-12,0,-12"/>
                     <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
-                        <Ellipse Style="{StaticResource SevDot}" Fill="#F87171">
+                        <Ellipse Style="{StaticResource SevDot}" Fill="{DynamicResource Danger}">
                             <Ellipse.Effect>
                                 <DropShadowEffect Color="#F87171" BlurRadius="8" ShadowDepth="0" Opacity="0.6"/>
                             </Ellipse.Effect>
                         </Ellipse>
                         <TextBlock Text="{Binding ErrorCount}" FontSize="20" FontWeight="Bold"
                                    Foreground="{DynamicResource Danger}" VerticalAlignment="Center" Margin="10,0,0,0"/>
-                        <TextBlock FontSize="12" Foreground="#64748B"
+                        <TextBlock FontSize="12" Foreground="{DynamicResource TextMuted}"
                                    VerticalAlignment="Center" Margin="10,0,0,0">
                             <Run Text="&#x25CF; Errors"/>
                         </TextBlock>
@@ -88,7 +88,7 @@
                 </Grid>
             </Border>
             <!-- Warnings -->
-            <Border Style="{StaticResource GlassCard}" Background="#14FBBF24" Margin="0,0,12,0"
+            <Border Style="{StaticResource GlassCard}" Background="{DynamicResource WarningBgSubtle}" Margin="0,0,12,0"
                     AutomationProperties.Name="{Binding WarningCount, StringFormat='Warnings: {0}'}">
                 <Grid>
                     <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
@@ -105,13 +105,13 @@
                         </Ellipse>
                         <TextBlock Text="{Binding WarningCount}" FontSize="20" FontWeight="Bold"
                                    Foreground="{DynamicResource Warning}" VerticalAlignment="Center" Margin="10,0,0,0"/>
-                        <TextBlock Text="Warnings" FontSize="12" Foreground="#64748B"
+                        <TextBlock Text="Warnings" FontSize="12" Foreground="{DynamicResource TextMuted}"
                                    VerticalAlignment="Center" Margin="10,0,0,0"/>
                     </StackPanel>
                 </Grid>
             </Border>
             <!-- Info -->
-            <Border Style="{StaticResource GlassCard}" Background="#1438BDF8"
+            <Border Style="{StaticResource GlassCard}" Background="{DynamicResource InfoBgSubtle}"
                     AutomationProperties.Name="{Binding InfoCount, StringFormat='Info events: {0}'}">
                 <Grid>
                     <Border Background="{DynamicResource Info}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
@@ -124,7 +124,7 @@
                         </Ellipse>
                         <TextBlock Text="{Binding InfoCount}" FontSize="20" FontWeight="Bold"
                                    Foreground="{DynamicResource Info}" VerticalAlignment="Center" Margin="10,0,0,0"/>
-                        <TextBlock Text="Info" FontSize="12" Foreground="#64748B"
+                        <TextBlock Text="Info" FontSize="12" Foreground="{DynamicResource TextMuted}"
                                    VerticalAlignment="Center" Margin="10,0,0,0"/>
                     </StackPanel>
                 </Grid>


### PR DESCRIPTION
## Problem

Two more hardcoded-color spots that broke on the light presets:
- **System Logs** — the Critical/Errors/Warnings/Info severity cards used hardcoded translucent backgrounds (`#14F87171` etc.), slate-gray labels (`#64748B`), a fixed translucent-white `GlassCard` border (`#0FFFFFFF`), and the Errors card stripe/dot (`#F87171`).
- **Environment Variables** — the "missing folder" tag used a fixed light-red (`#F87171`) while its neighbor "duplicate" already used a theme brush.

## Fix

Migrated to the theme-aware brushes: card backgrounds → `DangerBgSubtle`/`WarningBgSubtle`/`InfoBgSubtle`, labels → `TextMuted`, GlassCard border → `Border1`, Errors stripe/dot → `Danger`, "missing folder" → `DangerText`.

**Left intentionally unchanged:**
- The **Critical** card keeps its distinct brighter red (`#FF3B30`) — it's deliberately a different hue from Error for colorblind-safe separation (per the inline comment).
- The `DropShadowEffect Color=` literals — binding a `Brush` resource to a `Color` property throws at load (there's a comment documenting a past blank-tab incident from exactly that).

## Verification
- Built app: **0 errors, 0 warnings**.
- Verified **live on the light theme**: severity cards render with legible labels + soft theme-tinted backgrounds; Critical stays distinctly red.
