### PR TITLE
chore: use collection expressions for field/array initializers

### DIFF
--- a/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
@@ -64,12 +64,12 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
         foreach (var d in DriveInfo.GetDrives().Where(x => x.DriveType == DriveType.Fixed && x.IsReady))
             result.Add(d.RootDirectory.FullName);
 
-        var special = new[]
-        {
+        string[] special =
+        [
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
             Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
-        };
+        ];
         foreach (var p in special.Where(x => !string.IsNullOrEmpty(x) && Directory.Exists(x) && !result.Contains(x)))
             result.Add(p);
 

--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -20,7 +20,7 @@ namespace SysManager.ViewModels;
 public sealed partial class ServicesViewModel : ViewModelBase
 {
     private readonly PowerShellRunner _ps;
-    private List<ServiceEntry> _allServices = new();
+    private List<ServiceEntry> _allServices = [];
 
     public BulkObservableCollection<ServiceEntry> Services { get; } = new();
 

--- a/SysManager/SysManager/ViewModels/StartupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StartupViewModel.cs
@@ -19,7 +19,7 @@ namespace SysManager.ViewModels;
 public sealed partial class StartupViewModel : ViewModelBase
 {
     private readonly StartupService _service;
-    private readonly List<StartupEntry> _allEntries = new();
+    private readonly List<StartupEntry> _allEntries = [];
 
     public BulkObservableCollection<StartupEntry> Entries { get; } = new();
 


### PR DESCRIPTION
## What

Modernizes a few initializers to C# 12 **collection expressions**, per the project's .NET 10 modernization mandate ("collection expressions `[]` over `new List<>()`"):
- `ServicesViewModel._allServices` : `new()` → `[]`
- `StartupViewModel._allEntries` : `new()` → `[]`
- `DiskAnalyzerViewModel` "special folders" array literal : `new[]{ … }` → `[ … ]`

## Why chore (no release)

Behavior is **byte-identical** — collection expressions compile to the same construction. No version bump / CHANGELOG (chore: doesn't trigger a release).

## Scope discipline

Only the unambiguous field-initializer and array-literal cases were converted. Mutable local accumulators (`result` / `drifts` that are `.Add`'d in a loop) were **left as `new List<>()`** where that reads clearer — avoiding stylistic churn.

## Verification
- Built app **and** tests: **0 errors, 0 warnings**.
