### PR TITLE
fix: DataGrid text ellipsis (Boot Analyzer, Shortcut Cleaner) + uniform placeholder heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.33] - 2026-07-04
+
+### Fixed
+- **Long names in the Boot Analyzer and Shortcut Cleaner tables now truncate with an ellipsis.** Their free-text columns clipped long values hard at the column edge with no "…", unlike the other data tables in the app. Both now trim consistently. Also aligned the Work-in-Progress placeholder title to the app's shared "Display" heading style instead of a one-off inline font, so all headings stay uniform.
+
 ## [1.52.32] - 2026-07-04
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.32</Version>
-    <FileVersion>1.52.32.0</FileVersion>
-    <AssemblyVersion>1.52.32.0</AssemblyVersion>
+    <Version>1.52.33</Version>
+    <FileVersion>1.52.33.0</FileVersion>
+    <AssemblyVersion>1.52.33.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/BootAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/BootAnalyzerView.xaml
@@ -109,7 +109,13 @@
                               VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Kind" Binding="{Binding Kind}" Width="100"/>
-                            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
+                            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*" MinWidth="120">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
                             <DataGridTextColumn Header="Delay" Binding="{Binding DurationDisplay}" Width="80"/>
                         </DataGrid.Columns>
                     </DataGrid>

--- a/SysManager/SysManager/Views/PlaceholderView.xaml
+++ b/SysManager/SysManager/Views/PlaceholderView.xaml
@@ -11,9 +11,8 @@
                        HorizontalAlignment="Center" Margin="0,0,0,16"/>
 
             <!-- Feature name -->
-            <TextBlock Text="{Binding FeatureName}" FontSize="28" FontWeight="SemiBold"
-                       Foreground="{DynamicResource TextPrimary}" HorizontalAlignment="Center"
-                       TextWrapping="Wrap" TextAlignment="Center"/>
+            <TextBlock Text="{Binding FeatureName}" Style="{StaticResource Display}"
+                       HorizontalAlignment="Center" TextWrapping="Wrap" TextAlignment="Center"/>
 
             <!-- WIP badge -->
             <Border Background="{DynamicResource AccentSoft}" CornerRadius="4" Padding="12,6"

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml
@@ -108,9 +108,27 @@
                         </Style>
                     </DataGridCheckBoxColumn.EditingElementStyle>
                 </DataGridCheckBoxColumn>
-                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="200" MinWidth="100" IsReadOnly="True"/>
-                <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="150" MinWidth="80" IsReadOnly="True"/>
-                <DataGridTextColumn Header="Target (missing)" Binding="{Binding TargetPath}" Width="*" MinWidth="120" IsReadOnly="True"/>
+                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="200" MinWidth="100" IsReadOnly="True">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="150" MinWidth="80" IsReadOnly="True">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <DataGridTextColumn Header="Target (missing)" Binding="{Binding TargetPath}" Width="*" MinWidth="120" IsReadOnly="True">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
             </DataGrid.Columns>
         </DataGrid>
 


### PR DESCRIPTION
## Problem

- **Boot Analyzer** (Name column) and **Shortcut Cleaner** (Name / Location / Target columns) had no `TextTrimming`, so long values clipped hard at the column edge with no `…` — inconsistent with the app's other data tables (Services, Drivers, Task Scheduler, Uninstaller, …).
- The WIP **PlaceholderView** title duplicated the shared `Display` heading style inline (`FontSize=28` / `SemiBold` / `TextPrimary`) instead of referencing it.

## Fix

- Added the shared `CharacterEllipsis` `ElementStyle` to each free-text column (+ a `MinWidth` on Boot Analyzer's Name), matching the sibling idiom.
- Pointed the placeholder title at `{StaticResource Display}` (keeping its centering/wrapping) — single source of truth for the heading.

## Verification
- Built app: **0 errors, 0 warnings**.
- Verified **live**: the placeholder ("Gaming Profile") renders identically with the Display style — no regression on the placeholder view.
