### PR TITLE
chore: simplify boolean/ternary/LINQ per CodeQL quality notes

### DIFF
--- a/SysManager/SysManager/Services/CliRunner.cs
+++ b/SysManager/SysManager/Services/CliRunner.cs
@@ -50,11 +50,7 @@ public sealed class CliRunner
     /// to their own branches. Bare non-flag tokens never trigger CLI mode.</summary>
     public static bool IsCliInvocation(string[] args)
     {
-        foreach (var raw in args)
-        {
-            var a = raw.Trim();
-            if (NonCliSentinels.Contains(a)) return false;
-        }
+        if (args.Any(a => NonCliSentinels.Contains(a.Trim()))) return false;
         return args.Any(a => IsCliToken(a.Trim()));
     }
 

--- a/SysManager/SysManager/Services/SystemReportService.cs
+++ b/SysManager/SysManager/Services/SystemReportService.cs
@@ -68,21 +68,15 @@ public sealed class SystemReportService
     private static SystemReportData BuildData(SystemSnapshot snapshot, IReadOnlyList<DiskHealthReport> diskHealth)
     {
         // Prefer the richer SMART/health disks; fall back to the basic snapshot disks.
-        List<DiskReportInfo> disks;
-        if (diskHealth.Count > 0)
-        {
-            disks = diskHealth.Select(d => new DiskReportInfo(
+        List<DiskReportInfo> disks = diskHealth.Count > 0
+            ? diskHealth.Select(d => new DiskReportInfo(
                 d.FriendlyName, d.MediaType, d.BusType, d.SizeGB, d.HealthStatus,
                 string.IsNullOrWhiteSpace(d.Verdict) ? null : d.Verdict,
                 d.TemperatureC, d.WearPercent,
-                d.PowerOnHours.HasValue ? d.PowerOnDisplay : null)).ToList();
-        }
-        else
-        {
-            disks = snapshot.Disks.Select(d => new DiskReportInfo(
+                d.PowerOnHours.HasValue ? d.PowerOnDisplay : null)).ToList()
+            : snapshot.Disks.Select(d => new DiskReportInfo(
                 d.FriendlyName, d.MediaType, d.BusType, d.SizeGB, d.HealthStatus,
                 null, d.TemperatureC, d.WearPercent, null)).ToList();
-        }
 
         return new SystemReportData(
             GeneratedAt: DateTime.Now,

--- a/SysManager/SysManager/ViewModels/CpuAffinityViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CpuAffinityViewModel.cs
@@ -121,7 +121,7 @@ public sealed partial class CpuAffinityViewModel : ViewModelBase
     [RelayCommand]
     private void SelectPerformanceCores()
     {
-        foreach (var c in Cores) c.IsSelected = IsHybrid ? c.Core.IsPerformance : true;
+        foreach (var c in Cores) c.IsSelected = !IsHybrid || c.Core.IsPerformance;
         StatusMessage = IsHybrid ? "Selected P-cores." : "Selected all cores.";
     }
 


### PR DESCRIPTION
## What

Resolves 3 CodeQL note-level code-quality alerts with **behavior-identical** simplifications. No functional change.

| Alert | Rule | File | Change |
|---|---|---|---|
| #1693 | `cs/linq/missed-select` | `CliRunner.cs` | Sentinel `foreach` early-return → `args.Any(...)` |
| #1664 | `cs/missed-ternary-operator` | `SystemReportService.cs` | if/else disk-list assignment → ternary |
| #1688 | `cs/simplifiable-boolean-expression` | `CpuAffinityViewModel.cs` | `IsHybrid ? c.Core.IsPerformance : true` → `!IsHybrid \|\| c.Core.IsPerformance` |

## Why not the other open alerts

The remaining open alerts were reviewed and left intentionally:

- **`local-not-disposed` (FileShredderService, WARNING)** — false positive: the `FileStream` is disposed in the `finally` block via `DisposeAsync()`. CodeQL misses try-finally async disposal.
- **3× `linq/missed-select`** (GpuVramHelper, DnsService, HostsFileService) — false positives: those loops filter with multiple `continue`s and do conditional multi-target adds / early termination, not a clean map. A `.Select()` rewrite would obscure intent and change resource-cleanup ordering.
- **1× `missed-ternary`** (BootAnalyzerViewModel) — skipped: the rewrite would nest ternaries two-deep and hurt readability.
- **27× unmanaged-code / call-to-unmanaged-code** — by design for a privileged Windows utility (P/Invoke); informational only. 2 of these are in `obj/` generated `LibraryImports.g.cs`.

## Verification

- `dotnet build -c Release` (main project): **0 errors / 0 warnings**
- `dotnet build -c Release` (tests project): compiles clean
- Behavior pinned by existing tests: `CliRunnerTests` (elevation sentinel + update-applier arg cases), `CpuAffinityViewModelTests.SelectPerformanceCores_OnNonHybrid_SelectsAllCores`, `SystemReportServiceTests`.

`chore:` — no release, no version bump (matches the prior collection-expressions chore).
