### PR TITLE
fix: empty .sha256 body no longer crashes update verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.34] - 2026-07-04
+
+### Fixed
+- **A blank or malformed update checksum file no longer crashes the update check.** When verifying a downloaded update, SysManager reads the release's `.sha256` file; if that file came back empty or whitespace-only, parsing it threw an unhandled error instead of simply reporting the checksum as unverified. It now degrades cleanly to a verification failure (the update is treated as unverified rather than crashing), matching how a missing checksum file is already handled.
+
 ## [1.52.33] - 2026-07-04
 
 ### Fixed

--- a/SysManager/SysManager.Tests/UpdateServiceParseHashTests.cs
+++ b/SysManager/SysManager.Tests/UpdateServiceParseHashTests.cs
@@ -1,0 +1,48 @@
+// SysManager · UpdateServiceParseHashTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="UpdateService.ParseExpectedHash"/> — the pure parser that pulls the
+/// expected SHA-256 out of a downloaded <c>.sha256</c> file body. Regression guard: an empty or
+/// whitespace-only body must degrade to a verification failure (<c>null</c>), never throw. The
+/// pre-fix code did <c>Split(' ', RemoveEmptyEntries)[0]</c>, which indexed an empty array and
+/// threw <see cref="IndexOutOfRangeException"/> out of the update-integrity path.
+/// </summary>
+public class UpdateServiceParseHashTests
+{
+    private const string ValidHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    [Fact]
+    public void ParseExpectedHash_BareHash_Returned()
+        => Assert.Equal(ValidHash, UpdateService.ParseExpectedHash(ValidHash));
+
+    [Fact]
+    public void ParseExpectedHash_HashWithFilename_ReturnsHashOnly()
+        => Assert.Equal(ValidHash, UpdateService.ParseExpectedHash($"{ValidHash}  SysManager-v1.2.3.exe"));
+
+    [Fact]
+    public void ParseExpectedHash_SurroundingWhitespace_Trimmed()
+        => Assert.Equal(ValidHash, UpdateService.ParseExpectedHash($"  {ValidHash}  \r\n"));
+
+    // ── Regression: these previously threw IndexOutOfRangeException ──────────────
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\r\n")]
+    [InlineData("\t  \t")]
+    public void ParseExpectedHash_EmptyOrWhitespaceBody_ReturnsNull(string body)
+        => Assert.Null(UpdateService.ParseExpectedHash(body));
+
+    [Fact]
+    public void ParseExpectedHash_Null_ReturnsNull()
+        => Assert.Null(UpdateService.ParseExpectedHash(null));
+
+    [Fact]
+    public void ParseExpectedHash_TooShortToken_ReturnsNull()
+        => Assert.Null(UpdateService.ParseExpectedHash("deadbeef"));
+}

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -255,6 +255,21 @@ public sealed class UpdateService
     }
 
     /// <summary>
+    /// Extracts the expected SHA-256 from a <c>.sha256</c> file body, which is either
+    /// <c>"HASH  filename"</c> or a bare <c>"HASH"</c>. Returns the 64+ char hex token, or
+    /// <c>null</c> when the body is empty/whitespace or the first token isn't a plausible
+    /// hash — so a blank or malformed file becomes a verification failure, never a crash.
+    /// Pure so it can be unit-tested without the network.
+    /// </summary>
+    internal static string? ParseExpectedHash(string? hashText)
+    {
+        var expectedHash = hashText?.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()?.Trim();
+        if (string.IsNullOrWhiteSpace(expectedHash) || expectedHash.Length < 64)
+            return null;
+        return expectedHash;
+    }
+
+    /// <summary>
     /// Downloads the .sha256 file for a release and verifies the local file matches.
     /// Returns true if the hash matches, false if mismatch or if the .sha256 file
     /// is unavailable (verification is best-effort — network errors don't block install).
@@ -267,9 +282,8 @@ public sealed class UpdateService
             var sha256Url = $"https://github.com/{Owner}/{Repo}/releases/download/{rel.Tag}/SysManager-{rel.Tag}.exe.sha256";
             var hashText = await Http.GetStringAsync(sha256Url, ct).ConfigureAwait(false);
 
-            // .sha256 file format: "HASH  filename" or just "HASH"
-            var expectedHash = hashText.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries)[0].Trim();
-            if (string.IsNullOrWhiteSpace(expectedHash) || expectedHash.Length < 64)
+            var expectedHash = ParseExpectedHash(hashText);
+            if (expectedHash is null)
                 return (false, null, null);
 
             var actualHash = await Task.Run(() =>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.33</Version>
-    <FileVersion>1.52.33.0</FileVersion>
-    <AssemblyVersion>1.52.33.0</AssemblyVersion>
+    <Version>1.52.34</Version>
+    <FileVersion>1.52.34.0</FileVersion>
+    <AssemblyVersion>1.52.34.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## What

`UpdateService.VerifyHashAsync` parsed the downloaded `.sha256` file body with:

```csharp
var expectedHash = hashText.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries)[0].Trim();
```

When the body is **empty or whitespace-only**, `Split(RemoveEmptyEntries)` returns an empty array and `[0]` throws `IndexOutOfRangeException`. The `IsNullOrWhiteSpace` guard on the very next line was meant to catch this but ran too late. None of the three `catch` clauses (`HttpRequestException` / `OperationCanceledException` / `IOException`) handle it, so it propagated out of the update-integrity path.

## Fix

Extracted the parsing into a pure, unit-testable `internal static ParseExpectedHash(string?)` that returns `null` on an empty/malformed body (matching the existing seam idiom used by `ParseVersion` / `IsMainExeAsset`). Verification now degrades to a failure — the update is treated as **unverified**, exactly like a missing `.sha256` file already is — instead of crashing.

Behavior on valid input is unchanged (bare hash, `hash  filename`, surrounding whitespace all still parse correctly).

## Regression test

`UpdateServiceParseHashTests` pins:
- empty / whitespace / `\r\n` / tabs / `null` body → `null` (these threw `IndexOutOfRangeException` before the fix — RED confirmed via an isolated repro of the old expression)
- bare hash, `hash + filename`, surrounding-whitespace → correct 64-char hash
- too-short token → `null`

## Verification

- `dotnet build -c Release` (main + tests): **0 errors / 0 warnings**
- RED→GREEN: the old `Split(...)[0]` expression throws `IndexOutOfRangeException` on `""`; the new `ParseExpectedHash("")` returns `null`.

`fix:` → patch bump → v1.52.34.
