### PR TITLE
fix: don't double-release the update collection on failed download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.35] - 2026-07-04
+
+### Fixed
+- **Installing Windows updates no longer aborts the whole batch when one update fails to download.** In the install loop, a failed download released its update collection early and then `continue`d — but the loop's cleanup block always releases that same collection too, so it was released twice. The second release threw an error that stopped the entire install run on the first failed download. The redundant early release is removed; the collection is now released exactly once by the cleanup block, so the batch continues to the next update.
+
 ## [1.52.34] - 2026-07-04
 
 ### Fixed

--- a/SysManager/SysManager/Services/WindowsUpdateService.cs
+++ b/SysManager/SysManager/Services/WindowsUpdateService.cs
@@ -166,7 +166,10 @@ public sealed class WindowsUpdateService
                                 Emit($"  Download failed (code {dlCode}).");
                                 entry.Status = "Failed (download)";
                                 failed++;
-                                Marshal.FinalReleaseComObject(coll);
+                                // Do NOT release `coll` here: `continue` still runs the outer
+                                // finally, which releases it. Releasing it twice separates the
+                                // RCW and the finally's second call throws InvalidComObjectException,
+                                // aborting the whole install run on the first failed download.
                                 continue;
                             }
                         }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.34</Version>
-    <FileVersion>1.52.34.0</FileVersion>
-    <AssemblyVersion>1.52.34.0</AssemblyVersion>
+    <Version>1.52.35</Version>
+    <FileVersion>1.52.35.0</FileVersion>
+    <AssemblyVersion>1.52.35.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## What

In `WindowsUpdateService.InstallUpdatesAsync`, the per-update loop creates a COM update collection `coll` and wraps its use in a `try` whose `finally` always releases it:

```csharp
var coll = CreateUpdateCollection();
coll.Add(u);
try
{
    ...
    if (dlCode != 2)
    {
        ...
        Marshal.FinalReleaseComObject(coll);   // <-- redundant
        continue;
    }
    ...
}
finally
{
    Marshal.FinalReleaseComObject(coll);       // always runs, even after `continue`
}
```

A `continue` inside a `try` **does not skip the `finally`**. So on a failed download (`dlCode != 2`), `coll` was released at the explicit call, then released **again** by the `finally`. The second `FinalReleaseComObject` acts on an already-separated RCW and throws `InvalidComObjectException` — which is not a `COMException`, so it isn't caught by the loop's `catch` — aborting the entire install run on the first failed download.

## Fix

Removed the redundant explicit release. The `finally` releases `coll` exactly once, so a failed download now just `continue`s to the next update. Added a guard comment so the double-release isn't reintroduced. This matches the sibling downloader (lines ~150-162) and installer (lines ~187-209) patterns, which already rely solely on their `finally` blocks.

## Testing note (transparency)

This is a **live WUApiLib COM path** (`session.CreateUpdateDownloader()` / `CreateUpdateInstaller()` / real `IUpdateCollection`). It has no unit-test seam today — the same category the project already documents as not unit-tested (e.g. RestorePoint create/restore hit the OS). `WindowsUpdateServiceTests` covers only the pure helpers (`ClassifyCategory`, `FormatSize`). Adding an automated regression here would require a COM abstraction seam (a Gate-ARCH change), which is out of scope for a minimal correctness fix. The correctness is established by the C# language guarantee that `finally` runs on `continue`, and the redundant release is provably the only double-release of `coll`. **Follow-up candidate:** introduce an `IWindowsUpdateSession` seam so the install/download loop becomes testable with NSubstitute.

## Verification

- `dotnet build -c Release` (main): **0 errors / 0 warnings**
- `Marshal` is still used (21 remaining `FinalReleaseComObject` call sites) — no dead using.

`fix:` → patch bump → v1.52.35.
