### PR TITLE
fix: catch ExternalException on CLI Interface clipboard copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.36] - 2026-07-04
+
+### Fixed
+- **Copying a command from the CLI Interface tab no longer risks an unhandled error if the clipboard is briefly unavailable.** The copy handler only caught one specific clipboard failure type; a different (but related) clipboard error would have gone unhandled. It now catches the documented base error type — matching every other copy-to-clipboard action in the app — so a locked or unavailable clipboard always shows the friendly "try again" message instead.
+
 ## [1.52.35] - 2026-07-04
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.35</Version>
-    <FileVersion>1.52.35.0</FileVersion>
-    <AssemblyVersion>1.52.35.0</AssemblyVersion>
+    <Version>1.52.36</Version>
+    <FileVersion>1.52.36.0</FileVersion>
+    <AssemblyVersion>1.52.36.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/CliInterfaceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CliInterfaceViewModel.cs
@@ -50,9 +50,11 @@ public sealed partial class CliInterfaceViewModel : ViewModelBase
             Clipboard.SetText(text);
             StatusMessage = $"Copied: {text}";
         }
-        catch (System.Runtime.InteropServices.COMException)
+        catch (System.Runtime.InteropServices.ExternalException)
         {
             // The clipboard can be transiently locked by another process; report, don't crash.
+            // Clipboard.SetText throws ExternalException (COMException is only one subtype), so
+            // catch the base type to match the other clipboard-copy sites across the app.
             StatusMessage = "Could not access the clipboard — try again.";
         }
     }


### PR DESCRIPTION
## What

`CliInterfaceViewModel.TryCopy` wrapped `Clipboard.SetText` in a `catch (COMException)`. But `Clipboard.SetText` is documented to throw `ExternalException` — `COMException` is only one subtype of it. A non-COM `ExternalException` (e.g. a clipboard failure surfaced with a non-COM HRESULT) would go **unhandled** and crash the operation instead of showing the friendly "Could not access the clipboard — try again." message.

## Fix

Broaden the catch to `ExternalException`. This is a strict superset of `COMException`, so **no previously-handled case is lost** and no behavior changes on the success path — it only additionally handles the sibling failure types.

## Uniformity

This aligns the last outlier with the rest of the app. Of the 9 clipboard-copy sites, **8 already catch `ExternalException`**:

| Site | Caught |
|---|---|
| AboutViewModel:253 / :469 | `ExternalException` |
| ConsoleViewModel:58 | `ExternalException` |
| DeepCleanupViewModel:336 | `ExternalException` |
| DuplicateFileViewModel:185 | `ExternalException` |
| LogsViewModel:255 | `ExternalException` |
| SystemHealthViewModel:138 | `ExternalException` |
| SystemReportViewModel:117 | `ExternalException` |
| **CliInterfaceViewModel:50 (this PR)** | ~~`COMException`~~ → `ExternalException` |

## Testing note (transparency)

`TryCopy` calls the static WPF `Clipboard.SetText` on the STA thread — there's no injection seam, so it isn't unit-testable without a clipboard abstraction (out of scope for a one-line correctness fix). Correctness is established by the type hierarchy (`COMException : ExternalException`, so the catch strictly widens) and the documented throw type.

## Verification

- `dotnet build -c Release` (main + tests): **0 errors / 0 warnings**

`fix:` → patch bump → v1.52.36.

---

### Audit context (not in this PR)

This came out of a modernization/uniformity audit of the 60 ViewModels + 16 Helpers. Six other candidate findings were **refuted on codebase-wide counts** as half-migration churn rather than real uniformity wins, and deliberately not shipped:
- "align one IsBusy check to `is not`" — the codebase genuinely uses three interchangeable forms (`!=`, `==`, `is`); no dominant convention exists, so changing one makes uniformity worse.
- "add `ConfigureAwait(true)` to 2 awaits" — bare `await` is the dominant style in ViewModels (174 bare vs 55 `ConfigureAwait(true)`); `ConfigureAwait(true)` is a no-op under WPF's SynchronizationContext.
- "convert 3 `new()`/`new[]` to `[]`" — dozens of target-typed `new()` field initializers exist; converting an arbitrary 3 is churn, not consistency.
