### PR TITLE
fix: AdminButton legible on Light themes (theme-aware Warning brushes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.52.37] - 2026-07-04
+
+### Fixed
+- **The "Run as administrator" button is now legible on the Light themes.** Its golden-amber styling used fixed dark-theme colors (pale yellow text), so on a light preset the label washed out against the near-white button. It now uses the same theme-aware warning colors as the rest of the app, which switch to a dark amber on light themes — matching the elevation banners that were already fixed.
+
 ## [1.52.36] - 2026-07-04
 
 ### Fixed

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -486,32 +486,34 @@
                 </Setter>
             </Style>
 
-            <!-- Admin: golden glass button for elevation requests -->
+            <!-- Admin: golden glass button for elevation requests. Uses the theme-aware
+                 Warning* brushes (recomputed per preset by ThemeService) so the text stays
+                 legible on light presets — hardcoded amber (#FCD34D) washed out on white. -->
             <Style x:Key="AdminButton" TargetType="Button" BasedOn="{StaticResource ButtonBase}">
-                <Setter Property="Foreground" Value="#FCD34D"/>
+                <Setter Property="Foreground" Value="{DynamicResource WarningText}"/>
                 <Setter Property="Cursor" Value="Hand"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="Button">
                             <Border x:Name="Bd" CornerRadius="10" Padding="{TemplateBinding Padding}"
-                                    Background="#14FBBF24" BorderBrush="#30FBBF24" BorderThickness="1">
+                                    Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningStripe}" BorderThickness="1">
                                 <Grid>
-                                    <Border Background="#FBBF24" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                                    <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                                             Margin="-14,-8,0,-8" x:Name="Bar"/>
                                     <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
                                         <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
                                         <ContentPresenter Margin="8,0,0,0" VerticalAlignment="Center"
-                                                          TextBlock.Foreground="#FCD34D" TextBlock.FontWeight="SemiBold"/>
+                                                          TextBlock.Foreground="{DynamicResource WarningText}" TextBlock.FontWeight="SemiBold"/>
                                     </StackPanel>
                                 </Grid>
                             </Border>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="Bd" Property="BorderBrush" Value="#60FBBF24"/>
-                                    <Setter TargetName="Bd" Property="Background" Value="#20FBBF24"/>
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource WarningStripe}"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource WarningBg}"/>
                                 </Trigger>
                                 <Trigger Property="IsPressed" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="#28FBBF24"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource WarningBg}"/>
                                 </Trigger>
                                 <Trigger Property="IsEnabled" Value="False">
                                     <Setter Property="Opacity" Value="0.4"/>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.36</Version>
-    <FileVersion>1.52.36.0</FileVersion>
-    <AssemblyVersion>1.52.36.0</AssemblyVersion>
+    <Version>1.52.37</Version>
+    <FileVersion>1.52.37.0</FileVersion>
+    <AssemblyVersion>1.52.37.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## What

The `AdminButton` style in `App.xaml` (the "Run as administrator" button) hardcoded dark-theme amber colors:
- text `#FCD34D` (lines 491, 504)
- stripe `#FBBF24` (line 499)
- fills `#14FBBF24` / `#30FBBF24` (line 497) + hover/press variants

`ThemeService.ApplyStatusBrushes()` recomputes the `Warning*` brushes per preset — on light themes `WarningText` becomes `#92400E` (dark amber, WCAG AA on white). But `AdminButton` bypassed that by using literal hex, so on any light preset its pale-yellow label washed out against the near-white button surface (illegible).

This is the same bug class the theming waterfall fixed across the views; the `AdminButton` **style** was the last holdout.

## Fix

Swap the hardcoded hex to the theme-aware brushes:
- `Foreground` / ContentPresenter text → `{DynamicResource WarningText}`
- background → `{DynamicResource WarningBgSubtle}`
- stripe + border → `{DynamicResource WarningStripe}`
- hover/press fill → `{DynamicResource WarningBg}`

The **dark** brush values are byte-identical to the old hardcoded hex (`WarningText`=`#FCD34D`, `WarningStripe`=`#FBBF24`, `WarningBgSubtle`=`#1AFBBF24`), so dark themes render unchanged. Light now shows dark-amber, matching the elevation banners (ShortcutCleaner/Startup/etc.) already fixed in the waterfall.

## Testing

- Legibility is **already pinned** by the existing `ThemeStatusBrushTests`: it asserts `WarningText` ≥ 4.5:1 on both `#FFFFFF` (light) and the dark surface. AdminButton now consumes that exact tested brush, so no new test is required — the fix is "use the already-tested token instead of a hardcoded copy."
- `dotnet build -c Release`: **0 errors / 0 warnings**.

## Why the R3 visual audit missed it

The R3 dark+light screenshot pass ran with the capture session **elevated** (title bar shows "Administrator"), so every `AdminButton` banner was hidden via its `IsElevated`-inverse visibility. The button was never on screen, so only source analysis surfaced it. (Follow-up worth noting: a future UI-audit pass should capture at least one tab non-elevated to exercise the admin banners.)

`fix:` → patch bump → v1.52.37.
