### PR TITLE
chore: raise muted text to WCAG AA on all presets + contrast test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 - **Introduced a design-token foundation for the ongoing UI refresh.** Corner radii, spacing, and motion timings are now defined once as named tokens (a 4/8/12/16/999 radius scale, a 4px spacing rhythm, and 150/200/300 ms motion durations) and referenced by the shared control styles, instead of being hardcoded per style. This removes small inconsistencies that had crept in — cards, inputs, checkboxes and chips each used slightly different corner radii — so every surface now rounds on the same scale. The only visible effect is that cards round very slightly more (10 → 12 px) and inputs/checkboxes very slightly less (to 4 px). No behavior change.
 
+### Fixed
+- **Muted label text now meets WCAG AA contrast on every theme.** On six presets (Midnight Indigo, Deep Ocean, Violet Night, Clean Indigo, Sky Breeze, Mint Fresh) the muted/secondary label color sat just below the 4.5:1 accessibility bar against the lighter card surfaces (e.g. table column headers, captions) — a subtle legibility gap. The muted color on those presets is nudged a hair toward the primary text color so it clears AA on every layered surface, with a perceptual shift small enough to be invisible. A new automated contrast test now checks all twelve presets on every surface so this can't silently regress.
+
 ## [1.52.37] - 2026-07-04
 
 ### Fixed

--- a/SysManager/SysManager.Tests/ThemeTextContrastTests.cs
+++ b/SysManager/SysManager.Tests/ThemeTextContrastTests.cs
@@ -1,0 +1,87 @@
+// SysManager · ThemeTextContrastTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Media;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Contrast regression tests for the neutral TEXT ramp (TextMuted / TextSecondary) across every
+/// built-in preset. Companion to <see cref="ThemeStatusBrushTests"/>, which covers the semantic
+/// status brushes. The bug this pins: TextMuted was tuned by eye and, on six presets
+/// (midnight-indigo, deep-ocean, violet-night, clean-indigo, sky-breeze, mint-fresh), fell below
+/// WCAG AA (4.5:1) against the preset's lightest layered surface (Surface2 — the surface muted
+/// labels most commonly sit on, e.g. DataGrid column headers). These assertions FAIL against the
+/// old seeds and PASS after the fix. Every preset is checked so a future seed edit can't silently
+/// reintroduce a sub-AA muted value.
+/// </summary>
+public class ThemeTextContrastTests
+{
+    public static IEnumerable<object[]> AllPresets =>
+        ThemePreset.Defaults.Values.Select(p => new object[] { p.Id });
+
+    // TextMuted is body/label text — WCAG AA for normal text is 4.5:1. It must clear that against
+    // the WORST-CASE (lowest-contrast) layered surface it renders on. Surface3/Surface4 are derived
+    // by Lerp toward TextPrimary (higher contrast for muted, so not the worst case); the seeded
+    // Surface2 is the worst common case, so we assert against Background, Surface, and Surface2.
+    [Theory]
+    [MemberData(nameof(AllPresets))]
+    public void TextMuted_MeetsWcagAa_OnEveryLayeredSurface(string presetId)
+    {
+        var p = ThemePreset.Defaults[presetId];
+        foreach (var (label, surface) in new[]
+                 {
+                     ("Background", p.Background),
+                     ("Surface", p.Surface),
+                     ("Surface2", p.Surface2),
+                 })
+        {
+            var ratio = ContrastRatio(p.TextMuted, surface);
+            Assert.True(ratio >= 4.5,
+                $"Preset '{presetId}': TextMuted must meet WCAG AA (4.5:1) on {label}; got {ratio:F2}:1.");
+        }
+    }
+
+    // TextSecondary is the next tier up and should comfortably clear AA everywhere; assert it too so
+    // a future palette tweak can't quietly regress it below the muted tier.
+    [Theory]
+    [MemberData(nameof(AllPresets))]
+    public void TextSecondary_MeetsWcagAa_OnSurface2(string presetId)
+    {
+        var p = ThemePreset.Defaults[presetId];
+        var ratio = ContrastRatio(p.TextSecondary, p.Surface2);
+        Assert.True(ratio >= 4.5,
+            $"Preset '{presetId}': TextSecondary must meet WCAG AA (4.5:1) on Surface2; got {ratio:F2}:1.");
+    }
+
+    // TextPrimary is the highest tier — hold it to the stricter AAA bar (7:1) on the base background,
+    // matching the design brief's "don't go pure white — harsh, but must stay AAA" intent.
+    [Theory]
+    [MemberData(nameof(AllPresets))]
+    public void TextPrimary_MeetsWcagAaa_OnBackground(string presetId)
+    {
+        var p = ThemePreset.Defaults[presetId];
+        var ratio = ContrastRatio(p.TextPrimary, p.Background);
+        Assert.True(ratio >= 7.0,
+            $"Preset '{presetId}': TextPrimary must meet WCAG AAA (7:1) on Background; got {ratio:F2}:1.");
+    }
+
+    private static double ContrastRatio(Color a, Color b)
+    {
+        double la = RelLum(a), lb = RelLum(b);
+        var (hi, lo) = la >= lb ? (la, lb) : (lb, la);
+        return (hi + 0.05) / (lo + 0.05);
+    }
+
+    private static double RelLum(Color c)
+    {
+        static double Ch(byte v)
+        {
+            var s = v / 255.0;
+            return s <= 0.03928 ? s / 12.92 : Math.Pow((s + 0.055) / 1.055, 2.4);
+        }
+        return 0.2126 * Ch(c.R) + 0.7152 * Ch(c.G) + 0.0722 * Ch(c.B);
+    }
+}

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -54,7 +54,7 @@
             <!-- Text -->
             <SolidColorBrush x:Key="TextPrimary" Color="#F1F3F7"/>
             <SolidColorBrush x:Key="TextSecondary" Color="#A3ADBF"/>
-            <SolidColorBrush x:Key="TextMuted" Color="#6B7489"/>
+            <SolidColorBrush x:Key="TextMuted" Color="#7B8396"/>
             <SolidColorBrush x:Key="TextDisabled" Color="#4A5266"/>
 
             <!-- Accent (primary action) -->

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -316,10 +316,10 @@ public sealed record ThemePreset(
     {
         ["midnight-indigo"] = new("midnight-indigo", "Midnight Indigo", true,
             C("#6366F1"), C("#070A0F"), C("#0E1218"), C("#151A23"), C("#1F2633"),
-            C("#F1F3F7"), C("#A3ADBF"), C("#6B7489")),
+            C("#F1F3F7"), C("#A3ADBF"), C("#7B8396")), // muted: WCAG AA on Surface2 (was #6B7489, 3.72)
         ["deep-ocean"] = new("deep-ocean", "Deep Ocean", true,
             C("#3B82F6"), C("#050D1A"), C("#0A1628"), C("#0F1D33"), C("#1A2D4D"),
-            C("#E2E8F0"), C("#94A3B8"), C("#64748B")),
+            C("#E2E8F0"), C("#94A3B8"), C("#78879B")), // muted: WCAG AA on Surface2 (was #64748B, 3.55)
         ["dark-forest"] = new("dark-forest", "Dark Forest", true,
             C("#10B981"), C("#020F0A"), C("#021A12"), C("#03261A"), C("#0A3D2A"),
             C("#D1FAE5"), C("#6EE7B7"), C("#34D399")),
@@ -328,22 +328,22 @@ public sealed record ThemePreset(
             C("#FDF2F8"), C("#F9A8D4"), C("#F472B6")),
         ["violet-night"] = new("violet-night", "Violet Night", true,
             C("#A855F7"), C("#0A0515"), C("#0F0A1A"), C("#160F26"), C("#2D1B4E"),
-            C("#F3E8FF"), C("#C4B5FD"), C("#8B5CF6")),
+            C("#F3E8FF"), C("#C4B5FD"), C("#8E60F6")), // muted: WCAG AA on Surface2 (was #8B5CF6, 4.39)
         ["warm-ember"] = new("warm-ember", "Warm Ember", true,
             C("#F59E0B"), C("#0F0A04"), C("#1A1008"), C("#24180C"), C("#3D2A12"),
             C("#FEF3C7"), C("#FCD34D"), C("#FBBF24")),
         ["clean-indigo"] = new("clean-indigo", "Clean Indigo", false,
             C("#6366F1"), C("#FFFFFF"), C("#F8FAFC"), C("#F1F5F9"), C("#E2E8F0"),
-            C("#1E1B4B"), C("#4338CA"), C("#6366F1")),
+            C("#1E1B4B"), C("#4338CA"), C("#5D5FE2")), // muted: WCAG AA on Surface2 (was #6366F1, 4.08)
         ["sky-breeze"] = new("sky-breeze", "Sky Breeze", false,
             C("#0EA5E9"), C("#F8FAFC"), C("#F0F9FF"), C("#E0F2FE"), C("#BAE6FD"),
-            C("#0C4A6E"), C("#0369A1"), C("#0284C7")),
+            C("#0C4A6E"), C("#0369A1"), C("#0572AB")), // muted: WCAG AA on Surface2 (was #0284C7, 3.57)
         ["warm-sand"] = new("warm-sand", "Warm Sand", false,
             C("#D97706"), C("#FFFBEB"), C("#FEF3C7"), C("#FDE68A"), C("#FCD34D"),
             C("#451A03"), C("#78350F"), C("#92400E")),
         ["mint-fresh"] = new("mint-fresh", "Mint Fresh", false,
             C("#16A34A"), C("#F0FDF4"), C("#DCFCE7"), C("#BBF7D0"), C("#86EFAC"),
-            C("#14532D"), C("#166534"), C("#15803D")),
+            C("#14532D"), C("#166534"), C("#15783A")), // muted: WCAG AA on Surface2 (was #15803D, 4.14)
         ["soft-blossom"] = new("soft-blossom", "Soft Blossom", false,
             C("#DB2777"), C("#FDF2F8"), C("#FCE7F3"), C("#FBCFE8"), C("#F9A8D4"),
             C("#500724"), C("#831843"), C("#9D174D")),


### PR DESCRIPTION
## Summary

Fixes the audit's light-theme contrast blocker (and its dark-theme siblings): **muted label text was below WCAG AA on 6 of 12 presets**. `chore:` — beta track, no release; the whole UI refresh promotes to a stable release in one step at the end.

## The defect (measured, not eyeballed)

`TextMuted` was tuned by eye and fell under the 4.5:1 AA bar against the preset's lightest layered surface (Surface2 — where muted labels most often sit: DataGrid column headers, captions, meta text). Computed ratios on the real seeds:

| Preset | old muted | worst ratio (Surface2) |
|---|---|---|
| midnight-indigo | #6B7489 | 3.72 ❌ |
| deep-ocean | #64748B | 3.55 ❌ |
| violet-night | #8B5CF6 | 4.39 ❌ |
| clean-indigo | #6366F1 | 4.08 ❌ |
| sky-breeze | #0284C7 | 3.57 ❌ |
| mint-fresh | #15803D | 4.14 ❌ |

The other 6 presets already cleared AA and are untouched.

## The fix

Each failing `TextMuted` nudged minimally toward its TextPrimary until it clears **4.5:1 on Background, Surface, AND Surface2** — perceptual shift is tiny (ΔRGB 7–55, invisible). Changed in the `ThemePreset.Defaults` seeds (the runtime authority) + the App.xaml static default (midnight-indigo).

| Preset | new muted | Surface2 ratio |
|---|---|---|
| midnight-indigo | #7B8396 | 4.59 |
| deep-ocean | #78879B | 4.61 |
| violet-night | #8E60F6 | 4.56 |
| clean-indigo | #5D5FE2 | 4.56 |
| sky-breeze | #0572AB | 4.57 |
| mint-fresh | #15783A | 4.58 |

## Test (red→green proven)

New `ThemeTextContrastTests` asserts, across **all 12 presets**: TextMuted ≥ AA on Background/Surface/Surface2, TextSecondary ≥ AA on Surface2, TextPrimary ≥ AAA on Background. Companion to the existing `ThemeStatusBrushTests`.

- **Red ritual done:** reverting midnight-indigo to `#6B7489` makes the test fail for the right reason (`got 4.23:1 on Background`); restoring the fix makes it pass.
- **Full suite run locally: 3289 passed, 0 failed.** Build 0W/0E (main + tests).

## Verification
- `dotnet build -c Release` main + tests → 0 warnings, 0 errors
- Full `dotnet test` locally → 3289/3289 pass
- Diff leak-scanned clean; identity laurentiu021
