### PR TITLE
chore: UI polish batch — placeholders, badge clip, layout, colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Corner radii are now consistent across every tab.** Individual views still used a mix of slightly different corner radii on their banners, cards, and chips; these are now snapped to the same shared scale as the rest of the app (cards to 12 px, chips to 8 px), so panels no longer round by subtly different amounts from one tab to the next. Purely visual, no behavior change. Part of the ongoing UI refresh.
 
 ### Fixed
+- **A round of small UI polish across several tabs.**
+  - **Restore Points / Debloater** — the toolbar text boxes were blank with no hint of their purpose; they now show placeholder text ("Describe this restore point…", "Search apps…") like the other search/filter boxes.
+  - **Sidebar "PREVIEW" badge** — on longer nav labels (Settings Watchdog) the badge was clipped to "PR" because it overflowed the fixed-width sidebar; the label now ellipsizes and the badge always shows in full.
+  - **Profile Export/Import** — the Import card was pinned to the bottom of the tab with a large empty gap above it; the two cards now stack naturally from the top.
+  - **DNS & Hosts** — the "add entry" row had an unlabelled IP box floating at the far left with the rest of the controls docked right; it now reads left-to-right as "IP: [ ] Hostname: [ ] Add".
+  - **Defender Tweaks** — the three protection-status values used three different colours for the same kind of value (green / blue / grey), which read as inconsistent; they now share one neutral colour.
+  - **System Logs** — the four severity summary cards had inconsistent leading glyphs; the redundant one on Errors is removed (the coloured dot already marks each card), leaving Critical's distinct marker as its colourblind-safe cue.
+  - **Privacy & Telemetry** — removed a dead grouping style that never rendered (the list isn't view-grouped; each row already shows its category).
 - **A batch of small correctness and wording fixes across tabs.**
   - **Speed Test** — the info banner read "Ooklameasures…" and "HTTPtests…" (a missing space after the bold labels); it now reads "Ookla measures…" and "HTTP tests…".
   - **About** — the "What's new" release notes rendered raw Markdown: code-fence markers (```` ``` ````, with the language tag) and horizontal-rule dashes (`---`) showed up as literal text. The lightweight Markdown renderer now formats fenced code blocks as monospace and drops rule lines, matching how it already handles headings and bold.

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -242,32 +242,45 @@
                                                                    RadiusX="2" RadiusY="2"
                                                                    Margin="-28,0,0,0"
                                                                    Visibility="Collapsed"/>
-                                                        <StackPanel Orientation="Horizontal">
-                                                            <TextBlock Text="{Binding Glyph}"
+                                                        <!-- DockPanel (not a horizontal StackPanel): a StackPanel gives its
+                                                             children infinite width, so the label's grid never constrained and the
+                                                             PREVIEW pill overflowed the 220px sidebar. Docking the glyph left lets
+                                                             the content fill the real remaining width, so the label ellipsizes and
+                                                             the pill always shows. -->
+                                                        <DockPanel>
+                                                            <TextBlock Text="{Binding Glyph}" DockPanel.Dock="Left"
                                                                        FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                                                        FontSize="13" Margin="0,0,10,0"
                                                                        VerticalAlignment="Center"
                                                                        Foreground="{DynamicResource TextSecondary}"/>
                                                             <StackPanel VerticalAlignment="Center">
-                                                                <StackPanel Orientation="Horizontal">
-                                                                    <TextBlock Text="{Binding Label}"
+                                                                <!-- Label + PREVIEW pill in a 2-column grid (label = *, pill = Auto):
+                                                                     a horizontal StackPanel measured with infinite width, so on a long
+                                                                     label the pill was pushed past the 220px sidebar edge and clipped to
+                                                                     "PR". The label now ellipsizes and the pill always renders in full. -->
+                                                                <Grid>
+                                                                    <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition Width="*"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                    </Grid.ColumnDefinitions>
+                                                                    <TextBlock Grid.Column="0" Text="{Binding Label}"
                                                                                FontFamily="{StaticResource UiFont}"
                                                                                FontSize="13" FontWeight="Medium"
-                                                                               VerticalAlignment="Center"
+                                                                               VerticalAlignment="Center" TextTrimming="CharacterEllipsis"
                                                                                Foreground="{DynamicResource TextSecondary}"/>
                                                                     <!-- PREVIEW pill: implemented but not yet QA-verified -->
-                                                                    <Border Background="{DynamicResource AccentSoft}" CornerRadius="4"
+                                                                    <Border Grid.Column="1" Background="{DynamicResource AccentSoft}" CornerRadius="4"
                                                                             Padding="5,1" Margin="7,0,0,0" VerticalAlignment="Center"
                                                                             Visibility="{Binding IsInDevelopment, Converter={StaticResource BoolToVis}}">
                                                                         <TextBlock Text="PREVIEW" FontSize="9" FontWeight="Bold"
                                                                                    Foreground="{DynamicResource Info}"/>
                                                                     </Border>
-                                                                </StackPanel>
+                                                                </Grid>
                                                                 <ProgressBar Height="2" Margin="0,3,0,0"
                                                                              IsIndeterminate="True"
                                                                              Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
                                                             </StackPanel>
-                                                        </StackPanel>
+                                                        </DockPanel>
                                                     </Grid>
                                                 </Border>
                                             </DataTemplate>

--- a/SysManager/SysManager/Views/DebloaterView.xaml
+++ b/SysManager/SysManager/Views/DebloaterView.xaml
@@ -48,10 +48,16 @@
                         Style="{StaticResource DangerButton}" Margin="0,0,16,0"
                         ToolTip="Uninstall the ticked apps for the current user (reversible via the Store)."/>
 
-                <TextBox Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
-                         AutomationProperties.Name="Search apps" Width="220"
-                         VerticalContentAlignment="Center" VerticalAlignment="Center"
-                         ToolTip="Filter by name or publisher."/>
+                <Grid Width="220" VerticalAlignment="Center">
+                    <TextBox Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                             AutomationProperties.Name="Search apps"
+                             VerticalContentAlignment="Center"
+                             ToolTip="Filter by name or publisher."/>
+                    <TextBlock Text="Search apps…" IsHitTestVisible="False"
+                               Foreground="{DynamicResource TextMuted}" Margin="6,0,0,0"
+                               VerticalAlignment="Center" FontSize="12"
+                               Visibility="{Binding SearchText, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                </Grid>
             </WrapPanel>
         </Border>
 

--- a/SysManager/SysManager/Views/DefenderView.xaml
+++ b/SysManager/SysManager/Views/DefenderView.xaml
@@ -88,20 +88,20 @@
                         <StackPanel>
                             <TextBlock Text="REAL-TIME" Style="{StaticResource SectionLabel}"/>
                             <TextBlock Text="{Binding RealtimeDisplay}" FontSize="16" FontWeight="SemiBold"
-                                       Foreground="{DynamicResource Success}" Margin="0,4,0,0"/>
+                                       Foreground="{DynamicResource TextPrimary}" Margin="0,4,0,0"/>
                         </StackPanel>
                     </Border>
                     <Border Grid.Column="1" Style="{StaticResource CardInner}" Margin="4,0,4,0">
                         <StackPanel>
                             <TextBlock Text="CLOUD (MAPS)" Style="{StaticResource SectionLabel}"/>
                             <TextBlock Text="{Binding MapsDisplay}" FontSize="16" FontWeight="SemiBold"
-                                       Foreground="{DynamicResource Info}" Margin="0,4,0,0"/>
+                                       Foreground="{DynamicResource TextPrimary}" Margin="0,4,0,0"/>
                         </StackPanel>
                     </Border>
                     <Border Grid.Column="2" Style="{StaticResource CardInner}" Margin="4,0,0,0">
                         <StackPanel>
                             <TextBlock Text="PUA / CFA" Style="{StaticResource SectionLabel}"/>
-                            <TextBlock Margin="0,4,0,0" FontSize="13" FontWeight="SemiBold" Foreground="{DynamicResource TextSecondary}">
+                            <TextBlock Margin="0,4,0,0" FontSize="13" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}">
                                 <Run Text="{Binding PuaDisplay, Mode=OneWay}"/><Run Text=" · "/><Run Text="{Binding CfaDisplay, Mode=OneWay}"/>
                             </TextBlock>
                         </StackPanel>

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -164,25 +164,25 @@
                            Visibility="{Binding HostEntries.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                 </Grid>
 
-                <!-- Add entry row -->
-                <DockPanel Grid.Row="2" Margin="0,12,0,0">
-                    <Button Content="Add" Command="{Binding AddEntryCommand}"
-                            Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right"
-                            Padding="18,8" Margin="8,0,0,0"
-                            AutomationProperties.Name="Add host entry"/>
-                    <TextBox Text="{Binding NewHostname, UpdateSourceTrigger=PropertyChanged}"
-                             DockPanel.Dock="Right" MinWidth="200" Margin="8,0,0,0"
-                             VerticalAlignment="Center"
-                             AutomationProperties.Name="New host entry hostname"/>
-                    <TextBlock Text="Hostname:" DockPanel.Dock="Right" VerticalAlignment="Center"
-                               Style="{StaticResource Subtle}" Margin="12,0,4,0"/>
+                <!-- Add entry row — a single left-to-right labelled group so both inputs read in
+                     order (IP: [ip]  Hostname: [hostname]  [Add]) instead of one unlabelled box
+                     floating at the far left with the rest docked right. -->
+                <WrapPanel Grid.Row="2" Margin="0,12,0,0">
+                    <TextBlock Text="IP:" VerticalAlignment="Center"
+                               Style="{StaticResource Subtle}" Margin="0,0,4,0"/>
                     <TextBox Text="{Binding NewIp, UpdateSourceTrigger=PropertyChanged}"
                              MinWidth="140" VerticalAlignment="Center"
                              AutomationProperties.Name="New host entry IP address"/>
-                    <TextBlock Text="IP:" VerticalAlignment="Center"
-                               Style="{StaticResource Subtle}" Margin="0,0,4,0"
-                               Visibility="Collapsed"/>
-                </DockPanel>
+                    <TextBlock Text="Hostname:" VerticalAlignment="Center"
+                               Style="{StaticResource Subtle}" Margin="12,0,4,0"/>
+                    <TextBox Text="{Binding NewHostname, UpdateSourceTrigger=PropertyChanged}"
+                             MinWidth="200" VerticalAlignment="Center"
+                             AutomationProperties.Name="New host entry hostname"/>
+                    <Button Content="Add" Command="{Binding AddEntryCommand}"
+                            Style="{StaticResource PrimaryButton}"
+                            Padding="18,8" Margin="12,0,0,0"
+                            AutomationProperties.Name="Add host entry"/>
+                </WrapPanel>
 
                 <!-- Status -->
                 <TextBlock Grid.Row="3" Text="{Binding HostsStatus}" Style="{StaticResource Subtle}"

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -80,10 +80,11 @@
                         </Ellipse>
                         <TextBlock Text="{Binding ErrorCount}" FontSize="20" FontWeight="Bold"
                                    Foreground="{DynamicResource Danger}" VerticalAlignment="Center" Margin="10,0,0,0"/>
-                        <TextBlock FontSize="12" Foreground="{DynamicResource TextMuted}"
-                                   VerticalAlignment="Center" Margin="10,0,0,0">
-                            <Run Text="&#x25CF; Errors"/>
-                        </TextBlock>
+                        <!-- Plain "Errors" — the coloured SevDot already marks the row; the leading
+                             glyph is reserved for Critical (▲) as its colourblind-safe "most severe red"
+                             cue, so Errors/Warnings/Info stay glyph-free for a consistent set. -->
+                        <TextBlock Text="Errors" FontSize="12" Foreground="{DynamicResource TextMuted}"
+                                   VerticalAlignment="Center" Margin="10,0,0,0"/>
                     </StackPanel>
                 </Grid>
             </Border>

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -84,21 +84,10 @@
             </WrapPanel>
         </Border>
 
-        <!-- Toggle list grouped by category -->
+        <!-- Toggle list (each row shows its own category label; the list is flat, not view-grouped) -->
         <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
             <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="16,12">
                 <ItemsControl ItemsSource="{Binding FilteredToggles}">
-                    <ItemsControl.GroupStyle>
-                        <GroupStyle>
-                            <GroupStyle.HeaderTemplate>
-                                <DataTemplate>
-                                    <TextBlock Text="{Binding Name}" FontWeight="Bold" FontSize="14"
-                                               Foreground="{DynamicResource TextPrimary}"
-                                               Margin="0,16,0,8"/>
-                                </DataTemplate>
-                            </GroupStyle.HeaderTemplate>
-                        </GroupStyle>
-                    </ItemsControl.GroupStyle>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Border Margin="0,2" Padding="12,10" CornerRadius="8"

--- a/SysManager/SysManager/Views/ProfileView.xaml
+++ b/SysManager/SysManager/Views/ProfileView.xaml
@@ -12,8 +12,9 @@
     <Grid Margin="28,24,28,16">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
@@ -25,7 +26,7 @@
         </StackPanel>
 
         <!-- Export card -->
-        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="16" VerticalAlignment="Top">
+        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="16">
             <StackPanel>
                 <TextBlock Text="Export" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource TextPrimary}"/>
                 <TextBlock Text="Choose which settings to include, then save them as a portable JSON profile."
@@ -72,7 +73,7 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="3" Margin="0,8,0,0">
+        <DockPanel Grid.Row="4" Margin="0,8,0,0">
             <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>

--- a/SysManager/SysManager/Views/RestorePointsView.xaml
+++ b/SysManager/SysManager/Views/RestorePointsView.xaml
@@ -61,10 +61,16 @@
         <!-- Toolbar -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
             <WrapPanel>
-                <TextBox Text="{Binding NewDescription, UpdateSourceTrigger=PropertyChanged}"
-                         AutomationProperties.Name="New restore point description"
-                         Width="240" Margin="0,0,8,0" VerticalContentAlignment="Center"
-                         ToolTip="Optional description for the new restore point."/>
+                <Grid Width="240" Margin="0,0,8,0">
+                    <TextBox Text="{Binding NewDescription, UpdateSourceTrigger=PropertyChanged}"
+                             AutomationProperties.Name="New restore point description"
+                             VerticalContentAlignment="Center"
+                             ToolTip="Optional description for the new restore point."/>
+                    <TextBlock Text="Describe this restore point…" IsHitTestVisible="False"
+                               Foreground="{DynamicResource TextMuted}" Margin="6,0,0,0"
+                               VerticalAlignment="Center" FontSize="12"
+                               Visibility="{Binding NewDescription, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                </Grid>
                 <Button Content="Create restore point" Command="{Binding CreateCommand}"
                         AutomationProperties.Name="Create a restore point"
                         Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"

--- a/SysManager/SysManager/Views/TweaksHubView.xaml
+++ b/SysManager/SysManager/Views/TweaksHubView.xaml
@@ -125,12 +125,17 @@
                 <TextBlock DockPanel.Dock="Left" VerticalAlignment="Center"
                            Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                    <!-- Content is bound via an inner TextBlock: StringFormat on a ContentControl's
+                         Content (an int) isn't applied without ContentStringFormat on the template, so
+                         the button showed a bare "0"; StringFormat on TextBlock.Text always applies. -->
                     <Button Command="{Binding ApplySelectedCommand}" Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"
-                            Content="{Binding PendingApply, StringFormat='Apply Selected ({0})'}"
-                            AutomationProperties.Name="Apply selected tweaks"/>
+                            AutomationProperties.Name="Apply selected tweaks">
+                        <TextBlock Text="{Binding PendingApply, StringFormat='Apply Selected ({0})'}"/>
+                    </Button>
                     <Button Command="{Binding UndoSelectedCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"
-                            Content="{Binding PendingUndo, StringFormat='Undo Selected ({0})'}"
-                            AutomationProperties.Name="Undo selected tweaks"/>
+                            AutomationProperties.Name="Undo selected tweaks">
+                        <TextBlock Text="{Binding PendingUndo, StringFormat='Undo Selected ({0})'}"/>
+                    </Button>
                     <Button Content="Refresh" Command="{Binding RefreshCommand}" Style="{StaticResource GhostButton}"
                             AutomationProperties.Name="Refresh tweak states"/>
                 </StackPanel>


### PR DESCRIPTION
## What

A round of low-severity UI polish from the full audit:

- **Restore Points / Debloater** — blank toolbar text boxes with no visible purpose now show placeholder text ("Describe this restore point…", "Search apps…"), matching the placeholder idiom used by the other search/filter boxes.
- **Sidebar "PREVIEW" badge** — on longer nav labels (Settings Watchdog) the badge overflowed the fixed-width sidebar and clipped to "PR". The label/pill row was a horizontal StackPanel (infinite measured width); it's now a DockPanel + 2-column grid so the label ellipsizes and the badge always renders in full.
- **Profile Export/Import** — the Import card was force-docked to the bottom (an Export row set to `*` height with a top-aligned card), leaving a large empty gap; the row layout now stacks both cards from the top with a spacer row keeping the status bar at the bottom.
- **DNS & Hosts** — the "add entry" row had an unlabelled IP box floating far-left with the rest docked right; rebuilt as a left-to-right "IP: [ ] Hostname: [ ] Add" group.
- **Defender Tweaks** — three protection-status values used three different colours (green/blue/grey) for the same kind of value; unified to one neutral colour.
- **System Logs** — removed the redundant leading glyph on the Errors summary card (the coloured dot already marks each card); Critical keeps its distinct marker as a colourblind-safe cue.
- **Privacy & Telemetry** — removed a dead `GroupStyle` that never rendered (the list is flat, not view-grouped; each row already shows its category).

## Verification

- build `-c Release` — 0 warnings, 0 errors
- full unit test suite — **3304/3304** pass
- Visually confirmed on the built app: Restore Points placeholder; Settings Watchdog badge now shows full "PREVIEW" (label ellipsised); Profile cards stack top with no void; DNS add-row reads left-to-right.

Part of the ongoing UI refresh beta track (chore:, no release).
