### PR TITLE
fix: harden context-menu casing, resource-history writes, and standby auto-refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.39] - 2026-07-07
+
+### Fixed
+- **Context-menu entry names capitalize correctly on Turkish Windows.** The first letter of a cleaned-up context-menu entry name was upper-cased using the current culture, so on a Turkish (tr-TR) system a leading "i" became "İ" (dotted capital I) rather than "I", subtly corrupting names. It now upper-cases invariantly, since these are program and shell-verb identifiers rather than locale-sensitive prose.
+- **The resource-history file is now rewritten atomically.** When trimming samples past the retention window, the usage-history file was rewritten in place with a single full-file write; a crash or power loss mid-write could leave it truncated or corrupt. It is now written to a temporary file and swapped in atomically, so an interrupted prune can never damage the existing history.
+- **The Standby List Cleaner's background auto-refresh can no longer crash the app.** Its two-second timer tick ran without a top-level guard, so an unexpected fault while reading memory status or auto-purging would surface as an unhandled background exception and take the whole app down. The tick now catches and logs any such fault, matching the guard the tray-icon timer already uses.
+
 ## [1.52.38] - 2026-07-07
 
 ### Fixed

--- a/SysManager/SysManager.Tests/ContextMenuServiceTests.cs
+++ b/SysManager/SysManager.Tests/ContextMenuServiceTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using SysManager.Services;
 
 namespace SysManager.Tests;
@@ -30,5 +31,23 @@ public class ContextMenuServiceTests
     {
         Assert.Equal("", ContextMenuService.StripMnemonic(""));
         Assert.Null(ContextMenuService.StripMnemonic(null!));
+    }
+
+    [Fact]
+    public void SplitCamelCase_CapitalizesInvariantly_OnTurkishCulture()
+    {
+        // Regression: char.ToUpper on the first letter is culture-sensitive — under tr-TR it
+        // maps 'i' → 'İ' (dotted capital I), corrupting entry names. ToUpperInvariant keeps
+        // shell-verb / app identifiers ASCII-cased regardless of the user's locale.
+        var prev = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+        try
+        {
+            Assert.Equal("Iexplore", ContextMenuService.SplitCamelCase("iexplore"));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = prev;
+        }
     }
 }

--- a/SysManager/SysManager/Services/ContextMenuService.cs
+++ b/SysManager/SysManager/Services/ContextMenuService.cs
@@ -641,7 +641,7 @@ public sealed partial class ContextMenuService
     /// <summary>
     /// Splits a CamelCase or PascalCase string into separate words.
     /// </summary>
-    private static string SplitCamelCase(string input)
+    internal static string SplitCamelCase(string input)
     {
         if (string.IsNullOrWhiteSpace(input)) return input;
 
@@ -660,9 +660,11 @@ public sealed partial class ContextMenuService
         result = ConsecutiveUpperPattern().Replace(result, " $1");
         result = MultiSpacePattern().Replace(result, " ").Trim();
 
-        // Capitalize first letter
+        // Capitalize first letter. Invariant on purpose: these are shell-verb / app
+        // identifiers, not locale-sensitive prose — char.ToUpper maps 'i'→'İ' on tr-TR
+        // and would corrupt entry names for Turkish users.
         if (result.Length > 0)
-            result = char.ToUpper(result[0]) + result[1..];
+            result = char.ToUpperInvariant(result[0]) + result[1..];
 
         return result;
     }

--- a/SysManager/SysManager/Services/ResourceHistoryService.cs
+++ b/SysManager/SysManager/Services/ResourceHistoryService.cs
@@ -233,7 +233,12 @@ public sealed class ResourceHistoryService : IDisposable
             var kept = Prune(lines, DateTime.Now, TimeSpan.FromDays(_retentionDays));
             // Only rewrite when something actually changed, to avoid needless disk churn.
             if (kept.Count == lines.Length) return;
-            await File.WriteAllLinesAsync(DataPath, kept, ct).ConfigureAwait(false);
+            // Atomic rewrite: write to a temp file in the same directory, then swap it in
+            // with a single File.Move. A crash mid-write can then only leave a stray .tmp
+            // (never read — the sampler reads DataPath), never a truncated history file.
+            var tmp = DataPath + ".tmp";
+            await File.WriteAllLinesAsync(tmp, kept, ct).ConfigureAwait(false);
+            File.Move(tmp, DataPath, overwrite: true);
         }
         catch (OperationCanceledException) { /* shutdown */ }
         catch (IOException ex) { Log.Debug("Resource history prune failed: {Error}", ex.Message); }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.38</Version>
-    <FileVersion>1.52.38.0</FileVersion>
-    <AssemblyVersion>1.52.38.0</AssemblyVersion>
+    <Version>1.52.39</Version>
+    <FileVersion>1.52.39.0</FileVersion>
+    <AssemblyVersion>1.52.39.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/StandbyMemoryViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StandbyMemoryViewModel.cs
@@ -67,29 +67,40 @@ public sealed partial class StandbyMemoryViewModel : ViewModelBase
 
     private async void Tick()
     {
-        var status = _service.GetMemoryStatus();
-        TotalDisplay = status.TotalDisplay;
-        AvailableDisplay = status.AvailableDisplay;
-        LoadDisplay = status.LoadDisplay;
-
-        // Auto-purge off the UI thread (same reason as PurgeAsync). _autoPurgeInFlight
-        // guards against the 2s timer stacking a second purge on top of one still running.
-        if (AutoPurgeEnabled && IsElevated && !_autoPurgeInFlight
-            && ShouldAutoPurge(status.AvailableMb, ThresholdMb))
+        try
         {
-            _autoPurgeInFlight = true;
-            try
+            var status = _service.GetMemoryStatus();
+            TotalDisplay = status.TotalDisplay;
+            AvailableDisplay = status.AvailableDisplay;
+            LoadDisplay = status.LoadDisplay;
+
+            // Auto-purge off the UI thread (same reason as PurgeAsync). _autoPurgeInFlight
+            // guards against the 2s timer stacking a second purge on top of one still running.
+            if (AutoPurgeEnabled && IsElevated && !_autoPurgeInFlight
+                && ShouldAutoPurge(status.AvailableMb, ThresholdMb))
             {
-                var avail = status.AvailableMb;
-                var purged = await Task.Run(() => _service.TryPurgeStandbyList(out _)).ConfigureAwait(true);
-                if (purged)
+                _autoPurgeInFlight = true;
+                try
                 {
-                    Log.Information("Auto-purged standby list (available {Avail:F0} MB < {Threshold:F0} MB)", avail, ThresholdMb);
-                    StatusMessage = $"Auto-purged — available RAM was below {ThresholdMb:F0} MB.";
-                    Refresh();
+                    var avail = status.AvailableMb;
+                    var purged = await Task.Run(() => _service.TryPurgeStandbyList(out _)).ConfigureAwait(true);
+                    if (purged)
+                    {
+                        Log.Information("Auto-purged standby list (available {Avail:F0} MB < {Threshold:F0} MB)", avail, ThresholdMb);
+                        StatusMessage = $"Auto-purged — available RAM was below {ThresholdMb:F0} MB.";
+                        Refresh();
+                    }
                 }
+                finally { _autoPurgeInFlight = false; }
             }
-            finally { _autoPurgeInFlight = false; }
+        }
+        catch (Exception ex)
+        {
+            // Last-resort net: Tick is an async-void timer handler, so any escaping exception
+            // (an unexpected memory-status or purge fault) would crash the whole process.
+            // Swallow and log — a failed auto-refresh must never take the app down. Mirrors
+            // TrayIconService.OnTimerTick.
+            Log.Warning(ex, "Standby memory auto-refresh tick failed");
         }
     }
 


### PR DESCRIPTION
## Summary
Three small, independently-validated correctness/safety fixes. Each was re-verified against current source before batching; the audit's "ToastService per-toast timer" and most of the `[DllImport]`→`[LibraryImport]` sweep were **dropped as non-issues** after adversarial verification (the old timer is stopped before reassign and GC-safe; several `[DllImport]`s carry code comments explaining they are intentional for variable-length / CharSet marshaling).

## Fixes
1. **Context-menu casing (locale).** `ContextMenuService.SplitCamelCase` capitalized the first letter with `char.ToUpper` (current culture), so on Turkish (tr-TR) a leading "i" became "İ", corrupting entry names. Now `char.ToUpperInvariant` — these are program / shell-verb identifiers, not prose.
2. **Resource-history atomic write (data integrity).** `ResourceHistoryService.PruneAsync` rewrote the history file in place with a single `WriteAllLinesAsync`; a crash mid-write could truncate or corrupt it. Now writes to a temp file and swaps it in with `File.Move(overwrite: true)`.
3. **Standby auto-refresh crash guard.** `StandbyMemoryViewModel.Tick` is an `async void` timer handler with no top-level guard — an escaping fault (memory-status or purge error) would crash the process. Wrapped in catch-and-log, mirroring `TrayIconService.OnTimerTick`.

## Regression
- (1) `SplitCamelCase_CapitalizesInvariantly_OnTurkishCulture` sets `CurrentCulture = tr-TR` and asserts `SplitCamelCase("iexplore") == "Iexplore"`. Red before the fix (old code produced "İexplore"), green after.
- (2) and (3) are behaviour-preserving hardening whose failure modes — a crash mid-write, an unhandled background exception — are impractical to reproduce in a unit test; verified by inspection and by matching the atomic-write / async-void-guard patterns already established in the codebase.

## Release
csproj → 1.52.39; CHANGELOG `## [1.52.39]` lists all three. `fix:` → auto-releases v1.52.39 on merge.
