### PR TITLE
fix: refuse to shred a junction/symlink folder root (prevents out-of-scope data loss)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.40] - 2026-07-08
+
+### Fixed
+- **Shredding a folder that is a junction or symlink no longer destroys data outside it.** If the folder you picked for "Shred Folder" was itself a junction or symbolic link (for example, one that points at another drive or folder), the shredder followed it and securely erased the files at the *link's target* — data outside the folder you actually selected. It now refuses to shred a folder that is a junction/symlink and asks you to pick the real target folder instead; the existing protection that skips links found *inside* the folder is unchanged.
+- **A folder shred no longer reports failure after it has actually finished.** Removing the emptied folder structure at the end of a shred handled only one kind of error; if a leftover read-only or locked entry denied that final cleanup, the whole operation reported failure even though every file had already been securely overwritten. That cleanup denial is now logged and the shred is reported as completed.
+
 ## [1.52.39] - 2026-07-07
 
 ### Fixed

--- a/SysManager/SysManager/Services/FileShredderService.cs
+++ b/SysManager/SysManager/Services/FileShredderService.cs
@@ -171,6 +171,16 @@ public sealed partial class FileShredderService
         if (!Directory.Exists(folderPath))
             throw new DirectoryNotFoundException($"Folder not found: {folderPath}");
 
+        // A junction/symlink AT THE ROOT would make EnumerateFilesSafe follow it into the
+        // link target and shred files OUTSIDE the selected folder — the reparse-point skip in
+        // EnumerateFilesSafe only guards CHILD entries, never the root it starts enumerating
+        // from. Refuse a reparse-point root; the user must select the real target folder to
+        // shred it. (SecurityException is already the shred services' "not allowed" signal and
+        // is handled by the caller.)
+        if ((new DirectoryInfo(folderPath).Attributes & FileAttributes.ReparsePoint) != 0)
+            throw new SecurityException(
+                $"The selected folder is a junction or symlink; shredding it would destroy data at its target outside the selected location: {folderPath}");
+
         var files = EnumerateFilesSafe(folderPath);
         var totalFiles = files.Count;
 
@@ -208,6 +218,13 @@ public sealed partial class FileShredderService
         catch (IOException ex)
         {
             Log.Warning(ex, "Could not fully remove folder structure: {Path}", folderPath);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            // A read-only/locked entry can deny the final structure removal AFTER every file
+            // was already securely overwritten — log and treat the shred as done rather than
+            // surfacing a failure for work that completed.
+            Log.Warning(ex, "Access denied removing folder structure: {Path}", folderPath);
         }
 
         Log.Information("Folder shredded successfully: {Path} ({Method})", folderPath, method);

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.39</Version>
-    <FileVersion>1.52.39.0</FileVersion>
-    <AssemblyVersion>1.52.39.0</AssemblyVersion>
+    <Version>1.52.40</Version>
+    <FileVersion>1.52.40.0</FileVersion>
+    <AssemblyVersion>1.52.40.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem (security-sensitive services)
`FileShredderService.ShredFolderAsync` skips junctions/symlinks on **child** entries, but `EnumerateFilesSafe` pushes the **root** onto the walk (`stack.Push(new DirectoryInfo(rootPath))`) with no reparse-point check. If the selected folder is *itself* a junction/symlink, `GetFiles()` follows it into the link target and every file there — outside the selected folder — is securely (irreversibly) overwritten.

**Failure scenario:** user picks `C:\Users\me\Pics`, which is a junction → `D:\Photos`. "Shred Folder" enumerates and shreds `D:\Photos\*`, destroying data they never intended to touch.

## Fix
- `ShredFolderAsync` refuses a reparse-point root (`throw SecurityException`) before enumeration — the user must select the real target folder. The child-level reparse skip is unchanged.
- (P2, same method) the final `Directory.Delete(recursive: true)` now also catches `UnauthorizedAccessException`, so a locked/read-only leftover can't report a fully-completed shred as a failure.

## Regression
Reasoning-based: exercising the guard needs a real directory junction/symlink, which is privilege-gated and not reliably creatable in the unit runner (`dotnet test` is not run locally). Verified by inspection that a reparse-point root throws `SecurityException` before `EnumerateFilesSafe` runs; `FileShredderViewModel` already catches `SecurityException` around the shred calls, so it surfaces as a normal "not allowed" message with no crash.

## Deferred (tracked from the audit — follow-up FileShredder batch)
- Shred guarantee: a file whose secure overwrite fails is still plain-deleted by the final recursive delete (needs a contract decision).
- Hardlink detection: the child skip covers reparse points, not hardlinks (needs `GetFileInformationByHandle`).

## Release
csproj → 1.52.40; CHANGELOG `## [1.52.40]`. `fix:` → auto-releases v1.52.40.
