### PR TITLE
fix: catch UnauthorizedAccessException at four file/WMI boundaries that only handled I/O errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.41] - 2026-07-08
+
+### Fixed
+- **Four background operations no longer risk an unhandled error when Windows denies file or system access.** Saving and loading the activity log, enriching the drive list with disk media/bus details, downloading an update, and caching an app icon each already handled ordinary I/O errors but not an "access denied" (UnauthorizedAccess) error from a locked-down or permission-restricted system — which could surface as an unhandled exception (and, for the activity log, on the UI thread). Each now treats access-denied like the I/O errors it already handled: the activity log and icon cache degrade quietly, the drive list is still returned (just without the extra media/bus detail rather than coming back empty), and a denied update download reports failure cleanly so the About tab falls back to opening the download in your browser.
+
 ## [1.52.40] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager/Services/ActivityLogService.cs
+++ b/SysManager/SysManager/Services/ActivityLogService.cs
@@ -54,7 +54,7 @@ public sealed class ActivityLogService
             var json = File.ReadAllText(FilePath);
             _entries = JsonSerializer.Deserialize<List<ActivityEntry>>(json) ?? [];
         }
-        catch (Exception ex) when (ex is JsonException or IOException)
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
         {
             Serilog.Log.Debug("ActivityLog load failed: {Error}", ex.Message);
             _entries = [];
@@ -70,7 +70,7 @@ public sealed class ActivityLogService
             var json = JsonSerializer.Serialize(snapshot, new JsonSerializerOptions { WriteIndented = false });
             File.WriteAllText(FilePath, json);
         }
-        catch (IOException ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             Serilog.Log.Debug("ActivityLog save failed: {Error}", ex.Message);
         }

--- a/SysManager/SysManager/Services/AppIconService.cs
+++ b/SysManager/SysManager/Services/AppIconService.cs
@@ -98,7 +98,6 @@ public sealed class AppIconService
     /// </summary>
     public async Task<BitmapImage?> GetIconAsync(string appId, CancellationToken ct = default)
     {
-        Directory.CreateDirectory(CacheDir);
         var cachePath = Path.Combine(CacheDir, $"{SanitizeFileName(appId)}.png");
 
         // Return cached icon if it exists and is not empty. If the file is present
@@ -127,6 +126,7 @@ public sealed class AppIconService
             var bytes = await _http.GetByteArrayAsync(url, ct).ConfigureAwait(false);
             if (bytes.Length == 0) return null;
 
+            Directory.CreateDirectory(CacheDir);
             await File.WriteAllBytesAsync(cachePath, bytes, ct).ConfigureAwait(false);
             return LoadFromFile(cachePath);
         }
@@ -143,6 +143,11 @@ public sealed class AppIconService
         catch (IOException ex)
         {
             Log.Debug(ex, "Could not write icon cache for {AppId}", appId);
+            return null;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Log.Debug(ex, "Could not write icon cache (access denied) for {AppId}", appId);
             return null;
         }
     }

--- a/SysManager/SysManager/Services/FixedDriveService.cs
+++ b/SysManager/SysManager/Services/FixedDriveService.cs
@@ -126,6 +126,12 @@ public sealed class FixedDriveService
             // scope.Connect() can throw COMException when the Storage WMI namespace is
             // unavailable (older/headless Windows). Non-fatal — leave media/bus empty.
         }
+        catch (UnauthorizedAccessException)
+        {
+            // WMI namespace access can be denied on locked-down/enterprise Windows. Non-fatal —
+            // return the enumerated drives WITHOUT media/bus enrichment rather than discarding
+            // the whole list (matches DiskHealthService's degrade-don't-throw handling).
+        }
 
         return drives;
     }

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -155,7 +155,6 @@ public sealed class UpdateService
         var dir = Path.Join(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "SysManager", "updates");
-        Directory.CreateDirectory(dir);
         var target = Path.Join(dir, $"SysManager-{rel.Version}.exe");
 
         // SEC-M2: Skip re-download only if we have a cached hash that matches.
@@ -191,6 +190,7 @@ public sealed class UpdateService
         var tempFile = target + ".tmp";
         try
         {
+            Directory.CreateDirectory(dir);
             using var resp = await Http.GetAsync(rel.AssetUrl, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
             resp.EnsureSuccessStatusCode();
             var total = resp.Content.Headers.ContentLength ?? rel.AssetSize;
@@ -249,6 +249,15 @@ public sealed class UpdateService
         catch (IOException ex)
         {
             Serilog.Log.Warning(ex, "Failed to write release asset to disk");
+            CleanupFile(tempFile);
+            return null;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            // Documented contract is "null on failure" — a denied updates-dir create/write or
+            // a locked target must degrade to null (the About tab then keeps the browser
+            // download fallback), not escape as an unhandled exception.
+            Serilog.Log.Warning(ex, "Failed to write release asset (access denied)");
             CleanupFile(tempFile);
             return null;
         }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.40</Version>
-    <FileVersion>1.52.40.0</FileVersion>
-    <AssemblyVersion>1.52.40.0</AssemblyVersion>
+    <Version>1.52.41</Version>
+    <FileVersion>1.52.41.0</FileVersion>
+    <AssemblyVersion>1.52.41.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary (error-handling batch)
Four services caught `IOException` (or WMI `ManagementException`/`COMException`) at a file/WMI boundary but let a sibling `UnauthorizedAccessException` escape on a locked-down / permission-restricted system:

- **ActivityLogService** Save/Load — `Log()` runs on the UI thread, so a denied write/read could crash it. Now catches UAE (degrades quietly).
- **FixedDriveService** WMI media/bus enrichment — a denied Storage namespace threw out of the method and discarded the *entire* drive list. Now degrades like DiskHealthService: drives are returned without the media/bus detail.
- **UpdateService.DownloadAsync** — `CreateDirectory` (outside the try) plus `File.Create`/`File.Move` could leak UAE, breaking the documented "null on failure" contract (and the About-tab browser-download fallback). `CreateDirectory` moved inside the guarded try; UAE now returns null + logs.
- **AppIconService.GetIconAsync** — `CreateDirectory(CacheDir)` ran on *every* call outside the try; moved into the network-write path, and the write now catches UAE (icon cache degrades quietly).

## Regression
Reasoning-based: reproducing an access-denied fault needs a real ACL-restricted file/dir, impractical in the unit runner (`dotnet test` is not run locally). Verified by inspection that each new catch mirrors the existing `IOException` handling at the same site.

## Release
csproj → 1.52.41; CHANGELOG `## [1.52.41]`. `fix:` → auto-releases v1.52.41.
