### PR TITLE
fix: parse the correct processor minimum from powercfg on non-English Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.42] - 2026-07-08
+
+### Fixed
+- **On non-English Windows, the processor "minimum state" could be saved as 0% and later restored as 0%.** Before applying a performance tweak, SysManager takes a safety snapshot that records your current processor *minimum state* (read from Windows' `powercfg`). On English Windows it read the right value, but on a translated Windows the label it searched for was in another language, so it fell back to the first number in `powercfg`'s output — which is the fixed "minimum possible" value (0%), not your actual setting. That wrong 0% went into the snapshot, so a later "Restore All" wrote 0% back as if it were your original minimum. It now reads the correct value in any display language (the real setting is always the second-to-last value `powercfg` prints), so snapshots and restores are accurate on every Windows locale.
+
 ## [1.52.41] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager.Tests/PerformanceServiceTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceServiceTests.cs
@@ -198,12 +198,35 @@ public class PerformanceServiceTests
     }
 
     [Fact]
-    public void ParseProcessorMinPercent_NonEnglishLabel_StillParsesFirstHex()
+    public void ParseProcessorMinPercent_NonEnglishLabel_RealPowercfgShape_ReturnsAcValue()
     {
-        // Regression for the locale bug: on non-English Windows the "Current AC Power
-        // Setting Index" label is translated, so the old English-label match failed and the
-        // parser returned the fabricated 5. powercfg still prints the AC value first as a
-        // "0x…" token in every language, so the fallback now reads it. German example:
+        // Regression for the locale bug (completes an earlier, incomplete fix). REAL powercfg
+        // output for PROCTHROTTLEMIN prints Minimum/Maximum/increment hex values BEFORE the two
+        // current-index lines, and on non-English Windows the "Current AC/DC" labels are
+        // translated, so the English-label fast path misses. The previous fallback then returned
+        // the FIRST hex token — "Minimum Possible Setting" = 0x0 — so it read 0 (not the AC
+        // value), and a later Restore wrote 0% back. The AC index is always the second-to-last
+        // hex token (AC-before-DC, current-index lines last, in every language). German example
+        // (the labels are illustrative; the value ordering is what powercfg guarantees):
+        var lines = new List<string>
+        {
+            "  Mögliche Mindesteinstellung: 0x00000000",
+            "  Mögliche Höchsteinstellung: 0x00000064",
+            "  Inkrement für mögliche Einstellungen: 0x00000001",
+            "  Index für aktuelle Wechselstromeinstellung: 0x00000032",
+            "  Index für aktuelle Gleichstromeinstellung: 0x00000019",
+        };
+
+        var result = PerformanceService.ParseProcessorMinPercent(lines);
+
+        Assert.Equal(0x32, result); // 50 — AC (2nd-to-last), NOT Minimum-Possible 0x0 or DC 0x19
+    }
+
+    [Fact]
+    public void ParseProcessorMinPercent_NonEnglishLabel_TwoTokensOnly_ReturnsAcNotDc()
+    {
+        // Minimal non-English shape (no Min/Max/increment lines): the AC index is still the
+        // second-to-last hex token, so the parser must return AC (50), never the trailing DC (25).
         var lines = new List<string>
         {
             "  Index für aktuelle Wechselstromeinstellung: 0x00000032",
@@ -212,7 +235,7 @@ public class PerformanceServiceTests
 
         var result = PerformanceService.ParseProcessorMinPercent(lines);
 
-        Assert.Equal(0x32, result); // 50 — the AC value, not the DC value, not a fabricated 5
+        Assert.Equal(0x32, result); // 50 (AC), not 0x19 = 25 (DC)
     }
 
     [Fact]

--- a/SysManager/SysManager/Services/PerformanceService.cs
+++ b/SysManager/SysManager/Services/PerformanceService.cs
@@ -550,25 +550,31 @@ public sealed partial class PerformanceService : IDisposable
 
     internal static int? ParseProcessorMinPercent(IList<string> lines)
     {
-        // The query is PROCTHROTTLEMIN only, so powercfg prints exactly two hex values:
-        // "Current AC Power Setting Index: 0x…" then "Current DC Power Setting Index: 0x…"
-        // (AC always first, in every language). We want the AC value.
+        // powercfg /query SCHEME_CURRENT SUB_PROCESSOR PROCTHROTTLEMIN prints, in an order that
+        // is identical in every display language, up to five hex values:
+        //   Minimum Possible Setting, Maximum Possible Setting, Possible Settings increment,
+        //   Current AC Power Setting Index, Current DC Power Setting Index.
+        // Only the LABELS are translated; the AC-before-DC ordering and the fact that the two
+        // "current index" lines come LAST never change — so the AC index we want is always the
+        // second-to-last hex token in the output, and DC the last.
         //
-        // Fast path (en-US, unchanged): match the English AC label exactly.
-        // Locale-agnostic fallback: the label is translated on non-English Windows, so fall
-        // back to the FIRST "0x…" token in the output — which is the AC index by powercfg's
-        // fixed AC-before-DC ordering. Return null when nothing parses: the caller must NOT
-        // invent a value, or a snapshot/restore would fabricate a wrong minimum (the bug this
-        // fixes — the old code returned 5, which "Restore" then wrote back on non-English boxes).
+        // Fast path (en-US): match the English AC label exactly — cheap and unambiguous.
         foreach (var line in lines.Where(l => l.Contains("Current AC Power Setting Index", StringComparison.OrdinalIgnoreCase)))
         {
             if (TryParseHexToken(line, out var acVal)) return acVal;
         }
+        // Locale-agnostic fallback: on non-English Windows the label above is translated, so the
+        // fast path misses. Collect every hex token in order and take the second-to-last (AC).
+        // The previous fallback returned the FIRST hex token — "Minimum Possible Setting" (0x0) —
+        // so on non-English Windows it read 0, and a later "Restore" wrote 0% back as the minimum.
+        List<int> hexValues = [];
         foreach (var line in lines)
         {
-            if (TryParseHexToken(line, out var val)) return val;
+            if (TryParseHexToken(line, out var val)) hexValues.Add(val);
         }
-        return null; // couldn't read — do not guess
+        // Need both current-index tokens (AC + DC) to trust the ordering; AC is second-to-last.
+        // Fewer than two = ambiguous, so return null rather than guess — never fabricate a value.
+        return hexValues.Count >= 2 ? hexValues[^2] : null;
     }
 
     private static bool TryParseHexToken(string line, out int value)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.41</Version>
-    <FileVersion>1.52.41.0</FileVersion>
-    <AssemblyVersion>1.52.41.0</AssemblyVersion>
+    <Version>1.52.42</Version>
+    <FileVersion>1.52.42.0</FileVersion>
+    <AssemblyVersion>1.52.42.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem
On non-English Windows, the processor "minimum state" recorded in the performance safety snapshot could be **0%**, and a later "Restore All" would then write **0%** back as if it were the user's original minimum.

## Root cause
`powercfg /query SCHEME_CURRENT SUB_PROCESSOR PROCTHROTTLEMIN` prints several hex values in a fixed, language-independent order:

```
Minimum Possible Setting:       0x00000000
Maximum Possible Setting:       0x00000064
Possible Settings increment:    0x00000001
Current AC Power Setting Index: 0x...   <- the value we want
Current DC Power Setting Index: 0x...
```

Only the **labels** are translated. The parser had an English-label fast path (`"Current AC Power Setting Index"`) plus a locale-agnostic fallback for translated Windows — but that fallback returned the **first** `0x` token, which is `Minimum Possible Setting` (`0x0`), not the AC value. So on any non-English display language it read `0`.

## Fix
The fallback now collects every hex token and returns the **second-to-last** one. The two "current index" lines are always printed last, AC before DC, in every language — so AC is always second-to-last and DC last. English behavior is unchanged (the fast path still short-circuits).

## Tests
- The previous non-English test used an unrealistic two-line fixture (AC/DC only) that never reproduced the bug. It now uses the **real** `powercfg` shape (Min/Max/increment lines first): **red** on the old code (returns `0`), **green** after the fix (returns the AC value).
- Added a second test pinning **AC-not-DC** on the minimal two-token shape.
- English fixtures and the "return null when unreadable — never fabricate" contract are unchanged.

Patch release (`fix:`) -> `v1.52.42`.
