### PR TITLE
fix: disable Startup-folder items by their full filename so the toggle takes effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.43] - 2026-07-08
+
+### Fixed
+- **Disabling a Startup-folder program from the Startup Manager now actually stops it from launching.** For items that live in the Windows Startup *folder* (as opposed to the registry Run keys), SysManager identified the item by its name without the file extension, but Windows tracks the enabled/disabled state under the item's full filename (for example `Spotify.lnk`). Because of that mismatch, a Startup-folder item that was already disabled showed as enabled, and turning one off wrote the "disabled" flag under a name Windows ignores — so the program kept starting. SysManager now uses the full filename for these items, so their on/off state reads correctly and disabling one takes effect. (Registry Run entries and scheduled-task entries were unaffected.)
+
 ## [1.52.42] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager.Tests/StartupServiceTests.cs
+++ b/SysManager/SysManager.Tests/StartupServiceTests.cs
@@ -111,4 +111,38 @@ public class StartupServiceTests
             _ = entry.IsEnabled; // should not throw
         }
     }
+
+    // ── BuildStartupFolderEntry (pure — the StartupApproved key-name toggle bug) ──
+
+    [Theory]
+    [InlineData(@"C:\Users\aunt\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\Spotify.lnk", "Spotify", "Spotify.lnk")]
+    [InlineData(@"C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Startup\Backup Tool.exe", "Backup Tool", "Backup Tool.exe")]
+    public void BuildStartupFolderEntry_KeepsExtensionInValueName_DropsItInName(
+        string file, string expectedName, string expectedValueName)
+    {
+        // Regression: the StartupApproved\StartupFolder registry key is keyed by the file's FULL
+        // name (with extension). Keying by the extension-stripped name (the old behavior) made a
+        // disabled item read back as enabled, and made "disable" write its blob under a name
+        // Windows ignores — so the program kept launching. ValueName must retain the extension.
+        var entry = StartupService.BuildStartupFolderEntry(file, command: file, locationLabel: "User Startup Folder");
+
+        Assert.Equal(expectedName, entry.Name);           // display: extension stripped
+        Assert.Equal(expectedValueName, entry.ValueName);  // StartupApproved key: full filename
+        Assert.Equal(StartupSource.StartupFolder, entry.Source);
+    }
+
+    [Fact]
+    public void BuildStartupFolderEntry_NameAndValueName_DoNotCollapse()
+    {
+        // Name (display) and ValueName (registry key) must stay distinct for an extensioned file,
+        // so a shortcut and a same-stem executable cannot collide on the approved-state key.
+        var entry = StartupService.BuildStartupFolderEntry(
+            @"C:\Users\aunt\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\OneDrive.lnk",
+            command: @"C:\Program Files\OneDrive\OneDrive.exe",
+            locationLabel: "User Startup Folder");
+
+        Assert.NotEqual(entry.Name, entry.ValueName);
+        Assert.Equal("OneDrive", entry.Name);
+        Assert.Equal("OneDrive.lnk", entry.ValueName);
+    }
 }

--- a/SysManager/SysManager/Services/StartupService.cs
+++ b/SysManager/SysManager/Services/StartupService.cs
@@ -122,18 +122,7 @@ public sealed class StartupService
                     }
                 }
 
-                results.Add(new StartupEntry
-                {
-                    Name = name,
-                    Command = command,
-                    Location = locationLabel,
-                    Source = StartupSource.StartupFolder,
-                    RegistryKey = "",
-                    ValueName = name,
-                    IsEnabled = true,
-                    Publisher = ExtractPublisher(command),
-                    StatusText = "Enabled"
-                });
+                results.Add(BuildStartupFolderEntry(file, command, locationLabel));
             }
         }
         catch (UnauthorizedAccessException ex)
@@ -145,6 +134,30 @@ public sealed class StartupService
             Log.Debug("Startup folder I/O error {Folder}: {Error}", folderPath, ex.Message);
         }
     }
+
+    /// <summary>
+    /// Builds a startup-folder <see cref="StartupEntry"/> from a resolved file. The display
+    /// <see cref="StartupEntry.Name"/> drops the extension, but <see cref="StartupEntry.ValueName"/>
+    /// keeps the FULL filename (with extension) because that is the key Windows uses in
+    /// <c>...\Explorer\StartupApproved\StartupFolder</c>. Keying the approved-state read/write by
+    /// the extension-stripped name (as this did before) meant a disabled item read back as
+    /// enabled and, worse, a "disable" wrote a blob under a name Windows ignores — so the toggle
+    /// silently did nothing. Registry Run entries and scheduled tasks are unaffected (they key by
+    /// their own value/task name).
+    /// </summary>
+    internal static StartupEntry BuildStartupFolderEntry(string file, string command, string locationLabel) =>
+        new()
+        {
+            Name = System.IO.Path.GetFileNameWithoutExtension(file),
+            Command = command,
+            Location = locationLabel,
+            Source = StartupSource.StartupFolder,
+            RegistryKey = "",
+            ValueName = System.IO.Path.GetFileName(file),
+            IsEnabled = true,
+            Publisher = ExtractPublisher(command),
+            StatusText = "Enabled"
+        };
 
     private static void ReadScheduledTasks(List<StartupEntry> results)
     {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.42</Version>
-    <FileVersion>1.52.42.0</FileVersion>
-    <AssemblyVersion>1.52.42.0</AssemblyVersion>
+    <Version>1.52.43</Version>
+    <FileVersion>1.52.43.0</FileVersion>
+    <AssemblyVersion>1.52.43.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem
Turning **off** a Startup-folder program in the Startup Manager did nothing — it kept launching at boot — and an already-disabled folder item showed as **enabled**.

## Root cause
Windows tracks the on/off state of Startup-*folder* items in `...\Explorer\StartupApproved\StartupFolder`, keyed by the item's **full filename** (e.g. `Spotify.lnk`). `StartupService` built those entries with `ValueName` set to the **extension-stripped** name (`Spotify`), so:
- `ApplyApprovedState` looked up the wrong key -> a disabled item read back as enabled.
- `SetEnabledAsync` wrote the "disabled" blob under `Spotify` (a name Windows ignores) instead of `Spotify.lnk` -> the program kept starting, and a junk value was left in the registry.

Registry `Run` entries and scheduled tasks were unaffected (they legitimately key by their own value/task name).

## Fix
Startup-folder entries now set `ValueName` to the full filename (`Path.GetFileName`), while the display `Name` still drops the extension (`Path.GetFileNameWithoutExtension`). The read (`ApplyApprovedState`) and write (`SetEnabledAsync`) then hit the correct StartupApproved key.

## Tests
Entry construction is extracted into an internal `BuildStartupFolderEntry` factory so it is unit-testable without the registry:
- A `[Theory]` pins that `ValueName` keeps the extension while `Name` drops it (`Spotify.lnk` -> Name `Spotify`, ValueName `Spotify.lnk`) — **red** against the old inline code (which set `ValueName` to the stripped name), **green** after.
- A `[Fact]` asserts Name and ValueName do not collapse, so a shortcut and a same-stem exe cannot collide on the approved key.
- The existing 8 registry-enumeration tests are unchanged.

Patch release (`fix:`) -> `v1.52.43`.
