### PR TITLE
fix: report a cancelled duplicate-file scan as cancelled instead of "Complete"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.44] - 2026-07-08
+
+### Fixed
+- **Cancelling a duplicate-file scan now reports it as cancelled instead of showing partial results as "Complete."** If you stopped a duplicate scan between files (rather than while a file was being hashed), the scan quietly finished and presented whatever it had found so far as a completed result. It now treats cancellation consistently — the scan reports as cancelled and no partial list is shown as if it were the full result — matching how the Large Files scan already behaves.
+
 ## [1.52.43] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DuplicateFileServiceTests.cs
+++ b/SysManager/SysManager.Tests/DuplicateFileServiceTests.cs
@@ -238,6 +238,27 @@ public class DuplicateFileServiceTests : IDisposable
             () => _service.ScanAsync(_root, ct: cts.Token));
     }
 
+    [Fact]
+    public void Scan_CancelledBeforeFinalize_Throws_NotReportComplete()
+    {
+        // Regression: the outer scan loops BREAK on cancellation (only the mid-hash hashing
+        // throws), so a scan cancelled between files used to fall through to the "Complete"
+        // progress report and return partial results. It must throw instead, so the VM's cancel
+        // branch shows "Scan cancelled." — mirroring LargeFileScanner's finalize. We invoke the
+        // private Scan directly with a pre-cancelled token: ScanAsync's Task.Run(ct) would
+        // short-circuit before the body ran, so it cannot exercise this finalize path.
+        var scan = typeof(DuplicateFileService)
+            .GetMethod("Scan", BindingFlags.NonPublic | BindingFlags.Static)!;
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var ex = Record.Exception(() => scan.Invoke(null, new object?[] { _root, 1L, null, cts.Token }));
+
+        Assert.NotNull(ex);
+        // Reflection wraps the thrown exception; the underlying one must be a cancellation.
+        Assert.IsAssignableFrom<OperationCanceledException>(ex!.InnerException);
+    }
+
     // ── Progress reporting ──
 
     [Fact]

--- a/SysManager/SysManager/Services/DuplicateFileService.cs
+++ b/SysManager/SysManager/Services/DuplicateFileService.cs
@@ -192,6 +192,12 @@ public sealed class DuplicateFileService
                 }
         }
 
+        // A cancelled scan exits the loops above with partial results (they break on
+        // cancellation rather than throwing, unlike the mid-hash ThrowIfCancellationRequested).
+        // Surfacing those as "Complete" would mislead the user; throw so the caller's cancel
+        // branch shows "Scan cancelled." — mirroring LargeFileScanner's finalize.
+        ct.ThrowIfCancellationRequested();
+
         progress?.Report(new ScanProgress(discovered, hashed, bytesProcessed, "Done", "Complete"));
 
         // Only return groups with 2+ files (actual duplicates).

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.43</Version>
-    <FileVersion>1.52.43.0</FileVersion>
-    <AssemblyVersion>1.52.43.0</AssemblyVersion>
+    <Version>1.52.44</Version>
+    <FileVersion>1.52.44.0</FileVersion>
+    <AssemblyVersion>1.52.44.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem
Cancelling a duplicate-file scan **between files** left the Duplicate Finder showing the partial results as a **completed** scan, rather than reporting the scan as cancelled.

## Root cause
`DuplicateFileService.Scan` breaks out of its discovery and hashing loops when the token is cancelled (only the mid-hash `ComputeHash`/`ComputePartialHash` call `ThrowIfCancellationRequested`). So a cancellation detected at a loop boundary fell through to the final `"Complete"` progress report and returned the partial results.

## Fix
`Scan` now calls `ct.ThrowIfCancellationRequested()` immediately before the `"Complete"` report, so a cancellation surfaces as `OperationCanceledException`. `DuplicateFileViewModel` already has a `catch (OperationCanceledException)` branch that shows "Scan cancelled." This mirrors `LargeFileScanner`, which finalizes the same way. For a non-cancelled scan the new call is a no-op, so the normal report and results are unchanged.

## Tests
- New regression test invokes the private `Scan` via reflection with a pre-cancelled token — `ScanAsync`'s `Task.Run(ct)` short-circuits before the body runs, so it cannot reach the finalize path. **Red** before the fix (returns an empty list, no throw), **green** after (throws `OperationCanceledException`).
- The existing `Scan_ReportsProgress` test (non-cancelled) still sees the `"Complete"` phase, confirming the happy path is unchanged.

Patch release (`fix:`) -> `v1.52.44`.
