### PR TITLE
fix: guard the System Info Win32_DiskDrive fallback so a WMI fault can't crash the snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.45] - 2026-07-08
+
+### Fixed
+- **The System Info snapshot no longer risks an unhandled error on systems where the modern disk-info source is unavailable.** When the Windows Storage management interface cannot be reached (some older or minimal Windows installations), SysManager falls back to the classic disk query — but that fallback ran without its own error handling, so a second failure there (or a malformed size value from one drive) could surface as an unhandled error instead of simply showing the disk list it managed to read. The fallback is now guarded like every other hardware query: a fault degrades to the partial disk list, and a single unreadable drive is skipped rather than aborting the whole snapshot.
+
 ## [1.52.44] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager/Services/SystemInfoService.cs
+++ b/SysManager/SysManager/Services/SystemInfoService.cs
@@ -285,19 +285,36 @@ public sealed class SystemInfoService
         {
             // Fallback to Win32_DiskDrive if MSFT_PhysicalDisk / the Storage WMI namespace
             // isn't available (older/headless Windows — scope.Connect() throws COMException).
-            using var s = new ManagementObjectSearcher("SELECT Model,Size,Status FROM Win32_DiskDrive");
-            using var fallbackCollection = s.Get();
-            foreach (ManagementObject mo in fallbackCollection)
+            // This fallback runs precisely when WMI is already degraded, so it needs its own
+            // guard: a fault here (or a malformed Size) must degrade to the partial list, not
+            // propagate out of Capture() and surface as an error — mirroring every other method.
+            try
             {
-                using (mo)
+                using var s = new ManagementObjectSearcher("SELECT Model,Size,Status FROM Win32_DiskDrive");
+                using var fallbackCollection = s.Get();
+                foreach (ManagementObject mo in fallbackCollection)
                 {
-                    var size = Convert.ToDouble(mo["Size"] ?? 0) / 1024d / 1024d / 1024d;
-                    list.Add(new DiskInfo(
-                        mo["Model"]?.ToString() ?? "Disk",
-                        "Unknown", "Unknown", size,
-                        mo["Status"]?.ToString() ?? "Unknown",
-                        "Unknown", null, null));
+                    using (mo)
+                    {
+                        try
+                        {
+                            var size = Convert.ToDouble(mo["Size"] ?? 0) / 1024d / 1024d / 1024d;
+                            list.Add(new DiskInfo(
+                                mo["Model"]?.ToString() ?? "Disk",
+                                "Unknown", "Unknown", size,
+                                mo["Status"]?.ToString() ?? "Unknown",
+                                "Unknown", null, null));
+                        }
+                        catch (Exception exItem) when (exItem is FormatException or OverflowException or InvalidCastException)
+                        {
+                            /* malformed Size on this disk — skip it, keep the rest */
+                        }
+                    }
                 }
+            }
+            catch (Exception exFallback) when (exFallback is ManagementException or System.Runtime.InteropServices.COMException)
+            {
+                /* Win32_DiskDrive also unavailable — return whatever enumerated (mirrors the other WMI methods) */
             }
         }
         return list;

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.44</Version>
-    <FileVersion>1.52.44.0</FileVersion>
-    <AssemblyVersion>1.52.44.0</AssemblyVersion>
+    <Version>1.52.45</Version>
+    <FileVersion>1.52.45.0</FileVersion>
+    <AssemblyVersion>1.52.45.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem
On systems where the modern disk-info source (the Storage WMI namespace / `MSFT_PhysicalDisk`) is unavailable — some older or minimal Windows installs — a second failure while reading disks could surface as an **unhandled error** instead of degrading gracefully, faulting `Capture()` (the whole System Info snapshot).

## Root cause
`QueryDisks` queries `MSFT_PhysicalDisk` inside a `try`, and on `ManagementException`/`COMException` falls back to a classic `Win32_DiskDrive` query **inside the catch block**. That fallback had no guard of its own: if the fallback query also threw, or `Convert.ToDouble(mo["Size"])` threw on a malformed value, the exception propagated out of `QueryDisks` -> `Capture()` -> unhandled. Every *other* WMI method in the file already degrades on `ManagementException`/`COMException`; the fallback was the one gap.

## Fix
Wrap the fallback in its own `try/catch (ManagementException or COMException)` and add a per-drive `try/catch (FormatException/OverflowException/InvalidCastException)` around the size conversion. A fault now degrades to the partial disk list, and a single unreadable drive is skipped rather than aborting the snapshot — matching the pattern used throughout the file.

## Tests
No unit test: `QueryDisks` is a private static WMI path, and the fault branch cannot be exercised without an actually-degraded Storage namespace (no seam to inject a WMI fault). Verified by `dotnet build` (Release, 0 warnings / 0 errors) and by mirroring the guarded-WMI pattern every sibling method in this file already uses.

Patch release (`fix:`) -> `v1.52.45`.
