### PR TITLE
chore: move local working-artifact ignore patterns to .git/info/exclude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,23 +71,6 @@ _ReSharper*/
 !.vscode/extensions.json
 .commitmsg
 
-# Local working artifacts — review reports, scratch notes, and temp scratch that
-# tooling generates next to the source tree. These are never part of the project
-# and must never be committed.
-*_REPORT.json
-*_AUDIT.json
-*-REVIEW*.json
-*_REVIEW.json
-AUDIT-*.md
-audit-findings/
-temp_releases/
-temp_bugs.json
-pr-body.md
-pr_body.md
-mockup-*.html
-ui-test-results.txt
-*-results.txt
-
 # Temp / scratch files (any tmp_ or .tmp_ prefix, scratch query files)
 tmp_*.json
 .tmp_*


### PR DESCRIPTION
Moves machine-local scratch/working-artifact glob patterns out of the tracked `.gitignore` and into the untracked `.git/info/exclude`. Local, machine-specific ignore patterns belong in `.git/info/exclude` rather than the committed ignore file, which should stay limited to patterns meaningful for every clone.

The patterns still apply locally (verified with `git check-ignore` — they now resolve to `.git/info/exclude`). The generic build, editor, NuGet, test, log, OS and tmp patterns remain tracked and unchanged.

`chore:` — no code change, no release.
