### PR TITLE
docs: refresh ARCHITECTURE / CONTRIBUTING / CHANGELOG for current reality

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,7 +31,7 @@ SysManager/
 
 ## Tabs (view models)
 
-The sidebar organises tabs into 12 collapsible groups via `NavGroup` →
+The sidebar organises tabs into 12 groups (11 collapsible + a flat top-level Dashboard) via `NavGroup` →
 `NavItem` hierarchy built by `BuildNavGroups()` using `Group()` and
 `Item()` helper methods. Dashboard renders as a flat top-level entry.
 Collapsed groups show a child count badge, subtitle (auto-generated
@@ -118,7 +118,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 
 Thin wrappers around the underlying platform. Each service is designed to be
 unit-testable. Services that a view-model needs to substitute in tests sit behind
-an interface seam — currently `IPowerShellRunner` (PowerShellRunner),
+an interface seam — currently `IPowerShellRunner` (PowerShellRunner), `IWingetService` (WingetService),
 `IAppBlockerService` (AppBlockerService), `IDialogService` (DialogService),
 `ICpuAffinityService`, `IFileLockService`, `ISettingsWatchdogService`,
 `ITimerResolutionService`, `ITweaksHubService`, `IWindowsThemeService`,
@@ -361,7 +361,7 @@ Key services:
 
 ## Helpers
 
-Utility classes that don't fit neatly into Services or ViewModels:
+Key utility classes that don't fit neatly into Services or ViewModels (not an exhaustive list):
 
 - `AdminHelper` — elevation check (`IsElevated()`) and UAC relaunch.
 - `BulkObservableCollection<T>` — `ObservableCollection` subclass that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,8 +254,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Security
 - **Input validators that feed a command/registry boundary now reject a trailing newline.** Nine allowlist patterns (winget package IDs, service names, blocked-executable names, Appx package names, environment-variable names, Windows-feature names, event-log provider names, and hostnames) used `^…$` anchors, which in .NET match before a trailing newline — so a value like `pkg\n` slipped through and could smuggle a second line into the command. They now use absolute `\A…\z` anchors. The winget package-ID pattern additionally dropped `\s` (which allowed tabs/newlines mid-string) in favour of a literal space.
-
-### Tests
 - Added injection-rejection negative tests for the winget package-ID validators (`UpgradeAsync`, `UninstallAsync`) and the service-name/start-type validator (`SetStartupTypeAsync`), covering command separators, chaining, substitution, quotes, newlines, and over-length input.
 
 ## [1.51.13] - 2026-06-30

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,8 @@ follows, and what to expect when you open a pull request.
 ```powershell
 git clone https://github.com/laurentiu021/SystemManager.git
 cd SystemManager
-# There is no solution file — build the project explicitly (matches CI).
+# Build the app project directly — this is what CI does. A SysManager.sln also
+# exists (SysManager/SysManager.sln) if you prefer the full solution in Visual Studio / Rider.
 dotnet build SysManager/SysManager/SysManager.csproj -c Debug
 ```
 


### PR DESCRIPTION
Refreshes three docs to match the current codebase — no code change, no release.

**ARCHITECTURE.md**
- The sidebar is **12 groups (11 collapsible + a flat top-level Dashboard)**, not "12 collapsible groups" — the same paragraph already notes Dashboard renders flat.
- Added the **`IWingetService`** seam to the interface-seam list; it was introduced when the Dashboard's "Update All Apps" moved behind the shared winget seam, but the list wasn't updated.
- Framed the Helpers list as non-exhaustive ("Key utility classes … (not an exhaustive list)"), matching the "Key services" framing.

**CONTRIBUTING.md**
- Removed the stale "There is no solution file" note; `SysManager.sln` now exists. The comment now notes CI still builds per-project.

**CHANGELOG.md**
- Folded the invalid Keep-a-Changelog `### Tests` category (1.51.14) into the `### Security` block it accompanies.

`docs:` — no version bump, no release.
