### PR TITLE
fix: refuse to shred a file with multiple hard links (would destroy shared data)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.46] - 2026-07-08
+
+### Fixed
+- **The File Shredder now refuses to shred a file that has more than one hard link, instead of destroying data shared with other locations.** A file can have several names (hard links) that all point at the same data — including names outside the folder you selected, or a link that shares a protected system file's data. Overwriting the file's bytes to "shred" it would have destroyed that shared data everywhere, and the safety check that blocks system paths only sees the name you picked (it cannot tell the data is shared). The shredder now detects multiple hard links up front and refuses with a clear message, leaving every copy intact; remove the extra links first, or delete the file normally.
+
 ## [1.52.45] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager.Tests/FileShredderServiceTests.cs
+++ b/SysManager/SysManager.Tests/FileShredderServiceTests.cs
@@ -351,6 +351,56 @@ public class FileShredderServiceTests
         }
     }
 
+    // ---------- hard-link shred refusal (data shared outside the selected scope) ----------
+
+    [Fact]
+    public async Task ShredFileAsync_FileWithHardLink_Refuses_AndPreservesData()
+    {
+        // Regression: overwriting a hard-linked file destroys the data for EVERY name that
+        // points at it — links outside the selected scope, or a link a standard user placed to
+        // share a protected file's data (the path guard sees only the opened name, and
+        // GetFinalPathNameByHandle resolves symlinks/junctions but NOT hard links). The shredder
+        // must refuse a multi-link file rather than destroy the shared data.
+        var svc = NewService();
+        var target = Path.Combine(Path.GetTempPath(), "smtest_hltarget_" + Guid.NewGuid().ToString("N") + ".dat");
+        var link = Path.Combine(Path.GetTempPath(), "smtest_hllink_" + Guid.NewGuid().ToString("N") + ".dat");
+        const string content = "shared data behind two hard links";
+        await File.WriteAllTextAsync(target, content);
+
+        try
+        {
+            // mklink /H creates a hard link on the same volume; no admin required. If the
+            // environment can't create one, skip rather than fail on an environment limitation.
+            var psi = new System.Diagnostics.ProcessStartInfo("cmd.exe", $"/c mklink /H \"{link}\" \"{target}\"")
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+            using (var proc = System.Diagnostics.Process.Start(psi)!)
+            {
+                proc.WaitForExit(10_000);
+                if (proc.ExitCode != 0 || !File.Exists(link))
+                    return; // couldn't create a hard link here — nothing to assert
+            }
+
+            // Shredding through the link must be refused (IOException), and BOTH names plus the
+            // shared data must remain intact.
+            await Assert.ThrowsAsync<IOException>(
+                () => svc.ShredFileAsync(link, ShredMethod.Quick, null, CancellationToken.None));
+
+            Assert.True(File.Exists(target), "target destroyed despite the hard-link refusal");
+            Assert.True(File.Exists(link), "link destroyed despite the hard-link refusal");
+            Assert.Equal(content, await File.ReadAllTextAsync(target));
+        }
+        finally
+        {
+            if (File.Exists(link)) File.Delete(link);
+            if (File.Exists(target)) File.Delete(target);
+        }
+    }
+
     [Fact]
     public void ResolveFinalPath_MissingPath_ReturnsNull()
     {

--- a/SysManager/SysManager/Services/FileShredderService.cs
+++ b/SysManager/SysManager/Services/FileShredderService.cs
@@ -86,6 +86,19 @@ public sealed partial class FileShredderService
             if (heldCanonical is not null)
                 ThrowIfProtected(ExpandShortPath(heldCanonical));
 
+            // Refuse to overwrite a file that has more than one hard link. Overwriting the
+            // bytes destroys the data for EVERY name that points at this file — including links
+            // outside the selected scope, or a hard link a standard user placed at an unprotected
+            // path that shares its data with a protected file (the path guard sees only the name
+            // we opened, and GetFinalPathNameByHandle resolves symlinks/junctions but NOT hard
+            // links). Unlinking a single name is not a secure shred either — the data survives via
+            // the other links — so refuse outright. Best-effort: if the query fails we proceed
+            // (a normal single-link file is the overwhelming case), never blocking a real shred.
+            if (NativeMethods.GetFileInformationByHandle(stream.SafeFileHandle, out var info) && info.NumberOfLinks > 1)
+                throw new IOException(
+                    $"This file has {info.NumberOfLinks} hard links, so its data is shared with other locations. " +
+                    "Securely shredding it would destroy that shared data — remove the extra links first, or delete it normally.");
+
             var fileLength = stream.Length;
 
             for (var pass = 0; pass < totalPasses; pass++)
@@ -441,5 +454,35 @@ public sealed partial class FileShredderService
             [Out] char[] lpszFilePath,
             uint cchFilePath,
             uint dwFlags);
+
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool GetFileInformationByHandle(
+            SafeFileHandle hFile,
+            out ByHandleFileInformation lpFileInformation);
+
+        // Layout must match the native BY_HANDLE_FILE_INFORMATION exactly. All fields are plain
+        // 4-byte DWORDs — each FILETIME is two DWORDs, expanded here — so the struct is fully
+        // blittable. LibraryImport rejects a struct that needs runtime marshalling (SYSLIB1051),
+        // and enabling assembly-wide DisableRuntimeMarshalling would break the classic
+        // [DllImport] surfaces that DO rely on it. Expanding keeps NumberOfLinks at its native
+        // offset (40) with no padding.
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct ByHandleFileInformation
+        {
+            public uint FileAttributes;
+            public uint CreationTimeLow;
+            public uint CreationTimeHigh;
+            public uint LastAccessTimeLow;
+            public uint LastAccessTimeHigh;
+            public uint LastWriteTimeLow;
+            public uint LastWriteTimeHigh;
+            public uint VolumeSerialNumber;
+            public uint FileSizeHigh;
+            public uint FileSizeLow;
+            public uint NumberOfLinks;
+            public uint FileIndexHigh;
+            public uint FileIndexLow;
+        }
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.45</Version>
-    <FileVersion>1.52.45.0</FileVersion>
-    <AssemblyVersion>1.52.45.0</AssemblyVersion>
+    <Version>1.52.46</Version>
+    <FileVersion>1.52.46.0</FileVersion>
+    <AssemblyVersion>1.52.46.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem
The File Shredder overwrites a file's bytes in place. If the file has **hard links**, that destroys the data for *every* name pointing at it — including names outside the folder you selected, or a link a standard user placed at an unprotected path that shares its data with a **protected system file**. The system-path guard only sees the name it opened, and `GetFinalPathNameByHandle` resolves symlinks/junctions but **not** hard links, so neither catches it.

## Fix
After opening the exclusive write handle, `ShredFileAsync` queries `GetFileInformationByHandle` and refuses (`IOException`) when `nNumberOfLinks > 1`. Unlinking a single name is not a secure shred anyway — the data survives via the other links — so it refuses outright with a clear message. Best-effort: if the query fails it proceeds, so a normal single-link file is never blocked. `FileShredderViewModel` already reports `IOException` per item (shown as "failed").

The `BY_HANDLE_FILE_INFORMATION` interop struct is all-`DWORD` (each `FILETIME` expanded to two `uint`s) so it stays blittable for `[LibraryImport]` — `SYSLIB1051` rejects a struct that needs runtime marshalling, and enabling `DisableRuntimeMarshalling` assembly-wide would break the classic `[DllImport]` surfaces (FileLockService, DisplayProfileService) that rely on it.

## Tests
- New regression: creates a hard link with `mklink /H` (no admin, same volume; skips gracefully if the environment cannot), asserts the shred is **refused** and **both names + the shared data survive** — **red** before (the shred succeeds and destroys the data), **green** after.
- All existing shred guards (protected-root denylist, symlink/junction bypass, multi-pass overwrite, cancellation, folder shred) re-run unchanged as regression.

Patch release (`fix:`) -> `v1.52.46`.
