### PR TITLE
fix: a folder shred leaves any file it couldn't securely overwrite, instead of plain-deleting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.47] - 2026-07-08
+
+### Fixed
+- **Shredding a folder no longer plain-deletes (leaving recoverable) any file it could not securely overwrite.** When shredding a folder, a file that could not be securely overwritten — for example a locked or permission-denied file, or a hard-linked file the shredder now refuses — was still removed by the final recursive folder delete. That plain delete leaves the data recoverable while the operation reported success, so you could believe such a file had been securely erased. SysManager now leaves any file it could not securely overwrite in place (removing only the emptied folders around the files it did shred) and reports how many were left, so the outcome is honest.
+
 ## [1.52.46] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager.Tests/FileShredderServiceTests.cs
+++ b/SysManager/SysManager.Tests/FileShredderServiceTests.cs
@@ -402,6 +402,54 @@ public class FileShredderServiceTests
     }
 
     [Fact]
+    public async Task ShredFolderAsync_WithUnshreddableFile_LeavesItAndReportsFailure()
+    {
+        // Regression: a file the shredder cannot securely overwrite (here a hard-linked file,
+        // which ShredFileAsync refuses) must be LEFT in place, never plain-deleted by a recursive
+        // folder delete — otherwise the caller believes a recoverable file was securely shredded.
+        // The folder shred must report the failure (throw) rather than claim success.
+        var svc = NewService();
+        var dir = Path.Combine(Path.GetTempPath(), "smtest_guarantee_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var normal = Path.Combine(dir, "normal.dat");
+        var linkTarget = Path.Combine(Path.GetTempPath(), "smtest_gtarget_" + Guid.NewGuid().ToString("N") + ".dat");
+        var hardlink = Path.Combine(dir, "hardlink.dat");
+        await File.WriteAllTextAsync(normal, "shred me");
+        await File.WriteAllTextAsync(linkTarget, "shared data");
+
+        try
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo("cmd.exe", $"/c mklink /H \"{hardlink}\" \"{linkTarget}\"")
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+            using (var proc = System.Diagnostics.Process.Start(psi)!)
+            {
+                proc.WaitForExit(10_000);
+                if (proc.ExitCode != 0 || !File.Exists(hardlink))
+                    return; // environment can't create a hard link — nothing to assert
+            }
+
+            await Assert.ThrowsAsync<IOException>(
+                () => svc.ShredFolderAsync(dir, ShredMethod.Quick, null, CancellationToken.None));
+
+            Assert.False(File.Exists(normal), "the shreddable file should have been securely shredded and removed");
+            Assert.True(File.Exists(hardlink), "the hard-linked file must be LEFT in place, not plain-deleted");
+            Assert.Equal("shared data", await File.ReadAllTextAsync(linkTarget));
+            Assert.True(Directory.Exists(dir), "the folder holding the un-shreddable file must remain");
+        }
+        finally
+        {
+            if (File.Exists(hardlink)) File.Delete(hardlink);
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+            if (File.Exists(linkTarget)) File.Delete(linkTarget);
+        }
+    }
+
+    [Fact]
     public void ResolveFinalPath_MissingPath_ReturnsNull()
     {
         // A path that can't be opened must return null so ValidatePath falls back to the

--- a/SysManager/SysManager/Services/FileShredderService.cs
+++ b/SysManager/SysManager/Services/FileShredderService.cs
@@ -197,6 +197,12 @@ public sealed partial class FileShredderService
         var files = EnumerateFilesSafe(folderPath);
         var totalFiles = files.Count;
 
+        // Files whose secure overwrite did NOT complete (denied, locked, hard-linked, …). We
+        // must never fall back to a plain delete for these: the caller believes a shredded file
+        // was securely overwritten, so a plain-deleted (recoverable) file would silently break
+        // that guarantee. We leave them on disk and report them instead of force-deleting.
+        List<string> failedFiles = [];
+
         for (var i = 0; i < totalFiles; i++)
         {
             ct.ThrowIfCancellationRequested();
@@ -213,34 +219,58 @@ public sealed partial class FileShredderService
             catch (UnauthorizedAccessException ex)
             {
                 Log.Warning(ex, "Access denied while shredding file: {Path}", files[i]);
+                failedFiles.Add(files[i]);
             }
             catch (IOException ex)
             {
                 Log.Warning(ex, "I/O error while shredding file: {Path}", files[i]);
+                failedFiles.Add(files[i]);
             }
 
             var overallProgress = (int)((i + 1) * 100.0 / totalFiles);
             progress?.Report(overallProgress);
         }
 
-        // Remove empty directories bottom-up
-        try
+        // Remove now-empty directories deepest-first. A securely-shredded file was already
+        // deleted by ShredFileAsync, so its directory becomes empty and is removed here; a
+        // directory that still holds a file we could NOT shred is left in place (with the file).
+        // We only ever remove EMPTY directories (recursive:false), so this can never plain-delete
+        // an un-overwritten file — the bug this replaces (the old recursive delete did).
+        foreach (var dir in Directory.EnumerateDirectories(folderPath, "*", SearchOption.AllDirectories)
+                     .OrderByDescending(d => d.Count(c => c == Path.DirectorySeparatorChar)))
         {
-            Directory.Delete(folderPath, recursive: true);
+            TryRemoveIfEmpty(dir);
         }
-        catch (IOException ex)
+        TryRemoveIfEmpty(folderPath);
+
+        if (failedFiles.Count > 0)
         {
-            Log.Warning(ex, "Could not fully remove folder structure: {Path}", folderPath);
-        }
-        catch (UnauthorizedAccessException ex)
-        {
-            // A read-only/locked entry can deny the final structure removal AFTER every file
-            // was already securely overwritten — log and treat the shred as done rather than
-            // surfacing a failure for work that completed.
-            Log.Warning(ex, "Access denied removing folder structure: {Path}", folderPath);
+            // Honest partial failure: the folder was NOT fully shredded. Report which files were
+            // left in place so the caller (and the user) never believe a file that could not be
+            // securely overwritten was destroyed.
+            var sample = string.Join(", ", failedFiles.Take(5).Select(Path.GetFileName));
+            var more = failedFiles.Count > 5 ? $", and {failedFiles.Count - 5} more" : string.Empty;
+            throw new IOException(
+                $"{failedFiles.Count} of {totalFiles} file(s) could not be securely shredded and were left in place (not deleted): {sample}{more}.");
         }
 
         Log.Information("Folder shredded successfully: {Path} ({Method})", folderPath, method);
+    }
+
+    /// <summary>
+    /// Removes <paramref name="dir"/> only when it is empty, swallowing the expected
+    /// "not empty / denied / already gone" faults. Used to clean up the emptied directory
+    /// structure after a folder shred WITHOUT ever force-deleting a file that remains in it.
+    /// </summary>
+    private static void TryRemoveIfEmpty(string dir)
+    {
+        try
+        {
+            if (!Directory.EnumerateFileSystemEntries(dir).Any())
+                Directory.Delete(dir, recursive: false);
+        }
+        catch (IOException ex) { Log.Debug(ex, "Shredder: could not remove directory {Dir}", dir); }
+        catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Shredder: access denied removing directory {Dir}", dir); }
     }
 
     /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.46</Version>
-    <FileVersion>1.52.46.0</FileVersion>
-    <AssemblyVersion>1.52.46.0</AssemblyVersion>
+    <Version>1.52.47</Version>
+    <FileVersion>1.52.47.0</FileVersion>
+    <AssemblyVersion>1.52.47.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem
When shredding a **folder**, a file the shredder could not securely overwrite — a locked/permission-denied file, or (since the previous change) a **hard-linked** file it now refuses — was caught and logged, but then removed by the final `Directory.Delete(folderPath, recursive: true)`. A plain-deleted file is **recoverable**, yet the folder shred reported success — so you could believe such a file had been securely erased when it had not.

## Fix
`ShredFolderAsync` now:
1. Tracks every file it could **not** securely overwrite.
2. Removes only the **emptied** directories around the files it *did* shred — deepest-first, `recursive: false`, so it can **never** plain-delete a file that remains.
3. Throws an `IOException` naming how many files were left in place.

`FileShredderViewModel` already reports `IOException` per queue item, so the folder is honestly shown as partially failed instead of "complete." A file `ShredFileAsync` successfully shreds is still deleted by `ShredFileAsync` itself, so a fully-shreddable folder is emptied and removed exactly as before.

## Tests
- New regression: shred a folder containing a normal file **and** a hard-linked file — asserts the shred **throws**, the normal file is securely shredded and gone, and the **hard-linked file + its shared data survive** and the folder remains. **Red** before (the recursive delete removed everything, no throw), **green** after.
- The existing all-success folder-shred test is unchanged and still removes the folder — confirming the happy path is intact.

Patch release (`fix:`) -> `v1.52.47`.
