### PR TITLE
chore: dispose the WindowsIdentity token handle and drop a redundant serializer options object

### DIFF
--- a/SysManager/SysManager/Helpers/RecycleBinHelper.cs
+++ b/SysManager/SysManager/Helpers/RecycleBinHelper.cs
@@ -49,7 +49,13 @@ public static partial class RecycleBinHelper
     public static string[] CurrentUserBinPaths()
     {
         string? sid;
-        try { sid = WindowsIdentity.GetCurrent().User?.Value; }
+        try
+        {
+            // WindowsIdentity owns a native token handle — dispose it deterministically
+            // (matches AdminHelper.IsElevated / App.xaml.cs) instead of waiting for the finalizer.
+            using var identity = WindowsIdentity.GetCurrent();
+            sid = identity.User?.Value;
+        }
         catch (System.Security.SecurityException) { sid = null; }
         if (string.IsNullOrEmpty(sid)) return [];
 

--- a/SysManager/SysManager/Services/ActivityLogService.cs
+++ b/SysManager/SysManager/Services/ActivityLogService.cs
@@ -67,7 +67,9 @@ public sealed class ActivityLogService
         {
             var dir = Path.GetDirectoryName(FilePath)!;
             Directory.CreateDirectory(dir);
-            var json = JsonSerializer.Serialize(snapshot, new JsonSerializerOptions { WriteIndented = false });
+            // WriteIndented = false is the default, so no options object is needed — allocating
+            // one per save would only defeat System.Text.Json's per-options metadata cache.
+            var json = JsonSerializer.Serialize(snapshot);
             File.WriteAllText(FilePath, json);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)


### PR DESCRIPTION
Two pure, no-behavior-change hygiene tweaks:

- **RecycleBinHelper** — `CurrentUserBinPaths` opened `WindowsIdentity.GetCurrent()` (which owns a native token handle) without disposing it. Now wrapped in `using`, matching `AdminHelper.IsElevated` and `App.xaml.cs`.
- **ActivityLogService** — `Save` allocated a `new JsonSerializerOptions { WriteIndented = false }` on every call. `WriteIndented = false` is the default, so the object is dropped — and a fresh options instance per call also defeats System.Text.Json's per-options metadata cache.

The produced SID and JSON are byte-identical, so existing tests cover the behavior. `chore:` — no release.
