### PR TITLE
chore: reuse a single indented JsonSerializerOptions instead of allocating one per call

### DIFF
--- a/SysManager/SysManager/Services/CliRunner.cs
+++ b/SysManager/SysManager/Services/CliRunner.cs
@@ -206,7 +206,7 @@ public sealed class CliRunner
     }
 
     private static string Json(object value)
-        => JsonSerializer.Serialize(value, new JsonSerializerOptions { WriteIndented = true });
+        => JsonSerializer.Serialize(value, JsonDefaults.Indented);
 
     internal static string CurrentVersion => Version;
 }

--- a/SysManager/SysManager/Services/GamingProfileService.cs
+++ b/SysManager/SysManager/Services/GamingProfileService.cs
@@ -453,7 +453,7 @@ public sealed class GamingProfileService : IGamingProfileService, IDisposable
             Directory.CreateDirectory(dir);
             var json = JsonSerializer.Serialize(
                 store with { SchemaVersion = CurrentSchemaVersion },
-                new JsonSerializerOptions { WriteIndented = true });
+                JsonDefaults.Indented);
             File.WriteAllText(_storePath, json);
         }
         catch (IOException ex) { Log.Warning(ex, "Failed to save gaming profile store"); }

--- a/SysManager/SysManager/Services/JsonDefaults.cs
+++ b/SysManager/SysManager/Services/JsonDefaults.cs
@@ -1,0 +1,19 @@
+// SysManager · JsonDefaults
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Text.Json;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Shared <see cref="JsonSerializerOptions"/> instances. System.Text.Json caches its
+/// serialization metadata per options instance, so reusing one static readonly instance
+/// (instead of allocating a fresh options object per call) keeps that cache warm and avoids a
+/// per-call allocation. Matches the static-readonly idiom already used by ResourceHistoryService.
+/// </summary>
+internal static class JsonDefaults
+{
+    /// <summary>Human-readable, indented output — shared by the settings/snapshot/profile writers.</summary>
+    public static readonly JsonSerializerOptions Indented = new() { WriteIndented = true };
+}

--- a/SysManager/SysManager/Services/PerformanceService.cs
+++ b/SysManager/SysManager/Services/PerformanceService.cs
@@ -119,7 +119,7 @@ public sealed partial class PerformanceService : IDisposable
         {
             var dir = Path.GetDirectoryName(SnapshotPath)!;
             Directory.CreateDirectory(dir);
-            var json = JsonSerializer.Serialize(snapshot, new JsonSerializerOptions { WriteIndented = true });
+            var json = JsonSerializer.Serialize(snapshot, JsonDefaults.Indented);
             File.WriteAllText(SnapshotPath, json);
             Log.Information("Performance snapshot saved to {Path}", SnapshotPath);
         }

--- a/SysManager/SysManager/Services/SettingsWatchdogService.cs
+++ b/SysManager/SysManager/Services/SettingsWatchdogService.cs
@@ -183,8 +183,7 @@ public sealed class SettingsWatchdogService : ISettingsWatchdogService
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(BaselinePath)!);
-            File.WriteAllText(BaselinePath, JsonSerializer.Serialize(snapshot,
-                new JsonSerializerOptions { WriteIndented = true }));
+            File.WriteAllText(BaselinePath, JsonSerializer.Serialize(snapshot, JsonDefaults.Indented));
         }
         catch (IOException ex) { Log.Debug("Settings baseline save failed: {Error}", ex.Message); }
     }

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -321,7 +321,7 @@ public sealed class ThemeService
             var data = new ThemeSettings(CurrentPresetId, CurrentMode, ShadePosition,
                 CurrentTheme.Accent.ToString(), CurrentTheme.Background.ToString(),
                 CurrentTheme.Surface.ToString(), CurrentTheme.TextPrimary.ToString());
-            var json = JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
+            var json = JsonSerializer.Serialize(data, JsonDefaults.Indented);
             File.WriteAllText(SettingsPath, json);
         }
         catch (Exception ex) { Log.Debug("Theme save failed: {Error}", ex.Message); }

--- a/SysManager/SysManager/Services/WindowsThemeService.cs
+++ b/SysManager/SysManager/Services/WindowsThemeService.cs
@@ -99,7 +99,7 @@ public sealed partial class WindowsThemeService : IWindowsThemeService
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(SchedulePath)!);
-            string json = JsonSerializer.Serialize(schedule, new JsonSerializerOptions { WriteIndented = true });
+            string json = JsonSerializer.Serialize(schedule, JsonDefaults.Indented);
             File.WriteAllText(SchedulePath, json);
         }
         catch (IOException ex) { Log.Warning("Dark-mode schedule save failed: {Error}", ex.Message); }


### PR DESCRIPTION
Six settings/snapshot/profile writers each allocated a fresh `new JsonSerializerOptions { WriteIndented = true }` on every save. System.Text.Json caches serialization metadata **per options instance**, so a new instance per call both allocates and misses that cache. They now share one `JsonDefaults.Indented` static readonly instance — a single source of truth, matching `ResourceHistoryService`'s existing static-readonly idiom.

Files: `CliRunner`, `GamingProfileService`, `PerformanceService`, `SettingsWatchdogService`, `ThemeService`, `WindowsThemeService` + new `JsonDefaults`.

Pure — the emitted JSON is byte-identical (`WriteIndented = true` unchanged); existing round-trip tests cover it. `chore:` — no release.
