### PR TITLE
fix: resume Start/Stop service actions on the UI thread, like Enable/Disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.48] - 2026-07-08
+
+### Fixed
+- **Starting or stopping a Windows service from the Services tab no longer risks a cross-thread error.** After a start/stop completed, SysManager refreshed the service row and the on-screen status from a background thread — unlike the Enable/Disable actions in the same tab, which correctly resume on the UI thread. Updating UI-bound state off the UI thread can raise a cross-thread exception. Start and Stop now resume on the UI thread just like Enable and Disable, so the row and status update safely.
+
 ## [1.52.47] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.47</Version>
-    <FileVersion>1.52.47.0</FileVersion>
-    <AssemblyVersion>1.52.47.0</AssemblyVersion>
+    <Version>1.52.48</Version>
+    <FileVersion>1.52.48.0</FileVersion>
+    <AssemblyVersion>1.52.48.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -103,7 +103,9 @@ public sealed partial class ServicesViewModel : ViewModelBase
 
         try
         {
-            await ServiceManagerService.StartServiceAsync(entry.Name).ConfigureAwait(false);
+            // Resume on the UI thread (no ConfigureAwait(false)): the continuation updates
+            // bound state (RefreshStatus + StatusMessage), matching Enable/DisableServiceAsync.
+            await ServiceManagerService.StartServiceAsync(entry.Name);
             ServiceManagerService.RefreshStatus(entry);
             StatusMessage = $"✓ {entry.DisplayName} started.";
             Log.Information("Service started: {ServiceName}", entry.Name);
@@ -137,7 +139,8 @@ public sealed partial class ServicesViewModel : ViewModelBase
 
         try
         {
-            await ServiceManagerService.StopServiceAsync(entry.Name).ConfigureAwait(false);
+            // Resume on the UI thread — see StartServiceAsync.
+            await ServiceManagerService.StopServiceAsync(entry.Name);
             ServiceManagerService.RefreshStatus(entry);
             StatusMessage = $"✓ {entry.DisplayName} stopped.";
             Log.Information("Service stopped: {ServiceName}", entry.Name);


### PR DESCRIPTION
## Problem
Starting or stopping a Windows service from the Services tab could raise a cross-thread exception. After the start/stop completed, SysManager updated the service row (`RefreshStatus`) and the on-screen `StatusMessage` from a **thread-pool thread**.

## Root cause
`StartServiceAsync` and `StopServiceAsync` awaited with `.ConfigureAwait(false)`, so their continuation resumed off the UI thread and then touched UI-bound state. The sibling `EnableServiceAsync` / `DisableServiceAsync` in the same view model already omit `ConfigureAwait(false)` and resume on the UI thread — Start/Stop were the two outliers.

## Fix
Dropped `.ConfigureAwait(false)` on the Start/Stop awaits so their continuation resumes on the captured UI dispatcher, exactly like Enable/Disable. Added a short comment on each to keep the omission deliberate.

## Tests
No unit test: UI-thread marshaling isn't unit-testable without a UI harness (not run here). The change aligns the two outliers with the proven Enable/Disable siblings in the same file, and the existing `ServicesViewModel` tests regress the rest. Build is green (Release, 0 warnings / 0 errors).

Patch release (`fix:`) -> `v1.52.48`.
