### PR TITLE
fix: initialize the NVIDIA temperature API once instead of on every poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.49] - 2026-07-08
+
+### Fixed
+- **GPU temperature polling no longer re-initializes the NVIDIA API every couple of seconds — and no longer throws once per poll on PCs without an NVIDIA GPU.** The temperature reader called NVIDIA's `Initialize()` and re-enumerated GPUs on every poll (about every 2 seconds). On a machine with no NVIDIA GPU that raised and swallowed an exception on every single poll; on NVIDIA machines it redid the one-time setup each time. SysManager now initializes the NVIDIA API at most once, remembers whether an NVIDIA GPU is present, and skips the read entirely afterwards when there isn't one — so there's no per-poll exception and no repeated setup. GPU temperatures on NVIDIA machines are unchanged.
+
 ## [1.52.48] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager/Services/TemperatureService.cs
+++ b/SysManager/SysManager/Services/TemperatureService.cs
@@ -280,14 +280,39 @@ public sealed class TemperatureService : IDisposable
         return names;
     }
 
-    private static void ReadNvidiaGpuTemperatures(List<TemperatureReading> readings)
+    // NvAPI init is one-time. Re-running NVIDIA.Initialize() + GetPhysicalGPUs() on every poll
+    // re-does the setup and, on a non-NVIDIA machine, throws (and swallows) an exception on every
+    // tick — the temperature poll runs about every 2 s. We initialize at most once, remember
+    // whether any NVIDIA GPU is present, and skip the whole read thereafter when none is.
+    private bool _nvApiInitTried;
+    private bool _nvApiAvailable;
+
+    private void ReadNvidiaGpuTemperatures(List<TemperatureReading> readings)
     {
+        if (!_nvApiInitTried)
+        {
+            _nvApiInitTried = true;
+            try
+            {
+                NvAPIWrapper.NVIDIA.Initialize();
+                _nvApiAvailable = NvAPIWrapper.GPU.PhysicalGPU.GetPhysicalGPUs().Length > 0;
+            }
+            // No NVIDIA GPU / driver present is the normal case on AMD/Intel systems — record it
+            // once so later polls skip silently instead of throwing an exception every tick.
+            catch (NvAPIWrapper.Native.Exceptions.NVIDIAApiException) { _nvApiAvailable = false; }
+            catch (DllNotFoundException) { _nvApiAvailable = false; }
+            catch (Exception ex) when (ex is TypeInitializationException or InvalidOperationException)
+            {
+                _nvApiAvailable = false;
+                Log.Debug("NVIDIA API init failed: {Error}", ex.Message);
+            }
+        }
+
+        if (!_nvApiAvailable) return;
+
         try
         {
-            NvAPIWrapper.NVIDIA.Initialize();
-            var gpus = NvAPIWrapper.GPU.PhysicalGPU.GetPhysicalGPUs();
-
-            foreach (var gpu in gpus)
+            foreach (var gpu in NvAPIWrapper.GPU.PhysicalGPU.GetPhysicalGPUs())
             {
                 var sensor = gpu.ThermalInformation.ThermalSensors
                     .FirstOrDefault(s => s.CurrentTemperature > 0);
@@ -298,13 +323,11 @@ public sealed class TemperatureService : IDisposable
                 }
             }
         }
-        // No NVIDIA GPU / driver present is the normal case on AMD/Intel systems —
-        // skip GPU temperatures silently rather than logging noise on every poll.
-        catch (NvAPIWrapper.Native.Exceptions.NVIDIAApiException) { /* no NVIDIA GPU */ }
-        catch (DllNotFoundException) { /* nvapi.dll not installed */ }
+        // A transient read failure (e.g. a driver reset) must not crash the poll — skip this tick.
+        catch (NvAPIWrapper.Native.Exceptions.NVIDIAApiException) { /* transient GPU read failure */ }
         catch (Exception ex) when (ex is TypeInitializationException or InvalidOperationException)
         {
-            Log.Debug("NVIDIA API init failed: {Error}", ex.Message);
+            Log.Debug("NVIDIA GPU temperature read failed: {Error}", ex.Message);
         }
     }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.48</Version>
-    <FileVersion>1.52.48.0</FileVersion>
-    <AssemblyVersion>1.52.48.0</AssemblyVersion>
+    <Version>1.52.49</Version>
+    <FileVersion>1.52.49.0</FileVersion>
+    <AssemblyVersion>1.52.49.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem
The temperature poll re-initialized the NVIDIA API and re-enumerated GPUs on **every** poll (~2 s). On a machine with no NVIDIA GPU, that threw and swallowed an `NVIDIAApiException` on every single tick; on NVIDIA machines it repeated the one-time setup each time.

## Fix
`ReadNvidiaGpuTemperatures` now initializes the NVIDIA API **at most once** (instance flags `_nvApiInitTried` / `_nvApiAvailable`), records whether any NVIDIA GPU is present, and returns immediately on later polls when none is. GPU temperature reads on NVIDIA machines are unchanged (same sensors, same values). Mirrors the "resolve hardware once" pattern used elsewhere in the app.

## Tests
No unit test: the path is bound to the NvAPI hardware library and can't be exercised without an NVIDIA GPU. Only the init is now guarded — the read logic is unchanged. Build green (Release, 0 warnings / 0 errors).

Patch release (`fix:`) -> `v1.52.49`.
