### PR TITLE
fix: cache the NVIDIA GPU handle and reuse the startup health score on the Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.50] - 2026-07-08
+
+### Fixed
+- **The Dashboard does less redundant work at startup and while polling.** Two efficiency fixes, both leaving what you see unchanged: (1) the live GPU tile re-enumerated all physical GPUs through the NVIDIA API on every 300 ms poll — it now resolves the GPU once and reads usage/memory from that cached handle each tick; (2) the health score's heavy disk-SMART/memory/battery computation ran three times at startup (the Dashboard's own load plus the SMART and memory alert scans, two of them at once) — the alert scans now reuse the score the Dashboard already computed, falling back to a fresh computation only if that load failed.
+
 ## [1.52.49] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.49</Version>
-    <FileVersion>1.52.49.0</FileVersion>
-    <AssemblyVersion>1.52.49.0</AssemblyVersion>
+    <Version>1.52.50</Version>
+    <FileVersion>1.52.50.0</FileVersion>
+    <AssemblyVersion>1.52.50.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -29,6 +29,9 @@ public sealed partial class DashboardViewModel : ViewModelBase
     // query), instead of re-initialising and re-querying on every tick.
     private bool _nvApiInitTried;
     private bool _nvApiAvailable;
+    // Cached NVIDIA GPU handle, resolved once during init instead of re-enumerating every
+    // 300ms poll — matches the "resolve static hardware once" pattern used for the GPU name.
+    private NvAPIWrapper.GPU.PhysicalGPU? _gpu;
     private bool _gpuNameResolved;
 
     // ── Real-time vitals (300ms polling) ──────────────────────────────────
@@ -179,7 +182,11 @@ public sealed partial class DashboardViewModel : ViewModelBase
             try
             {
                 NvAPIWrapper.NVIDIA.Initialize();
-                _nvApiAvailable = NvAPIWrapper.GPU.PhysicalGPU.GetPhysicalGPUs().Length > 0;
+                // Resolve the GPU handle ONCE and cache it; each poll then reads live usage and
+                // memory off this handle instead of re-enumerating all physical GPUs every tick.
+                var gpus = NvAPIWrapper.GPU.PhysicalGPU.GetPhysicalGPUs();
+                _gpu = gpus.Length > 0 ? gpus[0] : null;
+                _nvApiAvailable = _gpu is not null;
             }
             catch (Exception ex)
             {
@@ -188,27 +195,23 @@ public sealed partial class DashboardViewModel : ViewModelBase
             }
         }
 
-        if (_nvApiAvailable)
+        if (_nvApiAvailable && _gpu is not null)
         {
             try
             {
-                var gpus = NvAPIWrapper.GPU.PhysicalGPU.GetPhysicalGPUs();
-                if (gpus.Length > 0)
-                {
-                    var gpu = gpus[0];
-                    var usage = gpu.UsageInformation.GPU.Percentage;
-                    var memTotal = gpu.MemoryInformation.DedicatedVideoMemoryInkB / 1024.0 / 1024.0;
-                    var memUsed = (gpu.MemoryInformation.DedicatedVideoMemoryInkB -
-                                   gpu.MemoryInformation.AvailableDedicatedVideoMemoryInkB) / 1024.0 / 1024.0;
+                var usage = _gpu.UsageInformation.GPU.Percentage;
+                var memTotal = _gpu.MemoryInformation.DedicatedVideoMemoryInkB / 1024.0 / 1024.0;
+                var memUsed = (_gpu.MemoryInformation.DedicatedVideoMemoryInkB -
+                               _gpu.MemoryInformation.AvailableDedicatedVideoMemoryInkB) / 1024.0 / 1024.0;
+                var name = _gpu.FullName;
 
-                    System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
-                    {
-                        GpuPercent = usage;
-                        GpuName = gpu.FullName;
-                        GpuVram = $"{memUsed:F1} / {memTotal:F1} GB VRAM";
-                    });
-                    return;
-                }
+                System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
+                {
+                    GpuPercent = usage;
+                    GpuName = name;
+                    GpuVram = $"{memUsed:F1} / {memTotal:F1} GB VRAM";
+                });
+                return;
             }
             catch (Exception ex)
             {
@@ -403,8 +406,10 @@ public sealed partial class DashboardViewModel : ViewModelBase
 
     private async Task ScanSmartHealthAsync(DashboardAlert alert)
     {
-        var result = await _healthScore.ComputeAsync();
-        var diskScore = result.DiskScore;
+        // Reuse the score LoadHealthScoreAsync already computed (it runs before the alert
+        // scans) instead of recomputing the heavy WMI/SMART/battery work; fall back to a fresh
+        // compute only if that load produced nothing (e.g. it failed).
+        var diskScore = (HealthResult ?? await _healthScore.ComputeAsync()).DiskScore;
         System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
         {
             if (diskScore >= 90)
@@ -461,7 +466,8 @@ public sealed partial class DashboardViewModel : ViewModelBase
 
     private async Task ScanMemoryHealthAsync(DashboardAlert alert)
     {
-        var result = await _healthScore.ComputeAsync();
+        // Reuse the already-computed score (see ScanSmartHealthAsync) rather than recomputing.
+        var result = HealthResult ?? await _healthScore.ComputeAsync();
         System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
         {
             if (result.RamScore >= 90)


### PR DESCRIPTION
Two behavior-preserving efficiency fixes on the Dashboard (what you see is unchanged):

## GPU tile — cache the handle
The live GPU tile called NvAPI's `GetPhysicalGPUs()` on **every 300 ms poll**. It now resolves the `PhysicalGPU` handle **once** during the one-time init (cached in `_gpu`) and reads usage/memory off that handle each tick — matching the "resolve static hardware once" pattern already used for the GPU name.

## Health score — compute once, not three times
The heavy disk-SMART / memory / battery computation ran **three times** at startup: `LoadHealthScoreAsync` (which stores `HealthResult`) plus the SMART and memory alert scans, which each called `ComputeAsync()` again (two of them concurrently). The alert scans now read the already-computed `HealthResult` (`DiskScore` / `RamScore`), falling back to a fresh `ComputeAsync()` only if `HealthResult` is `null` (the initial load failed). `LoadHealthScoreAsync` runs and completes before `StartAlertScans`, so the value is present on the normal path.

## Tests
No unit test: the GPU path is bound to the NvAPI hardware library and the health path is a startup polling / alert-scan flow — neither is unit-testable without hardware or a UI harness. Both are behavior-preserving; existing `DashboardViewModel` tests regress the rest. Build green (Release, 0/0).

Patch release (`fix:`) -> `v1.52.50`.
