### PR TITLE
fix: move the Environment Variables slow operations off the UI thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.51] - 2026-07-08
+
+### Fixed
+- **The Environment Variables tab no longer freezes the app while applying, restoring, or refreshing.** Applying changes broadcasts a system-wide "settings changed" message that waits up to 5 seconds for other windows to respond, and restoring or refreshing re-reads every user and system variable — all of which ran on the UI thread, freezing the whole window until they finished. The slow parts (the broadcast, the restore, and the full re-read) now run off the UI thread, so the app stays responsive; the actual variable writes are unchanged.
+
 ## [1.52.50] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.50</Version>
-    <FileVersion>1.52.50.0</FileVersion>
-    <AssemblyVersion>1.52.50.0</AssemblyVersion>
+    <Version>1.52.51</Version>
+    <FileVersion>1.52.51.0</FileVersion>
+    <AssemblyVersion>1.52.51.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
@@ -308,7 +308,7 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void ApplyChanges()
+    private async Task ApplyChanges()
     {
         if (PendingChangeCount == 0)
         {
@@ -371,7 +371,9 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
         }
 
         // Broadcast once so running processes (Explorer, new shells) pick up the changes.
-        if (applied > 0) EnvironmentVariableService.BroadcastSettingChange();
+        // The broadcast waits up to 5 s for windows to respond, so run it OFF the UI thread —
+        // the registry writes above are fast and stay on-thread (they own the change bookkeeping).
+        if (applied > 0) await Task.Run(EnvironmentVariableService.BroadcastSettingChange);
 
         RecomputePending();
 
@@ -401,7 +403,7 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
     public bool HasBackup => _service.HasBackup;
 
     [RelayCommand]
-    private void RestoreBackup()
+    private async Task RestoreBackup()
     {
         if (!_service.HasBackup)
         {
@@ -434,9 +436,11 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
             return;
         }
 
-        var r = _service.RestoreFromBackup();
-        if (r.Restored > 0 || r.Removed > 0) EnvironmentVariableService.BroadcastSettingChange();
-        Load();
+        // Restore rewrites many variables and then broadcasts (up to 5 s) — both run off the
+        // UI thread; the list is re-read off-thread too via LoadAsync so the window stays live.
+        var r = await Task.Run(_service.RestoreFromBackup);
+        if (r.Restored > 0 || r.Removed > 0) await Task.Run(EnvironmentVariableService.BroadcastSettingChange);
+        await LoadAsync();
 
         StatusMessage = r.Failed == 0
             ? $"Restored {r.Restored} variable{(r.Restored == 1 ? "" : "s")}" +
@@ -445,16 +449,16 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void DiscardChanges()
+    private async Task DiscardChanges()
     {
-        Load();
+        await LoadAsync();
         StatusMessage = "Pending changes discarded.";
     }
 
     [RelayCommand]
-    private void Refresh()
+    private async Task Refresh()
     {
-        Load();
+        await LoadAsync();
         StatusMessage = "Variables refreshed.";
         Log.Information("Environment: refreshed variable list");
     }


### PR DESCRIPTION
## Problem
The Environment Variables tab froze the whole window while applying, restoring, or refreshing changes.

## Root cause
Four commands ran their heavy work synchronously on the UI thread:
- **Apply** broadcasts `WM_SETTINGCHANGE`, which waits **up to 5 seconds** for windows to respond.
- **Restore** rewrites every variable to its backup value, then broadcasts.
- **Refresh / Discard / Restore** re-read every User and Machine variable from the registry.

## Fix
The four commands are now `async`; the slow calls — the broadcast, the restore write-back, and the full re-read (via the existing `LoadAsync`) — run under `Task.Run` and resume on the UI thread for the collection/status update. Apply's own registry writes stay on the UI thread: they are fast and own the change bookkeeping (`_baseline`/`_originals`), so keeping them on-thread avoids a cross-thread race with no measurable freeze.

## Tests
No unit test: UI-thread responsiveness isn't unit-testable without a UI harness (not run here). Variable reads/writes are unchanged — only *where* the slow calls run changed. Build green (Release, 0 warnings / 0 errors).

Patch release (`fix:`) -> `v1.52.51`.
