### PR TITLE
fix: shred a snapshot of the File Shredder queue and lock the queue while shredding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.52] - 2026-07-08
+
+### Fixed
+- **The File Shredder queue can no longer be changed while a shred is running.** During a shred, the Add Files, Add Folder and Remove buttons stayed active, and the shred walked the live queue by index across each file's overwrite — so adding or removing an item mid-shred could skip an item, act on the wrong one, or error. The shred now works on a snapshot of the queue taken when it starts, and the add/remove buttons are disabled until it finishes.
+
 ## [1.52.51] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.51</Version>
-    <FileVersion>1.52.51.0</FileVersion>
-    <AssemblyVersion>1.52.51.0</AssemblyVersion>
+    <Version>1.52.52</Version>
+    <FileVersion>1.52.52.0</FileVersion>
+    <AssemblyVersion>1.52.52.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/FileShredderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/FileShredderViewModel.cs
@@ -32,7 +32,7 @@ public sealed partial class FileShredderViewModel : ViewModelBase
         Items.CollectionChanged += (_, _) => ShredAllCommand.NotifyCanExecuteChanged();
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanEditQueue))]
     private void AddFiles()
     {
         var dialog = new Microsoft.Win32.OpenFileDialog
@@ -67,7 +67,7 @@ public sealed partial class FileShredderViewModel : ViewModelBase
         }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanEditQueue))]
     private void AddFolder()
     {
         var dialog = new Microsoft.Win32.OpenFolderDialog
@@ -105,7 +105,7 @@ public sealed partial class FileShredderViewModel : ViewModelBase
         }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanEditQueue))]
     private void RemoveItem(ShredItem? item)
     {
         if (item is not null)
@@ -137,12 +137,13 @@ public sealed partial class FileShredderViewModel : ViewModelBase
 
         try
         {
-            // Process items sequentially
-            for (var i = Items.Count - 1; i >= 0; i--)
+            // Shred a SNAPSHOT of the queue, not the live collection: indexing Items across the
+            // per-file awaits would race a concurrent Add/Remove. (Those commands are also
+            // disabled while shredding via CanEditQueue; the snapshot is the belt-and-suspenders.)
+            foreach (var item in Items.ToArray())
             {
                 ct.ThrowIfCancellationRequested();
 
-                var item = Items[i];
                 var totalPasses = (int)SelectedMethod;
 
                 var itemProgress = new Progress<int>(p =>
@@ -219,7 +220,15 @@ public sealed partial class FileShredderViewModel : ViewModelBase
     partial void OnIsShreddingChanged(bool value)
     {
         ShredAllCommand.NotifyCanExecuteChanged();
+        // The queue must not change mid-shred (the shred iterates a snapshot), so disable the
+        // add/remove commands while shredding and re-enable them when it finishes.
+        AddFilesCommand.NotifyCanExecuteChanged();
+        AddFolderCommand.NotifyCanExecuteChanged();
+        RemoveItemCommand.NotifyCanExecuteChanged();
     }
+
+    // Add/remove are disabled while a shred runs so the queue can't be mutated mid-operation.
+    private bool CanEditQueue => !IsShredding;
 
     protected override void Dispose(bool disposing)
     {


### PR DESCRIPTION
## Problem
Adding or removing items in the File Shredder **while a shred was running** could skip an item, act on the wrong one, or error out.

## Root cause
`ShredAllAsync` iterated the live `Items` collection **by index** (`for i = Count-1 … Items[i]`) across each file's `await`, while the **Add Files / Add Folder / Remove** commands stayed enabled. Mutating `Items` between awaits shifts the indices under the loop.

## Fix
- The shred now iterates a **snapshot** taken when the run starts: `foreach (var item in Items.ToArray())`.
- The add/remove commands are `CanExecute`-gated on a new `CanEditQueue => !IsShredding`, so the queue can't be changed until the shred finishes (and `OnIsShreddingChanged` re-evaluates them).

Successfully-shredded items are still removed from the live list afterward, and a normal (untouched) queue behaves exactly as before.

## Tests
No unit test: the command drives a real file shred plus UI-thread state — not unit-testable without a UI harness. Build green (Release, 0/0).

Patch release (`fix:`) -> `v1.52.52`.
