### PR TITLE
fix: read System info uptime and memory in one WMI query, not two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.53] - 2026-07-08
+
+### Fixed
+- **System-info refreshes now make one Windows query instead of two.** Each refresh read the current uptime and the memory totals with two separate WMI queries against the same OS object; they are now fetched in a single query, one fewer round-trip per poll. No visible change — the same uptime and memory figures.
+
 ## [1.52.52] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager/Services/SystemInfoService.cs
+++ b/SysManager/SysManager/Services/SystemInfoService.cs
@@ -26,16 +26,16 @@ public sealed class SystemInfoService
 
     private SystemSnapshot Capture()
     {
-        OsInfo os;
+        OsInfo osStatic;
         CpuInfo cpu;
         List<DiskInfo> disks;
+        IReadOnlyList<MemoryModule> modules;
 
         lock (_cacheLock)
         {
-            // Static OS info (caption, version, build, arch) — cache it.
-            // Uptime is dynamic, so we always refresh it.
+            // Static OS info (caption, version, build, arch) — cache it; uptime refreshes below.
             _cachedOs ??= QueryOsStatic();
-            os = _cachedOs with { Uptime = QueryUptime() };
+            osStatic = _cachedOs;
 
             // CPU name/cores/threads/clock are static; only LoadPercentage is dynamic.
             _cachedCpuStatic ??= QueryCpuStatic();
@@ -49,9 +49,13 @@ public sealed class SystemInfoService
             // hardware — enumerate the DIMMs once. Only the dynamic totals refresh below,
             // so the Dashboard's 300 ms vitals poll no longer re-queries Win32_PhysicalMemory.
             _cachedModules ??= QueryMemoryModules();
+            modules = _cachedModules;
         }
 
-        var mem = QueryMemory(_cachedModules);
+        // One Win32_OperatingSystem query for BOTH the dynamic uptime and memory totals —
+        // previously two separate round-trips (QueryUptime + QueryMemory) to the same class.
+        var (uptime, mem) = QueryDynamicOs(modules);
+        var os = osStatic with { Uptime = uptime };
         return new SystemSnapshot(os, cpu, mem, disks, DateTime.Now);
     }
 
@@ -90,11 +94,17 @@ public sealed class SystemInfoService
         return new OsInfo("Windows", "", "", TimeSpan.Zero, "");
     }
 
-    private static TimeSpan QueryUptime()
+    // Single Win32_OperatingSystem query for BOTH the dynamic uptime and the memory totals, so
+    // the per-poll path makes one round-trip instead of two (QueryUptime + QueryMemory previously
+    // queried the same class separately). The static DIMM modules are passed through unchanged.
+    private static (TimeSpan Uptime, MemoryInfo Memory) QueryDynamicOs(IReadOnlyList<MemoryModule> modules)
     {
+        var uptime = TimeSpan.Zero;
+        double totalKb = 0, freeKb = 0;
         try
         {
-            using var searcher = new ManagementObjectSearcher("SELECT LastBootUpTime FROM Win32_OperatingSystem");
+            using var searcher = new ManagementObjectSearcher(
+                "SELECT LastBootUpTime,TotalVisibleMemorySize,FreePhysicalMemory FROM Win32_OperatingSystem");
             using var osCollection = searcher.Get();
             foreach (ManagementObject mo in osCollection)
             {
@@ -103,18 +113,25 @@ public sealed class SystemInfoService
                     var lastBootRaw = mo["LastBootUpTime"]?.ToString();
                     if (!string.IsNullOrEmpty(lastBootRaw))
                     {
-                        try { return DateTime.Now - ManagementDateTimeConverter.ToDateTime(lastBootRaw); }
-                        catch (FormatException) { /* WMI date string malformed — fall through to zero */ }
-                        catch (InvalidCastException) { /* WMI returned unexpected type — fall through to zero */ }
+                        try { uptime = DateTime.Now - ManagementDateTimeConverter.ToDateTime(lastBootRaw); }
+                        catch (FormatException) { /* WMI date string malformed — keep zero uptime */ }
+                        catch (InvalidCastException) { /* WMI returned unexpected type — keep zero uptime */ }
                     }
+                    totalKb = Convert.ToDouble(mo["TotalVisibleMemorySize"] ?? 0);
+                    freeKb = Convert.ToDouble(mo["FreePhysicalMemory"] ?? 0);
                 }
             }
         }
         catch (Exception ex) when (ex is ManagementException or System.Runtime.InteropServices.COMException)
         {
-            /* WMI unavailable — degrade to zero uptime */
+            /* WMI unavailable — degrade to zero uptime + zeroed totals (modules still shown) */
         }
-        return TimeSpan.Zero;
+
+        double totalGB = totalKb / 1024d / 1024d;
+        double freeGB = freeKb / 1024d / 1024d;
+        double usedGB = totalGB - freeGB;
+        double pct = totalGB > 0 ? usedGB / totalGB * 100.0 : 0;
+        return (uptime, new MemoryInfo(totalGB, freeGB, usedGB, pct, modules));
     }
 
     private static CpuInfo QueryCpuStatic()
@@ -164,38 +181,8 @@ public sealed class SystemInfoService
         return 0;
     }
 
-    // Dynamic RAM totals (refreshed every poll) combined with the pre-enumerated,
-    // cached static DIMM modules. Only Win32_OperatingSystem is queried here.
-    private static MemoryInfo QueryMemory(IReadOnlyList<MemoryModule> modules)
-    {
-        double totalKb = 0, freeKb = 0;
-        try
-        {
-            using var s = new ManagementObjectSearcher("SELECT TotalVisibleMemorySize,FreePhysicalMemory FROM Win32_OperatingSystem");
-            using var memCollection = s.Get();
-            foreach (ManagementObject mo in memCollection)
-            {
-                using (mo)
-                {
-                    totalKb = Convert.ToDouble(mo["TotalVisibleMemorySize"] ?? 0);
-                    freeKb = Convert.ToDouble(mo["FreePhysicalMemory"] ?? 0);
-                }
-            }
-        }
-        catch (Exception ex) when (ex is ManagementException or System.Runtime.InteropServices.COMException)
-        {
-            /* WMI unavailable — degrade to zeroed totals (modules still shown) */
-        }
-        double totalGB = totalKb / 1024d / 1024d;
-        double freeGB = freeKb / 1024d / 1024d;
-        double usedGB = totalGB - freeGB;
-        double pct = totalGB > 0 ? usedGB / totalGB * 100.0 : 0;
-
-        return new MemoryInfo(totalGB, freeGB, usedGB, pct, modules);
-    }
-
-    // Physical DIMM inventory — static hardware, enumerated once and cached. Kept
-    // separate from QueryMemory so the per-poll path never re-scans Win32_PhysicalMemory.
+    // Physical DIMM inventory — static hardware, enumerated once and cached. Kept separate
+    // from the dynamic OS query so the per-poll path never re-scans Win32_PhysicalMemory.
     private static List<MemoryModule> QueryMemoryModules()
     {
         List<MemoryModule> modules = [];

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.52</Version>
-    <FileVersion>1.52.52.0</FileVersion>
-    <AssemblyVersion>1.52.52.0</AssemblyVersion>
+    <Version>1.52.53</Version>
+    <FileVersion>1.52.53.0</FileVersion>
+    <AssemblyVersion>1.52.53.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## What
`SystemInfoService.Capture` refreshed the dynamic OS values with **two** `Win32_OperatingSystem` queries per poll:
- `QueryUptime` -> `LastBootUpTime`
- `QueryMemory` -> `TotalVisibleMemorySize` / `FreePhysicalMemory`

Both are merged into a single `QueryDynamicOs` that selects all three columns in one round-trip, halving the `Win32_OperatingSystem` calls on the per-poll path. The cached static OS/CPU/disk/DIMM queries are untouched.

## Behavior
Identical — the same uptime and memory figures; only the number of WMI round-trips per poll changed (2 -> 1). The degrade-on-fault handling is preserved (a WMI fault yields zero uptime + zeroed totals, with DIMM modules still shown).

## Tests
No unit test: the path is bound to live WMI. Build green (Release, 0 warnings / 0 errors).

Patch release (`fix:`) -> `v1.52.53`.
