### PR TITLE
fix: skip re-reading static process identity for already-tracked PIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.54] - 2026-07-08
+
+### Fixed
+- **The Process Manager stops re-reading each program's static details every second.** On every 1-second refresh the process list read each process's description, executable path and file-existence check — even for the (often hundreds of) processes it was already showing and whose details it keeps unchanged. It now reads those static details only for processes that have just appeared and refreshes only the live metrics (CPU, memory, threads, status) for the rest, cutting the per-tick work substantially on machines with many processes.
+
 ## [1.52.53] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager.Tests/ProcessManagerServiceTests.cs
+++ b/SysManager/SysManager.Tests/ProcessManagerServiceTests.cs
@@ -72,7 +72,7 @@ public class ProcessManagerServiceTests
         using var cts = new CancellationTokenSource();
         cts.Cancel();
         await Assert.ThrowsAsync<TaskCanceledException>(
-            () => _service.SnapshotAsync(cts.Token));
+            () => _service.SnapshotAsync(ct: cts.Token));
     }
 
     // ── KillProcess ──

--- a/SysManager/SysManager/Services/ProcessManagerService.cs
+++ b/SysManager/SysManager/Services/ProcessManagerService.cs
@@ -15,10 +15,13 @@ namespace SysManager.Services;
 /// </summary>
 public sealed class ProcessManagerService
 {
-    public Task<IReadOnlyList<ProcessEntry>> SnapshotAsync(CancellationToken ct = default)
-        => Task.Run(() => Snapshot(ct), ct);
+    // knownPids: PIDs the caller already shows. Their identity (description/path) is static and the
+    // view model keeps it on the surviving entry (ReconcileInto), so for those PIDs we skip the
+    // expensive MainModule/FileVersionInfo/File.Exists reads and refresh only the volatile metrics.
+    public Task<IReadOnlyList<ProcessEntry>> SnapshotAsync(IReadOnlySet<int>? knownPids = null, CancellationToken ct = default)
+        => Task.Run(() => Snapshot(knownPids, ct), ct);
 
-    private static IReadOnlyList<ProcessEntry> Snapshot(CancellationToken ct)
+    private static IReadOnlyList<ProcessEntry> Snapshot(IReadOnlySet<int>? knownPids, CancellationToken ct)
     {
         List<ProcessEntry> results = [];
         Process[] procs;
@@ -71,16 +74,22 @@ public sealed class ProcessManagerService
                         catch (System.ComponentModel.Win32Exception) { /* process may have exited */ }
                     }
 
-                    try
+                    // Identity (description/path) is static per process and the view model keeps it
+                    // for a PID it already tracks, so only pay the expensive MainModule /
+                    // FileVersionInfo / File.Exists cost for a PID we haven't seen yet.
+                    if (knownPids is null || !knownPids.Contains(p.Id))
                     {
-                        var module = p.MainModule;
-                        entry.Description = module?.FileVersionInfo.FileDescription ?? "";
-                        entry.FilePath = module?.FileName ?? "";
+                        try
+                        {
+                            var module = p.MainModule;
+                            entry.Description = module?.FileVersionInfo.FileDescription ?? "";
+                            entry.FilePath = module?.FileName ?? "";
+                        }
+                        catch (InvalidOperationException) { /* access denied or process exited */ }
+                        catch (System.ComponentModel.Win32Exception) { /* access denied or process exited */ }
+                        entry.CanOpenFileLocation = !string.IsNullOrWhiteSpace(entry.FilePath)
+                                                   && System.IO.File.Exists(entry.FilePath);
                     }
-                    catch (InvalidOperationException) { /* access denied or process exited */ }
-                    catch (System.ComponentModel.Win32Exception) { /* access denied or process exited */ }
-                    entry.CanOpenFileLocation = !string.IsNullOrWhiteSpace(entry.FilePath)
-                                               && System.IO.File.Exists(entry.FilePath);
                     try { entry.StartTime = p.StartTime; }
                     catch (InvalidOperationException) { /* access denied or process exited */ }
                     catch (System.ComponentModel.Win32Exception) { /* access denied or process exited */ }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.53</Version>
-    <FileVersion>1.52.53.0</FileVersion>
-    <AssemblyVersion>1.52.53.0</AssemblyVersion>
+    <Version>1.52.54</Version>
+    <FileVersion>1.52.54.0</FileVersion>
+    <AssemblyVersion>1.52.54.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
@@ -91,7 +91,7 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
             var existingPids = Processes.Select(p => p.Pid).ToHashSet();
             var enriched = await Task.Run(async () =>
             {
-                var snapshot = await _service.SnapshotAsync();
+                var snapshot = await _service.SnapshotAsync(existingPids);
                 foreach (var p in snapshot)
                 {
                     // Only the volatile metrics change per tick; identity/description are


### PR DESCRIPTION
## Problem
On a machine with many processes, the Process Manager did a lot of redundant work on every 1-second refresh.

## Root cause
`ProcessManagerService.Snapshot` read each process's `MainModule` / `FileVersionInfo` / `File.Exists` **for every process, every tick** — including the (often hundreds of) processes already shown. The view model's `ReconcileInto` then keeps the *existing* entry's identity for a PID it already tracks, so all that expensive identity work was thrown away for known PIDs.

## Fix
`SnapshotAsync` now accepts the caller's known-PID set (the view model already computes `existingPids` for its own icon-skip). `Snapshot` reads identity only for PIDs **not** in that set and refreshes only the volatile metrics (CPU/memory/threads/status) for the rest. A `null` set (the default) reads all identities, so other callers/tests are unaffected.

Behavior is unchanged: `ReconcileInto` already kept the existing identity for known PIDs, so the skipped reads were already being discarded — this just avoids doing them.

## Tests
No unit test: the path enumerates live OS processes and isn't deterministically unit-testable. The existing `ProcessManagerService` tests still pass (one updated to pass the cancellation token by name, now that the first parameter is the known-PID set). Build green (Release, 0/0).

Patch release (`fix:`) -> `v1.52.54`.
