### PR TITLE
fix: skip junctions when cleaning up empty directories after a folder shred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.55] - 2026-07-08
+
+### Fixed
+- **Shredding a folder that contains a junction or symlink can no longer delete an empty directory outside the folder you selected.** When removing the emptied directories after a folder shred, SysManager listed sub-directories with a recursive scan that follows junctions and symbolic links — so a link inside the selected folder that pointed elsewhere was followed, and an empty directory at its target (outside your selection) could be removed. The cleanup now skips junctions and symlinks exactly like the file-shredding pass already does: it never descends through a link and only ever removes empty directories inside the folder you chose. Introduced in 1.52.47 with the folder-shred cleanup rewrite; no file contents were ever at risk — only empty directories, and only through a link located inside the selected folder.
+
 ## [1.52.54] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager.Tests/FileShredderServiceTests.cs
+++ b/SysManager/SysManager.Tests/FileShredderServiceTests.cs
@@ -449,6 +449,74 @@ public class FileShredderServiceTests
         }
     }
 
+    // ---------- child-junction cleanup regression (out-of-scope directory deletion) ----------
+
+    [Fact]
+    public async Task ShredFolderAsync_WithChildJunction_DoesNotDeleteThroughIt()
+    {
+        // Regression: the empty-directory cleanup after a folder shred must skip junctions and
+        // symlinks, exactly like the file walk. A child junction inside the selected folder used
+        // to be FOLLOWED by the recursive directory enumerator, so an empty directory at the
+        // junction's target — OUTSIDE the selected folder — was deleted by the cleanup pass.
+        // Nothing beyond the selected folder may be touched.
+        var svc = NewService();
+        var dir = Path.Combine(Path.GetTempPath(), "smtest_childjunc_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        // An external target, outside the shred folder, holding an EMPTY sub-directory that must
+        // survive. recursive:false can only ever delete an EMPTY directory, so the empty one is
+        // precisely what was at risk of deletion through the junction.
+        var external = Path.Combine(Path.GetTempPath(), "smtest_external_" + Guid.NewGuid().ToString("N"));
+        var victim = Path.Combine(external, "keep_me");
+        Directory.CreateDirectory(victim);
+
+        await File.WriteAllTextAsync(Path.Combine(dir, "normal.dat"), "shred me");
+        var junction = Path.Combine(dir, "linkout");
+
+        try
+        {
+            // mklink /J creates a directory junction; no admin rights required. If the environment
+            // can't create one, skip rather than fail on an environment limitation.
+            var psi = new System.Diagnostics.ProcessStartInfo("cmd.exe", $"/c mklink /J \"{junction}\" \"{external}\"")
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+            using (var proc = System.Diagnostics.Process.Start(psi)!)
+            {
+                proc.WaitForExit(10_000);
+                if (proc.ExitCode != 0 || !IsReparse(junction))
+                    return; // environment can't create junctions (rare) — nothing to assert
+            }
+
+            // Shredding the folder must not descend through the junction: the normal in-scope file
+            // is shredded, but the empty directory behind the junction (outside the folder) remains.
+            await svc.ShredFolderAsync(dir, ShredMethod.Quick, null, CancellationToken.None);
+
+            Assert.True(Directory.Exists(victim),
+                "an empty directory at the junction's target, outside the selected folder, was deleted through the junction");
+            Assert.True(Directory.Exists(external), "the junction's external target directory was removed");
+            Assert.False(File.Exists(Path.Combine(dir, "normal.dat")),
+                "the normal in-scope file should still have been securely shredded");
+        }
+        finally
+        {
+            // Remove the junction link itself first (Directory.Delete on a junction removes the
+            // link, not its target), then both trees.
+            try { Directory.Delete(junction); } catch { /* ignore */ }
+            try { Directory.Delete(dir, recursive: true); } catch { /* ignore */ }
+            try { Directory.Delete(external, recursive: true); } catch { /* ignore */ }
+        }
+
+        static bool IsReparse(string p)
+        {
+            try { return (File.GetAttributes(p) & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint; }
+            catch { return false; }
+        }
+    }
+
     [Fact]
     public void ResolveFinalPath_MissingPath_ReturnsNull()
     {

--- a/SysManager/SysManager/Services/FileShredderService.cs
+++ b/SysManager/SysManager/Services/FileShredderService.cs
@@ -236,7 +236,15 @@ public sealed partial class FileShredderService
         // directory that still holds a file we could NOT shred is left in place (with the file).
         // We only ever remove EMPTY directories (recursive:false), so this can never plain-delete
         // an un-overwritten file — the bug this replaces (the old recursive delete did).
-        foreach (var dir in Directory.EnumerateDirectories(folderPath, "*", SearchOption.AllDirectories)
+        //
+        // The directory list comes from EnumerateDirectoriesSafe, which skips junctions and
+        // symlinks exactly like EnumerateFilesSafe. The framework's recursive enumerator
+        // (Directory.EnumerateDirectories with AllDirectories) would instead DESCEND THROUGH a
+        // child junction and hand TryRemoveIfEmpty a path at the link's target, letting
+        // Directory.Delete remove an empty directory OUTSIDE the selected folder. Sharing the
+        // file walk's reparse boundary confines cleanup to the real tree; a folder that contains
+        // a child junction is intentionally left in place rather than descended into.
+        foreach (var dir in EnumerateDirectoriesSafe(folderPath)
                      .OrderByDescending(d => d.Count(c => c == Path.DirectorySeparatorChar)))
         {
             TryRemoveIfEmpty(dir);
@@ -306,6 +314,41 @@ public sealed partial class FileShredderService
             // Skip junctions/symlinks to avoid following reparse points out of the tree.
             foreach (var sub in subDirs.Where(s => (s.Attributes & FileAttributes.ReparsePoint) == 0))
             {
+                stack.Push(sub);
+            }
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Recursively enumerates sub-directories while skipping junctions and symlinks
+    /// (reparse points), mirroring <see cref="EnumerateFilesSafe"/>. Used to clean up the
+    /// emptied directory structure after a folder shred WITHOUT ever descending through a
+    /// reparse point: a child junction is left untouched, so the deepest-first
+    /// <see cref="TryRemoveIfEmpty"/> pass can never reach — and delete — an empty directory
+    /// at the link's target, outside the selected folder.
+    /// </summary>
+    private static List<string> EnumerateDirectoriesSafe(string rootPath)
+    {
+        List<string> results = [];
+        Stack<DirectoryInfo> stack = [];
+        stack.Push(new DirectoryInfo(rootPath));
+
+        while (stack.Count > 0)
+        {
+            var dir = stack.Pop();
+
+            DirectoryInfo[] subDirs;
+            try { subDirs = dir.GetDirectories(); }
+            catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Shredder: access denied enumerating {Dir}", dir.FullName); continue; }
+            catch (IOException ex) { Log.Debug(ex, "Shredder: I/O error enumerating {Dir}", dir.FullName); continue; }
+
+            // Skip junctions/symlinks — never descend through a reparse point (identical
+            // boundary to EnumerateFilesSafe, so cleanup honors the exact scope that was shredded).
+            foreach (var sub in subDirs.Where(s => (s.Attributes & FileAttributes.ReparsePoint) == 0))
+            {
+                results.Add(sub.FullName);
                 stack.Push(sub);
             }
         }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.54</Version>
-    <FileVersion>1.52.54.0</FileVersion>
-    <AssemblyVersion>1.52.54.0</AssemblyVersion>
+    <Version>1.52.55</Version>
+    <FileVersion>1.52.55.0</FileVersion>
+    <AssemblyVersion>1.52.55.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem
After securely shredding the files in a folder, the File Shredder removes the now-empty directories. That cleanup pass enumerated sub-directories with `Directory.EnumerateDirectories(folderPath, "*", SearchOption.AllDirectories)`, whose framework enumerator **follows junctions and symbolic links**. A directory junction placed *inside* the selected folder (a standard user can create one with `mklink /J`, no admin) was therefore descended into, and `TryRemoveIfEmpty` was handed a path resolving to the link's **target outside the selected folder** — where `Directory.Delete(recursive:false)` could remove an empty directory the user never selected.

The sibling `EnumerateFilesSafe` used for the actual overwrite already skips reparse points (it must, so a link never redirects a shred out of scope). The cleanup pass did not — the two walks disagreed on the in-scope boundary.

## Root cause / when introduced
Introduced in **1.52.47**, which replaced the old `Directory.Delete(folderPath, recursive:true)` with an empty-directory-only cleanup loop to stop plain-deleting files that could not be securely overwritten. Modern .NET's `Directory.Delete(recursive:true)` treats a junction as a link and never descends into it, so the old code never reached the target; the replacement loop reintroduced traversal by using the recursive enumerator.

## Fix
- New `EnumerateDirectoriesSafe` mirrors `EnumerateFilesSafe` exactly: a manual stack walk that **skips reparse-point sub-directories**. The cleanup loop now uses it instead of the framework recursive enumerator, so it never descends through a junction/symlink.
- A folder that contains a child junction is intentionally left in place (its real files are still shredded); the cleanup only ever removes empty directories that live inside the real selected tree.

## Blast radius
Bounded: `recursive:false` can only ever delete an **empty** directory, and only one reachable through a link located inside the selected folder. **No file contents were ever at risk** — only empty directory structures at a junction target.

## Test
Adds `ShredFolderAsync_WithChildJunction_DoesNotDeleteThroughIt`: creates an external target with an empty sub-directory, a `mklink /J` junction to it inside the shred folder, and a normal in-scope file. After the shred it asserts the external empty directory (and its parent) still exist and the in-scope file was shredded. Skips gracefully where junctions can't be created.

Red/green (per TEST-PROTOCOL; `dotnet test` is not run locally): against the pre-fix code the recursive enumerator yields the through-junction path, `TryRemoveIfEmpty` deletes the external empty directory, and `Directory.Exists(victim)` is **false** → test fails for the intended reason. With the fix the junction is skipped and the assertion is **true** → green. CI runs the suite.

## Notes
Found during the post-continuation regression sweep of the recent File Shredder / threading / perf changes. Build: full solution 0 warnings / 0 errors.