### PR TITLE
test: make the Gaming Profile revert-deadlock test deterministic instead of timing-based

### DIFF
--- a/SysManager/SysManager.Tests/GamingProfileServiceTests.cs
+++ b/SysManager/SysManager.Tests/GamingProfileServiceTests.cs
@@ -392,47 +392,84 @@ public class GamingProfileServiceTests
         public override void Send(SendOrPostCallback d, object? state) => Interlocked.Increment(ref PostCount);
     }
 
-    // A step whose RevertAsync genuinely suspends off-thread, so RevertAsync's `await
-    // RunRevertAsync(...)` is forced to schedule a continuation (which carries _gate.Release()).
-    private sealed class SuspendingRevertTweak : IGamingTweak
+    // A step whose RevertAsync suspends on a signal the test controls (no wall-clock sleep), so
+    // RevertAsync's `await RunRevertAsync(...)` is forced to schedule a real off-thread
+    // continuation (the one that carries _gate.Release()). Deterministic: the test decides exactly
+    // when the revert resumes, so the outcome never depends on timing or thread-pool scheduling.
+    private sealed class GatedRevertTweak : IGamingTweak
     {
-        public string Label => "suspending";
+        private readonly TaskCompletionSource _resume = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Completes once RevertAsync has begun awaiting this step (it is now suspended).</summary>
+        public Task Entered => _entered.Task;
+
+        /// <summary>Releases the suspended RevertAsync so its gate-release continuation runs.</summary>
+        public void Resume() => _resume.TrySetResult();
+
+        public string Label => "gated";
         public bool RequiresAdmin => false;
         public Task<GamingTweakResult> ApplyAsync(CancellationToken ct) => Task.FromResult(GamingTweakResult.Applied);
         public async Task RevertAsync(CancellationToken ct)
-            => await Task.Run(() => Thread.Sleep(80), ct).ConfigureAwait(false);
+        {
+            _entered.TrySetResult();
+            await _resume.Task.ConfigureAwait(false);
+        }
+    }
+
+    // Awaits <paramref name="task"/>, returning false instead of hanging if it does not finish
+    // within the deadlock backstop — the async, non-blocking equivalent of Task.Wait(timeout)
+    // (so the xUnit1031 "no blocking task operations in tests" analyzer stays satisfied).
+    private static async Task<bool> CompletesWithinAsync(Task task, int ms = 10_000)
+    {
+        try { await task.WaitAsync(TimeSpan.FromMilliseconds(ms)).ConfigureAwait(false); return true; }
+        catch (TimeoutException) { return false; }
     }
 
     [Fact]
-    public void RevertAsync_GateReleaseContinuation_DoesNotDependOnCallerSyncContext()
+    public async Task RevertAsync_GateReleaseContinuation_DoesNotDependOnCallerSyncContext()
     {
-        // Reproduces the Audit-2 deadlock scenario deterministically: run RevertAsync on a thread
+        // Reproduces the Audit-2 deadlock scenario deterministically: RevertAsync runs on a thread
         // whose SynchronizationContext is never pumped (a stand-in for the shutdown-blocked UI
-        // thread). With the ConfigureAwait(true) regression, the gate-release continuation is
-        // posted to this context and the revert Task never completes → the wait below times out.
-        // With the ConfigureAwait(false) fix, the continuation runs off-thread and it completes.
+        // thread). With the ConfigureAwait(true) regression the gate-release continuation is posted
+        // to that context — PostCount rises and the revert Task never completes; with the
+        // ConfigureAwait(false) fix the continuation runs off-thread, nothing is posted, and it
+        // completes. The suspension is signalled (no Thread.Sleep), so the pass path is near-instant
+        // and not thread-pool-timing dependent — the only timeout is the genuine-deadlock backstop.
         var path = Path.Combine(Path.GetTempPath(), $"sm-gaming-dl-{Guid.NewGuid():N}.json");
-        bool completed = false;
+        var ctx = new NonPumpingSyncContext();
+        var tweak = new GatedRevertTweak();
+        Task? revert = null;
+
         var worker = new Thread(() =>
         {
-            var ctx = new NonPumpingSyncContext();
             SynchronizationContext.SetSynchronizationContext(ctx);
-
             var svc = StoreOnlyService(path);
-            svc.SeedAppliedStepForTest(new SuspendingRevertTweak()); // IsActive is now true
-
-            var revert = svc.RevertAsync();      // gate acquired inline; step suspends off-thread
-            completed = revert.Wait(3000);       // no pump on this thread — fix makes it complete anyway
+            svc.SeedAppliedStepForTest(tweak);   // IsActive is now true
+            revert = svc.RevertAsync();          // gate acquired inline; the step suspends on _resume
         });
         worker.IsBackground = true;
         worker.Start();
-        worker.Join(6000);
+        // RevertAsync returns an incomplete Task synchronously (it awaits, it does not block), so the
+        // worker returns promptly; a successful Join also publishes the `revert` write to this thread.
+        Assert.True(worker.Join(10_000),
+            "worker did not return — RevertAsync blocked synchronously instead of suspending");
 
         try
         {
-            Assert.True(completed,
+            // Deterministic handshake: wait until RevertAsync is actually parked inside the step,
+            // then release it. The continuation that follows is the one carrying _gate.Release().
+            Assert.True(await CompletesWithinAsync(tweak.Entered), "RevertAsync never reached the suspending step");
+            tweak.Resume();
+
+            Assert.NotNull(revert);
+            // A genuine ConfigureAwait(true) regression posts the continuation to the never-pumped
+            // ctx, so the Task hangs and this wait fails; the fix completes it in milliseconds.
+            Assert.True(await CompletesWithinAsync(revert!),
                 "RevertAsync did not complete without pumping the caller's SynchronizationContext — " +
                 "its gate-release continuation is pinned to the (blockable) caller thread (the Audit-2 deadlock).");
+            // And prove it directly: nothing was ever posted back to the caller's context.
+            Assert.Equal(0, ctx.PostCount);
         }
         finally { if (File.Exists(path)) File.Delete(path); }
     }


### PR DESCRIPTION
## Problem
`GamingProfileServiceTests.RevertAsync_GateReleaseContinuation_DoesNotDependOnCallerSyncContext` is flaky. It **failed the v1.52.55 release pipeline** (`Run unit tests (must pass)` → 1 failed / 3393 passed) with:

> RevertAsync did not complete without pumping the caller's SynchronizationContext — its gate-release continuation is pinned to the (blockable) caller thread (the Audit-2 deadlock).

The same commit had **passed** the PR CI's `Build & unit tests`, and the code under test is correct — so this is a flaky test, not a regression. It was diagnosed during the post-continuation regression sweep after it blocked the release (the release then passed on re-run).

## Root cause
The test drove a real off-thread suspension with `Task.Run(() => Thread.Sleep(80))` and asserted completion with `revert.Wait(3000)` — **wall-clock + thread-pool timing**. Under xUnit's parallel execution the pool can be saturated (other tests blocking threads), so the *correct* continuation is occasionally delayed past the 3 s window and the test reports the deadlock it was meant to detect. This violates our own testing rule: no sleep-based / wall-clock timing.

`GamingProfileService.RevertAsync` itself is unchanged and correct — `_gate.WaitAsync(...).ConfigureAwait(false)`, `RunRevertAsync(...).ConfigureAwait(false)`, `finally { _gate.Release(); }` — the gate-release continuation genuinely resumes off the caller's context.

## Fix (test only — behavior of the product is unchanged)
- Replace the `Thread.Sleep(80)` step with a `GatedRevertTweak` that suspends on a `TaskCompletionSource` the test controls, so the revert resumes on an explicit signal — no sleep, no pool-thread held.
- Deterministic handshake: `Entered` completes when `RevertAsync` has parked inside the step; the test then calls `Resume()`.
- Keep a generous timeout **only** as the genuine-deadlock backstop (the pass path is near-instant), and assert directly that `NonPumpingSyncContext.PostCount == 0` — proving nothing was posted to the caller's context.
- Waits use `Task.WaitAsync(timeout)` via an `async` test (no blocking `.Wait()` in the test body), satisfying xUnit1031.

Detection is preserved: a `ConfigureAwait(true)` regression posts the continuation to the never-pumped context → `PostCount > 0` and the Task never completes → the test fails (now for a deterministic reason, not a timing race).

`test:` — no release. Build: full solution 0 warnings / 0 errors. (CI running the suite is the pass verification, since `dotnet test` is not run locally.)