### PR TITLE
fix: prevent Environment Variables Apply and Restore from writing the registry concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.56] - 2026-07-08
+
+### Fixed
+- **Applying and restoring Environment Variables can no longer run at the same time and leave a mixed result.** Since 1.52.51 the slow parts of Apply and Restore run off the UI thread, which keeps the window responsive — but it also meant that starting a Restore and then pressing Apply (or the reverse) could rewrite the user and system variables from both operations at once, leaving the environment in an unpredictable mix of the two. Apply and Restore now take the same app-wide system-modification lock the SFC/DISM tools use, so one waits with a clear message until the other finishes. Introduced in 1.52.51.
+
 ## [1.52.55] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.55</Version>
-    <FileVersion>1.52.55.0</FileVersion>
-    <AssemblyVersion>1.52.55.0</AssemblyVersion>
+    <Version>1.52.56</Version>
+    <FileVersion>1.52.56.0</FileVersion>
+    <AssemblyVersion>1.52.56.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
@@ -85,8 +85,6 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
         Load(loaded);
     }
 
-    private void Load() => Load(_service.ReadAll());
-
     private void Load(List<EnvVariable> loaded)
     {
         foreach (var v in Variables)
@@ -316,6 +314,17 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
             return;
         }
 
+        // Apply and Restore both rewrite the same HKCU/HKLM environment keys. Since 1.52.51 their
+        // slow parts run off the UI thread, so without a shared gate a Restore in progress and an
+        // Apply (or vice-versa) could write at once and leave a nondeterministic mix. Take the
+        // app-wide system-modification lock, exactly like the SFC/DISM operations do.
+        using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "Apply environment changes");
+        if (opLock is null)
+        {
+            StatusMessage = $"Cannot apply now — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.SystemModification)} is already running.";
+            return;
+        }
+
         var touchesMachine = ChangedVariables().Any(v => v.Scope == EnvVarScope.Machine)
             || DeletedEntries().Any(e => e.scope == EnvVarScope.Machine);
         if (touchesMachine && !IsElevated)
@@ -408,6 +417,15 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
         if (!_service.HasBackup)
         {
             StatusMessage = "There is no backup to restore yet — it is created the first time you apply changes.";
+            return;
+        }
+
+        // Serialize against Apply (and other system-modification operations) so the two can't
+        // rewrite the same environment keys concurrently — see ApplyChanges for the full note.
+        using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "Restore environment backup");
+        if (opLock is null)
+        {
+            StatusMessage = $"Cannot restore now — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.SystemModification)} is already running.";
             return;
         }
 


### PR DESCRIPTION
## Problem
On the Environment Variables tab, **Apply** and **Restore backup** both rewrite the same `HKCU\Environment` / `HKLM\...\Environment` keys. Since **1.52.51** their slow parts run off the UI thread (Apply awaits the system-wide broadcast; Restore rewrites every variable on a background thread), which correctly keeps the window responsive — but it also removed the implicit serialization the previously-synchronous (UI-freezing) versions provided. As a result, starting a Restore and then pressing Apply (or the reverse) could run both writers at once, leaving the environment in a nondeterministic mix of the two operations.

Found during the post-continuation regression sweep of the 1.52.51 threading change.

## Root cause
Neither command held any shared lock, and `AsyncRelayCommand`'s default only blocks *same-command* re-entry — not Apply-vs-Restore. With the slow work now off-thread, both command bodies can be in flight simultaneously.

## Fix
Reuse the app's existing `OperationLockService` (the same seam SFC/DISM and the disk/network operations use), category `SystemModification`:
- `ApplyChanges` and `RestoreBackup` each `TryAcquire(OperationCategory.SystemModification, …)` before doing any work; if the category is already busy they show `"Cannot apply/restore now — <op> is already running."` and return. The `using var` handle releases on every exit path, including across the awaits.
- Cheap pre-checks that do no work ("no changes to apply", "no backup yet") stay *before* the acquire, so they never contend for the lock.
- This also serializes Apply/Restore against other system-modification operations (SFC, DISM, performance tweaks), consistent with the rest of the app.

Also removes a `private void Load()` overload that 1.52.51 orphaned when it repointed all callers to `LoadAsync()` (dead code; no remaining caller).

## Testing
No new unit test: the VM is constructed with a concrete `EnvironmentVariableService` (its ctor reads the live registry) and the gate depends on the process-wide `OperationLockService` singleton, so a deterministic, side-effect-free unit test isn't feasible without a broader seam — matching the existing `OperationLockService` consumers (SFC/DISM etc.), which are likewise gated without a lock-busy unit test. Verified by build (full solution 0 warnings / 0 errors) and reasoning; the reused lock service is itself already covered.

`fix:` → patch release.