### PR TITLE
fix: handle AggregateException and access-denied faults in three background service operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.57] - 2026-07-08
+
+### Fixed
+- **Three background operations now fail safely instead of risking an unhandled error.** Ending a process could throw an unhandled error when part of its child-process tree refused to close — the Process Manager now reports that as a normal "couldn't end it" result. And loading the saved Speed Test history or the stored performance-tweak baseline could throw if the file was momentarily unreadable (locked or permission-denied) rather than access-denied being treated like any other read error; both now fall back cleanly (empty history / fresh baseline), matching how saving already behaves.
+
 ## [1.52.56] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager/Services/PerformanceService.cs
+++ b/SysManager/SysManager/Services/PerformanceService.cs
@@ -153,6 +153,7 @@ public sealed partial class PerformanceService : IDisposable
             return JsonSerializer.Deserialize<OriginalSnapshot>(json);
         }
         catch (IOException ex) { Log.Warning(ex, "Failed to load performance snapshot"); return null; }
+        catch (UnauthorizedAccessException ex) { Log.Warning(ex, "Failed to load performance snapshot"); return null; }
         catch (JsonException ex) { Log.Warning(ex, "Failed to parse performance snapshot"); return null; }
     }
 

--- a/SysManager/SysManager/Services/ProcessManagerService.cs
+++ b/SysManager/SysManager/Services/ProcessManagerService.cs
@@ -125,6 +125,10 @@ public sealed class ProcessManagerService
         catch (ArgumentException) { return false; }
         catch (InvalidOperationException) { return false; }
         catch (System.ComponentModel.Win32Exception) { return false; }
+        // Kill(entireProcessTree: true) throws AggregateException when one or more descendants
+        // could not be terminated. Report the failure through the bool contract like the rest,
+        // rather than letting it escape to the (synchronous) Kill command and crash the app.
+        catch (AggregateException) { return false; }
     }
 
     /// <summary>

--- a/SysManager/SysManager/Services/SpeedTestHistoryService.cs
+++ b/SysManager/SysManager/Services/SpeedTestHistoryService.cs
@@ -72,6 +72,11 @@ public sealed class SpeedTestHistoryService : IDisposable
             Log.Warning(ex, "Failed to parse speed test history JSON");
             return [];
         }
+        catch (UnauthorizedAccessException ex)
+        {
+            Log.Warning(ex, "Access denied loading speed test history");
+            return [];
+        }
     }
 
     /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.56</Version>
-    <FileVersion>1.52.56.0</FileVersion>
-    <AssemblyVersion>1.52.56.0</AssemblyVersion>
+    <Version>1.52.57</Version>
+    <FileVersion>1.52.57.0</FileVersion>
+    <AssemblyVersion>1.52.57.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem
Three service operations could let an exception escape instead of degrading, each verified against current source:

1. **`ProcessManagerService.KillProcess`** catches `ArgumentException`/`InvalidOperationException`/`Win32Exception` but not **`AggregateException`**, which `Process.Kill(entireProcessTree: true)` throws when one or more descendants can't be terminated. The `Kill` command is a synchronous `[RelayCommand]`, so the exception would escape to the dispatcher and crash the app instead of reporting "couldn't end it".
2. **`SpeedTestHistoryService.LoadCoreAsync`** documents "returns empty list on any error" and catches `IOException`/`JsonException`, but **`UnauthorizedAccessException`** does not derive from `IOException`, so a permission-denied read escapes — breaking the contract its `SaveAsync`/`ClearAsync` siblings honor.
3. **`PerformanceService.LoadSnapshot`** catches `IOException`/`JsonException` but not **`UnauthorizedAccessException`**, even though its own `SaveSnapshot`/`DeleteSnapshot` siblings do — so an unreadable cached snapshot would break Apply instead of degrading to a fresh baseline.

## Fix
- `KillProcess`: add `catch (AggregateException) { return false; }` — report via the existing bool contract like the other catches.
- `LoadCoreAsync`: add `catch (UnauthorizedAccessException) { Log.Warning(...); return []; }` — matches `SaveAsync`/`ClearAsync`.
- `LoadSnapshot`: add `catch (UnauthorizedAccessException) { Log.Warning(...); return null; }` — matches `SaveSnapshot`/`DeleteSnapshot`.

## Testing
No new unit test: each fault requires inducing OS-level state (a partially-unkillable process tree; a permission-denied read of a hard-coded `LocalApplicationData` path that isn't injectable) that can't be produced deterministically without system-dependent, flaky setup or admin — the same reason the existing degrade-don't-throw guards ship test-free. Each change mirrors an already-tested sibling's contract; verified by build (full solution 0 warnings / 0 errors).

`fix:` → patch release. Verified against live source; two other nearby audit items (ServiceManager boot/system token, TuneUp COMException arm) were re-checked and left out as unreachable/redundant.