### PR TITLE
fix: report PowerShell cancellation as OperationCanceledException and harden the cancel-kill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.59] - 2026-07-08
+
+### Fixed
+- **Cancelling a PowerShell-backed operation now ends cleanly instead of risking a stray error.** Two cases: cancelling an in-process PowerShell run reported the stop as a low-level pipeline error rather than a normal "cancelled", so callers watching for cancellation could treat it as a failure; and when cancelling an external PowerShell process, the attempt to stop its process tree only handled one of the errors it can raise, so an access-denied or partially-failed stop could surface as an unhandled error. Both now resolve to the standard "operation cancelled" outcome and swallow the expected stop-time errors.
+
 ## [1.52.58] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager/Services/PowerShellRunner.cs
+++ b/SysManager/SysManager/Services/PowerShellRunner.cs
@@ -126,7 +126,17 @@ public sealed class PowerShellRunner : IPowerShellRunner
             ps.BeginInvoke<PSObject, PSObject>(null, output),
             ar => ps.EndInvoke(ar));
 
-        await task.ConfigureAwait(false);
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+        catch (PipelineStoppedException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Cancellation calls ps.Stop(), which makes EndInvoke throw PipelineStoppedException.
+            // Surface the standard cancellation signal so callers that catch OperationCanceledException
+            // treat a cancelled in-process run as cancelled rather than as an error.
+            throw new OperationCanceledException(cancellationToken);
+        }
 
         return new Collection<PSObject>(output.ToList());
     }
@@ -209,7 +219,15 @@ public sealed class PowerShellRunner : IPowerShellRunner
             proc.BeginErrorReadLine();
         }).ConfigureAwait(false);
 
-        using var reg = cancellationToken.Register(() => { try { if (!proc.HasExited) proc.Kill(entireProcessTree: true); } catch (InvalidOperationException) { } });
+        using var reg = cancellationToken.Register(() =>
+        {
+            // Kill(entireProcessTree: true) can throw Win32Exception (access denied) or
+            // AggregateException (a descendant couldn't be terminated) as well as
+            // InvalidOperationException — swallow all three so a failed cancel-kill never
+            // escapes out of cts.Cancel() to whoever requested cancellation.
+            try { if (!proc.HasExited) proc.Kill(entireProcessTree: true); }
+            catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception or AggregateException) { }
+        });
         await proc.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
 
         // WaitForExitAsync returns when the process exits, but the asynchronous

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.58</Version>
-    <FileVersion>1.52.58.0</FileVersion>
-    <AssemblyVersion>1.52.58.0</AssemblyVersion>
+    <Version>1.52.59</Version>
+    <FileVersion>1.52.59.0</FileVersion>
+    <AssemblyVersion>1.52.59.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem
Two cancellation-path issues in `PowerShellRunner`:

1. **`RunAsync`** (in-process PowerShell): cancellation calls `ps.Stop()`, which makes `ps.EndInvoke(...)` throw **`PipelineStoppedException`**, so the awaited run surfaces a low-level pipeline error instead of the standard `OperationCanceledException`. Callers that catch `OperationCanceledException` to handle cancellation gracefully would miss it and treat a cancel as a failure.
2. **`RunProcessAsync`** (external `powershell.exe`): the cancellation callback's `proc.Kill(entireProcessTree: true)` only caught `InvalidOperationException`, but `Kill(entireProcessTree: true)` can also throw `Win32Exception` (access denied) and `AggregateException` (a descendant couldn't be terminated). Those would escape from the `CancellationTokenRegistration` callback out through `cts.Cancel()` to whoever requested cancellation.

## Fix
1. Wrap the `await task` in `RunAsync` with `catch (PipelineStoppedException) when (cancellationToken.IsCancellationRequested) { throw new OperationCanceledException(cancellationToken); }`, so a cancelled in-process run reports the standard cancellation signal.
2. Widen the cancel-callback catch to `catch (Exception ex) when (ex is InvalidOperationException or Win32Exception or AggregateException) { }`, so a failed cancel-kill is swallowed rather than escaping `cts.Cancel()`.

Fix #2 completes the class of the `KillProcess` `AggregateException` fix shipped in the previous release — the other in-tree `Kill(entireProcessTree: true)` call site.

## Testing
No new unit test: both require inducing real cancellation timing against an in-process PowerShell pipeline / an external process whose tree-kill partially fails — not deterministically reproducible without flaky, system-dependent setup. The translations are contract-narrow (typed `catch … when` guards keyed on the cancellation token) and verified by build (full solution 0 warnings / 0 errors).

`fix:` → patch release.