### PR TITLE
fix: free chart axis typefaces on rebuild and stop Task Scheduler double-querying run info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.52.59] - 2026-07-08
+## [1.52.60] - 2026-07-08
+
+### Fixed
+- **The live resource-history charts no longer leak a small amount of memory each time they're rebuilt.** Each chart axis uses a "Segoe UI" font handle; when the chart was torn down and re-created (for example on a theme change), those font handles weren't released — only the paint objects were. They're now freed alongside the paints, the same way the chart legend's font already was.
+- **Selecting a task in Task Scheduler no longer runs its "last run / next run" lookup twice.** Picking a task looked up its run details, and updating the row with those details re-triggered the selection handler, firing the same lookup a second time. The selection update is now guarded so the lookup runs once per selection.
 
 ### Fixed
 - **Cancelling a PowerShell-backed operation now ends cleanly instead of risking a stray error.** Two cases: cancelling an in-process PowerShell run reported the stop as a low-level pipeline error rather than a normal "cancelled", so callers watching for cancellation could treat it as a failure; and when cancelling an external PowerShell process, the attempt to stop its process tree only handled one of the errors it can raise, so an access-denied or partially-failed stop could surface as an unhandled error. Both now resolve to the standard "operation cancelled" outcome and swallow the expected stop-time errors.

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.59</Version>
-    <FileVersion>1.52.59.0</FileVersion>
-    <AssemblyVersion>1.52.59.0</AssemblyVersion>
+    <Version>1.52.60</Version>
+    <FileVersion>1.52.60.0</FileVersion>
+    <AssemblyVersion>1.52.60.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
@@ -271,6 +271,11 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
     {
         foreach (var axis in axes)
         {
+            // Free the native SKTypeface handles before the paints, mirroring how the legend
+            // typeface is released in Dispose — SolidColorPaint.Dispose does not free them, so the
+            // per-axis "Segoe UI" typefaces (BuildTimeAxis/BuildPercentAxis/BuildTempAxis) leak.
+            (axis.NamePaint as SolidColorPaint)?.SKTypeface?.Dispose();
+            (axis.LabelsPaint as SolidColorPaint)?.SKTypeface?.Dispose();
             (axis.NamePaint as IDisposable)?.Dispose();
             (axis.LabelsPaint as IDisposable)?.Dispose();
             (axis.SeparatorsPaint as IDisposable)?.Dispose();

--- a/SysManager/SysManager/ViewModels/TaskSchedulerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TaskSchedulerViewModel.cs
@@ -82,9 +82,14 @@ public sealed partial class TaskSchedulerViewModel : ViewModelBase
         ToggleEnabledCommand.NotifyCanExecuteChanged();
     }
 
+    // Guards the in-place re-selection below (SelectedTask = withInfo): without it, that
+    // reassignment re-enters OnSelectedTaskChanged and fires a second per-task run-info query.
+    private bool _reassigningSelection;
+
     partial void OnSelectedTaskChanged(ScheduledTaskInfo? value)
     {
         ToggleEnabledCommand.NotifyCanExecuteChanged();
+        if (_reassigningSelection) return;
         if (value is not null) _ = LoadRunInfoAsync(value);
     }
 
@@ -95,8 +100,13 @@ public sealed partial class TaskSchedulerViewModel : ViewModelBase
         if (ReferenceEquals(SelectedTask, task))
         {
             int idx = Tasks.IndexOf(task);
-            if (idx >= 0) Tasks[idx] = withInfo;
-            SelectedTask = withInfo;
+            _reassigningSelection = true;
+            try
+            {
+                if (idx >= 0) Tasks[idx] = withInfo;
+                SelectedTask = withInfo;
+            }
+            finally { _reassigningSelection = false; }
         }
     }
 


### PR DESCRIPTION
## Problem
Two independent issues, both verified against current source:

1. **`ResourceHistoryViewModel` leaks native SKTypeface handles.** Each chart axis paint is built with `SKTypeface = SKTypeface.FromFamilyName("Segoe UI")` (`BuildTimeAxis`/`BuildPercentAxis`/`BuildTempAxis`), but `DisposeAxisPaints` only disposed the paints, not their typefaces. `SolidColorPaint.Dispose()` does not free the typeface, so each chart teardown/rebuild (e.g. on a theme change) leaks the "Segoe UI" native handles — inconsistent with the legend paint, whose `SKTypeface` is explicitly disposed in `Dispose`.
2. **`TaskSchedulerViewModel` runs the per-task run-info query twice per selection.** `OnSelectedTaskChanged` kicks off `LoadRunInfoAsync`, which — to show the enriched row — reassigns `SelectedTask = withInfo`. That reassignment re-enters `OnSelectedTaskChanged`, firing the same PowerShell-backed lookup a second time.

## Fix
1. `DisposeAxisPaints` now frees `(axis.NamePaint as SolidColorPaint)?.SKTypeface` and `(axis.LabelsPaint as SolidColorPaint)?.SKTypeface` before disposing the paints — mirroring the legend typeface disposal. `SeparatorsPaint` carries no typeface. Null typefaces are a safe no-op.
2. Add a `_reassigningSelection` guard: set it around the in-place `Tasks[idx] = withInfo; SelectedTask = withInfo;` reassignment, and early-return from `OnSelectedTaskChanged` while it's set (after still notifying `ToggleEnabled` CanExecute). The lookup now runs once per selection.

## Testing
No new unit test: (1) is a native-resource disposal that isn't observable through a deterministic managed assertion; (2) is fire-and-forget selection-handler re-entrancy on a VM bound to a concrete PowerShell service. Both are verified by build (full solution 0 warnings / 0 errors) and by matching the file's own established patterns (legend typeface disposal; the re-entrancy-guard idiom used elsewhere).

`fix:` → patch release.