### PR TITLE
fix: match Process Manager rows by PID and start time so a reused PID can't mis-identify or mis-kill a process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.52.60] - 2026-07-08
+## [1.52.61] - 2026-07-08
+
+### Fixed
+- **The Process Manager can no longer show — or end — the wrong process when Windows reuses a process ID.** The list refreshes every second and matched rows by process ID (PID) alone, but Windows recycles PIDs, so between two refreshes the same PID can belong to a different program. When that happened, the row kept the old program's name and icon while showing the new program's activity — and because Kill targets the PID, confirming "End task" on that row would have ended the new program instead. Rows are now matched by PID together with the process start time, so a recycled PID is treated as a new process (old row removed, new one shown) and End task always acts on the process you see.
 
 ### Fixed
 - **The live resource-history charts no longer leak a small amount of memory each time they're rebuilt.** Each chart axis uses a "Segoe UI" font handle; when the chart was torn down and re-created (for example on a theme change), those font handles weren't released — only the paint objects were. They're now freed alongside the paints, the same way the chart legend's font already was.

--- a/SysManager/SysManager.Tests/ProcessManagerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ProcessManagerViewModelTests.cs
@@ -99,6 +99,33 @@ public class ProcessManagerViewModelTests
         Assert.DoesNotContain(dead, target);
     }
 
+    [Fact]
+    public void ReconcileInto_ReusedPid_ReplacesStaleIdentity()
+    {
+        // Regression: a PID alone is not a stable identity — Windows reuses PIDs, so the same
+        // number can belong to a DIFFERENT process between 1 Hz polls. Reconcile must not keep the
+        // old process's identity (name/icon) on that row, or the Kill confirm would name the old
+        // process while KillProcess(entry.Pid) terminates the new one (a mis-kill).
+        var target = new BulkObservableCollection<ProcessEntry>();
+        var old = Proc(100, mem: 10, cpu: 1);
+        old.Name = "old-process";
+        old.StartTime = new DateTime(2020, 1, 1);
+        target.Add(old);
+
+        // Same PID 100, but a different start time → the OS reused the PID for a new process.
+        var fresh = Proc(100, mem: 50, cpu: 5);
+        fresh.Name = "new-process";
+        fresh.StartTime = new DateTime(2021, 6, 1);
+
+        ProcessManagerViewModel.ReconcileInto(target, new List<ProcessEntry> { fresh });
+
+        Assert.Single(target);                              // no duplicate PID row
+        Assert.Same(fresh, target[0]);                      // stale instance dropped, fresh kept
+        Assert.Equal("new-process", target[0].Name);        // correct identity shown
+        Assert.Equal(new DateTime(2021, 6, 1), target[0].StartTime);
+        Assert.DoesNotContain(old, target);
+    }
+
     // ── SyncOrdered (regression: filtered view reorders without a Reset) ──
 
     [Fact]

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.60</Version>
-    <FileVersion>1.52.60.0</FileVersion>
-    <AssemblyVersion>1.52.60.0</AssemblyVersion>
+    <Version>1.52.61</Version>
+    <FileVersion>1.52.61.0</FileVersion>
+    <AssemblyVersion>1.52.61.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
@@ -159,11 +159,13 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
         foreach (var fresh in snapshot)
         {
             seen.Add(fresh.Pid);
-            if (existing.TryGetValue(fresh.Pid, out var current))
+            // Match on PID AND start time: a PID alone is not a stable identity because Windows
+            // reuses PIDs, so the same number can belong to a different process between polls.
+            if (existing.TryGetValue(fresh.Pid, out var current) && current.StartTime == fresh.StartTime)
             {
-                // Update only the volatile metrics on the existing instance; identity fields
+                // Same process instance — update only the volatile metrics; identity fields
                 // (Name, FilePath, Icon, PlainDescription, Category, SafetyLevel, StartTime)
-                // are stable for a given PID and stay as they were.
+                // are stable for a given process and stay as they were.
                 current.CpuPercent = fresh.CpuPercent;
                 current.MemoryBytes = fresh.MemoryBytes;
                 current.ThreadCount = fresh.ThreadCount;
@@ -172,6 +174,11 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
             }
             else
             {
+                // A brand-new PID, or a PID the OS reused for a DIFFERENT process (its start time
+                // changed). In the reuse case the existing row still carries the OLD process's
+                // identity, so keeping it would show — and let the user kill — the wrong process.
+                // Drop the stale row and add the fresh entry.
+                if (current is not null) target.Remove(current);
                 target.Add(fresh);
             }
         }


### PR DESCRIPTION
## Problem
The Process Manager refreshes every second and `ReconcileInto` matched rows by **PID alone**. Windows recycles PIDs, so between two polls the same PID can belong to a *different* process. When that happened, the surviving row kept the OLD process's identity (Name, Icon, FilePath, description) while its volatile metrics were overwritten with the NEW process's values. Because `KillProcess(entry.Pid)` targets the PID, the Kill confirm would name the old process while actually terminating the new one — a **mis-kill**.

This is pre-existing (introduced with the reconcile-in-place refresh, unchanged by the recent known-PID perf work). Surfaced by the post-continuation regression sweep.

## Fix
`ReconcileInto` now matches on **(PID + StartTime)**. `ProcessEntry.StartTime` is already captured every poll and is stable for a given process, so:
- Same process (PID and StartTime match) → update volatile metrics in place, exactly as before (the DataGrid keeps selection). **Common path is unchanged.**
- Reused PID (StartTime differs) → the existing row carries the old process's identity, so it's removed and the fresh entry is added. The row then shows the correct process, and Kill acts on what you see.
- New/exited PIDs → unchanged.

## Testing
Adds `ReconcileInto_ReusedPid_ReplacesStaleIdentity`: an existing row (PID 100, StartTime 2020) is reconciled against a snapshot with the same PID but StartTime 2021; asserts the stale instance is dropped, the fresh identity (`new-process`, 2021) is shown, and there's no duplicate PID row. **Red before the fix** (the stale instance survives with only its metrics updated), **green after**. The existing survivor/new/dead-PID tests still pass (their entries share the default StartTime, so the same-instance path is exercised unchanged).

Note: the replaced row shows the correct name and live metrics; its icon/description are not re-fetched for that rare recycled-PID tick (the per-tick optimization skips already-tracked PIDs by number). Full re-enrichment would require threading (PID, StartTime) through the service's skip logic — descoped here to keep this change zero-risk on the always-visible common path; the mis-kill (the safety issue) is fully resolved.

`fix:` → patch release.