### PR TITLE
fix: run Visual Effects/Game Mode/Xbox/GPU applies off the UI thread with a busy gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.52.61] - 2026-07-08
+## [1.52.62] - 2026-07-08
+
+### Fixed
+- **The Performance tab no longer briefly freezes when you apply Visual Effects, Game Mode, Xbox Game Bar, or GPU settings.** These four toggles wrote to the registry (and, for visual effects, broadcast a system-wide settings change) directly on the UI thread, so the window could hang for a moment while the change was applied. They now run that work off the UI thread and show the progress/busy indicator while they do — matching how the Power Plan and Processor State toggles on the same tab already behave. What each toggle does is unchanged.
 
 ### Fixed
 - **The Process Manager can no longer show — or end — the wrong process when Windows reuses a process ID.** The list refreshes every second and matched rows by process ID (PID) alone, but Windows recycles PIDs, so between two refreshes the same PID can belong to a different program. When that happened, the row kept the old program's name and icon while showing the new program's activity — and because Kill targets the PID, confirming "End task" on that row would have ended the new program instead. Rows are now matched by PID together with the process start time, so a recycled PID is treated as a new process (old row removed, new one shown) and End task always acts on the process you see.

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.61</Version>
-    <FileVersion>1.52.61.0</FileVersion>
-    <AssemblyVersion>1.52.61.0</AssemblyVersion>
+    <Version>1.52.62</Version>
+    <FileVersion>1.52.62.0</FileVersion>
+    <AssemblyVersion>1.52.62.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
@@ -209,10 +209,14 @@ public sealed partial class PerformanceViewModel : ViewModelBase
             $"{action} visual effects (animations, fades, shadows)?",
             "Visual Effects — Confirm")) { SyncTogglesFromProfile(); return; }
 
+        IsBusy = true;
+        IsProgressIndeterminate = true;
         try
         {
             await EnsureSnapshotAsync();
-            PerformanceService.SetUiEffects(!WantVisualEffectsReduced);
+            // Registry write + SystemParametersInfo broadcast off the UI thread so the window
+            // stays responsive, busy-gated like ApplyPowerPlanAsync.
+            await Task.Run(() => PerformanceService.SetUiEffects(!WantVisualEffectsReduced)).ConfigureAwait(true);
             await RefreshAsync();
             StatusMessage = $"Visual effects {(WantVisualEffectsReduced ? "reduced" : "restored")}.";
             Log.Information("Visual effects {Action}", WantVisualEffectsReduced ? "reduced" : "restored");
@@ -220,6 +224,7 @@ public sealed partial class PerformanceViewModel : ViewModelBase
         catch (InvalidOperationException ex) { StatusMessage = $"Visual effects change failed: {ex.Message}"; }
         catch (SecurityException ex) { StatusMessage = $"Visual effects change failed: {ex.Message}"; }
         catch (UnauthorizedAccessException ex) { StatusMessage = $"Visual effects change failed: {ex.Message}"; }
+        finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -241,10 +246,12 @@ public sealed partial class PerformanceViewModel : ViewModelBase
             $"{action} Game Mode?",
             "Game Mode — Confirm")) { SyncTogglesFromProfile(); return; }
 
+        IsBusy = true;
+        IsProgressIndeterminate = true;
         try
         {
             await EnsureSnapshotAsync();
-            PerformanceService.SetGameMode(enabling);
+            await Task.Run(() => PerformanceService.SetGameMode(enabling)).ConfigureAwait(true);
             await RefreshAsync();
             StatusMessage = $"Game Mode {(enabling ? "enabled" : "disabled")}.";
             Log.Information("Game Mode {Action}", enabling ? "enabled" : "disabled");
@@ -252,6 +259,7 @@ public sealed partial class PerformanceViewModel : ViewModelBase
         catch (InvalidOperationException ex) { StatusMessage = $"Game Mode change failed: {ex.Message}"; }
         catch (SecurityException ex) { StatusMessage = $"Game Mode change failed: {ex.Message}"; }
         catch (UnauthorizedAccessException ex) { StatusMessage = $"Game Mode change failed: {ex.Message}"; }
+        finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -273,10 +281,12 @@ public sealed partial class PerformanceViewModel : ViewModelBase
             $"{action} Xbox Game Bar and Game DVR overlay?",
             "Xbox Game Bar — Confirm")) { SyncTogglesFromProfile(); return; }
 
+        IsBusy = true;
+        IsProgressIndeterminate = true;
         try
         {
             await EnsureSnapshotAsync();
-            PerformanceService.SetXboxGameBar(!disabling);
+            await Task.Run(() => PerformanceService.SetXboxGameBar(!disabling)).ConfigureAwait(true);
             await RefreshAsync();
             StatusMessage = $"Xbox Game Bar {(disabling ? "disabled" : "enabled")}.";
             Log.Information("Xbox Game Bar {Action}", disabling ? "disabled" : "enabled");
@@ -285,6 +295,7 @@ public sealed partial class PerformanceViewModel : ViewModelBase
         catch (SecurityException ex) { StatusMessage = $"Xbox Game Bar change failed: {ex.Message}"; }
         catch (UnauthorizedAccessException ex) { StatusMessage = $"Xbox Game Bar change failed: {ex.Message}"; }
         catch (System.IO.IOException ex) { StatusMessage = $"Xbox Game Bar change failed: {ex.Message}"; }
+        finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -311,13 +322,22 @@ public sealed partial class PerformanceViewModel : ViewModelBase
             + "⚠ This change requires a REBOOT to take effect.",
             "GPU Performance — Confirm")) { SyncTogglesFromProfile(); return; }
 
+        IsBusy = true;
+        IsProgressIndeterminate = true;
         try
         {
             await EnsureSnapshotAsync();
-            var nvidiaKey = PerformanceService.FindNvidiaSubKey();
-            if (nvidiaKey is not null)
+            // FindNvidiaSubKey + the registry write run off the UI thread; the UI updates below
+            // resume on it (ConfigureAwait true), busy-gated like ApplyPowerPlanAsync.
+            var (found, ok) = await Task.Run(() =>
             {
-                var ok = PerformanceService.SetGpuMaxPerformance(nvidiaKey, WantGpuMaxPerformance);
+                var nvidiaKey = PerformanceService.FindNvidiaSubKey();
+                return nvidiaKey is null
+                    ? (Found: false, Ok: false)
+                    : (Found: true, Ok: PerformanceService.SetGpuMaxPerformance(nvidiaKey, WantGpuMaxPerformance));
+            }).ConfigureAwait(true);
+            if (found)
+            {
                 if (ok)
                 {
                     NeedsReboot = true;
@@ -332,6 +352,7 @@ public sealed partial class PerformanceViewModel : ViewModelBase
         catch (InvalidOperationException ex) { StatusMessage = $"GPU setting change failed: {ex.Message}"; }
         catch (SecurityException ex) { StatusMessage = $"GPU setting change failed: {ex.Message}"; }
         catch (UnauthorizedAccessException ex) { StatusMessage = $"GPU setting change failed: {ex.Message}"; }
+        finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
     // ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Problem
On the Performance tab, `ApplyVisualEffectsAsync`, `ApplyGameModeAsync`, `ApplyXboxGameBarAsync`, and `ApplyGpuAsync` called their **synchronous** `PerformanceService.SetX(...)` work (registry writes, and for visual effects a `SystemParametersInfo` system-wide broadcast) directly on the UI thread, and none set `IsBusy`. So applying one of these toggles could briefly hang the window with no progress indication — unlike the sibling `ApplyPowerPlanAsync` / `ApplyProcessorStateAsync` on the same tab, which run off-thread and busy-gate.

## Fix
Each of the four now mirrors `ApplyPowerPlanAsync` exactly:
- Set `IsBusy = true; IsProgressIndeterminate = true;` after the confirm (early-return paths — "already in that state", declined confirm — stay before it and are unaffected).
- Run the synchronous service call via `await Task.Run(() => PerformanceService.SetX(...)).ConfigureAwait(true)`, so the registry/`SystemParametersInfo` work is off the UI thread and the continuation resumes on it.
- `finally { IsBusy = false; IsProgressIndeterminate = false; }`.

`ApplyGpuAsync` additionally moves `FindNvidiaSubKey()` + `SetGpuMaxPerformance(...)` into the `Task.Run` and returns a `(found, ok)` tuple so the `NeedsReboot`/`StatusMessage` UI updates stay on the UI thread — behavior (including the null-key no-op and the failure message) is unchanged. Exceptions from the off-thread work unwrap through `await` into the existing typed catch clauses.

The shared `EnsureSnapshotAsync()` call (reversibility) is untouched and orthogonal to this change.

## Testing
No new unit test: these are UI-thread-marshaling changes on a system-modification VM (registry + SystemParametersInfo) that aren't deterministically unit-testable without a broader seam — the same reason the existing `ApplyPowerPlanAsync`/`ApplyProcessorStateAsync` ship this pattern test-free. Verified by build (full solution 0 warnings / 0 errors) and by mirroring the same-file precedent exactly.

`fix:` → patch release.