### PR TITLE
fix: scope the App Updates winget output subscription to its own operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.63] - 2026-07-08
+
+### Fixed
+- **The App Updates console no longer shows winget output from other tabs.** App Updates listened for winget output for as long as the app was open, and it shares one winget engine with the rest of the app — so running "Update All Apps" from the Dashboard (or any other winget action) quietly appended that output to the App Updates console. It now listens only while its own Check-for-updates or Update runs, so the console shows only what you started from that tab.
+
 ## [1.52.62] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager.Tests/AppUpdatesViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppUpdatesViewModelTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Reflection;
+using NSubstitute;
 using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
@@ -165,26 +166,40 @@ public class AppUpdatesViewModelTests
         Assert.True(vm.UpgradeSelectedCommand.CanExecute(null));
     }
 
-    // ---------- runner plumbing ----------
+    // ---------- console subscription is op-scoped (regression: cross-tab winget output leak) ----------
 
     [Fact]
-    public void WingetLineReceived_AppendsToConsole()
+    public async Task WingetLineReceived_DuringScan_AppendsToConsole()
     {
-        var runner = new PowerShellRunner();
-        var winget = new WingetService(runner);
+        // While THIS tab's scan runs, its own winget output must reach its console. The scan
+        // subscribes to LineReceived for the operation, so a line raised during the underlying
+        // ListUpgradableAsync call is captured.
+        var winget = Substitute.For<IWingetService>();
+        winget.ListUpgradableAsync(Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                winget.LineReceived += Raise.Event<Action<PowerShellLine>>(PowerShellLine.Output("scan line"));
+                return Task.FromResult(new List<AppPackage>());
+            });
         var vm = new AppUpdatesViewModel(winget);
 
-        // WingetService.LineReceived delegates to runner.LineReceived,
-        // so firing the runner event should propagate to the VM console.
-        var ev = typeof(PowerShellRunner)
-            .GetField(nameof(PowerShellRunner.LineReceived),
-                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
-        var del = (MulticastDelegate?)ev?.GetValue(runner);
-        Assert.NotNull(del);
+        await vm.ScanCommand.ExecuteAsync(null);
 
-        del!.DynamicInvoke(PowerShellLine.Output("winget test"));
+        Assert.Contains(vm.Console.Lines, l => l.Text == "scan line");
+    }
 
-        Assert.True(vm.Console.Lines.Count >= 1);
-        Assert.Equal("winget test", vm.Console.Lines[^1].Text);
+    [Fact]
+    public void WingetLineReceived_OutsideOperation_DoesNotAppend()
+    {
+        // Regression: WingetService is a singleton shared with other tabs (e.g. the Dashboard's
+        // "Update All Apps"). If this VM stayed subscribed to LineReceived for its whole lifetime,
+        // another tab's winget output would bleed into the App Updates console. With no scan or
+        // upgrade running, firing LineReceived must NOT touch this console.
+        var winget = Substitute.For<IWingetService>();
+        var vm = new AppUpdatesViewModel(winget);
+
+        winget.LineReceived += Raise.Event<Action<PowerShellLine>>(PowerShellLine.Output("from another tab"));
+
+        Assert.Empty(vm.Console.Lines);
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.62</Version>
-    <FileVersion>1.52.62.0</FileVersion>
-    <AssemblyVersion>1.52.62.0</AssemblyVersion>
+    <Version>1.52.63</Version>
+    <FileVersion>1.52.63.0</FileVersion>
+    <AssemblyVersion>1.52.63.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
@@ -43,7 +43,10 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
     {
         _winget = winget;
         _lineHandler = line => Console.Append(line);
-        _winget.LineReceived += _lineHandler;
+        // NOTE: the WingetService is a singleton shared with other tabs (e.g. the Dashboard's
+        // "Update All Apps"). LineReceived is subscribed only for the duration of THIS tab's own
+        // Scan/UpgradeSelected operations (see below), not for the VM's lifetime, so another tab's
+        // winget output never bleeds into this console.
         // Re-evaluate the long-running commands' CanExecute when IsBusy flips. Scan and
         // UpgradeSelected both recreate the shared _cts; without this gate a second
         // command could dispose the CTS the first is still awaiting (ObjectDisposedException).
@@ -88,6 +91,7 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
         Packages.Clear();
         _cts?.Dispose();
         _cts = new CancellationTokenSource();
+        _winget.LineReceived += _lineHandler; // op-scoped subscription (see constructor note)
         try
         {
             var list = await _winget.ListUpgradableAsync(_cts.Token);
@@ -97,7 +101,7 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
         }
         catch (OperationCanceledException) { StatusMessage = "Scan cancelled."; }
         catch (InvalidOperationException ex) { StatusMessage = $"Error: {ex.Message}"; }
-        finally { IsBusy = false; IsProgressIndeterminate = false; }
+        finally { _winget.LineReceived -= _lineHandler; IsBusy = false; IsProgressIndeterminate = false; }
     }
 
     [RelayCommand(CanExecute = nameof(NotBusy))]
@@ -112,6 +116,7 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
         int attempted = 0, succeeded = 0, failed = 0;
         UpgradeEtaText = string.Empty;
         _upgradeEta.Reset();
+        _winget.LineReceived += _lineHandler; // op-scoped subscription (see constructor note)
         try
         {
             foreach (var pkg in toUpgrade)
@@ -147,7 +152,7 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
             Log.Information("App upgrade batch: {Succeeded} ok, {Failed} failed of {Total}",
                 succeeded, failed, toUpgrade.Count);
         }
-        finally { IsBusy = false; UpgradeEtaText = string.Empty; }
+        finally { _winget.LineReceived -= _lineHandler; IsBusy = false; UpgradeEtaText = string.Empty; }
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Problem
`IWingetService` is registered as a **singleton** (`ServiceRegistration.cs`), shared across tabs — the Dashboard's "Update All Apps" calls the same instance (`_winget.UpgradeAllAsync`). `AppUpdatesViewModel` subscribed to `_winget.LineReceived` in its **constructor** and stayed subscribed for the VM's whole lifetime, so winget output from any other tab (e.g. a Dashboard-initiated "Update All Apps") was appended to the App Updates console in the background (deep review pass; found during the regression sweep follow-through).

## Fix
Subscribe to `LineReceived` only for the duration of App Updates' own operations:
- `ScanAsync` and `UpgradeSelectedAsync` each `+= _lineHandler` just before their work and `-= _lineHandler` in `finally`.
- Removed the constructor subscription; the `Dispose` unsubscribe stays as a defensive no-op.

So the console shows only output from a scan/upgrade started on that tab.

## Testing
Reworked the console-plumbing test into two (using a mocked `IWingetService`):
- `WingetLineReceived_OutsideOperation_DoesNotAppend` — fires `LineReceived` with no operation running and asserts the console stays empty. **Red before the fix** (the constructor subscription appended it), **green after**. This directly pins the cross-tab leak.
- `WingetLineReceived_DuringScan_AppendsToConsole` — the mock raises `LineReceived` during `ListUpgradableAsync`, asserting the tab's own scan output still reaches the console.

The previous `WingetLineReceived_AppendsToConsole` test asserted the *leaky* behavior (append with no op running) and is replaced. Build: full solution 0 warnings / 0 errors.

`fix:` → patch release.