### PR TITLE
fix: use the shared live console on the System Fixes tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.64] - 2026-07-09
+
+### Fixed
+- **The System Fixes output now uses the same live console as the rest of the app.** Its repair output was rendered with a slower approach that rebuilt the entire text on every new line and updated the UI thread line-by-line. It now uses the shared, capped, timestamped console control that the App Updates, Windows Update, and Cleanup tabs already use — smoother during long repairs, and consistent with those tabs (same Clear / Copy / Auto-scroll controls).
+
 ## [1.52.63] - 2026-07-08
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.63</Version>
-    <FileVersion>1.52.63.0</FileVersion>
-    <AssemblyVersion>1.52.63.0</AssemblyVersion>
+    <Version>1.52.64</Version>
+    <FileVersion>1.52.64.0</FileVersion>
+    <AssemblyVersion>1.52.64.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/SystemFixesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemFixesViewModel.cs
@@ -26,7 +26,9 @@ public sealed partial class SystemFixesViewModel : ViewModelBase
     private CancellationTokenSource? _cts;
 
     [ObservableProperty] private bool _isElevated;
-    [ObservableProperty] private string _output = "";
+
+    /// <summary>Shared, capped, thread-safe console — same control the other repair/scan tabs use.</summary>
+    public ConsoleViewModel Console { get; } = new();
 
     public SystemFixesViewModel(SystemFixService service)
     {
@@ -48,12 +50,9 @@ public sealed partial class SystemFixesViewModel : ViewModelBase
         }
     }
 
-    private void OnLine(PowerShellLine line)
-    {
-        var text = line.Text;
-        System.Windows.Application.Current?.Dispatcher.Invoke(() =>
-            Output += (Output.Length == 0 ? "" : Environment.NewLine) + text);
-    }
+    // ConsoleViewModel.Append marshals to the UI thread, locks, and caps the line count —
+    // replacing the old per-line synchronous Dispatcher.Invoke + O(n^2) string concatenation.
+    private void OnLine(PowerShellLine line) => Console.Append(line);
 
     [RelayCommand(CanExecute = nameof(CanRunFix))]
     private Task ResetWindowsUpdateAsync() => RunFixAsync(
@@ -80,7 +79,7 @@ public sealed partial class SystemFixesViewModel : ViewModelBase
 
         IsBusy = true;
         IsProgressIndeterminate = true;
-        Output = "";
+        Console.ClearCommand.Execute(null);
         _cts?.Dispose();
         _cts = new CancellationTokenSource();
         try

--- a/SysManager/SysManager/Views/SystemFixesView.xaml
+++ b/SysManager/SysManager/Views/SystemFixesView.xaml
@@ -111,22 +111,9 @@
             </StackPanel>
         </Border>
 
-        <!-- Output console -->
+        <!-- Output console — shared ConsoleView (same control the other repair/scan tabs use) -->
         <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
-            <Grid>
-                <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="14,12">
-                    <TextBox Text="{Binding Output, Mode=OneWay}"
-                             AutomationProperties.Name="Repair output"
-                             IsReadOnly="True" TextWrapping="Wrap"
-                             Background="Transparent" BorderThickness="0"
-                             FontFamily="{StaticResource MonoFont}" FontSize="12"
-                             Foreground="{DynamicResource TextPrimary}"/>
-                </ScrollViewer>
-                <v:EmptyState Glyph="&#xE756;"
-                              Title="No repair run yet"
-                              Message="Run a fix above to see its output here."
-                              Visibility="{Binding Output.Length, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
-            </Grid>
+            <v:ConsoleView DataContext="{Binding Console}"/>
         </Border>
 
         <!-- Status bar -->


### PR DESCRIPTION
## Problem
The System Fixes tab rendered repair output with a hand-rolled console: `[ObservableProperty] string Output` updated via `Output += … ` (O(n²) — each line reallocates the whole string) inside a per-line **synchronous** `Dispatcher.Invoke`. Every other repair/scan tab (App Updates, Windows Update, Cleanup, System Health, Uninstaller) uses the shared `ConsoleViewModel` + `ConsoleView` control, which marshals off the UI thread (`BeginInvoke`), locks, and caps the line count — so System Fixes was the lone inconsistent, slower one.

## Fix
- VM: replaced `Output` with `public ConsoleViewModel Console { get; } = new();`; `OnLine` now just calls `Console.Append(line)`; the pre-run reset uses `Console.ClearCommand.Execute(null)`.
- View: replaced the `ScrollViewer`+`TextBox`+custom `EmptyState` with `<v:ConsoleView DataContext="{Binding Console}"/>`, exactly like `WindowsUpdateView`. `ConsoleView` brings its own timestamped/colored list, Clear/Copy/Auto-scroll toolbar, and "No output yet" empty state.

This is a uniformity fix (adopting the app's established shared console control across the one view that wasn't using it — UNIFORMITY STANDARDS), not a new design; the visible outcome is that the System Fixes console now looks and behaves like every other console in the app.

## Testing
No new unit test: the change swaps a bound string for the shared, already-covered `ConsoleViewModel` and re-parents the view to the shared `ConsoleView` control — behavior is delegated to existing, tested components. Verified by build (full solution 0 warnings / 0 errors).

`fix:` → patch release.