### PR TITLE
fix: prevent concurrent use of the Cleanup tab's shared console runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.65] - 2026-07-09
+
+### Fixed
+- **The Cleanup tab no longer lets two repairs use its console at the same time.** Temp Cleanup and the SFC / DISM system repairs all stream their output into the tab's single console, but only SFC and DISM were stopped from running together — Temp Cleanup could still be started while SFC or DISM was running (they use different internal locks), so their output could interleave in the console. Starting any of the three while another is using the console is now declined with a clear message until the first finishes. (Emptying the Recycle Bin is unaffected — it doesn't use the console.)
+- **Dragging the theme shade (background-brightness) slider no longer rewrites the theme file on every tick.** Each tiny movement saved the theme settings to disk; the shade still updates instantly, but the save now happens once you settle on a position instead of many times during a single drag.
+
+### Added
+- **Dashboard buttons now expose their names to screen readers.** The Quick Tune-Up button, the four Quick Actions (Run Quick Cleanup, Update All Apps, Check Windows Updates, Run Speed Test), and the temperature "Run as administrator" button are icon-and-text buttons that didn't carry an accessible name; they now do, so assistive technologies announce what each button does.
+
 ## [1.52.64] - 2026-07-09
 
 ### Fixed

--- a/SysManager/SysManager.Tests/CleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/CleanupViewModelTests.cs
@@ -287,6 +287,26 @@ public class CleanupViewModelTests
         Assert.Equal(100, vm.Progress);
     }
 
+    // ---------- shared-runner mutual exclusion ----------
+
+    // Temp Cleanup, SFC, and DISM all stream through the single shared PowerShellRunner
+    // into the one Console. Their per-category OperationLockService locks (Temp = Disk,
+    // SFC/DISM = SystemModification) don't exclude Temp from SFC/DISM, so an intra-VM guard
+    // does. This pins that guard's mutual-exclusion contract directly; the full command path
+    // is gated behind elevation (SFC/DISM) or a live disk lock — both skipped or contended
+    // under CI — so testing the primitive is the deterministic sibling of the
+    // SystemModificationLock_IsMutuallyExclusive test below.
+    [Fact]
+    public void ConsoleRunnerGuard_IsMutuallyExclusive()
+    {
+        var vm = NewVm();
+        Assert.True(vm.TryBeginConsoleOp());   // e.g. SFC claims the shared runner
+        Assert.False(vm.TryBeginConsoleOp());  // Temp / DISM blocked while it is held
+        vm.EndConsoleOp();
+        Assert.True(vm.TryBeginConsoleOp());    // released — free to claim again
+        vm.EndConsoleOp();
+    }
+
     // ---------- base class properties (exercise ViewModelBase setters) ----------
 
     [Fact]

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Text.Json;
 using System.Windows;
 using System.Windows.Media;
+using System.Windows.Threading;
 using Serilog;
 
 namespace SysManager.Services;
@@ -27,6 +28,13 @@ public sealed class ThemeService
     public double ShadePosition { get; private set; } = 0.5;
 
     private ThemePreset _baseTheme = ThemePreset.Defaults["midnight-indigo"];
+
+    // The shade slider raises SetShade on every tick of a drag; persisting on each one would
+    // hammer the disk. Coalesce writes: SetShade applies the shade live but (re)starts this
+    // short timer, so the JSON is written once the drag settles. Created lazily on the first
+    // shade change (always on the UI thread). Discrete theme changes (SetPreset/SetAccent/
+    // SetCustom) still save immediately.
+    private DispatcherTimer? _shadeSaveTimer;
 
     private static readonly Dictionary<string, string> DarkToLight = new()
     {
@@ -79,7 +87,22 @@ public sealed class ThemeService
     {
         ShadePosition = Math.Clamp(position, 0, 1);
         ApplyShade();
-        Save();
+        DebouncedSave();
+    }
+
+    // Coalesces rapid shade-slider writes into a single disk save once the drag settles.
+    private void DebouncedSave()
+    {
+        _shadeSaveTimer ??= CreateShadeSaveTimer();
+        _shadeSaveTimer.Stop();
+        _shadeSaveTimer.Start();
+    }
+
+    private DispatcherTimer CreateShadeSaveTimer()
+    {
+        var timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(400) };
+        timer.Tick += (_, _) => { timer.Stop(); Save(); };
+        return timer;
     }
 
     public void SetCustom(Color accent, Color background, Color surface, Color text)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.64</Version>
-    <FileVersion>1.52.64.0</FileVersion>
-    <AssemblyVersion>1.52.64.0</AssemblyVersion>
+    <Version>1.52.65</Version>
+    <FileVersion>1.52.65.0</FileVersion>
+    <AssemblyVersion>1.52.65.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -25,6 +25,15 @@ public sealed partial class CleanupViewModel : ViewModelBase
     private CancellationTokenSource? _sfcCts;
     private CancellationTokenSource? _dismCts;
 
+    // Temp Cleanup, SFC, and DISM all stream through the single shared _runner and its
+    // LineReceived/ProgressChanged events into the one Console, so only one may run at a
+    // time — otherwise their output and progress cross-contaminate. The per-category
+    // OperationLockService locks don't close this gap: Temp Cleanup is a Disk operation
+    // while SFC/DISM are SystemModification, so those locks never exclude Temp from
+    // SFC/DISM. This intra-VM guard does. (Empty-Recycle-Bin doesn't touch _runner, so it
+    // is intentionally not gated.) Set and read only on the UI thread.
+    private bool _runnerBusy;
+
     public ConsoleViewModel Console { get; } = new();
 
     [ObservableProperty] private bool _isElevated;
@@ -65,6 +74,17 @@ public sealed partial class CleanupViewModel : ViewModelBase
 
     private void OnRunnerLineReceived(PowerShellLine l) => Console.Append(l);
     private void OnRunnerProgressChanged(int p) => Progress = p;
+
+    // Claims the shared _runner for one console/repair op; returns false if another already
+    // holds it. internal for the regression test (mirrors ParseSfcResult's test visibility).
+    internal bool TryBeginConsoleOp()
+    {
+        if (_runnerBusy) return false;
+        _runnerBusy = true;
+        return true;
+    }
+
+    internal void EndConsoleOp() => _runnerBusy = false;
 
     private async Task InitAsync()
     {
@@ -188,6 +208,11 @@ public sealed partial class CleanupViewModel : ViewModelBase
             StatusMessage = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.Disk)} is already running.";
             return;
         }
+        if (!TryBeginConsoleOp())
+        {
+            StatusMessage = "Cannot start — a repair is already using the console. Wait for it to finish.";
+            return;
+        }
         IsTempRunning = true;
         StatusMessage = "Cleaning temp folders...";
         _tempCts?.Dispose();
@@ -237,7 +262,7 @@ public sealed partial class CleanupViewModel : ViewModelBase
         }
         catch (OperationCanceledException) { StatusMessage = "Temp cleanup cancelled."; }
         catch (InvalidOperationException ex) { StatusMessage = $"Error: {ex.Message}"; }
-        finally { IsTempRunning = false; }
+        finally { EndConsoleOp(); IsTempRunning = false; }
     }
 
     [RelayCommand]
@@ -288,14 +313,21 @@ public sealed partial class CleanupViewModel : ViewModelBase
             return;
         }
 
-        // SFC and DISM share the single _runner (and its LineReceived event), so they
-        // must be mutually exclusive — running both at once cross-contaminates their
-        // captured output and progress. The SystemModification lock enforces that and
-        // also blocks against the other system-repair operations.
+        // SFC and DISM share the single _runner (and its LineReceived event) with each other
+        // AND with Temp Cleanup, so running two at once cross-contaminates their captured
+        // output and progress. The SystemModification lock makes SFC and DISM mutually
+        // exclusive (and blocks the other system-repair operations); the _runnerBusy guard
+        // below additionally excludes Temp Cleanup, which holds a different (Disk) lock and
+        // so is not covered by this one.
         using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "SFC scan");
         if (opLock is null)
         {
             StatusMessage = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.SystemModification)} is already running.";
+            return;
+        }
+        if (!TryBeginConsoleOp())
+        {
+            StatusMessage = "Cannot start — a repair is already using the console. Wait for it to finish.";
             return;
         }
 
@@ -337,7 +369,7 @@ public sealed partial class CleanupViewModel : ViewModelBase
         catch (OperationCanceledException) { SfcStatus = "Cancelled."; SfcVerdict = "Scan was cancelled."; SfcVerdictColorHex = StatusColors.Neutral; StatusMessage = SfcStatus; }
         catch (InvalidOperationException ex) { SfcStatus = $"Error: {ex.Message}"; SfcVerdict = ex.Message; SfcVerdictColorHex = StatusColors.Bad; StatusMessage = SfcStatus; }
         catch (System.ComponentModel.Win32Exception ex) { SfcStatus = $"Error: {ex.Message}"; SfcVerdict = ex.Message; SfcVerdictColorHex = StatusColors.Bad; StatusMessage = SfcStatus; }
-        finally { _runner.LineReceived -= Collect; IsSfcRunning = false; IsProgressIndeterminate = false; SfcEtaText = string.Empty; }
+        finally { _runner.LineReceived -= Collect; EndConsoleOp(); IsSfcRunning = false; IsProgressIndeterminate = false; SfcEtaText = string.Empty; }
     }
 
     /// <summary>
@@ -388,13 +420,20 @@ public sealed partial class CleanupViewModel : ViewModelBase
             return;
         }
 
-        // Mutually exclusive with SFC (and the other system-repair ops): both share the
+        // Mutually exclusive with SFC and the other system-repair ops (SystemModification
+        // lock) AND with Temp Cleanup (the _runnerBusy guard below): all three share the
         // single _runner and its LineReceived event, so concurrent runs would cross-
-        // contaminate captured output and progress.
+        // contaminate captured output and progress. Temp holds a different (Disk) lock, so
+        // only the guard — not this lock — excludes it.
         using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "DISM RestoreHealth");
         if (opLock is null)
         {
             StatusMessage = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.SystemModification)} is already running.";
+            return;
+        }
+        if (!TryBeginConsoleOp())
+        {
+            StatusMessage = "Cannot start — a repair is already using the console. Wait for it to finish.";
             return;
         }
 
@@ -436,7 +475,7 @@ public sealed partial class CleanupViewModel : ViewModelBase
         catch (OperationCanceledException) { DismStatus = "Cancelled."; DismVerdict = "Repair was cancelled."; DismVerdictColorHex = StatusColors.Neutral; StatusMessage = DismStatus; }
         catch (InvalidOperationException ex) { DismStatus = $"Error: {ex.Message}"; DismVerdict = ex.Message; DismVerdictColorHex = StatusColors.Bad; StatusMessage = DismStatus; }
         catch (System.ComponentModel.Win32Exception ex) { DismStatus = $"Error: {ex.Message}"; DismVerdict = ex.Message; DismVerdictColorHex = StatusColors.Bad; StatusMessage = DismStatus; }
-        finally { _runner.LineReceived -= Collect; IsDismRunning = false; IsProgressIndeterminate = false; DismEtaText = string.Empty; }
+        finally { _runner.LineReceived -= Collect; EndConsoleOp(); IsDismRunning = false; IsProgressIndeterminate = false; DismEtaText = string.Empty; }
     }
 
     /// <summary>

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -29,6 +29,7 @@
                     <Button Content="Scan system" Command="{Binding RefreshCommand}"
                             Style="{StaticResource SecondaryButton}" Padding="14,8" Margin="0,0,8,0"/>
                     <Button Command="{Binding RunTuneUpCommand}"
+                            AutomationProperties.Name="Quick Tune-Up"
                             Style="{StaticResource PrimaryButton}" Padding="16,8">
                         <StackPanel Orientation="Horizontal">
                             <TextBlock Text="&#xE945;" FontFamily="Segoe Fluent Icons" FontSize="14"
@@ -197,6 +198,7 @@
                             <TextBlock Text="TEMPERATURES" FontSize="11" FontWeight="SemiBold"
                                        Foreground="{DynamicResource TextMuted}" VerticalAlignment="Center"/>
                             <Button Command="{Binding RelaunchAsAdminCommand}" Margin="10,0,0,0"
+                                    AutomationProperties.Name="Run as administrator for all temperature sensors"
                                     Padding="6,3" FontSize="10" VerticalAlignment="Center"
                                     Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
                                 <Button.Template>
@@ -300,6 +302,7 @@
                         <TextBlock Text="QUICK ACTIONS" FontSize="11" FontWeight="SemiBold"
                                    Foreground="{DynamicResource TextMuted}" Margin="0,0,0,12"/>
                         <Button Command="{Binding QuickCleanupCommand}"
+                                AutomationProperties.Name="Run Quick Cleanup"
                                 Style="{StaticResource SecondaryButton}" Padding="10,8" Margin="0,0,0,6"
                                 HorizontalContentAlignment="Left" HorizontalAlignment="Stretch">
                             <StackPanel Orientation="Horizontal">
@@ -308,6 +311,7 @@
                             </StackPanel>
                         </Button>
                         <Button Command="{Binding QuickUpdateAppsCommand}"
+                                AutomationProperties.Name="Update All Apps"
                                 Style="{StaticResource SecondaryButton}" Padding="10,8" Margin="0,0,0,6"
                                 HorizontalContentAlignment="Left" HorizontalAlignment="Stretch">
                             <StackPanel Orientation="Horizontal">
@@ -316,6 +320,7 @@
                             </StackPanel>
                         </Button>
                         <Button Command="{Binding QuickWindowsUpdateCommand}"
+                                AutomationProperties.Name="Check Windows Updates"
                                 Style="{StaticResource SecondaryButton}" Padding="10,8" Margin="0,0,0,6"
                                 HorizontalContentAlignment="Left" HorizontalAlignment="Stretch">
                             <StackPanel Orientation="Horizontal">
@@ -324,6 +329,7 @@
                             </StackPanel>
                         </Button>
                         <Button Command="{Binding QuickSpeedTestCommand}"
+                                AutomationProperties.Name="Run Speed Test"
                                 Style="{StaticResource SecondaryButton}" Padding="10,8"
                                 HorizontalContentAlignment="Left" HorizontalAlignment="Stretch">
                             <StackPanel Orientation="Horizontal">


### PR DESCRIPTION
## Summary

Batched polish shipped as one release to avoid version-on-version winget churn. Three independent, low-risk changes:

### 1. Fix — Cleanup tab shared-runner race
Temp Cleanup, SFC, and DISM all stream through the single shared `PowerShellRunner` and its `LineReceived`/`ProgressChanged` events into the one `Console`. Only SFC and DISM were mutually exclusive (both take the `SystemModification` lock); Temp Cleanup takes the `Disk` lock, so it was **not** excluded from SFC/DISM and could run concurrently, interleaving output in the console (and polluting SFC's captured-lines list). `RunProcessAsync` uses a local `Process`, so there was no handle/cancellation corruption — the harm was output/progress cross-contamination.

**Fix:** an intra-VM guard (`_runnerBusy` via `TryBeginConsoleOp`/`EndConsoleOp`) shared by the three runner-using ops, so only one runs at a time; the others are declined with a clear message. Empty Recycle Bin is intentionally not gated (it doesn't use the runner). A regression test pins the mutual-exclusion contract (mirrors the existing `SystemModificationLock_IsMutuallyExclusive`; the full command path is elevation/lock-gated and skipped under CI).

### 2. Accessibility — Dashboard button names
Added `AutomationProperties.Name` to the six icon+text / templated buttons that had no accessible name: Quick Tune-Up, the four Quick Actions (Run Quick Cleanup, Update All Apps, Check Windows Updates, Run Speed Test), and the temperatures "Run as administrator" badge. Non-visual, additive.

### 3. Performance — theme shade-slider save debounce
Dragging the shade slider called `Save()` (a JSON disk write) on every `ValueChanged` tick. The shade still applies live, but the save is now debounced (400 ms `DispatcherTimer`) so it writes once the drag settles. Discrete theme changes (preset/accent/custom) still save immediately.

## Verification
- `dotnet build` main + tests: 0 warnings / 0 errors.
- `dotnet format --verify-no-changes` on changed files: clean.
- Self-review: no debug code, correct author headers.

## Follow-up (not in this PR)
A propagation check surfaced the same *class* in `WindowsUpdateViewModel`: `CheckModuleAsync` and `InstallModuleAsync` are ungated `[RelayCommand]`s that use the shared runner while the other update commands are `NotBusy`-gated, so an ungated one could overlap on the runner (milder — CheckModule uses a local listener, not the shared console). Flagged for a separate decision.
