### PR TITLE
fix: gate the Windows Update module commands on the busy state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.66] - 2026-07-09
+
+### Fixed
+- **The Windows Update tab no longer lets a module action run at the same time as another update operation.** Its "Check module" and "Install PSWindowsUpdate module" actions share the tab's single background engine and console with the Check-for-updates / History / Install-updates operations, but — unlike those — their buttons stayed enabled while another operation was running, so starting one could interleave its output on the shared console. They are now disabled while any update operation is in progress, matching the rest of the tab.
+
 ## [1.52.65] - 2026-07-09
 
 ### Fixed

--- a/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
+++ b/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
@@ -317,6 +317,25 @@ public class WindowsUpdateViewModelTests
         Assert.True(vm.ListUpdatesCommand.CanExecute(null));
     }
 
+    // Check/Install Module stream through the same shared runner and console, so they are
+    // gated on NotBusy too — otherwise starting one while another update operation runs
+    // would interleave output on the shared console (and race on the shared CTS).
+    [Fact]
+    public void ModuleCommands_DisabledWhileBusy()
+    {
+        var vm = NewVm();
+        Assert.True(vm.CheckModuleCommand.CanExecute(null));
+        Assert.True(vm.InstallModuleCommand.CanExecute(null));
+
+        vm.IsBusy = true;
+        Assert.False(vm.CheckModuleCommand.CanExecute(null));
+        Assert.False(vm.InstallModuleCommand.CanExecute(null));
+
+        vm.IsBusy = false;
+        Assert.True(vm.CheckModuleCommand.CanExecute(null));
+        Assert.True(vm.InstallModuleCommand.CanExecute(null));
+    }
+
     // ── Confirmation-gate test (installing updates must route through Confirm) ──
 
     [Fact]

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.65</Version>
-    <FileVersion>1.52.65.0</FileVersion>
-    <AssemblyVersion>1.52.65.0</AssemblyVersion>
+    <Version>1.52.66</Version>
+    <FileVersion>1.52.66.0</FileVersion>
+    <AssemblyVersion>1.52.66.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -135,6 +135,8 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
         ShowHistoryCommand.NotifyCanExecuteChanged();
         CheckPendingRebootCommand.NotifyCanExecuteChanged();
         InstallUpdatesCommand.NotifyCanExecuteChanged();
+        CheckModuleCommand.NotifyCanExecuteChanged();
+        InstallModuleCommand.NotifyCanExecuteChanged();
     }
 
     protected override void Dispose(bool disposing)
@@ -157,7 +159,12 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
             System.Windows.Application.Current?.Shutdown();
     }
 
-    [RelayCommand]
+    // Gated on NotBusy like the other runner-driven commands: CheckModule and
+    // InstallModule stream through the shared _runner into the same console, so letting
+    // them start while another update operation is running would cross-contaminate output
+    // (and race on the shared CTS). The internal call from InstallModuleAsync uses the
+    // method directly, so it is unaffected by this command-level gate.
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task CheckModuleAsync()
     {
         IsBusy = true;
@@ -185,7 +192,7 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
         finally { IsBusy = false; }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task InstallModuleAsync()
     {
         if (!AdminHelper.IsElevated())


### PR DESCRIPTION
## Summary

Follow-up to the v1.52.65 Cleanup shared-runner guard — the same class in a different tab, found by the propagation check.

`CheckModuleAsync` and `InstallModuleAsync` stream through the Windows Update tab's single shared `PowerShellRunner` and console, exactly like the Check-for-updates / History / Install-updates commands. But they were the **only** runner-driven commands not gated on `NotBusy`, so their buttons stayed enabled while another update operation was running — starting one could interleave its output on the shared console and race on the shared CTS.

**Fix:** both commands are now `[RelayCommand(CanExecute = nameof(NotBusy))]` with `NotifyCanExecuteChanged` wired in `OnVmPropertyChanged`, matching the rest of the tab. `InstallModuleAsync`'s internal `await CheckModuleAsync()` call uses the method directly, so it is unaffected by the command-level gate.

## Test
`ModuleCommands_DisabledWhileBusy` pins the disabled-while-busy contract (mirrors the existing `LongRunningCommands_DisabledWhileBusy`).

## Verification
- `dotnet build` main + tests: 0 warnings / 0 errors.
- `dotnet format --verify-no-changes` on changed files: clean.