### PR TITLE
fix: amber admin elevation cue, AdminButton focus ring, and toast accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.67] - 2026-07-09
+
+### Changed
+- **The sidebar "administrator" badge now uses the amber/gold admin colour instead of purple.** When SysManager runs elevated, the shield in the sidebar footer turned purple — but purple is the app's primary-action colour, while the admin/elevation cue is amber everywhere else (the "Run as administrator" buttons and banners). The shield now matches that amber, so the elevation cue is consistent across the app.
+- **The Logs cards now use the shared large corner-radius token** instead of a slightly different hard-coded value, so their rounding matches the other cards.
+
+### Added
+- **The "Run as administrator" buttons now show a keyboard-focus outline.** They were missing the focus cue the other buttons already have, so keyboard users couldn't tell when one was focused; they now show an amber focus ring that matches the button's colour.
+- **Completion notifications (toasts) are now announced by screen readers and can be dismissed with the keyboard.** The toast is now a live region — assistive technologies read it aloud when it appears — and its close control is a real button (keyboard-focusable, Enter/Space to dismiss) rather than a mouse-only target.
+
 ## [1.52.66] - 2026-07-09
 
 ### Fixed

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -564,6 +564,14 @@
                                 <Trigger Property="IsPressed" Value="True">
                                     <Setter TargetName="Bd" Property="Background" Value="{DynamicResource WarningBg}"/>
                                 </Trigger>
+                                <!-- Keyboard focus ring (a11y): AdminButton omitted the IsKeyboardFocused
+                                     trigger the other button styles carry, so it had no visible focus cue.
+                                     Uses the brighter amber (WarningText) + a thicker border, staying within
+                                     the admin/gold palette rather than the purple Accent the other buttons use. -->
+                                <Trigger Property="IsKeyboardFocused" Value="True">
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource WarningText}"/>
+                                    <Setter TargetName="Bd" Property="BorderThickness" Value="1.5"/>
+                                </Trigger>
                                 <Trigger Property="IsEnabled" Value="False">
                                     <Setter Property="Opacity" Value="0.4"/>
                                 </Trigger>

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -306,8 +306,11 @@
                                     <Style TargetType="TextBlock">
                                         <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
                                         <Style.Triggers>
+                                            <!-- Elevated cue uses the amber/gold admin colour (WarningStripe),
+                                                 matching AdminButton and the elevation banners. Purple (Accent)
+                                                 is reserved for primary actions, so it is not used for admin. -->
                                             <DataTrigger Binding="{Binding IsElevated}" Value="True">
-                                                <Setter Property="Foreground" Value="{DynamicResource Accent}"/>
+                                                <Setter Property="Foreground" Value="{DynamicResource WarningStripe}"/>
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
@@ -405,9 +408,12 @@
             </Grid>
         </Border>
 
-        <!-- Glass toast notification overlay -->
+        <!-- Glass toast notification overlay. LiveSetting makes screen readers announce the
+             toast when it appears (it carries operation-completion feedback and auto-dismisses,
+             so Assertive ensures the announcement lands before it fades). -->
         <Border x:Name="ToastOverlay" Grid.Column="1"
                 HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                AutomationProperties.LiveSetting="Assertive"
                 Margin="0,0,20,20" Visibility="Collapsed">
             <Border Background="{DynamicResource Surface2}" CornerRadius="10"
                     BorderBrush="#4022C55E" BorderThickness="1"
@@ -433,13 +439,24 @@
                         <TextBlock x:Name="ToastDetail" FontSize="11"
                                    Foreground="{DynamicResource TextSecondary}" Margin="0,2,0,0"/>
                     </StackPanel>
-                    <Border Grid.Column="2" Margin="14,0,0,0" Cursor="Hand"
-                            MouseLeftButtonUp="DismissToast_Click"
-                            Background="Transparent" Padding="4">
+                    <!-- Real Button so the dismiss is keyboard-focusable and Enter/Space-activatable
+                         (the previous Border handled MouseLeftButtonUp only). Minimal transparent
+                         template keeps the bare glyph look; the default focus adorner gives a focus cue. -->
+                    <Button Grid.Column="2" Margin="14,0,0,0" Cursor="Hand"
+                            Click="DismissToast_Click"
+                            AutomationProperties.Name="Dismiss notification"
+                            Background="Transparent" BorderThickness="0" Padding="4">
+                        <Button.Template>
+                            <ControlTemplate TargetType="Button">
+                                <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}">
+                                    <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                </Border>
+                            </ControlTemplate>
+                        </Button.Template>
                         <TextBlock Text="&#xE711;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                    FontSize="12" Foreground="{DynamicResource TextMuted}"
                                    VerticalAlignment="Center"/>
-                    </Border>
+                    </Button>
                 </Grid>
             </Border>
         </Border>

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -44,7 +44,7 @@ public partial class MainWindow : Window
         ToastOverlay.BeginAnimation(OpacityProperty, fade);
     }
 
-    private void DismissToast_Click(object sender, MouseButtonEventArgs e)
+    private void DismissToast_Click(object sender, RoutedEventArgs e)
     {
         ToastService.Instance.Dismiss();
     }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.66</Version>
-    <FileVersion>1.52.66.0</FileVersion>
-    <AssemblyVersion>1.52.66.0</AssemblyVersion>
+    <Version>1.52.67</Version>
+    <FileVersion>1.52.67.0</FileVersion>
+    <AssemblyVersion>1.52.67.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -11,7 +11,7 @@
         </Style>
 
         <Style x:Key="GlassCard" TargetType="Border">
-            <Setter Property="CornerRadius" Value="14"/>
+            <Setter Property="CornerRadius" Value="{StaticResource RadiusLg}"/>
             <Setter Property="Padding" Value="16,12"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="BorderBrush" Value="{DynamicResource Border1}"/>


### PR DESCRIPTION
## Summary

Visual + accessibility batch, shipped as one release (avoids version-on-version winget churn). All four are low-risk and were verified against the app's existing styles/contract.

### 1. Elevation badge: purple → amber (contract fix)
When SysManager runs elevated, the sidebar-footer shield turned **purple** (`Accent`). The colour contract reserves purple for primary actions and uses **amber/gold** for the admin/elevation cue (the "Run as administrator" buttons and banners). The shield now uses `WarningStripe`, matching `AdminButton` and the elevation banners. One-token change in `MainWindow.xaml`; text stays neutral, no layout change.

### 2. AdminButton keyboard-focus ring (a11y)
`AdminButton` was missing the `IsKeyboardFocused` trigger the other button styles carry, so keyboard users had **no visible focus cue** on it. Added an amber focus ring (`WarningText` brush + 1.5 border), staying within the admin/gold palette. Applies everywhere `AdminButton` is used.

### 3. Toast accessibility
The completion toast is now:
- a **live region** (`AutomationProperties.LiveSetting="Assertive"`) so screen readers announce it when it appears (it auto-dismisses, so Assertive ensures the announcement lands);
- dismissible by **keyboard** — the close control is now a real focusable `Button` (Enter/Space) with `AutomationProperties.Name="Dismiss notification"`, instead of a mouse-only `Border`. The `DismissToast_Click` body was unchanged (it never used the event args).

### 4. Logs cards corner radius token
`LogsView`'s `GlassCard` used a hard-coded `CornerRadius="14"`; now uses the shared `RadiusLg` token (12) so its rounding matches the other cards.

## Verification
- `dotnet build` main + tests: 0 warnings / 0 errors (XAML compiles, so `LiveSetting` and the retyped handler are valid).
- `dotnet format --verify-no-changes` on the changed `.cs`: clean.
- No unit test: these are XAML/visual + a11y changes with no unit-testable logic (UI-automation territory, non-blocking); verified by build + review, and in the running beta.
