### PR TITLE
fix: launch built-in Windows tools by full System32 path to prevent binary planting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.68] - 2026-07-10
+
+### Security
+- **Built-in Windows repair tools are now launched by their full trusted system path instead of by name.** Several maintenance actions started Windows' own tools by name only (the SFC / DISM / CHKDSK / network helpers behind the repair tabs, the scheduled-task and registry edits behind the Context Menu and Startup tabs, the memory-diagnostic scheduler, and the auto-logon dialog on the System Fixes tab). When a program is started by name with a direct (non-shell) launch, Windows searches the application's own folder before the system folder — so if SysManager were run as a portable copy from a folder other programs can write to (for example, a Downloads folder) with administrator rights, a look-alike file planted there under the same name could have run in place of the real Windows tool, inheriting those rights. SysManager now resolves these tools to their protected `System32` location before launching them, so a planted look-alike can no longer take their place.
+
 ## [1.52.67] - 2026-07-09
 
 ### Changed

--- a/SysManager/SysManager.Tests/SystemPathsTests.cs
+++ b/SysManager/SysManager.Tests/SystemPathsTests.cs
@@ -1,0 +1,66 @@
+// SysManager · SystemPathsTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Helpers;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Pins the binary-planting / LPE hardening: bare Windows tool names must resolve to their
+/// full trusted System32 path so an attacker-planted executable in the app's own directory
+/// cannot be run (especially elevated). Non-system / explicit paths must pass through unchanged.
+/// </summary>
+public class SystemPathsTests
+{
+    [Fact]
+    public void ResolveSystemTool_KnownSystem32Tool_ReturnsFullSystem32Path()
+    {
+        // cmd.exe is always present in System32 on Windows (CI runs on windows-latest).
+        var resolved = SystemPaths.ResolveSystemTool("cmd.exe");
+        Assert.True(Path.IsPathRooted(resolved), "resolved path must be rooted");
+        Assert.True(File.Exists(resolved), "resolved path must exist");
+        Assert.Equal(Path.Combine(Environment.SystemDirectory, "cmd.exe"), resolved, ignoreCase: true);
+    }
+
+    [Fact]
+    public void ResolveSystemTool_PowerShell_ResolvesToRootedExistingPath()
+    {
+        // powershell.exe lives in the System32\WindowsPowerShell\v1.0 subfolder, not System32 itself.
+        var resolved = SystemPaths.ResolveSystemTool("powershell.exe");
+        Assert.True(Path.IsPathRooted(resolved), "powershell.exe must resolve to a rooted path");
+        Assert.True(File.Exists(resolved), "resolved powershell.exe must exist");
+        Assert.EndsWith("powershell.exe", resolved, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ResolveSystemTool_AlreadyRootedPath_ReturnedUnchanged()
+    {
+        const string p = @"C:\Windows\System32\netsh.exe";
+        Assert.Equal(p, SystemPaths.ResolveSystemTool(p));
+    }
+
+    [Theory]
+    [InlineData(@"sub\dir\tool.exe")]
+    [InlineData("sub/dir/tool.exe")]
+    public void ResolveSystemTool_ContainsSeparator_ReturnedUnchanged(string name)
+    {
+        // A path separator means the caller already chose a location — never rewrite it.
+        Assert.Equal(name, SystemPaths.ResolveSystemTool(name));
+    }
+
+    [Fact]
+    public void ResolveSystemTool_UnknownBareName_ReturnedUnchanged()
+    {
+        const string name = "definitely-not-a-real-tool-xyz.exe";
+        Assert.Equal(name, SystemPaths.ResolveSystemTool(name));
+    }
+
+    [Fact]
+    public void ResolveSystemTool_EmptyOrNull_ReturnedUnchanged()
+    {
+        Assert.Equal("", SystemPaths.ResolveSystemTool(""));
+        Assert.Null(SystemPaths.ResolveSystemTool(null!));
+    }
+}

--- a/SysManager/SysManager/Helpers/SystemPaths.cs
+++ b/SysManager/SysManager/Helpers/SystemPaths.cs
@@ -1,0 +1,46 @@
+// SysManager · SystemPaths
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+
+namespace SysManager.Helpers;
+
+/// <summary>
+/// Resolves bare Windows tool names (sfc.exe, netsh.exe, reg.exe, schtasks.exe, powercfg.exe,
+/// powershell.exe, …) to their full trusted paths under %SystemRoot%\System32.
+/// <para>
+/// Launching a system tool by bare filename with <c>UseShellExecute=false</c> lets the Win32
+/// <c>CreateProcess</c> search order look in the CALLING process's own directory FIRST. SysManager
+/// ships as a single portable .exe that users often run from a user-writable location (Downloads),
+/// sometimes elevated — so an attacker-planted <c>netsh.exe</c> / <c>reg.exe</c> next to it would be
+/// executed with administrator rights (binary-planting / local privilege escalation). Pinning the
+/// full System32 path closes that vector while leaving behaviour otherwise identical.
+/// </para>
+/// </summary>
+internal static class SystemPaths
+{
+    private static readonly string System32 = Environment.SystemDirectory;
+
+    /// <summary>
+    /// Returns the full trusted path for a bare Windows tool name that exists under System32
+    /// (or the boxed Windows PowerShell 5.1 folder). Names that are already rooted / contain a
+    /// path separator, or that are not found in a trusted location, are returned unchanged so
+    /// callers of non-system executables and explicit paths are never altered.
+    /// </summary>
+    public static string ResolveSystemTool(string fileName)
+    {
+        if (string.IsNullOrEmpty(fileName)) return fileName;
+        if (Path.IsPathRooted(fileName) || fileName.Contains('\\') || fileName.Contains('/'))
+            return fileName;
+
+        var direct = Path.Combine(System32, fileName);
+        if (File.Exists(direct)) return direct;
+
+        // Windows PowerShell 5.1 lives in a System32 subfolder, not System32 itself.
+        var powerShell = Path.Combine(System32, "WindowsPowerShell", "v1.0", fileName);
+        if (File.Exists(powerShell)) return powerShell;
+
+        return fileName;
+    }
+}

--- a/SysManager/SysManager/Services/ContextMenuService.cs
+++ b/SysManager/SysManager/Services/ContextMenuService.cs
@@ -261,7 +261,7 @@ public sealed partial class ContextMenuService
 
             var psi = new ProcessStartInfo
             {
-                FileName = "reg.exe",
+                FileName = SysManager.Helpers.SystemPaths.ResolveSystemTool("reg.exe"),
                 Arguments = $"export \"{fullPath}\" \"{backupFile}\" /y",
                 UseShellExecute = false,
                 CreateNoWindow = true,

--- a/SysManager/SysManager/Services/MemoryTestService.cs
+++ b/SysManager/SysManager/Services/MemoryTestService.cs
@@ -97,7 +97,7 @@ public sealed class MemoryTestService
             // behind the scenes, but safest portable option is to launch mdsched.
             using var proc = Process.Start(new ProcessStartInfo
             {
-                FileName = "mdsched.exe",
+                FileName = SysManager.Helpers.SystemPaths.ResolveSystemTool("mdsched.exe"),
                 UseShellExecute = true
             });
             return true;

--- a/SysManager/SysManager/Services/PowerShellRunner.cs
+++ b/SysManager/SysManager/Services/PowerShellRunner.cs
@@ -187,7 +187,9 @@ public sealed class PowerShellRunner : IPowerShellRunner
 
         var psi = new System.Diagnostics.ProcessStartInfo
         {
-            FileName = fileName,
+            // Pin bare Windows tool names to their full System32 path so an attacker-planted
+            // executable in the (possibly user-writable) app directory can't be run elevated.
+            FileName = SysManager.Helpers.SystemPaths.ResolveSystemTool(fileName),
             Arguments = arguments,
             RedirectStandardOutput = true,
             RedirectStandardError = true,

--- a/SysManager/SysManager/Services/StartupService.cs
+++ b/SysManager/SysManager/Services/StartupService.cs
@@ -417,7 +417,7 @@ public sealed class StartupService
 
             var psi = new System.Diagnostics.ProcessStartInfo
             {
-                FileName = "schtasks.exe",
+                FileName = SysManager.Helpers.SystemPaths.ResolveSystemTool("schtasks.exe"),
                 Arguments = args,
                 UseShellExecute = false,
                 CreateNoWindow = true,

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.67</Version>
-    <FileVersion>1.52.67.0</FileVersion>
-    <AssemblyVersion>1.52.67.0</AssemblyVersion>
+    <Version>1.52.68</Version>
+    <FileVersion>1.52.68.0</FileVersion>
+    <AssemblyVersion>1.52.68.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/SystemFixesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemFixesViewModel.cs
@@ -113,7 +113,7 @@ public sealed partial class SystemFixesViewModel : ViewModelBase
         // credential securely (LSA secret) — SysManager never writes a plaintext password.
         try
         {
-            Process.Start(new ProcessStartInfo("netplwiz.exe") { UseShellExecute = true })?.Dispose();
+            Process.Start(new ProcessStartInfo(SysManager.Helpers.SystemPaths.ResolveSystemTool("netplwiz.exe")) { UseShellExecute = true })?.Dispose();
             StatusMessage = "Opened User Accounts (netplwiz). Untick \"Users must enter a user name and password\" to enable auto sign-in.";
         }
         catch (System.ComponentModel.Win32Exception ex)


### PR DESCRIPTION
## Problem

Several maintenance actions launched Windows' own tools by **bare filename** with a direct (`UseShellExecute=false`) launch. The Win32 `CreateProcess` search order probes the **calling process's own directory before System32**. SysManager ships as a single portable `.exe` that users often run from a user-writable location (e.g. Downloads), sometimes elevated — so a look-alike planted alongside it under the same name (`netsh.exe`, `reg.exe`, `schtasks.exe`, …) could have executed **with administrator rights**: classic binary-planting / local privilege escalation.

## Fix

New `Helpers/SystemPaths.ResolveSystemTool` pins bare Windows tool names to their full `%SystemRoot%\System32` path (or the boxed `WindowsPowerShell\v1.0` folder for `powershell.exe`). It leaves unchanged:
- already-rooted paths,
- names containing a path separator,
- non-system executables (e.g. `winget`, which resolves via App Execution Alias — never in System32).

Wired at the single **`PowerShellRunner.RunProcessAsync` choke point** (covers `sfc`/`DISM`/`chkdsk`/`netsh`/`ipconfig`/`powercfg`/`sc`/`powershell`), plus the four standalone `ProcessStartInfo` sites:
- `ContextMenuService` — `reg.exe` (was `UseShellExecute=false` — real vector)
- `StartupService` — `schtasks.exe` (was `UseShellExecute=false` — real vector)
- `MemoryTestService` — `mdsched.exe` (`UseShellExecute=true`, hardened for consistency)
- `SystemFixesViewModel` — `netplwiz.exe` (`UseShellExecute=true`, hardened for consistency)

## Behavior

Identical for every legitimate launch — the same tools run, only now from their trusted absolute path. If a tool isn't found in a trusted location the original name is returned, so no call path can regress to a missing-file error.

## Tests

`SystemPathsTests` (6 cases): known System32 tool → full rooted path; `powershell.exe` → rooted+existing; already-rooted unchanged; path-separator unchanged; unknown bare name unchanged; empty/null unchanged.

## Verification
- `dotnet build -c Release` (main + tests): 0 warnings / 0 errors
- `dotnet format --verify-no-changes` on all touched files: clean
- Class completeness: grepped all `RunProcessAsync` callers + every `Process.Start`/`ProcessStartInfo` site; the only remaining `UseShellExecute=false` launches are `winget` (not System32) and the Ookla speedtest binary (resolved path) — correctly untouched.