### PR TITLE
fix: serialize NvAPI temperature init under the shared sensor lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.69] - 2026-07-10
+
+### Fixed
+- **GPU temperature could stop being reported for the rest of a session on some NVIDIA machines.** The Dashboard reads temperatures from several places at once (the 2-second temperature tile, the manual Refresh button, and the always-on resource-history sampler). On a non-administrator session the NVIDIA read path set up its GPU connection without the guard the other sensor path already used, so two of those reads starting at the same moment could collide during that one-time setup — and if the colliding attempt failed, the app remembered "no NVIDIA GPU" permanently and quietly dropped GPU temperature until the app was restarted. That setup is now serialized behind the same lock the rest of the temperature reading already uses, so simultaneous reads no longer collide and a transient collision can't disable GPU temperature for the session.
+
 ## [1.52.68] - 2026-07-10
 
 ### Security

--- a/SysManager/SysManager/Services/TemperatureService.cs
+++ b/SysManager/SysManager/Services/TemperatureService.cs
@@ -24,8 +24,11 @@ public sealed class TemperatureService : IDisposable
     // enumerates all hardware — far too heavy to do on every 2s poll. Open it once
     // (lazily, on the first elevated read) and keep it alive for the service
     // lifetime; each poll then only calls Update(). The lock serialises the
-    // not-thread-safe LHM access in case more than one caller polls at once.
-    private readonly Lock _lhmLock = new();
+    // not-thread-safe native sensor access — both the LibreHardwareMonitor path
+    // (admin) and the NvAPI path (non-admin, incl. its init-once fields) — in case
+    // more than one caller polls at once (the 2s temperature poll, the user's
+    // Refresh command, and the always-on 10s resource sampler all share this service).
+    private readonly Lock _sensorLock = new();
     private Computer? _computer;
     private bool _disposed;
 
@@ -71,7 +74,7 @@ public sealed class TemperatureService : IDisposable
 
     private void ReadViaLibreHardwareMonitor(List<TemperatureReading> readings, bool includeStorage = true)
     {
-        lock (_lhmLock)
+        lock (_sensorLock)
         {
             if (_disposed) return;
             try
@@ -218,7 +221,7 @@ public sealed class TemperatureService : IDisposable
 
     public void Dispose()
     {
-        lock (_lhmLock)
+        lock (_sensorLock)
         {
             if (_disposed) return;
             _disposed = true;
@@ -289,45 +292,55 @@ public sealed class TemperatureService : IDisposable
 
     private void ReadNvidiaGpuTemperatures(List<TemperatureReading> readings)
     {
-        if (!_nvApiInitTried)
+        // Serialise under the same lock as the LHM path: NVIDIA.Initialize()/GetPhysicalGPUs()
+        // is a global native call that isn't documented thread-safe, and the init-once fields
+        // below are shared, non-volatile state. Concurrent non-admin callers (2s poll + user
+        // Refresh + 10s sampler) could otherwise both init at once and a losing thread could
+        // latch _nvApiAvailable=false permanently, silently dropping GPU temps for the session.
+        lock (_sensorLock)
         {
-            _nvApiInitTried = true;
-            try
-            {
-                NvAPIWrapper.NVIDIA.Initialize();
-                _nvApiAvailable = NvAPIWrapper.GPU.PhysicalGPU.GetPhysicalGPUs().Length > 0;
-            }
-            // No NVIDIA GPU / driver present is the normal case on AMD/Intel systems — record it
-            // once so later polls skip silently instead of throwing an exception every tick.
-            catch (NvAPIWrapper.Native.Exceptions.NVIDIAApiException) { _nvApiAvailable = false; }
-            catch (DllNotFoundException) { _nvApiAvailable = false; }
-            catch (Exception ex) when (ex is TypeInitializationException or InvalidOperationException)
-            {
-                _nvApiAvailable = false;
-                Log.Debug("NVIDIA API init failed: {Error}", ex.Message);
-            }
-        }
+            if (_disposed) return;
 
-        if (!_nvApiAvailable) return;
-
-        try
-        {
-            foreach (var gpu in NvAPIWrapper.GPU.PhysicalGPU.GetPhysicalGPUs())
+            if (!_nvApiInitTried)
             {
-                var sensor = gpu.ThermalInformation.ThermalSensors
-                    .FirstOrDefault(s => s.CurrentTemperature > 0);
-                if (sensor is not null)
+                _nvApiInitTried = true;
+                try
                 {
-                    readings.Add(new TemperatureReading("GPU", gpu.FullName,
-                        sensor.CurrentTemperature));
+                    NvAPIWrapper.NVIDIA.Initialize();
+                    _nvApiAvailable = NvAPIWrapper.GPU.PhysicalGPU.GetPhysicalGPUs().Length > 0;
+                }
+                // No NVIDIA GPU / driver present is the normal case on AMD/Intel systems — record it
+                // once so later polls skip silently instead of throwing an exception every tick.
+                catch (NvAPIWrapper.Native.Exceptions.NVIDIAApiException) { _nvApiAvailable = false; }
+                catch (DllNotFoundException) { _nvApiAvailable = false; }
+                catch (Exception ex) when (ex is TypeInitializationException or InvalidOperationException)
+                {
+                    _nvApiAvailable = false;
+                    Log.Debug("NVIDIA API init failed: {Error}", ex.Message);
                 }
             }
-        }
-        // A transient read failure (e.g. a driver reset) must not crash the poll — skip this tick.
-        catch (NvAPIWrapper.Native.Exceptions.NVIDIAApiException) { /* transient GPU read failure */ }
-        catch (Exception ex) when (ex is TypeInitializationException or InvalidOperationException)
-        {
-            Log.Debug("NVIDIA GPU temperature read failed: {Error}", ex.Message);
+
+            if (!_nvApiAvailable) return;
+
+            try
+            {
+                foreach (var gpu in NvAPIWrapper.GPU.PhysicalGPU.GetPhysicalGPUs())
+                {
+                    var sensor = gpu.ThermalInformation.ThermalSensors
+                        .FirstOrDefault(s => s.CurrentTemperature > 0);
+                    if (sensor is not null)
+                    {
+                        readings.Add(new TemperatureReading("GPU", gpu.FullName,
+                            sensor.CurrentTemperature));
+                    }
+                }
+            }
+            // A transient read failure (e.g. a driver reset) must not crash the poll — skip this tick.
+            catch (NvAPIWrapper.Native.Exceptions.NVIDIAApiException) { /* transient GPU read failure */ }
+            catch (Exception ex) when (ex is TypeInitializationException or InvalidOperationException)
+            {
+                Log.Debug("NVIDIA GPU temperature read failed: {Error}", ex.Message);
+            }
         }
     }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.68</Version>
-    <FileVersion>1.52.68.0</FileVersion>
-    <AssemblyVersion>1.52.68.0</AssemblyVersion>
+    <Version>1.52.69</Version>
+    <FileVersion>1.52.69.0</FileVersion>
+    <AssemblyVersion>1.52.69.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem

`TemperatureService` is a DI **singleton** whose `ReadAllAsync` is called **concurrently** on a non-admin session by three callers:
- the Dashboard 2-second temperature poll (`StartTemperaturePolling`),
- the user's `RefreshTemperatures` command,
- the always-on `ResourceHistoryService` sampler (every 10s, `ReadAllAsync(includeStorage:false)`).

The **admin** path (`ReadViaLibreHardwareMonitor`) serializes its not-thread-safe native access under `_lhmLock` — the class even documents *"The lock serialises the not-thread-safe … access in case more than one caller polls at once."* But the **non-admin** path (`ReadNvidiaGpuTemperatures`) ran **outside any lock** while:
- mutating the shared, non-volatile init-once fields `_nvApiInitTried` / `_nvApiAvailable`, and
- calling the global native `NVIDIA.Initialize()` + `GetPhysicalGPUs()` (not documented thread-safe).

Two threads could both observe `_nvApiInitTried == false` and init concurrently. A concurrent/transient init failure is swallowed and **latches `_nvApiAvailable = false` with no retry**, so GPU temperature silently disappears from the Dashboard and resource history for the rest of the session.

## Fix

Serialize the NvAPI init-once + read under the **same lock** the LHM path uses, and add the same `_disposed` guard. Renamed `_lhmLock` → `_sensorLock` because it now legitimately guards **both** native sensor backends. The admin (LHM) and non-admin (NvAPI) paths are **mutually exclusive by `AdminHelper.IsElevated()`**, so a single shared lock adds **no contention** — it only closes the race. Behavior is otherwise byte-for-byte identical.

## Verification
- `dotnet build -c Release`: 0 warnings / 0 errors
- `dotnet format --verify-no-changes`: clean
- Regression: confirmed 0 remaining refs to the old field name; verified the 3 concurrent `ReadAllAsync` callers are exactly the documented race scenario; the two locked paths never nest (mutually exclusive) so no reentrancy.

## On tests
No deterministic unit test is added: `_skipHardwareInit=true` short-circuits `ReadAllAsync` before the NvAPI path, there is no NvAPI seam to mock (tracked separately as the IPowerShellRunner-style arch-seam gap), and a timing-based race test would be non-deterministic (banned by testing discipline). The fix is a pure synchronization change matching the existing, already-tested-by-reasoning LHM locking idiom.