### PR TITLE
fix: resume Startup toggle/enable-all continuations on the UI thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.70] - 2026-07-10
+
+### Fixed
+- **The Startup tab could throw an error when toggling items while the "Hide Windows entries" filter was changed at the same time.** After enabling or disabling a startup item (or using "Enable all"), the tab finished its work on a background thread and then recounted the list from there. If the list was being re-filtered on the screen at that exact moment (for example, by ticking "Hide Windows entries"), the background recount could read the list while it was changing and fail. The work now finishes back on the screen's own thread — matching how the Services tab already does it — so the two can no longer collide.
+
 ## [1.52.69] - 2026-07-10
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.69</Version>
-    <FileVersion>1.52.69.0</FileVersion>
-    <AssemblyVersion>1.52.69.0</AssemblyVersion>
+    <Version>1.52.70</Version>
+    <FileVersion>1.52.70.0</FileVersion>
+    <AssemblyVersion>1.52.70.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/StartupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StartupViewModel.cs
@@ -132,7 +132,11 @@ public sealed partial class StartupViewModel : ViewModelBase
         // this command runs. We use the current (already-flipped) value as
         // the desired new state.
         var desiredState = entry.IsEnabled;
-        var success = await StartupService.SetEnabledAsync(entry, desiredState).ConfigureAwait(false);
+        // Resume on the UI thread (no ConfigureAwait(false)): the continuation reads/writes
+        // bound state (UpdateCounts enumerates the DataGrid-bound Entries, entry.IsEnabled,
+        // StatusMessage). SetEnabledAsync keeps its own internal ConfigureAwait(false).
+        // Matches the documented rule in ServicesViewModel.StartServiceAsync.
+        var success = await StartupService.SetEnabledAsync(entry, desiredState);
         if (success)
         {
             UpdateCounts();
@@ -177,7 +181,12 @@ public sealed partial class StartupViewModel : ViewModelBase
             var failed = 0;
             foreach (var entry in toEnable)
             {
-                if (await StartupService.SetEnabledAsync(entry, true).ConfigureAwait(false))
+                // Resume on the UI thread (no ConfigureAwait(false)): the loop body and the
+                // trailing UpdateCounts() enumerate the DataGrid-bound Entries and touch bound
+                // state. Off-thread (as before) a concurrent ApplyFilter — e.g. the user flipping
+                // "Hide Windows entries" — mutates Entries mid-enumeration and throws
+                // "Collection was modified". SetEnabledAsync keeps its own ConfigureAwait(false).
+                if (await StartupService.SetEnabledAsync(entry, true))
                     enabled++;
                 else
                     failed++;


### PR DESCRIPTION
## Problem

`StartupViewModel.ToggleEntryAsync` and `EnableAllAsync` awaited `StartupService.SetEnabledAsync` with **`.ConfigureAwait(false)` in the VM command body**. `SetEnabledAsync` genuinely yields for Task Scheduler-backed startup entries (`SetTaskSchedulerEnabledAsync` → `proc.WaitForExitAsync().ConfigureAwait(false)`), so the continuation ran on a **thread-pool thread**:

- `UpdateCounts()` enumerates the **DataGrid-bound `Entries`** three times,
- the `entry.IsEnabled` revert on failure,
- `StatusMessage`.

If the UI thread concurrently mutates `Entries` — e.g. the user ticks **"Hide Windows entries"** → `OnHideWindowsEntriesChanged` → `ApplyFilter` → `Entries.ReplaceWith` — the off-thread enumeration throws `InvalidOperationException` ("Collection was modified" / cross-thread). In `EnableAllAsync` the **entire remaining batch loop** runs off-thread after the first task-scheduler entry, not just one continuation. The command bodies have only a `finally` (no `catch`), so it escapes as a faulted async command.

## Fix

Drop `.ConfigureAwait(false)` from **both VM command bodies** so each continuation resumes on the captured UI Dispatcher — exactly the documented rule in `ServicesViewModel.StartServiceAsync` (*"Resume on the UI thread (no ConfigureAwait(false)): the continuation updates bound state"*). `StartupService` keeps its own internal `ConfigureAwait(false)`, so the service work stays off-thread; only the VM continuation moves back to the UI thread.

## Class check (fix the class, not the instance)

- `ScanAsync` (same VM) already marshals its `Entries` mutation through `dispatcher.Invoke` — safe.
- `DnsHostsViewModel` uses `.ConfigureAwait(false)` but wraps **every** post-await bound-state write in `Dispatcher.Invoke` — safe/intentional.
- `BulkInstallerViewModel` / `ViewModelBase` await off-thread but don't enumerate a bound collection in the continuation.
- ⇒ `StartupViewModel` was the **only** site with the defect.

## Verification
- `dotnet build -c Release`: 0 warnings / 0 errors
- `dotnet format --verify-no-changes`: clean
- Behavior otherwise identical; no signature changes.

## On tests
No unit test added: reproducing this requires a real cross-thread timing window against `Application.Current.Dispatcher` (no test dispatcher seam) and a genuinely-yielding `SetEnabledAsync`; a timing-based test would be non-deterministic (banned by testing discipline). The fix aligns with the already-established UI-thread-continuation idiom used across the sibling VMs.