### PR TITLE
fix: isolate winget runner per tab to prevent Dashboard/App Updates cross-talk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.71] - 2026-07-10
+
+### Fixed
+- **The Dashboard and App Updates tabs could cross-talk when both ran winget at the same time.** Both tabs shared a single winget service instance (and therefore a single underlying process runner). If the Dashboard's "Update All Apps" action ran while the App Updates tab was scanning, the output lines from one operation could bleed into the other tab's console, and the interleaved event subscriptions could produce garbled results or swallowed lines. Each tab now receives its own independent winget service with its own process runner, so concurrent winget operations are fully isolated.
+
 ## [1.52.70] - 2026-07-10
 
 ### Fixed

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -24,7 +24,10 @@ public static class ServiceRegistration
         services.AddTransient<PowerShellRunner>();
         services.AddTransient<IPowerShellRunner, PowerShellRunner>();
         services.AddSingleton<SystemInfoService>();
-        services.AddSingleton<IWingetService, WingetService>();
+        // WingetService is Transient so each consuming ViewModel gets its own
+        // IPowerShellRunner instance — avoids LineReceived cross-talk when
+        // Dashboard and AppUpdates both run winget concurrently.
+        services.AddTransient<IWingetService, WingetService>();
         services.AddSingleton<TrayIconService>();
         services.AddSingleton<UpdateService>();
         services.AddSingleton<ShortcutCleanerService>();

--- a/SysManager/SysManager/Services/WingetService.cs
+++ b/SysManager/SysManager/Services/WingetService.cs
@@ -13,9 +13,9 @@ namespace SysManager.Services;
 /// </summary>
 public sealed partial class WingetService : IWingetService
 {
-    private readonly PowerShellRunner _runner;
+    private readonly IPowerShellRunner _runner;
 
-    public WingetService(PowerShellRunner runner) => _runner = runner;
+    public WingetService(IPowerShellRunner runner) => _runner = runner;
 
     public event Action<PowerShellLine>? LineReceived
     {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.70</Version>
-    <FileVersion>1.52.70.0</FileVersion>
-    <AssemblyVersion>1.52.70.0</AssemblyVersion>
+    <Version>1.52.71</Version>
+    <FileVersion>1.52.71.0</FileVersion>
+    <AssemblyVersion>1.52.71.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
@@ -43,10 +43,6 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
     {
         _winget = winget;
         _lineHandler = line => Console.Append(line);
-        // NOTE: the WingetService is a singleton shared with other tabs (e.g. the Dashboard's
-        // "Update All Apps"). LineReceived is subscribed only for the duration of THIS tab's own
-        // Scan/UpgradeSelected operations (see below), not for the VM's lifetime, so another tab's
-        // winget output never bleeds into this console.
         // Re-evaluate the long-running commands' CanExecute when IsBusy flips. Scan and
         // UpgradeSelected both recreate the shared _cts; without this gate a second
         // command could dispose the CTS the first is still awaiting (ObjectDisposedException).


### PR DESCRIPTION
## Summary

Fixes a finding from the 2026-07-10 deep review pass: the Dashboard and App Updates tabs shared a single `WingetService` singleton which in turn held one `PowerShellRunner` instance. When both tabs ran winget operations concurrently (e.g. Dashboard's "Update All Apps" during an App Updates scan), their `LineReceived` event subscriptions interleaved, causing output lines from one operation to bleed into the other tab's console.

## Root cause

`WingetService` was registered as `AddSingleton` while `PowerShellRunner` was `AddTransient`. The singleton captured its transient runner at construction — both consuming ViewModels (`DashboardViewModel`, `AppUpdatesViewModel`) resolved the same service instance and therefore the same underlying process runner.

## Fix

1. **Seam adoption** — `WingetService` now depends on `IPowerShellRunner` (the interface) instead of the concrete `PowerShellRunner`.
2. **Lifetime correction** — `WingetService` registration changed from `AddSingleton` to `AddTransient`. Each Singleton ViewModel resolves its own `IWingetService` at construction, which in turn resolves its own `IPowerShellRunner` — full per-tab process isolation.
3. **Stale comment removed** from `AppUpdatesViewModel` constructor (claimed the service was still a shared singleton).

## Regression analysis

- Only 2 consumers of `IWingetService` exist: `DashboardViewModel` and `AppUpdatesViewModel` (grep-verified).
- Both are Singleton VMs — they each capture their Transient `WingetService` once at construction, so the per-tab-runner contract holds for the entire app lifetime.
- All test call sites (`new WingetService(new PowerShellRunner())`) still compile via interface widening (`PowerShellRunner` implements `IPowerShellRunner`).
- `MainWindowViewModel`'s designer fallback path is unaffected (same interface widening).

## Files changed

- `SysManager/SysManager/Services/WingetService.cs` — field + constructor: concrete → interface
- `SysManager/SysManager/ServiceRegistration.cs` — `AddSingleton` → `AddTransient` for `IWingetService`
- `SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs` — removed stale singleton comment
- `SysManager/SysManager/SysManager.csproj` — version 1.52.70 → 1.52.71
- `CHANGELOG.md` — new `[1.52.71]` entry