### PR TITLE
fix: widen remaining PowerShellRunner dependencies to IPowerShellRunner seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.72] - 2026-07-10
+
+### Fixed
+- **Several services and ViewModels depended on the concrete PowerShellRunner class instead of the IPowerShellRunner interface, making them impossible to unit-test in isolation.** UninstallerService, WindowsFeaturesService, PerformanceService, ServiceManagerService, CleanupViewModel, DriversViewModel, SystemHealthViewModel, WindowsUpdateViewModel, and ServicesViewModel all accepted a concrete PowerShellRunner in their constructors. This prevented substituting a mock in tests (NSubstitute cannot proxy sealed concrete classes) and violated the dependency-inversion principle the rest of the codebase already follows. All ten consumers now depend on IPowerShellRunner, and the redundant concrete-only DI registration was removed — every resolution goes through the interface mapping.
+
 ## [1.52.71] - 2026-07-10
 
 ### Fixed

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -18,10 +18,8 @@ public static class ServiceRegistration
     {
         // ── Core services ──────────────────────────────────────────────
         // PowerShellRunner is Transient — each consumer gets its own instance
-        // to avoid LineReceived event cross-talk between tabs. Registered under
-        // both the concrete type (legacy consumers) and the IPowerShellRunner
-        // seam (DNS / network repair / winget install — substitutable in tests).
-        services.AddTransient<PowerShellRunner>();
+        // to avoid LineReceived event cross-talk between tabs. All consumers
+        // depend on IPowerShellRunner (substitutable in tests via NSubstitute).
         services.AddTransient<IPowerShellRunner, PowerShellRunner>();
         services.AddSingleton<SystemInfoService>();
         // WingetService is Transient so each consuming ViewModel gets its own

--- a/SysManager/SysManager/Services/PerformanceService.cs
+++ b/SysManager/SysManager/Services/PerformanceService.cs
@@ -27,7 +27,7 @@ namespace SysManager.Services;
 /// </summary>
 public sealed partial class PerformanceService : IDisposable
 {
-    private readonly PowerShellRunner _ps;
+    private readonly IPowerShellRunner _ps;
     private readonly RestorePointService _restorePoints;
     private readonly SemaphoreSlim _psGate = new(1, 1);
     private bool _disposed;
@@ -58,7 +58,7 @@ public sealed partial class PerformanceService : IDisposable
     private static partial bool SystemParametersInfoSet(
         uint uiAction, uint uiParam, int pvParam, uint fWinIni);
 
-    public PerformanceService(PowerShellRunner ps, RestorePointService restorePoints)
+    public PerformanceService(IPowerShellRunner ps, RestorePointService restorePoints)
     {
         _ps = ps;
         _restorePoints = restorePoints;

--- a/SysManager/SysManager/Services/ServiceManagerService.cs
+++ b/SysManager/SysManager/Services/ServiceManagerService.cs
@@ -142,7 +142,7 @@ public sealed partial class ServiceManagerService
     }
 
     /// <summary>Change the startup type of a service via sc.exe. Requires admin.</summary>
-    public static async Task SetStartupTypeAsync(string serviceName, string startType, PowerShellRunner ps, CancellationToken ct = default)
+    public static async Task SetStartupTypeAsync(string serviceName, string startType, IPowerShellRunner ps, CancellationToken ct = default)
     {
         // SEC-006: Strict allowlist for service names — alphanumeric, spaces,
         // hyphens, underscores, dots, and dollar signs only (covers all valid

--- a/SysManager/SysManager/Services/UninstallerService.cs
+++ b/SysManager/SysManager/Services/UninstallerService.cs
@@ -14,9 +14,9 @@ namespace SysManager.Services;
 /// </summary>
 public sealed partial class UninstallerService
 {
-    private readonly PowerShellRunner _runner;
+    private readonly IPowerShellRunner _runner;
 
-    public UninstallerService(PowerShellRunner runner) => _runner = runner;
+    public UninstallerService(IPowerShellRunner runner) => _runner = runner;
 
     public event Action<PowerShellLine>? LineReceived
     {

--- a/SysManager/SysManager/Services/WindowsFeaturesService.cs
+++ b/SysManager/SysManager/Services/WindowsFeaturesService.cs
@@ -14,9 +14,9 @@ namespace SysManager.Services;
 /// </summary>
 public sealed partial class WindowsFeaturesService
 {
-    private readonly PowerShellRunner _runner;
+    private readonly IPowerShellRunner _runner;
 
-    public WindowsFeaturesService(PowerShellRunner runner) => _runner = runner;
+    public WindowsFeaturesService(IPowerShellRunner runner) => _runner = runner;
 
     /// <summary>
     /// Lists all Windows optional features with their current state.

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.71</Version>
-    <FileVersion>1.52.71.0</FileVersion>
-    <AssemblyVersion>1.52.71.0</AssemblyVersion>
+    <Version>1.52.72</Version>
+    <FileVersion>1.52.72.0</FileVersion>
+    <AssemblyVersion>1.52.72.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -15,7 +15,7 @@ namespace SysManager.ViewModels;
 
 public sealed partial class CleanupViewModel : ViewModelBase
 {
-    private readonly PowerShellRunner _runner;
+    private readonly IPowerShellRunner _runner;
 
     private readonly EtaCalculator _sfcEta = new();
     private readonly EtaCalculator _dismEta = new();
@@ -62,7 +62,7 @@ public sealed partial class CleanupViewModel : ViewModelBase
     /// <summary>True whenever any background task is running — for a small badge.</summary>
     public bool IsAnyRunning => IsTempRunning || IsBinRunning || IsSfcRunning || IsDismRunning;
 
-    public CleanupViewModel(PowerShellRunner runner)
+    public CleanupViewModel(IPowerShellRunner runner)
     {
         _runner = runner;
         _runner.LineReceived += OnRunnerLineReceived;

--- a/SysManager/SysManager/ViewModels/DriversViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DriversViewModel.cs
@@ -15,7 +15,7 @@ namespace SysManager.ViewModels;
 
 public sealed partial class DriversViewModel : ViewModelBase
 {
-    private readonly PowerShellRunner _runner;
+    private readonly IPowerShellRunner _runner;
     private CancellationTokenSource? _cts;
     private readonly List<DriverEntry> _allDrivers = new();
 
@@ -25,7 +25,7 @@ public sealed partial class DriversViewModel : ViewModelBase
     [ObservableProperty] private string _summary = "Click List drivers to scan installed drivers.";
     [ObservableProperty] private bool _hideSystemDrivers;
 
-    public DriversViewModel(PowerShellRunner runner)
+    public DriversViewModel(IPowerShellRunner runner)
     {
         _runner = runner;
         // Re-evaluate ListDrivers' CanExecute when IsBusy flips. Without this gate a second

--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -19,7 +19,7 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class ServicesViewModel : ViewModelBase
 {
-    private readonly PowerShellRunner _ps;
+    private readonly IPowerShellRunner _ps;
     private List<ServiceEntry> _allServices = [];
 
     public BulkObservableCollection<ServiceEntry> Services { get; } = new();
@@ -37,7 +37,7 @@ public sealed partial class ServicesViewModel : ViewModelBase
     public string[] FilterOptions { get; } =
         { "All", "Running", "Stopped", "Safe", "Caution", "Critical" };
 
-    public ServicesViewModel(PowerShellRunner ps)
+    public ServicesViewModel(IPowerShellRunner ps)
     {
         _ps = ps;
         IsElevated = AdminHelper.IsElevated();

--- a/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
@@ -21,7 +21,7 @@ public sealed partial class SystemHealthViewModel : ViewModelBase
     private readonly DiskHealthService _diskHealth;
     private readonly MemoryTestService _memTest;
     private readonly FixedDriveService _drives;
-    private readonly PowerShellRunner _runner;
+    private readonly IPowerShellRunner _runner;
     private readonly BiosService _biosService;
     private CancellationTokenSource? _cts;
 
@@ -49,7 +49,7 @@ public sealed partial class SystemHealthViewModel : ViewModelBase
     // BIOS / firmware (read-only); populated on Scan.
     [ObservableProperty] private BiosInfo? _bios;
 
-    public SystemHealthViewModel(SystemInfoService sys, DiskHealthService diskHealth, MemoryTestService memTest, FixedDriveService drives, PowerShellRunner runner, BiosService biosService)
+    public SystemHealthViewModel(SystemInfoService sys, DiskHealthService diskHealth, MemoryTestService memTest, FixedDriveService drives, IPowerShellRunner runner, BiosService biosService)
     {
         _sys = sys;
         _diskHealth = diskHealth;

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -15,7 +15,7 @@ namespace SysManager.ViewModels;
 
 public sealed partial class WindowsUpdateViewModel : ViewModelBase
 {
-    private readonly PowerShellRunner _runner;
+    private readonly IPowerShellRunner _runner;
     private readonly WindowsUpdateService _wu;
     private readonly WindowsUpdatePolicyService _policy;
     private CancellationTokenSource? _cts;
@@ -43,7 +43,7 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
     [ObservableProperty] private int _deferDays = 30;
     [ObservableProperty] private int _pauseDays = 7;
 
-    public WindowsUpdateViewModel(PowerShellRunner runner, WindowsUpdateService wu, WindowsUpdatePolicyService policy)
+    public WindowsUpdateViewModel(IPowerShellRunner runner, WindowsUpdateService wu, WindowsUpdatePolicyService policy)
     {
         _runner = runner;
         _wu = wu;


### PR DESCRIPTION
## Summary

- Widens constructor parameters from concrete `PowerShellRunner` to `IPowerShellRunner` across all remaining consumers (3 services + 5 ViewModels + 1 static method parameter)
- Removes the now-redundant `services.AddTransient<PowerShellRunner>()` registration — all consumers resolve through the interface mapping
- Enables NSubstitute mocking for unit tests of these 10 types (previously impossible — sealed concrete class)

## Files changed

| File | Change |
|------|--------|
| `ServiceRegistration.cs` | Removed redundant concrete registration, updated comment |
| `UninstallerService.cs` | Field + ctor `PowerShellRunner` → `IPowerShellRunner` |
| `WindowsFeaturesService.cs` | Field + ctor `PowerShellRunner` → `IPowerShellRunner` |
| `PerformanceService.cs` | Field + ctor `PowerShellRunner` → `IPowerShellRunner` |
| `ServiceManagerService.cs` | Static method param `PowerShellRunner` → `IPowerShellRunner` |
| `CleanupViewModel.cs` | Field + ctor `PowerShellRunner` → `IPowerShellRunner` |
| `DriversViewModel.cs` | Field + ctor `PowerShellRunner` → `IPowerShellRunner` |
| `SystemHealthViewModel.cs` | Field + ctor `PowerShellRunner` → `IPowerShellRunner` |
| `WindowsUpdateViewModel.cs` | Field + ctor `PowerShellRunner` → `IPowerShellRunner` |
| `ServicesViewModel.cs` | Field + ctor `PowerShellRunner` → `IPowerShellRunner` |
| `SysManager.csproj` | Version bump 1.52.71 → 1.52.72 |
| `CHANGELOG.md` | Entry for 1.52.72 |

## Test plan

- [x] `dotnet build -c Release` — 0 errors, 0 warnings (main + tests)
- [x] Propagation check: zero `private readonly PowerShellRunner` remaining
- [x] All DI resolutions flow through `AddTransient<IPowerShellRunner, PowerShellRunner>()`
- [ ] CI build + unit tests pass
- [ ] CodeQL passes