### PR TITLE
ci: fix dead UI-test annotation and add missing auto-release paths

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - "SysManager/SysManager/**"
+      - "SysManager/Directory.Packages.props"
+      - "SysManager/Directory.Build.props"
+      - "global.json"
 
 permissions:
   contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,12 +141,13 @@ jobs:
           --results-directory TestResults
         continue-on-error: true
 
-      # Surface UI test failures as a visible warning annotation. Use `conclusion`,
-      # NOT `outcome`: with continue-on-error the step's `outcome` is forced to
-      # 'success', so an `outcome == 'failure'` check never fires and the failure is
-      # masked entirely. `conclusion` reflects the real step result.
+      # Surface UI test failures as a visible warning annotation. Use `outcome`,
+      # NOT `conclusion`: with continue-on-error the step's `conclusion` is forced to
+      # 'success', so a `conclusion == 'failure'` check never fires and the failure is
+      # masked entirely. `outcome` reflects the real step result before continue-on-error
+      # is applied.
       - name: Annotate UI test failures
-        if: steps.ui-tests.conclusion == 'failure'
+        if: steps.ui-tests.outcome == 'failure'
         run: echo "::warning::UI automation tests failed — review the ui-test-results artifact for details."
 
       - name: Upload UI test results


### PR DESCRIPTION
## Summary
- **P2 #8:** The UI-test failure annotation (`Annotate UI test failures` step) checked `steps.ui-tests.conclusion == 'failure'`, which is always forced to `'success'` by `continue-on-error: true`. Swapped to `steps.ui-tests.outcome == 'failure'` (evaluated before continue-on-error is applied) so the `::warning::` annotation actually fires when UI tests fail. Also corrected the comment that had `outcome`/`conclusion` semantics exactly inverted.
- **P2 #9:** `auto-release.yml` only monitored `SysManager/SysManager/**`. Changes to `Directory.Packages.props`, `Directory.Build.props`, or `global.json` (SDK version, central package versions) in a `fix:`/`feat:` commit would silently skip the release workflow. Added those three paths.

## Test plan
- [ ] CI passes on this PR (the workflow itself validates YAML syntax)
- [ ] Force a UI test failure in a future PR → confirm `::warning::` annotation appears
- [ ] A future `fix:` commit touching only `Directory.Packages.props` triggers auto-release