### PR TITLE
fix: refuse to kill kernel-critical processes in Process Manager (BSOD prevention)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.73] - 2026-07-10
+
+### Fixed
+- **The Process Manager can no longer force-kill kernel-critical processes (csrss, lsass, smss, services, wininit, etc.) that would cause an immediate BSOD.** The Kill command was the only destructive surface in the app that did not guard against acting on a known-critical target — unlike the Services tab (which refuses to stop/disable critical services) and the File Lock tab (which refuses to end critical lockers). It now refuses outright when the process is classified as "System" in the process database, and as defense-in-depth also checks against a hardcoded boot-critical denylist so protection holds even for processes not yet in the database.
+
 ## [1.52.72] - 2026-07-10
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.72</Version>
-    <FileVersion>1.52.72.0</FileVersion>
-    <AssemblyVersion>1.52.72.0</AssemblyVersion>
+    <Version>1.52.73</Version>
+    <FileVersion>1.52.73.0</FileVersion>
+    <AssemblyVersion>1.52.73.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Collections.ObjectModel;
+using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
@@ -192,10 +193,25 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
         }
     }
 
+    private static readonly HashSet<string> BootCriticalProcesses = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "winlogon", "wininit", "csrss", "smss", "services",
+        "lsass", "lsaiso", "fontdrvhost", "dwm", "logonui",
+        "svchost", "ctfmon", "userinit"
+    };
+
     [RelayCommand]
     private void KillProcess(ProcessEntry? entry)
     {
         if (entry is null) return;
+
+        if (IsKernelCritical(entry))
+        {
+            StatusMessage = $"⛔ \"{entry.Name}\" is a critical system process and cannot be ended — " +
+                            "killing it would cause a system crash (BSOD).";
+            Log.Warning("Refused to kill critical process: {Name} (PID {Pid})", entry.Name, entry.Pid);
+            return;
+        }
 
         if (!DialogService.Instance.Confirm(
             $"Are you sure you want to kill \"{entry.Name}\" (PID {entry.Pid})?\n\nThis may cause unsaved data loss.",
@@ -215,6 +231,15 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
             StatusMessage = $"Could not kill {entry.Name} — may need admin rights.";
             Log.Warning("Failed to kill process PID {Pid}", entry.Pid);
         }
+    }
+
+    private static bool IsKernelCritical(ProcessEntry entry)
+    {
+        if (string.Equals(entry.SafetyLevel, "System", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        var name = Path.GetFileNameWithoutExtension(entry.Name);
+        return BootCriticalProcesses.Contains(name);
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary

- The Process Manager's Kill command was the only destructive surface in the app that did not guard against acting on a known-critical target — killing csrss/lsass/smss/services/wininit while elevated causes an immediate CRITICAL_PROCESS_DIED bugcheck (BSOD).
- Added a two-layer safety guard before the confirmation dialog:
 1. Checks `entry.SafetyLevel == "System"` (from ProcessDescriptions.json database)
 2. As defense-in-depth, checks the process name against a hardcoded `BootCriticalProcesses` denylist (same set as AppBlockerService uses)
- Mirrors the existing pattern in ServicesViewModel (refuses stop/disable of Critical services) and FileLockViewModel (refuses to end critical lockers).

## Context

Found by a deep review pass. (security-sensitive services). Phase 0 safety-critical item per the strategic roadmap.

## Test plan

- [ ] CI passes (build + unit tests)
- [ ] Verify refusal message surfaces when a System-class process is selected
- [ ] Existing ProcessManagerViewModelTests still pass (no signature change)