### PR TITLE
fix: harden Context Menu tab — resilient explorer restart, correct enable feedback, async toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.74] - 2026-07-10
+
+### Fixed
+- **RestartExplorer could leave the user without a taskbar/desktop if any explorer.exe process was unkillable (e.g. elevated or another user's session).** The kill loop and the shell relaunch lived in a single try block, so one `Win32Exception` from `Kill()` on a higher-integrity explorer aborted the entire method — explorer was dead but never relaunched. Each process is now killed in its own guarded block (matching `FileLockService.KillProcess`'s per-process pattern), and the `Process.Start("explorer.exe")` relaunch runs unconditionally after the loop so the shell is always restored.
+- **The Context Menu tab's "Enable" action on HKLM-disabled entries reported success but actually did nothing.** The HKCU fallback path used `CreateSubKey` even when enabling (removing `LegacyDisable`), which created an empty orphan key and deleted a value that never existed there, then returned `true`. The HKLM `LegacyDisable` was never touched, so Explorer still hid the entry and the next scan snapped the toggle back. The enable path now uses `OpenSubKey` and returns `false` if no user-authored override exists to clear — surfacing the "needs admin" message instead of silently lying.
+- **Every Context Menu toggle froze the UI thread for up to 5 seconds.** `ToggleEntry` was synchronous and called `BackupRegistry` which spawns `reg.exe` with a 5-second `WaitForExit` — all on the dispatcher thread. Converted to an async command with `Task.Run`, matching the existing `ApplyPresetAsync` pattern that already offloads the same service calls for exactly this reason.
+
 ## [1.52.73] - 2026-07-10
 
 ### Fixed

--- a/SysManager/SysManager/Services/ContextMenuService.cs
+++ b/SysManager/SysManager/Services/ContextMenuService.cs
@@ -227,13 +227,19 @@ public sealed partial class ContextMenuService
 
         // Attempt 2: HKCU override (for system-owned entries in HKLM)
         var hkcuPath = @"Software\Classes\" + relativePath;
-        using var hkcuKey = Registry.CurrentUser.CreateSubKey(hkcuPath);
-        if (hkcuKey is null) return false;
 
         if (set)
+        {
+            using var hkcuKey = Registry.CurrentUser.CreateSubKey(hkcuPath);
+            if (hkcuKey is null) return false;
             hkcuKey.SetValue("LegacyDisable", "", RegistryValueKind.String);
+        }
         else
+        {
+            using var hkcuKey = Registry.CurrentUser.OpenSubKey(hkcuPath, writable: true);
+            if (hkcuKey is null) return false;
             hkcuKey.DeleteValue("LegacyDisable", throwOnMissingValue: false);
+        }
 
         Log.Debug("Used HKCU override for {Path}", relativePath);
         return true;
@@ -347,24 +353,38 @@ public sealed partial class ContextMenuService
 
     /// <summary>
     /// Restarts Windows Explorer to apply context menu style changes.
+    /// Each process is killed individually so one unkillable instance (e.g. a
+    /// higher-integrity or other-session explorer) cannot abort the loop and
+    /// leave the user without a shell.
     /// </summary>
     public static void RestartExplorer()
     {
-        try
+        foreach (var proc in Process.GetProcessesByName("explorer"))
         {
-            foreach (var proc in Process.GetProcessesByName("explorer"))
+            try
             {
                 proc.Kill();
                 proc.WaitForExit(3000);
+            }
+            catch (InvalidOperationException) { }
+            catch (System.ComponentModel.Win32Exception ex)
+            {
+                Log.Debug("Could not kill explorer PID {Pid}: {Error}", proc.Id, ex.Message);
+            }
+            finally
+            {
                 proc.Dispose();
             }
+        }
 
+        try
+        {
             Process.Start(new ProcessStartInfo("explorer.exe") { UseShellExecute = true })?.Dispose();
             Log.Information("Explorer restarted to apply context menu changes");
         }
-        catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception)
+        catch (System.ComponentModel.Win32Exception ex)
         {
-            Log.Warning("Failed to restart Explorer: {Error}", ex.Message);
+            Log.Warning("Failed to relaunch Explorer: {Error}", ex.Message);
         }
     }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.73</Version>
-    <FileVersion>1.52.73.0</FileVersion>
-    <AssemblyVersion>1.52.73.0</AssemblyVersion>
+    <Version>1.52.74</Version>
+    <FileVersion>1.52.74.0</FileVersion>
+    <AssemblyVersion>1.52.74.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ContextMenuViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ContextMenuViewModel.cs
@@ -132,17 +132,15 @@ public sealed partial class ContextMenuViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void ToggleEntry(object? parameter)
+    private async Task ToggleEntryAsync(object? parameter)
     {
         if (parameter is not ContextMenuEntry entry) return;
 
         var desiredState = entry.IsEnabled;
-        bool success;
 
-        if (desiredState)
-            success = _service.EnableEntry(entry);
-        else
-            success = _service.DisableEntry(entry);
+        var success = await Task.Run(() => desiredState
+            ? _service.EnableEntry(entry)
+            : _service.DisableEntry(entry));
 
         if (success)
         {


### PR DESCRIPTION
## Summary

Three Context Menu bugs fixed in one area-batch:

1. **RestartExplorer left the user without a shell** if any explorer.exe instance was unkillable (elevated or other-session). Per-process try/catch now mirrors FileLockService.KillProcess, and the relaunch runs unconditionally.

2. **EnableEntry HKCU fallback reported false success** — `CreateSubKey` + `DeleteValue` on a freshly-created key was a no-op that returned `true`. Now uses `OpenSubKey(writable: true)` for the enable path and returns `false` when no user-authored override exists.

3. **ToggleEntry blocked the UI thread for up to 5 seconds** via synchronous `reg.exe` backup + `WaitForExit(5000)`. Converted to async with `Task.Run`, matching the existing `ApplyPresetAsync` pattern.

## Test plan
- [ ] CI green (build + unit tests + CodeQL)
- [ ] Context Menu tab: toggle an entry → UI stays responsive, no freeze
- [ ] Context Menu tab: apply Win10 preset (triggers RestartExplorer) → taskbar returns
- [ ] Context Menu tab: enable an HKLM-disabled system entry without admin → toggle snaps back and offers elevation prompt (no false "enabled" state)