### PR TITLE
fix: apply SkipSegments filter during Disk Analyzer recursion (WinSxS over-count)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.75] - 2026-07-10
+
+### Fixed
+- **Disk Analyzer over-counted drive usage by descending into WinSxS and other heavyweight system directories during recursion.** The `SkipSegments` filter (`\windows\winsxs`, `\windows\csc`, `\$recycle.bin`, `\system volume information`) was only applied to the top-level children of the analyzed root (line 71). The recursive `MeasureFolder` walk pushed every non-reparse subdirectory onto the stack without re-checking against `SkipSegments`, so scanning a drive root like `C:\` would enter `C:\Windows` (not skipped — it's not in the list) and then descend into `C:\Windows\WinSxS` (a hardlink farm, not a reparse point) and `C:\Windows\CSC` (offline files cache), double-counting hundreds of thousands of hardlinked files at full `FileInfo.Length`. The recursive loop now guards each subdirectory with `ShouldSkip(d)` before pushing it, matching the top-level behavior.
+
 ## [1.52.74] - 2026-07-10
 
 ### Fixed

--- a/SysManager/SysManager/Services/DiskAnalyzerService.cs
+++ b/SysManager/SysManager/Services/DiskAnalyzerService.cs
@@ -166,6 +166,8 @@ public sealed class DiskAnalyzerService
 
             foreach (var d in dirs)
             {
+                if (ShouldSkip(d)) continue;
+
                 // Skip junctions, symbolic links, and mount points to avoid
                 // double-counting the same files through multiple paths.
                 try

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.74</Version>
-    <FileVersion>1.52.74.0</FileVersion>
-    <AssemblyVersion>1.52.74.0</AssemblyVersion>
+    <Version>1.52.75</Version>
+    <FileVersion>1.52.75.0</FileVersion>
+    <AssemblyVersion>1.52.75.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary
- The `ShouldSkip` guard (which filters WinSxS, CSC, $Recycle.Bin, System Volume Information) was only applied at the top-level directory loop
- The recursive `MeasureFolder` walk pushed every non-reparse subdirectory onto the stack without re-checking against `SkipSegments`
- Scanning a drive root like `C:\` would enter `C:\Windows` (not in the skip list) and then descend into `C:\Windows\WinSxS` (a hardlink farm — not a reparse point), over-counting files at full `FileInfo.Length`
- Fix: add `if (ShouldSkip(d)) continue;` before `stack.Push(d)` in the recursive subdirectory loop, matching the top-level behavior

## Impact
Drive-root disk analysis was reporting inflated sizes because WinSxS hardlinks were counted at full file size through multiple paths. Post-fix, sizes are accurate.

## Test plan
- [ ] CI green (build + unit tests + CodeQL)
- [ ] Verify the fix: `ShouldSkip(d)` now appears in both the top-level loop (line 71) and the recursive `MeasureFolder` loop
- [ ] Regression: no other behavior changed — the fix is a single `continue` guard insertion