### PR TITLE
fix: pin DNS restore to the adapter captured at apply time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.77] - 2026-07-10
+
+### Fixed
+- **DNS "Undo" could silently apply the previous configuration to the wrong network adapter if network topology changed between Apply and Undo (e.g. VPN connected, USB NIC plugged in, Wi-Fi toggled).** The `DnsSnapshot` record captured the DNS addresses but not the identity of the adapter they belonged to. At restore time, `RestoreSnapshotAsync` re-queried for the "currently active" adapter using the same lowest-ifIndex heuristic — which could resolve to a completely different NIC than the one originally configured. The snapshot now pins the adapter's interface index at capture time (`IfIndex` field); restore targets that specific adapter directly and verifies it still exists before applying, throwing a clear user-facing message if it was removed rather than silently reconfiguring the wrong interface. Legacy snapshots (pre-existing code paths that don't carry an index) fall back to the dynamic lookup so backward compatibility is preserved.
+
 ## [1.52.76] - 2026-07-10
 
 ### Fixed

--- a/SysManager/SysManager.Tests/DnsServiceTests.cs
+++ b/SysManager/SysManager.Tests/DnsServiceTests.cs
@@ -461,4 +461,113 @@ public class DnsServiceTests
         // Validation happens before any interface lookup or Set script runs.
         await runner.DidNotReceiveWithAnyArgs().RunAsync(default!, default, default);
     }
+
+    // ---------- adapter-pinned snapshot (#23 reversibility) ----------
+
+    [Fact]
+    public async Task CaptureSnapshotAsync_PopulatesIfIndexFromAdapterOutput()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+              .Returns(new Collection<PSObject>
+              {
+                  PSObject.AsPSObject("IFINDEX=12"),
+                  PSObject.AsPSObject("IPv4=1.1.1.1"),
+                  PSObject.AsPSObject("IPv6=2606:4700:4700::1111"),
+              });
+        using var svc = new DnsService(runner);
+
+        var snap = await svc.CaptureSnapshotAsync();
+
+        Assert.Equal(12, snap.IfIndex);
+        Assert.Equal(["1.1.1.1"], snap.V4);
+        Assert.Equal(["2606:4700:4700::1111"], snap.V6);
+    }
+
+    [Fact]
+    public async Task CaptureSnapshotAsync_NoAdapter_ReturnsZeroIfIndex()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+              .Returns(new Collection<PSObject>());
+        using var svc = new DnsService(runner);
+
+        var snap = await svc.CaptureSnapshotAsync();
+
+        Assert.Equal(0, snap.IfIndex);
+        Assert.Empty(snap.V4);
+        Assert.Empty(snap.V6);
+    }
+
+    [Fact]
+    public async Task RestoreSnapshotAsync_PinnedIfIndex_VerifiesAdapterAndTargetsIt()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        // Both the verify call and the restore call return "12" — the verify script
+        // emits the ifIndex, confirming the adapter exists.
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+              .Returns(Result("12"));
+        using var svc = new DnsService(runner);
+
+        await svc.RestoreSnapshotAsync(new DnsService.DnsSnapshot(["9.9.9.9"], ["2620:fe::fe"], 12));
+
+        // First call: verify the adapter is still present.
+        await runner.Received(1).RunAsync(
+            Arg.Is<string>(s => s.Contains("Get-NetAdapter -InterfaceIndex 12")),
+            Arg.Any<IDictionary<string, object?>?>(),
+            Arg.Any<CancellationToken>());
+
+        // Second call: restore targets the pinned adapter, not a re-queried one.
+        await runner.Received(1).RunAsync(
+            Arg.Is<string>(s =>
+                s.Contains("-InterfaceIndex 12") &&
+                s.Contains("-ResetServerAddresses") &&
+                s.Contains("9.9.9.9") &&
+                s.Contains("2620:fe::fe")),
+            Arg.Any<IDictionary<string, object?>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RestoreSnapshotAsync_PinnedIfIndex_AdapterGone_ThrowsClearMessage()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        // Verify script returns empty (adapter no longer exists).
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+              .Returns(new Collection<PSObject>());
+        using var svc = new DnsService(runner);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => svc.RestoreSnapshotAsync(new DnsService.DnsSnapshot(["1.1.1.1"], [], 99)));
+
+        Assert.Contains("interface index 99", ex.Message);
+        Assert.Contains("no longer present", ex.Message);
+    }
+
+    [Fact]
+    public async Task RestoreSnapshotAsync_ZeroIfIndex_FallsBackToDynamicLookup()
+    {
+        // IfIndex=0 means legacy snapshot — should use GetActiveInterfaceIndexAsync
+        // (the ActiveAdapterSelector script), not the Get-NetAdapter verify path.
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+              .Returns(Result("5"));
+        using var svc = new DnsService(runner);
+
+        await svc.RestoreSnapshotAsync(new DnsService.DnsSnapshot(["8.8.8.8"], [], 0));
+
+        // Should NOT issue Get-NetAdapter -InterfaceIndex 0 verify.
+        await runner.DidNotReceive().RunAsync(
+            Arg.Is<string>(s => s.Contains("Get-NetAdapter -InterfaceIndex 0")),
+            Arg.Any<IDictionary<string, object?>?>(),
+            Arg.Any<CancellationToken>());
+
+        // Should use the dynamic selector and then target the resolved index.
+        await runner.Received(1).RunAsync(
+            Arg.Is<string>(s =>
+                s.Contains("-InterfaceIndex 5") &&
+                s.Contains("-ResetServerAddresses")),
+            Arg.Any<IDictionary<string, object?>?>(),
+            Arg.Any<CancellationToken>());
+    }
 }

--- a/SysManager/SysManager/Services/DnsService.cs
+++ b/SysManager/SysManager/Services/DnsService.cs
@@ -110,8 +110,12 @@ public sealed class DnsService : IDisposable
     /// A point-in-time snapshot of an adapter's DNS configuration for BOTH families, so a
     /// change can be reverted exactly. An empty list for a family means that family was on
     /// automatic (DHCP) at capture time and is restored by clearing it back to DHCP.
+    /// <paramref name="IfIndex"/> pins the adapter that was active at capture time; restore
+    /// targets this adapter directly instead of re-querying (which could pick a different NIC
+    /// if network topology changed between apply and undo). Zero means "not captured" and
+    /// falls back to dynamic lookup (backward-compat with pre-existing snapshots).
     /// </summary>
-    public sealed record DnsSnapshot(IReadOnlyList<string> V4, IReadOnlyList<string> V6)
+    public sealed record DnsSnapshot(IReadOnlyList<string> V4, IReadOnlyList<string> V6, int IfIndex = 0)
     {
         public static readonly DnsSnapshot Empty = new([], []);
     }
@@ -136,9 +140,11 @@ public sealed class DnsService : IDisposable
         try
         {
             // Tag each address with its family so one query returns both, in order.
+            // Also emit "IFINDEX=<n>" so the snapshot pins the adapter identity.
             const string script = ActiveAdapterSelector + """
 
                 if ($adapter) {
+                    "IFINDEX=$($adapter.ifIndex)"
                     foreach ($fam in @('IPv4','IPv6')) {
                         $dns = Get-DnsClientServerAddress -InterfaceIndex $adapter.ifIndex -AddressFamily $fam
                         foreach ($a in $dns.ServerAddresses) { "$fam=$a" }
@@ -150,19 +156,25 @@ public sealed class DnsService : IDisposable
                 .ConfigureAwait(false);
 
             List<string> v4 = [], v6 = [];
+            int capturedIfIndex = 0;
             foreach (var r in results)
             {
                 var line = r?.ToString();
                 if (string.IsNullOrWhiteSpace(line)) continue;
                 var eq = line.IndexOf('=');
                 if (eq <= 0) continue;
-                var fam = line[..eq];
-                var addr = line[(eq + 1)..];
-                if (!IPAddress.TryParse(addr, out _)) continue;
-                if (fam == "IPv4") v4.Add(addr);
-                else if (fam == "IPv6") v6.Add(addr);
+                var tag = line[..eq];
+                var value = line[(eq + 1)..];
+                if (tag == "IFINDEX")
+                {
+                    int.TryParse(value, out capturedIfIndex);
+                    continue;
+                }
+                if (!IPAddress.TryParse(value, out _)) continue;
+                if (tag == "IPv4") v4.Add(value);
+                else if (tag == "IPv6") v6.Add(value);
             }
-            return new DnsSnapshot(v4, v6);
+            return new DnsSnapshot(v4, v6, capturedIfIndex);
         }
         finally { _gate.Release(); }
     }
@@ -198,7 +210,28 @@ public sealed class DnsService : IDisposable
         await _gate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            int ifIndex = await GetActiveInterfaceIndexAsync(ct).ConfigureAwait(false);
+            // Use the adapter pinned at capture time when available; fall back to dynamic
+            // lookup only for legacy snapshots that don't carry an index (IfIndex == 0).
+            // This prevents topology changes (VPN connect/disconnect, USB NIC plug, etc.)
+            // from retargeting the restore to the wrong adapter.
+            int ifIndex;
+            if (snapshot.IfIndex > 0)
+            {
+                // Verify the pinned adapter still exists — if it was removed, fail clearly
+                // rather than silently applying to whatever interface now owns that index.
+                string verifyScript = $"Get-NetAdapter -InterfaceIndex {snapshot.IfIndex} -ErrorAction Stop | Select-Object -ExpandProperty ifIndex";
+                Collection<PSObject> verifyResult = await _ps.RunAsync(verifyScript, cancellationToken: ct)
+                    .ConfigureAwait(false);
+                if (verifyResult.Count == 0 || !int.TryParse(verifyResult[0]?.ToString(), out ifIndex))
+                    throw new InvalidOperationException(
+                        $"The network adapter captured at apply time (interface index {snapshot.IfIndex}) is no longer present. " +
+                        "Reconnect it or reset DNS manually via Settings → Network.");
+            }
+            else
+            {
+                ifIndex = await GetActiveInterfaceIndexAsync(ct).ConfigureAwait(false);
+            }
+
             var script = new System.Text.StringBuilder();
             script.AppendLine("$ErrorActionPreference = 'Stop'");
             // Clear BOTH families first so any servers applied since (incl. IPv6) are removed.

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.76</Version>
-    <FileVersion>1.52.76.0</FileVersion>
-    <AssemblyVersion>1.52.76.0</AssemblyVersion>
+    <Version>1.52.77</Version>
+    <FileVersion>1.52.77.0</FileVersion>
+    <AssemblyVersion>1.52.77.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary
- **DnsSnapshot** now records `IfIndex` (the interface index of the adapter active at capture time) as a third positional parameter with default 0 for backward compatibility.
- **CaptureSnapshotAsync** emits `IFINDEX=<n>` as the first tagged output line; the parser extracts it into the snapshot.
- **RestoreSnapshotAsync** with `IfIndex > 0` verifies the pinned adapter still exists (`Get-NetAdapter -InterfaceIndex N`) before applying — throws `InvalidOperationException` with a clear user-facing message if it was removed. `IfIndex == 0` (legacy path) falls back to dynamic lookup via `GetActiveInterfaceIndexAsync`.

## Root cause
Topology changes between Apply and Undo (VPN connect, USB NIC plug, Wi-Fi toggle) caused the `ActiveAdapterSelector` to resolve a different NIC at restore time, silently applying the old DNS to the wrong adapter.

## Test plan
- [x] `CaptureSnapshotAsync_PopulatesIfIndexFromAdapterOutput` — verifies IfIndex parsed from mock output
- [x] `CaptureSnapshotAsync_NoAdapter_ReturnsZeroIfIndex` — empty output → IfIndex=0
- [x] `RestoreSnapshotAsync_PinnedIfIndex_VerifiesAdapterAndTargetsIt` — verify script + Set script target correct index
- [x] `RestoreSnapshotAsync_PinnedIfIndex_AdapterGone_ThrowsClearMessage` — empty verify → InvalidOperationException
- [x] `RestoreSnapshotAsync_ZeroIfIndex_FallsBackToDynamicLookup` — no verify, uses selector
- [x] Existing tests (IfIndex=0 default) pass unchanged
- [x] Build 0 errors, 0 warnings (main + tests)