### PR TITLE
fix: correct hosts file comment/entry detection heuristic (data loss on save)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.78] - 2026-07-10
+
+### Fixed
+- **Hosts file manager silently deleted standalone comments starting with a digit or colon (e.g. "# 5G adapter notes", "# 1. Block ads") and failed to recognize disabled IPv6 entries whose address starts with a hex letter (e.g. "# fe80::1 myserver").** The internal `LooksLikeIpStart` heuristic only checked whether the first character after `#` was a digit or colon — a crude approximation that disagreed with the real acceptance test (`IPAddress.TryParse` + two-token minimum) in both directions. (1) False negatives: IPv6 addresses starting with `a`–`f` (like `fe80::`, `fd00::`) failed the heuristic, so those disabled entries were invisible in the grid (no data loss — they survived as comments — but could not be re-enabled through the UI). (2) False positives: digit-or-colon-leading comments passed the heuristic (line 71) and were treated as candidate entries, but then failed `IPAddress.TryParse` (line 86) and fell through both code paths — they were neither parsed as entries nor preserved as standalone comments, causing silent data loss on the next save. Replaced with `IsDisabledEntryLine` that mirrors the parser's own logic: strip inline comment, split on whitespace, require `tokens.Length >= 2 && IPAddress.TryParse(tokens[0], out _)`.
+
 ## [1.52.77] - 2026-07-10
 
 ### Fixed

--- a/SysManager/SysManager.Tests/HostsFileServiceTests.cs
+++ b/SysManager/SysManager.Tests/HostsFileServiceTests.cs
@@ -357,4 +357,110 @@ public class HostsFileServiceTests
             try { Directory.Delete(dir, recursive: true); } catch { }
         }
     }
+
+    // ---------- P2 #29/#30/#31: LooksLikeIpStart heuristic fix (IsDisabledEntryLine) ----------
+
+    [Fact]
+    public async Task ReadHostsAsync_DisabledIPv6HexStart_ParsedAsDisabledEntry()
+    {
+        // Regression (P2 #29): IPv6 addresses starting with a hex letter (a-f, e.g. "fe80::")
+        // were invisible because the old LooksLikeIpStart only checked for a digit or ':'.
+        // After the fix, "# fe80::1 myserver" must be parsed as a disabled HostsEntry.
+        const string content = "# fe80::1 myserver\n127.0.0.1 localhost\n";
+        var (svc, _, dir) = NewServiceWithTempHosts(content);
+        try
+        {
+            var entries = await svc.ReadHostsAsync();
+            var disabled = entries.FirstOrDefault(e => e.Hostname == "myserver");
+            Assert.NotNull(disabled);
+            Assert.Equal("fe80::1", disabled.IpAddress);
+            Assert.False(disabled.IsEnabled);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    [Fact]
+    public async Task ReadHostsAsync_DisabledIPv6HexStart_RoundTrips()
+    {
+        // End-to-end: "# fe80::1 myserver" survives a read→save→re-read cycle as
+        // a disabled entry, not silently dropped or corrupted.
+        const string content = "# fe80::1 myserver\n127.0.0.1 localhost\n";
+        var (svc, hosts, dir) = NewServiceWithTempHosts(content);
+        try
+        {
+            var entries = await svc.ReadHostsAsync();
+            svc.SaveHosts(entries);
+            var reloaded = await svc.ReadHostsAsync();
+            var disabled = reloaded.FirstOrDefault(e => e.Hostname == "myserver");
+            Assert.NotNull(disabled);
+            Assert.Equal("fe80::1", disabled.IpAddress);
+            Assert.False(disabled.IsEnabled);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    [Theory]
+    [InlineData("# 5G adapter notes")]
+    [InlineData("# 1. Block ads")]
+    [InlineData("# :) just a smiley comment")]
+    public async Task SaveHosts_DigitOrColonLeadingComments_PreservedNotDeleted(string commentLine)
+    {
+        // Regression (P2 #30/#31): standalone comments starting with a digit or colon
+        // (e.g. "# 5G adapter notes", "# 1. Block ads") passed the old LooksLikeIpStart
+        // heuristic but failed IPAddress.TryParse — causing them to be skipped from both
+        // the entry list AND the preserved comments, silently deleting them on save.
+        var content = $"{commentLine}\n127.0.0.1 localhost\n";
+        var (svc, hosts, dir) = NewServiceWithTempHosts(content);
+        try
+        {
+            var entries = await svc.ReadHostsAsync();
+            svc.SaveHosts(entries);
+            var saved = File.ReadAllText(hosts);
+            Assert.Contains(commentLine, saved);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    [Fact]
+    public async Task SaveHosts_DisabledIPv4StillWorks_AfterHeuristicFix()
+    {
+        // Sanity: the classic disabled IPv4 case ("# 0.0.0.0 blocked") must still
+        // round-trip as a disabled entry — ensure the fix didn't break existing behavior.
+        const string content = "# 0.0.0.0\tblocked.example.com\n127.0.0.1 localhost\n";
+        var (svc, hosts, dir) = NewServiceWithTempHosts(content);
+        try
+        {
+            var entries = await svc.ReadHostsAsync();
+            var disabled = entries.FirstOrDefault(e => e.Hostname == "blocked.example.com");
+            Assert.NotNull(disabled);
+            Assert.False(disabled.IsEnabled);
+
+            svc.SaveHosts(entries);
+            var reloaded = await svc.ReadHostsAsync();
+            var reloadedDisabled = reloaded.FirstOrDefault(e => e.Hostname == "blocked.example.com");
+            Assert.NotNull(reloadedDisabled);
+            Assert.False(reloadedDisabled.IsEnabled);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    [Fact]
+    public async Task SaveHosts_CommentWithOnlyIpNoHostname_PreservedAsComment()
+    {
+        // Edge case: "# 192.168.1.1" (one token only — an IP but no hostname) is NOT a
+        // valid disabled entry (needs at least two tokens: IP + hostname). It must be
+        // preserved as a standalone comment, not silently deleted.
+        const string content = "# 192.168.1.1\n127.0.0.1 localhost\n";
+        var (svc, hosts, dir) = NewServiceWithTempHosts(content);
+        try
+        {
+            var entries = await svc.ReadHostsAsync();
+            Assert.DoesNotContain(entries, e => e.IpAddress == "192.168.1.1");
+
+            svc.SaveHosts(entries);
+            var saved = File.ReadAllText(hosts);
+            Assert.Contains("# 192.168.1.1", saved);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
 }

--- a/SysManager/SysManager/Services/HostsFileService.cs
+++ b/SysManager/SysManager/Services/HostsFileService.cs
@@ -67,8 +67,8 @@ public sealed partial class HostsFileService
             if (line.StartsWith('#'))
             {
                 workLine = line[1..].TrimStart();
-                // If the remainder doesn't start with something that looks like an IP, skip it
-                if (!LooksLikeIpStart(workLine)) continue;
+                // If the remainder isn't a valid disabled entry (IP + hostname), skip it
+                if (!IsDisabledEntryLine(workLine)) continue;
                 isDisabled = true;
             }
 
@@ -138,9 +138,9 @@ public sealed partial class HostsFileService
             if (!line.StartsWith('#')) continue;                       // an IP entry — carried by `entries`
             if (line == ManagedHeaderLine1 || line == ManagedHeaderLine2) continue; // our own header
 
-            // A '#' followed by something IP-shaped is a disabled entry, already represented as a
+            // A '#' followed by a valid disabled entry (IP + hostname) is already represented as a
             // HostsEntry with IsEnabled=false — skip it here so it isn't duplicated.
-            if (LooksLikeIpStart(line[1..].TrimStart())) continue;
+            if (IsDisabledEntryLine(line[1..].TrimStart())) continue;
 
             preserved.Add(line);
         }
@@ -291,8 +291,23 @@ public sealed partial class HostsFileService
     }
 
     /// <summary>
-    /// Quick check: does the string start with a digit or colon (IPv6)?
+    /// Determines whether a '#'-stripped remainder represents a disabled hosts entry
+    /// (IP + hostname), using the SAME acceptance test as <see cref="ReadHostsAsync"/>:
+    /// strip an optional inline comment, split on whitespace, require at least two
+    /// tokens, and validate the first as an IP address. This replaces the old
+    /// <c>LooksLikeIpStart</c> heuristic that only checked the leading character — which
+    /// missed IPv6 addresses starting with hex letters (e.g. <c>fe80::</c>) and
+    /// falsely matched digit-leading comments (e.g. <c># 5G adapter notes</c>).
     /// </summary>
-    private static bool LooksLikeIpStart(string s) =>
-        s.Length > 0 && (char.IsDigit(s[0]) || s[0] == ':');
+    private static bool IsDisabledEntryLine(string afterHash)
+    {
+        if (afterHash.Length == 0) return false;
+
+        // Mirror ReadHostsAsync: strip inline comment, then tokenize.
+        string[] parts = afterHash.Split(['#'], 2);
+        string entryPart = parts[0].Trim();
+        string[] tokens = entryPart.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries);
+
+        return tokens.Length >= 2 && IPAddress.TryParse(tokens[0], out _);
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.77</Version>
-    <FileVersion>1.52.77.0</FileVersion>
-    <AssemblyVersion>1.52.77.0</AssemblyVersion>
+    <Version>1.52.78</Version>
+    <FileVersion>1.52.78.0</FileVersion>
+    <AssemblyVersion>1.52.78.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Fixes three related findings from a deep review pass — all rooted in the same defect: `LooksLikeIpStart` (a single-char heuristic) disagreeing with the real acceptance test (`IPAddress.TryParse` + two-token minimum) in both directions.

**Root cause:** The internal helper `LooksLikeIpStart(string s)` only checked `char.IsDigit(s[0]) || s[0] == ':'`. This was used at two points:
1. **Line 71 (ReadHostsAsync)** — to decide if a `#`-prefixed line is a disabled entry vs. a standalone comment
2. **Line 143 (ReadStandaloneCommentLines)** — to skip disabled entries from the preservation list

**Failure modes fixed:**
- **#29 — Invisible disabled IPv6:** Addresses starting with hex letters (`fe80::`, `fd00::`, `abcd::`) failed the heuristic → those disabled entries were invisible in the grid (couldn't be re-enabled through the UI).
- **#30/#31 — Silent data loss:** Comments starting with a digit or colon (`# 5G adapter notes`, `# 1. Block ads`, `#:) smiley`) passed the heuristic at line 71 but failed `IPAddress.TryParse` at line 86. They fell through both code paths — neither preserved as comments nor kept as entries — and were silently deleted on the next `SaveHosts`.

**Fix:** Replaced `LooksLikeIpStart` with `IsDisabledEntryLine` that mirrors `ReadHostsAsync`'s own parser logic: strip inline comment (`Split(['#'], 2)`), split on whitespace (RemoveEmptyEntries), return `tokens.Length >= 2 && IPAddress.TryParse(tokens[0], out _)`.

## Regression tests added (6)

- `ReadHostsAsync_DisabledIPv6HexStart_ParsedAsDisabledEntry` — `# fe80::1 myserver` parsed as disabled entry
- `ReadHostsAsync_DisabledIPv6HexStart_RoundTrips` — full read→save→re-read cycle preserves it
- `SaveHosts_DigitOrColonLeadingComments_PreservedNotDeleted` — Theory with 3 cases: `# 5G adapter notes`, `# 1. Block ads`, `#:) just a smiley comment`
- `SaveHosts_DisabledIPv4StillWorks_AfterHeuristicFix` — existing behavior preserved
- `SaveHosts_CommentWithOnlyIpNoHostname_PreservedAsComment` — edge: `# 192.168.1.1` (IP only, no hostname) stays as comment

## Test plan

- [x] Both projects build 0 errors 0 warnings
- [x] Leak scan clean (no identity/AI terms in diff)
- [x] Author headers verified on both files
- [x] No remaining `LooksLikeIpStart` in live code (only in doc comments/test descriptions)
- [x] Propagate check: no other callers of removed helper
- [ ] CI: unit tests pass (including the 6 new ones)
- [ ] CI: CodeQL clean