### PR TITLE
fix: environment restore/apply no longer aborts on non-conforming variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.80] - 2026-07-10
+
+### Fixed
+- **Environment Variables restore/apply aborted partway through when encountering a variable name that passes the registry but fails the application's user-input validation regex.** Windows registries can legally contain environment variable names with spaces, `#`, `@`, `+`, `!`, leading digits, or the `=C:` pseudo-variable prefix — all of which fail `ValidateName`'s strict regex (`\A[A-Za-z_][A-Za-z0-9_.()\-]*\z`). `SetVariable` called the throwing `ValidateName` outside any try/catch, so `RestoreFromBackup` (which iterates all backed-up names) and the ViewModel's `ApplyChanges` loop both threw `ArgumentException` on the first non-conforming name — aborting mid-iteration and leaving the environment HALF-RESTORED (some variables written, others not, no rollback). Added a non-throwing `TryValidateName` that returns `false` for non-conforming names, and `SetVariable` now uses it to skip/count failures instead of throwing — the restore loop processes every valid variable and reports a failure count rather than aborting. Additionally, `EnvBackup` now records each variable's `RegistryValueKind` so that restores round-trip REG_EXPAND_SZ fidelity exactly instead of re-deriving it from a `%`-contains heuristic (which misclassifies expandable variables whose current value happens not to contain a percent sign).
+
 ## [1.52.79] - 2026-07-10
 
 ### Fixed

--- a/SysManager/SysManager.Tests/EnvironmentVariableServiceTests.cs
+++ b/SysManager/SysManager.Tests/EnvironmentVariableServiceTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.IO;
+using System.Text.Json;
 using Microsoft.Win32;
 using SysManager.Models;
 using SysManager.Services;
@@ -234,5 +235,135 @@ public class EnvironmentVariableServiceTests
             Assert.Equal(names.OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList(), names);
         }
         finally { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+    }
+
+    // ── P2 #17 regression: TryValidateName, non-throwing restore, kind fidelity ──
+
+    [Theory]
+    [InlineData("PATH", true)]
+    [InlineData("JAVA_HOME", true)]
+    [InlineData("_underscore", true)]
+    [InlineData("My.Var", true)]
+    [InlineData("Var-1", true)]
+    [InlineData("foo(1)", true)]
+    public void TryValidateName_AcceptsConformingNames(string name, bool expected)
+    {
+        var result = EnvironmentVariableService.TryValidateName(name, out var validated);
+        Assert.Equal(expected, result);
+        if (expected) Assert.Equal(name.Trim(), validated);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("=C:")]
+    [InlineData("1startsWithDigit")]
+    [InlineData("has space")]
+    [InlineData("special#char")]
+    [InlineData("has@at")]
+    [InlineData("plus+sign")]
+    [InlineData("with!bang")]
+    public void TryValidateName_RejectsNonConforming_ReturnsFalse(string name)
+    {
+        var result = EnvironmentVariableService.TryValidateName(name, out var validated);
+        Assert.False(result);
+        Assert.Equal("", validated);
+    }
+
+    [Fact]
+    public void TryValidateName_RejectsOverlongName()
+    {
+        var longName = new string('A', 256);
+        Assert.False(EnvironmentVariableService.TryValidateName(longName, out _));
+    }
+
+    [Fact]
+    public void SetVariable_ReturnsFalse_ForInvalidName_DoesNotThrow()
+    {
+        var svc = new EnvironmentVariableService();
+
+        var result = svc.SetVariable("HAS SPACE", "somevalue", EnvVarScope.User);
+        Assert.False(result);
+
+        result = svc.SetVariable("=C:", "somepath", EnvVarScope.User);
+        Assert.False(result);
+
+        result = svc.SetVariable("1DIGIT_START", "x", EnvVarScope.User);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void EnvBackup_WithKinds_RoundTrips()
+    {
+        var backup = new EnvironmentVariableService.EnvBackup(
+            User: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["PATH"] = "%SystemRoot%\\system32",
+                ["TEMP"] = "C:\\Temp"
+            },
+            Machine: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ComSpec"] = "cmd.exe"
+            },
+            UserKinds: new Dictionary<string, RegistryValueKind>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["PATH"] = RegistryValueKind.ExpandString,
+                ["TEMP"] = RegistryValueKind.String
+            },
+            MachineKinds: new Dictionary<string, RegistryValueKind>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ComSpec"] = RegistryValueKind.String
+            });
+
+        var json = JsonSerializer.Serialize(backup);
+        var restored = JsonSerializer.Deserialize<EnvironmentVariableService.EnvBackup>(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal(2, restored!.User.Count);
+        Assert.Equal("%SystemRoot%\\system32", restored.User["PATH"]);
+        Assert.NotNull(restored.UserKinds);
+        Assert.Equal(RegistryValueKind.ExpandString, restored.UserKinds!["PATH"]);
+        Assert.Equal(RegistryValueKind.String, restored.UserKinds["TEMP"]);
+        Assert.NotNull(restored.MachineKinds);
+        Assert.Equal(RegistryValueKind.String, restored.MachineKinds!["ComSpec"]);
+    }
+
+    [Fact]
+    public void EnvBackup_OldFormat_DeserializesWithNullKinds()
+    {
+        var oldJson = """
+        {
+            "User": { "PATH": "C:\\Windows" },
+            "Machine": { "TEMP": "C:\\Temp" }
+        }
+        """;
+
+        var restored = JsonSerializer.Deserialize<EnvironmentVariableService.EnvBackup>(oldJson);
+
+        Assert.NotNull(restored);
+        Assert.Single(restored!.User);
+        Assert.Single(restored.Machine);
+        Assert.Null(restored.UserKinds);
+        Assert.Null(restored.MachineKinds);
+    }
+
+    [Fact]
+    public void SetVariable_WithExplicitKind_WritesCorrectKind()
+    {
+        var svc = new EnvironmentVariableService();
+        var name = "SM_TEST_KIND_" + Guid.NewGuid().ToString("N");
+        try
+        {
+            Assert.True(svc.SetVariable(name, "plain_no_percent", EnvVarScope.User, RegistryValueKind.ExpandString));
+
+            using var key = Registry.CurrentUser.OpenSubKey("Environment");
+            Assert.NotNull(key);
+            Assert.Equal(RegistryValueKind.ExpandString, key!.GetValueKind(name));
+        }
+        finally
+        {
+            using var key = Registry.CurrentUser.OpenSubKey("Environment", writable: true);
+            key?.DeleteValue(name, throwOnMissingValue: false);
+        }
     }
 }

--- a/SysManager/SysManager/Services/EnvironmentVariableService.cs
+++ b/SysManager/SysManager/Services/EnvironmentVariableService.cs
@@ -79,6 +79,25 @@ public sealed partial class EnvironmentVariableService
         return name.Trim();
     }
 
+    /// <summary>
+    /// Non-throwing validation for pre-existing (registry-originated) names that may not
+    /// conform to the strict user-input rules. Returns <c>false</c> for names that fail
+    /// validation, allowing the caller to skip/count them rather than aborting.
+    /// </summary>
+    public static bool TryValidateName(string name, out string validatedName)
+    {
+        validatedName = "";
+        if (string.IsNullOrWhiteSpace(name)) return false;
+        if (name.Length > 255) return false;
+        if (!VariableNameRegex().IsMatch(name))
+        {
+            Log.Debug("Environment: skipping variable with non-conforming name: '{Name}'", name);
+            return false;
+        }
+        validatedName = name.Trim();
+        return true;
+    }
+
     // ── Reading ──────────────────────────────────────────────────────────────
 
     private static (RegistryKey hive, string path) Location(EnvVarScope scope) =>
@@ -139,16 +158,30 @@ public sealed partial class EnvironmentVariableService
     /// Sets (or, when <paramref name="value"/> is null, deletes) a variable, writing
     /// directly to the registry so the value KIND is preserved. An existing variable
     /// keeps its kind (REG_EXPAND_SZ stays expandable); a new variable is written as
-    /// REG_EXPAND_SZ when its value contains a %VAR% token, else REG_SZ. Validates the
-    /// name at the trust boundary. Returns <c>false</c> if the write is denied (typically
-    /// a Machine-scope write without elevation) instead of throwing.
+    /// REG_EXPAND_SZ when its value contains a %VAR% token, else REG_SZ. Returns
+    /// <c>false</c> if the name fails validation or the write is denied — never throws
+    /// for these cases, so callers (RestoreFromBackup, ApplyChanges) can count failures
+    /// and continue instead of aborting.
     ///
     /// Does NOT broadcast WM_SETTINGCHANGE — the caller broadcasts once after a batch via
     /// <see cref="BroadcastSettingChange"/>.
     /// </summary>
     public bool SetVariable(string name, string? value, EnvVarScope scope)
+        => SetVariable(name, value, scope, explicitKind: null);
+
+    /// <summary>
+    /// Sets (or deletes) a variable with an explicit <see cref="RegistryValueKind"/> override.
+    /// When <paramref name="explicitKind"/> is non-null the variable is written as that kind,
+    /// bypassing the <see cref="ChooseKind"/> heuristic — used by <see cref="RestoreFromBackup"/>
+    /// to restore REG_EXPAND_SZ fidelity from the backup's recorded kind.
+    /// </summary>
+    public bool SetVariable(string name, string? value, EnvVarScope scope, RegistryValueKind? explicitKind)
     {
-        var validName = ValidateName(name);
+        if (!TryValidateName(name, out var validName))
+        {
+            Log.Warning("Environment: cannot set variable with invalid name '{Name}' in {Scope} — skipped", name, scope);
+            return false;
+        }
         var (hive, path) = Location(scope);
         try
         {
@@ -166,10 +199,7 @@ public sealed partial class EnvironmentVariableService
                 return true;
             }
 
-            // Preserve the existing kind; for a new value, choose ExpandString when it
-            // references a %VAR% token so expansion keeps working (matches how Windows
-            // itself stores PATH and similar variables).
-            var kind = ChooseKind(ExistingKind(key, validName), value);
+            var kind = explicitKind ?? ChooseKind(ExistingKind(key, validName), value);
             key.SetValue(validName, value, kind);
             Log.Information("Environment: set {Scope} variable {Name} ({Kind})", scope, validName, kind);
             return true;
@@ -280,9 +310,13 @@ public sealed partial class EnvironmentVariableService
     {
         if (HasBackup) return;
         Directory.CreateDirectory(_backupDir);
+        var userVars = Read(EnvVarScope.User);
+        var machineVars = Read(EnvVarScope.Machine);
         var snapshot = new EnvBackup(
-            User: ToDict(Read(EnvVarScope.User)),
-            Machine: ToDict(Read(EnvVarScope.Machine)));
+            User: ToDict(userVars),
+            Machine: ToDict(machineVars),
+            UserKinds: ToKindDict(userVars),
+            MachineKinds: ToKindDict(machineVars));
         File.WriteAllText(BackupPath, JsonSerializer.Serialize(snapshot, JsonOptions),
             new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
         Log.Information("Environment: pristine backup written to {Path}", BackupPath);
@@ -295,10 +329,25 @@ public sealed partial class EnvironmentVariableService
         return dict;
     }
 
-    /// <summary>A point-in-time snapshot of both environment scopes.</summary>
+    private static Dictionary<string, RegistryValueKind> ToKindDict(IEnumerable<EnvVariable> vars)
+    {
+        Dictionary<string, RegistryValueKind> dict = new(StringComparer.OrdinalIgnoreCase);
+        foreach (var v in vars)
+            dict[v.Name] = v.IsExpandable ? RegistryValueKind.ExpandString : RegistryValueKind.String;
+        return dict;
+    }
+
+    /// <summary>
+    /// A point-in-time snapshot of both environment scopes. The Kind dictionaries record
+    /// each variable's <see cref="RegistryValueKind"/> so a restore round-trips
+    /// REG_EXPAND_SZ faithfully instead of relying on the '%' heuristic. Nullable for
+    /// backward compatibility with backups written before this field was added.
+    /// </summary>
     public sealed record EnvBackup(
         Dictionary<string, string> User,
-        Dictionary<string, string> Machine);
+        Dictionary<string, string> Machine,
+        Dictionary<string, RegistryValueKind>? UserKinds = null,
+        Dictionary<string, RegistryValueKind>? MachineKinds = null);
 
     /// <summary>Reads the backup snapshot, or null if there is none / it cannot be parsed.</summary>
     public EnvBackup? ReadBackup()
@@ -339,15 +388,17 @@ public sealed partial class EnvironmentVariableService
         foreach (var scope in new[] { EnvVarScope.User, EnvVarScope.Machine })
         {
             var saved = scope == EnvVarScope.Machine ? backup.Machine : backup.User;
+            var kinds = scope == EnvVarScope.Machine ? backup.MachineKinds : backup.UserKinds;
 
-            // Re-write every backed-up variable to its original value.
             foreach (var (name, value) in saved)
             {
-                if (SetVariable(name, value, scope)) restored++;
+                RegistryValueKind? explicitKind = kinds is not null && kinds.TryGetValue(name, out var savedKind)
+                    ? savedKind
+                    : null;
+                if (SetVariable(name, value, scope, explicitKind)) restored++;
                 else failed++;
             }
 
-            // Remove anything present now but absent from the backup (added since).
             foreach (var current in Read(scope))
             {
                 if (saved.ContainsKey(current.Name)) continue;

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.79</Version>
-    <FileVersion>1.52.79.0</FileVersion>
-    <AssemblyVersion>1.52.79.0</AssemblyVersion>
+    <Version>1.52.80</Version>
+    <FileVersion>1.52.80.0</FileVersion>
+    <AssemblyVersion>1.52.80.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary
- **Bug:** `RestoreFromBackup` and the ViewModel's `ApplyChanges` loop threw `ArgumentException` on the first environment variable whose name contains spaces, `#`, `@`, `+`, `!`, leading digits, or the `=C:` pseudo-prefix — all legal in the Windows registry but rejected by the user-input validation regex. This left the environment **half-restored** (some vars written, the rest skipped with no recovery).
- **Root cause:** `SetVariable` called the throwing `ValidateName` on every name (including registry-originated ones) outside any try/catch. The restore loop had no individual-item error handling.
- **Fix:** Added `TryValidateName` (non-throwing, returns false for non-conforming names). `SetVariable` now uses it to skip/count rather than abort. `EnvBackup` extended with `UserKinds`/`MachineKinds` dictionaries so restores round-trip `RegistryValueKind` exactly (backward compatible — old backups deserialize with null kinds, falling back to the existing heuristic).
- 7 regression tests added covering `TryValidateName`, non-throwing `SetVariable`, `EnvBackup` JSON round-trip, backward compat with old format, and explicit-kind write fidelity.

## Test plan
- [ ] CI: Build & unit tests pass (includes the 7 new regression tests)
- [ ] CI: CodeQL / Analyze clean
- [ ] Verify: create a backup containing a name with a space (e.g. via regedit), trigger restore — should skip that var and report the count, not crash