### PR TITLE
fix: Event Logs Info severity filter now includes Level 0 (LogAlways) events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.81] - 2026-07-10
+
+### Fixed
+- **Event Logs tab's "Info" severity filter missed Level 0 (LogAlways) events.** Windows Event Log providers can emit events at Level 0 ("LogAlways" — informational events from legacy/classic providers). `MapLevel` correctly classifies Level 0 as `EventSeverity.Info` when reading records, but the XPath filter in `BuildXPath` used `SeverityToLevel(Info)` which returned only `Level=4`. This asymmetry meant the OS-side query for "Info" events excluded all Level-0 records from the result set — the user saw fewer informational entries than the system actually logged (commonly from providers like `Microsoft-Windows-Kernel-General`, `Service Control Manager`, and other classic providers in the System log). Added `SeverityToLevels` — the exact inverse of `MapLevel` — which maps Info to `{0, 4}`, and switched `BuildXPath` from `Select(SeverityToLevel)` to `SelectMany(SeverityToLevels)` so the generated XPath clause reads `(Level=0 or Level=4)` when the user selects Info.
+
 ## [1.52.80] - 2026-07-10
 
 ### Fixed

--- a/SysManager/SysManager.Tests/EventLogServiceTests.cs
+++ b/SysManager/SysManager.Tests/EventLogServiceTests.cs
@@ -192,6 +192,46 @@ public class EventLogServiceTests
     public void SeverityToLevel_RoundTrips(EventSeverity severity, byte expected)
         => Assert.Equal(expected, InvokeSeverityToLevel(severity));
 
+    // ---------- P2 #32 regression: Info filter must include Level 0 (LogAlways) ----------
+
+    [Fact]
+    public void BuildXPath_InfoSeverity_IncludesLevel0AndLevel4()
+    {
+        var opt = new EventLogQueryOptions
+        {
+            Severities = [EventSeverity.Info]
+        };
+        var result = InvokeBuildXPath(opt);
+        Assert.Contains("Level=0", result);
+        Assert.Contains("Level=4", result);
+        Assert.Contains(" or ", result);
+    }
+
+    [Fact]
+    public void BuildXPath_InfoAndError_IncludesLevel0_Level4_Level2()
+    {
+        var opt = new EventLogQueryOptions
+        {
+            Severities = [EventSeverity.Info, EventSeverity.Error]
+        };
+        var result = InvokeBuildXPath(opt);
+        Assert.Contains("Level=0", result);
+        Assert.Contains("Level=4", result);
+        Assert.Contains("Level=2", result);
+    }
+
+    [Fact]
+    public void BuildXPath_CriticalOnly_DoesNotIncludeLevel0()
+    {
+        var opt = new EventLogQueryOptions
+        {
+            Severities = [EventSeverity.Critical]
+        };
+        var result = InvokeBuildXPath(opt);
+        Assert.Contains("Level=1", result);
+        Assert.DoesNotContain("Level=0", result);
+    }
+
     // ---------- EventLogQueryOptions defaults ----------
 
     [Fact]

--- a/SysManager/SysManager/Services/EventLogService.cs
+++ b/SysManager/SysManager/Services/EventLogService.cs
@@ -151,7 +151,7 @@ public sealed partial class EventLogService
 
         if (opt.Severities is { Count: > 0 })
         {
-            var levels = opt.Severities.Select(s => (int)SeverityToLevel(s)).Distinct().ToList();
+            var levels = opt.Severities.SelectMany(SeverityToLevels).Distinct().ToList();
             clauses.Add("(" + string.Join(" or ", levels.Select(l => $"Level={l}")) + ")");
         }
 
@@ -193,5 +193,21 @@ public sealed partial class EventLogService
         EventSeverity.Info => 4,
         EventSeverity.Verbose => 5,
         _ => 4
+    };
+
+    /// <summary>
+    /// Maps a severity back to ALL event levels that <see cref="MapLevel"/> folds into it.
+    /// Used by <see cref="BuildXPath"/> so the XPath Level clause is the exact inverse of
+    /// the read-side classification. In particular, Level 0 (LogAlways) is classified as
+    /// Info by MapLevel, so Info must query BOTH Level=0 and Level=4.
+    /// </summary>
+    private static IEnumerable<int> SeverityToLevels(EventSeverity s) => s switch
+    {
+        EventSeverity.Critical => [1],
+        EventSeverity.Error => [2],
+        EventSeverity.Warning => [3],
+        EventSeverity.Info => [0, 4],
+        EventSeverity.Verbose => [5],
+        _ => [0, 4]
     };
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.80</Version>
-    <FileVersion>1.52.80.0</FileVersion>
-    <AssemblyVersion>1.52.80.0</AssemblyVersion>
+    <Version>1.52.81</Version>
+    <FileVersion>1.52.81.0</FileVersion>
+    <AssemblyVersion>1.52.81.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary
- **Event Logs tab's "Info" severity filter missed Level 0 (LogAlways) events.** `MapLevel` correctly classifies Level 0 as `EventSeverity.Info` when reading records, but `BuildXPath` used `SeverityToLevel(Info)` which returned only `Level=4`. The XPath query for Info events excluded all Level-0 records from the result set.
- Added `SeverityToLevels` — the exact inverse of `MapLevel` — which maps Info to `{0, 4}`, and switched `BuildXPath` from `Select(SeverityToLevel)` to `SelectMany(SeverityToLevels)`.
- The generated XPath now reads `(Level=0 or Level=4)` when the user selects Info, matching every level that the read-side classification folds into that severity bucket.

## Files changed
- `SysManager/SysManager/Services/EventLogService.cs` — new `SeverityToLevels` method; `BuildXPath` switched to `SelectMany(SeverityToLevels).Distinct()`
- `SysManager/SysManager.Tests/EventLogServiceTests.cs` — 3 regression tests (Info→{0,4}, Info+Error combined, Critical excludes Level=0)
- `SysManager/SysManager/SysManager.csproj` — version bump to 1.52.81
- `CHANGELOG.md` — [1.52.81] entry

## Test plan
- [x] `dotnet build -c Release` passes 0 errors/0 warnings (main + tests projects)
- [ ] CI: Build & unit tests green (3 new tests pass)
- [ ] CI: CodeQL clean
- [x] Regression: existing `SeverityToLevel_RoundTrips`, `MapLevel_*`, `BuildXPath_*` tests still compile and their semantics unchanged
- [x] Propagate: no other callers of `SeverityToLevel` or `MapLevel` in production code

Closes #1399