### PR TITLE
fix: drive enumeration no longer aborts when one volume's DriveFormat throws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.82] - 2026-07-10
+
+### Fixed
+- **Drive enumeration aborted entirely when a single volume's `DriveFormat` property threw (e.g. BitLocker-locked or transiently busy).** `FixedDriveService.Enumerate()` used a LINQ `.Where(di => ... di.DriveFormat ...)` predicate to filter drives to NTFS/ReFS. Because LINQ predicates evaluate lazily during `MoveNext()`, the `DriveFormat` property access ran OUTSIDE the per-drive try/catch block (which only covered the loop body). An `IOException` from one BitLocker-locked or transiently-busy volume caused the `IEnumerator.MoveNext()` call to throw, aborting enumeration of ALL remaining drives — even healthy ones. Callers (Deep Cleanup, System Health) saw zero drives instead of all-minus-one. Moved the `DriveFormat` filter inside the per-drive try block so one flaky volume is skipped (logged at Debug) while all remaining drives enumerate normally. The `DriveType` and `IsReady` checks remain in the predicate — those are backed by cached kernel data and do not hit the volume handle.
+
 ## [1.52.80] - 2026-07-10
 
 ### Fixed

--- a/SysManager/SysManager.IntegrationTests/FixedDriveServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/FixedDriveServiceTests.cs
@@ -120,4 +120,30 @@ public class FixedDriveServiceTests
         var r = await s.EnumerateAsync();
         Assert.All(r, d => Assert.False(string.IsNullOrWhiteSpace(d.Label)));
     }
+
+    // ---------- P2 #33 regression: DriveFormat IOException must not abort all drives ----------
+
+    [Fact]
+    public void Enumerate_DoesNotThrow_WhenDriveFormatAccessible()
+    {
+        // Contract: Enumerate() must never throw — it degrades by skipping individual
+        // drives whose properties are inaccessible. Before the fix, DriveFormat was read
+        // in a LINQ .Where() predicate (lazy evaluation during MoveNext), which threw
+        // OUTSIDE the per-drive try/catch and aborted enumeration of ALL remaining drives
+        // when a single volume was BitLocker-locked or transiently busy.
+        var ex = Record.Exception(() => FixedDriveService.Enumerate());
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Enumerate_ReturnsOnlyNtfsOrRefs()
+    {
+        // Post-fix: the format filter still works correctly (just moved inside try).
+        var drives = FixedDriveService.Enumerate();
+        Assert.All(drives, d =>
+        {
+            var fs = (d.FileSystem ?? "").ToUpperInvariant();
+            Assert.True(fs is "NTFS" or "REFS", $"Unexpected FS '{fs}' on {d.Letter}");
+        });
+    }
 }

--- a/SysManager/SysManager.Tests/FixedDriveServiceTests.cs
+++ b/SysManager/SysManager.Tests/FixedDriveServiceTests.cs
@@ -77,6 +77,21 @@ public class FixedDriveServiceTests
         Assert.Equal("", a.MediaType); // original unchanged
     }
 
+    // ---------- P2 #33 regression: structural verification ----------
+
+    [Fact]
+    public void Enumerate_NeverThrows()
+    {
+        // P2 #33: DriveFormat was previously read in a LINQ .Where() predicate (lazy
+        // evaluation) that ran during foreach MoveNext — OUTSIDE the per-drive try/catch.
+        // An IOException from a BitLocker-locked volume would abort enumeration of ALL
+        // remaining drives. After the fix, DriveFormat is read inside the try block, so
+        // one flaky drive cannot poison the entire result. This test verifies the method
+        // degrades gracefully (returns what it can) rather than throwing.
+        var ex = Record.Exception(() => FixedDriveService.Enumerate());
+        Assert.Null(ex);
+    }
+
     // Regression: WMI returns DBNull.Value (not null) for absent properties, and
     // Convert.ToUInt32(DBNull.Value) throws — which crashed drive enumeration.
     [Fact]

--- a/SysManager/SysManager/Services/FixedDriveService.cs
+++ b/SysManager/SysManager/Services/FixedDriveService.cs
@@ -32,19 +32,28 @@ public sealed class FixedDriveService
     {
         // Primary source: DriveInfo (fast, always works, no admin).
         List<FixedDrive> drives = [];
+
+        // Filter only on DriveType/IsReady here — these are backed by cached kernel
+        // data and do not hit the volume. The DriveFormat check (which opens the
+        // volume handle and CAN throw IOException on BitLocker-locked/transiently-busy
+        // drives) is deferred to inside the per-drive try/catch below, so one flaky
+        // volume cannot abort enumeration of all remaining drives.
         var fixedReady = DriveInfo.GetDrives()
-            .Where(di => di.DriveType == DriveType.Fixed && di.IsReady)
-            .Where(di => (di.DriveFormat ?? string.Empty).ToUpperInvariant() is "NTFS" or "REFS");
+            .Where(di => di.DriveType == DriveType.Fixed && di.IsReady);
 
         foreach (var di in fixedReady)
         {
-            // DriveInfo getters (VolumeLabel/TotalSize/AvailableFreeSpace) hit the
-            // volume and can throw IOException/UnauthorizedAccessException if it goes
-            // away or is denied between the IsReady check and the read (e.g. a
+            // DriveInfo getters (DriveFormat/VolumeLabel/TotalSize/AvailableFreeSpace)
+            // hit the volume and can throw IOException/UnauthorizedAccessException if
+            // it goes away or is denied between the IsReady check and the read (e.g. a
             // BitLocker-locked or transiently-busy volume). Skip that one drive
             // instead of aborting enumeration of the rest.
             try
             {
+                var format = (di.DriveFormat ?? string.Empty).ToUpperInvariant();
+                if (format is not ("NTFS" or "REFS"))
+                    continue;
+
                 var letter = di.Name.TrimEnd('\\', '/');
                 drives.Add(new FixedDrive(
                     Letter: letter,

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.80</Version>
-    <FileVersion>1.52.80.0</FileVersion>
-    <AssemblyVersion>1.52.80.0</AssemblyVersion>
+    <Version>1.52.82</Version>
+    <FileVersion>1.52.82.0</FileVersion>
+    <AssemblyVersion>1.52.82.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary
- **`FixedDriveService.Enumerate()` aborted entirely when a single volume's `DriveFormat` threw.** The LINQ `.Where(di => ... di.DriveFormat ...)` predicate evaluated lazily during `MoveNext()` — **outside** the per-drive try/catch. An `IOException` from one BitLocker-locked or transiently-busy volume caused `MoveNext()` to throw, aborting enumeration of ALL remaining healthy drives.
- Moved the `DriveFormat` filter inside the per-drive try block. `DriveType` and `IsReady` remain in the predicate (cached kernel data, no volume handle opened).
- Callers (Deep Cleanup, System Health) now see all accessible drives even when one volume is temporarily locked.

## Files changed
- `SysManager/SysManager/Services/FixedDriveService.cs` — moved DriveFormat check inside per-drive try/catch
- `SysManager/SysManager.Tests/FixedDriveServiceTests.cs` — regression test: `Enumerate_NeverThrows`
- `SysManager/SysManager.IntegrationTests/FixedDriveServiceTests.cs` — 2 regression tests (never-throws + NTFS/ReFS-only contract)
- `SysManager/SysManager/SysManager.csproj` — version bump to 1.52.82
- `CHANGELOG.md` — [1.52.82] entry

## Test plan
- [x] `dotnet build -c Release` passes 0 errors/0 warnings (main + tests + integration tests)
- [ ] CI: Build & unit tests green
- [ ] CI: CodeQL clean
- [x] Propagate: `AboutViewModel.cs:360` has a related pattern (noted for future fix — lower severity, about-page cosmetic)
- [x] Regression: existing `FixedDriveServiceTests` (MapMedia, MapBus, ToUInt32Safe, record tests) still compile