### PR TITLE
fix: Ookla speed test cancel no longer misreported as error; cancel-kill failures no longer mask cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.83] - 2026-07-10
+
+### Fixed
+- **Cancelling an Ookla speed test during the first-run CLI download was misreported as an error instead of "Cancelled".** `RunOoklaAsync` wrapped the prepare phase (`EnsureOoklaAsync` — download, extract, signature-verify) in a blanket `catch (Exception)` that re-threw everything as `InvalidOperationException("Could not prepare Ookla CLI: …")`. Because `OperationCanceledException` derives from `Exception`, a user cancel during the download/extract was converted into that error type, bypassing the ViewModel's dedicated `catch (OperationCanceledException) { OoklaStatus = "Cancelled"; }` handler — the user saw `Error: Could not prepare Ookla CLI: A task was canceled.` for a clean cancel. Cancellation now propagates untouched when the caller's token is signalled (an `OperationCanceledException` *without* the token signalled — HttpClient's internal 2-minute timeout — is reported as a truthful "download timed out" error), and the wrapping catch carries a `when (ex is not OperationCanceledException)` filter so cancellation can never be swallowed again.
+- **A failed cancel-kill of `speedtest.exe` could mask the cancellation and escape as an unhandled error.** The cancel path killed the child with `proc.Kill(entireProcessTree: true)` but only caught `InvalidOperationException`. `Kill(entireProcessTree: true)` also throws `Win32Exception` (process access-denied/terminating) and `AggregateException` (a descendant couldn't be terminated) — either one propagated *instead of* the intended `throw;`, so the original `OperationCanceledException` was lost and an exception type the caller doesn't handle escaped `RunOoklaAsync` entirely. Now uses the same three-exception filter as `PowerShellRunner`'s cancel-kill (`InvalidOperationException or Win32Exception or AggregateException`). The analogous `schtasks` timeout-kill in `StartupService.SetTaskSchedulerEnabledAsync` had the same gap — a `Win32Exception` from `Kill()` escaped to the outer catch, which mislabeled the timeout as "schtasks not available"; it now uses the same filter and reports the truthful "timed out" status.
+
 ## [1.52.82] - 2026-07-10
 
 ### Fixed

--- a/SysManager/SysManager.Tests/SpeedTestServiceTests.cs
+++ b/SysManager/SysManager.Tests/SpeedTestServiceTests.cs
@@ -48,4 +48,22 @@ public class SpeedTestServiceTests
         var dest = Path.GetFullPath(Path.Combine(Root + "-evil", "payload.exe"));
         Assert.False(SpeedTestService.IsInsideDirectory(Root, dest));
     }
+
+    [Fact]
+    public async Task RunOoklaAsync_UserCancelDuringPrepare_SurfacesAsCancellation()
+    {
+        // Regression: the prepare phase (EnsureOoklaAsync) was wrapped in a blanket
+        // catch (Exception) that re-threw OperationCanceledException as
+        // InvalidOperationException("Could not prepare Ookla CLI: A task was canceled."),
+        // bypassing the ViewModel's dedicated "Cancelled" handler and misreporting a
+        // clean user cancel as an error. A pre-cancelled token makes the first
+        // Task.Run(..., ct) inside EnsureOoklaAsync throw before any network or
+        // filesystem work, so this test is deterministic and offline.
+        var svc = new SpeedTestService();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => svc.RunOoklaAsync(progress: null, cts.Token));
+    }
 }

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -194,8 +194,25 @@ public sealed class SpeedTestService
         {
             exe = await EnsureOoklaAsync(progress, ct).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
+            // User cancel during the first-run download/extract — let it propagate so
+            // the ViewModel's dedicated "Cancelled" handler runs instead of misreporting
+            // a clean cancel as "Error: Could not prepare Ookla CLI: A task was canceled."
+            throw;
+        }
+        catch (OperationCanceledException ex)
+        {
+            // Cancelled without our token being signalled = HttpClient's own 2-minute
+            // timeout fired during the download — a network failure, not a user cancel.
+            throw new InvalidOperationException("Could not prepare Ookla CLI: download timed out.", ex);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Wrap real prepare failures (HttpRequestException, IOException, InvalidDataException,
+            // FileNotFoundException, …) in a friendly message the ViewModel displays. The filter
+            // mechanically guarantees cancellation can never be swallowed here even if the
+            // OCE branches above are ever restructured.
             throw new InvalidOperationException($"Could not prepare Ookla CLI: {ex.Message}", ex);
         }
 
@@ -248,8 +265,13 @@ public sealed class SpeedTestService
             // kill the child either way so speedtest.exe is never orphaned. (Previously
             // the kill only covered WaitForExitAsync, so a cancel during the reads
             // leaked the process.)
+            // Kill(entireProcessTree: true) can throw Win32Exception (access denied) or
+            // AggregateException (a descendant couldn't be terminated) as well as
+            // InvalidOperationException — swallow all three so a failed cancel-kill never
+            // masks the OperationCanceledException re-thrown below (same filter as
+            // PowerShellRunner's cancel-kill).
             try { if (!proc.HasExited) proc.Kill(entireProcessTree: true); }
-            catch (InvalidOperationException) { /* already exited */ }
+            catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception or AggregateException) { }
             throw;
         }
 

--- a/SysManager/SysManager/Services/StartupService.cs
+++ b/SysManager/SysManager/Services/StartupService.cs
@@ -444,8 +444,14 @@ public sealed class StartupService
             }
             catch (OperationCanceledException)
             {
+                // Kill() can also throw Win32Exception (access denied / terminating) —
+                // previously that escaped to the outer Win32Exception catch, which
+                // mislabeled the timeout as "schtasks not available". Swallow the same
+                // kill-failure set PowerShellRunner's cancel-kill uses so the truthful
+                // "timed out" status is always reported.
                 try { proc.Kill(); }
-                catch (InvalidOperationException ex) { Log.Debug(ex, "Process already exited before Kill"); }
+                catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception or AggregateException)
+                { Log.Debug(ex, "Could not kill schtasks after timeout"); }
                 entry.StatusText = "Error — schtasks timed out";
                 return false;
             }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.82</Version>
-    <FileVersion>1.52.82.0</FileVersion>
-    <AssemblyVersion>1.52.82.0</AssemblyVersion>
+    <Version>1.52.83</Version>
+    <FileVersion>1.52.83.0</FileVersion>
+    <AssemblyVersion>1.52.83.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Fixes two findings from a deep review pass (SpeedTestService cancellation paths), plus the same kill-filter gap in StartupService (fix-the-class).

### P2 #37 — blanket catch converts cancellation during CLI prepare into a hard error
`RunOoklaAsync` wrapped the prepare phase (`EnsureOoklaAsync` — download / extract / signature-verify) in `catch (Exception ex) => throw new InvalidOperationException(...)`. `OperationCanceledException` derives from `Exception`, so a user cancel during the first-run download was re-thrown as `InvalidOperationException` — bypassing `SpeedTestViewModel`'s dedicated `catch (OperationCanceledException) { OoklaStatus = "Cancelled"; }` and showing **"Error: Could not prepare Ookla CLI: A task was canceled."** for a clean cancel.

**Fix:** cancellation propagates untouched when the caller's token is signalled. An OCE *without* our token signalled (HttpClient's internal 2-min timeout) is reported as a truthful "download timed out" error. The wrapping catch now carries `when (ex is not OperationCanceledException)` so cancellation can mechanically never be swallowed again.

### P2 #34 — cancel-path Kill only catches InvalidOperationException
The cancel handler killed the child via `proc.Kill(entireProcessTree: true)` but caught only `InvalidOperationException`. `Kill(entireProcessTree: true)` also throws `Win32Exception` (access denied / terminating) and `AggregateException` (a descendant couldn't be terminated) — either propagated **before** the `throw;`, losing the original `OperationCanceledException` and escaping `RunOoklaAsync` as a type the caller doesn't handle.

**Fix:** the canonical three-exception filter from `PowerShellRunner` (`InvalidOperationException or Win32Exception or AggregateException`).

### Fix-the-class: StartupService.SetTaskSchedulerEnabledAsync
The audit flagged the analogous `schtasks` timeout-kill: a `Win32Exception` from `Kill()` escaped to the outer catch, which mislabeled the timeout as **"schtasks not available"**. Same filter applied — the truthful "timed out" status is always reported.

## Regression test
`RunOoklaAsync_UserCancelDuringPrepare_SurfacesAsCancellation`: pre-cancelled token → must surface `OperationCanceledException`. **Red before the fix** (the blanket catch re-threw it as `InvalidOperationException`, failing `ThrowsAnyAsync<OperationCanceledException>`), **green after**. Deterministic and offline — the pre-cancelled `Task.Run(..., ct)` inside `EnsureOoklaAsync` throws before any network or filesystem work.

## Checks
- All 3 projects build 0 warnings / 0 errors
- Leak scan on diff: clean
- No behavior change outside the cancellation/error paths