### PR TITLE
fix: config profile import no longer NREs on missing Sections; PATHEXT no longer flagged as missing directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.85] - 2026-07-10
+
+### Fixed
+- **Importing a config profile that omitted its `Sections` list crashed with an unhandled `NullReferenceException`.** `ConfigProfile.Sections` was a non-nullable positional record parameter, but System.Text.Json does not enforce non-null on positional params — so any syntactically-valid profile JSON lacking a `"Sections"` property (an empty `{}`, a truncated export, or foreign/hand-edited JSON chosen in the Import dialog) deserialized `Sections` to null. `ProfileViewModel.Import` then called `profile.Sections.Count`, throwing an NRE that escaped the surrounding try/catch (which only caught `IOException`/`UnauthorizedAccessException`/`NotSupportedException`) unhandled on the UI thread. `Sections` is now a defaulted `init` property (`= []`, matching the `CleanupResult.Errors` / `HealthScoreResult.Recommendations` idiom), and `ProfileService.Deserialize` also normalizes a null list to empty (mirroring `SettingsWatchdogService.LoadBaseline`) so the import path can always enumerate it safely.
+- **The PATH editor flagged every `PATHEXT` entry as a "missing directory", rendering the whole list in red.** `PATHEXT` is a `;`-separated list of file *extensions* (`.COM;.EXE;.BAT;…`), not directories, but `EnvVariable.IsPathLike` returned true for it and that single flag gated the editor's `Directory.Exists()` annotation — so each extension row was checked as a path (`Directory.Exists(".COM")` is false) and marked missing. Added a distinct `IsDirectoryList` (every path-like variable *except* `PATHEXT`) and gated the missing-directory annotation on it. `PATHEXT` still opens the reorderable list editor (`IsPathLike` is unchanged); its entries are simply no longer checked for directory existence.
+
 ## [1.52.84] - 2026-07-10
 
 ### Fixed

--- a/SysManager/SysManager.Tests/EnvVariableTests.cs
+++ b/SysManager/SysManager.Tests/EnvVariableTests.cs
@@ -1,0 +1,55 @@
+// SysManager · EnvVariableTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="EnvVariable"/>'s list-classification logic — the gates that
+/// drive the PATH list editor and its directory-existence annotation.
+/// </summary>
+public class EnvVariableTests
+{
+    private static EnvVariable Make(string name) =>
+        new() { Name = name, Scope = EnvVarScope.Machine, Value = "" };
+
+    [Theory]
+    [InlineData("Path")]
+    [InlineData("PATH")]
+    [InlineData("PATHEXT")]
+    [InlineData("PSModulePath")]
+    public void IsPathLike_TrueForPathVariables(string name)
+        => Assert.True(Make(name).IsPathLike);
+
+    [Theory]
+    [InlineData("TEMP")]
+    [InlineData("USERNAME")]
+    [InlineData("OS")]
+    public void IsPathLike_FalseForOrdinaryVariables(string name)
+        => Assert.False(Make(name).IsPathLike);
+
+    [Theory]
+    [InlineData("Path")]
+    [InlineData("PATH")]
+    [InlineData("PSModulePath")]
+    public void IsDirectoryList_TrueForRealDirectoryLists(string name)
+        => Assert.True(Make(name).IsDirectoryList);
+
+    [Theory]
+    [InlineData("PATHEXT")]
+    [InlineData("pathext")]
+    public void IsDirectoryList_FalseForPathext(string name)
+    {
+        // Regression (P2 #12): PATHEXT is a list of file EXTENSIONS (.COM;.EXE;…), not
+        // directories. Before the fix, IsPathLike alone gated the PATH editor's
+        // Directory.Exists() annotation, so every PATHEXT entry (present in System scope
+        // on every Windows install) was flagged IsMissing=true and the whole list
+        // rendered red. IsDirectoryList must exclude PATHEXT while IsPathLike still
+        // includes it (so the reorderable list editor is still shown).
+        var v = Make(name);
+        Assert.True(v.IsPathLike, "PATHEXT should still open the list editor");
+        Assert.False(v.IsDirectoryList, "PATHEXT entries are extensions, not directories");
+    }
+}

--- a/SysManager/SysManager.Tests/ProfileServiceTests.cs
+++ b/SysManager/SysManager.Tests/ProfileServiceTests.cs
@@ -74,6 +74,33 @@ public class ProfileServiceTests : IDisposable
         Assert.Throws<NotSupportedException>(() => ProfileService.Deserialize(future));
     }
 
+    [Fact]
+    public void Deserialize_MissingSectionsProperty_YieldsEmptyList_NotNull()
+    {
+        // Regression (P2 #11): a syntactically-valid profile JSON that OMITS "Sections"
+        // (a truncated export, an empty-ish object, or foreign JSON picked in Import)
+        // used to deserialize Sections to null — System.Text.Json does not enforce
+        // non-null on positional record params — and ProfileViewModel.Import then threw
+        // an unhandled NullReferenceException on profile.Sections.Count. Now the model
+        // defaults it to [] and Deserialize normalizes it, so callers can always
+        // enumerate .Sections safely.
+        var json = $"{{\"SchemaVersion\":{ProfileService.CurrentSchemaVersion},\"AppVersion\":\"1.0.0\",\"ExportedAt\":\"2026-01-01T00:00:00\"}}";
+        var profile = ProfileService.Deserialize(json);
+        Assert.NotNull(profile);
+        Assert.NotNull(profile!.Sections);
+        Assert.Empty(profile.Sections);
+    }
+
+    [Fact]
+    public void Deserialize_EmptyObject_YieldsEmptySections()
+    {
+        // The most degenerate valid JSON object — every property absent — must still
+        // produce a usable profile with an empty (non-null) Sections list.
+        var profile = ProfileService.Deserialize("{}");
+        Assert.NotNull(profile);
+        Assert.Empty(profile!.Sections);
+    }
+
     // ---------- ApplySections ----------
 
     [Fact]

--- a/SysManager/SysManager/Models/ConfigProfile.cs
+++ b/SysManager/SysManager/Models/ConfigProfile.cs
@@ -13,8 +13,19 @@ namespace SysManager.Models;
 public sealed record ConfigProfile(
     int SchemaVersion,
     string AppVersion,
-    DateTime ExportedAt,
-    IReadOnlyList<ConfigSection> Sections);
+    DateTime ExportedAt)
+{
+    /// <summary>
+    /// The exported config files. A defaulted init property (not a positional param)
+    /// because System.Text.Json does NOT enforce non-null on positional record params:
+    /// a syntactically-valid JSON object lacking a "Sections" property (an empty <c>{}</c>,
+    /// a truncated export, or foreign JSON picked in the Import dialog) would otherwise
+    /// deserialize <c>Sections</c> to null and crash Import with an NRE. Defaulting to
+    /// <c>[]</c> mirrors the codebase idiom already used by CleanupResult.Errors,
+    /// HealthScoreResult.Recommendations and TuneUpResult.DiskResults.
+    /// </summary>
+    public IReadOnlyList<ConfigSection> Sections { get; init; } = [];
+}
 
 /// <summary>One exported config file: its logical key, file name, and raw JSON content.</summary>
 public sealed record ConfigSection(

--- a/SysManager/SysManager/Models/EnvVariable.cs
+++ b/SysManager/SysManager/Models/EnvVariable.cs
@@ -36,11 +36,26 @@ public sealed partial class EnvVariable : ObservableObject
     /// </summary>
     public bool IsExpandable { get; init; }
 
-    /// <summary>True for PATH-like variables whose value is a ';'-separated directory list.</summary>
+    /// <summary>
+    /// True for variables whose value is a ';'-separated list worth showing in the list
+    /// editor — PATH, PATHEXT, and any *PATH variable. Note PATHEXT is a list of file
+    /// EXTENSIONS, not directories, so use <see cref="IsDirectoryList"/> before treating
+    /// entries as paths (e.g. checking directory existence).
+    /// </summary>
     public bool IsPathLike =>
         Name.Equals("Path", StringComparison.OrdinalIgnoreCase) ||
         Name.Equals("PATHEXT", StringComparison.OrdinalIgnoreCase) ||
         Name.EndsWith("PATH", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// True for list variables whose entries are directories (so directory-existence
+    /// checks are meaningful) — every <see cref="IsPathLike"/> variable EXCEPT PATHEXT,
+    /// whose entries are file extensions (.COM;.EXE;.BAT;…). Without this distinction the
+    /// PATH editor ran <c>Directory.Exists(".COM")</c> on each PATHEXT entry and flagged
+    /// them all as "missing", showing the whole list in red.
+    /// </summary>
+    public bool IsDirectoryList =>
+        IsPathLike && !Name.Equals("PATHEXT", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>Human-readable scope label for the grid ("User" / "System").</summary>
     public string ScopeLabel => Scope == EnvVarScope.Machine ? "System" : "User";

--- a/SysManager/SysManager/Services/ProfileService.cs
+++ b/SysManager/SysManager/Services/ProfileService.cs
@@ -91,8 +91,8 @@ public sealed class ProfileService
 
     /// <summary>Builds a profile from the given sections (defaults to all available).</summary>
     public ConfigProfile BuildProfile(DateTime exportedAt, IReadOnlyList<ConfigSection>? sections = null)
-        => new(CurrentSchemaVersion, UpdateService.CurrentVersion.ToString(3), exportedAt,
-               sections ?? AvailableSections());
+        => new(CurrentSchemaVersion, UpdateService.CurrentVersion.ToString(3), exportedAt)
+           { Sections = sections ?? AvailableSections() };
 
     /// <summary>Serializes a profile to indented JSON.</summary>
     public static string Serialize(ConfigProfile profile) => JsonSerializer.Serialize(profile, JsonOptions);
@@ -112,7 +112,12 @@ public sealed class ProfileService
         if (profile.SchemaVersion > CurrentSchemaVersion)
             throw new NotSupportedException(
                 $"This profile was made by a newer version of SysManager (format v{profile.SchemaVersion}). Update SysManager to import it.");
-        return profile;
+        // Normalize a missing "Sections" property to an empty list, mirroring
+        // SettingsWatchdogService.LoadBaseline's handling of BaselineSnapshot.Values.
+        // The model default already covers this, but keep the guard so any future
+        // construction path (or a change to the record shape) can't reintroduce the
+        // NRE that ProfileViewModel.Import hit on profile.Sections.Count.
+        return profile is { Sections: null } ? profile with { Sections = [] } : profile;
     }
 
     /// <summary>Writes a profile to a file the user chose.</summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.84</Version>
-    <FileVersion>1.52.84.0</FileVersion>
-    <AssemblyVersion>1.52.84.0</AssemblyVersion>
+    <Version>1.52.85</Version>
+    <FileVersion>1.52.85.0</FileVersion>
+    <AssemblyVersion>1.52.85.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
@@ -182,11 +182,16 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
 
     private void AnnotatePathEntries()
     {
+        // PATHEXT entries are file extensions (.COM;.EXE;…), not directories, so a
+        // directory-existence check is meaningless and would flag every entry as
+        // "missing". Only annotate IsMissing for genuine directory lists (PATH/*PATH).
+        var checkMissing = SelectedVariable?.IsDirectoryList == true;
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var entry in PathEntries)
         {
             var key = entry.Directory.TrimEnd('\\', '/');
             entry.IsDuplicate = !seen.Add(key);
+            if (!checkMissing) { entry.IsMissing = false; continue; }
             try { entry.IsMissing = !string.IsNullOrWhiteSpace(entry.Directory) && !Directory.Exists(entry.Directory); }
             catch (ArgumentException) { entry.IsMissing = true; } // malformed path characters
         }


### PR DESCRIPTION
## Summary

Two self-contained model defects in the `Models/` layer — two findings from a deep review pass.

### P2 #11 — ConfigProfile.Sections NRE on import
`ConfigProfile.Sections` was a non-nullable **positional** record parameter, but System.Text.Json does **not** enforce non-null on positional params. Any syntactically-valid profile JSON lacking a `"Sections"` property — an empty `{}`, a truncated export, or foreign/hand-edited JSON picked in the Import dialog — deserialized `Sections` to **null**. `ProfileViewModel.Import` then called `profile.Sections.Count`, throwing a `NullReferenceException` that escaped the surrounding try/catch (which only caught `IOException`/`UnauthorizedAccessException`/`NotSupportedException`) unhandled on the UI thread.

**Fix:** `Sections` is now a defaulted `init` property (`= []`), matching the existing `CleanupResult.Errors` / `HealthScoreResult.Recommendations` / `TuneUpResult.DiskResults` idiom. `ProfileService.Deserialize` also normalizes a null list to empty (mirroring `SettingsWatchdogService.LoadBaseline`'s handling of `BaselineSnapshot.Values`), so the import path can always enumerate `.Sections` safely.

### P2 #12 — PATHEXT flagged as missing directories
`PATHEXT` is a `;`-separated list of file **extensions** (`.COM;.EXE;.BAT;…`), not directories, but `EnvVariable.IsPathLike` returned true for it — and that single flag gated the PATH editor's `Directory.Exists()` annotation. So every `PATHEXT` entry (present in System scope on every Windows install) was checked as a path (`Directory.Exists(".COM")` is false) and marked `IsMissing=true`, rendering the whole list red — misleading for the non-technical target persona.

**Fix:** added a distinct `IsDirectoryList` (every path-like variable **except** `PATHEXT`) and gated the missing-directory annotation on it. `PATHEXT` still opens the reorderable list editor (`IsPathLike` unchanged); its entries are simply no longer checked for directory existence.

## Regression tests
- `Deserialize_MissingSectionsProperty_YieldsEmptyList_NotNull` + `Deserialize_EmptyObject_YieldsEmptySections` — **red before** (Sections was null → the Import path NRE'd), green after.
- New `EnvVariableTests`: `IsDirectoryList_FalseForPathext` / `IsDirectoryList_TrueForRealDirectoryLists` / `IsPathLike_*` — **red before** (`IsDirectoryList` did not exist), green after. Confirms PATHEXT stays `IsPathLike` (list editor still shown) but is excluded from `IsDirectoryList`.

## Checks
- All 3 projects build 0 warnings / 0 errors
- Leak scan on diff: clean
- `BuildProfile` updated to the object-initializer form (the only `ConfigProfile` construction site); no other callers affected