### PR TITLE
fix: an added-then-deleted env variable in one session is now actually removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.89] - 2026-07-10
+
+### Fixed
+- **An environment variable added and applied, then deleted in the same session, could not actually be removed — it stayed orphaned in the registry while the pending-change counter got stuck.** `ApplyChanges` maintains two parallel maps: `_baseline` (drives the pending-change count) and `_originals` (the sole source for the deletion list). The delete loop removed the variable from both maps, but the add/edit loop updated only `_baseline` — so a freshly-added variable was never recorded in `_originals`. If the user then deleted that variable and pressed Apply again, `RecomputePending` (reads `_baseline`) counted it as a pending deletion and the UI showed "1 pending change", but `DeletedEntries` (reads `_originals`) didn't include it, so it was never deleted from the registry — leaving `PendingChangeCount` stuck at 1 and the variable orphaned. (A manual Refresh silently self-healed it by reloading `_originals`.) The apply loop now writes `_originals[Key(v)]` alongside `_baseline[Key(v)]` on a successful `SetVariable`, keeping the two maps in lock-step.
+
 ## [1.52.87] - 2026-07-10
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.87</Version>
-    <FileVersion>1.52.87.0</FileVersion>
-    <AssemblyVersion>1.52.87.0</AssemblyVersion>
+    <Version>1.52.89</Version>
+    <FileVersion>1.52.89.0</FileVersion>
+    <AssemblyVersion>1.52.89.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
@@ -380,7 +380,18 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
         // Adds + edits.
         foreach (var v in ChangedVariables().ToList())
         {
-            if (_service.SetVariable(v.Name, v.Value, v.Scope)) { applied++; _baseline[Key(v)] = v.Value; }
+            if (_service.SetVariable(v.Name, v.Value, v.Scope))
+            {
+                applied++;
+                _baseline[Key(v)] = v.Value;
+                // Keep _originals in lock-step with _baseline. _originals is the SOLE source
+                // for DeletedEntries()/registry deletion; if an applied ADD only updated
+                // _baseline, a later delete of that same variable (same session, before any
+                // Refresh) would be counted as pending by RecomputePending (reads _baseline)
+                // yet skipped by DeletedEntries (reads _originals) — leaving it orphaned in the
+                // registry with PendingChangeCount stuck at 1.
+                _originals[Key(v)] = (v.Scope, v.Name);
+            }
             else failures++;
         }
 


### PR DESCRIPTION
## Summary

Fixes a finding from a deep review pass.

`EnvironmentVariablesViewModel.ApplyChanges` keeps two parallel bookkeeping maps:
- `_baseline` (Key → value) — drives `RecomputePending` / the pending-change count.
- `_originals` (Key → (scope, name)) — the **sole** source for `DeletedEntries()` and the actual registry deletion.

The delete loop removed the variable from **both** maps, but the add/edit loop updated **only** `_baseline` — a freshly-added variable was never recorded in `_originals`, and `ApplyChanges` never re-runs `Load()`.

**Concrete failure (single session, no Refresh):**
1. Add a new variable *C* → Apply. `SetVariable` writes it to the registry, `_baseline` gets *C*, `_originals` does **not**.
2. Delete *C* in the grid → Apply. `RecomputePending` (reads `_baseline`) counts *C* as a pending deletion → UI shows "1 pending change", but `DeletedEntries` (reads `_originals`) is empty → `DeleteVariable(C)` is never called. Status says "Applied 0 changes", `PendingChangeCount` stays stuck at 1, and *C* remains orphaned in the registry. (A manual Refresh self-heals by reloading `_originals`.)

## Fix
The apply loop now writes `_originals[Key(v)] = (v.Scope, v.Name)` alongside `_baseline[Key(v)] = v.Value` on a successful `SetVariable`, keeping the two maps in lock-step (the exact invariant the existing code comment claims).

## Testing note
No unit test added: `EnvironmentVariableService` is a **sealed** concrete class with no interface seam, and its `SetVariable`/`DeleteVariable`/`ReadAll` hit the real HKCU/HKLM `Environment` hive — exercising `ApplyChanges` end-to-end would mutate the **live user registry**, which the no-system-deps unit-test rule forbids. The fix is a symmetric one-line bookkeeping sync verifiable by inspection; a proper test is gated on introducing `IEnvironmentVariableService` (tracked by the broader arch-seam findings).

## Checks
- All 3 projects build 0 warnings / 0 errors
- Leak scan on diff: clean