### PR TITLE
fix: transient WMI fault no longer poisons the static-hardware cache for the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.90] - 2026-07-10
+
+### Fixed
+- **A single transient WMI hiccup on startup could permanently show "Unknown CPU" / "Windows" / no disks / no RAM modules for the whole session.** `SystemInfoService` caches static hardware info with `??=`, but every `Query*` helper returned a **non-null** fallback on a WMI fault (`CpuInfo("Unknown", …)`, `OsInfo("Windows", …)`, an empty disk/module list). Because the fallback was non-null, `??=` stored it and never re-queried — so if the first `CaptureAsync` raced a transient WMI fault (plausible under the ~36-service startup load → `RPC server too busy`), the fallback defaults were cached process-wide (the service is a singleton) even after WMI recovered milliseconds later. The Dashboard, System Info tab, System Report and tray tooltip stayed stuck on the fallbacks until restart. Each `Query*` now returns `null` on a WMI **fault** (distinguished from a genuinely empty-but-successful result, which is still cached), so `??=` caches only a successful query and retries on the next poll; `Capture` uses a transient, non-cached default for the current snapshot only.
+
 ## [1.52.88] - 2026-07-10
 
 ### Fixed

--- a/SysManager/SysManager.IntegrationTests/SystemInfoServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/SystemInfoServiceTests.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Reflection;
+using SysManager.Models;
 using SysManager.Services;
 
 namespace SysManager.IntegrationTests;
@@ -102,5 +104,37 @@ public class SystemInfoServiceTests
         var ex = await Record.ExceptionAsync(async () => await svc.CaptureAsync(cts.Token));
         // Either TaskCanceledException or completes fine — both acceptable.
         _ = ex;
+    }
+
+    [Fact]
+    public async Task CaptureAsync_ReQueriesStaticInfo_AfterCacheCleared()
+    {
+        // Regression (P2 #40): the static-hardware cache used ??= with a NON-NULL fallback
+        // returned on a WMI fault, so a transient first-call fault poisoned the cache for the
+        // whole process — permanently showing "Unknown CPU" / "Windows" / no disks / no RAM.
+        // The fix makes each Query* return null on a fault so ??= caches ONLY a successful
+        // query and re-queries otherwise. This verifies the retry path: after a successful
+        // capture populates the cache, clearing the cache field forces the NEXT capture to
+        // re-query (rather than being stuck on a stale/absent value).
+        var svc = new SystemInfoService();
+        var first = await svc.CaptureAsync();
+        Assert.False(string.IsNullOrWhiteSpace(first.Cpu.Name));
+
+        // Simulate the post-fault state: cache empty (as if the first query had faulted and
+        // returned null instead of caching a fallback).
+        typeof(SystemInfoService)
+            .GetField("_cachedCpuStatic", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(svc, null);
+
+        var second = await svc.CaptureAsync();
+        // On this (WMI-healthy) host the re-query must succeed and repopulate the real CPU —
+        // proving a cleared/null cache is retried, not left permanently degraded.
+        Assert.False(string.IsNullOrWhiteSpace(second.Cpu.Name));
+        Assert.True(second.Cpu.Cores > 0);
+
+        var cached = (CpuInfo?)typeof(SystemInfoService)
+            .GetField("_cachedCpuStatic", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(svc);
+        Assert.NotNull(cached); // re-query cached a fresh successful result
     }
 }

--- a/SysManager/SysManager/Services/SystemInfoService.cs
+++ b/SysManager/SysManager/Services/SystemInfoService.cs
@@ -33,23 +33,29 @@ public sealed class SystemInfoService
 
         lock (_cacheLock)
         {
-            // Static OS info (caption, version, build, arch) — cache it; uptime refreshes below.
+            // Each Query* returns null on a WMI FAULT (not on a genuine empty result), so the
+            // ??= caches ONLY a successful query and RE-QUERIES on the next poll after a
+            // transient hiccup. Without this, a WMI fault on the very first CaptureAsync (likely
+            // under the startup thundering-herd → RPC-server-too-busy) would cache the fallback
+            // defaults for the whole process lifetime — permanently showing "Unknown CPU" /
+            // "Windows" / no disks / no RAM even after WMI recovered milliseconds later.
+            // A transient default is used for the CURRENT snapshot only and is never cached.
             _cachedOs ??= QueryOsStatic();
-            osStatic = _cachedOs;
+            osStatic = _cachedOs ?? new OsInfo("Windows", "", "", TimeSpan.Zero, "");
 
             // CPU name/cores/threads/clock are static; only LoadPercentage is dynamic.
             _cachedCpuStatic ??= QueryCpuStatic();
-            cpu = _cachedCpuStatic with { LoadPercent = QueryCpuLoad() };
+            cpu = (_cachedCpuStatic ?? new CpuInfo("Unknown", 0, 0, 0, 0)) with { LoadPercent = QueryCpuLoad() };
 
             // Disk info is static (models don't change at runtime).
             _cachedDisks ??= QueryDisks();
-            disks = _cachedDisks;
+            disks = _cachedDisks ?? [];
 
             // Physical memory modules (bank/manufacturer/capacity/speed/part) are static
             // hardware — enumerate the DIMMs once. Only the dynamic totals refresh below,
             // so the Dashboard's 300 ms vitals poll no longer re-queries Win32_PhysicalMemory.
             _cachedModules ??= QueryMemoryModules();
-            modules = _cachedModules;
+            modules = _cachedModules ?? [];
         }
 
         // One Win32_OperatingSystem query for BOTH the dynamic uptime and memory totals —
@@ -59,10 +65,13 @@ public sealed class SystemInfoService
         return new SystemSnapshot(os, cpu, mem, disks, DateTime.Now);
     }
 
-    private static OsInfo QueryOsStatic()
+    // Returns null on a WMI fault so the caller's ??= cache retries next poll (see Capture).
+    // A successful query always returns a non-null OsInfo (falling through to the loop-less
+    // case only when the class returned no rows, which is itself a valid "OS unknown" answer).
+    private static OsInfo? QueryOsStatic()
     {
-        // A WMI fault (service down, corrupt repository) must degrade to a safe default, not
-        // propagate out of Capture() and surface as an error dialog — mirrors QueryDisks.
+        // A WMI fault (service down, corrupt repository) returns null so it is NOT cached and
+        // is retried on the next poll — Capture() supplies a transient default for this snapshot.
         try
         {
             using var searcher = new ManagementObjectSearcher("SELECT Caption,Version,BuildNumber,OSArchitecture,LastBootUpTime FROM Win32_OperatingSystem");
@@ -89,8 +98,10 @@ public sealed class SystemInfoService
         }
         catch (Exception ex) when (ex is ManagementException or System.Runtime.InteropServices.COMException)
         {
-            /* WMI unavailable — degrade to defaults (mirrors QueryDisks) */
+            /* WMI unavailable — return null so the cache retries (Capture supplies a transient default) */
+            return null;
         }
+        // Query succeeded but returned no rows — a valid (if unusual) answer; cache it.
         return new OsInfo("Windows", "", "", TimeSpan.Zero, "");
     }
 
@@ -134,7 +145,8 @@ public sealed class SystemInfoService
         return (uptime, new MemoryInfo(totalGB, freeGB, usedGB, pct, modules));
     }
 
-    private static CpuInfo QueryCpuStatic()
+    // Returns null on a WMI fault so the caller's ??= cache retries next poll (see Capture).
+    private static CpuInfo? QueryCpuStatic()
     {
         try
         {
@@ -155,8 +167,10 @@ public sealed class SystemInfoService
         }
         catch (Exception ex) when (ex is ManagementException or System.Runtime.InteropServices.COMException)
         {
-            /* WMI unavailable — degrade to defaults */
+            /* WMI unavailable — return null so the cache retries (Capture supplies a transient default) */
+            return null;
         }
+        // Query succeeded but returned no rows — cache the "unknown" answer.
         return new CpuInfo("Unknown", 0, 0, 0, 0);
     }
 
@@ -183,7 +197,9 @@ public sealed class SystemInfoService
 
     // Physical DIMM inventory — static hardware, enumerated once and cached. Kept separate
     // from the dynamic OS query so the per-poll path never re-scans Win32_PhysicalMemory.
-    private static List<MemoryModule> QueryMemoryModules()
+    // Returns null on a WMI fault so the caller's ??= cache retries next poll; a successful
+    // (even if empty) enumeration returns the list so it is cached.
+    private static List<MemoryModule>? QueryMemoryModules()
     {
         List<MemoryModule> modules = [];
         try
@@ -206,14 +222,20 @@ public sealed class SystemInfoService
         }
         catch (Exception ex) when (ex is ManagementException or System.Runtime.InteropServices.COMException)
         {
-            /* WMI unavailable — return whatever modules enumerated before the fault */
+            // WMI unavailable. If NOTHING enumerated, return null so the cache retries next poll
+            // (a first-call fault must not permanently cache an empty DIMM list). If SOME modules
+            // enumerated before the fault, that partial list is a usable answer — cache it.
+            return modules.Count > 0 ? modules : null;
         }
         return modules;
     }
 
-    private static List<DiskInfo> QueryDisks()
+    // Returns null on a WMI fault that yields NO disks so the caller's ??= cache retries next
+    // poll; a successful (even if empty) enumeration returns the list so it is cached.
+    private static List<DiskInfo>? QueryDisks()
     {
         List<DiskInfo> list = [];
+        var faulted = false;
         // Use Storage namespace for MSFT_PhysicalDisk (gives HealthStatus / MediaType)
         try
         {
@@ -301,10 +323,14 @@ public sealed class SystemInfoService
             }
             catch (Exception exFallback) when (exFallback is ManagementException or System.Runtime.InteropServices.COMException)
             {
-                /* Win32_DiskDrive also unavailable — return whatever enumerated (mirrors the other WMI methods) */
+                /* Win32_DiskDrive also unavailable — both WMI sources faulted */
+                faulted = true;
             }
         }
-        return list;
+        // If WMI faulted AND nothing enumerated from either source, return null so the cache
+        // retries next poll (a first-call fault must not permanently cache an empty disk list).
+        // A partial list (some disks enumerated before the fault) is a usable answer — cache it.
+        return faulted && list.Count == 0 ? null : list;
     }
 
     private static string OpStatusName(ushort v) => v switch

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.88</Version>
-    <FileVersion>1.52.88.0</FileVersion>
-    <AssemblyVersion>1.52.88.0</AssemblyVersion>
+    <Version>1.52.90</Version>
+    <FileVersion>1.52.90.0</FileVersion>
+    <AssemblyVersion>1.52.90.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Fixes a finding from a deep review pass.

`SystemInfoService` caches static hardware info with `??=`, but every `Query*` helper returned a **non-null** fallback on a WMI fault (`CpuInfo("Unknown", …)`, `OsInfo("Windows", …)`, an empty disk/module list). Because the fallback was non-null, `??=` stored it and **never re-queried**. So if the first `CaptureAsync` raced a transient WMI fault — plausible under the app's documented ~36-service startup thundering herd → `RPC server too busy` (0x800706BB) — the fallback defaults were cached **process-wide** (the service is a singleton) even after WMI recovered milliseconds later. The Dashboard, System Info tab, System Report and tray tooltip then permanently showed **"Unknown CPU" / "Windows" / no disks / no RAM modules** until the app was restarted.

## Fix
Cache only a **successful** query:
- `QueryOsStatic` / `QueryCpuStatic` return `null` on a WMI fault (a successful no-rows result still returns the "unknown" answer and is cached).
- `QueryDisks` / `QueryMemoryModules` return `null` only when a fault yielded **nothing**; a genuinely empty-but-successful enumeration (or a partial list gathered before a fault) is a usable answer and is cached.
- `Capture` uses a transient, non-cached default for the current snapshot when the cache is still null, so `??=` retries on the next poll.

## Regression test (integration)
`CaptureAsync_ReQueriesStaticInfo_AfterCacheCleared`: after a successful capture populates the cache, nulling `_cachedCpuStatic` (the post-fault state the fix now produces) and re-capturing must repopulate a real CPU — proving a cleared/null cache is **retried**, not left permanently degraded. **Red before the fix** (the fault path cached a non-null fallback, so the cache was never null to retry).

## Checks
- All 3 projects build 0 warnings / 0 errors
- Leak scan on diff: clean
- Behavior unchanged on the happy path (WMI healthy): static info still queried once and cached