### PR TITLE
fix: WindowsFeaturesService binary-planting LPE via extension-less powershell launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.91] - 2026-07-11
+
+### Fixed
+- **`WindowsFeaturesService` launched PowerShell by the extension-less name `"powershell"`, defeating the System32 path-pinning that blocks binary-planting privilege escalation on an elevated code path.** All three call sites (`ListFeaturesAsync`, `EnableFeatureAsync`, `DisableFeatureAsync` — the enable/disable paths run elevated) called `RunProcessAsync("powershell", …)`. `PowerShellRunner` hardens the target via `SystemPaths.ResolveSystemTool`, but that helper resolved by `File.Exists` and only ever probed the bare name — `File.Exists(@"…\System32\WindowsPowerShell\v1.0\powershell")` is `false` (the file is `powershell.exe`), so both probes missed and it returned the **unrooted** `"powershell"`. With `UseShellExecute=false`, Win32 `CreateProcess` then searches the calling process's own directory first — so an attacker-planted `powershell.exe` next to SysManager's portable .exe (often run from a user-writable folder, sometimes elevated) would execute with the app's privileges. Changed all three sites to `"powershell.exe"` (matching `PowerShellRunner.RunScriptViaPwshAsync` and every other system-tool caller, which all use the `.exe` suffix). **Fix-the-class:** `SystemPaths.ResolveSystemTool` now also probes `"<name>.exe"` when given an extension-less bare name, so a future caller that forgets the suffix can't silently reopen the same hole.
+
 ## [1.52.90] - 2026-07-10
 
 ### Fixed

--- a/SysManager/SysManager.Tests/SystemPathsTests.cs
+++ b/SysManager/SysManager.Tests/SystemPathsTests.cs
@@ -35,6 +35,30 @@ public class SystemPathsTests
     }
 
     [Fact]
+    public void ResolveSystemTool_BareNameWithoutExeSuffix_ResolvesToRootedExistingPath()
+    {
+        // Regression: a caller passing the extension-less name "powershell" (as
+        // WindowsFeaturesService did) must still be pinned to the trusted System32 path.
+        // Before the ".exe"-fallback fix, File.Exists("...\\powershell") was false so the
+        // method fell through and returned the UNROOTED bare name — re-opening the exact
+        // binary-planting/LPE vector the helper exists to close.
+        var resolved = SystemPaths.ResolveSystemTool("powershell");
+        Assert.True(Path.IsPathRooted(resolved), "bare 'powershell' must resolve to a rooted path");
+        Assert.True(File.Exists(resolved), "resolved path must exist on disk");
+        Assert.EndsWith("powershell.exe", resolved, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ResolveSystemTool_BareSystem32NameWithoutExe_ResolvesToRootedExistingPath()
+    {
+        // Same fallback for a plain System32 tool: "cmd" -> full path to cmd.exe.
+        var resolved = SystemPaths.ResolveSystemTool("cmd");
+        Assert.True(Path.IsPathRooted(resolved));
+        Assert.True(File.Exists(resolved));
+        Assert.Equal(Path.Combine(Environment.SystemDirectory, "cmd.exe"), resolved, ignoreCase: true);
+    }
+
+    [Fact]
     public void ResolveSystemTool_AlreadyRootedPath_ReturnedUnchanged()
     {
         const string p = @"C:\Windows\System32\netsh.exe";

--- a/SysManager/SysManager/Helpers/SystemPaths.cs
+++ b/SysManager/SysManager/Helpers/SystemPaths.cs
@@ -34,12 +34,25 @@ internal static class SystemPaths
         if (Path.IsPathRooted(fileName) || fileName.Contains('\\') || fileName.Contains('/'))
             return fileName;
 
-        var direct = Path.Combine(System32, fileName);
-        if (File.Exists(direct)) return direct;
+        // Try the name as given, then with a ".exe" suffix. Callers that pass a bare name
+        // WITHOUT the extension (e.g. "powershell") would otherwise never match on disk —
+        // File.Exists("...\\powershell") is false, only "...\\powershell.exe" exists — so the
+        // method would fall through and return the unrooted bare name, re-opening the exact
+        // binary-planting/LPE vector this helper exists to close. Probing "<name>.exe" as a
+        // fallback makes the guard robust to that mistake (defense-in-depth).
+        var candidates = fileName.Contains('.')
+            ? new[] { fileName }
+            : new[] { fileName, fileName + ".exe" };
 
-        // Windows PowerShell 5.1 lives in a System32 subfolder, not System32 itself.
-        var powerShell = Path.Combine(System32, "WindowsPowerShell", "v1.0", fileName);
-        if (File.Exists(powerShell)) return powerShell;
+        foreach (var name in candidates)
+        {
+            var direct = Path.Combine(System32, name);
+            if (File.Exists(direct)) return direct;
+
+            // Windows PowerShell 5.1 lives in a System32 subfolder, not System32 itself.
+            var powerShell = Path.Combine(System32, "WindowsPowerShell", "v1.0", name);
+            if (File.Exists(powerShell)) return powerShell;
+        }
 
         return fileName;
     }

--- a/SysManager/SysManager/Services/WindowsFeaturesService.cs
+++ b/SysManager/SysManager/Services/WindowsFeaturesService.cs
@@ -33,7 +33,7 @@ public sealed partial class WindowsFeaturesService
         _runner.LineReceived += Collect;
         try
         {
-            await _runner.RunProcessAsync("powershell",
+            await _runner.RunProcessAsync("powershell.exe",
                 "-NoProfile -Command \"Get-WindowsOptionalFeature -Online | " +
                 "Select-Object FeatureName, State | " +
                 "ForEach-Object { $_.FeatureName + '|' + $_.State }\"", ct).ConfigureAwait(false);
@@ -67,7 +67,7 @@ public sealed partial class WindowsFeaturesService
             // Wrap in try/catch + `exit 1` so a DISM cmdlet failure propagates to the
             // process exit code. Without this the cmdlet's non-terminating error is
             // ignored and powershell.exe still exits 0, reporting a false success.
-            var code = await _runner.RunProcessAsync("powershell",
+            var code = await _runner.RunProcessAsync("powershell.exe",
                 $"-NoProfile -Command \"try {{ Enable-WindowsOptionalFeature -Online " +
                 $"-FeatureName '{featureName}' -NoRestart -All -ErrorAction Stop | " +
                 $"Select-Object RestartNeeded | ForEach-Object {{ $_.RestartNeeded }} }} catch {{ exit 1 }}\"", ct).ConfigureAwait(false);
@@ -104,7 +104,7 @@ public sealed partial class WindowsFeaturesService
             // Wrap in try/catch + `exit 1` so a DISM cmdlet failure propagates to the
             // process exit code. Without this the cmdlet's non-terminating error is
             // ignored and powershell.exe still exits 0, reporting a false success.
-            var code = await _runner.RunProcessAsync("powershell",
+            var code = await _runner.RunProcessAsync("powershell.exe",
                 $"-NoProfile -Command \"try {{ Disable-WindowsOptionalFeature -Online " +
                 $"-FeatureName '{featureName}' -NoRestart -ErrorAction Stop | " +
                 $"Select-Object RestartNeeded | ForEach-Object {{ $_.RestartNeeded }} }} catch {{ exit 1 }}\"", ct).ConfigureAwait(false);

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.90</Version>
-    <FileVersion>1.52.90.0</FileVersion>
-    <AssemblyVersion>1.52.90.0</AssemblyVersion>
+    <Version>1.52.91</Version>
+    <FileVersion>1.52.91.0</FileVersion>
+    <AssemblyVersion>1.52.91.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Found by a deep review pass, independently re-verified against the source.

All three `WindowsFeaturesService` call sites — `ListFeaturesAsync` (:36), `EnableFeatureAsync` (:70), `DisableFeatureAsync` (:107); the enable/disable paths run **elevated** — launched PowerShell as the extension-less bare name `"powershell"`.

`PowerShellRunner.RunProcessAsync` hardens the target via `SystemPaths.ResolveSystemTool`, but that helper resolved by `File.Exists` on the exact name only: `File.Exists(@"…\System32\WindowsPowerShell\v1.0\powershell")` is **false** (the file is `powershell.exe`), so both probes missed and it returned the **unrooted** `"powershell"`. With `UseShellExecute=false`, Win32 `CreateProcess` then searches the **calling process's own directory first** — so an attacker-planted `powershell.exe` next to SysManager's single portable.exe (often run from a user-writable folder like Downloads, sometimes elevated) would execute with the app's privileges. This is the same binary-planting / LPE class already fixed for System32 tools and winget.

## Fix
- All three sites now pass `"powershell.exe"` — matching `PowerShellRunner.RunScriptViaPwshAsync` (:163) and every other system-tool caller (`reg.exe`, `schtasks.exe`, `mdsched.exe`, `netplwiz.exe`), which all carry the `.exe` suffix.
- **Fix-the-class:** `SystemPaths.ResolveSystemTool` now also probes `"<name>.exe"` when handed an extension-less bare name, so a future caller that forgets the suffix cannot silently reopen the same hole.

## Regression tests
- `ResolveSystemTool_BareNameWithoutExeSuffix_ResolvesToRootedExistingPath` — `"powershell"` must resolve to a rooted, existing `powershell.exe`. **Red before** (returned the unrooted bare name).
- `ResolveSystemTool_BareSystem32NameWithoutExe_ResolvesToRootedExistingPath` — `"cmd"` → full path to `cmd.exe`. **Red before.**

## Checks
- All 3 projects build 0 warnings / 0 errors
- Leak scan on diff: clean
- PROPAGATE: the remaining unqualified `winget` launches are a *separate* finding (winget is an App Execution Alias, not a System32 tool — needs a winget-specific resolver); tracked for its own PR.