### PR TITLE
docs: reword a banned leak-term flagged by the enforced ban list

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -34,7 +34,7 @@ SysManager/
 The sidebar organises tabs into 12 groups (11 collapsible + a flat top-level Dashboard) via `NavGroup` →
 `NavItem` hierarchy built by `BuildNavGroups()` using `Group()` and
 `Item()` helper methods. Dashboard renders as a flat top-level entry.
-Collapsed groups show a child count badge, subtitle (auto-generated
+Collapsed groups show a child count badge, subtitle (derived
 from child labels joined with " · "), and tooltip.
 Planned features use `PlaceholderViewModel` with a WIP view.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1733,7 +1733,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 - **InitNavigation refactored to data-driven** — sidebar tree construction replaced with
   `BuildNavGroups()` returning a `NavGroup[]` via `Group()` and `Item()` helper methods.
-  Subtitle and Tooltip are auto-generated from child labels.
+  Subtitle and Tooltip are derived from child labels.
 - **Version** aligned to 1.7.17.
 
 ## [1.7.16] - 2026-05-22
@@ -2091,7 +2091,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - Removed redundant `(SolidColorBrush)` cast in
     `OutputKindToBrushConverter`.
 - **CodeQL workflow** — added `codeql-config.yml` to exclude `obj/` and
-  `bin/` directories from analysis (36 alerts in auto-generated code).
+  `bin/` directories from analysis (36 alerts in compiler-generated code).
 
 ## [0.48.27] - 2026-05-15
 


### PR DESCRIPTION
## Summary

Found by a deep review pass, verified against current source.

`leak-terms.txt` (line 28) bans a specific compound term case-insensitively, and the pre-commit hook builds its blocking regex from that exact file. Yet three tracked lines still contained that term:
- `ARCHITECTURE.md:37` — nav-group subtitle description
- `CHANGELOG.md:1736` — a historical entry (nav subtitle)
- `CHANGELOG.md:2094` — a historical entry (CodeQL obj/+bin/ exclusion)

This conflicts with the enforced zero-tolerance list and would **block the pre-commit hook** on any future edit that touches those files.

## Fix
Reworded to meaning-preserving synonyms outside the ban regex:
- the two nav-subtitle lines to 'derived from child labels'
- the CodeQL note to 'compiler-generated code'

The tracked tree is now literally **zero-match** against the ban list for this term (grep returns nothing).

Docs-only change: no version bump, no release.