### PR TITLE
fix: App Alerts 'Start Monitoring' no longer freezes the UI during baseline scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.93] - 2026-07-11
+
+### Fixed
+- **The App Alerts tab froze the window while "Start Monitoring" took its baseline snapshot.** `StartMonitoring` was a synchronous command that called `AppAlertService.TakeBaseline()` directly on the UI thread — a walk of Program Files / Program Files (x86) / LocalAppData\Programs plus a full enumeration of both HKLM `Uninstall` registry trees (hundreds of subkeys), the same heavy scan the tab's own `RefreshInstalledAppsAsync` already offloads with `Task.Run`. On a machine with many installed apps or a slow disk the window hung for the whole scan. `StartMonitoring` is now an async command that runs `TakeBaseline()` + `Start()` on a background thread and resumes on the UI thread to set the monitoring state. This is safe: `FileSystemWatcher` creation is thread-agnostic and the service's `NewAppDetected` event is already marshaled via the `SynchronizationContext` captured at construction.
+
 ## [1.52.92] - 2026-07-11
 
 ### Fixed

--- a/SysManager/SysManager.Tests/AppAlertsViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppAlertsViewModelTests.cs
@@ -63,7 +63,9 @@ public class AppAlertsViewModelTests
         // Regression (idx 235): a manual refresh must not switch off the busy/monitoring
         // affordance while monitoring is active — IsBusy has to track IsMonitoring.
         using var vm = new AppAlertsViewModel(new Services.AppAlertService());
-        vm.StartMonitoringCommand.Execute(null);
+        // StartMonitoring is now async (the baseline scan is offloaded off the UI thread);
+        // await it so IsMonitoring/IsBusy are set before asserting.
+        await vm.StartMonitoringCommand.ExecuteAsync(null);
         Assert.True(vm.IsMonitoring);
         Assert.True(vm.IsBusy);
 
@@ -71,6 +73,25 @@ public class AppAlertsViewModelTests
 
         Assert.True(vm.IsMonitoring);
         Assert.True(vm.IsBusy); // was incorrectly forced to false before the fix
+    }
+
+    [Fact]
+    public async Task StartMonitoring_IsAsync_AndSetsMonitoringState()
+    {
+        // Regression (P2 #42): StartMonitoring was a synchronous [RelayCommand] that ran the
+        // full baseline scan (Program Files walk + double HKLM Uninstall enumeration) on the
+        // UI thread, freezing the window. It is now an async command that offloads the scan.
+        // The generated command must expose IAsyncRelayCommand and, once awaited, leave the
+        // VM monitoring.
+        using var vm = new AppAlertsViewModel(new Services.AppAlertService());
+        Assert.IsAssignableFrom<CommunityToolkit.Mvvm.Input.IAsyncRelayCommand>(vm.StartMonitoringCommand);
+
+        await vm.StartMonitoringCommand.ExecuteAsync(null);
+
+        Assert.True(vm.IsMonitoring);
+        Assert.True(vm.IsBusy);
+
+        vm.StopMonitoringCommand.Execute(null); // clean up watchers/timer
     }
 
     [Fact]

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.92</Version>
-    <FileVersion>1.52.92.0</FileVersion>
-    <AssemblyVersion>1.52.92.0</AssemblyVersion>
+    <Version>1.52.93</Version>
+    <FileVersion>1.52.93.0</FileVersion>
+    <AssemblyVersion>1.52.93.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
@@ -37,12 +37,24 @@ public sealed partial class AppAlertsViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void StartMonitoring()
+    private async Task StartMonitoringAsync()
     {
         if (IsMonitoring) return;
 
-        _service.TakeBaseline();
-        _service.Start();
+        // TakeBaseline() walks Program Files / LocalAppData\Programs AND enumerates both
+        // HKLM Uninstall trees (hundreds of subkeys) — the same heavy scan
+        // RefreshInstalledAppsAsync deliberately offloads. Running it synchronously in the
+        // command froze the UI for the whole scan. Offload it (and Start(), whose
+        // FileSystemWatcher creation is thread-agnostic and whose NewAppDetected event is
+        // marshaled via the SynchronizationContext captured at service construction), then
+        // resume on the UI thread to set the bound state.
+        MonitorStatus = "Starting monitoring…";
+        await Task.Run(() =>
+        {
+            _service.TakeBaseline();
+            _service.Start();
+        }).ConfigureAwait(true);
+
         IsMonitoring = true;
         IsBusy = true;
         MonitorStatus = "Monitoring active — watching for new installations...";


### PR DESCRIPTION
## Summary

Found by a deep review pass, verified against current source.

`AppAlertsViewModel.StartMonitoring` was a **synchronous** `[RelayCommand]` that called `AppAlertService.TakeBaseline()` directly on the UI thread. `TakeBaseline()` walks Program Files / Program Files (x86) / `LocalAppData\Programs` **and** enumerates **both** HKLM `Uninstall` registry trees (hundreds of subkeys) — the same heavy scan the tab's own `RefreshInstalledAppsAsync` already deliberately offloads with `Task.Run`. On a machine with many installed apps or a slow disk, the window froze for the whole scan.

## Fix
`StartMonitoring` is now an **async** command that runs `TakeBaseline()` + `Start()` on a background thread (`Task.Run`) and resumes on the UI thread to set `IsMonitoring`/`IsBusy`/`MonitorStatus`. The generated command name (`StartMonitoringCommand`) is unchanged, so the XAML binding still resolves.

**Safety:** `FileSystemWatcher` creation is thread-agnostic, and the service's `NewAppDetected` event is marshaled via the `SynchronizationContext` captured at service construction — so moving `Start()` off-thread is safe (verified in `AppAlertService`).

## Regression tests
- `StartMonitoring_IsAsync_AndSetsMonitoringState` — the command is now `IAsyncRelayCommand` and, once awaited, leaves the VM monitoring.
- Existing `RefreshInstalledApps_WhileMonitoring_KeepsBusyInSyncWithMonitoring` updated to `await` the now-async command (was `.Execute(null)` fire-and-forget).

## Checks
- All 3 projects build 0 warnings / 0 errors
- Leak scan on diff: clean