### PR TITLE
fix: memoize static disk-name resolution so the Dashboard 2s temp poll stops re-querying WMI/SMART

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.94] - 2026-07-11
+
+### Fixed
+- **The Dashboard's 2-second temperature poll re-ran a Win32_DiskDrive WMI query and a per-disk SMART association walk on every tick, purely to relabel storage sensors with (unchanging) disk names.** `RefreshTemperaturesAsync` calls `TemperatureService.ReadAllAsync()` with `includeStorage` defaulting to `true`; on an elevated session that ran `GetDiskNamesFromWmi()` (a `Win32_DiskDrive` query) **and** `EnrichStorageNamesAsync` → `DiskHealthService.CollectAsync()` (an `MSFT_PhysicalDisk` enumeration plus a per-disk `MSFT_StorageReliabilityCounter` walk — by the code's own comments "by far the heaviest part of a read") every 2 seconds while the Dashboard (the app's default tab) was open. Disk friendly-names are static hardware identity, so both resolutions are now memoized once (mirroring the existing `_nvApiInitTried` "resolve static hardware once" pattern), with a `SemaphoreSlim` gate making the first resolution race-safe across the 2s poll, the user's Refresh, and the 10s resource sampler. After the first read the hot poll only calls LibreHardwareMonitor's `Update()` for live temperatures.
+
 ## [1.52.93] - 2026-07-11
 
 ### Fixed

--- a/SysManager/SysManager.IntegrationTests/TemperatureServiceMemoizeTests.cs
+++ b/SysManager/SysManager.IntegrationTests/TemperatureServiceMemoizeTests.cs
@@ -1,0 +1,48 @@
+// SysManager · TemperatureServiceMemoizeTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Reflection;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.IntegrationTests;
+
+/// <summary>
+/// Regression (P2 #14): the Dashboard's 2s temperature poll called
+/// <c>ReadAllAsync(includeStorage: true)</c>, which re-resolved static disk friendly-names on
+/// every tick — a Win32_DiskDrive WMI query plus a DiskHealthService SMART-association walk (the
+/// heaviest part of a read). Disk names are static hardware identity, so <see cref="TemperatureService"/>
+/// now memoizes both resolutions once. These tests pin the memoization contract at the cache-field
+/// level (the service has no interface seam and the resolution paths are elevation/WMI-gated, so a
+/// call-count spy isn't available — the private enricher is driven directly and the cache asserted).
+/// </summary>
+public class TemperatureServiceMemoizeTests
+{
+    private static readonly MethodInfo EnrichMethod =
+        typeof(TemperatureService).GetMethod("EnrichStorageNamesAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    private static FieldInfo CacheField =>
+        typeof(TemperatureService).GetField("_cachedStorageFriendlyNames", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    private static async Task InvokeEnrichAsync(TemperatureService svc, List<TemperatureReading> readings)
+        => await (Task)EnrichMethod.Invoke(svc, [readings])!;
+
+    [Fact]
+    public async Task EnrichStorageNames_ResolvesOnce_AndCachesFriendlyNames()
+    {
+        using var svc = new TemperatureService(new DiskHealthService());
+        var readings = new List<TemperatureReading>();
+
+        // First enrich resolves + caches the friendly names (real DiskHealthService; on a WMI-less
+        // CI host CollectAsync degrades to an empty list — still a valid, cached resolution).
+        await InvokeEnrichAsync(svc, readings);
+        var afterFirst = CacheField.GetValue(svc);
+        Assert.NotNull(afterFirst); // cache populated (even if empty) — never re-resolved after this
+
+        // Second enrich must reuse the SAME cached instance, not re-run the SMART walk.
+        await InvokeEnrichAsync(svc, readings);
+        var afterSecond = CacheField.GetValue(svc);
+        Assert.Same(afterFirst, afterSecond);
+    }
+}

--- a/SysManager/SysManager/Services/TemperatureService.cs
+++ b/SysManager/SysManager/Services/TemperatureService.cs
@@ -32,6 +32,15 @@ public sealed class TemperatureService : IDisposable
     private Computer? _computer;
     private bool _disposed;
 
+    // Disk friendly-names are static hardware identity — they never change during a session,
+    // yet the Dashboard's 2s temperature poll (includeStorage=true) re-resolved them every tick
+    // via a Win32_DiskDrive WMI query AND a DiskHealthService SMART-association walk (by far the
+    // heaviest part of a read). Memoize both once — mirroring the _nvApiInitTried "resolve static
+    // hardware once" pattern — so the hot poll only calls LHM Update() for live temps.
+    private List<string>? _cachedWmiDiskNames;      // GetDiskNamesFromWmi(), guarded by _sensorLock
+    private List<string>? _cachedStorageFriendlyNames; // DiskHealthService friendly names, guarded by _enrichGate
+    private readonly SemaphoreSlim _enrichGate = new(1, 1);
+
     public TemperatureService(DiskHealthService diskHealth, bool skipHardwareInit = false)
     {
         _diskHealth = diskHealth;
@@ -84,8 +93,10 @@ public sealed class TemperatureService : IDisposable
                 _computer ??= OpenComputer();
 
                 // Pre-fetch disk names from WMI for cross-reference (skipped on the fast path —
-                // this WMI query runs every poll otherwise and the sampler doesn't need names).
-                var diskNames = includeStorage ? GetDiskNamesFromWmi() : [];
+                // the sampler doesn't need names). Memoized: disk models are static hardware, so
+                // resolve the Win32_DiskDrive query once and reuse it — the 2s poll no longer
+                // re-queries WMI every tick. Guarded by _sensorLock (already held here).
+                var diskNames = includeStorage ? (_cachedWmiDiskNames ??= GetDiskNamesFromWmi()) : [];
 
                 foreach (var hardware in _computer.Hardware)
                 {
@@ -229,14 +240,33 @@ public sealed class TemperatureService : IDisposable
             catch (Exception ex) { Log.Debug(ex, "LibreHardwareMonitor close failed"); }
             _computer = null;
         }
+        _enrichGate.Dispose();
     }
 
     private async Task EnrichStorageNamesAsync(List<TemperatureReading> readings)
     {
         try
         {
-            var disks = await _diskHealth.CollectAsync();
-            var diskNames = disks.Select(d => d.FriendlyName).ToList();
+            // The friendly names come from DiskHealthService.CollectAsync()'s MSFT_PhysicalDisk +
+            // per-disk MSFT_StorageReliabilityCounter (SMART) walk — the heaviest part of a read.
+            // They are static hardware identity, so resolve once and cache; the 2s Dashboard poll
+            // then skips the SMART walk entirely on every tick after the first. The gate makes the
+            // first-resolution race-safe when the poll, the user Refresh, and the sampler overlap.
+            var diskNames = _cachedStorageFriendlyNames;
+            if (diskNames is null)
+            {
+                await _enrichGate.WaitAsync().ConfigureAwait(false);
+                try
+                {
+                    if (_cachedStorageFriendlyNames is null)
+                    {
+                        var disks = await _diskHealth.CollectAsync().ConfigureAwait(false);
+                        _cachedStorageFriendlyNames = disks.Select(d => d.FriendlyName).ToList();
+                    }
+                    diskNames = _cachedStorageFriendlyNames;
+                }
+                finally { _enrichGate.Release(); }
+            }
 
             var storageReadings = readings
                 .Select((r, i) => (Reading: r, Index: i))

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.93</Version>
-    <FileVersion>1.52.93.0</FileVersion>
-    <AssemblyVersion>1.52.93.0</AssemblyVersion>
+    <Version>1.52.94</Version>
+    <FileVersion>1.52.94.0</FileVersion>
+    <AssemblyVersion>1.52.94.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Found by a deep review pass, verified against current source.

`RefreshTemperaturesAsync` calls `TemperatureService.ReadAllAsync()` with `includeStorage` defaulting to **true**. On an elevated session, the Dashboard's **2-second** temperature poll (the Dashboard is the app's default/home tab) therefore ran, on **every tick**:
- `GetDiskNamesFromWmi()` — a `Win32_DiskDrive` WMI query, and
- `EnrichStorageNamesAsync` → `DiskHealthService.CollectAsync()` — an `MSFT_PhysicalDisk` enumeration **plus a per-disk `MSFT_StorageReliabilityCounter` (SMART) association walk**, which the code's own comments call *"by far the heaviest part of a read."*

All of that was spent solely to relabel LibreHardwareMonitor storage sensors with disk friendly-names — **static hardware identity that never changes**. (The 10s resource sampler was already optimized to skip this with `includeStorage:false`; the more frequent Dashboard poll was not.)

## Fix
Both resolutions are memoized once, mirroring the existing `_nvApiInitTried` "resolve static hardware once" pattern:
- `_cachedWmiDiskNames` (`??=`, under the existing `_sensorLock`).
- `_cachedStorageFriendlyNames` behind a `SemaphoreSlim` gate (double-checked) so the first resolution is race-safe when the 2s poll, the user's Refresh, and the 10s sampler overlap.

After the first read the hot poll only calls LibreHardwareMonitor's `Update()` for live temperatures. `_enrichGate` is disposed in `Dispose()`.

## Regression test (integration)
`EnrichStorageNames_ResolvesOnce_AndCachesFriendlyNames` — drives the private enricher twice and asserts `_cachedStorageFriendlyNames` is populated once and **reference-stable** across calls (proving it resolves once). `DiskHealthService.CollectAsync()` degrades to an empty list on a WMI-less CI host but still caches, so the assertion is deterministic.

## Checks
- All 3 projects build 0 warnings / 0 errors
- Leak scan on diff: clean
- Behavior unchanged: the same friendly-names are applied; they're just resolved once instead of every 2s.