### PR TITLE
fix: RunOnce startup items report an honest 'cannot disable' instead of a fake success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.95] - 2026-07-11
+
+### Fixed
+- **Disabling a "run once" startup item in the Startup Manager reported success but did nothing — the item still ran at the next boot.** The scan lists both the `Run` and `RunOnce` registry keys, and `SetEnabledAsync` keyed purely off the entry's scope, so disabling a `RunOnce` entry wrote the "disabled" blob to `…\Explorer\StartupApproved\Run\{name}` and returned success. But Windows has no `StartupApproved\RunOnce` subkey and never consults `StartupApproved` for `RunOnce` keys, so the command still executed on the next boot while the UI showed "Disabled" — a system-mutation toggle that silently lied to the (non-technical) user. `SetEnabledAsync` now detects a `RunOnce` entry and returns a truthful non-success with a plain-language message ("Run-once item — runs next boot, then removes itself; cannot be disabled here.") instead of writing an ineffective blob. The item stays visible so the user still knows it's scheduled to run once.
+
 ## [1.52.94] - 2026-07-11
 
 ### Fixed

--- a/SysManager/SysManager.Tests/StartupToggleTests.cs
+++ b/SysManager/SysManager.Tests/StartupToggleTests.cs
@@ -107,4 +107,34 @@ public class StartupToggleTests
 
         Assert.True(entry.IsEnabled);
     }
+
+    // ---------- RunOnce entries can't be toggled via StartupApproved (P2 #35) ----------
+
+    [Theory]
+    [InlineData(StartupSource.RegistryCurrentUser)]
+    [InlineData(StartupSource.RegistryLocalMachine)]
+    public async Task SetEnabledAsync_RunOnce_ReturnsFalseWithHonestMessage_AndDoesNotDisable(StartupSource source)
+    {
+        // Regression (P2 #35): Windows has no StartupApproved\RunOnce and never consults
+        // StartupApproved for RunOnce keys, so the old code wrote the disable blob to
+        // StartupApproved\Run and returned true — the item still ran at next boot while the
+        // UI showed "Disabled". The toggle must now report a truthful non-success and leave
+        // IsEnabled untouched (the RunOnce guard short-circuits before any registry write).
+        var entry = new StartupEntry
+        {
+            Name = "OneShotSetup",
+            Command = "setup.exe /oncemore",
+            Source = source,
+            RegistryKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce",
+            ValueName = "OneShotSetup",
+            IsEnabled = true,
+            StatusText = "Enabled"
+        };
+
+        var result = await StartupService.SetEnabledAsync(entry, false);
+
+        Assert.False(result);
+        Assert.Contains("run-once", entry.StatusText, StringComparison.OrdinalIgnoreCase);
+        Assert.True(entry.IsEnabled); // never flipped to disabled
+    }
 }

--- a/SysManager/SysManager/Services/StartupService.cs
+++ b/SysManager/SysManager/Services/StartupService.cs
@@ -332,6 +332,17 @@ public sealed class StartupService
                 return await SetTaskSchedulerEnabledAsync(entry, enabled).ConfigureAwait(false);
             }
 
+            // RunOnce entries cannot be toggled via StartupApproved: Windows has no
+            // StartupApproved\RunOnce subkey and never consults StartupApproved for RunOnce
+            // keys, so writing the disable blob to StartupApproved\Run (the fallback below)
+            // does nothing while returning success — the item still runs at next boot and the
+            // UI falsely shows "Disabled". Report the truth instead of pretending it worked.
+            if (entry.RegistryKey.EndsWith("RunOnce", StringComparison.OrdinalIgnoreCase))
+            {
+                entry.StatusText = "Run-once item — runs next boot, then removes itself; cannot be disabled here.";
+                return false;
+            }
+
             var (root, approvedPath) = entry.Source switch
             {
                 StartupSource.RegistryCurrentUser => (Registry.CurrentUser, ApprovedRunHKCU),

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.94</Version>
-    <FileVersion>1.52.94.0</FileVersion>
-    <AssemblyVersion>1.52.94.0</AssemblyVersion>
+    <Version>1.52.95</Version>
+    <FileVersion>1.52.95.0</FileVersion>
+    <AssemblyVersion>1.52.95.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Found by a deep review pass, verified against current source.

The Startup scan lists both the `Run` **and** `RunOnce` registry keys, and `SetEnabledAsync` keyed purely off the entry's scope (`RegistryCurrentUser`/`RegistryLocalMachine`). So disabling a `RunOnce` entry wrote the "disabled" blob to `…\Explorer\StartupApproved\Run\{name}` and returned **true**. But Windows has **no `StartupApproved\RunOnce` subkey** and never consults `StartupApproved` for `RunOnce` keys — so the command still ran at the next boot while the UI reported **"Disabled"**. For a startup manager aimed at non-technical users, a disable that claims success but doesn't disable is a trust/correctness defect.

## Fix
`SetEnabledAsync` now detects a `RunOnce` entry (its `RegistryKey` ends with `RunOnce`) and returns a truthful non-success with a plain-language message — *"Run-once item — runs next boot, then removes itself; cannot be disabled here."* — instead of writing an ineffective blob. The item stays **visible** (the user still sees it's scheduled to run once), and the ViewModel already reverts the checkbox on a `false` return, so the toggle snaps back with the explanation.

## Regression test
`SetEnabledAsync_RunOnce_ReturnsFalseWithHonestMessage_AndDoesNotDisable` (HKCU + HKLM RunOnce): returns `false`, status contains "run-once", `IsEnabled` stays `true`. **Red before** the fix (returned `true`, flipped `IsEnabled` to false, *and* wrote the real HKCU registry as a side effect); **green after** (the guard short-circuits before any registry access).

## Checks
- All 3 projects build 0 warnings / 0 errors
- Leak scan on diff: clean
- Plain `Run` entries are unaffected — only keys ending in `RunOnce` hit the guard.