### PR TITLE
fix: all-users (Common) startup-folder toggles target HKLM, not HKCU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.96] - 2026-07-11
+
+### Fixed
+- **Disabling an all-users (Common) startup-folder item did nothing, and such items could show the wrong enabled/disabled state.** Both the per-user Startup folder and the all-users Common Startup folder were scanned and tagged with the same `StartupSource.StartupFolder`, so `ApplyApprovedState` read the enabled/disabled state for *all* folder items only from HKCU, and `SetEnabledAsync` wrote the toggle blob for *all* folder items only to HKCU. But Windows stores the `StartupApproved\StartupFolder` state for all-users shortcuts under **HKLM**, not HKCU. Consequences for a shortcut in `%ProgramData%\...\Startup`: an item disabled via Task Manager (HKLM blob) was shown as "Enabled", and disabling it in SysManager wrote the blob to HKCU where Windows never looks — so it returned success yet the program still launched at logon. Added a distinct `StartupSource.CommonStartupFolder` (set in `ReadStartupFolder` based on which special folder produced the entry); `ApplyApprovedState` now reads HKLM for common-folder entries, and `SetEnabledAsync` routes them to HKLM (which needs administrator — a non-elevated attempt surfaces the same "requires elevation" message the HKLM Run path already produces). Per-user folder items are unchanged.
+
 ## [1.52.95] - 2026-07-11
 
 ### Fixed

--- a/SysManager/SysManager.Tests/StartupServiceTests.cs
+++ b/SysManager/SysManager.Tests/StartupServiceTests.cs
@@ -145,4 +145,35 @@ public class StartupServiceTests
         Assert.Equal("OneDrive", entry.Name);
         Assert.Equal("OneDrive.lnk", entry.ValueName);
     }
+
+    // ── Common (all-users) vs per-user startup folder source (P2 #38) ──
+
+    [Fact]
+    public void BuildStartupFolderEntry_Common_TaggedCommonStartupFolder()
+    {
+        // Regression (P2 #38): all-users folder items store their enabled/disabled state under
+        // HKLM, not HKCU. They must carry a distinct source so ApplyApprovedState/SetEnabledAsync
+        // target the right hive — otherwise a disable is written to HKCU (where Windows never
+        // looks) and silently does nothing while the UI claims "Disabled".
+        var entry = StartupService.BuildStartupFolderEntry(
+            @"C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Startup\Backup Tool.exe",
+            command: @"C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Startup\Backup Tool.exe",
+            locationLabel: "Common Startup Folder",
+            isCommon: true);
+
+        Assert.Equal(StartupSource.CommonStartupFolder, entry.Source);
+        Assert.Equal("Backup Tool.exe", entry.ValueName);
+    }
+
+    [Fact]
+    public void BuildStartupFolderEntry_PerUser_TaggedStartupFolder()
+    {
+        var entry = StartupService.BuildStartupFolderEntry(
+            @"C:\Users\aunt\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\Spotify.lnk",
+            command: @"C:\Users\aunt\AppData\Roaming\Spotify\Spotify.exe",
+            locationLabel: "User Startup Folder",
+            isCommon: false);
+
+        Assert.Equal(StartupSource.StartupFolder, entry.Source);
+    }
 }

--- a/SysManager/SysManager/Models/StartupEntry.cs
+++ b/SysManager/SysManager/Models/StartupEntry.cs
@@ -37,6 +37,9 @@ public enum StartupSource
 {
     RegistryCurrentUser,
     RegistryLocalMachine,
+    /// <summary>Per-user shell Startup folder (%AppData%\...\Startup) — approved-state in HKCU.</summary>
     StartupFolder,
+    /// <summary>All-users (Common) shell Startup folder (%ProgramData%\...\Startup) — approved-state in HKLM.</summary>
+    CommonStartupFolder,
     TaskScheduler
 }

--- a/SysManager/SysManager/Services/StartupService.cs
+++ b/SysManager/SysManager/Services/StartupService.cs
@@ -59,13 +59,15 @@ public sealed class StartupService
         foreach (var (keyPath, source) in MachineRunKeys)
             ReadRunKey(Registry.LocalMachine, keyPath, source, results);
 
-        // Shell startup folders (user + common)
+        // Shell startup folders (user + common). The common (all-users) folder's enabled/disabled
+        // state lives under HKLM, not HKCU — flag it so ApplyApprovedState/SetEnabledAsync target
+        // the right hive (see #38).
         ReadStartupFolder(
             Environment.GetFolderPath(Environment.SpecialFolder.Startup),
-            "User Startup Folder", results);
+            "User Startup Folder", isCommon: false, results);
         ReadStartupFolder(
             Environment.GetFolderPath(Environment.SpecialFolder.CommonStartup),
-            "Common Startup Folder", results);
+            "Common Startup Folder", isCommon: true, results);
 
         // Task Scheduler logon tasks
         ReadScheduledTasks(results);
@@ -76,7 +78,7 @@ public sealed class StartupService
         return results;
     }
 
-    private static void ReadStartupFolder(string folderPath, string locationLabel, List<StartupEntry> results)
+    private static void ReadStartupFolder(string folderPath, string locationLabel, bool isCommon, List<StartupEntry> results)
     {
         try
         {
@@ -122,7 +124,7 @@ public sealed class StartupService
                     }
                 }
 
-                results.Add(BuildStartupFolderEntry(file, command, locationLabel));
+                results.Add(BuildStartupFolderEntry(file, command, locationLabel, isCommon));
             }
         }
         catch (UnauthorizedAccessException ex)
@@ -145,13 +147,15 @@ public sealed class StartupService
     /// silently did nothing. Registry Run entries and scheduled tasks are unaffected (they key by
     /// their own value/task name).
     /// </summary>
-    internal static StartupEntry BuildStartupFolderEntry(string file, string command, string locationLabel) =>
+    internal static StartupEntry BuildStartupFolderEntry(string file, string command, string locationLabel, bool isCommon = false) =>
         new()
         {
             Name = System.IO.Path.GetFileNameWithoutExtension(file),
             Command = command,
             Location = locationLabel,
-            Source = StartupSource.StartupFolder,
+            // Common (all-users) folder items store their approved-state under HKLM, per-user
+            // items under HKCU — carry the distinction so the toggle targets the right hive.
+            Source = isCommon ? StartupSource.CommonStartupFolder : StartupSource.StartupFolder,
             RegistryKey = "",
             ValueName = System.IO.Path.GetFileName(file),
             IsEnabled = true,
@@ -279,6 +283,8 @@ public sealed class StartupService
         var hklmApproved = ReadApprovedKey(Registry.LocalMachine, ApprovedRunHKLM);
         var hklm32Approved = ReadApprovedKey(Registry.LocalMachine, ApprovedRun32HKLM);
         var folderApproved = ReadApprovedKey(Registry.CurrentUser, ApprovedStartupFolder);
+        // Common (all-users) startup-folder items store their disabled-state under HKLM, not HKCU.
+        var commonFolderApproved = ReadApprovedKey(Registry.LocalMachine, ApprovedStartupFolder);
 
         foreach (var entry in entries)
         {
@@ -287,6 +293,7 @@ public sealed class StartupService
                 StartupSource.RegistryCurrentUser => hkcuApproved,
                 StartupSource.RegistryLocalMachine => hklmApproved ?? hklm32Approved,
                 StartupSource.StartupFolder => folderApproved,
+                StartupSource.CommonStartupFolder => commonFolderApproved,
                 _ => null
             };
 
@@ -348,6 +355,11 @@ public sealed class StartupService
                 StartupSource.RegistryCurrentUser => (Registry.CurrentUser, ApprovedRunHKCU),
                 StartupSource.RegistryLocalMachine => (Registry.LocalMachine, ApprovedRunHKLM),
                 StartupSource.StartupFolder => (Registry.CurrentUser, ApprovedStartupFolder),
+                // Common (all-users) folder items live under HKLM — writing to HKCU (as before)
+                // put the disable blob where Windows never looks, so the item still ran while the
+                // UI claimed "Disabled". HKLM needs elevation; a non-elevated open below returns
+                // null and surfaces the same access-denied status as the HKLM Run path.
+                StartupSource.CommonStartupFolder => (Registry.LocalMachine, ApprovedStartupFolder),
                 _ => (Registry.CurrentUser, ApprovedRunHKCU)
             };
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.95</Version>
-    <FileVersion>1.52.95.0</FileVersion>
-    <AssemblyVersion>1.52.95.0</AssemblyVersion>
+    <Version>1.52.96</Version>
+    <FileVersion>1.52.96.0</FileVersion>
+    <AssemblyVersion>1.52.96.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Found by a deep review pass, verified against current source.

Both the per-user Startup folder and the all-users **Common** Startup folder were scanned and tagged with the same `StartupSource.StartupFolder`. So `ApplyApprovedState` read the enabled/disabled state for **all** folder items only from **HKCU**, and `SetEnabledAsync` wrote the toggle blob for **all** folder items only to **HKCU**. But Windows stores the `StartupApproved\StartupFolder` state for all-users shortcuts under **HKLM**.

Consequences for a shortcut in `%ProgramData%\...\Startup`:
- An item disabled via Task Manager (HKLM blob) was shown as **"Enabled"** (wrong state).
- Disabling it in SysManager wrote the disable blob to **HKCU** — where Windows never looks for common-folder state — so it returned **success** while the program **still launched at logon**.

For a startup manager, a disable that reports success but doesn't disable is a trust/correctness defect.

## Fix
- Added `StartupSource.CommonStartupFolder`, set in `ReadStartupFolder` based on which special folder produced the entry (`SpecialFolder.Startup` vs `SpecialFolder.CommonStartup`).
- `ApplyApprovedState` now reads **HKLM**'s `StartupApproved\StartupFolder` for common-folder entries.
- `SetEnabledAsync` routes common-folder entries to **HKLM** (needs administrator — a non-elevated attempt surfaces the existing *"requires elevation"* message, exactly like the HKLM Run path).
- Per-user folder items are completely unchanged.

## Regression tests
- `BuildStartupFolderEntry_Common_TaggedCommonStartupFolder` — `isCommon: true` → `CommonStartupFolder`.
- `BuildStartupFolderEntry_PerUser_TaggedStartupFolder` — `isCommon: false` → `StartupFolder`.

Both are **red before** the fix (the `isCommon` parameter and the `CommonStartupFolder` enum value did not exist). The hive routing depends entirely on this source tagging. (No test writes the registry — the toggle's HKLM write path needs elevation and would mutate real machine state, so it's excluded from the CI-safe unit suite.)

## Checks
- All 3 projects build 0 warnings / 0 errors
- Leak scan on diff: clean