### PR TITLE
fix: serialize Performance tab system-mutations through the operation lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.97] - 2026-07-11
+
+### Fixed
+- **The Performance tab's system-mutating actions weren't serialized against each other, so "Restore All" could run while an "Apply" was still in flight and corrupt the reversible snapshot.** Every Apply command (power plan, visual effects, Game Mode, Xbox Game Bar, GPU, processor state) plus Restore All, Trim RAM, Create Restore Point and Toggle Hibernation is `async` and awaits real system work (registry writes, `powercfg`, `EmptyWorkingSet` across all processes). Nothing prevented a second command from starting mid-flight: the snapshot's own `SemaphoreSlim` only guards the load-modify of the `_snapshot` field, not the full apply→revert sequence. In the worst case, pressing **Restore All** while an Apply's registry write was still running let Restore All null `_snapshot` and delete the persisted baseline, leaving a tweak applied with nothing left to revert it (and other tabs that mutate the same system state — Tweaks, Cleanup's SFC/DISM — could interleave too). Every one of these ten commands now acquires the app-wide `OperationLockService` `SystemModification` lock (the same lock SFC/DISM and the Environment Variables editor already use) right after its confirmation dialog; if another system-modification operation is running, the command reports "Cannot start — <op> is already running." and bails before touching the system. Toggle-based commands re-sync their toggle from the live profile on that early return so the UI doesn't show a change that wasn't applied.
+
 ## [1.52.96] - 2026-07-11
 
 ### Fixed

--- a/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Reflection;
+using NSubstitute;
 using SysManager.Services;
 using SysManager.ViewModels;
 
@@ -11,6 +13,12 @@ namespace SysManager.Tests;
 /// Tests for <see cref="PerformanceViewModel"/>. Verifies initial state,
 /// per-section commands, and property defaults.
 /// </summary>
+/// <remarks>
+/// In the DialogService collection (serialized): the operation-lock regression
+/// tests below swap the global <see cref="DialogService.Instance"/> and take the
+/// shared <see cref="OperationLockService"/>, both process-wide singletons.
+/// </remarks>
+[Collection("DialogService")]
 public class PerformanceViewModelTests
 {
     private static PerformanceViewModel NewVm()
@@ -202,5 +210,115 @@ public class PerformanceViewModelTests
         // (offloaded), not executed synchronously on the dispatcher.
         var vm = NewVm();
         Assert.IsAssignableFrom<CommunityToolkit.Mvvm.Input.IAsyncRelayCommand>(vm.TrimRamCommand);
+    }
+
+    // ── System-modification lock (ultra-audit #46) ──
+    //
+    // Every mutating command (Apply* / Restore All / Trim RAM / Create restore point /
+    // Toggle hibernation) must serialize through OperationLockService before touching the
+    // system. Without it, Restore All can null the snapshot mid-Apply and leave a tweak
+    // applied with nothing to revert it. These pin the guard the way ShortcutCleaner's
+    // DeleteSelected_WhenDiskLocked_DoesNotDelete pins its Disk-lock guard: stub the dialog
+    // to "Yes", hold the SystemModification lock, and prove the command bails at the guard.
+
+    private static void SeedSnapshot(PerformanceViewModel vm)
+    {
+        // Restore All early-returns when _snapshot is null (before the lock guard). Seed a
+        // snapshot via the private field so the command reaches the guard we're testing.
+        var snapshot = new PerformanceService.OriginalSnapshot(
+            PowerPlanGuid: "guid", PowerPlanName: "Balanced", UiEffectsEnabled: true,
+            GameModeEnabled: true, XboxGameBarEnabled: true, XboxGameDvrEnabled: true,
+            GpuDynamicPstate: true, ProcessorMinPercentAc: 5, NvidiaSubKey: null);
+        typeof(PerformanceViewModel)
+            .GetField("_snapshot", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(vm, snapshot);
+    }
+
+    [Fact]
+    public async Task RestoreAll_WhenSystemModificationLocked_BailsAtGuard()
+    {
+        var vm = NewVm();
+        SeedSnapshot(vm);
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true); // user clicks "Yes"
+        DialogService.Instance = dialog;
+
+        // Hold the SystemModification lock so Restore All must bail rather than race an Apply.
+        using var held = OperationLockService.Instance.TryAcquire(
+            OperationCategory.SystemModification, "Test Holder");
+        Assert.NotNull(held);
+        try
+        {
+            await vm.RestoreAllCommand.ExecuteAsync(null);
+
+            // Confirm was shown, but the lock was unavailable → the command reported the
+            // contention and did NOT run the restore body (which nulls _snapshot). The seeded
+            // snapshot survives, proving the guard short-circuited before the mutation.
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            Assert.Contains("already running", vm.StatusMessage);
+            var snapshotAfter = typeof(PerformanceViewModel)
+                .GetField("_snapshot", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(vm);
+            Assert.NotNull(snapshotAfter);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public async Task TrimRam_WhenSystemModificationLocked_BailsAtGuard()
+    {
+        var vm = NewVm();
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+
+        using var held = OperationLockService.Instance.TryAcquire(
+            OperationCategory.SystemModification, "Test Holder");
+        Assert.NotNull(held);
+        try
+        {
+            await vm.TrimRamCommand.ExecuteAsync(null);
+
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            Assert.Contains("already running", vm.StatusMessage);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public async Task ApplyPowerPlan_WhenSystemModificationLocked_BailsAtGuard()
+    {
+        var vm = NewVm();
+        // Force SelectedPlan away from the current plan so the "already set" early-return
+        // (before the lock guard) doesn't short-circuit the command first.
+        vm.SelectedPlan = "ultimate";
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+
+        using var held = OperationLockService.Instance.TryAcquire(
+            OperationCategory.SystemModification, "Test Holder");
+        Assert.NotNull(held);
+        try
+        {
+            await vm.ApplyPowerPlanCommand.ExecuteAsync(null);
+            Assert.Contains("already running", vm.StatusMessage);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.96</Version>
-    <FileVersion>1.52.96.0</FileVersion>
-    <AssemblyVersion>1.52.96.0</AssemblyVersion>
+    <Version>1.52.97</Version>
+    <FileVersion>1.52.97.0</FileVersion>
+    <AssemblyVersion>1.52.97.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
@@ -159,6 +159,17 @@ public sealed partial class PerformanceViewModel : ViewModelBase
             $"Switch power plan to {planName}?",
             "Power Plan — Confirm")) return;
 
+        // Serialize every system-mutating command through the app-wide lock (like the SFC/DISM
+        // and Environment-variable operations). Without it, Apply* and Restore All can race:
+        // e.g. Restore All can delete the snapshot + null _snapshot while an Apply's registry
+        // write is still in flight, leaving a tweak applied with no snapshot to revert it.
+        using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "Apply power plan");
+        if (opLock is null)
+        {
+            StatusMessage = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.SystemModification)} is already running.";
+            return;
+        }
+
         IsBusy = true;
         IsProgressIndeterminate = true;
         try
@@ -209,6 +220,15 @@ public sealed partial class PerformanceViewModel : ViewModelBase
             $"{action} visual effects (animations, fades, shadows)?",
             "Visual Effects — Confirm")) { SyncTogglesFromProfile(); return; }
 
+        // Serialize with the app-wide system-modification lock (see ApplyPowerPlanAsync).
+        using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "Apply visual effects");
+        if (opLock is null)
+        {
+            StatusMessage = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.SystemModification)} is already running.";
+            SyncTogglesFromProfile();
+            return;
+        }
+
         IsBusy = true;
         IsProgressIndeterminate = true;
         try
@@ -246,6 +266,15 @@ public sealed partial class PerformanceViewModel : ViewModelBase
             $"{action} Game Mode?",
             "Game Mode — Confirm")) { SyncTogglesFromProfile(); return; }
 
+        // Serialize with the app-wide system-modification lock (see ApplyPowerPlanAsync).
+        using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "Apply Game Mode");
+        if (opLock is null)
+        {
+            StatusMessage = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.SystemModification)} is already running.";
+            SyncTogglesFromProfile();
+            return;
+        }
+
         IsBusy = true;
         IsProgressIndeterminate = true;
         try
@@ -280,6 +309,15 @@ public sealed partial class PerformanceViewModel : ViewModelBase
         if (!DialogService.Instance.Confirm(
             $"{action} Xbox Game Bar and Game DVR overlay?",
             "Xbox Game Bar — Confirm")) { SyncTogglesFromProfile(); return; }
+
+        // Serialize with the app-wide system-modification lock (see ApplyPowerPlanAsync).
+        using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "Apply Xbox Game Bar");
+        if (opLock is null)
+        {
+            StatusMessage = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.SystemModification)} is already running.";
+            SyncTogglesFromProfile();
+            return;
+        }
 
         IsBusy = true;
         IsProgressIndeterminate = true;
@@ -321,6 +359,15 @@ public sealed partial class PerformanceViewModel : ViewModelBase
             $"{action} NVIDIA GPU max performance (DisableDynamicPstate)?\n\n"
             + "⚠ This change requires a REBOOT to take effect.",
             "GPU Performance — Confirm")) { SyncTogglesFromProfile(); return; }
+
+        // Serialize with the app-wide system-modification lock (see ApplyPowerPlanAsync).
+        using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "Apply GPU performance");
+        if (opLock is null)
+        {
+            StatusMessage = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.SystemModification)} is already running.";
+            SyncTogglesFromProfile();
+            return;
+        }
 
         IsBusy = true;
         IsProgressIndeterminate = true;
@@ -379,6 +426,15 @@ public sealed partial class PerformanceViewModel : ViewModelBase
             $"{action} processor minimum state?",
             "Processor State — Confirm")) { SyncTogglesFromProfile(); return; }
 
+        // Serialize with the app-wide system-modification lock (see ApplyPowerPlanAsync).
+        using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "Apply processor state");
+        if (opLock is null)
+        {
+            StatusMessage = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.SystemModification)} is already running.";
+            SyncTogglesFromProfile();
+            return;
+        }
+
         IsBusy = true;
         IsProgressIndeterminate = true;
         try
@@ -413,6 +469,14 @@ public sealed partial class PerformanceViewModel : ViewModelBase
 
         if (!DialogService.Instance.Confirm("Create a System Restore point?\n\nThis saves the current system state so you can roll back later if something goes wrong.", "Restore Point — Confirm")) return;
 
+        // Serialize with the app-wide system-modification lock (see ApplyPowerPlanAsync).
+        using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "Create restore point");
+        if (opLock is null)
+        {
+            StatusMessage = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.SystemModification)} is already running.";
+            return;
+        }
+
         IsBusy = true;
         IsProgressIndeterminate = true;
         StatusMessage = "Creating restore point…";
@@ -446,6 +510,14 @@ public sealed partial class PerformanceViewModel : ViewModelBase
             + "Apps may feel briefly slower on next access.\n\n"
             + "This is the same as \"Empty Working Set\" in RAMMap.",
             "RAM Trim — Confirm")) return;
+
+        // Serialize with the app-wide system-modification lock (see ApplyPowerPlanAsync).
+        using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "Trim RAM");
+        if (opLock is null)
+        {
+            StatusMessage = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.SystemModification)} is already running.";
+            return;
+        }
 
         try
         {
@@ -484,6 +556,14 @@ public sealed partial class PerformanceViewModel : ViewModelBase
         if (!DialogService.Instance.Confirm(
             $"{action} hibernation?\n\n{detail}",
             "Hibernation — Confirm")) return;
+
+        // Serialize with the app-wide system-modification lock (see ApplyPowerPlanAsync).
+        using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "Toggle hibernation");
+        if (opLock is null)
+        {
+            StatusMessage = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.SystemModification)} is already running.";
+            return;
+        }
 
         IsBusy = true;
         IsProgressIndeterminate = true;
@@ -527,6 +607,16 @@ public sealed partial class PerformanceViewModel : ViewModelBase
             + (gpuWasChanged ? "• GPU → Dynamic P-state (reboot needed)\n" : "")
             + "\nContinue?",
             "Restore Original Settings — Confirm")) return;
+
+        // Serialize with the app-wide system-modification lock (see ApplyPowerPlanAsync). This is
+        // the finding's core: without it, Restore All can run concurrently with an Apply command
+        // and revert to / persist a half-mutated snapshot.
+        using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "Restore all performance settings");
+        if (opLock is null)
+        {
+            StatusMessage = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.SystemModification)} is already running.";
+            return;
+        }
 
         IsBusy = true;
         IsProgressIndeterminate = true;


### PR DESCRIPTION
## Problem

Every system-mutating command on the Performance tab is `async` and awaits real system work (registry writes, `powercfg`, `EmptyWorkingSet` across all processes), but nothing serialized them against each other. The snapshot's `SemaphoreSlim` guards only the load-modify of the `_snapshot` field — not the full apply→revert sequence.

Worst case: pressing **Restore All** while an **Apply**'s registry write was still in flight let Restore All null `_snapshot` and delete the persisted baseline, leaving a tweak applied with nothing to revert it. Other tabs that mutate the same system state (Tweaks, Cleanup's SFC/DISM) could interleave too.

## Fix

All ten mutating commands (Apply power plan / visual effects / Game Mode / Xbox Game Bar / GPU / processor state, plus Restore All, Trim RAM, Create Restore Point, Toggle Hibernation) now acquire the app-wide `OperationLockService` `SystemModification` lock — the same lock SFC/DISM and the Environment Variables editor already use — immediately after the confirmation dialog. If another system-modification operation holds it, the command reports `Cannot start — <op> is already running.` and bails before touching the system. Toggle-based commands re-sync from the live profile on that early return so the UI never shows an unapplied change.

This also aligns the tab with its sibling `EnvironmentVariablesViewModel`, which already wraps every mutation in the same guard.

## Tests

Three regression tests pin the guard (dialog stubbed to Yes + `SystemModification` lock held → command bails at the guard, snapshot preserved), mirroring `ShortcutCleanerViewModelTests.DeleteSelected_WhenDiskLocked_DoesNotDelete`:
- `RestoreAll_WhenSystemModificationLocked_BailsAtGuard` (asserts `_snapshot` survives)
- `TrimRam_WhenSystemModificationLocked_BailsAtGuard`
- `ApplyPowerPlan_WhenSystemModificationLocked_BailsAtGuard`

Regression test red before fix / green after: without the guard the commands proceed past the (absent) lock check and set a success/other status — `Assert.Contains("already running")` fails; with the guard they short-circuit and it passes. (`dotnet test` is not run locally; verified via CI.)

## Regression sweep

- `dotnet build` main + tests: **0 warnings / 0 errors**.
- Leak-term + debug-code scan on both touched files: clean.
- Author headers intact; version bumped 1.52.96 → 1.52.97; CHANGELOG entry in this PR.