### PR TITLE
fix: serialize Gaming Profile crash-recovery on the service gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.99] - 2026-07-11
+
+### Fixed
+- **The Gaming Profile crash-recovery sweep reverted the leftover session and rewrote its store without holding the service lock, so a quick Start click could race it.** On launch, if a previous run closed with game-mode tweaks still applied, the tab offers to revert them via `RecoverPendingAsync`. Unlike `ApplyAsync` and `RevertAsync` — which both serialize on the service's `SemaphoreSlim` (`_gate`) — `RecoverPendingAsync` ran its `RunRevertAsync` **and** its `LoadStore`→`SaveStore` completely ungated. After the user answered the "restore?" dialog the UI was live again, so clicking **Start** launched `ApplyAsync` concurrently with the still-running recovery revert: two paths reverting/applying the same machine-wide tweaks (power plan, visual effects, search indexing, notifications) and doing an unsynchronized read-modify-write of the on-disk store — which could lose the `ActiveSession = null` clear (resurrecting the leftover marker so it re-prompts forever) or interleave conflicting tweak steps. `RecoverPendingAsync` now acquires `_gate` for its whole body (mirroring `RevertAsync`, including the `ConfigureAwait(false)` that keeps the gate-release continuation off the UI thread so `Dispose`'s shutdown `_gate.Wait()` can't deadlock) and re-reads the store **inside** the gate so the read-modify-write is atomic against a concurrent `SaveStore`.
+
 ## [1.52.98] - 2026-07-11
 
 ### Fixed

--- a/SysManager/SysManager.Tests/GamingProfileServiceTests.cs
+++ b/SysManager/SysManager.Tests/GamingProfileServiceTests.cs
@@ -473,4 +473,63 @@ public class GamingProfileServiceTests
         }
         finally { if (File.Exists(path)) File.Delete(path); }
     }
+
+    // ── Ultra-audit fix: RecoverPendingAsync must serialize on _gate ───────────
+    //
+    // The startup crash-recovery sweep used to revert the leftover session and rewrite the store
+    // WITHOUT holding _gate. After the user answers the "restore?" dialog the UI is live again, so a
+    // Start click could run ApplyAsync concurrently with the still-running recovery revert — two
+    // paths mutating the same machine-wide tweaks and doing an unsynchronized LoadStore→SaveStore,
+    // which can lose the ActiveSession=null clear (resurrecting the leftover marker) or interleave
+    // conflicting steps. The fix wraps RecoverPendingAsync in _gate like RevertAsync. This pins that
+    // contract deterministically: while a revert is suspended HOLDING the gate, RecoverPendingAsync
+    // must not proceed (it is parked on _gate.WaitAsync) — and it completes once the gate frees.
+
+    private static string SerializePendingStore(GamingProfileStore store)
+        => JsonSerializer.Serialize(store with { SchemaVersion = GamingProfileService.CurrentSchemaVersion },
+            new JsonSerializerOptions { WriteIndented = true });
+
+    [Fact]
+    public async Task RecoverPendingAsync_WaitsForGate_WhenARevertHoldsIt()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"sm-gaming-rec-{Guid.NewGuid():N}.json");
+        try
+        {
+            // A pending session with an ALL-FALSE profile: BuildMachineWideSteps returns an empty
+            // list, so recovery's own revert is an inert no-op (no power/registry/service call) —
+            // the test stays deterministic and touches nothing on the machine.
+            File.WriteAllText(path, SerializePendingStore(new GamingProfileStore
+            {
+                ActiveSession = new GamingSessionRecord(new GamingProfile(), new GamingSnapshot()),
+            }));
+
+            var svc = StoreOnlyService(path);
+            Assert.True(svc.HasPendingRecovery, "precondition: a leftover session is present on disk");
+
+            // Start a revert that suspends INSIDE the gated step — RevertAsync is now holding _gate.
+            var tweak = new GatedRevertTweak();
+            svc.SeedAppliedStepForTest(tweak);        // IsActive → true
+            var revert = svc.RevertAsync();           // acquires _gate, then parks on the step
+            Assert.True(await CompletesWithinAsync(tweak.Entered),
+                "RevertAsync never reached the suspending step (so it isn't holding the gate yet)");
+
+            // With the fix, RecoverPendingAsync must block on _gate.WaitAsync while the revert holds
+            // it. Deterministic assertion (no timing window): the returned Task is NOT yet completed.
+            var recover = svc.RecoverPendingAsync();
+            Assert.False(recover.IsCompleted,
+                "RecoverPendingAsync completed while a revert held _gate — it is not serializing on the gate (the race).");
+
+            // Release the revert; its gate-release lets the parked recovery acquire, run its (empty)
+            // revert, clear the marker, and complete.
+            tweak.Resume();
+            Assert.True(await CompletesWithinAsync(revert), "the suspended revert did not complete after Resume");
+            Assert.True(await CompletesWithinAsync(recover),
+                "RecoverPendingAsync never completed after the gate was released");
+
+            // The leftover marker is cleared exactly once, under the gate.
+            Assert.False(StoreOnlyService(path).HasPendingRecovery,
+                "the recovered session's ActiveSession marker should be cleared after recovery");
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
 }

--- a/SysManager/SysManager/Services/GamingProfileService.cs
+++ b/SysManager/SysManager/Services/GamingProfileService.cs
@@ -238,16 +238,30 @@ public sealed class GamingProfileService : IGamingProfileService, IDisposable
 
     public async Task RecoverPendingAsync(CancellationToken ct = default)
     {
-        var store = LoadStore();
-        if (store.ActiveSession is not { } session) return;
+        // Serialize with ApplyAsync / RevertAsync on _gate. Without this the startup recovery
+        // sweep runs unguarded: after the user answers the "restore?" dialog, the UI is live
+        // again and a Start click can launch ApplyAsync while this revert + store rewrite is
+        // still in flight — two paths reverting/applying the same machine-wide tweaks and doing
+        // an unsynchronized LoadStore→SaveStore, which can lose the ActiveSession=null clear (so
+        // the leftover marker resurrects) or interleave conflicting tweak steps. Reload the store
+        // INSIDE the gate so the read-modify-write is atomic against a concurrent SaveStore.
+        // ConfigureAwait(false) under the gate for the same anti-deadlock reason as RevertAsync
+        // (Dispose's blocking _gate.Wait() at shutdown must never wait on a UI-thread continuation).
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var store = LoadStore();
+            if (store.ActiveSession is not { } session) return;
 
-        // Rebuild ONLY the machine-wide tweaks from the persisted snapshot (per-game
-        // affinity/priority are not persisted — a since-recycled PID must never be touched)
-        // and revert them through the SAME engine path as an in-session revert.
-        var steps = BuildMachineWideSteps(session.Profile, session.Snapshot);
-        await RunRevertAsync(steps, ct).ConfigureAwait(true);
-        SaveStore(store with { ActiveSession = null });
-        Log.Information("Gaming Profile recovered a leftover session from a previous run");
+            // Rebuild ONLY the machine-wide tweaks from the persisted snapshot (per-game
+            // affinity/priority are not persisted — a since-recycled PID must never be touched)
+            // and revert them through the SAME engine path as an in-session revert.
+            var steps = BuildMachineWideSteps(session.Profile, session.Snapshot);
+            await RunRevertAsync(steps, ct).ConfigureAwait(false);
+            SaveStore(store with { ActiveSession = null });
+            Log.Information("Gaming Profile recovered a leftover session from a previous run");
+        }
+        finally { _gate.Release(); }
     }
 
     // ── Snapshot + step construction ───────────────────────────────────────────

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.98</Version>
-    <FileVersion>1.52.98.0</FileVersion>
-    <AssemblyVersion>1.52.98.0</AssemblyVersion>
+    <Version>1.52.99</Version>
+    <FileVersion>1.52.99.0</FileVersion>
+    <AssemblyVersion>1.52.99.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem (P2 — startup race, non-destructive but user-visible)

On launch, if a previous run closed/crashed with game-mode tweaks still applied, the Gaming Profile tab offers to revert them via `GamingProfileService.RecoverPendingAsync`. Unlike `ApplyAsync` and `RevertAsync` — which both serialize on the service's `SemaphoreSlim` (`_gate`) — `RecoverPendingAsync` ran its `RunRevertAsync` **and** its `LoadStore`→`SaveStore` **completely ungated**.

After the user answers the "restore leftover changes?" dialog, the UI is live again. Clicking **Start** then launches `ApplyAsync` concurrently with the still-running recovery revert:
- Two paths reverting/applying the **same machine-wide tweaks** (power plan, visual effects, search indexing, notifications) at once.
- An **unsynchronized read-modify-write** of the on-disk store: recovery's `LoadStore … SaveStore(store with { ActiveSession = null })` can interleave with Apply's `SaveStore(… with { ActiveSession = <new> })`, losing one write. If the `ActiveSession = null` clear is the one lost, the leftover marker **resurrects** and the app re-prompts for recovery on every launch.

## Fix

`RecoverPendingAsync` now acquires `_gate` for its whole body, mirroring `RevertAsync`:
- Serializes against `ApplyAsync` / `RevertAsync` (a concurrent Start now waits for recovery to finish, and vice-versa).
- Re-reads the store **inside** the gate so the read-modify-write is atomic against a concurrent `SaveStore`.
- Uses `ConfigureAwait(false)` under the gate for the same anti-deadlock reason the other two do (the gate-release continuation must stay off the UI thread so `Dispose`'s shutdown `_gate.Wait()` can't deadlock against it).

All three gate consumers (`ApplyAsync`, `RevertAsync`, `RecoverPendingAsync`) are now consistent.

## Test

`RecoverPendingAsync_WaitsForGate_WhenARevertHoldsIt` — reuses the file's existing deterministic seam (`GatedRevertTweak`, which suspends on a signal the test controls — no wall-clock): with a revert suspended **holding** `_gate`, `RecoverPendingAsync()`'s returned Task is asserted **not completed** (it's parked on `_gate.WaitAsync`); after `Resume()`, both complete and the `ActiveSession` marker is cleared exactly once. The pending session uses an all-false profile so recovery's own revert is an inert no-op (no power/registry/service call) — fully deterministic, touches nothing on the machine.

Red→green: pre-fix (ungated) `RecoverPendingAsync` completes immediately even while the revert holds the gate, so `Assert.False(recover.IsCompleted)` fails; post-fix it blocks on the gate → passes. (`dotnet test` not run locally per repo policy; verified via CI.)

## Regression sweep
- `dotnet build` main + tests: **0 warnings / 0 errors**.
- Leak-term + debug-code scan on both touched files: clean.
- Author headers intact; version bumped 1.52.98 → 1.52.99; CHANGELOG entry in this PR.
