### PR TITLE
fix: refuse to block SysManager's own executable in App Blocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.100] - 2026-07-11
+
+### Fixed
+- **App Blocker could block SysManager's own executable, making the app impossible to relaunch and impossible to unblock from within the app.** `BlockApp` writes an IFEO `Debugger` redirection for any executable name that passes validation, and it already refuses a fixed set of boot-critical processes (`winlogon.exe`, `lsass.exe`, …) precisely because an IFEO block on those is unrecoverable — but SysManager's own executable was not protected. A user could block it trivially (the Browse button fills in the real file name of any picked `.exe`, or they could just type it), after which the next launch is redirected to the non-existent `System32\SysManager_Blocked.exe` and fails; because `UnblockApp` requires the app to be running, recovery then needs `regedit` — beyond the non-technical target user. `BlockApp` now refuses to block SysManager's own executable (resolved once from `Environment.ProcessPath`, matching both the dev name `SysManager.exe` and the released `SysManager-vX.Y.Z.exe`), enforced at the service trust boundary alongside the existing boot-critical guard.
+
 ## [1.52.99] - 2026-07-11
 
 ### Fixed

--- a/SysManager/SysManager.Tests/AppBlockerServiceRegistryTests.cs
+++ b/SysManager/SysManager.Tests/AppBlockerServiceRegistryTests.cs
@@ -109,4 +109,35 @@ public sealed class AppBlockerServiceRegistryTests : IDisposable
         Assert.True(_svc.UnblockApp("external.exe"));
         Assert.Equal(@"C:\Tools\dbg.exe", ReadDebugger("external.exe"));
     }
+
+    // ── Ultra-audit fix: never let App Blocker block SysManager itself ─────────
+    //
+    // An IFEO block on our own exe is unrecoverable in-app (UnblockApp needs the app running,
+    // but the next launch is redirected to the non-existent blocker path and fails) — the same
+    // hazard the BootCriticalExecutables list guards. The own-exe name is injectable so this
+    // test can drive the guard (the xUnit host's process name is testhost/dotnet, not SysManager).
+
+    [Theory]
+    [InlineData("SysManager.exe", "SysManager.exe")]           // dev/assembly name
+    [InlineData("SysManager-v1.52.99.exe", "SysManager-v1.52.99.exe")] // released name
+    [InlineData("sysmanager.exe", "SysManager.exe")]           // case-insensitive
+    [InlineData("SysManager", "SysManager.exe")]               // bare name (.exe appended before the check)
+    public void BlockApp_OwnExecutable_IsRefused_AndNotWritten(string typedName, string ownExeName)
+    {
+        var svc = new AppBlockerService(_root, ownExecutableName: ownExeName);
+
+        Assert.False(svc.BlockApp(typedName));
+        // Prove nothing was written to the (redirected) IFEO hive — the guard bailed before the write.
+        Assert.Null(ReadDebugger(ownExeName));
+        Assert.False(svc.IsBlocked(ownExeName));
+    }
+
+    [Fact]
+    public void BlockApp_OwnExeGuard_DoesNotBlockOtherApps()
+    {
+        // The self-guard must not over-reach: a different app is still blockable as normal.
+        var svc = new AppBlockerService(_root, ownExecutableName: "SysManager.exe");
+        Assert.True(svc.BlockApp("notepad.exe"));
+        Assert.Equal(BlockerDebugger, ReadDebugger("notepad.exe"));
+    }
 }

--- a/SysManager/SysManager/Services/AppBlockerService.cs
+++ b/SysManager/SysManager/Services/AppBlockerService.cs
@@ -51,12 +51,44 @@ public sealed partial class AppBlockerService : IAppBlockerService
     private readonly RegistryKey _baseKey;
 
     /// <summary>
+    /// The file name of SysManager's own running executable (e.g. <c>SysManager.exe</c> in dev,
+    /// <c>SysManager-vX.Y.Z.exe</c> when released), used by <see cref="BlockApp"/> to refuse a
+    /// self-block. Resolved once from <see cref="Environment.ProcessPath"/> (falling back to the
+    /// main-module name). Injectable so the self-block guard is unit-testable — the xUnit host's
+    /// own process name is testhost/dotnet, not SysManager, so a test passes the app's real name.
+    /// </summary>
+    private readonly string? _ownExecutableName;
+
+    private string? OwnExecutableName => _ownExecutableName;
+
+    /// <summary>
     /// Creates the service over a registry root. Defaults to
     /// <see cref="Registry.LocalMachine"/> (the real IFEO hive); tests pass a
     /// redirected root (e.g. an HKCU subkey) to avoid admin and machine writes.
     /// </summary>
-    public AppBlockerService(RegistryKey? baseKey = null)
-        => _baseKey = baseKey ?? Registry.LocalMachine;
+    /// <param name="baseKey">IFEO registry root (defaults to HKLM).</param>
+    /// <param name="ownExecutableName">Override for the app's own exe file name (defaults to the
+    /// real running process's file name). Tests pass this to exercise the self-block guard.</param>
+    public AppBlockerService(RegistryKey? baseKey = null, string? ownExecutableName = null)
+    {
+        _baseKey = baseKey ?? Registry.LocalMachine;
+        _ownExecutableName = ownExecutableName ?? ResolveOwnExecutableName();
+    }
+
+    private static string? ResolveOwnExecutableName()
+    {
+        try
+        {
+            var path = Environment.ProcessPath;
+            if (!string.IsNullOrEmpty(path)) return Path.GetFileName(path);
+            using var proc = System.Diagnostics.Process.GetCurrentProcess();
+            return proc.MainModule?.ModuleName;
+        }
+        // MainModule can throw for a protected/cross-bitness process; a null own-name simply
+        // disables the self-guard (fail-open) rather than crashing block operations.
+        catch (System.ComponentModel.Win32Exception) { return null; }
+        catch (InvalidOperationException) { return null; }
+    }
 
     /// <summary>
     /// Blocks an executable from running.
@@ -81,6 +113,18 @@ public sealed partial class AppBlockerService : IAppBlockerService
         if (BootCriticalExecutables.Contains(exeName))
         {
             Log.Warning("Refusing to block boot-critical executable: {ExeName}", exeName);
+            return false;
+        }
+
+        // Never block SysManager's own executable. UnblockApp requires the app to be
+        // running, so an IFEO block on our own exe is unrecoverable in-app (the next
+        // launch is redirected to the non-existent blocker path and fails) — the same
+        // "unrecoverable IFEO block" hazard the boot-critical list guards. Reachable via
+        // Browse (fills in the picked exe's real name) or by typing it; matches both the
+        // dev name (SysManager.exe) and the released name (SysManager-vX.Y.Z.exe).
+        if (OwnExecutableName is { } self && exeName.Equals(self, StringComparison.OrdinalIgnoreCase))
+        {
+            Log.Warning("Refusing to block SysManager's own executable: {ExeName}", exeName);
             return false;
         }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.99</Version>
-    <FileVersion>1.52.99.0</FileVersion>
-    <AssemblyVersion>1.52.99.0</AssemblyVersion>
+    <Version>1.52.100</Version>
+    <FileVersion>1.52.100.0</FileVersion>
+    <AssemblyVersion>1.52.100.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem (P2 — unrecoverable self-block)

`AppBlockerService.BlockApp` writes an IFEO `Debugger` redirection for any executable name that passes validation. It already refuses a fixed set of **boot-critical** processes (`winlogon.exe`, `lsass.exe`, …) precisely because an IFEO block on those is unrecoverable — but **SysManager's own executable was not protected**.

A user could block it trivially: the Browse button fills `NewExeName` with the real file name of any picked `.exe`, or they could just type it. After that, the next launch is redirected to the non-existent `System32\SysManager_Blocked.exe` and fails. Because `UnblockApp` requires the app to be running, the app can no longer unblock itself — recovery needs `regedit`, which is beyond the non-technical target persona. Same "unrecoverable IFEO block" class the boot-critical list guards; the app just failed to protect itself.

## Fix

`BlockApp` now refuses to block SysManager's own executable, right after the boot-critical guard (service trust boundary, not just the ViewModel). The own-exe name is resolved once from `Environment.ProcessPath` (falling back to the main-module name), so it matches both the dev/assembly name `SysManager.exe` and the released `SysManager-vX.Y.Z.exe`. If the process path can't be read the guard fails open (returns null → no self-guard) rather than breaking all block operations.

The own-exe name is **injectable** (`new AppBlockerService(baseKey, ownExecutableName)`) so the guard is unit-testable — the xUnit host's own process name is `testhost`/`dotnet`, not SysManager.

## Tests

New cases in the redirected-HKCU registry harness (no admin, no machine writes):
- `BlockApp_OwnExecutable_IsRefused_AndNotWritten` — blocking the own exe by dev name / released name / case variant / bare name returns false **and** writes nothing to the IFEO hive.
- `BlockApp_OwnExeGuard_DoesNotBlockOtherApps` — a different app is still blockable (no over-reach).

Red→green: pre-fix `BlockApp("SysManager.exe")` returns true and writes the Debugger value, failing both asserts; post-fix it bails before the write. (`dotnet test` not run locally per repo policy; verified via CI.)

## Regression sweep
- `dotnet build` main + tests: **0 warnings / 0 errors**.
- Leak-term + debug-code scan on both touched files: clean.
- Author headers intact; version bumped 1.52.99 → 1.52.100; CHANGELOG entry in this PR.
