### PR TITLE
fix: theme-brush + a11y consistency (ToggleSwitch focus, badges, Logs, checkboxes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.102] - 2026-07-11
+
+### Fixed
+- **Keyboard focus was invisible on every toggle switch.** The shared `ToggleSwitch` style set `FocusVisualStyle` to null but — unlike every other interactive style (buttons, TextBox) — had no `IsKeyboardFocused` trigger, so a keyboard user tabbing onto a switch (severity filters, performance tweaks, startup entries, Windows features, …) got no focus cue while Space still flipped it (WCAG 2.4.7). The switch's Track now shows an accent focus ring when focused, matching the button styles; a reserved transparent 1.5px border keeps the layout from shifting when it lights up.
+- **Windows Update category badges were unreadable on the light themes.** Seven of the eight category badge colors (Security, Defender, Driver, Servicing, .NET, Feature upgrade, default) were hardcoded pale dark-theme tints (~1.8:1 on the near-white light presets), while only "Cumulative" had been migrated to a theme brush. All eight now use per-preset status/badge brushes that `ThemeService` recomputes for light-theme legibility.
+- **The Logs tab's Critical severity card and two filter dots bypassed the per-preset color palette.** The Critical card's background/stripe/dot and the Error/Verbose filter dots were hardcoded (the Critical card's 8%-alpha red was near-invisible on light themes — the most severe category was the least visible), while the sibling Error/Warning/Info cards re-themed. Critical now uses new per-preset `CriticalText`/`CriticalBgSubtle` brushes, and the Error/Verbose dots use `Danger`/`TextMuted` — so all severity colors flow through one palette. The colorblind-safe ▲ glyph is unchanged.
+
+### Accessibility
+- **The DNS/Hosts "On" checkboxes and the Windows Update per-row select checkboxes had no accessible name**, so a screen reader announced an unnamed checkbox with no way to tell which host entry or update it toggled. Each now names its row (e.g. "Enable hosts entry example.com", "Select <update title>"), matching the App Updates / Shortcut Cleaner / Uninstaller grids.
+
+### Changed
+- **App Blocker tab's bottom gutter now matches every other tab** (root margin `28,24,28,16` instead of `28,24,28,0`), so its footer no longer sits flush against the window edge when switching tabs.
+
 ## [1.52.100] - 2026-07-11
 
 ### Fixed

--- a/SysManager/SysManager.Tests/ThemeStatusBrushTests.cs
+++ b/SysManager/SysManager.Tests/ThemeStatusBrushTests.cs
@@ -125,6 +125,47 @@ public class ThemeStatusBrushTests
                             Lookup(ThemeService.StatusPalette(false), key));
     }
 
+    // Critical (LogsView) + category-badge text brushes added when those views were migrated off
+    // hardcoded pale dark-theme tints. Same regression class as the semantic brushes above: pin AA
+    // on the tinted light surface and mode-divergence so the light-theme washout can't return.
+    [Theory]
+    [InlineData("CriticalText")]
+    [InlineData("BadgeIndigoText")]
+    [InlineData("BadgePurpleText")]
+    [InlineData("BadgePinkText")]
+    public void LightPalette_CriticalAndBadgeText_MeetsWcagAaOnTintedSurface(string key)
+    {
+        var ratio = ContrastRatio(Lookup(ThemeService.StatusPalette(false), key), LightTintedSurface);
+        Assert.True(ratio >= 4.5,
+            $"Light-theme '{key}' must meet WCAG AA (4.5:1) as small badge text on the most-tinted light surface; got {ratio:F2}:1.");
+    }
+
+    [Theory]
+    [InlineData("CriticalText")]
+    [InlineData("BadgeIndigoText")]
+    [InlineData("BadgePurpleText")]
+    [InlineData("BadgePinkText")]
+    public void DarkPalette_CriticalAndBadgeText_StaysLegibleOnDark(string key)
+    {
+        var ratio = ContrastRatio(Lookup(ThemeService.StatusPalette(true), key), DarkSurface);
+        Assert.True(ratio >= 4.5,
+            $"Dark-theme '{key}' must stay legible (4.5:1) on the dark surface; got {ratio:F2}:1.");
+    }
+
+    [Fact]
+    public void CriticalAndBadge_PresentInBothModes_AndDiverge()
+    {
+        foreach (var key in new[] { "CriticalText", "CriticalBgSubtle", "BadgeIndigoText", "BadgePurpleText", "BadgePinkText" })
+        {
+            Assert.Contains(key, ThemeService.StatusPalette(true).Select(p => p.Key));
+            Assert.Contains(key, ThemeService.StatusPalette(false).Select(p => p.Key));
+        }
+        // The text tones must differ per mode (the whole point of migrating off the fixed literal).
+        foreach (var key in new[] { "CriticalText", "BadgeIndigoText", "BadgePurpleText", "BadgePinkText" })
+            Assert.NotEqual(Lookup(ThemeService.StatusPalette(true), key),
+                            Lookup(ThemeService.StatusPalette(false), key));
+    }
+
     private static Color Lookup(IReadOnlyList<(string Key, Color Color)> palette, string key)
         => palette.First(p => p.Key == key).Color;
 

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -422,7 +422,10 @@
                                      presets TextMuted is an accent-family tint (tuned for AA body text),
                                      so it collided with the ON Accent and the on/off states looked alike.
                                      Surface4 stays a neutral grey in both modes, keeping OFF clearly distinct. -->
-                                <Border x:Name="Track" CornerRadius="11" Background="{DynamicResource Surface4}"/>
+                                <!-- BorderThickness reserved at 1.5 (transparent) so the IsKeyboardFocused
+                                     trigger can light the Accent ring without shifting the thumb/track layout. -->
+                                <Border x:Name="Track" CornerRadius="11" Background="{DynamicResource Surface4}"
+                                        BorderThickness="1.5" BorderBrush="Transparent"/>
                                 <Border x:Name="Thumb" Width="18" Height="18" CornerRadius="9"
                                         Background="White" HorizontalAlignment="Left" Margin="2,2,0,2"
                                         VerticalAlignment="Center">
@@ -439,6 +442,15 @@
                                 </Trigger>
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter TargetName="Track" Property="Opacity" Value="0.88"/>
+                                </Trigger>
+                                <!-- Keyboard focus ring (a11y, WCAG 2.4.7): the other interactive styles
+                                     (ButtonBase, Ghost/Admin/Danger buttons, TextBox) all carry this trigger;
+                                     ToggleSwitch was missed, so a keyboard user tabbing onto a switch saw no
+                                     focus cue while Space still toggled it. Track is a Border, so it takes an
+                                     Accent border like the button styles do. -->
+                                <Trigger Property="IsKeyboardFocused" Value="True">
+                                    <Setter TargetName="Track" Property="BorderBrush" Value="{DynamicResource Accent}"/>
+                                    <Setter TargetName="Track" Property="BorderThickness" Value="1.5"/>
                                 </Trigger>
                                 <Trigger Property="IsEnabled" Value="False">
                                     <Setter Property="Opacity" Value="0.4"/>

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -255,6 +255,15 @@ public sealed class ThemeService
             ("InfoText", C("#7DD3FC")), ("InfoBgSubtle", C("#1A38BDF8")), ("InfoBorder", C("#3338BDF8")),
             ("DangerText", C("#F87171")), ("DangerBgSubtle", C("#1AEF4444")), ("DangerBorder", C("#33EF4444")),
 
+            // Critical severity (LogsView): a distinct, hotter red than Danger. Dark values mirror the
+            // previous hardcoded #FF3B30 literals so dark themes are unchanged; the light array darkens
+            // them for AA legibility on near-white surfaces (the Critical card used to stay invisible).
+            ("CriticalText", C("#FF3B30")), ("CriticalBgSubtle", C("#14FF3B30")),
+            // WindowsUpdate category badges: Driver/.NET/Feature-upgrade have no semantic equivalent,
+            // so they get their own per-preset brushes (Security/Defender/Servicing reuse Danger/Success/
+            // Info text). Dark = the previous hardcoded Tailwind-300 tints; light darkened for AA.
+            ("BadgeIndigoText", C("#A5B4FC")), ("BadgePurpleText", C("#D8B4FE")), ("BadgePinkText", C("#F9A8D4")),
+
             // Base semantic brushes (used directly as small-text Foreground / dot Fill across the app,
             // e.g. Cleanup's TEMP-folders stat). These were static App.xaml resources that never
             // recomputed per mode, so their light-cyan/green/amber/red washed out on near-white light
@@ -275,6 +284,13 @@ public sealed class ThemeService
             ("SuccessText", C("#15803D")), ("SuccessBgSubtle", C("#2622C55E")), ("SuccessBorder", C("#5522C55E")),
             ("InfoText", C("#0369A1")), ("InfoBgSubtle", C("#2638BDF8")), ("InfoBorder", C("#5538BDF8")),
             ("DangerText", C("#B91C1C")), ("DangerBgSubtle", C("#26EF4444")), ("DangerBorder", C("#55EF4444")),
+
+            // Critical severity (LogsView) — darker red than dark-mode so the Critical card/dot stay AA
+            // on the tinted light surfaces (was a fixed #FF3B30 that washed out); BgSubtle bumped alpha.
+            ("CriticalText", C("#B01508")), ("CriticalBgSubtle", C("#20FF3B30")),
+            // Category badges darkened for AA on light presets (indigo-700 / purple-700 / pink-800).
+            // pink-800 #9D174D (not pink-700) clears 4.5:1 on the most-tinted light surface #FBCFE8.
+            ("BadgeIndigoText", C("#4338CA")), ("BadgePurpleText", C("#7E22CE")), ("BadgePinkText", C("#9D174D")),
 
             // Light: darker, saturated tones that meet WCAG AA as SMALL text — not just on pure white,
             // but on the most-tinted light preset card surface (soft-blossom Surface2 #FBCFE8 is the

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.100</Version>
-    <FileVersion>1.52.100.0</FileVersion>
-    <AssemblyVersion>1.52.100.0</AssemblyVersion>
+    <Version>1.52.102</Version>
+    <FileVersion>1.52.102.0</FileVersion>
+    <AssemblyVersion>1.52.102.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AppBlockerView.xaml
+++ b/SysManager/SysManager/Views/AppBlockerView.xaml
@@ -10,7 +10,7 @@
              mc:Ignorable="d"
              Background="{DynamicResource Surface0}">
 
-    <Grid Margin="28,24,28,0">
+    <Grid Margin="28,24,28,16">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -139,7 +139,20 @@
                           VirtualizingPanel.IsVirtualizing="True"
                           VirtualizingPanel.VirtualizationMode="Recycling">
                     <DataGrid.Columns>
-                        <DataGridCheckBoxColumn Header="On" Binding="{Binding IsEnabled, UpdateSourceTrigger=PropertyChanged}" Width="40" MinWidth="40" CanUserResize="False"/>
+                        <DataGridCheckBoxColumn Header="On" Binding="{Binding IsEnabled, UpdateSourceTrigger=PropertyChanged}" Width="40" MinWidth="40" CanUserResize="False">
+                            <!-- Per-row name so a screen reader announces which hosts entry each checkbox
+                                 enables, matching the AppUpdates/ShortcutCleaner/Uninstaller checkbox columns. -->
+                            <DataGridCheckBoxColumn.ElementStyle>
+                                <Style TargetType="CheckBox">
+                                    <Setter Property="AutomationProperties.Name" Value="{Binding Hostname, StringFormat='Enable hosts entry {0}'}"/>
+                                </Style>
+                            </DataGridCheckBoxColumn.ElementStyle>
+                            <DataGridCheckBoxColumn.EditingElementStyle>
+                                <Style TargetType="CheckBox">
+                                    <Setter Property="AutomationProperties.Name" Value="{Binding Hostname, StringFormat='Enable hosts entry {0}'}"/>
+                                </Style>
+                            </DataGridCheckBoxColumn.EditingElementStyle>
+                        </DataGridCheckBoxColumn>
                         <DataGridTextColumn Header="IP Address" Binding="{Binding IpAddress}" Width="150" MinWidth="80" IsReadOnly="True"/>
                         <DataGridTextColumn Header="Hostname" Binding="{Binding Hostname}" Width="*" MinWidth="120" IsReadOnly="True"/>
                         <DataGridTextColumn Header="Comment" Binding="{Binding Comment}" Width="150" MinWidth="80" IsReadOnly="True"/>

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -43,14 +43,16 @@
 
         <!-- Severity count glass cards -->
         <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="28,16,28,0">
-            <!-- Critical -->
-            <Border Style="{StaticResource GlassCard}" Background="#14FF3B30" Margin="0,0,12,0"
+            <!-- Critical — uses the per-preset Critical brushes (ThemeService.ApplyStatusBrushes)
+                 like its sibling cards, so it stays legible on the light presets instead of keeping a
+                 dark-calibrated 8%-alpha red that washed out to near-invisible on near-white. -->
+            <Border Style="{StaticResource GlassCard}" Background="{DynamicResource CriticalBgSubtle}" Margin="0,0,12,0"
                     AutomationProperties.Name="{Binding CriticalCount, StringFormat='Critical events: {0}'}">
                 <Grid>
-                    <Border Background="#FF3B30" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                    <Border Background="{DynamicResource CriticalText}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                             Margin="-16,-12,0,-12"/>
                     <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
-                        <Ellipse Style="{StaticResource SevDot}" Fill="#FF3B30">
+                        <Ellipse Style="{StaticResource SevDot}" Fill="{DynamicResource CriticalText}">
                             <Ellipse.Effect>
                                 <DropShadowEffect Color="#FF3B30" BlurRadius="8" ShadowDepth="0" Opacity="0.6"/>
                             </Ellipse.Effect>
@@ -176,12 +178,12 @@
                     <!-- Each toggle has its own colored dot next to the label -->
                     <StackPanel Orientation="Horizontal" Margin="0,0,14,0">
                         <ToggleButton Style="{StaticResource ToggleSwitch}" AutomationProperties.Name="Show Critical events" IsChecked="{Binding ShowCritical}" VerticalAlignment="Center"/>
-                        <Ellipse Style="{StaticResource SevDot}" Fill="#FF3B30" Margin="8,0,6,0"/>
+                        <Ellipse Style="{StaticResource SevDot}" Fill="{DynamicResource CriticalText}" Margin="8,0,6,0"/>
                         <TextBlock Text="Critical" Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,14,0">
                         <ToggleButton Style="{StaticResource ToggleSwitch}" AutomationProperties.Name="Show Error events" IsChecked="{Binding ShowError}" VerticalAlignment="Center"/>
-                        <Ellipse Style="{StaticResource SevDot}" Fill="#F87171" Margin="8,0,6,0"/>
+                        <Ellipse Style="{StaticResource SevDot}" Fill="{DynamicResource Danger}" Margin="8,0,6,0"/>
                         <TextBlock Text="Error" Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,14,0">
@@ -196,7 +198,7 @@
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,22,0">
                         <ToggleButton Style="{StaticResource ToggleSwitch}" AutomationProperties.Name="Show Verbose events" IsChecked="{Binding ShowVerbose}" VerticalAlignment="Center"/>
-                        <Ellipse Style="{StaticResource SevDot}" Fill="#9AA0A6" Margin="8,0,6,0"/>
+                        <Ellipse Style="{StaticResource SevDot}" Fill="{DynamicResource TextMuted}" Margin="8,0,6,0"/>
                         <TextBlock Text="Verbose" Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
                     </StackPanel>
 

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -171,6 +171,18 @@
                                       ToolTip="Select all updates"
                                       HorizontalAlignment="Center"/>
                         </DataGridCheckBoxColumn.Header>
+                        <!-- Per-row name so a screen reader announces which update each checkbox selects
+                             (the header checkbox is named, the rows were not) — matches AppUpdatesView. -->
+                        <DataGridCheckBoxColumn.ElementStyle>
+                            <Style TargetType="CheckBox">
+                                <Setter Property="AutomationProperties.Name" Value="{Binding Title, StringFormat='Select {0}'}"/>
+                            </Style>
+                        </DataGridCheckBoxColumn.ElementStyle>
+                        <DataGridCheckBoxColumn.EditingElementStyle>
+                            <Style TargetType="CheckBox">
+                                <Setter Property="AutomationProperties.Name" Value="{Binding Title, StringFormat='Select {0}'}"/>
+                            </Style>
+                        </DataGridCheckBoxColumn.EditingElementStyle>
                     </DataGridCheckBoxColumn>
 
                     <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="*" MinWidth="150" IsReadOnly="True"
@@ -284,29 +296,34 @@
                                     </Border.Style>
                                     <TextBlock Text="{Binding Category}" FontSize="11" FontWeight="SemiBold">
                                         <TextBlock.Style>
+                                            <!-- Category badge text uses the per-preset status/badge brushes
+                                                 (recomputed by ThemeService.ApplyStatusBrushes for light-theme
+                                                 legibility) rather than hardcoded pale dark-theme tints, which
+                                                 fell to ~1.8:1 on the light presets. Matches the Cumulative
+                                                 trigger that was already migrated. -->
                                             <Style TargetType="TextBlock">
-                                                <Setter Property="Foreground" Value="#94A3B8"/>
+                                                <Setter Property="Foreground" Value="{DynamicResource TextMuted}"/>
                                                 <Style.Triggers>
                                                     <DataTrigger Binding="{Binding Category}" Value="Security">
-                                                        <Setter Property="Foreground" Value="#FCA5A5"/>
+                                                        <Setter Property="Foreground" Value="{DynamicResource DangerText}"/>
                                                     </DataTrigger>
                                                     <DataTrigger Binding="{Binding Category}" Value="Cumulative">
                                                         <Setter Property="Foreground" Value="{DynamicResource WarningText}"/>
                                                     </DataTrigger>
                                                     <DataTrigger Binding="{Binding Category}" Value="Defender">
-                                                        <Setter Property="Foreground" Value="#86EFAC"/>
+                                                        <Setter Property="Foreground" Value="{DynamicResource SuccessText}"/>
                                                     </DataTrigger>
                                                     <DataTrigger Binding="{Binding Category}" Value="Driver">
-                                                        <Setter Property="Foreground" Value="#A5B4FC"/>
+                                                        <Setter Property="Foreground" Value="{DynamicResource BadgeIndigoText}"/>
                                                     </DataTrigger>
                                                     <DataTrigger Binding="{Binding Category}" Value="Servicing">
-                                                        <Setter Property="Foreground" Value="#7DD3FC"/>
+                                                        <Setter Property="Foreground" Value="{DynamicResource InfoText}"/>
                                                     </DataTrigger>
                                                     <DataTrigger Binding="{Binding Category}" Value=".NET">
-                                                        <Setter Property="Foreground" Value="#D8B4FE"/>
+                                                        <Setter Property="Foreground" Value="{DynamicResource BadgePurpleText}"/>
                                                     </DataTrigger>
                                                     <DataTrigger Binding="{Binding Category}" Value="Feature upgrade">
-                                                        <Setter Property="Foreground" Value="#F9A8D4"/>
+                                                        <Setter Property="Foreground" Value="{DynamicResource BadgePinkText}"/>
                                                     </DataTrigger>
                                                 </Style.Triggers>
                                             </Style>


### PR DESCRIPTION
## UI-uniformity batch (Protocol H)

Six confirmed audit findings that share a theme (theme-brush + a11y consistency, **no layout restructuring**), verified against current source before fixing.

### Fixed
- **[2, P2] ToggleSwitch keyboard focus invisible.** The shared `ToggleSwitch` style set `FocusVisualStyle` null but — unlike ButtonBase/Ghost/Admin/Danger/TextBox — had no `IsKeyboardFocused` trigger. A keyboard user tabbing onto any switch (severity filters, perf tweaks, startup entries, Windows features) got no focus cue while Space still toggled it (WCAG 2.4.7). Added an Accent focus ring on the Track; a reserved transparent 1.5px border prevents layout shift when it lights.
- **[4, P2] Windows Update category badges unreadable on light themes.** 7 of 8 badge foregrounds were hardcoded pale dark-theme tints (~1.8:1 on light presets); only Cumulative had been migrated. All now use per-preset status/badge brushes.
- **[7, P3] Logs Critical card + Error/Verbose filter dots** bypassed the per-preset palette (Critical's 8%-alpha red was near-invisible on light — the most severe category was least visible). Now use new `CriticalText`/`CriticalBgSubtle` + `Danger`/`TextMuted`.

### Accessibility
- **[9, P3]** DNS/Hosts "On" and Windows Update per-row select checkboxes had no accessible name; each now names its row, matching the App Updates / Shortcut Cleaner / Uninstaller grids.

### Changed
- **[10, P3]** App Blocker root margin `28,24,28,0` → `28,24,28,16` to match the other 34 root-gutter views.

## Palette + tests
Added `CriticalText`/`CriticalBgSubtle` + `BadgeIndigoText`/`BadgePurpleText`/`BadgePinkText` to `ThemeService.StatusPalette` (both presets). `ThemeStatusBrushTests` extended to pin **WCAG AA (≥4.5:1)** on the worst-case tinted light surface (`#FBCFE8`) and dark surface, plus mode-divergence. Contrast pre-verified: pink-800 `#9D174D` chosen (pink-700 dipped to 4.37 on the tinted surface).

Red→green: the new light badge/critical colors are asserted ≥4.5:1; the old hardcoded pale tints they replace would fail those assertions.

_Split out of the batch into its own follow-up: [8] the elevated "Running as administrator" banner on 6 views (6 layout insertions, tracked separately)._

## Regression sweep
- `dotnet build` main + tests: **0 warnings / 0 errors**.
- Leak-term + debug-code scan on all 7 touched files: clean; XAML author headers intact.
- Version → 1.52.102; CHANGELOG entry in this PR; rebased on main (1.52.101) with CHANGELOG/csproj conflicts resolved.
