### PR TITLE
docs: fix changelog gaps and stale README/ARCHITECTURE/CONTRIBUTING claims

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -103,7 +103,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `DefenderViewModel` — view Microsoft Defender status, toggle PUA / Controlled Folder Access, and manage scan-exclusion folders; every change is admin-gated, confirmed, and verified by read-back (Tamper Protection can silently reject).
 - `TaskSchedulerViewModel` — browse Windows scheduled tasks with a safety classification and enable/disable them (reversible, never deletes); system tasks warn before disabling, changes verified by read-back.
 - `DarkModeViewModel` — switch the Windows light/dark theme manually or on a fixed-time schedule (DispatcherTimer poll while the app runs); persists the schedule.
-- `AudioMixerViewModel` — per-app volume mixer (Volume Control tab, Preview): lists apps playing on the default render device with a volume slider, mute toggle, and a live peak meter. Membership reconciles on a ~1&#160;s loop and a shared DispatcherTimer drives the meters, both paused while the tab is hidden (`IsActive`). Rows reconcile in place by session id (a wholesale replace would drop a slider mid-drag). Per-app output-device routing and volume presets are intentionally out of scope for the preview. Row VMs (`AudioSessionRowViewModel`) propagate volume/mute to the service, with a re-entrancy guard so an external change surfaced by a refresh is not echoed back.
+- `AudioMixerViewModel` — per-app volume mixer (Volume Control tab): lists apps playing on the default render device with a volume slider, mute toggle, and a live peak meter. Membership reconciles on a ~1&#160;s loop and a shared DispatcherTimer drives the meters, both paused while the tab is hidden (`IsActive`). Rows reconcile in place by session id (a wholesale replace would drop a slider mid-drag). Per-app output-device routing and volume presets are planned for a later update. Row VMs (`AudioSessionRowViewModel`) propagate volume/mute to the service, with a re-entrancy guard so an external change surfaced by a refresh is not echoed back.
 - `StandbyMemoryViewModel` — live memory stats (2s poll) with on-demand and threshold-based auto-purge of the Windows standby list; purge needs admin.
 - `GamingProfileViewModel` — one-click game mode (Gaming Profile tab, Preview): gathers the desired reversible optimizations plus an optional running-game target and delegates to `IGamingProfileService` to apply/revert them as a unit. Reports the batch outcome honestly (applied / needs-admin / failed), seeds its toggles from the last-used config, and offers to restore a leftover session on startup (crash recovery). Fully reversible; killing background apps and named per-game profiles are intentionally out of scope for the preview.
 - `ProfileViewModel` — export/import SysManager's own config (theme, speed-test history) as a portable JSON profile with selective sections and version checking.
@@ -385,10 +385,11 @@ Key utility classes that don't fit neatly into Services or ViewModels (not an ex
 `ServiceRegistration.cs` configures `Microsoft.Extensions.DependencyInjection`.
 `App.OnStartup` builds the `IServiceProvider` and exposes it as `App.Services`.
 Most core services and ViewModels are registered as singletons — one shared
-instance per app lifetime. The exception is `PowerShellRunner` /
-`IPowerShellRunner`, registered **transient** so each consumer gets its own
-instance, avoiding `LineReceived` event cross-talk between tabs (see
-`ServiceRegistration.cs:24-25`). `MainWindowViewModel` resolves child VMs from
+instance per app lifetime. The exceptions are `IPowerShellRunner` / `PowerShellRunner`
+and `IWingetService` / `WingetService`, both registered **transient** so each
+consumer gets its own runner instance, avoiding `LineReceived` event cross-talk
+between tabs (e.g. Dashboard and App Updates running winget concurrently — see the
+transient registrations at the top of `ServiceRegistration.cs`). `MainWindowViewModel` resolves child VMs from
 the container at runtime; falls back to manual creation in tests (no DI
 dependency in the test project).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - **Traceroute re-resolved the destination hostname on every probe, so a round-robin / CDN host could produce a garbled route toward different servers.** `TracerouteService.RunAsync` passed the raw hostname string into `Ping.SendPingAsync` inside the per-hop/per-probe loop, re-running DNS for each of up to `MaxHops * ProbesPerHop` (30×2 = 60) probes. For a load-balanced hostname (e.g. `google.com`), consecutive TTLs could resolve to *different* destination IPs, interleaving hops toward different servers into one nonsensical route — plus ~60× redundant DNS lookups. The destination is now resolved exactly once, up front, via a new `ResolveDestinationAsync` helper (IP literals are used verbatim with no DNS; hostnames pin the first `Dns.GetHostAddressesAsync` result), and every probe targets that fixed `IPAddress`. A resolution failure now surfaces as `InvalidOperationException` (the type the ViewModel already handles) instead of silently looping `MaxHops` times with per-probe DNS failures. Single-IP hosts and IP literals were never affected; the reverse-DNS lookup of each *responding* hop is unchanged.
+
 ## [1.52.83] - 2026-07-10
 
 ### Fixed
@@ -134,11 +135,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [1.52.76] - 2026-07-10
 
 ### Fixed
-- **Disk Analyzer over-counted drive usage by descending into WinSxS and other heavyweight system directories during recursion.** The `SkipSegments` filter (`\windows\winsxs`, `\windows\csc`, `\$recycle.bin`, `\system volume information`) was only applied to the top-level children of the analyzed root (line 71). The recursive `MeasureFolder` walk pushed every non-reparse subdirectory onto the stack without re-checking against `SkipSegments`, so scanning a drive root like `C:\` would enter `C:\Windows` (not skipped — it's not in the list) and then descend into `C:\Windows\WinSxS` (a hardlink farm, not a reparse point) and `C:\Windows\CSC` (offline files cache), double-counting hundreds of thousands of hardlinked files at full `FileInfo.Length`. The recursive loop now guards each subdirectory with `ShouldSkip(d)` before pushing it, matching the top-level behavior.
 - **App icon cache loading crashed on corrupt PNG/JPEG files that trigger WIC codec errors.** `AppIconService.LoadFromFile` caught `NotSupportedException`, `IOException`, and `UriFormatException`, but `BitmapImage.EndInit()` throws `FileFormatException` (derives from `FormatException`, not `IOException`) for malformed image headers and `ExternalException` for native WIC decoder failures. Both are now caught, matching the established pattern in `IconExtractorService` (lines 203/234). Without this fix, a single corrupt cached icon file caused the entire app-icon load path to throw unhandled to the caller.
 - **File Shredder failed on read-only files when invoked for a single file (not via folder shred).** `ShredFileAsync` opened a write stream (`FileAccess.Write`) without first clearing the `ReadOnly` attribute, throwing `UnauthorizedAccessException`. `ShredFolderAsync` already stripped ReadOnly (lines 213-215) before calling `ShredFileAsync`, but the ViewModel's single-file path (`FileShredderViewModel:170`) called `ShredFileAsync` directly — the file survived with its data intact while the UI reported "Failed". The ReadOnly strip now lives inside `ShredFileAsync` itself so both entry points are covered.
 - **Memory health scan returned partial or empty results when any single RAM module reported a `DBNull` property.** `MemoryTestService` used `Convert.ToDouble(mo["Capacity"] ?? 0)` and `Convert.ToUInt32(mo["Speed"] ?? 0u)` — the `??` operator does not catch `DBNull.Value` (which is non-null), so `Convert.ToUInt32(DBNull.Value)` throws `InvalidCastException`. The catch block for that exception sat OUTSIDE the `foreach` loop, so one problematic module aborted the entire scan. Now uses `FixedDriveService.ToDoubleSafe`/`ToUInt32Safe` (DBNull-aware, already tested) and the defensive catch wraps each individual module so remaining modules are still reported.
 - **Flaky test (`ContextMenuViewModelTests.Constructor_TotalCount_DefaultsToZero`) that raced the ViewModel's constructor-initiated async registry scan.** On CI, the scan could complete before the assertion checked, producing `Expected: 0, Actual: 6`. Replaced all four timing-dependent baseline tests with post-scan invariant assertions that await `InitializationComplete` — the same deterministic pattern used by 16 other VM test classes.
+
+## [1.52.75] - 2026-07-10
+
+### Fixed
+- **Disk Analyzer over-counted drive usage by descending into WinSxS and other heavyweight system directories during recursion.** The `SkipSegments` filter (`\windows\winsxs`, `\windows\csc`, `\$recycle.bin`, `\system volume information`) was only applied to the top-level children of the analyzed root (line 71). The recursive `MeasureFolder` walk pushed every non-reparse subdirectory onto the stack without re-checking against `SkipSegments`, so scanning a drive root like `C:\` would enter `C:\Windows` (not skipped — it's not in the list) and then descend into `C:\Windows\WinSxS` (a hardlink farm, not a reparse point) and `C:\Windows\CSC` (offline files cache), double-counting hundreds of thousands of hardlinked files at full `FileInfo.Length`. The recursive loop now guards each subdirectory with `ShouldSkip(d)` before pushing it, matching the top-level behavior.
 
 ## [1.52.74] - 2026-07-10
 
@@ -424,6 +429,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 - **Outline buttons are now visible on the light themes.** "Ghost" buttons (e.g. Export text / Copy on the System Report tab, and similar secondary actions elsewhere) drew their border in a translucent white that was invisible against the light presets' pale backgrounds — the buttons looked borderless. They now use the theme's own border color, so they're clearly outlined on every theme.
 - **Startup Manager asks before re-enabling everything.** The "Enable All" button immediately re-enabled every disabled startup item — a bulk system change that adds boot time — with no confirmation. It now asks first (showing how many items will be affected), matching the confirm-before-bulk-change behavior used elsewhere in the app.
+
+## [1.52.21] - 2026-07-03
+
+### Fixed
 - **Editing the hosts file no longer erases your own comments.** When you added, removed, or toggled an entry on the DNS & Hosts tab, SysManager rewrote the file from just the address mappings — silently dropping any standalone comment lines or blank spacing you'd written (section notes, documentation). Those comment and blank lines are now preserved through an edit, kept above the entries. Repeated saves stay stable (no duplicated headers), and a file with no comments is written exactly as before.
 
 ## [1.52.20] - 2026-07-03
@@ -431,6 +440,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 - **The theme picker now opens on your saved theme's presets.** If you'd set a Light or Custom theme, the theme popup initially built its preset list from the default Dark mode and only corrected itself once you clicked something — so it briefly showed the wrong set of presets. It now reads your saved mode first, so the correct presets appear immediately.
 - **Ping and System Logs numbers are now readable on the Light themes.** The average-ping / jitter / latency figures on the Network Ping tab and the severity counts (Critical, Errors, Warnings, Info) on the System Logs tab used fixed pale colors that nearly disappeared against the light preset backgrounds. They now use the app's semantic status colors, so they stay legible on every theme.
+
+## [1.52.19] - 2026-07-03
+
+### Fixed
 - **Recycle Bin size estimates now match what emptying actually frees.** Both Quick Cleanup and Deep Cleanup summed the whole hidden `$Recycle.Bin` folder on every drive — which, on a shared PC (especially when running as administrator), also counts *other users'* deleted files. But emptying the bin only ever clears the current user's items, so the "X MB in Recycle Bin" figure could be far larger than what actually gets freed. The estimate now measures only the current user's Recycle Bin, so the number is honest.
 - **Installed-app detection no longer mislabels similarly-named apps.** In the Bulk Installer, an app was marked "Installed" if its winget Id appeared anywhere in a `winget list` row — so an app whose Id is a prefix of another (e.g. `Microsoft.Teams` vs. an installed `Microsoft.Teams.Classic`) was wrongly shown as already installed. Detection now compares exact winget Ids.
 - **System Report and About page now show the correct VRAM for GPUs over 4 GB.** Video memory was read from a 32-bit WMI field that caps at ~4 GiB, so an 8 GB or 12 GB card was reported as ~4 GB. The true size is now read from the graphics driver's 64-bit registry value, falling back to the old field only when that isn't available.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,9 +132,10 @@ dotnet test SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.c
 dotnet test SysManager/SysManager.UITests/SysManager.UITests.csproj -c Release
 ```
 
-The integration and UI tests touch the live system / require an interactive
-desktop session, so they run locally only (not in CI) — run them locally,
-not over SSH/Remote PowerShell. CI runs the unit tests.
+The integration tests touch the live system, so CI only compile-checks them —
+run them locally, not over SSH/Remote PowerShell. CI runs the unit tests as the
+merge gate and the UI-automation tests as a separate, non-blocking job (they need
+the interactive desktop a `windows-latest` runner provides).
 
 Filter to one class while iterating (pass the project the class lives in —
 `PingMonitorServiceTests` is an integration test):

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ work-in-progress placeholders marked with ⚙️:
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS & Hosts |
 | 📦 Apps | App Updates · Bulk Installer · Uninstaller |
 | 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover ⚙️ · Defender Tweaks · Notification Blocker ⚙️ |
-| 🎨 Customization | Context Menu · Dark Mode Scheduler · Volume Control 🔬 |
+| 🎨 Customization | Context Menu · Dark Mode Scheduler · Volume Control |
 | ℹ️ Info | Drivers · Battery Health · System Logs · System Report · Legacy Panels · About |
 | ⚙️ Advanced | Profile Export/Import · CLI Interface 🔬 · Environment Variables |
 
@@ -157,7 +157,7 @@ Edit Windows environment variables without the cramped built-in dialog:
 - **Honest about its limits** — the schedule runs while SysManager (or its tray)
   is open; it's not a background Windows service
 
-### Volume Control 🔬
+### Volume Control
 - **Per-app volume mixer** — lists every app currently playing on your default
   playback device, each with its own volume slider, mute toggle, and a live peak meter
 - **Live and lightweight** — the app list reconciles on a ~1-second loop and the meters
@@ -165,8 +165,8 @@ Edit Windows environment variables without the cramped built-in dialog:
   the background
 - **Real names and icons** — resolved from each audio session's process (with a safe
   fallback for protected processes), including the Windows "system sounds" session
-- 🔬 Preview — per-app output-device routing and saved volume presets are intentionally
-  out of scope for now, planned for a later update
+- **Planned** — per-app output-device routing and saved volume presets are planned for
+  a later update
 
 ### Network monitor
 - Live ping across multiple targets overlaid on a single latency chart
@@ -435,8 +435,10 @@ a confirmation before it runs:
 - Operations grouped by category (Disk, Network, SystemModification)
 - If a conflicting operation is already running, the UI shows which operation
   is blocking and refuses to start the new one
-- Integrated into: Dashboard, Deep Cleanup, Disk Analyzer, Duplicate Finder,
-  Quick Cleanup, Speed Test, Traceroute, Network Repair, Shortcut Cleaner
+- Integrated into every tab that mutates disk, network, or system state
+  (Cleanup, Deep Cleanup, Disk Analyzer, Duplicate Finder, Speed Test, Traceroute,
+  Network Repair, Shortcut Cleaner, Performance Mode, Environment Variables, and the
+  Dashboard's quick actions)
 
 ### Shortcut Cleaner
 - Scans Desktop, Start Menu, Quick Launch, and Recent Items for broken .lnk


### PR DESCRIPTION
## Docs-freshness batch (Protocol D — no release)

Six confirmed docs findings, each verified against current source.

### CHANGELOG
- **[6, P2] Three released versions were missing their CHANGELOG headers.** Tags `v1.52.75`, `v1.52.21`, `v1.52.19` exist in git but had no header — their bullets were absorbed into the *next* version's section during conflict resolution between racing PRs (Disk Analyzer → 1.52.76, hosts-comments → 1.52.22, Recycle-Bin/installed-app/VRAM → 1.52.20). Restored each header with its exact text recovered from `git show vX:CHANGELOG.md`, and removed the bullets from the absorbing sections so nothing is duplicated. Anyone looking up a tagged release now finds it, dated correctly.
- **[15, P3]** Added the one missing blank line before `## [1.52.83]` (markdownlint MD022) — the same conflict-resolution seam.

### README / ARCHITECTURE
- **[11, P3] Volume Control was un-graduated by a docs-only commit.** It ships graduated in code (no `inDevelopment: true`, no `DevelopmentBanner`), but a later docs commit re-added the 🔬 Preview badge (sidebar table, section title, bullet) + an ARCHITECTURE "Preview" note against stale knowledge. Removed all four; the tab is documented as shipped with routing/presets "planned".
- **[12, P3] Operation Lock "Integrated into" list was stale** (missing Performance Mode + Environment Variables — 11 VMs use the lock, the list named 9). Replaced the hand-maintained enumeration with a non-enumerating description so it can't drift again.
- **[14, P3] ARCHITECTURE DI section understated the transient exceptions** — `IWingetService` is a second `AddTransient` alongside `IPowerShellRunner`, and the hardcoded `ServiceRegistration.cs:24-25` citation now points at a singleton line. Fixed both; reference the symbols, not a line number.

### CONTRIBUTING
- **[13, P3]** "The integration and UI tests … run locally only (not in CI)" contradicted `ci.yml` (which has a `ui-tests` job) and CONTRIBUTING's own PR-process section. Reworded to match: CI runs unit tests as the merge gate and UI-automation as a separate non-blocking job; integration tests are compile-checked only.

No code changes → `docs:` → no release. All claims re-derived from source (`grep`/`git show`/`git tag`), not memory.

_Follow-up (out of scope, `ci:`): add a CI step that fails when a `v1.*` tag has no CHANGELOG header, so a dropped release header can't recur — as [6] recommends._
