### PR TITLE
fix: show the elevated 'Running as administrator' banner on six admin views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.103] - 2026-07-11
+
+### Accessibility
+- **Six admin-capable tabs showed no "Running as administrator" confirmation when the app was elevated.** Boot Analyzer, Gaming Profile, Settings Watchdog, Standby List Cleaner, Tweaks Hub and the Dashboard each had only the *not-elevated* banner (a grey "Run as administrator" prompt); when the app actually ran elevated the banner row simply collapsed, unlike the other 23 admin views which show a golden "Running as administrator — <what's unlocked>" confirmation. This broke the app's golden admin-control contract (grey when elevation is unavailable, golden when active) and the cross-tab uniformity the other views establish — most visibly on the hard-admin tabs (Boot Analyzer, Standby List Cleaner) where the core action requires elevation. Each of the six now shows the same golden elevated banner (matching `AppBlockerView`), with view-specific text describing what elevation unlocks, bound to `IsElevated` in the same grid row as the existing not-elevated banner.
+
 ## [1.52.102] - 2026-07-11
 
 ### Fixed

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.102</Version>
-    <FileVersion>1.52.102.0</FileVersion>
-    <AssemblyVersion>1.52.102.0</AssemblyVersion>
+    <Version>1.52.103</Version>
+    <FileVersion>1.52.103.0</FileVersion>
+    <AssemblyVersion>1.52.103.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/BootAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/BootAnalyzerView.xaml
@@ -43,6 +43,21 @@
             </DockPanel>
         </Border>
 
+        <!-- Elevation banner: elevated (golden admin contract, matches AppBlockerView) -->
+        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
+                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — the Windows boot-performance history can be read."
+                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
         <!-- Summary -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="16"
                 Visibility="{Binding HasData, Converter={StaticResource FlexVis}}">

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -64,6 +64,21 @@
                 </DockPanel>
             </Border>
 
+            <!-- ═══ ROW 1: Elevation banner — elevated (golden admin contract, matches AppBlockerView) ═══ -->
+            <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
+                    CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
+                    Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+                <Grid>
+                    <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                            Margin="-12,-8,0,-8"/>
+                    <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                        <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                        <TextBlock Text="Running as administrator — all sensors and quick actions have full access."
+                                   Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
             <!-- ═══ ROW 2: Health Score Hero ═══ -->
             <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="20"
                     Visibility="{Binding HasHealthScore, Converter={StaticResource FlexVis}}">

--- a/SysManager/SysManager/Views/GamingProfileView.xaml
+++ b/SysManager/SysManager/Views/GamingProfileView.xaml
@@ -47,6 +47,21 @@
             </DockPanel>
         </Border>
 
+        <!-- Elevation banner: elevated (golden admin contract, matches AppBlockerView) -->
+        <Border Grid.Row="2" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
+                CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — every optimization, including freeing standby memory and pausing search indexing, can be applied."
+                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
         <!-- Content: game target + optimization toggles -->
         <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto" Margin="28,16,28,0">
             <StackPanel>

--- a/SysManager/SysManager/Views/SettingsWatchdogView.xaml
+++ b/SysManager/SysManager/Views/SettingsWatchdogView.xaml
@@ -62,6 +62,21 @@
             </DockPanel>
         </Border>
 
+        <!-- Elevation banner: elevated (golden admin contract, matches AppBlockerView) -->
+        <Border Grid.Row="2" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
+                CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — machine-wide watched settings can be restored, not just per-user ones."
+                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
         <!-- Baseline status banner -->
         <Border Grid.Row="3" Style="{StaticResource Card}" Margin="28,12,28,0" Padding="14,10"
                 Visibility="{Binding HasBaseline, Converter={StaticResource FlexVis}}">

--- a/SysManager/SysManager/Views/StandbyMemoryView.xaml
+++ b/SysManager/SysManager/Views/StandbyMemoryView.xaml
@@ -43,6 +43,21 @@
             </DockPanel>
         </Border>
 
+        <!-- Elevation banner: elevated (golden admin contract, matches AppBlockerView) -->
+        <Border Grid.Row="2" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
+                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — you can purge the standby memory list."
+                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
         <!-- Memory cards -->
         <Border Grid.Row="3" Style="{StaticResource Card}" Margin="0,0,0,12">
             <Grid>

--- a/SysManager/SysManager/Views/TweaksHubView.xaml
+++ b/SysManager/SysManager/Views/TweaksHubView.xaml
@@ -86,6 +86,21 @@
             </DockPanel>
         </Border>
 
+        <!-- Elevation banner: elevated (golden admin contract, matches AppBlockerView) -->
+        <Border Grid.Row="2" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
+                CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — both Essential and Advanced (machine-wide) tweaks can be applied."
+                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
         <!-- Tweaks: Essential + Advanced -->
         <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto" Margin="28,16,28,0">
             <StackPanel>


### PR DESCRIPTION
## Elevated admin banner on six views (P3, a11y/uniformity)

23 of the 29 views with a `RelaunchAsAdminCommand` implement the full golden admin contract: a grey banner when **not** elevated *plus* a golden "Running as administrator — you can …" banner when elevated. Six did not — **Boot Analyzer, Gaming Profile, Settings Watchdog, Standby List Cleaner, Tweaks Hub, and the Dashboard** had only the not-elevated banner, so when the app ran elevated the row simply collapsed and showed no elevation state at all.

This broke the repo's golden admin-control contract (grey when elevation is unavailable, golden when active) and the cross-tab uniformity the other 23 views establish — most visible on the hard-admin tabs (Boot Analyzer and Standby List Cleaner, whose core action requires elevation).

## Fix

Each of the six now shows the same golden elevated `Border` (copied from `AppBlockerView.xaml`), bound to `IsElevated` (non-inverse) in the **same grid row** as the existing not-elevated banner, with **view-specific text** describing what elevation unlocks:
- Boot Analyzer — "the Windows boot-performance history can be read"
- Gaming Profile — "every optimization, including freeing standby memory and pausing search indexing, can be applied"
- Settings Watchdog — "machine-wide watched settings can be restored, not just per-user ones"
- Standby List Cleaner — "you can purge the standby memory list"
- Tweaks Hub — "both Essential and Advanced (machine-wide) tweaks can be applied"
- Dashboard — "all sensors and quick actions have full access"

Each insertion honors that view's existing layout strategy (root-gutter `Margin="0,0,0,12"` vs per-section `Margin="28,12,28,0"`), so no layout shifts.

## Testing

View-only XAML (mutually-exclusive banner `Border`s bound to `IsElevated` — the pattern 23 sibling views already use); no pure-logic seam to unit-test on the main PC, and UI automation is laptop-only per TEST-PROTOCOL. Build is 0/0. The elevated state is best confirmed on the laptop's FlaUI/visual pass.

## Regression sweep
- `dotnet build` main: **0 warnings / 0 errors**.
- Leak-term + debug-code scan on all 6 touched files: clean; XAML author headers intact.
- Version → 1.52.103; CHANGELOG entry in this PR; rebased on main (post-docs-merge).
