### PR TITLE
chore(deps): bump NSubstitute to 6.0.0 and fix arg-matcher nullability

### DIFF
--- a/SysManager/Directory.Packages.props
+++ b/SysManager/Directory.Packages.props
@@ -37,7 +37,7 @@
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NSubstitute" Version="6.0.0" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/SysManager/SysManager.Tests/BulkInstallerServiceTests.cs
+++ b/SysManager/SysManager.Tests/BulkInstallerServiceTests.cs
@@ -75,7 +75,7 @@ public class BulkInstallerServiceTests
         Assert.Equal(0, exit);
         await runner.Received(1).RunProcessAsync(
             "winget",
-            Arg.Is<string>(a =>
+            Arg.Is<string>(a => a != null &&
                 a.Contains("install") &&
                 a.Contains("--id \"Git.Git\"") &&
                 a.Contains("-e") &&
@@ -102,7 +102,7 @@ public class BulkInstallerServiceTests
         Assert.Equal(0, exit);
         await runner.Received(1).RunProcessAsync(
             "winget",
-            Arg.Is<string>(a => a.Contains($"--id \"{id}\"")),
+            Arg.Is<string>(a => a != null && a.Contains($"--id \"{id}\"")),
             Arg.Any<CancellationToken>(),
             Arg.Any<System.Text.Encoding?>());
     }
@@ -159,7 +159,7 @@ public class BulkInstallerServiceTests
         // (UseShellExecute=false). So exactly ONE opening + ONE closing quote wrap the query.
         await runner.Received(1).RunProcessAsync(
             "winget",
-            Arg.Is<string>(a => a.Contains("search \"foo & calc\"") && a.Split('"').Length == 3),
+            Arg.Is<string>(a => a != null && a.Contains("search \"foo & calc\"") && a.Split('"').Length == 3),
             Arg.Any<CancellationToken>(),
             Arg.Any<System.Text.Encoding?>());
     }
@@ -188,7 +188,7 @@ public class BulkInstallerServiceTests
 
         await runner.Received(1).RunProcessAsync(
             "winget",
-            Arg.Is<string>(a => a.Contains("list")),
+            Arg.Is<string>(a => a != null && a.Contains("list")),
             Arg.Any<CancellationToken>(),
             Arg.Any<System.Text.Encoding?>());
     }

--- a/SysManager/SysManager.Tests/DarkModeViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DarkModeViewModelTests.cs
@@ -142,7 +142,7 @@ public class DarkModeViewModelTests
         vm.ScheduleEnabled = true;
 
         // OnScheduleEnabledChanged persists the new schedule with Enabled == true.
-        service.Received().SaveSchedule(Arg.Is<DarkModeSchedule>(s => s.Enabled));
+        service.Received().SaveSchedule(Arg.Is<DarkModeSchedule>(s => s != null && s.Enabled));
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/DebloaterServiceTests.cs
+++ b/SysManager/SysManager.Tests/DebloaterServiceTests.cs
@@ -210,7 +210,7 @@ public class DebloaterServiceTests
 
         Assert.True(result);
         await runner.Received(1).RunAsync(
-            Arg.Is<string>(s => s.Contains("Remove-AppxPackage") && s.Contains("Contoso.RandomApp_1.0.0.0_x64__abc")),
+            Arg.Is<string>(s => s != null && s.Contains("Remove-AppxPackage") && s.Contains("Contoso.RandomApp_1.0.0.0_x64__abc")),
             Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>());
     }
 }

--- a/SysManager/SysManager.Tests/DnsServiceTests.cs
+++ b/SysManager/SysManager.Tests/DnsServiceTests.cs
@@ -75,7 +75,7 @@ public class DnsServiceTests
         await svc.SetDnsAsync("1.1.1.1", "1.0.0.1");
 
         await runner.Received(1).RunAsync(
-            Arg.Is<string>(s =>
+            Arg.Is<string>(s => s != null &&
                 s.Contains("Set-DnsClientServerAddress") &&
                 s.Contains("-InterfaceIndex 5") &&
                 s.Contains("1.1.1.1") &&
@@ -95,7 +95,7 @@ public class DnsServiceTests
         await svc.ResetToDhcpAsync();
 
         await runner.Received(1).RunAsync(
-            Arg.Is<string>(s =>
+            Arg.Is<string>(s => s != null &&
                 s.Contains("Set-DnsClientServerAddress") &&
                 s.Contains("-InterfaceIndex 3") &&
                 s.Contains("-ResetServerAddresses")),
@@ -118,7 +118,7 @@ public class DnsServiceTests
         // The Set call must request terminating errors so a non-terminating cmdlet
         // failure surfaces instead of being reported as a false success.
         await runner.Received(1).RunAsync(
-            Arg.Is<string>(s =>
+            Arg.Is<string>(s => s != null &&
                 s.Contains("Set-DnsClientServerAddress") &&
                 s.Contains("-ErrorAction Stop") &&
                 s.Contains("$ErrorActionPreference = 'Stop'")),
@@ -137,7 +137,7 @@ public class DnsServiceTests
         await svc.ResetToDhcpAsync();
 
         await runner.Received(1).RunAsync(
-            Arg.Is<string>(s =>
+            Arg.Is<string>(s => s != null &&
                 s.Contains("-ResetServerAddresses") && s.Contains("-ErrorAction Stop")),
             Arg.Any<IDictionary<string, object?>?>(),
             Arg.Any<CancellationToken>());
@@ -158,7 +158,7 @@ public class DnsServiceTests
         await svc.SetDnsAsync("9.9.9.9", "149.112.112.112");
 
         await runner.Received().RunAsync(
-            Arg.Is<string>(s =>
+            Arg.Is<string>(s => s != null &&
                 s.Contains("Virtual -eq $false") &&
                 s.Contains("Sort-Object -Property ifIndex")),
             Arg.Any<IDictionary<string, object?>?>(),
@@ -299,7 +299,7 @@ public class DnsServiceTests
         await svc.RestoreServersAsync(["9.9.9.9", "149.112.112.112"]);
 
         await runner.Received(1).RunAsync(
-            Arg.Is<string>(s =>
+            Arg.Is<string>(s => s != null &&
                 s.Contains("Set-DnsClientServerAddress") &&
                 s.Contains("-InterfaceIndex 7") &&
                 s.Contains("9.9.9.9") &&
@@ -319,7 +319,7 @@ public class DnsServiceTests
         await svc.RestoreServersAsync([]);
 
         await runner.Received(1).RunAsync(
-            Arg.Is<string>(s => s.Contains("-ResetServerAddresses")),
+            Arg.Is<string>(s => s != null && s.Contains("-ResetServerAddresses")),
             Arg.Any<IDictionary<string, object?>?>(),
             Arg.Any<CancellationToken>());
     }
@@ -338,7 +338,7 @@ public class DnsServiceTests
         await svc.RestoreSnapshotAsync(new DnsService.DnsSnapshot(["9.9.9.9"], ["2620:fe::fe"]));
 
         await runner.Received(1).RunAsync(
-            Arg.Is<string>(s =>
+            Arg.Is<string>(s => s != null &&
                 s.Contains("-ResetServerAddresses") &&        // clears whatever was applied since
                 s.Contains("9.9.9.9") &&                      // re-applies captured IPv4
                 s.Contains("2620:fe::fe")),                   // re-applies captured IPv6
@@ -357,7 +357,7 @@ public class DnsServiceTests
         await svc.RestoreSnapshotAsync(DnsService.DnsSnapshot.Empty);
 
         await runner.Received(1).RunAsync(
-            Arg.Is<string>(s => s.Contains("-ResetServerAddresses") && !s.Contains("@(\"")),
+            Arg.Is<string>(s => s != null && s.Contains("-ResetServerAddresses") && !s.Contains("@(\"")),
             Arg.Any<IDictionary<string, object?>?>(),
             Arg.Any<CancellationToken>());
     }
@@ -414,7 +414,7 @@ public class DnsServiceTests
 
         // One script issues two Set-DnsClientServerAddress calls: one IPv4, one IPv6.
         await runner.Received(1).RunAsync(
-            Arg.Is<string>(s =>
+            Arg.Is<string>(s => s != null &&
                 s.Contains("-InterfaceIndex 7") &&
                 s.Contains("1.1.1.2") && s.Contains("1.0.0.2") &&
                 s.Contains("2606:4700:4700::1112") && s.Contains("2606:4700:4700::1002")),
@@ -433,7 +433,7 @@ public class DnsServiceTests
         await svc.SetDnsAsync("8.8.8.8", "8.8.4.4", "", "");
 
         await runner.Received(1).RunAsync(
-            Arg.Is<string>(s => s.Contains("8.8.8.8") && !s.Contains("::")),
+            Arg.Is<string>(s => s != null && s.Contains("8.8.8.8") && !s.Contains("::")),
             Arg.Any<IDictionary<string, object?>?>(),
             Arg.Any<CancellationToken>());
     }
@@ -513,13 +513,13 @@ public class DnsServiceTests
 
         // First call: verify the adapter is still present.
         await runner.Received(1).RunAsync(
-            Arg.Is<string>(s => s.Contains("Get-NetAdapter -InterfaceIndex 12")),
+            Arg.Is<string>(s => s != null && s.Contains("Get-NetAdapter -InterfaceIndex 12")),
             Arg.Any<IDictionary<string, object?>?>(),
             Arg.Any<CancellationToken>());
 
         // Second call: restore targets the pinned adapter, not a re-queried one.
         await runner.Received(1).RunAsync(
-            Arg.Is<string>(s =>
+            Arg.Is<string>(s => s != null &&
                 s.Contains("-InterfaceIndex 12") &&
                 s.Contains("-ResetServerAddresses") &&
                 s.Contains("9.9.9.9") &&
@@ -558,13 +558,13 @@ public class DnsServiceTests
 
         // Should NOT issue Get-NetAdapter -InterfaceIndex 0 verify.
         await runner.DidNotReceive().RunAsync(
-            Arg.Is<string>(s => s.Contains("Get-NetAdapter -InterfaceIndex 0")),
+            Arg.Is<string>(s => s != null && s.Contains("Get-NetAdapter -InterfaceIndex 0")),
             Arg.Any<IDictionary<string, object?>?>(),
             Arg.Any<CancellationToken>());
 
         // Should use the dynamic selector and then target the resolved index.
         await runner.Received(1).RunAsync(
-            Arg.Is<string>(s =>
+            Arg.Is<string>(s => s != null &&
                 s.Contains("-InterfaceIndex 5") &&
                 s.Contains("-ResetServerAddresses")),
             Arg.Any<IDictionary<string, object?>?>(),

--- a/SysManager/SysManager.Tests/GamingProfileViewModelTests.cs
+++ b/SysManager/SysManager.Tests/GamingProfileViewModelTests.cs
@@ -125,9 +125,9 @@ public class GamingProfileViewModelTests
 
         await WithConfirm(true, () => vm.StartCommand.ExecuteAsync(null));
 
-        service.SaveLastConfig(Arg.Is<GamingProfile>(p => p.FinestTimerResolution && p.HighGameCpuPriority));
+        service.SaveLastConfig(Arg.Is<GamingProfile>(p => p != null && p.FinestTimerResolution && p.HighGameCpuPriority));
         await service.Received(1).ApplyAsync(
-            Arg.Is<GamingProfile>(p => p.FinestTimerResolution && p.HighGameCpuPriority),
+            Arg.Is<GamingProfile>(p => p != null && p.FinestTimerResolution && p.HighGameCpuPriority),
             Arg.Is<GameTarget?>(g => g != null && g.ProcessId == 4242 && g.Name == "doom.exe"));
     }
 

--- a/SysManager/SysManager.Tests/TweaksHubViewModelTests.cs
+++ b/SysManager/SysManager.Tests/TweaksHubViewModelTests.cs
@@ -84,7 +84,7 @@ public class TweaksHubViewModelTests
             vm.ApplySelectedCommand.Execute(null);
             // Only the selected, not-yet-applied item is sent to enable=true.
             svc.Received(1).ApplyAsync(
-                Arg.Is<IReadOnlyList<TweakItem>>(l => l.Count == 1 && l[0] == sel),
+                Arg.Is<IReadOnlyList<TweakItem>>(l => l != null && l.Count == 1 && l[0] == sel),
                 true, Arg.Any<CancellationToken>());
         }
         finally { DialogService.Instance = prev; }


### PR DESCRIPTION
## What

Bumps **NSubstitute 5.3.0 → 6.0.0** (test-only dependency) and fixes the resulting build break.

Supersedes Dependabot **#1440**, which failed CI: NSubstitute 6.0.0 annotates `Arg.Is<T>` matcher-lambda parameters as **nullable**, so under the repo's `Nullable=enable` + `TreatWarningsAsErrors` the existing `Arg.Is<T>(x => x.Member…)` matchers raised **48 `CS8602` (possible null dereference)** errors across 6 unit-test files.

## Fix

Guarded each matcher lambda with a leading `x != null &&` so the parameter narrows to non-null for the rest of the predicate. This is behavior-preserving: NSubstitute only ever invokes the predicate with the captured (non-null) argument, so the added guard is always true at runtime — it exists purely to satisfy the compiler's flow analysis.

Files touched (all tests): `BulkInstallerServiceTests`, `DarkModeViewModelTests`, `DebloaterServiceTests`, `DnsServiceTests`, `GamingProfileViewModelTests`, `TweaksHubViewModelTests`.

## Verification
- `dotnet build` of **all three** test projects (Tests / IntegrationTests / UITests) in Release: **0 warnings / 0 errors** with NSubstitute 6.0.0. (Previously 48 CS8602 in the unit-test project.)
- Main app project unaffected (NSubstitute is test-only).
- No open Dependabot **security** advisory drives this — it's a routine major bump; taken to keep the test tooling current.
- `chore:` — no release.
