### PR TITLE
ci(deps): bump github-actions group (codeql-action, action-gh-release)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           languages: csharp
           queries: security-and-quality
@@ -38,6 +38,6 @@ jobs:
         run: dotnet build SysManager/SysManager/SysManager.csproj -c Release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           category: csharp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
 
       - name: Create GitHub Release
         id: release
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: SysManager ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## What

Bumps three pinned GitHub Actions to their latest patched commits, all still **SHA-pinned** (per the DevOps non-negotiable "Actions SHA-pinned"):
- `github/codeql-action/init` + `analyze` → `7188fc3` (v4)
- `softprops/action-gh-release` → `3d0d988` (v3)

## Why re-homed from #1441

This is the same change Dependabot proposed in #1441. That PR was `BLOCKED` by strict up-to-date branch protection (behind main after the other dep merges). Pushing a merge commit to the Dependabot branch to bring it up to date caused Dependabot to auto-close #1441 (it abandons branches that get non-Dependabot commits). Re-homed onto a plain `ci/` branch — identical diff, fully under our control, no Dependabot branch to fight.

## Safety
- Only `.github/workflows/codeql.yml` + `release.yml` change; no app code.
- Both actions remain commit-SHA-pinned (supply-chain hardening intact).
- `ci:` — no release.