### PR TITLE
fix: build tab view-models lazily instead of all at startup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -389,9 +389,19 @@ instance per app lifetime. The exceptions are `IPowerShellRunner` / `PowerShellR
 and `IWingetService` / `WingetService`, both registered **transient** so each
 consumer gets its own runner instance, avoiding `LineReceived` event cross-talk
 between tabs (e.g. Dashboard and App Updates running winget concurrently — see the
-transient registrations at the top of `ServiceRegistration.cs`). `MainWindowViewModel` resolves child VMs from
-the container at runtime; falls back to manual creation in tests (no DI
-dependency in the test project).
+transient registrations at the top of `ServiceRegistration.cs`).
+
+`MainWindowViewModel` resolves child VMs from the container **lazily**: each tab's
+`NavItem` holds a `ContentFactory` and builds its view-model from DI only when the tab
+is first opened (`NavItem.Content`). This avoids constructing all ~50 tab VMs at startup
+— most kick off a background scan/timer in their constructor, so eager construction ran
+that work up front for tabs the user might never open. A small set stays eager because
+its constructor drives always-on, app-wide behavior independent of its tab: `Dashboard`
+(the initially-selected tab), `DarkModeViewModel` (owns the theme-schedule poll), and
+`AboutViewModel` (its startup update-check feeds the app-shell version label and update
+banner). The four Network tabs also stay eager because they share one
+`NetworkSharedState` and their constructors do no work. In tests/designer (no DI
+container) every VM is built eagerly via a manual dependency graph, exactly as before.
 
 ## Admin elevation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.104] - 2026-07-21
+
+### Fixed
+- **The app built every one of its ~55 tab view-models at startup, even the tabs you never open.** `MainWindowViewModel` eagerly constructed all tab VMs up front, and most of them kick off real work in their constructor — a background scan, a poll timer, a WMI/registry query — so launching the app fired ~40 of those at once regardless of which tab you actually used (e.g. opening the app to the Dashboard still spun up Services, Drivers, Debloater, Bulk Installer and dozens more). Each tab's view-model is now built lazily, the first time its tab is opened (`NavItem` carries a `ContentFactory` that resolves the VM from DI on first access), so a fresh launch constructs only what the initial view needs. Startup tab-VM construction drops from ~55 to a handful. A deliberately small set stays eager because its constructor drives always-on, app-wide behavior that must run whether or not you open its tab: the Dashboard (the tab shown at launch), the Dark Mode scheduler (owns the theme-schedule poll), and About (its startup update-check feeds the title-bar version label and the "update available" banner). The four Network tabs also stay eager — they share a single network-state object and their constructors do no work. Behavior is otherwise identical; nothing is disabled, only deferred.
+
 ## [1.52.103] - 2026-07-11
 
 ### Accessibility

--- a/SysManager/SysManager.IntegrationTests/AboutViewUiTests.cs
+++ b/SysManager/SysManager.IntegrationTests/AboutViewUiTests.cs
@@ -42,8 +42,12 @@ public class AboutViewUiTests
         {
             EnsureAppResources();
             var mainVm = new MainWindowViewModel();
-            var view = new AboutView { DataContext = mainVm.About };
+            // Reach the About VM through the real nav graph — the per-tab accessor was removed
+            // when tab VMs became lazily built (the "eager-VM startup herd" fix).
+            var aboutVm = mainVm.NavItems.First(n => n.Id == "nav-about").Content;
+            var view = new AboutView { DataContext = aboutVm };
             Assert.NotNull(view.DataContext);
+            Assert.IsType<AboutViewModel>(view.DataContext);
         });
     }
 

--- a/SysManager/SysManager.IntegrationTests/DeepCleanupViewUiTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DeepCleanupViewUiTests.cs
@@ -38,7 +38,10 @@ public class DeepCleanupViewUiTests
     public void MainVm_DeepCleanup_Instantiates()
     {
         var vm = new MainWindowViewModel();
-        Assert.NotNull(vm.DeepCleanup);
+        // The per-tab accessor was removed when tab VMs became lazily built (the "eager-VM
+        // startup herd" fix); reach the VM through the real nav graph instead.
+        var deepCleanup = vm.NavItems.First(n => n.Id == "nav-deep-cleanup").Content;
+        Assert.IsType<DeepCleanupViewModel>(deepCleanup);
     }
 
     [Fact]

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -9,24 +9,47 @@ namespace SysManager.IntegrationTests;
 [Collection("Network")]
 public class MainWindowViewModelTests
 {
+    // Tabs are addressed through the real navigation surface (NavItems → Content), not
+    // through per-tab accessor properties: those were test-only sugar removed when tab
+    // view-models became lazily built (the "eager-VM startup herd" fix). In the test path
+    // (no DI container) every NavItem's Content is still eager, so touching it proves the VM
+    // constructs exactly as before — while pinning the surface the app actually navigates.
+    private static object TabContent(MainWindowViewModel vm, string navId)
+        => vm.NavItems.First(n => n.Id == navId).Content;
+
     [Fact]
     public void AllTabsAreInstantiated()
     {
         var vm = new MainWindowViewModel();
-        Assert.NotNull(vm.Dashboard);
-        Assert.NotNull(vm.AppUpdates);
-        Assert.NotNull(vm.WindowsUpdate);
-        Assert.NotNull(vm.SystemHealth);
-        Assert.NotNull(vm.Cleanup);
-        Assert.NotNull(vm.DeepCleanup);
-        Assert.NotNull(vm.NetworkShared);
-        Assert.NotNull(vm.Ping);
-        Assert.NotNull(vm.Traceroute);
-        Assert.NotNull(vm.SpeedTest);
-        Assert.NotNull(vm.NetworkRepair);
-        Assert.NotNull(vm.Drivers);
-        Assert.NotNull(vm.Logs);
+        Assert.NotNull(TabContent(vm, "nav-dashboard"));
+        Assert.NotNull(TabContent(vm, "nav-app-updates"));
+        Assert.NotNull(TabContent(vm, "nav-windows-update"));
+        Assert.NotNull(TabContent(vm, "nav-system-health"));
+        Assert.NotNull(TabContent(vm, "nav-cleanup"));
+        Assert.NotNull(TabContent(vm, "nav-deep-cleanup"));
+        Assert.NotNull(TabContent(vm, "nav-ping"));
+        Assert.NotNull(TabContent(vm, "nav-traceroute"));
+        Assert.NotNull(TabContent(vm, "nav-speed-test"));
+        Assert.NotNull(TabContent(vm, "nav-network-repair"));
+        Assert.NotNull(TabContent(vm, "nav-drivers"));
+        Assert.NotNull(TabContent(vm, "nav-logs"));
+        Assert.NotNull(TabContent(vm, "nav-about"));
+        // NetworkSharedState is not a tab of its own — it is shared by the four network tabs.
+        // Assert it exists AND that the tabs genuinely share it (the whole point of the type).
+        Assert.NotNull(((PingViewModel)TabContent(vm, "nav-ping")).Shared);
+    }
+
+    // Regression (lazy-VM startup fix): the app shell (MainWindow.xaml) binds its version label
+    // and update banner to About.*, and About's constructor runs the startup update-check that
+    // fills those bindings. So About MUST stay eager and be exposed as a property — making it a
+    // lazy tab would leave the shell banner/version blank until the About tab was first opened.
+    // The About tab and the shell must also share ONE instance (one update-check, one state).
+    [Fact]
+    public void About_IsEagerlyExposed_AndSharedWithItsTab()
+    {
+        var vm = new MainWindowViewModel();
         Assert.NotNull(vm.About);
+        Assert.Same(vm.About, TabContent(vm, "nav-about"));
     }
 
     [Fact]
@@ -58,20 +81,27 @@ public class MainWindowViewModelTests
     public void EachTabViewModel_HasCorrectType()
     {
         var vm = new MainWindowViewModel();
-        Assert.IsType<DashboardViewModel>(vm.Dashboard);
-        Assert.IsType<AppUpdatesViewModel>(vm.AppUpdates);
-        Assert.IsType<WindowsUpdateViewModel>(vm.WindowsUpdate);
-        Assert.IsType<SystemHealthViewModel>(vm.SystemHealth);
-        Assert.IsType<CleanupViewModel>(vm.Cleanup);
-        Assert.IsType<DeepCleanupViewModel>(vm.DeepCleanup);
-        Assert.IsType<NetworkSharedState>(vm.NetworkShared);
-        Assert.IsType<PingViewModel>(vm.Ping);
-        Assert.IsType<TracerouteViewModel>(vm.Traceroute);
-        Assert.IsType<SpeedTestViewModel>(vm.SpeedTest);
-        Assert.IsType<NetworkRepairViewModel>(vm.NetworkRepair);
-        Assert.IsType<DriversViewModel>(vm.Drivers);
-        Assert.IsType<LogsViewModel>(vm.Logs);
-        Assert.IsType<AboutViewModel>(vm.About);
+        Assert.IsType<DashboardViewModel>(TabContent(vm, "nav-dashboard"));
+        Assert.IsType<AppUpdatesViewModel>(TabContent(vm, "nav-app-updates"));
+        Assert.IsType<WindowsUpdateViewModel>(TabContent(vm, "nav-windows-update"));
+        Assert.IsType<SystemHealthViewModel>(TabContent(vm, "nav-system-health"));
+        Assert.IsType<CleanupViewModel>(TabContent(vm, "nav-cleanup"));
+        Assert.IsType<DeepCleanupViewModel>(TabContent(vm, "nav-deep-cleanup"));
+        Assert.IsType<PingViewModel>(TabContent(vm, "nav-ping"));
+        Assert.IsType<TracerouteViewModel>(TabContent(vm, "nav-traceroute"));
+        Assert.IsType<SpeedTestViewModel>(TabContent(vm, "nav-speed-test"));
+        Assert.IsType<NetworkRepairViewModel>(TabContent(vm, "nav-network-repair"));
+        Assert.IsType<DriversViewModel>(TabContent(vm, "nav-drivers"));
+        Assert.IsType<LogsViewModel>(TabContent(vm, "nav-logs"));
+        Assert.IsType<AboutViewModel>(TabContent(vm, "nav-about"));
+
+        // The four network tabs share ONE NetworkSharedState instance (created once in the
+        // MainWindowViewModel, injected into each). Pin both its type and the sharing.
+        var ping = (PingViewModel)TabContent(vm, "nav-ping");
+        Assert.IsType<NetworkSharedState>(ping.Shared);
+        Assert.Same(ping.Shared, ((TracerouteViewModel)TabContent(vm, "nav-traceroute")).Shared);
+        Assert.Same(ping.Shared, ((SpeedTestViewModel)TabContent(vm, "nav-speed-test")).Shared);
+        Assert.Same(ping.Shared, ((NetworkRepairViewModel)TabContent(vm, "nav-network-repair")).Shared);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/NavItemLazyContentTests.cs
+++ b/SysManager/SysManager.Tests/NavItemLazyContentTests.cs
@@ -1,0 +1,139 @@
+// SysManager · NavItemLazyContentTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Pins the lazy-Content contract that lets MainWindowViewModel defer building the ~49 tab
+/// view-models until their tab is first opened (the "eager-VM startup herd" fix). A NavItem must:
+/// build nothing until Content is first accessed, then cache it; never force creation from
+/// IsContentCreated or Dispose; and still support an eagerly-assigned instance (tests + the few
+/// startup-required tabs like Dark Mode).
+/// </summary>
+public class NavItemLazyContentTests
+{
+    private sealed class CountingVm : ViewModelBase
+    {
+        public static int Built;
+        public CountingVm() => Built++;
+    }
+
+    private static NavItem LazyItem(Func<object> factory) => new()
+    {
+        Id = "lazy",
+        Label = "Lazy",
+        Glyph = "",
+        ViewType = typeof(object),
+        ContentFactory = factory,
+    };
+
+    [Fact]
+    public void Lazy_DoesNotBuildContent_UntilFirstAccess()
+    {
+        int built = 0;
+        var item = LazyItem(() => { built++; return new object(); });
+
+        Assert.False(item.IsContentCreated);
+        Assert.Equal(0, built);
+
+        _ = item.Content;              // first access materialises
+
+        Assert.True(item.IsContentCreated);
+        Assert.Equal(1, built);
+    }
+
+    [Fact]
+    public void Lazy_CachesContent_FactoryRunsOnce()
+    {
+        int built = 0;
+        var item = LazyItem(() => { built++; return new object(); });
+
+        var a = item.Content;
+        var b = item.Content;
+
+        Assert.Same(a, b);
+        Assert.Equal(1, built);        // second access does NOT re-run the factory
+    }
+
+    [Fact]
+    public void IsContentCreated_DoesNotForceCreation()
+    {
+        int built = 0;
+        var item = LazyItem(() => { built++; return new object(); });
+
+        _ = item.IsContentCreated;     // must not build
+        _ = item.IsContentCreated;
+
+        Assert.Equal(0, built);
+    }
+
+    [Fact]
+    public void Dispose_OnUnopenedLazyItem_DoesNotBuildContent()
+    {
+        int built = 0;
+        var item = LazyItem(() => { built++; return new object(); });
+
+        item.Dispose();                // never opened → nothing to dispose, nothing to build
+
+        Assert.False(item.IsContentCreated);
+        Assert.Equal(0, built);
+    }
+
+    [Fact]
+    public void Eager_ContentAvailableImmediately_WithoutFactory()
+    {
+        var vm = new object();
+        var item = new NavItem
+        {
+            Id = "eager",
+            Label = "Eager",
+            Glyph = "",
+            ViewType = typeof(object),
+            Content = vm,
+        };
+
+        Assert.True(item.IsContentCreated);
+        Assert.Same(vm, item.Content);
+    }
+
+    [Fact]
+    public void Lazy_ForwardsIsBusy_AfterMaterialisation()
+    {
+        var backing = new CountingVm();
+        var item = LazyItem(() => backing);
+
+        // Before open: the item is not wired to the VM, so it reports not-busy.
+        Assert.False(item.IsBusy);
+
+        _ = item.Content;              // materialise + wire IsBusy forwarding
+
+        backing.IsBusy = true;
+        Assert.True(item.IsBusy);      // now forwarded
+        backing.IsBusy = false;
+        Assert.False(item.IsBusy);
+    }
+
+    [Fact]
+    public void Dispose_OnOpenedItem_UnsubscribesAndDisposesVm()
+    {
+        var backing = new CountingVm();
+        var item = LazyItem(() => backing);
+        _ = item.Content;              // open it
+
+        item.Dispose();
+
+        // After dispose, VM events no longer forward (stale IsBusy must not update).
+        backing.IsBusy = true;
+        Assert.False(item.IsBusy);
+    }
+
+    [Fact]
+    public void Content_WithNeitherEagerNorFactory_Throws()
+    {
+        var item = new NavItem { Id = "bad", Label = "Bad", Glyph = "", ViewType = typeof(object) };
+        Assert.Throws<InvalidOperationException>(() => _ = item.Content);
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.103</Version>
-    <FileVersion>1.52.103.0</FileVersion>
-    <AssemblyVersion>1.52.103.0</AssemblyVersion>
+    <Version>1.52.104</Version>
+    <FileVersion>1.52.104.0</FileVersion>
+    <AssemblyVersion>1.52.104.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -14,80 +14,30 @@ namespace SysManager.ViewModels;
 
 public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 {
-    public DashboardViewModel Dashboard { get; }
-    public AppUpdatesViewModel AppUpdates { get; }
-    public WindowsUpdateViewModel WindowsUpdate { get; }
-    public SystemHealthViewModel SystemHealth { get; }
-    public CleanupViewModel Cleanup { get; }
-    public DeepCleanupViewModel DeepCleanup { get; }
-    public DuplicateFileViewModel DuplicateFile { get; }
-    public DiskAnalyzerViewModel DiskAnalyzer { get; }
-    public ProcessManagerViewModel ProcessManager { get; }
-    public BatteryHealthViewModel BatteryHealth { get; }
-    public UninstallerViewModel Uninstaller { get; }
-    public PerformanceViewModel Performance { get; }
-    public StartupViewModel Startup { get; }
-    public NetworkSharedState NetworkShared { get; }
-    public PingViewModel Ping { get; }
-    public TracerouteViewModel Traceroute { get; }
-    public SpeedTestViewModel SpeedTest { get; }
-    public NetworkRepairViewModel NetworkRepair { get; }
-    public DriversViewModel Drivers { get; }
-    public LogsViewModel Logs { get; }
+    // The DI container (runtime) or null (designer/tests). When present, tab VMs are
+    // resolved lazily — each tab's NavItem builds its VM on first open (see NavItem.Content).
+    private readonly IServiceProvider? _sp;
+
+    // Shared network state — injected into all four network tab VMs and owning SkiaSharp paint
+    // handles, so it is created once here (not per tab) and disposed explicitly below. It starts
+    // no background polling on construction, so keeping it eager costs nothing at startup.
+    private readonly NetworkSharedState? _networkShared;
+
+    // Kept eager (must exist at startup, independent of whether their tab is ever opened):
+    //  • Dashboard — it is the initially-selected tab, so it is built immediately anyway.
+    //  • DarkMode  — owns the always-on dark/light theme SCHEDULE poll; nothing else runs it, so
+    //                if it were lazy a user's schedule would silently stop until they opened the tab.
+    //  • About     — its constructor runs the startup update-check that drives the app-shell
+    //                update banner (MainWindow binds About.UpdateAvailable / .CurrentVersion). If it
+    //                were lazy, the banner and version label would stay blank until the tab was opened.
+    private readonly DashboardViewModel? _dashboard;
+
+    /// <summary>
+    /// The About tab's view-model. Exposed as a property (not just a NavItem) because the app
+    /// shell (MainWindow.xaml) binds its version label and update banner to it, and its
+    /// constructor runs the startup update-check that populates those bindings.
+    /// </summary>
     public AboutViewModel About { get; }
-    public ServicesViewModel Services { get; }
-
-    // ── Implemented ViewModels (resolved from DI at runtime) ────────
-    public WindowsFeaturesViewModel WindowsFeatures { get; }
-    public AppAlertsViewModel AppAlerts { get; }
-    public ShortcutCleanerViewModel ShortcutCleaner { get; }
-    public AppBlockerViewModel AppBlocker { get; }
-    public BulkInstallerViewModel BulkInstaller { get; }
-    public FileShredderViewModel FileShredder { get; }
-    public PrivacyViewModel Privacy { get; }
-    public DnsHostsViewModel DnsHosts { get; }
-    public ContextMenuViewModel ContextMenu { get; }
-    public SystemReportViewModel SystemReport { get; }
-    public EnvironmentVariablesViewModel EnvironmentVariables { get; }
-    public RestorePointsViewModel RestorePoints { get; }
-    public DebloaterViewModel Debloater { get; }
-    public LegacyPanelsViewModel LegacyPanels { get; }
-    public SystemFixesViewModel SystemFixes { get; }
-    public ProfileViewModel Profile { get; }
-    public BrowserCleanerViewModel BrowserCleaner { get; }
-    public PrivacyMonitorViewModel PrivacyMonitor { get; }
-    public BootAnalyzerViewModel BootAnalyzer { get; }
-    public TimerResolutionViewModel TimerResolution { get; }
-    public FileLockViewModel FileLock { get; }
-    public DisplayProfileViewModel DisplayProfile { get; }
-    public CpuAffinityViewModel CpuAffinity { get; }
-    public DefenderViewModel Defender { get; }
-    public TaskSchedulerViewModel TaskScheduler { get; }
-    public DarkModeViewModel DarkMode { get; }
-    public StandbyMemoryViewModel StandbyMemory { get; }
-    public ResourceHistoryViewModel ResourceHistory { get; }
-    public SettingsWatchdogViewModel SettingsWatchdog { get; }
-    public CliInterfaceViewModel CliInterface { get; }
-    public ScheduledMaintenanceViewModel ScheduledMaintenance { get; }
-    public TweaksHubViewModel TweaksHub { get; }
-    public AudioMixerViewModel AudioMixer { get; }
-    public GamingProfileViewModel GamingProfile { get; }
-
-    // ── Placeholder ViewModels for planned features (WIP) ──────────
-    // Monitor group
-    public PlaceholderViewModel WipBandwidthMonitor { get; private set; } = null!;
-
-    // Gaming & Profiles group (Gaming Profile now implemented as PREVIEW)
-
-    // Network group — DNS Changer + Hosts Editor now fully implemented as DnsHosts
-
-    // Apps group (Bulk Installer is now fully implemented)
-
-    // Privacy & Security group (Privacy & Telemetry + Debloater + Browser Cleaner now fully implemented)
-    public PlaceholderViewModel WipEdgeOneDriveRemover { get; private set; } = null!;
-    public PlaceholderViewModel WipNotificationBlocker { get; private set; } = null!;
-
-    // Customization group (Context Menu + Volume Control now implemented; Volume Control is PREVIEW)
 
     /// <summary>Grouped sidebar tree (12 categories).</summary>
     public ObservableCollection<NavGroup> NavGroups { get; } = new();
@@ -100,188 +50,44 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     [ObservableProperty] private bool _isElevated;
     [ObservableProperty] private string _elevationBadge = "";
 
+    // Placeholder VMs for planned features (cheap; built once, referenced by their NavItems).
+    private readonly PlaceholderViewModel _wipBandwidthMonitor =
+        new("Bandwidth Monitor", "Real-time per-app network usage with history graphs and alerts.", "#337");
+    private readonly PlaceholderViewModel _wipEdgeOneDriveRemover =
+        new("Edge/OneDrive Remover", "Safely remove or disable Edge and OneDrive with full restore capability.", "#339");
+    private readonly PlaceholderViewModel _wipNotificationBlocker =
+        new("Notification Blocker", "Suppress annoying app pop-ups (update nags, trial reminders) with allowlist.", "#340");
+
     private bool _disposed;
 
     /// <summary>
     /// Parameterless constructor — used by XAML designer and tests.
-    /// When DI container is available (runtime), resolves child VMs from it.
-    /// When not available (tests/designer), creates dependencies manually.
+    /// At runtime (DI container available) tab VMs are resolved LAZILY: each NavItem builds its
+    /// view-model on first open, so the ~40 tabs that kick off a background scan/timer in their
+    /// constructor no longer all run at startup. When DI is unavailable (tests/designer), every VM
+    /// is created eagerly and handed to its NavItem as before.
     /// </summary>
     public MainWindowViewModel()
     {
-        var sp = App.Services;
-        if (sp is not null)
+        _sp = App.Services;
+        if (_sp is null)
         {
-            // Runtime path — resolve from DI container (shared singletons)
-            Dashboard = sp.GetRequiredService<DashboardViewModel>();
-            AppUpdates = sp.GetRequiredService<AppUpdatesViewModel>();
-            WindowsUpdate = sp.GetRequiredService<WindowsUpdateViewModel>();
-            SystemHealth = sp.GetRequiredService<SystemHealthViewModel>();
-            Cleanup = sp.GetRequiredService<CleanupViewModel>();
-            DeepCleanup = sp.GetRequiredService<DeepCleanupViewModel>();
-            DuplicateFile = sp.GetRequiredService<DuplicateFileViewModel>();
-            DiskAnalyzer = sp.GetRequiredService<DiskAnalyzerViewModel>();
-            ProcessManager = sp.GetRequiredService<ProcessManagerViewModel>();
-            BatteryHealth = sp.GetRequiredService<BatteryHealthViewModel>();
-            Uninstaller = sp.GetRequiredService<UninstallerViewModel>();
-            Performance = sp.GetRequiredService<PerformanceViewModel>();
-            Startup = sp.GetRequiredService<StartupViewModel>();
-            NetworkShared = sp.GetRequiredService<NetworkSharedState>();
-            Ping = sp.GetRequiredService<PingViewModel>();
-            Traceroute = sp.GetRequiredService<TracerouteViewModel>();
-            SpeedTest = sp.GetRequiredService<SpeedTestViewModel>();
-            NetworkRepair = sp.GetRequiredService<NetworkRepairViewModel>();
-            Drivers = sp.GetRequiredService<DriversViewModel>();
-            Logs = sp.GetRequiredService<LogsViewModel>();
-            About = sp.GetRequiredService<AboutViewModel>();
-            Services = sp.GetRequiredService<ServicesViewModel>();
-            AppAlerts = sp.GetRequiredService<AppAlertsViewModel>();
-            ShortcutCleaner = sp.GetRequiredService<ShortcutCleanerViewModel>();
-            AppBlocker = sp.GetRequiredService<AppBlockerViewModel>();
-            BulkInstaller = sp.GetRequiredService<BulkInstallerViewModel>();
-            FileShredder = sp.GetRequiredService<FileShredderViewModel>();
-            DnsHosts = sp.GetRequiredService<DnsHostsViewModel>();
-            WindowsFeatures = sp.GetRequiredService<WindowsFeaturesViewModel>();
-            Privacy = sp.GetRequiredService<PrivacyViewModel>();
-            ContextMenu = sp.GetRequiredService<ContextMenuViewModel>();
-            SystemReport = sp.GetRequiredService<SystemReportViewModel>();
-            EnvironmentVariables = sp.GetRequiredService<EnvironmentVariablesViewModel>();
-            RestorePoints = sp.GetRequiredService<RestorePointsViewModel>();
-            Debloater = sp.GetRequiredService<DebloaterViewModel>();
-            LegacyPanels = sp.GetRequiredService<LegacyPanelsViewModel>();
-            SystemFixes = sp.GetRequiredService<SystemFixesViewModel>();
-            Profile = sp.GetRequiredService<ProfileViewModel>();
-            BrowserCleaner = sp.GetRequiredService<BrowserCleanerViewModel>();
-            PrivacyMonitor = sp.GetRequiredService<PrivacyMonitorViewModel>();
-            BootAnalyzer = sp.GetRequiredService<BootAnalyzerViewModel>();
-            TimerResolution = sp.GetRequiredService<TimerResolutionViewModel>();
-            FileLock = sp.GetRequiredService<FileLockViewModel>();
-            DisplayProfile = sp.GetRequiredService<DisplayProfileViewModel>();
-            CpuAffinity = sp.GetRequiredService<CpuAffinityViewModel>();
-            Defender = sp.GetRequiredService<DefenderViewModel>();
-            TaskScheduler = sp.GetRequiredService<TaskSchedulerViewModel>();
-            DarkMode = sp.GetRequiredService<DarkModeViewModel>();
-            StandbyMemory = sp.GetRequiredService<StandbyMemoryViewModel>();
-            ResourceHistory = sp.GetRequiredService<ResourceHistoryViewModel>();
-            SettingsWatchdog = sp.GetRequiredService<SettingsWatchdogViewModel>();
-            CliInterface = sp.GetRequiredService<CliInterfaceViewModel>();
-            ScheduledMaintenance = sp.GetRequiredService<ScheduledMaintenanceViewModel>();
-            TweaksHub = sp.GetRequiredService<TweaksHubViewModel>();
-            AudioMixer = sp.GetRequiredService<AudioMixerViewModel>();
-            GamingProfile = sp.GetRequiredService<GamingProfileViewModel>();
-        }
-        else
-        {
-            // Test/designer path — create dependencies manually
-            var runner = new PowerShellRunner();
-            var sysInfo = new SystemInfoService();
-            var winget = new WingetService(runner);
-            var diskHealth = new DiskHealthService();
-            var battery = new BatteryService();
-            var shortcuts = new ShortcutCleanerService();
-            var tuneUp = new TuneUpService(shortcuts, diskHealth, sysInfo);
-            var healthScore = new HealthScoreService(sysInfo, diskHealth, battery);
-            var fixedDrives = new FixedDriveService();
-            var pinger = new PingMonitorService();
-            var tracer = new TracerouteService();
-            var traceMonitor = new TracerouteMonitorService();
-            var speedTest = new SpeedTestService();
-            var netRepair = new NetworkRepairService(runner);
-
-            Dashboard = new DashboardViewModel(sysInfo, tuneUp, healthScore, new TemperatureService(diskHealth), winget);
-            AppUpdates = new AppUpdatesViewModel(winget);
-            WindowsUpdate = new WindowsUpdateViewModel(runner, new WindowsUpdateService(), new WindowsUpdatePolicyService());
-            SystemHealth = new SystemHealthViewModel(sysInfo, diskHealth, new MemoryTestService(), fixedDrives, runner, new BiosService());
-            Cleanup = new CleanupViewModel(runner);
-            DeepCleanup = new DeepCleanupViewModel(new DeepCleanupService(), new LargeFileScanner(), fixedDrives);
-            DuplicateFile = new DuplicateFileViewModel(new DuplicateFileService());
-            DiskAnalyzer = new DiskAnalyzerViewModel(new DiskAnalyzerService());
-            ProcessManager = new ProcessManagerViewModel(new ProcessManagerService());
-            BatteryHealth = new BatteryHealthViewModel(battery);
-            Uninstaller = new UninstallerViewModel(new UninstallerService(runner));
-            var restorePoints = new RestorePointService(runner);
-            Performance = new PerformanceViewModel(new PerformanceService(runner, restorePoints));
-            Startup = new StartupViewModel(new StartupService());
-            NetworkShared = new NetworkSharedState(pinger, tracer, traceMonitor, speedTest, netRepair);
-            Ping = new PingViewModel(NetworkShared);
-            Traceroute = new TracerouteViewModel(NetworkShared);
-            SpeedTest = new SpeedTestViewModel(NetworkShared, new SpeedTestHistoryService());
-            NetworkRepair = new NetworkRepairViewModel(NetworkShared);
-            Drivers = new DriversViewModel(runner);
-            Logs = new LogsViewModel(new EventLogService());
-            About = new AboutViewModel();
-            Services = new ServicesViewModel(runner);
-            AppAlerts = new AppAlertsViewModel(new AppAlertService());
-            ShortcutCleaner = new ShortcutCleanerViewModel(shortcuts);
-            AppBlocker = new AppBlockerViewModel(new AppBlockerService());
-            BulkInstaller = new BulkInstallerViewModel(new BulkInstallerService(new PowerShellRunner()), new AppIconService());
-            FileShredder = new FileShredderViewModel(new FileShredderService());
-            DnsHosts = new DnsHostsViewModel(new DnsService(new PowerShellRunner()), new HostsFileService());
-            WindowsFeatures = new WindowsFeaturesViewModel(new WindowsFeaturesService(runner));
-            Privacy = new PrivacyViewModel(new PrivacyService());
-            ContextMenu = new ContextMenuViewModel(new ContextMenuService());
-            SystemReport = new SystemReportViewModel(new SystemReportService(sysInfo, diskHealth));
-            EnvironmentVariables = new EnvironmentVariablesViewModel(new EnvironmentVariableService());
-            RestorePoints = new RestorePointsViewModel(restorePoints);
-            Debloater = new DebloaterViewModel(new DebloaterService(new PowerShellRunner()));
-            LegacyPanels = new LegacyPanelsViewModel(new LegacyPanelService());
-            SystemFixes = new SystemFixesViewModel(new SystemFixService(new PowerShellRunner()));
-            Profile = new ProfileViewModel(new ProfileService());
-            BrowserCleaner = new BrowserCleanerViewModel(new BrowserCleanerService());
-            PrivacyMonitor = new PrivacyMonitorViewModel(new PrivacyMonitorService());
-            BootAnalyzer = new BootAnalyzerViewModel(new BootAnalyzerService());
-            TimerResolution = new TimerResolutionViewModel(new TimerResolutionService());
-            FileLock = new FileLockViewModel(new FileLockService());
-            DisplayProfile = new DisplayProfileViewModel(new DisplayProfileService());
-            CpuAffinity = new CpuAffinityViewModel(new CpuAffinityService());
-            Defender = new DefenderViewModel(new DefenderService(new PowerShellRunner()));
-            TaskScheduler = new TaskSchedulerViewModel(new TaskSchedulerService(new PowerShellRunner()));
-            DarkMode = new DarkModeViewModel(new WindowsThemeService());
-            StandbyMemory = new StandbyMemoryViewModel(new StandbyMemoryService());
-            ResourceHistory = new ResourceHistoryViewModel(new ResourceHistoryService(sysInfo, new TemperatureService(diskHealth)));
-            SettingsWatchdog = new SettingsWatchdogViewModel(new SettingsWatchdogService());
-            CliInterface = new CliInterfaceViewModel();
-            ScheduledMaintenance = new ScheduledMaintenanceViewModel(new MaintenanceSchedulerService(new PowerShellRunner()));
-            TweaksHub = new TweaksHubViewModel(new TweaksHubService(new PrivacyService(), restorePoints));
-            AudioMixer = new AudioMixerViewModel(new AudioMixerService());
-            var gamingCpu = new CpuAffinityService();
-            GamingProfile = new GamingProfileViewModel(
-                new GamingProfileService(
-                    new PerformanceService(runner, restorePoints),
-                    new TimerResolutionService(), gamingCpu,
-                    new StandbyMemoryService(), restorePoints,
-                    Helpers.AdminHelper.IsElevated()),
-                gamingCpu);
+            // Designer / test path: no container → build the whole VM graph eagerly up front.
+            _designerVms = BuildDesignerGraph();
         }
 
-        InitPlaceholders();
+        // NetworkSharedState is shared by the four network tabs and disposed explicitly below.
+        _networkShared = Eager<NetworkSharedState>();
+        // Dashboard is the initially-selected tab (built immediately regardless).
+        _dashboard = Eager<DashboardViewModel>();
+        // DarkMode is resolved eagerly so its always-on theme schedule poll starts with the app,
+        // independent of whether the user ever opens that tab.
+        _ = Eager<DarkModeViewModel>();
+        // About is resolved eagerly so its constructor's startup update-check runs immediately —
+        // the app-shell update banner and version label bind to it (see the About property above).
+        About = Eager<AboutViewModel>();
+
         InitNavigation();
-    }
-
-    private void InitPlaceholders()
-    {
-        // ── WIP placeholders for planned features ──────────────────────
-
-        // Monitor group
-        WipBandwidthMonitor = new PlaceholderViewModel("Bandwidth Monitor", "Real-time per-app network usage with history graphs and alerts.", "#337");
-
-        // Gaming & Profiles group — Gaming Profile now implemented as PREVIEW (see nav)
-
-        // Cleanup group (File Shredder is now fully implemented)
-
-        // Network group — DNS Changer + Hosts Editor now fully implemented as DnsHosts
-
-        // Apps group — Bulk Installer is now fully implemented (no placeholder needed)
-
-        // Privacy & Security group (Privacy & Telemetry is now fully implemented)
-        WipEdgeOneDriveRemover = new PlaceholderViewModel("Edge/OneDrive Remover", "Safely remove or disable Edge and OneDrive with full restore capability.", "#339");
-        WipNotificationBlocker = new PlaceholderViewModel("Notification Blocker", "Suppress annoying app pop-ups (update nags, trial reminders) with allowlist.", "#340");
-
-        // Customization group (Context Menu + Volume Control now implemented; Volume Control ships as PREVIEW)
-
-        // System group (additions)
-
-        // Advanced group
     }
 
     private void InitNavigation()
@@ -296,7 +102,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             NavGroups.Add(g);
             foreach (var item in g.Children)
             {
-                item.WireBusy();
+                item.WireBusy(); // no-op for lazy items until their VM is first materialised
                 NavItems.Add(item);
             }
         }
@@ -304,123 +110,177 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         SelectedNav = NavItems[0];
     }
 
+    // ── Tab factories ───────────────────────────────────────────────────────
+    // At runtime each returns a lazy NavItem (VM resolved from DI on first open). In the
+    // designer/test path (no container) they build the VM eagerly and register it for disposal.
+
+    private NavItem Tab<TVm>(string id, string label, Type viewType, bool inDevelopment = false)
+        where TVm : class
+    {
+        if (_sp is not null)
+        {
+            return new NavItem
+            {
+                Id = id,
+                Label = label,
+                Glyph = "",
+                ViewType = viewType,
+                IsInDevelopment = inDevelopment,
+                ContentFactory = () => _sp.GetRequiredService<TVm>(),
+            };
+        }
+        // Designer/test path: no container → build eagerly from the manual graph.
+        var vm = _designerVms![typeof(TVm)];
+        return EagerItem(id, label, viewType, vm, inDevelopment);
+    }
+
+    // An eagerly-provided VM (Dashboard, DarkMode, network tabs, placeholders). The instance is
+    // set as the NavItem's Content, so NavItem.Dispose disposes it on teardown like any other tab.
+    private static NavItem EagerItem(string id, string label, Type viewType, object content, bool inDevelopment = false)
+        => new()
+        {
+            Id = id,
+            Label = label,
+            Glyph = "",
+            ViewType = viewType,
+            Content = content,
+            IsInDevelopment = inDevelopment,
+        };
+
+    // Resolve an eager VM: from DI when available, else from the designer graph.
+    private T Eager<T>() where T : class =>
+        _sp is not null ? _sp.GetRequiredService<T>() : (T)_designerVms![typeof(T)];
+
     private NavGroup[] BuildNavGroups() =>
     [
-        Group("grp-dashboard", "Dashboard", "",
-            Item("nav-dashboard", "Dashboard", "", Dashboard, typeof(Views.DashboardView))),
+        Group("grp-dashboard", "Dashboard",
+            EagerItem("nav-dashboard", "Dashboard", typeof(Views.DashboardView), _dashboard ?? Eager<DashboardViewModel>())),
 
-        Group("grp-system", "System", "",
-            Item("nav-system-health",    "System Health",    "", SystemHealth,     typeof(Views.SystemHealthView)),
-            Item("nav-windows-update",   "Windows Update",   "", WindowsUpdate,    typeof(Views.WindowsUpdateView)),
-            Item("nav-performance",      "Performance Mode", "", Performance,      typeof(Views.PerformanceView)),
-            Item("nav-services",         "Services",         "", Services,         typeof(Views.ServicesView)),
-            Item("nav-startup",          "Startup Manager",  "", Startup,          typeof(Views.StartupView)),
-            Item("nav-windows-features", "Windows Features", "", WindowsFeatures,  typeof(Views.WindowsFeaturesView)),
-            Item("nav-restore-points",   "Restore Points",   "", RestorePoints,    typeof(Views.RestorePointsView)),
-            Item("nav-task-scheduler",   "Task Scheduler",   "", TaskScheduler,    typeof(Views.TaskSchedulerView)),
-            Item("nav-boot-analyzer",    "Boot Analyzer",    "", BootAnalyzer,     typeof(Views.BootAnalyzerView)),
-            Item("nav-system-fixes",     "System Fixes",     "", SystemFixes,      typeof(Views.SystemFixesView)),
-            Item("nav-tweaks-hub",      "Tweaks Hub",       "", TweaksHub,        typeof(Views.TweaksHubView), inDevelopment: true)),
+        Group("grp-system", "System",
+            Tab<SystemHealthViewModel>("nav-system-health",    "System Health",    typeof(Views.SystemHealthView)),
+            Tab<WindowsUpdateViewModel>("nav-windows-update",  "Windows Update",   typeof(Views.WindowsUpdateView)),
+            Tab<PerformanceViewModel>("nav-performance",       "Performance Mode", typeof(Views.PerformanceView)),
+            Tab<ServicesViewModel>("nav-services",             "Services",         typeof(Views.ServicesView)),
+            Tab<StartupViewModel>("nav-startup",               "Startup Manager",  typeof(Views.StartupView)),
+            Tab<WindowsFeaturesViewModel>("nav-windows-features", "Windows Features", typeof(Views.WindowsFeaturesView)),
+            Tab<RestorePointsViewModel>("nav-restore-points",  "Restore Points",   typeof(Views.RestorePointsView)),
+            Tab<TaskSchedulerViewModel>("nav-task-scheduler",  "Task Scheduler",   typeof(Views.TaskSchedulerView)),
+            Tab<BootAnalyzerViewModel>("nav-boot-analyzer",    "Boot Analyzer",    typeof(Views.BootAnalyzerView)),
+            Tab<SystemFixesViewModel>("nav-system-fixes",      "System Fixes",     typeof(Views.SystemFixesView)),
+            Tab<TweaksHubViewModel>("nav-tweaks-hub",          "Tweaks Hub",       typeof(Views.TweaksHubView), inDevelopment: true)),
 
-        Group("grp-gaming", "Gaming & Profiles", "",
-            Item("nav-gaming-profile",   "Gaming Profile",       "", GamingProfile,         typeof(Views.GamingProfileView), inDevelopment: true),
-            Item("nav-standby-cleaner",  "Standby List Cleaner", "", StandbyMemory,         typeof(Views.StandbyMemoryView)),
-            Item("nav-timer-resolution", "Timer Resolution",     "", TimerResolution,       typeof(Views.TimerResolutionView)),
-            Item("nav-cpu-affinity",     "CPU Core Affinity",    "", CpuAffinity,           typeof(Views.CpuAffinityView)),
-            Item("nav-display-profiles", "Display Profiles",     "", DisplayProfile,        typeof(Views.DisplayProfileView))),
+        Group("grp-gaming", "Gaming & Profiles",
+            Tab<GamingProfileViewModel>("nav-gaming-profile",   "Gaming Profile",       typeof(Views.GamingProfileView), inDevelopment: true),
+            Tab<StandbyMemoryViewModel>("nav-standby-cleaner",  "Standby List Cleaner", typeof(Views.StandbyMemoryView)),
+            Tab<TimerResolutionViewModel>("nav-timer-resolution", "Timer Resolution",   typeof(Views.TimerResolutionView)),
+            Tab<CpuAffinityViewModel>("nav-cpu-affinity",       "CPU Core Affinity",    typeof(Views.CpuAffinityView)),
+            Tab<DisplayProfileViewModel>("nav-display-profiles", "Display Profiles",    typeof(Views.DisplayProfileView))),
 
-        Group("grp-monitor", "Monitor", "",
-            Item("nav-processes",         "Process Manager",    "", ProcessManager,      typeof(Views.ProcessManagerView)),
-            Item("nav-resource-history",  "Resource History",   "", ResourceHistory,     typeof(Views.ResourceHistoryView), inDevelopment: true),
-            Item("nav-privacy-monitor",   "Camera/Mic/Location",    "", PrivacyMonitor,      typeof(Views.PrivacyMonitorView)),
-            Item("nav-app-alerts",        "App Alerts",         "", AppAlerts,           typeof(Views.AppAlertsView)),
-            Item("nav-file-lock",         "File Lock Detector", "", FileLock,            typeof(Views.FileLockView)),
-            Item("nav-settings-watchdog", "Settings Watchdog",  "", SettingsWatchdog,    typeof(Views.SettingsWatchdogView), inDevelopment: true),
-            Item("nav-bandwidth-monitor", "Bandwidth Monitor",  "", WipBandwidthMonitor, typeof(Views.PlaceholderView), inDevelopment: true)),
+        Group("grp-monitor", "Monitor",
+            Tab<ProcessManagerViewModel>("nav-processes",       "Process Manager",    typeof(Views.ProcessManagerView)),
+            Tab<ResourceHistoryViewModel>("nav-resource-history", "Resource History", typeof(Views.ResourceHistoryView), inDevelopment: true),
+            Tab<PrivacyMonitorViewModel>("nav-privacy-monitor", "Camera/Mic/Location", typeof(Views.PrivacyMonitorView)),
+            Tab<AppAlertsViewModel>("nav-app-alerts",           "App Alerts",         typeof(Views.AppAlertsView)),
+            Tab<FileLockViewModel>("nav-file-lock",             "File Lock Detector", typeof(Views.FileLockView)),
+            Tab<SettingsWatchdogViewModel>("nav-settings-watchdog", "Settings Watchdog", typeof(Views.SettingsWatchdogView), inDevelopment: true),
+            EagerItem("nav-bandwidth-monitor", "Bandwidth Monitor", typeof(Views.PlaceholderView), _wipBandwidthMonitor, inDevelopment: true)),
 
-        Group("grp-cleanup", "Cleanup", "",
-            Item("nav-cleanup",               "Quick Cleanup",         "", Cleanup,                 typeof(Views.CleanupView)),
-            Item("nav-deep-cleanup",          "Deep Cleanup",          "", DeepCleanup,             typeof(Views.DeepCleanupView)),
-            Item("nav-shortcut-cleaner",      "Shortcut Cleaner",      "", ShortcutCleaner,         typeof(Views.ShortcutCleanerView)),
-            Item("nav-scheduled-maintenance", "Scheduled Maintenance", "", ScheduledMaintenance,    typeof(Views.ScheduledMaintenanceView), inDevelopment: true)),
+        Group("grp-cleanup", "Cleanup",
+            Tab<CleanupViewModel>("nav-cleanup",                     "Quick Cleanup",         typeof(Views.CleanupView)),
+            Tab<DeepCleanupViewModel>("nav-deep-cleanup",            "Deep Cleanup",          typeof(Views.DeepCleanupView)),
+            Tab<ShortcutCleanerViewModel>("nav-shortcut-cleaner",    "Shortcut Cleaner",      typeof(Views.ShortcutCleanerView)),
+            Tab<ScheduledMaintenanceViewModel>("nav-scheduled-maintenance", "Scheduled Maintenance", typeof(Views.ScheduledMaintenanceView), inDevelopment: true)),
 
-        Group("grp-storage", "Storage", "",
-            Item("nav-disk-analyzer", "Disk Analyzer",    "", DiskAnalyzer,  typeof(Views.DiskAnalyzerView)),
-            Item("nav-duplicates",    "Duplicate Finder", "", DuplicateFile, typeof(Views.DuplicateFileView))),
+        Group("grp-storage", "Storage",
+            Tab<DiskAnalyzerViewModel>("nav-disk-analyzer", "Disk Analyzer",    typeof(Views.DiskAnalyzerView)),
+            Tab<DuplicateFileViewModel>("nav-duplicates",   "Duplicate Finder", typeof(Views.DuplicateFileView))),
 
-        Group("grp-network", "Network", "",
-            Item("nav-ping",           "Ping",           "", Ping,          typeof(Views.PingView)),
-            Item("nav-traceroute",     "Traceroute",     "", Traceroute,    typeof(Views.TracerouteView)),
-            Item("nav-speed-test",     "Speed Test",     "", SpeedTest,     typeof(Views.SpeedTestView)),
-            Item("nav-network-repair", "Network Repair", "", NetworkRepair, typeof(Views.NetworkRepairView)),
-            Item("nav-dns-hosts",      "DNS & Hosts",    "", DnsHosts,      typeof(Views.DnsHostsView))),
+        Group("grp-network", "Network",
+            EagerItem("nav-ping",           "Ping",           typeof(Views.PingView),          new PingViewModel(Eager<NetworkSharedState>())),
+            EagerItem("nav-traceroute",     "Traceroute",     typeof(Views.TracerouteView),    new TracerouteViewModel(Eager<NetworkSharedState>())),
+            EagerItem("nav-speed-test",     "Speed Test",     typeof(Views.SpeedTestView),     new SpeedTestViewModel(Eager<NetworkSharedState>(), new SpeedTestHistoryService())),
+            EagerItem("nav-network-repair", "Network Repair", typeof(Views.NetworkRepairView), new NetworkRepairViewModel(Eager<NetworkSharedState>())),
+            Tab<DnsHostsViewModel>("nav-dns-hosts", "DNS & Hosts", typeof(Views.DnsHostsView))),
 
-        Group("grp-apps", "Apps", "",
-            Item("nav-app-updates",    "App Updates",    "", AppUpdates,    typeof(Views.AppUpdatesView)),
-            Item("nav-bulk-installer", "Bulk Installer", "", BulkInstaller, typeof(Views.BulkInstallerView)),
-            Item("nav-uninstaller",    "Uninstaller",    "", Uninstaller,   typeof(Views.UninstallerView))),
+        Group("grp-apps", "Apps",
+            Tab<AppUpdatesViewModel>("nav-app-updates",    "App Updates",    typeof(Views.AppUpdatesView)),
+            Tab<BulkInstallerViewModel>("nav-bulk-installer", "Bulk Installer", typeof(Views.BulkInstallerView)),
+            Tab<UninstallerViewModel>("nav-uninstaller",   "Uninstaller",    typeof(Views.UninstallerView))),
 
-        Group("grp-privacy", "Privacy & Security", "",
-            Item("nav-privacy-settings",     "Privacy & Telemetry",   "", Privacy,                typeof(Views.PrivacyView)),
-            Item("nav-file-shredder",        "File Shredder",         "", FileShredder,           typeof(Views.FileShredderView)),
-            Item("nav-app-blocker",          "App Blocker",           "", AppBlocker,             typeof(Views.AppBlockerView)),
-            Item("nav-debloater",            "Debloater & Ads",       "", Debloater,             typeof(Views.DebloaterView)),
-            Item("nav-browser-cleaner",      "Browser Cleaner",       "", BrowserCleaner,         typeof(Views.BrowserCleanerView)),
-            Item("nav-edge-onedrive",        "Edge/OneDrive Remover", "", WipEdgeOneDriveRemover, typeof(Views.PlaceholderView), inDevelopment: true),
-            Item("nav-defender-tweaks",      "Defender Tweaks",       "", Defender,               typeof(Views.DefenderView)),
-            Item("nav-notification-blocker", "Notification Blocker",  "", WipNotificationBlocker, typeof(Views.PlaceholderView), inDevelopment: true)),
+        Group("grp-privacy", "Privacy & Security",
+            Tab<PrivacyViewModel>("nav-privacy-settings",  "Privacy & Telemetry",   typeof(Views.PrivacyView)),
+            Tab<FileShredderViewModel>("nav-file-shredder", "File Shredder",         typeof(Views.FileShredderView)),
+            Tab<AppBlockerViewModel>("nav-app-blocker",     "App Blocker",           typeof(Views.AppBlockerView)),
+            Tab<DebloaterViewModel>("nav-debloater",        "Debloater & Ads",       typeof(Views.DebloaterView)),
+            Tab<BrowserCleanerViewModel>("nav-browser-cleaner", "Browser Cleaner",   typeof(Views.BrowserCleanerView)),
+            EagerItem("nav-edge-onedrive",   "Edge/OneDrive Remover", typeof(Views.PlaceholderView), _wipEdgeOneDriveRemover, inDevelopment: true),
+            Tab<DefenderViewModel>("nav-defender-tweaks",   "Defender Tweaks",       typeof(Views.DefenderView)),
+            EagerItem("nav-notification-blocker", "Notification Blocker", typeof(Views.PlaceholderView), _wipNotificationBlocker, inDevelopment: true)),
 
-        Group("grp-customization", "Customization", "",
-            Item("nav-context-menu",   "Context Menu",          "", ContextMenu,          typeof(Views.ContextMenuView)),
-            Item("nav-dark-mode",      "Dark Mode Scheduler",   "", DarkMode,             typeof(Views.DarkModeView)),
-            Item("nav-volume-control", "Volume Control",        "", AudioMixer,           typeof(Views.AudioMixerView))),
+        Group("grp-customization", "Customization",
+            Tab<ContextMenuViewModel>("nav-context-menu",   "Context Menu",          typeof(Views.ContextMenuView)),
+            // DarkMode is eager (schedule poll must run app-wide); hand the DI singleton to its NavItem.
+            EagerItem("nav-dark-mode", "Dark Mode Scheduler", typeof(Views.DarkModeView), Eager<DarkModeViewModel>()),
+            Tab<AudioMixerViewModel>("nav-volume-control",  "Volume Control",        typeof(Views.AudioMixerView))),
 
-        Group("grp-info", "Info", "",
-            Item("nav-drivers",       "Drivers",        "", Drivers,        typeof(Views.DriversView)),
-            Item("nav-battery",       "Battery Health", "", BatteryHealth,  typeof(Views.BatteryHealthView)),
-            Item("nav-logs",          "System Logs",    "", Logs,           typeof(Views.LogsView)),
-            Item("nav-system-report", "System Report",  "", SystemReport, typeof(Views.SystemReportView)),
-            Item("nav-legacy-panels", "Legacy Panels",  "", LegacyPanels, typeof(Views.LegacyPanelsView)),
-            Item("nav-about",         "About",          "", About,          typeof(Views.AboutView))),
+        Group("grp-info", "Info",
+            Tab<DriversViewModel>("nav-drivers",       "Drivers",        typeof(Views.DriversView)),
+            Tab<BatteryHealthViewModel>("nav-battery", "Battery Health", typeof(Views.BatteryHealthView)),
+            Tab<LogsViewModel>("nav-logs",             "System Logs",    typeof(Views.LogsView)),
+            Tab<SystemReportViewModel>("nav-system-report", "System Report", typeof(Views.SystemReportView)),
+            Tab<LegacyPanelsViewModel>("nav-legacy-panels", "Legacy Panels", typeof(Views.LegacyPanelsView)),
+            // About is eager (its startup update-check drives the shell banner); the tab reuses
+            // that same instance so the sidebar version label and the tab show one shared VM.
+            EagerItem("nav-about", "About", typeof(Views.AboutView), About)),
 
-        Group("grp-advanced", "Advanced", "",
-            Item("nav-profile-export", "Profile Export/Import", "", Profile,               typeof(Views.ProfileView)),
-            Item("nav-cli-interface",  "CLI Interface",         "", CliInterface,           typeof(Views.CliInterfaceView), inDevelopment: true),
-            Item("nav-env-variables",  "Environment Variables", "", EnvironmentVariables, typeof(Views.EnvironmentVariablesView))),
+        Group("grp-advanced", "Advanced",
+            Tab<ProfileViewModel>("nav-profile-export", "Profile Export/Import", typeof(Views.ProfileView)),
+            Tab<CliInterfaceViewModel>("nav-cli-interface", "CLI Interface",     typeof(Views.CliInterfaceView), inDevelopment: true),
+            Tab<EnvironmentVariablesViewModel>("nav-env-variables", "Environment Variables", typeof(Views.EnvironmentVariablesView))),
     ];
 
-    private static NavGroup Group(string id, string label, string glyph, params NavItem[] children)
+    private static NavGroup Group(string id, string label, params NavItem[] children)
     {
-        var g = new NavGroup { Id = id, Label = label, Glyph = glyph };
+        var g = new NavGroup { Id = id, Label = label, Glyph = "" };
         foreach (var c in children) g.Children.Add(c);
         g.Subtitle = string.Join(" · ", children.Select(c => c.Label));
         g.Tooltip = string.Join("\n", children.Select(c => c.Label));
         return g;
     }
 
-    private static NavItem Item(string id, string label, string glyph, object content, Type viewType, bool inDevelopment = false)
-        => new() { Id = id, Label = label, Glyph = glyph, Content = content, ViewType = viewType, IsInDevelopment = inDevelopment };
-
-    partial void OnSelectedNavChanged(NavItem? value)
+    partial void OnSelectedNavChanged(NavItem? oldValue, NavItem? newValue)
     {
-        if (value is null) return;
-        Log.Information("Tab navigated: {TabLabel}", value.Label);
+        if (newValue is null) return;
+        Log.Information("Tab navigated: {TabLabel}", newValue.Label);
 
         // Record the feature the user opened in the Dashboard's "Recent activity"
         // (skip Dashboard itself — Recent activity lives there, so logging every return
         // to view it would just push real entries out of the list).
-        if (value.Id != "nav-dashboard")
-            ActivityLogService.Instance.Log("Opened", value.Label);
+        if (newValue.Id != "nav-dashboard")
+            ActivityLogService.Instance.Log("Opened", newValue.Label);
 
         // Auto-expand the parent group when a child is selected.
-        var parentGroup = NavGroups.FirstOrDefault(g => g.Children.Contains(value));
+        var parentGroup = NavGroups.FirstOrDefault(g => g.Children.Contains(newValue));
         if (parentGroup is not null) parentGroup.IsExpanded = true;
 
         // Pause/resume per-tab poll loops based on visibility (reconcile loops + the volume
-        // mixer's peak-meter timer only run while their tab is the one on screen).
-        ProcessManager.IsActive = ReferenceEquals(value.Content, ProcessManager);
-        Dashboard.IsActive = ReferenceEquals(value.Content, Dashboard);
-        AudioMixer.IsActive = ReferenceEquals(value.Content, AudioMixer);
+        // mixer's peak-meter timer only run while their tab is on screen). Deactivate the tab
+        // we left and activate the one we entered — but only touch a tab's VM if it was actually
+        // built (a never-opened lazy tab has no VM and, by definition, nothing polling).
+        if (oldValue is { IsContentCreated: true }) SetActive(oldValue.Content, false);
+        SetActive(newValue.Content, true); // accessing Content here materialises the entered tab's VM
+    }
+
+    // The three tabs with a visibility-gated poll expose an IsActive flag. Toggle it generically
+    // so this doesn't depend on eager VM properties that no longer exist for lazy tabs.
+    private static void SetActive(object content, bool active)
+    {
+        switch (content)
+        {
+            case ProcessManagerViewModel pm: pm.IsActive = active; break;
+            case DashboardViewModel db: db.IsActive = active; break;
+            case AudioMixerViewModel am: am.IsActive = active; break;
+        }
     }
 
     /// <summary>Select a nav item by its automation id.</summary>
@@ -456,76 +316,103 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         if (_disposed) return;
         _disposed = true;
 
-        // Dispose NavItems to unsubscribe PropertyChanged handlers
+        // Dispose each NavItem — this unsubscribes its IsBusy handler AND disposes the tab VM,
+        // but ONLY for tabs that were actually opened (NavItem.Dispose no-ops on an un-built VM).
+        // In the DI path the VMs are singletons; the container also disposes them at OnExit, but
+        // ViewModelBase.Dispose is idempotent so the double call is safe.
         foreach (var item in NavItems)
             item.Dispose();
 
-        Dashboard?.Dispose();
-        AppUpdates?.Dispose();
-        WindowsUpdate?.Dispose();
-        SystemHealth?.Dispose();
-        Cleanup?.Dispose();
-        DeepCleanup?.Dispose();
-        DuplicateFile?.Dispose();
-        DiskAnalyzer?.Dispose();
-        ProcessManager?.Dispose();
-        BatteryHealth?.Dispose();
-        Uninstaller?.Dispose();
-        Performance?.Dispose();
-        Startup?.Dispose();
-        Ping?.Dispose();
-        Traceroute?.Dispose();
-        SpeedTest?.Dispose();
-        NetworkRepair?.Dispose();
-        Drivers?.Dispose();
-        Logs?.Dispose();
-        About?.Dispose();
-        Services?.Dispose();
-        NetworkShared?.Dispose();
-        WindowsFeatures?.Dispose();
-        AppAlerts?.Dispose();
-        ShortcutCleaner?.Dispose();
-        AppBlocker?.Dispose();
-        BulkInstaller?.Dispose();
-        FileShredder?.Dispose();
-        DnsHosts?.Dispose();
-
-        // Implemented PREVIEW tabs — these own timers / event subscriptions
-        // (e.g. DisplayProfile's revert DispatcherTimer, Defender's PropertyChanged),
-        // so they must be disposed on shutdown like every other real VM.
-        TimerResolution?.Dispose();
-        FileLock?.Dispose();
-        DisplayProfile?.Dispose();
-        CpuAffinity?.Dispose();
-        Defender?.Dispose();
-        TaskScheduler?.Dispose();
-        DarkMode?.Dispose();
-        StandbyMemory?.Dispose();
-        ResourceHistory?.Dispose();
-        SettingsWatchdog?.Dispose();
-        CliInterface?.Dispose();
-        ScheduledMaintenance?.Dispose();
-        TweaksHub?.Dispose();
-        AudioMixer?.Dispose();
-        GamingProfile?.Dispose();
-
-        // WIP placeholders
-        WipBandwidthMonitor?.Dispose();
-        Privacy?.Dispose();
-        ContextMenu?.Dispose();
-        SystemReport?.Dispose();
-        EnvironmentVariables?.Dispose();
-        RestorePoints?.Dispose();
-        Debloater?.Dispose();
-        LegacyPanels?.Dispose();
-        SystemFixes?.Dispose();
-        Profile?.Dispose();
-        BrowserCleaner?.Dispose();
-        PrivacyMonitor?.Dispose();
-        BootAnalyzer?.Dispose();
-        WipEdgeOneDriveRemover?.Dispose();
-        WipNotificationBlocker?.Dispose();
+        // Shared network state is not a tab — dispose it explicitly (once).
+        _networkShared?.Dispose();
 
         GC.SuppressFinalize(this);
+    }
+
+    // ── Designer / test dependency graph ────────────────────────────────────
+    // Built lazily (and only when there is no DI container) so the parameterless ctor keeps
+    // working in the XAML designer and unit tests exactly as before — every VM eager, no DI.
+    private Dictionary<Type, object>? _designerVms;
+
+    private Dictionary<Type, object> BuildDesignerGraph()
+    {
+        var runner = new PowerShellRunner();
+        var sysInfo = new SystemInfoService();
+        var winget = new WingetService(runner);
+        var diskHealth = new DiskHealthService();
+        var battery = new BatteryService();
+        var shortcuts = new ShortcutCleanerService();
+        var tuneUp = new TuneUpService(shortcuts, diskHealth, sysInfo);
+        var healthScore = new HealthScoreService(sysInfo, diskHealth, battery);
+        var fixedDrives = new FixedDriveService();
+        var pinger = new PingMonitorService();
+        var tracer = new TracerouteService();
+        var traceMonitor = new TracerouteMonitorService();
+        var speedTest = new SpeedTestService();
+        var netRepair = new NetworkRepairService(runner);
+        var restorePoints = new RestorePointService(runner);
+        var gamingCpu = new CpuAffinityService();
+
+        return new Dictionary<Type, object>
+        {
+            [typeof(DashboardViewModel)] = new DashboardViewModel(sysInfo, tuneUp, healthScore, new TemperatureService(diskHealth), winget),
+            [typeof(AppUpdatesViewModel)] = new AppUpdatesViewModel(winget),
+            [typeof(WindowsUpdateViewModel)] = new WindowsUpdateViewModel(runner, new WindowsUpdateService(), new WindowsUpdatePolicyService()),
+            [typeof(SystemHealthViewModel)] = new SystemHealthViewModel(sysInfo, diskHealth, new MemoryTestService(), fixedDrives, runner, new BiosService()),
+            [typeof(CleanupViewModel)] = new CleanupViewModel(runner),
+            [typeof(DeepCleanupViewModel)] = new DeepCleanupViewModel(new DeepCleanupService(), new LargeFileScanner(), fixedDrives),
+            [typeof(DuplicateFileViewModel)] = new DuplicateFileViewModel(new DuplicateFileService()),
+            [typeof(DiskAnalyzerViewModel)] = new DiskAnalyzerViewModel(new DiskAnalyzerService()),
+            [typeof(ProcessManagerViewModel)] = new ProcessManagerViewModel(new ProcessManagerService()),
+            [typeof(BatteryHealthViewModel)] = new BatteryHealthViewModel(battery),
+            [typeof(UninstallerViewModel)] = new UninstallerViewModel(new UninstallerService(runner)),
+            [typeof(PerformanceViewModel)] = new PerformanceViewModel(new PerformanceService(runner, restorePoints)),
+            [typeof(StartupViewModel)] = new StartupViewModel(new StartupService()),
+            [typeof(NetworkSharedState)] = new NetworkSharedState(pinger, tracer, traceMonitor, speedTest, netRepair),
+            [typeof(DriversViewModel)] = new DriversViewModel(runner),
+            [typeof(LogsViewModel)] = new LogsViewModel(new EventLogService()),
+            [typeof(AboutViewModel)] = new AboutViewModel(),
+            [typeof(ServicesViewModel)] = new ServicesViewModel(runner),
+            [typeof(AppAlertsViewModel)] = new AppAlertsViewModel(new AppAlertService()),
+            [typeof(ShortcutCleanerViewModel)] = new ShortcutCleanerViewModel(shortcuts),
+            [typeof(AppBlockerViewModel)] = new AppBlockerViewModel(new AppBlockerService()),
+            [typeof(BulkInstallerViewModel)] = new BulkInstallerViewModel(new BulkInstallerService(new PowerShellRunner()), new AppIconService()),
+            [typeof(FileShredderViewModel)] = new FileShredderViewModel(new FileShredderService()),
+            [typeof(DnsHostsViewModel)] = new DnsHostsViewModel(new DnsService(new PowerShellRunner()), new HostsFileService()),
+            [typeof(WindowsFeaturesViewModel)] = new WindowsFeaturesViewModel(new WindowsFeaturesService(runner)),
+            [typeof(PrivacyViewModel)] = new PrivacyViewModel(new PrivacyService()),
+            [typeof(ContextMenuViewModel)] = new ContextMenuViewModel(new ContextMenuService()),
+            [typeof(SystemReportViewModel)] = new SystemReportViewModel(new SystemReportService(sysInfo, diskHealth)),
+            [typeof(EnvironmentVariablesViewModel)] = new EnvironmentVariablesViewModel(new EnvironmentVariableService()),
+            [typeof(RestorePointsViewModel)] = new RestorePointsViewModel(restorePoints),
+            [typeof(DebloaterViewModel)] = new DebloaterViewModel(new DebloaterService(new PowerShellRunner())),
+            [typeof(LegacyPanelsViewModel)] = new LegacyPanelsViewModel(new LegacyPanelService()),
+            [typeof(SystemFixesViewModel)] = new SystemFixesViewModel(new SystemFixService(new PowerShellRunner())),
+            [typeof(ProfileViewModel)] = new ProfileViewModel(new ProfileService()),
+            [typeof(BrowserCleanerViewModel)] = new BrowserCleanerViewModel(new BrowserCleanerService()),
+            [typeof(PrivacyMonitorViewModel)] = new PrivacyMonitorViewModel(new PrivacyMonitorService()),
+            [typeof(BootAnalyzerViewModel)] = new BootAnalyzerViewModel(new BootAnalyzerService()),
+            [typeof(TimerResolutionViewModel)] = new TimerResolutionViewModel(new TimerResolutionService()),
+            [typeof(FileLockViewModel)] = new FileLockViewModel(new FileLockService()),
+            [typeof(DisplayProfileViewModel)] = new DisplayProfileViewModel(new DisplayProfileService()),
+            [typeof(CpuAffinityViewModel)] = new CpuAffinityViewModel(new CpuAffinityService()),
+            [typeof(DefenderViewModel)] = new DefenderViewModel(new DefenderService(new PowerShellRunner())),
+            [typeof(TaskSchedulerViewModel)] = new TaskSchedulerViewModel(new TaskSchedulerService(new PowerShellRunner())),
+            [typeof(DarkModeViewModel)] = new DarkModeViewModel(new WindowsThemeService()),
+            [typeof(StandbyMemoryViewModel)] = new StandbyMemoryViewModel(new StandbyMemoryService()),
+            [typeof(ResourceHistoryViewModel)] = new ResourceHistoryViewModel(new ResourceHistoryService(sysInfo, new TemperatureService(diskHealth))),
+            [typeof(SettingsWatchdogViewModel)] = new SettingsWatchdogViewModel(new SettingsWatchdogService()),
+            [typeof(CliInterfaceViewModel)] = new CliInterfaceViewModel(),
+            [typeof(ScheduledMaintenanceViewModel)] = new ScheduledMaintenanceViewModel(new MaintenanceSchedulerService(new PowerShellRunner())),
+            [typeof(TweaksHubViewModel)] = new TweaksHubViewModel(new TweaksHubService(new PrivacyService(), restorePoints)),
+            [typeof(AudioMixerViewModel)] = new AudioMixerViewModel(new AudioMixerService()),
+            [typeof(GamingProfileViewModel)] = new GamingProfileViewModel(
+                new GamingProfileService(
+                    new PerformanceService(runner, restorePoints),
+                    new TimerResolutionService(), gamingCpu,
+                    new StandbyMemoryService(), restorePoints,
+                    Helpers.AdminHelper.IsElevated()),
+                gamingCpu),
+        };
     }
 }

--- a/SysManager/SysManager/ViewModels/NavItem.cs
+++ b/SysManager/SysManager/ViewModels/NavItem.cs
@@ -9,22 +9,70 @@ using CommunityToolkit.Mvvm.ComponentModel;
 namespace SysManager.ViewModels;
 
 /// <summary>
-/// A single entry in the left nav. View is materialised lazily on first
-/// access — keeps unit tests STA-free and makes the VM cheap to construct.
-/// Exposes <see cref="IsBusy"/> from the underlying ViewModel so the sidebar
-/// can show a progress indicator when the tab is working.
-/// Implements <see cref="IDisposable"/> to unsubscribe from ViewModel
-/// PropertyChanged events on teardown.
+/// A single entry in the left nav. Both the <see cref="View"/> AND the underlying
+/// ViewModel (<see cref="Content"/>) are materialised lazily on first access, so the
+/// ~55 tab view-models (most of which kick off a background scan / timer in their
+/// constructor) are NOT all built at startup — only the tab the user actually opens.
+/// Exposes <see cref="IsBusy"/> from the underlying ViewModel so the sidebar can show
+/// a progress indicator when the tab is working. Implements <see cref="IDisposable"/>
+/// to unsubscribe from ViewModel PropertyChanged events on teardown.
 /// </summary>
 public sealed partial class NavItem : ObservableObject, IDisposable
 {
     private UserControl? _view;
+    private object? _content;
+    private Func<object>? _contentFactory;
 
     public required string Id { get; init; }
     public required string Label { get; init; }
     public required string Glyph { get; init; }
-    public required object Content { get; init; }
     public required Type ViewType { get; init; }
+
+    /// <summary>
+    /// The tab's ViewModel. Two ways to supply it:
+    /// <list type="bullet">
+    /// <item>Eager — assign a ready instance (<c>Content = vm</c>). Used by tests and by the
+    /// few tabs that must exist at startup (e.g. Dark Mode owns the always-on theme schedule).</item>
+    /// <item>Lazy — leave it unset and provide <see cref="ContentFactory"/>; the instance is built
+    /// on first access and cached.</item>
+    /// </list>
+    /// First materialisation (either way, via the getter) wires <see cref="IsBusy"/> forwarding,
+    /// so the sidebar spinner works regardless. A tab that is never opened never builds its VM.
+    /// </summary>
+    public object Content
+    {
+        get
+        {
+            if (_content is not null) return _content;
+
+            _content = _contentFactory?.Invoke()
+                ?? throw new InvalidOperationException(
+                    $"NavItem '{Id}' has neither an eager Content nor a ContentFactory set.");
+            WireBusy(_content);
+            return _content;
+        }
+        init
+        {
+            _content = value;   // eager path — instance provided up front
+        }
+    }
+
+    /// <summary>
+    /// Factory that builds the tab's ViewModel on first <see cref="Content"/> access (lazy path,
+    /// e.g. resolve from DI only when the tab is first opened). Ignored if an eager
+    /// <see cref="Content"/> instance was assigned.
+    /// </summary>
+    public Func<object>? ContentFactory
+    {
+        private get => _contentFactory;
+        init => _contentFactory = value;
+    }
+
+    /// <summary>
+    /// True once <see cref="Content"/> has been materialised. Lets teardown / activation logic
+    /// touch the VM without forcing a never-opened tab to build one.
+    /// </summary>
+    public bool IsContentCreated => _content is not null;
 
     /// <summary>
     /// True for features that are implemented but not yet QA-verified. The sidebar
@@ -36,20 +84,39 @@ public sealed partial class NavItem : ObservableObject, IDisposable
     [ObservableProperty] private bool _isBusy;
 
     /// <summary>
-    /// Call after construction to wire up IsBusy forwarding from the ViewModel.
+    /// Wire IsBusy forwarding from the underlying ViewModel. Called automatically on first
+    /// materialisation of <see cref="Content"/>. For an eagerly-assigned instance that must
+    /// forward IsBusy before it is ever displayed, call this after construction.
     /// </summary>
     public NavItem WireBusy()
     {
-        if (Content is ViewModelBase vm)
-            vm.PropertyChanged += OnViewModelPropertyChanged;
+        if (_content is not null) WireBusy(_content);
         return this;
     }
 
-    /// <summary>Unsubscribe from ViewModel events to prevent memory leaks.</summary>
+    private void WireBusy(object content)
+    {
+        if (content is ViewModelBase vm)
+        {
+            // Idempotent: -= then += so an eager WireBusy() followed by the getter's wiring
+            // (or a double WireBusy) never double-subscribes.
+            vm.PropertyChanged -= OnViewModelPropertyChanged;
+            vm.PropertyChanged += OnViewModelPropertyChanged;
+            IsBusy = vm.IsBusy;
+        }
+    }
+
+    /// <summary>
+    /// Unsubscribe from ViewModel events and dispose the VM — but only if it was ever
+    /// materialised. A tab the user never opened built no VM, so there is nothing to release
+    /// (and forcing creation here would defeat the whole lazy design).
+    /// </summary>
     public void Dispose()
     {
-        if (Content is ViewModelBase vm)
+        if (_content is null) return; // never opened → nothing built
+        if (_content is ViewModelBase vm)
             vm.PropertyChanged -= OnViewModelPropertyChanged;
+        (_content as IDisposable)?.Dispose();
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -64,7 +131,7 @@ public sealed partial class NavItem : ObservableObject, IDisposable
         {
             if (_view is not null) return _view;
             _view = (UserControl)Activator.CreateInstance(ViewType)!;
-            _view.DataContext = Content;
+            _view.DataContext = Content; // materialises the VM on first view
             return _view;
         }
     }


### PR DESCRIPTION
## Problem

`MainWindowViewModel` eagerly constructed **every one of its ~55 tab view-models at startup** — even tabs the user never opens. Most tab VMs kick off real work in their constructor (a background scan, a poll timer, a WMI/registry query), so a fresh launch fired ~40 of those at once regardless of which tab was actually shown. Opening the app to the Dashboard still spun up Services, Drivers, Debloater, Bulk Installer and dozens more in the background.

## Fix

Each tab's view-model is now built **lazily, on first open**. `NavItem` carries a `ContentFactory` that resolves the VM from DI the first time `Content` is accessed (and caches it). A fresh launch constructs only what the initial view needs — startup tab-VM construction drops from ~55 to a handful.

A deliberately small set stays **eager**, because its constructor drives always-on, app-wide behavior that must run whether or not its tab is opened:
- **Dashboard** — the tab shown at launch (built immediately anyway).
- **DarkModeViewModel** — owns the always-on theme-schedule poll; nothing else runs it.
- **AboutViewModel** — its startup update-check feeds the app-shell version label and the "update available" banner (`MainWindow.xaml` binds `About.CurrentVersion` / `About.UpdateAvailable` / `About.LatestVersionLabel` / `About.LatestPublishedLabel`).
- **The four Network tabs** — they share one `NetworkSharedState` and their constructors do no work, so eager construction costs nothing.

`About` is re-exposed as a `MainWindowViewModel` property (the shell binds to it) and the About tab reuses that same instance — one update-check, one shared state.

Behavior is otherwise identical: **nothing is disabled, only deferred.** In tests/designer (no DI container) every VM is still built eagerly via a manual dependency graph, exactly as before.

## Tests

- **`NavItemLazyContentTests`** (unit, CI-run) — pins the lazy-`Content` contract: builds nothing until first access, then caches (factory runs once); `IsContentCreated` and `Dispose` never force creation; `IsBusy` forwards after materialisation; the eager path still works; and a NavItem with neither eager Content nor factory throws.
- **`MainWindowViewModelTests`** — now reaches tabs through the real `NavItems` graph (the removed per-tab accessors were test-only sugar) and asserts the four network tabs share one `NetworkSharedState`. Adds **`About_IsEagerlyExposed_AndSharedWithItsTab`**, which pins the shell-binding regression (About must stay eager and be the same instance the tab uses).

## Verification

- All 4 projects build Release with **0 warnings / 0 errors** (`TreatWarningsAsErrors` on).
- `dotnet format --verify-no-changes` clean on every touched file.
- Public-surface diff confirmed: 58 test-only accessors removed, `About` retained, nothing else changed.
- Release CHANGELOG-extraction regex verified to match the `1.52.104` block.

Docs: ARCHITECTURE.md DI section documents the lazy resolution + the eager exceptions. CHANGELOG updated.
