### PR TITLE
fix: strip backslash in Bulk Installer search sanitizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.105] - 2026-07-22
+
+### Fixed
+- **A backslash in the Bulk Installer search box corrupted the winget search command.** `SanitizeQuery` stripped double quotes and control characters (so a search term couldn't inject extra arguments) but left backslashes untouched. Because the query is passed as `search "{term}"`, a term ending in a backslash turned the closing quote into an escaped quote (`search "foo\"`), collapsing the quoted-argument boundary and producing a malformed winget invocation (a broken or empty search). The sanitizer now also strips backslashes — a winget search term has no legitimate use for one — so the quoted argument can no longer be broken. Hardening at the input trust boundary; not remotely exploitable (winget arguments are passed as data, not through a shell), but the search now behaves correctly for any input.
+
 ## [1.52.104] - 2026-07-21
 
 ### Fixed

--- a/SysManager/SysManager.Tests/BulkInstallerServiceTests.cs
+++ b/SysManager/SysManager.Tests/BulkInstallerServiceTests.cs
@@ -128,8 +128,24 @@ public class BulkInstallerServiceTests
     [InlineData("foo\" & calc \"", "foo & calc")]                   // embedded quotes stripped (the & is harmless inside a quoted, non-shell arg)
     [InlineData("bar\"--source\"evil", "bar--sourceevil")]          // quote break-out stripped
     [InlineData("baz\r\ninject", "bazinject")]                       // control chars (CR/LF) stripped
+    [InlineData("notepad\\", "notepad")]                             // trailing backslash stripped (would escape the closing quote)
+    [InlineData("a\\b\\c", "abc")]                                    // embedded backslashes stripped
     public void SanitizeQuery_StripsQuotesAndControlChars(string input, string expected)
         => Assert.Equal(expected, BulkInstallerService.SanitizeQuery(input));
+
+    // Regression: a query ending in a backslash previously survived sanitization and, once
+    // interpolated as search "{safe}", turned the closing quote into an escaped quote
+    // ("notepad\"), collapsing the argument boundary and corrupting the winget invocation.
+    // The sanitized output must never end in a backslash.
+    [Theory]
+    [InlineData("notepad\\")]
+    [InlineData("path\\to\\thing\\")]
+    [InlineData("\\\\")]
+    public void SanitizeQuery_NeverEndsInBackslash(string input)
+    {
+        var safe = BulkInstallerService.SanitizeQuery(input);
+        Assert.DoesNotContain('\\', safe);
+    }
 
     [Theory]
     [InlineData(null)]

--- a/SysManager/SysManager/Services/BulkInstallerService.cs
+++ b/SysManager/SysManager/Services/BulkInstallerService.cs
@@ -92,13 +92,16 @@ public sealed class BulkInstallerService
 
     /// <summary>
     /// Strips characters that could break out of the quoted winget argument (double quotes,
-    /// control chars) so a search box entry like <c>foo" &amp; calc "</c> cannot inject extra
-    /// arguments. Returns the trimmed, sanitized query (may be empty if nothing usable remains).
+    /// backslashes, control chars) so a search box entry like <c>foo" &amp; calc "</c> cannot
+    /// inject extra arguments. The backslash is stripped because a trailing one turns the closing
+    /// quote into an escaped quote (<c>"foo\"</c>), collapsing the argument boundary — and a winget
+    /// search term has no legitimate use for it. Returns the trimmed, sanitized query (may be empty
+    /// if nothing usable remains).
     /// </summary>
     internal static string SanitizeQuery(string? query)
     {
         if (string.IsNullOrWhiteSpace(query)) return string.Empty;
-        var cleaned = new string(query.Where(c => c != '"' && !char.IsControl(c)).ToArray());
+        var cleaned = new string(query.Where(c => c != '"' && c != '\\' && !char.IsControl(c)).ToArray());
         return cleaned.Trim();
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.104</Version>
-    <FileVersion>1.52.104.0</FileVersion>
-    <AssemblyVersion>1.52.104.0</AssemblyVersion>
+    <Version>1.52.105</Version>
+    <FileVersion>1.52.105.0</FileVersion>
+    <AssemblyVersion>1.52.105.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem

`BulkInstallerService.SanitizeQuery` (the Bulk Installer search box guard) stripped double quotes and control characters — so a search term couldn't inject extra winget arguments — but left **backslashes** untouched.

The query is interpolated as `search "{term}"`. A term ending in a backslash turns the closing quote into an **escaped quote** (`search "foo\"`), which collapses the quoted-argument boundary and produces a malformed winget invocation — a broken or empty search result.

## Fix

Strip backslashes in the sanitizer too (`c != '\'` added to the filter). A winget search term has no legitimate use for a backslash, so this loses nothing and closes the boundary-break.

Hardening at the input trust boundary. **Not remotely exploitable** — winget arguments are passed as data through the process runner, not via a shell — but the search now behaves correctly for any input, and the sanitizer's contract (nothing can break out of the quoted argument) is now complete.

## Tests (regression: red before, green after)

- `SanitizeQuery_NeverEndsInBackslash` (new Theory) — asserts the sanitized output never contains a backslash, for `notepad\`, `path\to\thing\`, `\`.
- Two new cases in the existing `SanitizeQuery_StripsQuotesAndControlChars` theory: `notepad\ → notepad`, `a\b\c → abc`.

Before the fix these fail (backslash survived); after, they pass.

## Provenance

Surfaced by a full swarm audit of the codebase (security / performance / correctness / interop / async / architecture / modernization / docs / leak dimensions). This was the one confirmed defect; every other candidate across those dimensions was verified benign against current source (ManagementObject disposal, catch-all logging, destructive-op confirms, .NET 10 idioms, doc/version consistency all checked and clean).
