### PR TITLE
ci: fix auto-release broken-pipe on tag lookup

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -63,7 +63,14 @@ jobs:
         id: latest
         shell: bash
         run: |
-          TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1)
+          # NOTE: do NOT pipe `git tag | grep | head`. With `set -o pipefail` (GitHub's
+          # default bash flags), `head -n1` closes the pipe after the first line and grep
+          # gets SIGPIPE while still writing the remaining matches — "grep: write error:
+          # Broken pipe", exit 2, failing the whole release. This surfaced once the tag
+          # list grew past ~100 entries. Read grep's full (newest-first) output into a
+          # var and take the first line with parameter expansion — no pipe to close early.
+          MATCHES=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)
+          TAG=${MATCHES%%$'\n'*}
           if [ -z "$TAG" ]; then TAG="v0.0.0"; fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Latest tag: $TAG"


### PR DESCRIPTION
## Problem

The auto-release `Get latest tag` step ran:
```bash
TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1)
```
Under bash's `set -o pipefail` (GitHub Actions' default bash flags), `head -n1` closes the pipe after reading the first line, and `grep` receives **SIGPIPE** while still writing the remaining matches → `grep: write error: Broken pipe`, exit 2, which `pipefail` propagates to fail the whole `bump-and-tag` job.

This became **deterministic** once the tag list grew past ~100 entries: **v1.52.105 could not release** (both the initial run and a re-run failed identically at this step). Surfaced by a full-repo audit of the release/supply-chain surface.

## Fix

Read grep's full (newest-first) output into a variable and take the first line with parameter expansion — no pipe for `head` to close early, so no SIGPIPE:
```bash
MATCHES=$(git tag --sort=-v:refname | grep -E '...' || true)
TAG=${MATCHES%%$'\n'*}
```
Behavior is identical: newest matching `vX.Y.Z` tag, or `v0.0.0` when none exist. Verified locally under `set -o pipefail` (picks the newest tag, exit 0).

No release triggered by this PR (`.github/**` is not in auto-release's `paths:` filter); it only hardens the workflow. The stuck 1.52.105 release will be re-driven after merge.