### PR TITLE
feat: add Edge/OneDrive Remover tab (safe, reversible)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,7 +48,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Storage | `DiskAnalyzerViewModel` · `DuplicateFileViewModel` |
 | Network | `PingViewModel` · `TracerouteViewModel` · `SpeedTestViewModel` · `NetworkRepairViewModel` (shared: `NetworkSharedState`) · `DnsHostsViewModel` |
 | Apps | `AppUpdatesViewModel` · `BulkInstallerViewModel` · `UninstallerViewModel` |
-| Privacy & Security | `PrivacyViewModel` · `FileShredderViewModel` · `AppBlockerViewModel` · `DebloaterViewModel` · `BrowserCleanerViewModel` · `DefenderViewModel` · `PlaceholderViewModel` (Edge/OneDrive Remover · Notification Blocker) |
+| Privacy & Security | `PrivacyViewModel` · `FileShredderViewModel` · `AppBlockerViewModel` · `DebloaterViewModel` · `BrowserCleanerViewModel` · `EdgeOneDriveViewModel` · `DefenderViewModel` · `PlaceholderViewModel` (Notification Blocker) |
 | Customization | `ContextMenuViewModel` · `DarkModeViewModel` · `AudioMixerViewModel` |
 | Info | `DriversViewModel` · `BatteryHealthViewModel` · `LogsViewModel` · `SystemReportViewModel` · `LegacyPanelsViewModel` · `AboutViewModel` |
 | Advanced | `ProfileViewModel` · `EnvironmentVariablesViewModel` · `CliInterfaceViewModel` |
@@ -109,6 +109,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `ProfileViewModel` — export/import SysManager's own config (theme, speed-test history) as a portable JSON profile with selective sections and version checking.
 - `DebloaterViewModel` — list and remove preinstalled Store apps with a curated bloat preset; system-critical packages are denylisted; removal is per-user and reversible via the Store.
 - `BrowserCleanerViewModel` — scan per-browser cache/history/cookies/sessions with sizes and clean the selected categories; cookies/sessions default unticked.
+- `EdgeOneDriveViewModel` — reversibly de-integrate Edge and OneDrive (Edge/OneDrive Remover tab): OneDrive is fully removed per-user (no admin) with restore; Edge is only disabled & de-integrated (background/startup-boost policy + auto-update tasks, admin-gated) with restore — never uninstalled; guides the user to Windows settings to change the default browser. Every action confirms first and reports its honest outcome (success / needs-admin / not-applicable).
 - `PrivacyMonitorViewModel` — read-only camera/mic/location access history from the consent store; hands off to Windows settings to change permissions.
 - `ConsoleViewModel` — shared, per-tab scrollable console (each tab gets its own
   instance; lines capped at 5000 to bound memory) backing the in-app Console mirror
@@ -240,6 +241,13 @@ Key services:
   Firefox) under injectable LOCALAPPDATA/APPDATA roots. Scan is read-only (sizes);
   Clean deletes only discovered files, skips locked files, and never follows
   reparse points. Cookies/sessions are flagged sensitive.
+- `EdgeOneDriveService` — reversibly de-integrates Edge and OneDrive through the
+  `IPowerShellRunner` seam plus injectable HKCU/HKLM roots. OneDrive is fully removed
+  per-user (`OneDriveSetup.exe /uninstall` + nav-pane unpin, no elevation); Edge is
+  never uninstalled — only its background/startup-boost Group-Policy keys and its two
+  auto-update scheduled tasks (a fixed, injection-safe allowlist) are toggled, which
+  needs admin. Each action has a matching restore. All scripts are hard-coded constants
+  (no user input); the pin/policy logic is unit-tested against a redirected registry.
 - `PrivacyMonitorService` — read-only reader of the CapabilityAccessManager consent
   store (camera/microphone/location access history). Injectable registry root;
   friendly-name decoding and FILETIME conversion are pure, unit-tested static methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.53.0] - 2026-07-22
+
+### Added
+- **Edge/OneDrive Remover — a new Privacy & Security tab that takes Microsoft Edge and OneDrive out of your way, reversibly** (replaces the previous work-in-progress placeholder). Both of these are frequently-unwanted but awkward to deal with by hand, so the tab does it safely and offers a matching restore for every action:
+  - **OneDrive: full removal for your account, no admin needed.** Stops the running client, runs the official `OneDriveSetup.exe /uninstall`, and clears its File Explorer navigation-pane entry. Files already synced to the PC stay on disk; cloud-only files simply aren't downloaded. **Restore OneDrive** reinstalls it and re-pins the sidebar entry.
+  - **Edge: disable & de-integrate, never uninstall.** Windows relies on Edge (WebView2) and reinstalls it if forced out — and forcing it breaks other apps irreversibly — so the tab never uninstalls it. Instead it turns off Edge's background mode and startup boost (the documented `BackgroundModeEnabled` / `StartupBoostEnabled` Group-Policy values) and disables its two machine auto-update scheduled tasks, so Edge stops launching and running on its own; you can still open it normally. **Restore Edge** clears those policies and re-enables the update tasks. These changes are machine-scope and need administrator (the tab shows the standard golden admin banner explaining why); removing OneDrive does not.
+  - **Honest about the default browser.** Windows hash-protects the default-browser association, so no app can switch it programmatically; the tab opens Windows' default-apps settings and guides the user rather than pretending to change it.
+  - Every action confirms first with a plain-language impact summary and reports its honest outcome (done / needs administrator / not installed). The service routes all PowerShell and process launches through the shared runner seam with hard-coded scripts (no user input is ever interpolated — the Edge update-task names are a fixed, injection-safe allowlist), and its registry logic is unit-tested against a redirected hive. Closes #339.
+
 ## [1.52.105] - 2026-07-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ fully open source.
 ### Sidebar navigation
 The sidebar organises 58 feature tabs into 12 groups — 11 collapsible groups
 plus a flat top-level Dashboard entry — so you can find what you need without
-scrolling through a flat list. 55 tabs are fully implemented; 3 are
+scrolling through a flat list. 56 tabs are fully implemented; 2 are
 work-in-progress placeholders marked with ⚙️:
 
 | Group | Tabs |
@@ -101,7 +101,7 @@ work-in-progress placeholders marked with ⚙️:
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS & Hosts |
 | 📦 Apps | App Updates · Bulk Installer · Uninstaller |
-| 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover ⚙️ · Defender Tweaks · Notification Blocker ⚙️ |
+| 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover · Defender Tweaks · Notification Blocker ⚙️ |
 | 🎨 Customization | Context Menu · Dark Mode Scheduler · Volume Control |
 | ℹ️ Info | Drivers · Battery Health · System Logs · System Report · Legacy Panels · About |
 | ⚙️ Advanced | Profile Export/Import · CLI Interface 🔬 · Environment Variables |
@@ -543,6 +543,23 @@ Reclaim space and clear browsing traces, per browser:
 - **Confirmation with an impact summary** before anything is deleted
 - Per-user (no admin); locked files (browser open) are skipped, not forced, and
   symlinks/junctions are never followed
+
+### Edge/OneDrive Remover
+Get Microsoft Edge and OneDrive out of your way — reversibly:
+- **OneDrive: full removal for your account** — stops the client, runs the official
+  uninstaller, and clears its File Explorer sidebar entry. No admin needed. Files
+  already synced to this PC stay on disk; cloud-only files simply aren't downloaded
+- **Edge: disable & de-integrate, never uninstall** — Windows relies on Edge (WebView2)
+  and reinstalls it if forced out, so instead this turns off its background mode and
+  startup boost (via the documented Group-Policy keys) and disables its automatic-update
+  scheduled tasks, so Edge stops running on its own. You can still open it normally
+- **A Restore button for each** — reinstall OneDrive and re-pin its sidebar entry, or
+  clear the Edge policies and re-enable its update tasks — so nothing here is one-way
+- **Honest about the default browser** — Windows hash-protects the default-browser
+  choice, so no app can switch it for you; the tab opens Windows' default-apps settings
+  and guides you instead of pretending to change it
+- Every action confirms first with a plain-language impact summary; disabling Edge needs
+  administrator (the tab explains why and what it unlocks), removing OneDrive does not
 
 ### Defender Tweaks
 Manage Microsoft Defender without digging through Windows Security:

--- a/SysManager/SysManager.Tests/EdgeOneDriveServiceTests.cs
+++ b/SysManager/SysManager.Tests/EdgeOneDriveServiceTests.cs
@@ -1,0 +1,169 @@
+// SysManager · EdgeOneDriveServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+using Microsoft.Win32;
+using NSubstitute;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="EdgeOneDriveService"/>. The registry-mutating logic (Edge machine
+/// policy, OneDrive nav-pane pin) runs against a disposable HKCU subkey standing in for both
+/// hives, so writes are verified against a real registry without administrator rights or
+/// touching real machine state (mirrors <see cref="AppBlockerServiceRegistryTests"/>). All
+/// PowerShell is routed through a substituted <see cref="IPowerShellRunner"/>, so no process
+/// or scheduled-task ever runs.
+/// </summary>
+public sealed class EdgeOneDriveServiceTests : IDisposable
+{
+    private const string EdgePolicyPath = @"SOFTWARE\Policies\Microsoft\Edge";
+    private const string OneDriveClsidPath = @"Software\Classes\CLSID\{018D5C66-4533-4307-9B53-224DE2ED1FE6}";
+
+    private readonly string _rootName = @"Software\SysManagerTests\EdgeOneDrive_" + Guid.NewGuid().ToString("N");
+    private readonly RegistryKey _root;
+    private readonly IPowerShellRunner _runner;
+    private readonly EdgeOneDriveService _svc;
+
+    public EdgeOneDriveServiceTests()
+    {
+        _root = Registry.CurrentUser.CreateSubKey(_rootName, writable: true)!;
+        _runner = Substitute.For<IPowerShellRunner>();
+        // GetStatusAsync accesses results.Count on the task query — return an empty (not null)
+        // collection so the query resolves to "no tasks enabled" deterministically.
+        _runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+               .Returns(new Collection<PSObject>());
+        // The same redirected root stands in for BOTH hives — Edge uses SOFTWARE\Policies\…,
+        // OneDrive uses Software\Classes\CLSID\…, so there is no key collision.
+        _svc = new EdgeOneDriveService(_runner, hkcuRoot: _root, hklmRoot: _root);
+    }
+
+    public void Dispose()
+    {
+        _root.Dispose();
+        try { Registry.CurrentUser.DeleteSubKeyTree(_rootName, throwOnMissingSubKey: false); } catch { /* best-effort cleanup */ }
+    }
+
+    private object? ReadEdgePolicy(string name)
+    {
+        using var key = _root.OpenSubKey(EdgePolicyPath);
+        return key?.GetValue(name);
+    }
+
+    // ── Task-name injection guard ───────────────────────────────────────────
+
+    [Theory]
+    [InlineData("MicrosoftEdgeUpdateTaskMachineCore")]
+    [InlineData("MicrosoftEdgeUpdateTaskMachineUA")]
+    [InlineData("SomeAlphaNumeric123")]
+    public void IsSafeTaskName_TrueForAlphanumeric(string name)
+        => Assert.True(EdgeOneDriveService.IsSafeTaskName(name));
+
+    [Theory]
+    [InlineData("Task'; Remove-Item C:\\ #")]   // quote break-out + command
+    [InlineData("Task Name With Spaces")]         // whitespace
+    [InlineData("Task$(whoami)")]                 // subexpression
+    [InlineData("Task`n")]                        // backtick
+    [InlineData("Task\\Path")]                    // backslash (path traversal)
+    [InlineData("")]                               // empty
+    public void IsSafeTaskName_FalseForUnsafe(string name)
+        => Assert.False(EdgeOneDriveService.IsSafeTaskName(name));
+
+    // Regression guard: the fixed allowlist is interpolated into the enable/disable script, so
+    // every entry MUST be embedding-safe. This fails the build if a future edit adds an unsafe name.
+    [Fact]
+    public void EdgeUpdateTaskNames_AreAllInjectionSafe()
+        => Assert.All(EdgeOneDriveService.EdgeUpdateTaskNames, n => Assert.True(EdgeOneDriveService.IsSafeTaskName(n)));
+
+    // ── Edge policy round-trip (needs-admin path proven writable via redirect) ─
+
+    [Fact]
+    public async Task DisableEdgeAsync_WritesBackgroundAndStartupBoostToZero_AndSucceeds()
+    {
+        var outcome = await _svc.DisableEdgeAsync();
+
+        Assert.Equal(EdgeOneDriveOutcome.Success, outcome);
+        Assert.Equal(0, ReadEdgePolicy("BackgroundModeEnabled"));
+        Assert.Equal(0, ReadEdgePolicy("StartupBoostEnabled"));
+    }
+
+    [Fact]
+    public async Task RestoreEdgeAsync_ClearsThePolicyValues_AndSucceeds()
+    {
+        await _svc.DisableEdgeAsync();               // seed the disabled state
+        Assert.NotNull(ReadEdgePolicy("BackgroundModeEnabled"));
+
+        var outcome = await _svc.RestoreEdgeAsync();
+
+        Assert.Equal(EdgeOneDriveOutcome.Success, outcome);
+        Assert.Null(ReadEdgePolicy("BackgroundModeEnabled"));
+        Assert.Null(ReadEdgePolicy("StartupBoostEnabled"));
+    }
+
+    [Fact]
+    public async Task DisableEdgeAsync_DisablesUpdateTasks_ViaHardCodedAllowlistScript()
+    {
+        await _svc.DisableEdgeAsync();
+
+        // The task toggle must go through the runner with a Disable script naming ONLY the
+        // fixed allowlist entries — never an arbitrary/interpolated task name.
+        await _runner.Received().RunAsync(
+            Arg.Is<string>(s => s != null
+                && s.Contains("Disable-ScheduledTask")
+                && s.Contains("MicrosoftEdgeUpdateTaskMachineCore")
+                && s.Contains("MicrosoftEdgeUpdateTaskMachineUA")),
+            Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RestoreEdgeAsync_EnablesUpdateTasks_ViaHardCodedAllowlistScript()
+    {
+        await _svc.RestoreEdgeAsync();
+
+        await _runner.Received().RunAsync(
+            Arg.Is<string>(s => s != null
+                && s.Contains("Enable-ScheduledTask")
+                && s.Contains("MicrosoftEdgeUpdateTaskMachineCore")),
+            Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── GetStatusAsync reads the redirected registry back ───────────────────
+
+    [Fact]
+    public async Task GetStatusAsync_ReportsEdgeBackgroundDisabled_AfterDisable()
+    {
+        Assert.False((await _svc.GetStatusAsync()).EdgeBackgroundDisabled);   // clean baseline
+
+        await _svc.DisableEdgeAsync();
+        Assert.True((await _svc.GetStatusAsync()).EdgeBackgroundDisabled);
+
+        await _svc.RestoreEdgeAsync();
+        Assert.False((await _svc.GetStatusAsync()).EdgeBackgroundDisabled);
+    }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    public async Task GetStatusAsync_ReadsOneDrivePinFromRegistry(int pinValue, bool expectedPinned)
+    {
+        using (var key = _root.CreateSubKey(OneDriveClsidPath, writable: true)!)
+            key.SetValue("System.IsPinnedToNameSpaceTree", pinValue, RegistryValueKind.DWord);
+
+        var status = await _svc.GetStatusAsync();
+
+        Assert.Equal(expectedPinned, status.OneDrivePinned);
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_NeverThrows_WithEmptyRedirectedRoots()
+    {
+        // No pre-seeded keys — every read falls back to its safe default without throwing.
+        var status = await _svc.GetStatusAsync();
+        Assert.False(status.EdgeBackgroundDisabled);
+        Assert.False(status.EdgeUpdateTasksEnabled);
+    }
+}

--- a/SysManager/SysManager.Tests/EdgeOneDriveViewModelTests.cs
+++ b/SysManager/SysManager.Tests/EdgeOneDriveViewModelTests.cs
@@ -1,0 +1,142 @@
+// SysManager · EdgeOneDriveViewModelTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+using Microsoft.Win32;
+using NSubstitute;
+using SysManager.Models;
+using SysManager.Services;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="EdgeOneDriveViewModel"/> — the re-entrancy guard (NotBusy) that
+/// serialises the four mutating commands, and the pure state-text derivation the status panel
+/// binds to. The service is constructed over redirected HKCU roots and a substituted runner, so
+/// no process, scheduled task, or real machine key is touched.
+/// </summary>
+[Collection("DialogService")]
+public sealed class EdgeOneDriveViewModelTests : IDisposable
+{
+    private readonly string _rootName = @"Software\SysManagerTests\EdgeOneDriveVm_" + Guid.NewGuid().ToString("N");
+    private readonly RegistryKey _root;
+
+    public EdgeOneDriveViewModelTests()
+        => _root = Registry.CurrentUser.CreateSubKey(_rootName, writable: true)!;
+
+    public void Dispose()
+    {
+        _root.Dispose();
+        try { Registry.CurrentUser.DeleteSubKeyTree(_rootName, throwOnMissingSubKey: false); } catch { /* best-effort cleanup */ }
+    }
+
+    private EdgeOneDriveViewModel NewVm()
+    {
+        var ps = Substitute.For<IPowerShellRunner>();
+        ps.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+          .Returns(new Collection<PSObject>());
+        var vm = new EdgeOneDriveViewModel(new EdgeOneDriveService(ps, hkcuRoot: _root, hklmRoot: _root));
+        vm.InitializationComplete.GetAwaiter().GetResult();
+        return vm;
+    }
+
+    [Fact]
+    public void AfterInit_NotBusy_IsTrue()
+    {
+        var vm = NewVm();
+        Assert.False(vm.IsBusy);
+        Assert.True(vm.NotBusy);
+    }
+
+    [Fact]
+    public void MutatingCommands_AreGatedOnNotBusy()
+    {
+        var vm = NewVm();
+
+        Assert.True(vm.RemoveOneDriveCommand.CanExecute(null));
+        Assert.True(vm.RestoreOneDriveCommand.CanExecute(null));
+        Assert.True(vm.DisableEdgeCommand.CanExecute(null));
+        Assert.True(vm.RestoreEdgeCommand.CanExecute(null));
+        Assert.True(vm.RefreshCommand.CanExecute(null));
+
+        vm.IsBusy = true;
+        Assert.False(vm.NotBusy);
+        Assert.False(vm.RemoveOneDriveCommand.CanExecute(null));
+        Assert.False(vm.RestoreOneDriveCommand.CanExecute(null));
+        Assert.False(vm.DisableEdgeCommand.CanExecute(null));
+        Assert.False(vm.RestoreEdgeCommand.CanExecute(null));
+        Assert.False(vm.RefreshCommand.CanExecute(null));
+
+        vm.IsBusy = false;
+        Assert.True(vm.RemoveOneDriveCommand.CanExecute(null));
+    }
+
+    // ── State-text derivation ───────────────────────────────────────────────
+
+    [Fact]
+    public void OneDriveStateText_ReflectsInstalledAndRunning()
+    {
+        var vm = NewVm();
+
+        vm.OneDriveInstalled = false;
+        Assert.Contains("not installed", vm.OneDriveStateText);
+
+        vm.OneDriveInstalled = true;
+        vm.OneDriveRunning = false;
+        Assert.Contains("installed", vm.OneDriveStateText);
+        Assert.DoesNotContain("running", vm.OneDriveStateText);
+
+        vm.OneDriveRunning = true;
+        Assert.Contains("running", vm.OneDriveStateText);
+    }
+
+    [Fact]
+    public void EdgeStateText_ReflectsInstalledAndDeintegratedState()
+    {
+        var vm = NewVm();
+
+        vm.EdgeInstalled = false;
+        Assert.Contains("not installed", vm.EdgeStateText);
+
+        vm.EdgeInstalled = true;
+        vm.EdgeBackgroundDisabled = false;
+        Assert.Contains("active", vm.EdgeStateText);
+
+        vm.EdgeBackgroundDisabled = true;
+        Assert.Contains("de-integrated", vm.EdgeStateText);
+    }
+
+    // ── Confirm gate: a declined dialog performs no work ────────────────────
+
+    [Fact]
+    public async Task RemoveOneDrive_WhenUserDeclines_DoesNotInvokeService()
+    {
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+        DialogService.Instance = dialog;
+        try
+        {
+            var ps = Substitute.For<IPowerShellRunner>();
+            ps.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+              .Returns(new Collection<PSObject>());
+            var vm = new EdgeOneDriveViewModel(new EdgeOneDriveService(ps, hkcuRoot: _root, hklmRoot: _root));
+            await vm.InitializationComplete;
+            // Force the "installed" precondition so the guard reaches the confirm dialog.
+            vm.OneDriveInstalled = true;
+            ps.ClearReceivedCalls();
+
+            await vm.RemoveOneDriveCommand.ExecuteAsync(null);
+
+            Assert.Contains("cancelled", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+            // No process launch happened — the decline short-circuited before any service call.
+            await ps.DidNotReceive().RunProcessAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>(), Arg.Any<System.Text.Encoding?>());
+        }
+        finally { DialogService.Instance = prevDialog; }
+    }
+}

--- a/SysManager/SysManager/Models/EdgeOneDriveStatus.cs
+++ b/SysManager/SysManager/Models/EdgeOneDriveStatus.cs
@@ -1,0 +1,30 @@
+// SysManager · EdgeOneDriveStatus
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// A read-only snapshot of the Microsoft Edge and OneDrive integration state that the
+/// Edge/OneDrive Remover tab surfaces. All fields are raw, independently-observed signals;
+/// the ViewModel derives the user-facing "de-integrated / active" labels from them so the
+/// service stays free of presentation logic.
+/// <para>
+/// OneDrive is handled per-user (no elevation): it can be uninstalled with
+/// <c>OneDriveSetup.exe /uninstall</c> and unpinned from the Explorer navigation pane, both
+/// reversible. Edge is NEVER uninstalled — only a fully reversible "disable &amp;
+/// de-integrate" is offered (turn off background mode / startup boost via Group Policy and
+/// disable its auto-update scheduled tasks), which needs administrator rights.
+/// </para>
+/// </summary>
+public sealed record EdgeOneDriveStatus(
+    bool OneDriveInstalled,
+    bool OneDriveRunning,
+    bool OneDrivePinned,
+    bool EdgeInstalled,
+    bool EdgeUpdateTasksEnabled,
+    bool EdgeBackgroundDisabled)
+{
+    /// <summary>The all-false snapshot returned when the state could not be read.</summary>
+    public static EdgeOneDriveStatus Empty { get; } = new(false, false, false, false, false, false);
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -64,6 +64,7 @@ public static class ServiceRegistration
         services.AddSingleton<EnvironmentVariableService>();
         services.AddSingleton<RestorePointService>();
         services.AddSingleton<DebloaterService>();
+        services.AddSingleton<EdgeOneDriveService>();
         services.AddSingleton<LegacyPanelService>();
         services.AddSingleton<SystemFixService>();
         services.AddSingleton<ProfileService>();
@@ -133,6 +134,7 @@ public static class ServiceRegistration
         services.AddSingleton<EnvironmentVariablesViewModel>();
         services.AddSingleton<RestorePointsViewModel>();
         services.AddSingleton<DebloaterViewModel>();
+        services.AddSingleton<EdgeOneDriveViewModel>();
         services.AddSingleton<LegacyPanelsViewModel>();
         services.AddSingleton<SystemFixesViewModel>();
         services.AddSingleton<ProfileViewModel>();

--- a/SysManager/SysManager/Services/EdgeOneDriveService.cs
+++ b/SysManager/SysManager/Services/EdgeOneDriveService.cs
@@ -1,0 +1,376 @@
+// SysManager · EdgeOneDriveService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.Win32;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>The honest outcome of an Edge/OneDrive operation, so the ViewModel can report
+/// exactly what happened rather than guessing from an exception.</summary>
+public enum EdgeOneDriveOutcome
+{
+    /// <summary>The operation completed.</summary>
+    Success,
+    /// <summary>A machine-scope change (Edge HKLM policy / scheduled tasks) was denied — needs administrator.</summary>
+    NeedsAdmin,
+    /// <summary>Nothing to do — the component isn't installed on this system.</summary>
+    NotApplicable,
+    /// <summary>The operation was attempted but did not succeed.</summary>
+    Failed,
+}
+
+/// <summary>
+/// Safely de-integrates Microsoft Edge and OneDrive, and restores them — the two most-requested
+/// "get this off my machine" targets, handled without the brittle manual registry surgery users
+/// otherwise copy from forums.
+/// <para>
+/// <b>OneDrive is fully removable (per-user, no elevation).</b> Removal stops the running client,
+/// runs the official <c>OneDriveSetup.exe /uninstall</c>, and unpins the File Explorer navigation-
+/// pane entry; every step is reversible (re-run the setup, re-pin). The uninstaller itself clears
+/// OneDrive's startup entry and shell integration.
+/// </para>
+/// <para>
+/// <b>Edge is NEVER uninstalled.</b> There is no supported way to remove Edge (it backs WebView2
+/// and Windows Update reinstalls it), and forcing it breaks other apps irreversibly. Instead this
+/// offers a fully-reversible "disable &amp; de-integrate": turn off Edge's background mode and
+/// startup boost via the documented Group-Policy keys and disable its auto-update scheduled tasks.
+/// Those are machine-scope (HKLM / machine tasks) and therefore need administrator; restore clears
+/// the policy values and re-enables the tasks. Changing the default browser can't be done
+/// programmatically on modern Windows (the UserChoice association is hash-protected), so the tab
+/// guides the user to the Settings page rather than pretending to switch it.
+/// </para>
+/// <para>
+/// All PowerShell/process work routes through the <see cref="IPowerShellRunner"/> seam and every
+/// script is a hard-coded constant with no user input, so there is no injection surface. The
+/// registry roots are injectable (mirroring <see cref="WindowsUpdatePolicyService"/> and
+/// <see cref="AppBlockerService"/>) so the pin/policy logic is unit-tested against a redirected
+/// HKCU subkey without administrator rights or touching real machine state.
+/// </para>
+/// </summary>
+public sealed partial class EdgeOneDriveService
+{
+    private readonly IPowerShellRunner _ps;
+    private readonly RegistryKey _hkcuRoot;   // OneDrive nav-pane pin (Software\Classes\CLSID\…)
+    private readonly RegistryKey _hklmRoot;   // Edge policies (SOFTWARE\Policies\Microsoft\Edge)
+
+    /// <summary>
+    /// Creates the service. <paramref name="hkcuRoot"/> defaults to <see cref="Registry.CurrentUser"/>
+    /// (OneDrive's per-user nav-pane pin) and <paramref name="hklmRoot"/> to
+    /// <see cref="Registry.LocalMachine"/> (Edge's machine policy, needs admin). Tests pass redirected
+    /// roots (HKCU subkeys) so the logic runs without elevation or real machine writes.
+    /// </summary>
+    public EdgeOneDriveService(IPowerShellRunner ps, RegistryKey? hkcuRoot = null, RegistryKey? hklmRoot = null)
+    {
+        _ps = ps;
+        _hkcuRoot = hkcuRoot ?? Registry.CurrentUser;
+        _hklmRoot = hklmRoot ?? Registry.LocalMachine;
+    }
+
+    // OneDrive's File Explorer navigation-pane entry is a shell namespace CLSID; toggling
+    // System.IsPinnedToNameSpaceTree (0/1) hides/shows it (both the native and Wow6432Node views).
+    private const string OneDriveClsidPath = @"Software\Classes\CLSID\{018D5C66-4533-4307-9B53-224DE2ED1FE6}";
+    private const string OneDriveClsidWowPath = @"Software\Classes\Wow6432Node\CLSID\{018D5C66-4533-4307-9B53-224DE2ED1FE6}";
+    private const string PinValue = "System.IsPinnedToNameSpaceTree";
+
+    // Documented Microsoft Edge enterprise-policy values. Setting both to 0 stops Edge from running
+    // in the background after it's closed and from preloading at sign-in; deleting them restores the
+    // Windows defaults. The key lives under HKLM, so writing needs administrator.
+    private const string EdgePolicyPath = @"SOFTWARE\Policies\Microsoft\Edge";
+    private const string BackgroundModeValue = "BackgroundModeEnabled";
+    private const string StartupBoostValue = "StartupBoostEnabled";
+
+    // The ONLY scheduled tasks this service will ever touch — Edge's two machine auto-update tasks.
+    // A fixed allowlist (never a user- or catalog-supplied name) means the disable/enable path can
+    // never be pointed at an arbitrary task. Each name is validated as embedding-safe by a unit test.
+    internal static readonly string[] EdgeUpdateTaskNames =
+    [
+        "MicrosoftEdgeUpdateTaskMachineCore",
+        "MicrosoftEdgeUpdateTaskMachineUA",
+    ];
+
+    // Stops the running OneDrive client so the uninstaller isn't blocked by a live process.
+    private const string KillOneDriveScript =
+        "Stop-Process -Name OneDrive -Force -ErrorAction SilentlyContinue";
+
+    /// <summary>
+    /// Reads the current Edge/OneDrive integration state for the status panel. Never throws —
+    /// unreadable signals fall back to their safe default (treated as "not de-integrated").
+    /// </summary>
+    public async Task<EdgeOneDriveStatus> GetStatusAsync(CancellationToken ct = default)
+    {
+        bool oneDriveInstalled = ResolveOneDriveSetup() is not null;
+        bool oneDriveRunning = IsOneDriveRunning();
+        bool oneDrivePinned = ReadOneDrivePinned(oneDriveInstalled);
+        bool edgeInstalled = ResolveEdgeExe() is not null;
+        bool edgeBackgroundDisabled = ReadEdgeBackgroundDisabled();
+        bool edgeUpdateTasksEnabled = await QueryEdgeUpdateTasksEnabledAsync(ct).ConfigureAwait(false);
+
+        return new EdgeOneDriveStatus(
+            OneDriveInstalled: oneDriveInstalled,
+            OneDriveRunning: oneDriveRunning,
+            OneDrivePinned: oneDrivePinned,
+            EdgeInstalled: edgeInstalled,
+            EdgeUpdateTasksEnabled: edgeUpdateTasksEnabled,
+            EdgeBackgroundDisabled: edgeBackgroundDisabled);
+    }
+
+    // ── OneDrive (per-user, no elevation) ───────────────────────────────────
+
+    /// <summary>
+    /// Removes OneDrive for the current user: stops the client, runs the official uninstaller,
+    /// and unpins the File Explorer navigation-pane entry. Reversible via
+    /// <see cref="RestoreOneDriveAsync"/>. Returns <see cref="EdgeOneDriveOutcome.NotApplicable"/>
+    /// if OneDrive isn't installed.
+    /// </summary>
+    public async Task<EdgeOneDriveOutcome> RemoveOneDriveAsync(CancellationToken ct = default)
+    {
+        var setup = ResolveOneDriveSetup();
+        if (setup is null) return EdgeOneDriveOutcome.NotApplicable;
+
+        try { await _ps.RunAsync(KillOneDriveScript, cancellationToken: ct).ConfigureAwait(false); }
+        catch (System.Management.Automation.RuntimeException ex) { Log.Debug("OneDrive: stop-process failed: {Error}", ex.Message); }
+
+        int exit;
+        try
+        {
+            exit = await _ps.RunProcessAsync(setup, "/uninstall", ct).ConfigureAwait(false);
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            Log.Warning("OneDrive: uninstall launch failed: {Error}", ex.Message);
+            return EdgeOneDriveOutcome.Failed;
+        }
+
+        // Unpin the nav-pane entry regardless — a best-effort per-user cleanup that the
+        // uninstaller doesn't always clear immediately.
+        SetOneDrivePinned(false);
+        Log.Information("OneDrive: uninstall requested (exit {Exit})", exit);
+        return exit == 0 ? EdgeOneDriveOutcome.Success : EdgeOneDriveOutcome.Failed;
+    }
+
+    /// <summary>
+    /// Reinstalls OneDrive for the current user (re-runs the setup that survived under System32/
+    /// SysWOW64) and re-pins the File Explorer entry. Returns
+    /// <see cref="EdgeOneDriveOutcome.NotApplicable"/> if no OneDrive setup can be found.
+    /// </summary>
+    public async Task<EdgeOneDriveOutcome> RestoreOneDriveAsync(CancellationToken ct = default)
+    {
+        var setup = ResolveOneDriveSetup();
+        if (setup is null) return EdgeOneDriveOutcome.NotApplicable;
+
+        try
+        {
+            await _ps.RunProcessAsync(setup, string.Empty, ct).ConfigureAwait(false);
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            Log.Warning("OneDrive: reinstall launch failed: {Error}", ex.Message);
+            return EdgeOneDriveOutcome.Failed;
+        }
+
+        SetOneDrivePinned(true);
+        Log.Information("OneDrive: reinstall requested");
+        return EdgeOneDriveOutcome.Success;
+    }
+
+    // ── Edge (machine-scope, needs admin; disable & de-integrate only) ───────
+
+    /// <summary>
+    /// Disables Edge's background mode and startup boost (HKLM Group-Policy keys) and disables its
+    /// auto-update scheduled tasks. Fully reversible via <see cref="RestoreEdgeAsync"/>. Never
+    /// uninstalls Edge. Returns <see cref="EdgeOneDriveOutcome.NeedsAdmin"/> if the machine policy
+    /// write is denied.
+    /// </summary>
+    public async Task<EdgeOneDriveOutcome> DisableEdgeAsync(CancellationToken ct = default)
+    {
+        if (!TrySetEdgeBackgroundDisabled(true)) return EdgeOneDriveOutcome.NeedsAdmin;
+        try { await _ps.RunAsync(BuildSetEdgeTasksScript(enabled: false), cancellationToken: ct).ConfigureAwait(false); }
+        catch (System.Management.Automation.RuntimeException ex) { Log.Debug("Edge: disable update tasks failed: {Error}", ex.Message); }
+        Log.Information("Edge: disabled background/startup-boost and update tasks");
+        return EdgeOneDriveOutcome.Success;
+    }
+
+    /// <summary>
+    /// Restores Edge to Windows defaults: clears the background/startup-boost policy values and
+    /// re-enables its auto-update scheduled tasks. Returns <see cref="EdgeOneDriveOutcome.NeedsAdmin"/>
+    /// if the machine policy write is denied.
+    /// </summary>
+    public async Task<EdgeOneDriveOutcome> RestoreEdgeAsync(CancellationToken ct = default)
+    {
+        if (!TrySetEdgeBackgroundDisabled(false)) return EdgeOneDriveOutcome.NeedsAdmin;
+        try { await _ps.RunAsync(BuildSetEdgeTasksScript(enabled: true), cancellationToken: ct).ConfigureAwait(false); }
+        catch (System.Management.Automation.RuntimeException ex) { Log.Debug("Edge: enable update tasks failed: {Error}", ex.Message); }
+        Log.Information("Edge: restored background/startup-boost and update tasks");
+        return EdgeOneDriveOutcome.Success;
+    }
+
+    // ── Registry helpers (OneDrive pin) ─────────────────────────────────────
+
+    private void SetOneDrivePinned(bool pinned)
+    {
+        foreach (var path in new[] { OneDriveClsidPath, OneDriveClsidWowPath })
+        {
+            try
+            {
+                using var key = _hkcuRoot.CreateSubKey(path, writable: true);
+                key?.SetValue(PinValue, pinned ? 1 : 0, RegistryValueKind.DWord);
+            }
+            catch (UnauthorizedAccessException ex) { Log.Debug("OneDrive pin write denied {Path}: {Error}", path, ex.Message); }
+            catch (System.Security.SecurityException ex) { Log.Debug("OneDrive pin write denied {Path}: {Error}", path, ex.Message); }
+            catch (IOException ex) { Log.Debug("OneDrive pin write I/O error {Path}: {Error}", path, ex.Message); }
+        }
+    }
+
+    private bool ReadOneDrivePinned(bool installed)
+    {
+        foreach (var path in new[] { OneDriveClsidPath, OneDriveClsidWowPath })
+        {
+            try
+            {
+                using var key = _hkcuRoot.OpenSubKey(path);
+                if (key?.GetValue(PinValue) is int v) return v != 0;
+            }
+            catch (System.Security.SecurityException) { /* protected key — try the other view */ }
+            catch (IOException) { /* transient — try the other view */ }
+        }
+        // No explicit pin value present: OneDrive pins itself by default when installed.
+        return installed;
+    }
+
+    // ── Registry helpers (Edge policy) ──────────────────────────────────────
+
+    /// <summary>
+    /// Writes (disabled=true) or clears (disabled=false) the Edge background/startup-boost policy
+    /// values. Returns false when the HKLM write is denied (no elevation) so the caller can report
+    /// NeedsAdmin — the same "write denied ⇒ no change" signal <see cref="WindowsUpdatePolicyService"/>
+    /// uses.
+    /// </summary>
+    private bool TrySetEdgeBackgroundDisabled(bool disabled)
+    {
+        try
+        {
+            using var key = _hklmRoot.CreateSubKey(EdgePolicyPath, writable: true);
+            if (key is null) return false;
+            if (disabled)
+            {
+                key.SetValue(BackgroundModeValue, 0, RegistryValueKind.DWord);
+                key.SetValue(StartupBoostValue, 0, RegistryValueKind.DWord);
+            }
+            else
+            {
+                key.DeleteValue(BackgroundModeValue, throwOnMissingValue: false);
+                key.DeleteValue(StartupBoostValue, throwOnMissingValue: false);
+            }
+            return true;
+        }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Edge policy write denied: {Error}", ex.Message); return false; }
+        catch (System.Security.SecurityException ex) { Log.Debug("Edge policy write denied: {Error}", ex.Message); return false; }
+        catch (IOException ex) { Log.Debug("Edge policy write I/O error: {Error}", ex.Message); return false; }
+    }
+
+    private bool ReadEdgeBackgroundDisabled()
+    {
+        try
+        {
+            using var key = _hklmRoot.OpenSubKey(EdgePolicyPath);
+            if (key is null) return false;
+            return key.GetValue(BackgroundModeValue) is int bg && bg == 0
+                && key.GetValue(StartupBoostValue) is int sb && sb == 0;
+        }
+        catch (System.Security.SecurityException) { return false; }
+        catch (IOException) { return false; }
+    }
+
+    // ── Scheduled-task helpers (Edge auto-update) ───────────────────────────
+
+    /// <summary>
+    /// Builds the hard-coded enable/disable script over the fixed Edge update-task allowlist. The
+    /// task names are compile-time constants validated as embedding-safe (<see cref="IsSafeTaskName"/>),
+    /// so this carries no injection surface even though the names are interpolated.
+    /// </summary>
+    private static string BuildSetEdgeTasksScript(bool enabled)
+    {
+        var names = string.Join(",", EdgeUpdateTaskNames.Select(n => $"'{n}'"));
+        var verb = enabled ? "Enable-ScheduledTask" : "Disable-ScheduledTask";
+        return $"foreach ($t in {names}) {{ {verb} -TaskName $t -ErrorAction SilentlyContinue | Out-Null }}";
+    }
+
+    private static string BuildQueryEdgeTasksScript()
+    {
+        var names = string.Join(",", EdgeUpdateTaskNames.Select(n => $"'{n}'"));
+        return $"$s = foreach ($t in {names}) {{ $x = Get-ScheduledTask -TaskName $t -ErrorAction SilentlyContinue; if ($x) {{ [string]$x.State }} }}; " +
+               "[PSCustomObject]@{ AnyEnabled = (@($s | Where-Object { $_ -eq 'Ready' }).Count -gt 0) }";
+    }
+
+    private async Task<bool> QueryEdgeUpdateTasksEnabledAsync(CancellationToken ct)
+    {
+        try
+        {
+            var results = await _ps.RunAsync(BuildQueryEdgeTasksScript(), cancellationToken: ct).ConfigureAwait(false);
+            if (results.Count == 0) return false;
+            // The script projects a PowerShell [bool], which marshals back as System.Boolean.
+            return results[0].Properties["AnyEnabled"]?.Value is true;
+        }
+        catch (System.Management.Automation.RuntimeException ex)
+        {
+            Log.Debug("Edge: query update tasks failed: {Error}", ex.Message);
+            return false;
+        }
+    }
+
+    /// <summary>A task name is safe to embed in a script only if it is purely alphanumeric —
+    /// no quotes, whitespace, or PowerShell metacharacters. The Edge allowlist entries all pass;
+    /// a unit test enforces it so a future edit can't introduce an unsafe name.</summary>
+    internal static bool IsSafeTaskName(string name) => SafeTaskNameRegex().IsMatch(name);
+
+    [GeneratedRegex(@"\A[A-Za-z0-9]+\z")]
+    private static partial Regex SafeTaskNameRegex();
+
+    // ── Filesystem/process probes ───────────────────────────────────────────
+
+    /// <summary>
+    /// Resolves the OneDriveSetup.exe to launch, preferring the trusted, admin-only-writable
+    /// System32/SysWOW64 copy (which also survives an uninstall, so restore still works) and
+    /// falling back to the per-user copy under LOCALAPPDATA. Returns null when none exists
+    /// (OneDrive not installed). Preferring the System copy also avoids launching a user-writable
+    /// binary should the app ever be elevated for the Edge portion (binary-planting guard, matching
+    /// <see cref="SystemPaths"/>).
+    /// </summary>
+    private static string? ResolveOneDriveSetup()
+    {
+        var windows = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+        string[] candidates =
+        [
+            Path.Combine(windows, "SysWOW64", "OneDriveSetup.exe"),
+            Path.Combine(windows, "System32", "OneDriveSetup.exe"),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Microsoft", "OneDrive", "OneDriveSetup.exe"),
+        ];
+        return candidates.FirstOrDefault(File.Exists);
+    }
+
+    private static string? ResolveEdgeExe()
+    {
+        string[] candidates =
+        [
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+                "Microsoft", "Edge", "Application", "msedge.exe"),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+                "Microsoft", "Edge", "Application", "msedge.exe"),
+        ];
+        return candidates.FirstOrDefault(File.Exists);
+    }
+
+    private static bool IsOneDriveRunning()
+    {
+        var procs = System.Diagnostics.Process.GetProcessesByName("OneDrive");
+        try { return procs.Length > 0; }
+        finally { foreach (var p in procs) p.Dispose(); }
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.52.105</Version>
-    <FileVersion>1.52.105.0</FileVersion>
-    <AssemblyVersion>1.52.105.0</AssemblyVersion>
+    <Version>1.53.0</Version>
+    <FileVersion>1.53.0.0</FileVersion>
+    <AssemblyVersion>1.53.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/EdgeOneDriveViewModel.cs
+++ b/SysManager/SysManager/ViewModels/EdgeOneDriveViewModel.cs
@@ -1,0 +1,254 @@
+// SysManager · EdgeOneDriveViewModel
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Diagnostics;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// ViewModel for the Edge/OneDrive Remover tab. Surfaces the current integration state and
+/// offers reversible actions: OneDrive is fully removable per-user (no admin), while Edge is
+/// only ever "disabled &amp; de-integrated" (background/startup-boost policy + auto-update tasks),
+/// never uninstalled — with a matching Restore for each. Changing the default browser can't be
+/// done programmatically, so the tab guides the user to Windows Settings. Every action confirms
+/// first and reports its honest outcome.
+/// </summary>
+public sealed partial class EdgeOneDriveViewModel : ViewModelBase
+{
+    private readonly EdgeOneDriveService _service;
+
+    [ObservableProperty] private bool _isElevated;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(OneDriveStateText))]
+    private bool _oneDriveInstalled;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(OneDriveStateText))]
+    private bool _oneDriveRunning;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(EdgeStateText))]
+    private bool _edgeInstalled;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(EdgeStateText))]
+    private bool _edgeBackgroundDisabled;
+
+    public string OneDriveStateText => !OneDriveInstalled
+        ? "OneDrive is not installed."
+        : OneDriveRunning ? "OneDrive is installed and running." : "OneDrive is installed.";
+
+    public string EdgeStateText => !EdgeInstalled
+        ? "Microsoft Edge is not installed."
+        : EdgeBackgroundDisabled
+            ? "Edge is de-integrated (background mode and startup boost are off)."
+            : "Edge is active (background mode / startup boost may be on).";
+
+    public EdgeOneDriveViewModel(EdgeOneDriveService service)
+    {
+        _service = service;
+        IsElevated = AdminHelper.IsElevated();
+        StatusMessage = "Reading Edge and OneDrive status…";
+        PropertyChanged += OnVmPropertyChanged;
+        InitializeAsync(RefreshAsync);
+    }
+
+    /// <summary>True when no operation is in flight — gates every mutating command so a second
+    /// action can't start while the first is still running.</summary>
+    public bool NotBusy => !IsBusy;
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(IsBusy)) return;
+        OnPropertyChanged(nameof(NotBusy));
+        RefreshCommand.NotifyCanExecuteChanged();
+        RemoveOneDriveCommand.NotifyCanExecuteChanged();
+        RestoreOneDriveCommand.NotifyCanExecuteChanged();
+        DisableEdgeCommand.NotifyCanExecuteChanged();
+        RestoreEdgeCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand]
+    private void RelaunchAsAdmin()
+    {
+        if (AdminHelper.RelaunchAsAdmin())
+            System.Windows.Application.Current?.Shutdown();
+    }
+
+    [RelayCommand(CanExecute = nameof(NotBusy))]
+    private async Task RefreshAsync()
+    {
+        IsBusy = true;
+        IsProgressIndeterminate = true;
+        try
+        {
+            var status = await _service.GetStatusAsync().ConfigureAwait(true);
+            Apply(status);
+            StatusMessage = "Status loaded.";
+        }
+        // GetStatusAsync runs PowerShell; a runspace-level fault (not the RuntimeException the
+        // service catches) would otherwise escape this async command unobserved.
+        catch (InvalidOperationException ex) { StatusMessage = $"Could not read status: {ex.Message}"; }
+        catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"Could not read status: {ex.Message}"; }
+        finally { IsBusy = false; IsProgressIndeterminate = false; }
+    }
+
+    [RelayCommand(CanExecute = nameof(NotBusy))]
+    private async Task RemoveOneDriveAsync()
+    {
+        if (!OneDriveInstalled) { StatusMessage = "OneDrive is not installed — nothing to remove."; return; }
+        if (!Confirm(
+                "Remove OneDrive for your account?\n\n" +
+                "This stops OneDrive, uninstalls it for the current user, and removes its File Explorer " +
+                "sidebar entry. Your files already synced to this PC stay on disk; files that live only " +
+                "in the cloud won't be downloaded. You can reinstall OneDrive from this tab at any time.",
+                "Remove OneDrive"))
+        {
+            StatusMessage = "OneDrive removal cancelled.";
+            return;
+        }
+        await RunOperationAsync(_service.RemoveOneDriveAsync, "OneDrive", "removed").ConfigureAwait(true);
+    }
+
+    [RelayCommand(CanExecute = nameof(NotBusy))]
+    private async Task RestoreOneDriveAsync()
+    {
+        if (!Confirm("Reinstall OneDrive for your account and restore its File Explorer sidebar entry?",
+                "Restore OneDrive"))
+        {
+            StatusMessage = "OneDrive restore cancelled.";
+            return;
+        }
+        await RunOperationAsync(_service.RestoreOneDriveAsync, "OneDrive", "restored").ConfigureAwait(true);
+    }
+
+    [RelayCommand(CanExecute = nameof(NotBusy))]
+    private async Task DisableEdgeAsync()
+    {
+        if (!EdgeInstalled) { StatusMessage = "Microsoft Edge is not installed — nothing to change."; return; }
+        if (!Confirm(
+                "Disable and de-integrate Microsoft Edge?\n\n" +
+                "Edge is never uninstalled — Windows needs it and would reinstall it anyway. This turns " +
+                "off Edge's background mode and startup boost and disables its automatic-update tasks, so " +
+                "it stops running on its own. You can still open Edge normally, and you can undo all of " +
+                "this from the Restore button. This needs administrator rights.",
+                "Disable & de-integrate Edge"))
+        {
+            StatusMessage = "Edge change cancelled.";
+            return;
+        }
+        await RunOperationAsync(_service.DisableEdgeAsync, "Edge", "de-integrated").ConfigureAwait(true);
+    }
+
+    [RelayCommand(CanExecute = nameof(NotBusy))]
+    private async Task RestoreEdgeAsync()
+    {
+        if (!Confirm(
+                "Restore Microsoft Edge to its Windows defaults?\n\n" +
+                "This clears the background-mode and startup-boost policies and re-enables Edge's " +
+                "automatic-update tasks. This needs administrator rights.",
+                "Restore Edge"))
+        {
+            StatusMessage = "Edge restore cancelled.";
+            return;
+        }
+        await RunOperationAsync(_service.RestoreEdgeAsync, "Edge", "restored").ConfigureAwait(true);
+    }
+
+    /// <summary>
+    /// Hands off to the Windows "Default apps" Settings page so the user can pick their browser.
+    /// SysManager never changes the default browser itself — the UserChoice association is
+    /// hash-protected on modern Windows, so any programmatic change would be rejected or reverted.
+    /// </summary>
+    [RelayCommand]
+    private void OpenDefaultAppsSettings()
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo("ms-settings:defaultapps") { UseShellExecute = true })?.Dispose();
+            StatusMessage = "Opened Windows default-apps settings — pick your preferred browser there.";
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            Log.Warning("Could not open default-apps settings: {Error}", ex.Message);
+            StatusMessage = "Couldn't open Windows default-apps settings.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            Log.Warning("Could not open default-apps settings: {Error}", ex.Message);
+            StatusMessage = "Couldn't open Windows default-apps settings.";
+        }
+    }
+
+    /// <summary>
+    /// Shared runner for the four mutating operations: flips busy, invokes the service, maps the
+    /// honest <see cref="EdgeOneDriveOutcome"/> to a status message, logs a successful change, and
+    /// always re-reads the status so the panel reflects reality.
+    /// </summary>
+    private async Task RunOperationAsync(Func<CancellationToken, Task<EdgeOneDriveOutcome>> operation, string component, string pastTense)
+    {
+        IsBusy = true;
+        IsProgressIndeterminate = true;
+        try
+        {
+            var outcome = await operation(CancellationToken.None).ConfigureAwait(true);
+            StatusMessage = outcome switch
+            {
+                EdgeOneDriveOutcome.Success => $"{component} {pastTense}.",
+                EdgeOneDriveOutcome.NeedsAdmin => $"{component} was not changed — this needs administrator rights. Use \"Run as administrator\" above.",
+                EdgeOneDriveOutcome.NotApplicable => $"{component} is not installed — nothing to do.",
+                _ => $"{component} could not be {pastTense}.",
+            };
+            if (outcome == EdgeOneDriveOutcome.Success)
+            {
+                Log.Information("EdgeOneDrive: {Component} {PastTense}", component, pastTense);
+                ActivityLogService.Instance.Log("Edge/OneDrive", $"{component} {pastTense}");
+            }
+        }
+        catch (InvalidOperationException ex) { StatusMessage = $"{component} operation failed: {ex.Message}"; }
+        catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"{component} operation failed: {ex.Message}"; }
+        finally
+        {
+            IsBusy = false;
+            IsProgressIndeterminate = false;
+            // Re-read so the status panel matches the new reality, regardless of outcome.
+            await RefreshAfterOperationAsync().ConfigureAwait(true);
+        }
+    }
+
+    private async Task RefreshAfterOperationAsync()
+    {
+        try
+        {
+            var status = await _service.GetStatusAsync().ConfigureAwait(true);
+            Apply(status);
+        }
+        catch (InvalidOperationException ex) { Log.Debug("EdgeOneDrive: post-op refresh failed: {Error}", ex.Message); }
+        catch (System.ComponentModel.Win32Exception ex) { Log.Debug("EdgeOneDrive: post-op refresh failed: {Error}", ex.Message); }
+    }
+
+    private void Apply(EdgeOneDriveStatus status)
+    {
+        OneDriveInstalled = status.OneDriveInstalled;
+        OneDriveRunning = status.OneDriveRunning;
+        EdgeInstalled = status.EdgeInstalled;
+        EdgeBackgroundDisabled = status.EdgeBackgroundDisabled;
+    }
+
+    private static bool Confirm(string message, string title)
+        => DialogService.Instance.Confirm(message, title);
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing) PropertyChanged -= OnVmPropertyChanged;
+        base.Dispose(disposing);
+    }
+}

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -53,8 +53,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     // Placeholder VMs for planned features (cheap; built once, referenced by their NavItems).
     private readonly PlaceholderViewModel _wipBandwidthMonitor =
         new("Bandwidth Monitor", "Real-time per-app network usage with history graphs and alerts.", "#337");
-    private readonly PlaceholderViewModel _wipEdgeOneDriveRemover =
-        new("Edge/OneDrive Remover", "Safely remove or disable Edge and OneDrive with full restore capability.", "#339");
     private readonly PlaceholderViewModel _wipNotificationBlocker =
         new("Notification Blocker", "Suppress annoying app pop-ups (update nags, trial reminders) with allowlist.", "#340");
 
@@ -213,7 +211,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Tab<AppBlockerViewModel>("nav-app-blocker",     "App Blocker",           typeof(Views.AppBlockerView)),
             Tab<DebloaterViewModel>("nav-debloater",        "Debloater & Ads",       typeof(Views.DebloaterView)),
             Tab<BrowserCleanerViewModel>("nav-browser-cleaner", "Browser Cleaner",   typeof(Views.BrowserCleanerView)),
-            EagerItem("nav-edge-onedrive",   "Edge/OneDrive Remover", typeof(Views.PlaceholderView), _wipEdgeOneDriveRemover, inDevelopment: true),
+            Tab<EdgeOneDriveViewModel>("nav-edge-onedrive", "Edge/OneDrive Remover", typeof(Views.EdgeOneDriveView)),
             Tab<DefenderViewModel>("nav-defender-tweaks",   "Defender Tweaks",       typeof(Views.DefenderView)),
             EagerItem("nav-notification-blocker", "Notification Blocker", typeof(Views.PlaceholderView), _wipNotificationBlocker, inDevelopment: true)),
 
@@ -386,6 +384,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             [typeof(EnvironmentVariablesViewModel)] = new EnvironmentVariablesViewModel(new EnvironmentVariableService()),
             [typeof(RestorePointsViewModel)] = new RestorePointsViewModel(restorePoints),
             [typeof(DebloaterViewModel)] = new DebloaterViewModel(new DebloaterService(new PowerShellRunner())),
+            [typeof(EdgeOneDriveViewModel)] = new EdgeOneDriveViewModel(new EdgeOneDriveService(new PowerShellRunner())),
             [typeof(LegacyPanelsViewModel)] = new LegacyPanelsViewModel(new LegacyPanelService()),
             [typeof(SystemFixesViewModel)] = new SystemFixesViewModel(new SystemFixService(new PowerShellRunner())),
             [typeof(ProfileViewModel)] = new ProfileViewModel(new ProfileService()),

--- a/SysManager/SysManager/Views/EdgeOneDriveView.xaml
+++ b/SysManager/SysManager/Views/EdgeOneDriveView.xaml
@@ -1,0 +1,130 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.EdgeOneDriveView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:EdgeOneDriveViewModel}"
+             Background="{DynamicResource Surface0}">
+
+    <Grid Margin="28,24,28,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,16">
+            <TextBlock Text="Edge/OneDrive Remover" Style="{StaticResource Display}"/>
+            <TextBlock Text="Safely take Microsoft Edge and OneDrive out of your way — and put them back whenever you like. OneDrive can be fully removed for your account. Edge is never uninstalled (Windows needs it and would reinstall it); instead it's disabled and de-integrated so it stops running on its own. Everything here is reversible."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <!-- Elevation banner: not elevated. OneDrive removal works without admin; the Edge
+             portion writes machine policy + scheduled tasks, so it needs elevation. -->
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
+                        AutomationProperties.Name="Run as administrator"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
+                    <TextBlock Text="Disabling Edge needs administrator privileges. Removing OneDrive works without it."
+                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- Elevation banner: elevated -->
+        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
+                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
+                        Margin="-12,-8,0,-8"/>
+                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="Running as administrator — you can disable Edge and remove OneDrive."
+                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Content cards -->
+        <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" Padding="0,0,4,0">
+            <StackPanel>
+
+                <!-- OneDrive -->
+                <Border Style="{StaticResource Card}" Margin="0,0,0,12">
+                    <StackPanel>
+                        <TextBlock Text="OneDrive" Style="{StaticResource SectionTitle}"/>
+                        <TextBlock Text="{Binding OneDriveStateText}" FontSize="13" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextPrimary}" Margin="0,8,0,0"/>
+                        <TextBlock Text="Removing OneDrive stops it, uninstalls it for your account, and clears its File Explorer sidebar entry. Files already downloaded to this PC stay put; cloud-only files won't be downloaded. Reinstall it any time with Restore."
+                                   Style="{StaticResource Subtle}" TextWrapping="Wrap" Margin="0,6,0,0"/>
+                        <WrapPanel Orientation="Horizontal" Margin="0,14,0,0">
+                            <Button Content="Remove OneDrive…" Command="{Binding RemoveOneDriveCommand}"
+                                    Style="{StaticResource DangerButton}" Margin="0,0,8,0"
+                                    AutomationProperties.Name="Remove OneDrive for the current user"
+                                    ToolTip="Uninstall OneDrive for your account (reversible via Restore)."/>
+                            <Button Content="Restore OneDrive" Command="{Binding RestoreOneDriveCommand}"
+                                    Style="{StaticResource SecondaryButton}"
+                                    AutomationProperties.Name="Reinstall OneDrive"
+                                    ToolTip="Reinstall OneDrive and re-add its File Explorer sidebar entry."/>
+                        </WrapPanel>
+                    </StackPanel>
+                </Border>
+
+                <!-- Microsoft Edge -->
+                <Border Style="{StaticResource Card}" Margin="0,0,0,12">
+                    <StackPanel>
+                        <TextBlock Text="Microsoft Edge" Style="{StaticResource SectionTitle}"/>
+                        <TextBlock Text="{Binding EdgeStateText}" FontSize="13" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextPrimary}" Margin="0,8,0,0"/>
+                        <TextBlock Text="Edge is never uninstalled — Windows relies on it (WebView2) and would reinstall it, and forcing it out breaks other apps. Instead, disabling turns off Edge's background mode and startup boost and disables its automatic-update tasks, so it stops launching and running on its own. You can still open Edge normally, and Restore undoes all of it. These changes need administrator rights."
+                                   Style="{StaticResource Subtle}" TextWrapping="Wrap" Margin="0,6,0,0"/>
+                        <WrapPanel Orientation="Horizontal" Margin="0,14,0,0">
+                            <Button Content="Disable &amp; de-integrate Edge…" Command="{Binding DisableEdgeCommand}"
+                                    Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"
+                                    AutomationProperties.Name="Disable and de-integrate Microsoft Edge"
+                                    ToolTip="Turn off Edge background mode, startup boost, and auto-update tasks (reversible)."/>
+                            <Button Content="Restore Edge" Command="{Binding RestoreEdgeCommand}"
+                                    Style="{StaticResource SecondaryButton}"
+                                    AutomationProperties.Name="Restore Microsoft Edge to defaults"
+                                    ToolTip="Clear the policies and re-enable Edge's automatic-update tasks."/>
+                        </WrapPanel>
+                    </StackPanel>
+                </Border>
+
+                <!-- Default browser guidance -->
+                <Border Style="{StaticResource Card}" Margin="0,0,0,12">
+                    <StackPanel>
+                        <TextBlock Text="Default browser" Style="{StaticResource SectionTitle}"/>
+                        <TextBlock Text="Windows protects the default-browser choice, so no app (including this one) can switch it for you. Open Windows' default-apps settings and pick your preferred browser there — do this before disabling Edge if Edge is currently your default."
+                                   Style="{StaticResource Subtle}" TextWrapping="Wrap" Margin="0,8,0,0"/>
+                        <Button Content="Choose default browser…" Command="{Binding OpenDefaultAppsSettingsCommand}"
+                                Style="{StaticResource GhostButton}" HorizontalAlignment="Left" Margin="0,14,0,0"
+                                AutomationProperties.Name="Open Windows default-apps settings"/>
+                    </StackPanel>
+                </Border>
+
+            </StackPanel>
+        </ScrollViewer>
+
+        <!-- Status bar -->
+        <DockPanel Grid.Row="3" Margin="0,8,0,0">
+            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+                         IsIndeterminate="{Binding IsProgressIndeterminate}"
+                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/EdgeOneDriveView.xaml.cs
+++ b/SysManager/SysManager/Views/EdgeOneDriveView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · EdgeOneDriveView
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class EdgeOneDriveView : UserControl
+{
+    public EdgeOneDriveView() => InitializeComponent();
+}


### PR DESCRIPTION
## What & why
Replaces the work-in-progress placeholder in **Privacy & Security** with a real **Edge/OneDrive Remover** tab. These are two of the most-requested "get this off my machine" targets, but doing it by hand means brittle registry surgery copied from forums. The tab does it safely, in plain language, with a matching **Restore** for every action.

## Behavior
- **OneDrive — full removal for the current user, no admin.** Stops the running client, runs the official `OneDriveSetup.exe /uninstall`, and clears its File Explorer navigation-pane entry. Files already synced to the PC stay on disk; cloud-only files aren't downloaded. **Restore OneDrive** reinstalls it and re-pins the sidebar entry.
- **Edge — disable & de-integrate, NEVER uninstall.** Windows relies on Edge (WebView2) and reinstalls it if forced out — and forcing it breaks other apps irreversibly — so the tab never uninstalls it. Instead it sets the documented `BackgroundModeEnabled` / `StartupBoostEnabled` Group-Policy values to 0 and disables Edge's two machine auto-update scheduled tasks, so Edge stops launching/running on its own; the user can still open it normally. **Restore Edge** clears the policies and re-enables the tasks. Machine-scope → admin-gated (standard golden admin banner explains why).
- **Default browser — guided, not faked.** The UserChoice association is hash-protected on modern Windows, so no app can switch it programmatically; the tab opens Windows' default-apps settings and guides the user.

## Safety / architecture
- All PowerShell + process launches route through the `IPowerShellRunner` seam with **hard-coded scripts** — no user input is ever interpolated. The Edge update-task names are a **fixed, injection-safe allowlist** (enforced by a unit test).
- Registry roots (`HKCU` for the OneDrive pin, `HKLM` for Edge policy) are **injectable**, so the pin/policy logic is unit-tested against a redirected hive without admin or real machine writes (mirrors `AppBlockerService` / `WindowsUpdatePolicyService`).
- Every mutating action confirms first with a plain-language impact summary and reports an **honest outcome**: done / needs-administrator / not-installed. `NotBusy` gate serialises the four commands.
- OneDriveSetup is resolved preferring the trusted System32/SysWOW64 copy (binary-planting guard, matching `SystemPaths`).

## Files
- **New:** `Models/EdgeOneDriveStatus.cs`, `Services/EdgeOneDriveService.cs`, `ViewModels/EdgeOneDriveViewModel.cs`, `Views/EdgeOneDriveView.xaml(.cs)`, `SysManager.Tests/EdgeOneDriveServiceTests.cs`, `SysManager.Tests/EdgeOneDriveViewModelTests.cs`
- **Wiring:** `ServiceRegistration.cs` (service + VM singletons), `MainWindowViewModel.cs` (nav `Tab<EdgeOneDriveViewModel>` replaces the placeholder; designer-graph entry; `_wipEdgeOneDriveRemover` field removed)
- **Docs:** `README.md` (tab counts 55→56 implemented / 3→2 WIP, ⚙️ dropped from Edge/OneDrive, new feature section), `ARCHITECTURE.md` (service + VM lists, Privacy VM row), `CHANGELOG.md` (1.53.0)
- **Version:** csproj 1.52.105 → **1.53.0** (feat: minor bump)

## Tests
- Service: Edge policy round-trip (disable writes both values / restore clears them), status read-back, OneDrive pin read for 0/1, task-name injection guard (allowlist is safe, unsafe names rejected), never-throws on empty roots.
- VM: `NotBusy` gates all four commands, `OneDriveStateText` / `EdgeStateText` derivation, and a declined-confirm performs no service call.
- `dotnet build` green on all four projects (main + Tests + IntegrationTests + UITests), 0 warnings / 0 errors. (`dotnet test` left to CI.)

Closes #339