### PR TITLE
feat: complete Volume Control — per-app routing, presets, tray shortcut

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -103,7 +103,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 - `DefenderViewModel` — view Microsoft Defender status, toggle PUA / Controlled Folder Access, and manage scan-exclusion folders; every change is admin-gated, confirmed, and verified by read-back (Tamper Protection can silently reject).
 - `TaskSchedulerViewModel` — browse Windows scheduled tasks with a safety classification and enable/disable them (reversible, never deletes); system tasks warn before disabling, changes verified by read-back.
 - `DarkModeViewModel` — switch the Windows light/dark theme manually or on a fixed-time schedule (DispatcherTimer poll while the app runs); persists the schedule.
-- `AudioMixerViewModel` — per-app volume mixer (Volume Control tab): lists apps playing on the default render device with a volume slider, mute toggle, and a live peak meter. Membership reconciles on a ~1&#160;s loop and a shared DispatcherTimer drives the meters, both paused while the tab is hidden (`IsActive`). Rows reconcile in place by session id (a wholesale replace would drop a slider mid-drag). Per-app output-device routing and volume presets are planned for a later update. Row VMs (`AudioSessionRowViewModel`) propagate volume/mute to the service, with a re-entrancy guard so an external change surfaced by a refresh is not echoed back.
+- `AudioMixerViewModel` — per-app volume mixer (Volume Control tab): lists apps playing on the default render device with a volume slider, mute toggle, and a live peak meter. Membership reconciles on a ~1&#160;s loop and a shared DispatcherTimer drives the meters, both paused while the tab is hidden (`IsActive`). Rows reconcile in place by session id (a wholesale replace would drop a slider mid-drag). Adds per-app output-device routing (via the guarded `AudioPolicyConfigFactory`; falls back to guiding the user to Windows sound settings when the OS lacks the interface) and named volume presets (persisted by `VolumePresetService`, keyed by exe name so they re-apply across restarts). Row VMs (`AudioSessionRowViewModel`) propagate volume/mute/route to the service, with a re-entrancy guard so an external change surfaced by a refresh is not echoed back.
 - `StandbyMemoryViewModel` — live memory stats (2s poll) with on-demand and threshold-based auto-purge of the Windows standby list; purge needs admin.
 - `GamingProfileViewModel` — one-click game mode (Gaming Profile tab, Preview): gathers the desired reversible optimizations plus an optional running-game target and delegates to `IGamingProfileService` to apply/revert them as a unit. Reports the batch outcome honestly (applied / needs-admin / failed), seeds its toggles from the last-used config, and offers to restore a leftover session on startup (crash recovery). Fully reversible; killing background apps and named per-game profiles are intentionally out of scope for the preview.
 - `ProfileViewModel` — export/import SysManager's own config (theme, speed-test history) as a portable JSON profile with selective sections and version checking.
@@ -282,7 +282,21 @@ Key services:
   system-sounds pseudo-session. Holds the manager/enumerator handle open across polls and
   releases every COM RCW deterministically in `Dispose` (never finalizer-only, since the
   tab is created/destroyed on navigation). All COM types stay inside the concrete class;
-  the interface exposes only plain models so the VM unit-tests with no audio hardware.
+  the interface exposes only plain models so the VM unit-tests with no audio hardware. Also
+  enumerates render devices (documented device API) and performs per-app output routing via
+  the UNDOCUMENTED `IAudioPolicyConfig` (see `AudioPolicyConfigFactory`), feature-detected so
+  a build without it degrades to the guided fallback rather than failing.
+- `AudioPolicyConfigFactory` — a defensive, isolated wrapper over the undocumented
+  `IAudioPolicyConfig` interface (the mechanism EarTrumpet uses to route one app to a specific
+  output device). Feature-detected (`TryCreate` returns null when it can't bind), guarded (the
+  SET call is invoked only after a successful `QueryInterface` for the exact IID and any failure
+  returns false), and its endpoint-id/process-token string helpers are pure + unit-tested. The
+  routing SET path can only be runtime-verified on a real desktop (laptop workstation), not the
+  build box.
+- `VolumePresetService` — persists named per-app volume/mute presets as JSON under
+  `%LocalAppData%\SysManager\volume-presets.json`, keyed by exe name so a preset re-applies to
+  whatever instance of an app is running. Save/parse/upsert and the "apply preset → live
+  sessions" plan are pure, unit-tested static helpers; the file IO never throws to the caller.
 - `GamingProfileService` (`IGamingProfileService`) — a pure ORCHESTRATOR behind the Gaming
   Profile tab: it composes the already-audited services (`PerformanceService`,
   `ITimerResolutionService`, `ICpuAffinityService`, `StandbyMemoryService`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.55.0] - 2026-07-22
+
+### Added
+- **Volume Control gained per-app output-device routing, saved presets, and a tray shortcut** — completing the per-app mixer (these were previously noted as planned).
+  - **Per-app output routing** — route one app to your headset and another to your speakers. Each app row shows an output-device picker where Windows exposes the routing interface; on builds where it doesn't, the row shows a "Choose output device…" button that opens Windows' per-app sound settings, so there's always a path. Routing is applied for the Multimedia and Console roles (Communications is left to the system so a device switch doesn't hijack call audio).
+  - **Volume presets** — save the current per-app volumes and mutes as a named preset (e.g. "Gaming", "Focus") and re-apply it in one click. Presets are keyed by executable name so they re-apply to whatever instance of an app is running across restarts, and are stored locally in `%LocalAppData%\SysManager\volume-presets.json`.
+  - **Tray shortcut** — a "Volume mixer" item in the system-tray menu opens SysManager straight to the Volume Control tab.
+  - Output-device enumeration uses the documented Core Audio device API. Per-app routing uses the undocumented `IAudioPolicyConfig` interface (the mechanism EarTrumpet uses); it is feature-detected and fully guarded — if it can't bind on this Windows build, the tab silently falls back to the guided path rather than failing. Preset logic and the device/endpoint string handling are unit-tested. Closes #332.
+
 ## [1.54.0] - 2026-07-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -165,8 +165,15 @@ Edit Windows environment variables without the cramped built-in dialog:
   the background
 - **Real names and icons** — resolved from each audio session's process (with a safe
   fallback for protected processes), including the Windows "system sounds" session
-- **Planned** — per-app output-device routing and saved volume presets are planned for
-  a later update
+- **Per-app output routing** — send one app to your headset and another to your speakers.
+  Where Windows exposes the routing interface, each app gets an output-device picker in the
+  row; on builds where it doesn't, the row shows a "Choose output device…" button that opens
+  Windows' per-app sound settings so you're never left without a path
+- **Volume presets** — save the current per-app volumes and mutes as a named preset (e.g.
+  "Gaming", "Focus") and re-apply it in one click; presets are keyed by app so they work
+  across restarts, and are stored locally in `%LocalAppData%\SysManager`
+- **Tray shortcut** — a "Volume mixer" item in the system-tray menu opens the app straight
+  to this tab
 
 ### Network monitor
 - Live ping across multiple targets overlaid on a single latency chart

--- a/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
@@ -53,7 +53,11 @@ public class AudioMixerViewModelTests
     // Sessions is populated before asserting (mirrors CpuAffinityViewModelTests.NewVm).
     private static AudioMixerViewModel NewVm(IAudioMixerService service)
     {
-        var vm = new AudioMixerViewModel(service);
+        // A preset service pointed at a throwaway temp dir so tests never read/write the real
+        // %LocalAppData%\SysManager\volume-presets.json.
+        var presets = new VolumePresetService(System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "SysManagerTests", System.Guid.NewGuid().ToString("N")));
+        var vm = new AudioMixerViewModel(service, presets);
         vm.InitializationComplete.GetAwaiter().GetResult();
         return vm;
     }
@@ -308,7 +312,9 @@ public class AudioMixerViewModelTests
         // the first await, Dispose cancels+disposes+nulls it, and InitAsync's post-await guard
         // sees the null/cancelled token and starts NO reconcile loop.
         var service = ServiceWith(Session("s1"));
-        var vm = new AudioMixerViewModel(service);
+        var presets = new VolumePresetService(System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "SysManagerTests", System.Guid.NewGuid().ToString("N")));
+        var vm = new AudioMixerViewModel(service, presets);
 
         vm.Dispose();                    // races the fire-and-forget InitAsync
         await vm.InitializationComplete; // must complete, not fault

--- a/SysManager/SysManager.Tests/AudioPolicyConfigTests.cs
+++ b/SysManager/SysManager.Tests/AudioPolicyConfigTests.cs
@@ -1,0 +1,45 @@
+// SysManager · AudioPolicyConfigTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for the pure, easy-to-get-wrong string helpers in <see cref="AudioPolicyConfigFactory"/> —
+/// the endpoint-id wrapping and the process token. The COM activation path itself is undocumented
+/// and can only be exercised on a real Windows desktop (verified on the laptop workstation), so it
+/// is intentionally not unit-tested here; these pin the formatting the routing SET call depends on.
+/// </summary>
+public class AudioPolicyConfigTests
+{
+    [Fact]
+    public void ToPolicyEndpointId_Empty_ReturnsEmpty()
+        => Assert.Equal("", AudioPolicyConfigFactory.ToPolicyEndpointId(""));
+
+    [Fact]
+    public void ToPolicyEndpointId_WrapsPlainEndpointId()
+    {
+        var plain = "{0.0.0.00000000}.{a1b2c3d4-0000-0000-0000-000000000000}";
+        var wrapped = AudioPolicyConfigFactory.ToPolicyEndpointId(plain);
+
+        Assert.StartsWith(@"\\?\SWD#MMDEVAPI#", wrapped);
+        Assert.Contains(plain, wrapped);
+        // The render interface GUID suffix is what the interface keys the endpoint on.
+        Assert.EndsWith("{e6327cad-dcec-4949-ae8a-991e976a79d2}", wrapped);
+    }
+
+    [Fact]
+    public void ToPolicyEndpointId_AlreadyWrapped_PassesThrough()
+    {
+        var already = @"\\?\SWD#MMDEVAPI#{0.0.0.00000000}.{guid}#{e6327cad-dcec-4949-ae8a-991e976a79d2}";
+        Assert.Equal(already, AudioPolicyConfigFactory.ToPolicyEndpointId(already));
+    }
+
+    [Theory]
+    [InlineData(1234u, "1234")]
+    [InlineData(1u, "1")]
+    public void BuildProcessToken_IsRawPid(uint pid, string expected)
+        => Assert.Equal(expected, AudioPolicyConfigFactory.BuildProcessToken(pid));
+}

--- a/SysManager/SysManager.Tests/VolumePresetServiceTests.cs
+++ b/SysManager/SysManager.Tests/VolumePresetServiceTests.cs
@@ -1,0 +1,144 @@
+// SysManager · VolumePresetServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Linq;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="VolumePresetService"/>'s pure logic — JSON round-trip, name-keyed upsert,
+/// exe-name extraction, and the apply-plan that maps a preset onto live sessions by executable
+/// name. No file IO is exercised here (the persistence path is thin file read/write).
+/// </summary>
+public class VolumePresetServiceTests
+{
+    private static VolumePreset Preset(string name, params (string exe, float vol, bool mute)[] apps)
+        => new(name, apps.Select(a => new VolumePresetEntry(a.exe, a.exe, a.vol, a.mute)).ToList());
+
+    // ── Serialize / Parse round-trip ───────────────────────────────────────
+
+    [Fact]
+    public void SerializeParse_RoundTrips()
+    {
+        var presets = new[]
+        {
+            Preset("Gaming", ("game.exe", 1.0f, false), ("spotify.exe", 0.2f, false)),
+            Preset("Focus", ("chrome.exe", 0.5f, true)),
+        };
+
+        var json = VolumePresetService.Serialize(presets);
+        var parsed = VolumePresetService.Parse(json);
+
+        Assert.Equal(2, parsed.Count);
+        Assert.Equal("Gaming", parsed[0].Name);
+        Assert.Equal(2, parsed[0].Entries.Count);
+        Assert.Equal("spotify.exe", parsed[0].Entries[1].ExecutableName);
+        Assert.Equal(0.2f, parsed[0].Entries[1].Volume);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    [InlineData("not json")]
+    [InlineData("{ oops")]
+    public void Parse_BlankOrMalformed_ReturnsEmpty(string? json)
+        => Assert.Empty(VolumePresetService.Parse(json));
+
+    // ── Upsert (add vs replace by name, case-insensitive) ──────────────────
+
+    [Fact]
+    public void Upsert_AppendsNewName()
+    {
+        var existing = new[] { Preset("A", ("a.exe", 1f, false)) };
+        var result = VolumePresetService.Upsert(existing, Preset("B", ("b.exe", 0.5f, false)));
+        Assert.Equal(2, result.Count);
+        Assert.Equal("B", result[1].Name);
+    }
+
+    [Fact]
+    public void Upsert_ReplacesSameName_CaseInsensitive_InPlace()
+    {
+        var existing = new[]
+        {
+            Preset("Gaming", ("old.exe", 1f, false)),
+            Preset("Focus", ("f.exe", 0.5f, false)),
+        };
+
+        var result = VolumePresetService.Upsert(existing, Preset("gaming", ("new.exe", 0.3f, true)));
+
+        Assert.Equal(2, result.Count);                 // replaced, not appended
+        Assert.Equal("gaming", result[0].Name);        // in place at index 0
+        Assert.Equal("new.exe", result[0].Entries[0].ExecutableName);
+        Assert.Equal("Focus", result[1].Name);         // sibling untouched
+    }
+
+    [Fact]
+    public void Upsert_DoesNotMutateInput()
+    {
+        var existing = new List<VolumePreset> { Preset("A", ("a.exe", 1f, false)) };
+        VolumePresetService.Upsert(existing, Preset("B", ("b.exe", 1f, false)));
+        Assert.Single(existing); // original list unchanged
+    }
+
+    // ── ExeName ────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(@"C:\Program Files\Game\game.exe", "game.exe")]
+    [InlineData(@"D:\apps\spotify.exe", "spotify.exe")]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void ExeName_ExtractsFileName(string? path, string expected)
+        => Assert.Equal(expected, VolumePresetService.ExeName(path));
+
+    // ── BuildApplyPlan (map preset → live sessions by exe name) ────────────
+
+    private static AudioSessionInfo Session(string sessionId, string exePath)
+        => new(sessionId, 100, exePath, exePath, 0f, false, AudioSessionState.Active, false, 0f);
+
+    [Fact]
+    public void BuildApplyPlan_MatchesByExeName_CaseInsensitive()
+    {
+        var preset = Preset("Gaming", ("game.exe", 0.9f, false), ("spotify.exe", 0.1f, true));
+        var live = new[]
+        {
+            Session("s1", @"C:\Games\GAME.EXE"),   // matches game.exe (case-insensitive)
+            Session("s2", @"C:\Music\spotify.exe"),
+            Session("s3", @"C:\Other\notepad.exe"), // no preset entry → not in plan
+        };
+
+        var plan = VolumePresetService.BuildApplyPlan(preset, live);
+
+        Assert.Equal(2, plan.Count);
+        var game = plan.First(p => p.SessionId == "s1");
+        Assert.Equal(0.9f, game.Volume);
+        Assert.False(game.IsMuted);
+        var spotify = plan.First(p => p.SessionId == "s2");
+        Assert.Equal(0.1f, spotify.Volume);
+        Assert.True(spotify.IsMuted);
+        Assert.DoesNotContain(plan, p => p.SessionId == "s3");
+    }
+
+    [Fact]
+    public void BuildApplyPlan_ClampsVolumeIntoRange()
+    {
+        var preset = Preset("Weird", ("a.exe", 5f, false), ("b.exe", -1f, false));
+        var live = new[] { Session("s1", @"x\a.exe"), Session("s2", @"x\b.exe") };
+
+        var plan = VolumePresetService.BuildApplyPlan(preset, live);
+
+        Assert.Equal(1f, plan.First(p => p.SessionId == "s1").Volume);   // clamped high
+        Assert.Equal(0f, plan.First(p => p.SessionId == "s2").Volume);   // clamped low
+    }
+
+    [Fact]
+    public void BuildApplyPlan_NoMatches_ReturnsEmpty()
+    {
+        var preset = Preset("X", ("nothere.exe", 0.5f, false));
+        var plan = VolumePresetService.BuildApplyPlan(preset, [Session("s1", @"x\other.exe")]);
+        Assert.Empty(plan);
+    }
+}

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -69,9 +69,14 @@ public partial class MainWindow : Window
             ApplyDarkTitleBar(source.Handle);
         }
 
-        // Initialize tray icon after window handle is available
+        // Initialize tray icon after window handle is available. Pass a navigation callback so the
+        // tray's "Volume mixer" shortcut can jump to that tab — the View layer legitimately knows
+        // the shell view-model, keeping the tray service itself free of a ViewModels dependency.
         if (Application.Current is App app && app.TrayService != null)
-            app.TrayService.Initialize(this);
+            app.TrayService.Initialize(this, navId =>
+            {
+                if (DataContext is ViewModels.MainWindowViewModel vm) vm.NavigateTo(navId);
+            });
     }
 
     private static void ApplyDarkTitleBar(IntPtr hwnd)

--- a/SysManager/SysManager/Models/AudioDevice.cs
+++ b/SysManager/SysManager/Models/AudioDevice.cs
@@ -1,0 +1,17 @@
+// SysManager · AudioDevice
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// An immutable snapshot of one active audio render endpoint (output device), returned by
+/// <c>IAudioMixerService.GetRenderDevices</c>. Carries no COM types so the mixer ViewModel and its
+/// tests never touch Core Audio directly. <see cref="Id"/> is the Core Audio endpoint id string
+/// (stable per device) used as the routing target; <see cref="IsDefault"/> marks the current
+/// system default multimedia render endpoint.
+/// </summary>
+public sealed record AudioDevice(
+    string Id,
+    string FriendlyName,
+    bool IsDefault);

--- a/SysManager/SysManager/Models/VolumePreset.cs
+++ b/SysManager/SysManager/Models/VolumePreset.cs
@@ -1,0 +1,23 @@
+// SysManager · VolumePreset
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// A saved snapshot of per-application volume/mute settings the user can re-apply later — e.g. a
+/// "Gaming" preset (game loud, music quiet) or a "Focus" preset. Persisted as JSON under
+/// <c>%LocalAppData%\SysManager</c> by <c>VolumePresetService</c>. Apps are keyed by executable
+/// name (not PID, which Windows recycles, and not the session id, which changes between runs) so a
+/// preset re-applies across restarts to whatever instance of the app is running.
+/// </summary>
+public sealed record VolumePreset(
+    string Name,
+    IReadOnlyList<VolumePresetEntry> Entries);
+
+/// <summary>One app's saved volume/mute within a <see cref="VolumePreset"/>, keyed by exe name.</summary>
+public sealed record VolumePresetEntry(
+    string ExecutableName,
+    string DisplayName,
+    float Volume,
+    bool IsMuted);

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -88,6 +88,7 @@ public static class ServiceRegistration
         services.AddSingleton<MaintenanceSchedulerService>();
         services.AddSingleton<ITweaksHubService, TweaksHubService>();
         services.AddSingleton<IAudioMixerService, AudioMixerService>();
+        services.AddSingleton<VolumePresetService>();
         // Gaming Profile orchestrates the audited services above; it needs the process's
         // elevation state at construction (a value DI can't resolve), hence the factory.
         services.AddSingleton<IGamingProfileService>(sp => new GamingProfileService(

--- a/SysManager/SysManager/Services/AudioMixerService.cs
+++ b/SysManager/SysManager/Services/AudioMixerService.cs
@@ -20,10 +20,12 @@ namespace SysManager.Services;
 /// <c>ISimpleAudioVolume</c> / <c>IAudioMeterInformation</c>) so nothing but the .NET
 /// runtime is added to the single portable .exe.
 ///
-/// <para>Scope: default render endpoint only (Windows' own mixer is per-device too);
-/// sessions on other output devices are not shown. Per-app <em>output-device routing</em>
-/// and volume <em>presets</em> are intentionally out of scope for this preview — the only
-/// public path to routing is an undocumented, version-fragile internal WinRT class.</para>
+/// <para>Scope: enumerates sessions on the default render endpoint. Output devices are listed via
+/// the documented device API (<see cref="GetRenderDevices"/>). Per-app output-device routing uses
+/// the UNDOCUMENTED <c>IAudioPolicyConfig</c> interface (the same one EarTrumpet reverse-engineers)
+/// and is feature-detected at runtime: if it can't bind on this Windows build,
+/// <see cref="IsRoutingSupported"/> is false and the UI falls back to guiding the user to Windows'
+/// per-app sound settings. Volume presets live in a separate pure service.</para>
 ///
 /// <para>Thread-safety: every COM access is guarded by <see cref="_gate"/>. The manager /
 /// device / enumerator handle is held open across polls; the per-app session interfaces
@@ -48,6 +50,10 @@ public sealed class AudioMixerService : IAudioMixerService, IDisposable
     // all of their control RCWs so a single slider/mute drives every stream of the app.
     private readonly Dictionary<string, List<object>> _groups = new(StringComparer.Ordinal);
 
+    // Per-group (session id → owning PID + exe name), captured during enumeration so routing can
+    // build the app's audio-session identifier for IAudioPolicyConfig without re-walking COM.
+    private readonly Dictionary<string, (uint Pid, string ExeName)> _routingKeys = new(StringComparer.Ordinal);
+
     /// <inheritdoc/>
     public IReadOnlyList<AudioSessionInfo> GetSessions()
     {
@@ -67,12 +73,21 @@ public sealed class AudioMixerService : IAudioMixerService, IDisposable
         // safe (and correct) to run it outside _gate. GetSessions is only ever called from the
         // single serialized reconcile loop, so _identityCache needs no extra synchronization.
         var results = new List<AudioSessionInfo>(groups.Count);
+        var routing = new Dictionary<string, (uint, string)>(groups.Count, StringComparer.Ordinal);
         foreach (var g in groups)
         {
             var (name, path) = g.IsSystemSounds
                 ? ("System Sounds", string.Empty)
                 : ResolveIdentityCached(g.GroupKey, g.ProcessId, g.PidKnown);
             results.Add(g.ToInfo(name, path));
+            if (!g.IsSystemSounds)
+                routing[g.GroupKey] = (g.ProcessId, System.IO.Path.GetFileName(path) ?? string.Empty);
+        }
+        // Publish the routing keys atomically under the gate (SetSessionOutputDevice reads them).
+        lock (_gate)
+        {
+            _routingKeys.Clear();
+            foreach (var kv in routing) _routingKeys[kv.Key] = kv.Value;
         }
 
         // Stable order so the reconcile diff is deterministic: system sounds last,
@@ -278,6 +293,156 @@ public sealed class AudioMixerService : IAudioMixerService, IDisposable
         }
     }
 
+    // ── Output-device enumeration (documented API) ─────────────────────────
+
+    /// <inheritdoc/>
+    public IReadOnlyList<Models.AudioDevice> GetRenderDevices()
+    {
+        lock (_gate)
+        {
+            if (_disposed) return [];
+            try
+            {
+                if (!EnsureManager()) return [];
+                var devEnum = (IMMDeviceEnumerator)_enumerator!;
+
+                // Default endpoint id (to flag IsDefault) — best-effort.
+                string defaultId = "";
+                if (devEnum.GetDefaultAudioEndpoint(EDataFlow.Render, ERole.Multimedia, out var def) == 0 && def is not null)
+                {
+                    if (def.GetId(out var dp) == 0 && dp != IntPtr.Zero)
+                    {
+                        defaultId = Marshal.PtrToStringUni(dp) ?? "";
+                        Marshal.FreeCoTaskMem(dp);
+                    }
+                    Release(def);
+                }
+
+                // DEVICE_STATE_ACTIVE (0x1) render endpoints.
+                if (devEnum.EnumAudioEndpoints(EDataFlow.Render, 0x1, out var collPtr) != 0 || collPtr == IntPtr.Zero)
+                    return [];
+                var collection = (IMMDeviceCollection)Marshal.GetObjectForIUnknown(collPtr);
+                try
+                {
+                    if (collection.GetCount(out int count) != 0) return [];
+                    var devices = new List<Models.AudioDevice>(count);
+                    for (int i = 0; i < count; i++)
+                    {
+                        if (collection.Item(i, out var dev) != 0 || dev is null) continue;
+                        try
+                        {
+                            string id = "";
+                            if (dev.GetId(out var idPtr) == 0 && idPtr != IntPtr.Zero)
+                            {
+                                id = Marshal.PtrToStringUni(idPtr) ?? "";
+                                Marshal.FreeCoTaskMem(idPtr);
+                            }
+                            if (id.Length == 0) continue;
+                            var name = ReadFriendlyName(dev) ?? id;
+                            devices.Add(new Models.AudioDevice(id, name, string.Equals(id, defaultId, StringComparison.OrdinalIgnoreCase)));
+                        }
+                        finally { Release(dev); }
+                    }
+                    // Default first, then alphabetical.
+                    devices.Sort(static (a, b) =>
+                    {
+                        if (a.IsDefault != b.IsDefault) return a.IsDefault ? -1 : 1;
+                        return string.Compare(a.FriendlyName, b.FriendlyName, StringComparison.OrdinalIgnoreCase);
+                    });
+                    return devices;
+                }
+                finally { Release(collection); Marshal.Release(collPtr); }
+            }
+            catch (COMException ex)
+            {
+                Log.Debug("Audio device enumeration failed: {Error}", ex.Message);
+                ResetManager();
+                return [];
+            }
+        }
+    }
+
+    /// <summary>Reads a device's friendly name from its property store (PKEY_Device_FriendlyName).</summary>
+    private static string? ReadFriendlyName(IMMDevice device)
+    {
+        // STGM_READ = 0.
+        if (device.OpenPropertyStore(0, out var store) != 0 || store is null) return null;
+        try
+        {
+            var key = PKEY_Device_FriendlyName;
+            if (store.GetValue(ref key, out var pv) != 0) return null;
+            try { return pv.GetString(); }
+            finally { PropVariantClear(ref pv); }
+        }
+        catch (COMException) { return null; }
+        finally { Release(store); }
+    }
+
+    // ── Per-app output routing (UNDOCUMENTED IAudioPolicyConfig — guarded) ──
+
+    private bool _routingProbed;
+    private bool _routingSupported;
+
+    /// <inheritdoc/>
+    public bool IsRoutingSupported
+    {
+        get { lock (_gate) { return ProbeRoutingLocked(); } }
+    }
+
+    /// <summary>
+    /// Lazily binds <c>IAudioPolicyConfig</c> once and caches whether it's available. The interface
+    /// is undocumented and its CLSID/IID/vtable are the community-reverse-engineered values; any
+    /// failure to activate leaves routing unsupported (the UI then uses the guided fallback).
+    /// </summary>
+    private bool ProbeRoutingLocked()
+    {
+        if (_routingProbed) return _routingSupported;
+        _routingProbed = true;
+        _routingSupported = false;
+        try
+        {
+            _policyConfig = AudioPolicyConfigFactory.TryCreate();
+            _routingSupported = _policyConfig is not null;
+        }
+        catch (COMException ex) { Log.Debug("Audio routing probe failed: {Error}", ex.Message); }
+        catch (InvalidCastException ex) { Log.Debug("Audio routing probe cast failed: {Error}", ex.Message); }
+        if (!_routingSupported)
+            Log.Information("Audio routing: IAudioPolicyConfig unavailable on this build — using guided fallback");
+        return _routingSupported;
+    }
+
+    private object? _policyConfig; // IAudioPolicyConfig (undocumented)
+
+    /// <inheritdoc/>
+    public string GetSessionOutputDevice(string sessionId)
+    {
+        lock (_gate)
+        {
+            if (_disposed || !ProbeRoutingLocked() || _policyConfig is null) return string.Empty;
+            if (!_routingKeys.TryGetValue(sessionId, out var key)) return string.Empty;
+            try
+            {
+                return AudioPolicyConfigFactory.GetPersistedDefaultEndpoint(_policyConfig, key.Pid) ?? string.Empty;
+            }
+            catch (COMException ex) { Log.Debug("GetSessionOutputDevice failed: {Error}", ex.Message); return string.Empty; }
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool SetSessionOutputDevice(string sessionId, string deviceId)
+    {
+        lock (_gate)
+        {
+            if (_disposed || !ProbeRoutingLocked() || _policyConfig is null) return false;
+            if (!_routingKeys.TryGetValue(sessionId, out var key)) return false;
+            try
+            {
+                return AudioPolicyConfigFactory.SetPersistedDefaultEndpoint(_policyConfig, key.Pid, deviceId);
+            }
+            catch (COMException ex) { Log.Debug("SetSessionOutputDevice failed: {Error}", ex.Message); return false; }
+        }
+    }
+
     // ── COM lifetime ──────────────────────────────────────────────────────
 
     private bool EnsureManager()
@@ -316,6 +481,9 @@ public sealed class AudioMixerService : IAudioMixerService, IDisposable
         Release(_manager); _manager = null;
         Release(_device); _device = null;
         Release(_enumerator); _enumerator = null;
+        // Routing keys reference the (now-stale) enumeration; drop them. The policy-config RCW is
+        // independent of the endpoint handle, so it survives a manager reset (re-probed lazily).
+        _routingKeys.Clear();
     }
 
     private void ReleaseGroups()
@@ -340,6 +508,7 @@ public sealed class AudioMixerService : IAudioMixerService, IDisposable
             if (_disposed) return;
             _disposed = true;
             ResetManager();
+            Release(_policyConfig); _policyConfig = null;
         }
     }
 
@@ -443,8 +612,58 @@ public sealed class AudioMixerService : IAudioMixerService, IDisposable
     {
         [PreserveSig] int Activate(ref Guid iid, uint dwClsCtx, IntPtr pActivationParams,
             [MarshalAs(UnmanagedType.IUnknown)] out object ppInterface);
-        // OpenPropertyStore / GetId / GetState are unused — not declared.
+        // Slots 2-4, declared to preserve vtable order (device enumeration reads name + id).
+        [PreserveSig] int OpenPropertyStore(uint stgmAccess, out IPropertyStore ppProperties);
+        [PreserveSig] int GetId(out IntPtr ppstrId);
+        [PreserveSig] int GetState(out uint pdwState);
     }
+
+    [ComImport, Guid("0BD7A1BE-7A1A-44DB-8397-CC5392387B5E"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IMMDeviceCollection
+    {
+        [PreserveSig] int GetCount(out int pcDevices);
+        [PreserveSig] int Item(int nDevice, out IMMDevice ppDevice);
+    }
+
+    [ComImport, Guid("886d8eeb-8cf2-4446-8d02-cdba1dbdcf99"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IPropertyStore
+    {
+        [PreserveSig] int GetCount(out uint cProps);
+        [PreserveSig] int GetAt(uint iProp, out PropertyKey pkey);
+        [PreserveSig] int GetValue(ref PropertyKey key, out PropVariant pv);
+        [PreserveSig] int SetValue(ref PropertyKey key, ref PropVariant propvar);
+        [PreserveSig] int Commit();
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PropertyKey
+    {
+        public Guid FmtId;
+        public uint Pid;
+    }
+
+    // PKEY_Device_FriendlyName = {a45c254e-df1c-4efd-8020-67d146a850e0}, 14.
+    private static PropertyKey PKEY_Device_FriendlyName => new()
+    {
+        FmtId = new Guid("a45c254e-df1c-4efd-8020-67d146a850e0"),
+        Pid = 14
+    };
+
+    // Minimal PROPVARIANT: we only ever read a VT_LPWSTR (string) friendly name. The union is
+    // represented by the pointer-sized field at offset 8 (x64); we read it as a wide string.
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PropVariant
+    {
+        public ushort vt;
+        public ushort r1, r2, r3;
+        public IntPtr p; // union: for VT_LPWSTR this is the wide-string pointer
+        public IntPtr p2;
+
+        public readonly string? GetString() => vt == 31 /* VT_LPWSTR */ ? Marshal.PtrToStringUni(p) : null;
+    }
+
+    [DllImport("ole32.dll")]
+    private static extern int PropVariantClear(ref PropVariant pvar);
 
     [ComImport, Guid("77AA99A0-1BD6-484F-8BC7-2C654C9A9B6F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     private interface IAudioSessionManager2

--- a/SysManager/SysManager/Services/AudioPolicyConfig.cs
+++ b/SysManager/SysManager/Services/AudioPolicyConfig.cs
@@ -1,0 +1,169 @@
+// SysManager · AudioPolicyConfig — UNDOCUMENTED per-app audio routing (guarded, feature-detected)
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Globalization;
+using System.Runtime.InteropServices;
+using Serilog;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Thin, defensive wrapper over the <b>undocumented</b> Windows <c>IAudioPolicyConfig</c> interface
+/// — the only mechanism that lets an app set another app's default output endpoint (what EarTrumpet
+/// uses for per-app routing). Because it is undocumented:
+/// <list type="bullet">
+/// <item>The CLSID/IID and method layout are the community-reverse-engineered values (the same ones
+/// the MIT-licensed EarTrumpet ships). Two IIDs are tried — Windows 10 then Windows 11 — over one
+/// method layout that is identical across both in the modern definitions.</item>
+/// <item>Everything is feature-detected and guarded: <see cref="TryCreate"/> returns null if the
+/// interface can't be activated/queried, and <see cref="SetPersistedDefaultEndpoint"/> catches COM
+/// failures and returns false. Callers treat "unavailable/false" as "fall back to guiding the user
+/// to Windows sound settings", so a build where this shape changed degrades gracefully.</item>
+/// </list>
+/// <para>Safety note: the SET call goes through a <c>[ComImport]</c> interface (CLR-marshaled, not a
+/// raw vtable pointer), invoked only after a successful <c>QueryInterface</c> for the exact IID — by
+/// COM's contract the returned object's vtable then matches that interface, which is what makes the
+/// call safe rather than a blind offset. The route-read is intentionally not attempted (returning
+/// "system default") because its out-string marshaling is the most build-variant part.</para>
+/// </summary>
+internal static class AudioPolicyConfigFactory
+{
+    // MMDevAPI CAudioPolicyConfigFactory CLSID (stable across builds).
+    private static readonly Guid CLSID_AudioPolicyConfigFactory = new("870af99c-171d-4f9e-af0d-e63df40c2bc9");
+
+    // Endpoint-string wrappers IAudioPolicyConfig expects around a plain Core Audio endpoint id.
+    private const string MMDeviceApiTokenPrefix = @"\\?\SWD#MMDEVAPI#";
+    private const string RenderInterfaceGuid = "{e6327cad-dcec-4949-ae8a-991e976a79d2}"; // DEVINTERFACE_AUDIO_RENDER
+
+    private enum EDataFlow { Render = 0, Capture = 1, All = 2 }
+    private enum ERole { Console = 0, Multimedia = 1, Communications = 2 }
+
+    /// <summary>
+    /// Attempts to activate <c>IAudioPolicyConfig</c>. Returns the RCW (typed as the interface, boxed
+    /// in <see cref="object"/> so no undocumented type leaks to callers) on success, else null. Never
+    /// throws.
+    /// </summary>
+    public static object? TryCreate()
+    {
+        try
+        {
+            var type = Type.GetTypeFromCLSID(CLSID_AudioPolicyConfigFactory, throwOnError: false);
+            if (type is null) return null;
+            var factory = Activator.CreateInstance(type);
+            if (factory is null) return null;
+
+            // The interface is declared with the Win11 IID; a direct cast QIs for it. If that fails
+            // (older build exposing only the Win10 IID over the same layout), QI manually for the
+            // Win10 IID and reinterpret the pointer as the same managed interface type.
+            if (factory is IAudioPolicyConfig direct) return direct;
+
+            var unk = Marshal.GetIUnknownForObject(factory);
+            try
+            {
+                var win10 = new Guid("2a59116d-6c4f-45e0-a74f-707e3fef9258");
+                if (Marshal.QueryInterface(unk, in win10, out var ppv) == 0 && ppv != IntPtr.Zero)
+                {
+                    try
+                    {
+                        // Same modern method layout as the Win11 IID → safe to project onto it.
+                        return Marshal.GetTypedObjectForIUnknown(ppv, typeof(IAudioPolicyConfig));
+                    }
+                    finally { Marshal.Release(ppv); }
+                }
+            }
+            finally { Marshal.Release(unk); }
+
+            if (Marshal.IsComObject(factory)) { try { Marshal.ReleaseComObject(factory); } catch (ArgumentException) { } }
+            return null;
+        }
+        catch (COMException ex) { Log.Debug("AudioPolicyConfig activate failed: {Error}", ex.Message); return null; }
+        catch (InvalidCastException ex) { Log.Debug("AudioPolicyConfig cast failed: {Error}", ex.Message); return null; }
+        catch (NotSupportedException ex) { Log.Debug("AudioPolicyConfig not supported: {Error}", ex.Message); return null; }
+    }
+
+    /// <summary>
+    /// Route-read is intentionally not attempted (its out-string marshaling is the most build-variant
+    /// slot); the UI shows "System default" and lets the user pick. Returns null. Kept as the seam so
+    /// a future, verified read path can slot in without changing callers.
+    /// </summary>
+    public static string? GetPersistedDefaultEndpoint(object policyConfig, uint processId)
+    {
+        _ = policyConfig;
+        _ = processId;
+        return null;
+    }
+
+    /// <summary>
+    /// Sets the persisted default render endpoint for a process (empty <paramref name="endpointId"/>
+    /// clears the override → follow system default), for both the Multimedia and Console roles (what
+    /// EarTrumpet does so both "media" and "communication" default to the chosen device). Returns true
+    /// only if the COM calls succeeded. Never throws.
+    /// </summary>
+    public static bool SetPersistedDefaultEndpoint(object policyConfig, uint processId, string endpointId)
+    {
+        if (policyConfig is not IAudioPolicyConfig cfg) return false;
+        string deviceString = string.IsNullOrEmpty(endpointId) ? string.Empty : ToPolicyEndpointId(endpointId);
+        try
+        {
+            // Apply to Multimedia AND Console roles for the render flow (Communications is left to the
+            // system so a headset-switch doesn't hijack call audio unexpectedly).
+            int hr1 = cfg.SetPersistedDefaultAudioEndpoint(processId, EDataFlow.Render, ERole.Multimedia, deviceString);
+            int hr2 = cfg.SetPersistedDefaultAudioEndpoint(processId, EDataFlow.Render, ERole.Console, deviceString);
+            return hr1 >= 0 && hr2 >= 0;
+        }
+        catch (COMException ex) { Log.Debug("SetPersistedDefaultAudioEndpoint failed: {Error}", ex.Message); return false; }
+        catch (ArgumentException ex) { Log.Debug("SetPersistedDefaultAudioEndpoint arg failed: {Error}", ex.Message); return false; }
+    }
+
+    /// <summary>
+    /// Wraps a plain Core Audio endpoint id in the <c>\\?\SWD#MMDEVAPI#…#{render-iface-guid}</c> form
+    /// <c>IAudioPolicyConfig</c> persists. Pass-through if it already carries the SWD prefix. Pure and
+    /// unit-tested (the format is easy to get subtly wrong, so it is pinned by a test).
+    /// </summary>
+    internal static string ToPolicyEndpointId(string endpointId)
+    {
+        if (string.IsNullOrEmpty(endpointId)) return string.Empty;
+        if (endpointId.StartsWith(MMDeviceApiTokenPrefix, StringComparison.OrdinalIgnoreCase)) return endpointId;
+        return $"{MMDeviceApiTokenPrefix}{endpointId}#{RenderInterfaceGuid}";
+    }
+
+    // Retained for tests/diagnostics: the process token IAudioPolicyConfig keys on is the raw PID.
+    internal static string BuildProcessToken(uint processId) => processId.ToString(CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// The undocumented <c>IAudioPolicyConfig</c> (Windows 11 IID; the Windows 10 IID shares this
+    /// modern method layout). Only the two methods SysManager needs carry real signatures; the 19
+    /// preceding vtable slots are declared as no-arg <c>[PreserveSig]</c> HRESULT placeholders purely
+    /// to preserve vtable order — they are never called. Layout mirrors EarTrumpet's definition.
+    /// </summary>
+    [ComImport, Guid("ab3d4648-e242-459f-b02f-541c70306324"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IAudioPolicyConfig
+    {
+        [PreserveSig] int Slot00_add_CtxVolumeChange();
+        [PreserveSig] int Slot01_remove_CtxVolumeChanged();
+        [PreserveSig] int Slot02_add_RingerVibrateStateChanged();
+        [PreserveSig] int Slot03_remove_RingerVibrateStateChanged();
+        [PreserveSig] int Slot04_SetVolumeGroupGainForId();
+        [PreserveSig] int Slot05_GetVolumeGroupGainForId();
+        [PreserveSig] int Slot06_GetActiveVolumeGroupForEndpointId();
+        [PreserveSig] int Slot07_GetVolumeGroupsForEndpoint();
+        [PreserveSig] int Slot08_GetCurrentVolumeContext();
+        [PreserveSig] int Slot09_SetVolumeGroupMuteForId();
+        [PreserveSig] int Slot10_GetVolumeGroupMuteForId();
+        [PreserveSig] int Slot11_SetRingerVibrateState();
+        [PreserveSig] int Slot12_GetRingerVibrateState();
+        [PreserveSig] int Slot13_SetPreferredChatApplication();
+        [PreserveSig] int Slot14_ResetPreferredChatApplication();
+        [PreserveSig] int Slot15_GetPreferredChatApplication();
+        [PreserveSig] int Slot16_GetCurrentChatApplications();
+        [PreserveSig] int Slot17_add_ChatContextChanged();
+        [PreserveSig] int Slot18_remove_ChatContextChanged();
+
+        // Slot 19: the one we call. deviceId is a plain LPWStr (the EarTrumpet-observed marshaling on
+        // Win10 1803+ and Win11); an empty string clears the per-app override.
+        [PreserveSig] int SetPersistedDefaultAudioEndpoint(
+            uint processId, EDataFlow flow, ERole role,
+            [MarshalAs(UnmanagedType.LPWStr)] string deviceId);
+    }
+}

--- a/SysManager/SysManager/Services/IAudioMixerService.cs
+++ b/SysManager/SysManager/Services/IAudioMixerService.cs
@@ -41,4 +41,33 @@ public interface IAudioMixerService
     /// if the session is gone or the value can't be read. Cheap enough to poll.
     /// </summary>
     float GetPeak(string sessionId);
+
+    /// <summary>
+    /// Enumerate the active render (output) devices via the documented Core Audio device API.
+    /// Never throws — returns an empty list on a transient device fault. The one flagged
+    /// <see cref="Models.AudioDevice.IsDefault"/> is the current system default.
+    /// </summary>
+    IReadOnlyList<Models.AudioDevice> GetRenderDevices();
+
+    /// <summary>
+    /// True when true in-app per-app output-device routing is available on this Windows build —
+    /// i.e. the (undocumented) <c>IAudioPolicyConfig</c> interface bound successfully. When false,
+    /// the UI must fall back to guiding the user to Windows' per-app sound settings, and
+    /// <see cref="SetSessionOutputDevice"/> will no-op.
+    /// </summary>
+    bool IsRoutingSupported { get; }
+
+    /// <summary>
+    /// Reads the endpoint id this session is currently routed to, or an empty string for
+    /// "follow the system default" (or when routing can't be read). Best-effort.
+    /// </summary>
+    string GetSessionOutputDevice(string sessionId);
+
+    /// <summary>
+    /// Routes a session's app to a specific output device (empty <paramref name="deviceId"/> =
+    /// follow the system default). Returns true only when the change was applied via
+    /// <c>IAudioPolicyConfig</c>; returns false (a no-op) when routing isn't supported, so the
+    /// caller can fall back to the guided path. Never throws.
+    /// </summary>
+    bool SetSessionOutputDevice(string sessionId, string deviceId);
 }

--- a/SysManager/SysManager/Services/TrayIconService.cs
+++ b/SysManager/SysManager/Services/TrayIconService.cs
@@ -130,6 +130,17 @@ public sealed class TrayIconService : IDisposable
         showItem.Click += (_, _) => ShowWindow(mainWindow);
         menu.Items.Add(showItem);
 
+        // Quick access to the per-app Volume Control tab (issue #337… #332 tray-integration ask):
+        // show the window and jump straight to the mixer.
+        var volumeItem = new System.Windows.Controls.MenuItem { Header = "Volume mixer" };
+        volumeItem.Click += (_, _) =>
+        {
+            ShowWindow(mainWindow);
+            if (mainWindow.DataContext is ViewModels.MainWindowViewModel vm)
+                vm.NavigateTo("nav-volume-control");
+        };
+        menu.Items.Add(volumeItem);
+
         menu.Items.Add(new System.Windows.Controls.Separator());
 
         var exitItem = new System.Windows.Controls.MenuItem { Header = "Exit" };

--- a/SysManager/SysManager/Services/TrayIconService.cs
+++ b/SysManager/SysManager/Services/TrayIconService.cs
@@ -52,8 +52,12 @@ public sealed class TrayIconService : IDisposable
 
     /// <summary>
     /// Initializes the tray icon. Must be called from the UI thread.
+    /// <para><paramref name="navigateToTab"/> is an optional callback the caller (the View layer,
+    /// which legitimately knows the shell view-model) supplies to jump to a tab by nav id — used by
+    /// the "Volume mixer" menu shortcut. Keeping it a callback rather than referencing the shell VM
+    /// here preserves the Services→(not ViewModels) layering the architecture tests enforce.</para>
     /// </summary>
-    public void Initialize(Window mainWindow)
+    public void Initialize(Window mainWindow, Action<string>? navigateToTab = null)
     {
         // Track only an icon we own so Dispose can free its GDI handle. The shared
         // SystemIcons.Application fallback is process-wide and must not be disposed.
@@ -63,7 +67,7 @@ public sealed class TrayIconService : IDisposable
         {
             ToolTipText = "SysManager",
             Icon = icon,
-            ContextMenu = BuildContextMenu(mainWindow),
+            ContextMenu = BuildContextMenu(mainWindow, navigateToTab),
             Visibility = System.Windows.Visibility.Visible
         };
         _trayIcon.ForceCreate();
@@ -122,7 +126,7 @@ public sealed class TrayIconService : IDisposable
         }
     }
 
-    private static System.Windows.Controls.ContextMenu BuildContextMenu(Window mainWindow)
+    private static System.Windows.Controls.ContextMenu BuildContextMenu(Window mainWindow, Action<string>? navigateToTab)
     {
         var menu = new System.Windows.Controls.ContextMenu();
 
@@ -130,16 +134,19 @@ public sealed class TrayIconService : IDisposable
         showItem.Click += (_, _) => ShowWindow(mainWindow);
         menu.Items.Add(showItem);
 
-        // Quick access to the per-app Volume Control tab (issue #337… #332 tray-integration ask):
-        // show the window and jump straight to the mixer.
-        var volumeItem = new System.Windows.Controls.MenuItem { Header = "Volume mixer" };
-        volumeItem.Click += (_, _) =>
+        // Quick access to the per-app Volume Control tab (#332 tray-integration ask): show the
+        // window and, via the caller-supplied navigation callback, jump straight to the mixer.
+        // Only added when a navigation callback was provided (keeps this VM-agnostic).
+        if (navigateToTab is not null)
         {
-            ShowWindow(mainWindow);
-            if (mainWindow.DataContext is ViewModels.MainWindowViewModel vm)
-                vm.NavigateTo("nav-volume-control");
-        };
-        menu.Items.Add(volumeItem);
+            var volumeItem = new System.Windows.Controls.MenuItem { Header = "Volume mixer" };
+            volumeItem.Click += (_, _) =>
+            {
+                ShowWindow(mainWindow);
+                navigateToTab("nav-volume-control");
+            };
+            menu.Items.Add(volumeItem);
+        }
 
         menu.Items.Add(new System.Windows.Controls.Separator());
 

--- a/SysManager/SysManager/Services/VolumePresetService.cs
+++ b/SysManager/SysManager/Services/VolumePresetService.cs
@@ -1,0 +1,136 @@
+// SysManager · VolumePresetService — save/load per-app volume presets as JSON
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Persists named per-application volume presets to a single JSON file under
+/// <c>%LocalAppData%\SysManager\volume-presets.json</c>. A preset captures each app's volume + mute
+/// keyed by executable name (stable across restarts, unlike PID/session id), so re-applying a
+/// "Gaming" or "Focus" preset works on whatever instance of the app is running. Save/load/delete +
+/// the merge that maps a preset onto the live sessions are pure and unit-tested; the file IO is
+/// isolated and never throws to the caller (returns defaults on error). Strictly local — the file
+/// stays on the machine.
+/// </summary>
+public sealed class VolumePresetService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
+    private readonly string _path;
+
+    /// <summary>Creates the service. <paramref name="configDir"/> is overridable for tests.</summary>
+    public VolumePresetService(string? configDir = null)
+    {
+        var dir = configDir ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager");
+        _path = Path.Combine(dir, "volume-presets.json");
+    }
+
+    /// <summary>Loads all saved presets, newest-named-last (insertion order preserved). Never throws.</summary>
+    public IReadOnlyList<VolumePreset> Load()
+    {
+        try
+        {
+            if (!File.Exists(_path)) return [];
+            return Parse(File.ReadAllText(_path));
+        }
+        catch (IOException ex) { Log.Debug("Volume presets load failed: {Error}", ex.Message); return []; }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Volume presets load denied: {Error}", ex.Message); return []; }
+    }
+
+    /// <summary>
+    /// Saves (adds or replaces by name, case-insensitive) a preset and persists the full set.
+    /// Returns the updated list. A blank name is rejected (returns the unchanged current set).
+    /// </summary>
+    public IReadOnlyList<VolumePreset> Save(VolumePreset preset)
+    {
+        if (string.IsNullOrWhiteSpace(preset.Name)) return Load();
+        var merged = Upsert(Load(), preset);
+        Persist(merged);
+        return merged;
+    }
+
+    /// <summary>Deletes the named preset (case-insensitive) and persists. Returns the updated list.</summary>
+    public IReadOnlyList<VolumePreset> Delete(string name)
+    {
+        var remaining = Load().Where(p => !string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase)).ToList();
+        Persist(remaining);
+        return remaining;
+    }
+
+    private void Persist(IReadOnlyList<VolumePreset> presets)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+            File.WriteAllText(_path, Serialize(presets));
+        }
+        catch (IOException ex) { Log.Debug("Volume presets save failed: {Error}", ex.Message); }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Volume presets save denied: {Error}", ex.Message); }
+    }
+
+    // ── Pure helpers (unit-testable, no file IO) ───────────────────────────
+
+    /// <summary>Serializes the preset list to indented JSON.</summary>
+    public static string Serialize(IReadOnlyList<VolumePreset> presets) => JsonSerializer.Serialize(presets, JsonOptions);
+
+    /// <summary>Parses the preset list from JSON; returns empty for null/blank/malformed input.</summary>
+    public static IReadOnlyList<VolumePreset> Parse(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return [];
+        try { return JsonSerializer.Deserialize<List<VolumePreset>>(json, JsonOptions) ?? []; }
+        catch (JsonException) { return []; }
+    }
+
+    /// <summary>
+    /// Adds <paramref name="preset"/> to <paramref name="existing"/>, replacing any preset with the
+    /// same name (case-insensitive) in place, else appending. Pure so the replace-vs-append rule is
+    /// unit-tested. Returns a new list; the input is not mutated.
+    /// </summary>
+    public static IReadOnlyList<VolumePreset> Upsert(IReadOnlyList<VolumePreset> existing, VolumePreset preset)
+    {
+        var result = existing.ToList();
+        int i = result.FindIndex(p => string.Equals(p.Name, preset.Name, StringComparison.OrdinalIgnoreCase));
+        if (i >= 0) result[i] = preset;
+        else result.Add(preset);
+        return result;
+    }
+
+    /// <summary>
+    /// Builds the concrete volume/mute writes to apply a preset to the live sessions: for each live
+    /// session whose executable name matches a preset entry (case-insensitive), returns its session
+    /// id with the preset's target volume + mute. Sessions with no matching entry are left untouched
+    /// (not returned). Pure — the caller performs the actual <c>SetVolume</c>/<c>SetMute</c> writes.
+    /// </summary>
+    public static IReadOnlyList<(string SessionId, float Volume, bool IsMuted)> BuildApplyPlan(
+        VolumePreset preset, IReadOnlyList<AudioSessionInfo> liveSessions)
+    {
+        var byExe = new Dictionary<string, VolumePresetEntry>(StringComparer.OrdinalIgnoreCase);
+        foreach (var e in preset.Entries)
+            if (!string.IsNullOrEmpty(e.ExecutableName)) byExe[e.ExecutableName] = e;
+
+        var plan = new List<(string, float, bool)>();
+        foreach (var s in liveSessions)
+        {
+            var exe = ExeName(s.ExePath);
+            if (exe.Length > 0 && byExe.TryGetValue(exe, out var entry))
+                plan.Add((s.SessionId, Math.Clamp(entry.Volume, 0f, 1f), entry.IsMuted));
+        }
+        return plan;
+    }
+
+    /// <summary>Extracts the bare executable file name from a full path (empty if none). Case preserved.</summary>
+    public static string ExeName(string? exePath)
+        => string.IsNullOrWhiteSpace(exePath) ? string.Empty : Path.GetFileName(exePath);
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.54.0</Version>
-    <FileVersion>1.54.0.0</FileVersion>
-    <AssemblyVersion>1.54.0.0</AssemblyVersion>
+    <Version>1.55.0</Version>
+    <FileVersion>1.55.0.0</FileVersion>
+    <AssemblyVersion>1.55.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AudioMixerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AudioMixerViewModel.cs
@@ -29,17 +29,34 @@ public sealed partial class AudioMixerViewModel : ViewModelBase
     private const double PeakIntervalMs = 50;
 
     private readonly IAudioMixerService _service;
+    private readonly VolumePresetService _presets;
     private readonly DispatcherTimer _peakTimer;
     private CancellationTokenSource? _reconcileCts;
 
     public BulkObservableCollection<AudioSessionRowViewModel> Sessions { get; } = new();
 
+    /// <summary>Output devices offered in each row's routing picker (refreshed with the session list).</summary>
+    public BulkObservableCollection<AudioDevice> OutputDevices { get; } = new();
+
+    /// <summary>Saved volume presets the user can apply or delete.</summary>
+    public BulkObservableCollection<VolumePreset> Presets { get; } = new();
+
     [ObservableProperty] private bool _isActive;
     [ObservableProperty] private bool _hasSessions;
 
-    public AudioMixerViewModel(IAudioMixerService service)
+    /// <summary>True when true in-app per-app routing is available; false shows the guided fallback.</summary>
+    [ObservableProperty] private bool _routingSupported;
+
+    /// <summary>The preset the user has selected to apply/delete.</summary>
+    [ObservableProperty] private VolumePreset? _selectedPreset;
+
+    /// <summary>Name typed in the "save preset" box.</summary>
+    [ObservableProperty] private string _newPresetName = "";
+
+    public AudioMixerViewModel(IAudioMixerService service, VolumePresetService presets)
     {
         _service = service;
+        _presets = presets;
         _peakTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(PeakIntervalMs) };
         _peakTimer.Tick += (_, _) => UpdatePeaks();
         StatusMessage = "Reading audio sessions…";
@@ -55,6 +72,9 @@ public sealed partial class AudioMixerViewModel : ViewModelBase
         _reconcileCts = new CancellationTokenSource();
         var ct = _reconcileCts.Token;
 
+        RoutingSupported = _service.IsRoutingSupported;
+        Presets.ReplaceWith(_presets.Load());
+        await RefreshDevicesAsync();
         await ReconcileAsync();
 
         if (_reconcileCts is null || ct.IsCancellationRequested) return; // disposed during init
@@ -112,7 +132,12 @@ public sealed partial class AudioMixerViewModel : ViewModelBase
             if (existing.TryGetValue(info.SessionId, out var row))
                 row.ApplyUpdate(info);
             else
-                Sessions.Add(new AudioSessionRowViewModel(_service, info));
+            {
+                var newRow = new AudioSessionRowViewModel(_service, info, OutputDevices.ToList(), RoutingSupported);
+                if (RoutingSupported && !info.IsSystemSounds)
+                    newRow.SetOutputDeviceFromService(_service.GetSessionOutputDevice(info.SessionId));
+                Sessions.Add(newRow);
+            }
         }
 
         for (int i = Sessions.Count - 1; i >= 0; i--)
@@ -146,6 +171,80 @@ public sealed partial class AudioMixerViewModel : ViewModelBase
         foreach (var row in Sessions)
             row.PeakLevel = _service.GetPeak(row.SessionId);
     }
+
+    /// <summary>Re-enumerate output devices (off the UI thread) into the shared picker list.</summary>
+    private async Task RefreshDevicesAsync()
+    {
+        // Defensive: a substituted/edge-case service could return null; treat it as "no devices"
+        // rather than letting ReplaceWith's null-guard throw into the fire-and-forget init.
+        var devices = await Task.Run(_service.GetRenderDevices).ConfigureAwait(true);
+        OutputDevices.ReplaceWith(devices ?? []);
+    }
+
+    /// <summary>
+    /// Save the current per-app volume/mute as a named preset (keyed by exe name so it re-applies
+    /// across restarts). Overwrites a same-named preset. No-ops on a blank name.
+    /// </summary>
+    [RelayCommand]
+    private void SavePreset()
+    {
+        var name = NewPresetName.Trim();
+        if (name.Length == 0) { StatusMessage = "Enter a name for the preset first."; return; }
+
+        var entries = Sessions
+            .Where(s => !s.IsSystemSounds)
+            .Select(s => new VolumePresetEntry(
+                ExeNameOf(s), s.DisplayName, s.Volume, s.IsMuted))
+            .Where(e => e.ExecutableName.Length > 0)
+            .ToList();
+
+        if (entries.Count == 0) { StatusMessage = "No apps to save into a preset right now."; return; }
+
+        Presets.ReplaceWith(_presets.Save(new VolumePreset(name, entries)));
+        NewPresetName = "";
+        StatusMessage = $"Saved preset \"{name}\" with {entries.Count} app{(entries.Count == 1 ? "" : "s")}.";
+        ActivityLogService.Instance.Log("Volume", $"Saved preset '{name}'");
+    }
+
+    /// <summary>Apply the selected preset's volumes/mutes to the matching live sessions.</summary>
+    [RelayCommand]
+    private void ApplyPreset()
+    {
+        if (SelectedPreset is null) { StatusMessage = "Pick a preset to apply."; return; }
+
+        var live = Sessions.Select(s => new AudioSessionInfo(
+            s.SessionId, s.ProcessId, s.DisplayName, ExePathOf(s), s.Volume, s.IsMuted,
+            s.IsActive ? AudioSessionState.Active : AudioSessionState.Inactive, s.IsSystemSounds, 0f)).ToList();
+
+        var plan = VolumePresetService.BuildApplyPlan(SelectedPreset, live);
+        int applied = 0;
+        foreach (var (sessionId, volume, muted) in plan)
+        {
+            var row = Sessions.FirstOrDefault(s => s.SessionId == sessionId);
+            if (row is null) continue;
+            row.Volume = volume;   // propagates to the service via the row's changed-handler
+            row.IsMuted = muted;
+            applied++;
+        }
+        StatusMessage = applied > 0
+            ? $"Applied \"{SelectedPreset.Name}\" to {applied} app{(applied == 1 ? "" : "s")}."
+            : $"No running apps matched \"{SelectedPreset.Name}\".";
+    }
+
+    /// <summary>Delete the selected preset.</summary>
+    [RelayCommand]
+    private void DeletePreset()
+    {
+        if (SelectedPreset is null) return;
+        var name = SelectedPreset.Name;
+        Presets.ReplaceWith(_presets.Delete(name));
+        SelectedPreset = null;
+        StatusMessage = $"Deleted preset \"{name}\".";
+    }
+
+    // The row doesn't expose the exe path directly; derive both from its icon-source path proxy.
+    private static string ExeNameOf(AudioSessionRowViewModel row) => VolumePresetService.ExeName(ExePathOf(row));
+    private static string ExePathOf(AudioSessionRowViewModel row) => row.ExePath;
 
     partial void OnIsActiveChanged(bool value)
     {

--- a/SysManager/SysManager/ViewModels/AudioSessionRowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AudioSessionRowViewModel.cs
@@ -2,9 +2,11 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Diagnostics;
 using System.Windows.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Serilog;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -37,6 +39,9 @@ public sealed partial class AudioSessionRowViewModel : ObservableObject
 
     public bool IsSystemSounds { get; }
 
+    /// <summary>The owning app's executable path (as last resolved), used for preset keying by exe name.</summary>
+    public string ExePath => _iconSourcePath;
+
     [ObservableProperty] private uint _processId;
     [ObservableProperty] private string _displayName;
     [ObservableProperty] private ImageSource? _icon;
@@ -50,6 +55,31 @@ public sealed partial class AudioSessionRowViewModel : ObservableObject
     [ObservableProperty] private float _peakLevel;
 
     /// <summary>
+    /// The output device this app is routed to. Bound to the per-row device picker when in-app
+    /// routing is supported. Set from the service on refresh under the propagation guard; a
+    /// user-initiated change writes through <see cref="OnSelectedOutputDeviceChanged"/>.
+    /// </summary>
+    [ObservableProperty] private AudioDevice? _selectedOutputDevice;
+
+    /// <summary>
+    /// True when true in-app routing is available for THIS row (the device picker is shown). False
+    /// for the system-sounds pseudo-session (never routable) and when the OS lacks the routing
+    /// interface. Set by the parent VM.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowGuidedRouting))]
+    private bool _routingSupported;
+
+    /// <summary>
+    /// True when the guided "open Windows sound settings" button should show instead of the picker:
+    /// a real (non-system) app on a build without in-app routing. System sounds show neither.
+    /// </summary>
+    public bool ShowGuidedRouting => !RoutingSupported && !IsSystemSounds;
+
+    /// <summary>The output devices offered in the per-row picker (shared list from the parent VM).</summary>
+    public IReadOnlyList<AudioDevice> OutputDevices { get; }
+
+    /// <summary>
     /// True while the user is actively dragging the volume slider. A background refresh must NOT
     /// overwrite <see cref="Volume"/> during a drag, or a stale snapshot value would fight the
     /// thumb. Set by the view on Thumb.DragStarted/DragCompleted.
@@ -59,7 +89,8 @@ public sealed partial class AudioSessionRowViewModel : ObservableObject
     /// <summary>Volume as a friendly percentage, e.g. "65%".</summary>
     public string VolumeDisplay => $"{Volume * 100:F0}%";
 
-    public AudioSessionRowViewModel(IAudioMixerService service, AudioSessionInfo info)
+    public AudioSessionRowViewModel(IAudioMixerService service, AudioSessionInfo info,
+        IReadOnlyList<AudioDevice>? outputDevices = null, bool routingSupported = false)
     {
         _service = service;
         SessionId = info.SessionId;
@@ -73,6 +104,10 @@ public sealed partial class AudioSessionRowViewModel : ObservableObject
         IsActive = info.State == AudioSessionState.Active;
         _iconSourcePath = info.ExePath;
         Icon = ResolveIcon(info);
+
+        OutputDevices = outputDevices ?? [];
+        // System-sounds can't be rerouted; only real apps get the picker.
+        _routingSupported = routingSupported && !info.IsSystemSounds;
     }
 
     private static ImageSource? ResolveIcon(AudioSessionInfo info) =>
@@ -127,4 +162,47 @@ public sealed partial class AudioSessionRowViewModel : ObservableObject
     /// <summary>Flip the mute state; the change propagates via <see cref="OnIsMutedChanged"/>.</summary>
     [RelayCommand]
     private void ToggleMute() => IsMuted = !IsMuted;
+
+    /// <summary>
+    /// User picked an output device for this app → route it via the service. Skipped when the
+    /// change came from a refresh (guard) or when in-app routing isn't supported. A failed write
+    /// (the service returned false) is left to the parent VM's status; the picker keeps the choice.
+    /// </summary>
+    partial void OnSelectedOutputDeviceChanged(AudioDevice? value)
+    {
+        if (_suppressPropagation || !RoutingSupported || value is null) return;
+        _service.SetSessionOutputDevice(SessionId, value.IsDefault ? string.Empty : value.Id);
+    }
+
+    /// <summary>
+    /// Guided fallback (shown when in-app routing isn't supported): open Windows' per-app volume &amp;
+    /// device settings so the user can route this app there. SysManager never reroutes in this mode.
+    /// </summary>
+    [RelayCommand]
+    private void OpenSoundSettings()
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo("ms-settings:apps-volume") { UseShellExecute = true })?.Dispose();
+        }
+        catch (System.ComponentModel.Win32Exception ex) { Log.Debug("Open apps-volume settings failed: {Error}", ex.Message); }
+        catch (InvalidOperationException ex) { Log.Debug("Open apps-volume settings failed: {Error}", ex.Message); }
+    }
+
+    /// <summary>
+    /// Sets the current output-device selection from the service snapshot without writing back
+    /// (used on refresh). Matches by endpoint id; a null/empty id selects the default device.
+    /// </summary>
+    public void SetOutputDeviceFromService(string endpointId)
+    {
+        _suppressPropagation = true;
+        try
+        {
+            SelectedOutputDevice = string.IsNullOrEmpty(endpointId)
+                ? OutputDevices.FirstOrDefault(d => d.IsDefault)
+                : OutputDevices.FirstOrDefault(d => string.Equals(d.Id, endpointId, StringComparison.OrdinalIgnoreCase))
+                  ?? OutputDevices.FirstOrDefault(d => d.IsDefault);
+        }
+        finally { _suppressPropagation = false; }
+    }
 }

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -287,6 +287,12 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         if (item is not null) SelectedNav = item;
     }
 
+    /// <summary>
+    /// Public navigation seam for out-of-tree callers (e.g. the system-tray "Volume mixer"
+    /// shortcut). Selects the tab by its nav id; unknown ids are ignored.
+    /// </summary>
+    public void NavigateTo(string navId) => SelectNavById(navId);
+
     [RelayCommand]
     private void OpenAboutTab() => SelectNavById("nav-about");
 
@@ -404,7 +410,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             [typeof(CliInterfaceViewModel)] = new CliInterfaceViewModel(),
             [typeof(ScheduledMaintenanceViewModel)] = new ScheduledMaintenanceViewModel(new MaintenanceSchedulerService(new PowerShellRunner())),
             [typeof(TweaksHubViewModel)] = new TweaksHubViewModel(new TweaksHubService(new PrivacyService(), restorePoints)),
-            [typeof(AudioMixerViewModel)] = new AudioMixerViewModel(new AudioMixerService()),
+            [typeof(AudioMixerViewModel)] = new AudioMixerViewModel(new AudioMixerService(), new VolumePresetService()),
             [typeof(GamingProfileViewModel)] = new GamingProfileViewModel(
                 new GamingProfileService(
                     new PerformanceService(runner, restorePoints),

--- a/SysManager/SysManager/Views/AudioMixerView.xaml
+++ b/SysManager/SysManager/Views/AudioMixerView.xaml
@@ -12,6 +12,7 @@
     <Grid Background="{DynamicResource Surface0}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -19,13 +20,37 @@
         <!-- Header -->
         <StackPanel Grid.Row="0" Margin="28,24,28,0">
             <TextBlock Text="Volume Control" Style="{StaticResource Display}"/>
-            <TextBlock Text="Set the volume and mute for each app playing sound, with a live level meter. Shows apps on your default playback device — per-app output routing and saved presets are coming in a later update."
+            <TextBlock Text="Set the volume and mute for each app playing sound, with a live level meter. Route an app to a specific output device (headset, speakers), and save volume presets you can re-apply in one click."
                        Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"
                        MaxWidth="820" HorizontalAlignment="Left"/>
         </StackPanel>
 
+        <!-- Presets toolbar -->
+        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="28,16,28,0" Padding="12">
+            <WrapPanel>
+                <TextBlock Text="Presets" Style="{StaticResource Subtle}" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <ComboBox ItemsSource="{Binding Presets}" SelectedItem="{Binding SelectedPreset, Mode=TwoWay}"
+                          DisplayMemberPath="Name" Width="180" Margin="0,0,8,0" VerticalContentAlignment="Center"
+                          AutomationProperties.Name="Saved volume presets"/>
+                <Button Content="Apply" Command="{Binding ApplyPresetCommand}"
+                        Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"
+                        AutomationProperties.Name="Apply selected preset"/>
+                <Button Content="Delete" Command="{Binding DeletePresetCommand}"
+                        Style="{StaticResource GhostButton}" Margin="0,0,16,0"
+                        AutomationProperties.Name="Delete selected preset"/>
+
+                <TextBox Text="{Binding NewPresetName, UpdateSourceTrigger=PropertyChanged}"
+                         Width="160" Margin="0,0,8,0" VerticalContentAlignment="Center"
+                         AutomationProperties.Name="New preset name"
+                         ToolTip="Name the current per-app volumes as a preset."/>
+                <Button Content="Save current as preset" Command="{Binding SavePresetCommand}"
+                        Style="{StaticResource PrimaryButton}" Padding="12,6"
+                        AutomationProperties.Name="Save current volumes as a preset"/>
+            </WrapPanel>
+        </Border>
+
         <!-- App mixer list -->
-        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="28,16,28,0" Padding="0">
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,0" Padding="0">
             <Grid>
                 <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="8"
                               Visibility="{Binding HasSessions, Converter={StaticResource FlexVis}}">
@@ -80,6 +105,34 @@
                                                          Foreground="{DynamicResource Accent}"
                                                          Background="Transparent" BorderThickness="0"
                                                          IsHitTestVisible="False"/>
+
+                                            <!-- Output routing: real per-app device picker when supported, else a
+                                                 guided "open Windows sound settings" link. Hidden entirely for the
+                                                 System Sounds pseudo-session (RoutingSupported is false for it). -->
+                                            <StackPanel Orientation="Horizontal" Margin="0,8,0,0"
+                                                        Visibility="{Binding RoutingSupported, Converter={StaticResource FlexVis}}">
+                                                <TextBlock Text="&#xE7F5;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                                                           FontSize="12" VerticalAlignment="Center" Margin="0,0,6,0"
+                                                           Foreground="{DynamicResource TextMuted}"/>
+                                                <TextBlock Text="Output:" Style="{StaticResource Caption}"
+                                                           VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                                <ComboBox ItemsSource="{Binding OutputDevices}"
+                                                          SelectedItem="{Binding SelectedOutputDevice, Mode=TwoWay}"
+                                                          DisplayMemberPath="FriendlyName" MinWidth="160" FontSize="12"
+                                                          VerticalContentAlignment="Center"
+                                                          AutomationProperties.Name="{Binding DisplayName, StringFormat='Output device for {0}'}"/>
+                                            </StackPanel>
+                                            <Button Margin="0,8,0,0" HorizontalAlignment="Left"
+                                                    Style="{StaticResource GhostButton}" Padding="8,4"
+                                                    Command="{Binding OpenSoundSettingsCommand}"
+                                                    Visibility="{Binding ShowGuidedRouting, Converter={StaticResource FlexVis}}"
+                                                    AutomationProperties.Name="{Binding DisplayName, StringFormat='Choose output device for {0} in Windows settings'}">
+                                                <StackPanel Orientation="Horizontal">
+                                                    <TextBlock Text="&#xE7F5;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                                                               FontSize="12" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                                    <TextBlock Text="Choose output device…" FontSize="12" VerticalAlignment="Center"/>
+                                                </StackPanel>
+                                            </Button>
                                         </StackPanel>
 
                                         <!-- Mute button. A plain Button (not a ToggleButton): the two-state
@@ -123,7 +176,7 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="2" Margin="28,12,28,24">
+        <DockPanel Grid.Row="3" Margin="28,12,28,24">
             <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>


### PR DESCRIPTION
## What & why
Completes the per-app Volume Control mixer with the three capabilities that were previously noted as "planned": **per-app output-device routing**, **saved volume presets**, and a **tray shortcut**. The routing sub-feature has no documented Windows API, so it's built as a **hybrid** (agreed approach): real in-app routing where the OS exposes the interface, a guided fallback everywhere else.

## Behavior
- **Per-app output routing** — send one app to the headset, another to the speakers. Each app row shows an **output-device picker** when the routing interface is available; on builds where it isn't, the row shows a **"Choose output device…"** button that opens Windows' per-app sound settings — so there's always a path. Applied for the Multimedia + Console roles (Communications left to the system so a switch doesn't hijack call audio). System-sounds shows neither control.
- **Volume presets** — save the current per-app volumes/mutes as a named preset ("Gaming", "Focus", …) and re-apply in one click. **Keyed by executable name** so a preset re-applies to whatever instance is running across restarts. Stored locally in `%LocalAppData%\SysManager\volume-presets.json`.
- **Tray shortcut** — a "Volume mixer" item in the system-tray menu opens the app straight to the Volume Control tab.

## Architecture & safety (Gate-ARCH)
- Output-device **enumeration** uses the **documented** Core Audio device API (`IMMDeviceEnumerator.EnumAudioEndpoints` + property store for the friendly name).
- Per-app **routing** uses the **undocumented** `IAudioPolicyConfig` (the mechanism EarTrumpet uses), isolated in `AudioPolicyConfigFactory` and **fully guarded**:
  - Feature-detected: `TryCreate` QIs for the Win11 IID (then the Win10 IID over the same modern layout) and returns null if neither binds → `IsRoutingSupported` is false → UI uses the guided fallback.
  - The SET call goes through a `[ComImport]` interface (CLR-marshaled), invoked **only after** a successful `QueryInterface` for the exact IID (so the vtable is guaranteed to match, not a blind offset), and any COM failure is caught → returns false → guided fallback. It never crashes the tab.
- `VolumePresetService` holds pure, unit-tested save/parse/**upsert**/apply-plan logic; file IO never throws to the caller.
- New models (`AudioDevice`, `VolumePreset`) carry no COM types. `IAudioMixerService` gains `GetRenderDevices` / `IsRoutingSupported` / `Get`+`SetSessionOutputDevice`. Row VM adds a routing picker + guided command with a re-entrancy guard so a refresh-sourced device selection isn't echoed back.

## ⚠️ Runtime-verification caveat (please note)
`IAudioPolicyConfig` is undocumented — there's no assembly to compile-check against, and its `deviceId` marshaling (LPWStr) is the one genuinely build-variant detail. It **builds** and is **guarded to fail safe**, but the routing **SET path can only be truly verified by launching the app on a real desktop** — which per project rules happens on the **laptop workstation**, not the build box. Everything else (enumeration, presets, tray, guided fallback, the whole no-routing path) is fully CI-verifiable. Recommend a laptop smoke of "route an app to another device" before trusting that specific path in the field.

## Files
- **New:** `Models/AudioDevice.cs`, `Models/VolumePreset.cs`, `Services/VolumePresetService.cs`, `Services/AudioPolicyConfig.cs`, `SysManager.Tests/VolumePresetServiceTests.cs`, `SysManager.Tests/AudioPolicyConfigTests.cs`
- **Extended:** `Services/AudioMixerService.cs` (+device enum, +routing, +COM interfaces), `Services/IAudioMixerService.cs`, `ViewModels/AudioMixerViewModel.cs` (+presets, +device list), `ViewModels/AudioSessionRowViewModel.cs` (+routing picker/guided), `Services/TrayIconService.cs` (+Volume mixer item), `ViewModels/MainWindowViewModel.cs` (+`NavigateTo` seam), `ServiceRegistration.cs`
- **Docs:** README (Volume Control section), ARCHITECTURE (VM + service entries), CHANGELOG (1.55.0)
- **Version:** 1.54.0 → **1.55.0**

## Tests
- `VolumePresetService`: JSON round-trip, blank/malformed → empty, case-insensitive upsert (replace-in-place vs append, no input mutation), exe-name extraction, apply-plan matching by exe name + volume clamp + no-match empty.
- `AudioPolicyConfigFactory`: endpoint-id wrapping (plain → SWD-wrapped with render iface GUID; already-wrapped pass-through; empty), process token.
- Existing `AudioMixerViewModelTests` updated for the new ctor (temp-dir preset service).
- `dotnet build` green on all four projects (0/0). (`dotnet test` left to CI.)

Closes #332