### PR TITLE
fix: clear the last two CodeQL warnings (constant-condition, local-not-disposed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.55.1] - 2026-07-23
+
+### Fixed
+- **Cleared the last two CodeQL code-quality warnings, bringing the scanner to zero open findings.** Neither was a field-visible bug — both paths behaved correctly — but each code shape earned its warning and reads better fixed:
+  - *Temperature service (`cs/constant-condition`):* the one-time disk-name resolution used a double-checked lock (re-testing the cached field inside the semaphore), whose inner re-test CodeQL flags as a constant condition because it doesn't model the cross-thread race the re-test guards. Replaced with a plain "always take the gate, `??=` the cache" shape — an uncontended `SemaphoreSlim` acquire is trivial next to the SMART walk it guards, the race-safety is identical, and the flagged pattern is gone.
+  - *File shredder (`cs/local-not-disposed`):* the exclusive shred stream WAS disposed (via `DisposeAsync` in a `finally`), but the manual form isn't recognized by the analyzer. Converted to a scoped `await using` block — same semantics, including disposing the exclusive `FileShare.None` handle *before* the final `File.Delete` (which would otherwise fail while the handle is held) — a shape both humans and the analyzer read as safe.
+
 ## [1.55.0] - 2026-07-22
 
 ### Added

--- a/SysManager/SysManager/Services/FileShredderService.cs
+++ b/SysManager/SysManager/Services/FileShredderService.cs
@@ -72,16 +72,17 @@ public sealed partial class FileShredderService
         // before writing a byte, a reparse point swapped in after ValidatePath can no longer
         // redirect the overwrite — the handle is already bound to the resolved object, and
         // FileShare.None blocks anyone from moving/replacing it mid-shred.
-        var stream = new FileStream(
-            filePath,
-            FileMode.Open,
-            FileAccess.Write,
-            FileShare.None,
-            BufferSize,
-            FileOptions.WriteThrough | FileOptions.SequentialScan);
-
-        try
+        // The explicit block scopes the `await using` so the exclusive handle is disposed
+        // BEFORE the File.Delete below — deleting while we still hold FileShare.None would fail.
         {
+            await using var stream = new FileStream(
+                filePath,
+                FileMode.Open,
+                FileAccess.Write,
+                FileShare.None,
+                BufferSize,
+                FileOptions.WriteThrough | FileOptions.SequentialScan);
+
             // Re-validate the identity of the object we actually hold. If the resolved path
             // sits under a protected root (a reparse point swapped in between ValidatePath and
             // this open pointed us there), refuse — the exclusive handle guarantees this is the
@@ -148,11 +149,7 @@ public sealed partial class FileShredderService
             // Final truncate on the SAME held handle — no by-path reopen.
             stream.SetLength(0);
             await stream.FlushAsync(ct).ConfigureAwait(false);
-        }
-        finally
-        {
-            await stream.DisposeAsync().ConfigureAwait(false);
-        }
+        } // `await using` disposes the exclusive handle here, releasing FileShare.None for Delete.
 
         // The file contents are already securely overwritten and truncated to zero at
         // this point, so the shred guarantee holds even if the directory-entry removal

--- a/SysManager/SysManager/Services/TemperatureService.cs
+++ b/SysManager/SysManager/Services/TemperatureService.cs
@@ -249,24 +249,20 @@ public sealed class TemperatureService : IDisposable
         {
             // The friendly names come from DiskHealthService.CollectAsync()'s MSFT_PhysicalDisk +
             // per-disk MSFT_StorageReliabilityCounter (SMART) walk — the heaviest part of a read.
-            // They are static hardware identity, so resolve once and cache; the 2s Dashboard poll
-            // then skips the SMART walk entirely on every tick after the first. The gate makes the
-            // first-resolution race-safe when the poll, the user Refresh, and the sampler overlap.
-            var diskNames = _cachedStorageFriendlyNames;
-            if (diskNames is null)
+            // They are static hardware identity, so resolve once under the gate and cache; every
+            // later call (the 2s Dashboard poll, the sampler, a user Refresh) returns the cached
+            // list. The gate is taken unconditionally — an uncontended SemaphoreSlim acquire is
+            // trivial next to the SMART walk it guards — which keeps the first resolution
+            // race-safe without the double-checked re-test the previous shape needed.
+            await _enrichGate.WaitAsync().ConfigureAwait(false);
+            List<string> diskNames;
+            try
             {
-                await _enrichGate.WaitAsync().ConfigureAwait(false);
-                try
-                {
-                    if (_cachedStorageFriendlyNames is null)
-                    {
-                        var disks = await _diskHealth.CollectAsync().ConfigureAwait(false);
-                        _cachedStorageFriendlyNames = disks.Select(d => d.FriendlyName).ToList();
-                    }
-                    diskNames = _cachedStorageFriendlyNames;
-                }
-                finally { _enrichGate.Release(); }
+                diskNames = _cachedStorageFriendlyNames ??=
+                    (await _diskHealth.CollectAsync().ConfigureAwait(false))
+                    .Select(d => d.FriendlyName).ToList();
             }
+            finally { _enrichGate.Release(); }
 
             var storageReadings = readings
                 .Select((r, i) => (Reading: r, Index: i))

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.55.0</Version>
-    <FileVersion>1.55.0.0</FileVersion>
-    <AssemblyVersion>1.55.0.0</AssemblyVersion>
+    <Version>1.55.1</Version>
+    <FileVersion>1.55.1.0</FileVersion>
+    <AssemblyVersion>1.55.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Clears the only two open **warning**-severity CodeQL alerts, bringing the scanner to zero open warnings. Both changes are behavior-identical refactors of code the analyzer could not model.

### Alert #1698 — `cs/constant-condition` — `TemperatureService.cs:261`
`EnrichStorageNamesAsync` used a double-checked lock around `_cachedStorageFriendlyNames` (fast-path null test + re-test inside the `SemaphoreSlim` gate). CodeQL does not model cross-thread mutation, so it flagged the inner re-test as a constant condition. Replaced with an always-take-gate + `??=`: the gate is acquired unconditionally and the cache is populated with a single null-coalescing assignment. Race-safety is identical; an uncontended `SemaphoreSlim` acquire is trivial next to the SMART walk it guards.

### Alert #1694 — `cs/local-not-disposed` — `FileShredderService.cs:75`
`ShredFileAsync` disposed its exclusive `FileStream` manually via `try/finally { DisposeAsync() }` — correct, but a shape the analyzer does not recognize. Rewritten as a scoped `await using var` block with the same lifetime: the handle still closes before `File.Delete` (required — the stream holds `FileShare.None`). Matches the existing `await using` idiom in App.xaml.cs, SpeedTestService, and UpdateService.

## Verification
- `dotnet build -c Release` — 0 errors / 0 warnings on all projects (main + Tests + IntegrationTests + UITests).
- No public API change, no behavior change — overwrite passes, handle-identity validation, hard-link check, and TOCTOU guard in the shredder are untouched.
- Unit tests run in CI (`dotnet test` is CI-only by policy).

## Housekeeping
- CHANGELOG: 1.55.1 entry (Fixed).
- Version bump: 1.55.0 → 1.55.1.