### PR TITLE
docs: bump SECURITY.md supported versions to 1.55.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.52.x   | :white_check_mark: |
-| < 1.52   | :x:                |
+| 1.55.x   | :white_check_mark: |
+| < 1.55   | :x:                |
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
## Summary

SECURITY.md still advertised 1.52.x as the supported line; the project is now on 1.55.x (three minor releases later: 1.53.0 Edge/OneDrive Remover, 1.54.0 Bandwidth Monitor, 1.55.0 Volume Control completion, 1.55.1 CodeQL cleanup). Security fixes land on the latest minor only, so the table follows.

Docs-only change — `docs:` prefix, no release triggered.