### PR TITLE
feat: add Notification Blocker tab (per-app notification muting)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,7 +36,8 @@ The sidebar organises tabs into 12 groups (11 collapsible + a flat top-level Das
 `Item()` helper methods. Dashboard renders as a flat top-level entry.
 Collapsed groups show a child count badge, subtitle (derived
 from child labels joined with " · "), and tooltip.
-Planned features use `PlaceholderViewModel` with a WIP view.
+A planned-but-unbuilt feature would use `PlaceholderViewModel` with a WIP view
+(none currently — every tab is implemented).
 
 | Group | View Models |
 |-------|-------------|
@@ -48,7 +49,7 @@ Planned features use `PlaceholderViewModel` with a WIP view.
 | Storage | `DiskAnalyzerViewModel` · `DuplicateFileViewModel` |
 | Network | `PingViewModel` · `TracerouteViewModel` · `SpeedTestViewModel` · `NetworkRepairViewModel` (shared: `NetworkSharedState`) · `DnsHostsViewModel` |
 | Apps | `AppUpdatesViewModel` · `BulkInstallerViewModel` · `UninstallerViewModel` |
-| Privacy & Security | `PrivacyViewModel` · `FileShredderViewModel` · `AppBlockerViewModel` · `DebloaterViewModel` · `BrowserCleanerViewModel` · `EdgeOneDriveViewModel` · `DefenderViewModel` · `PlaceholderViewModel` (Notification Blocker) |
+| Privacy & Security | `PrivacyViewModel` · `FileShredderViewModel` · `AppBlockerViewModel` · `DebloaterViewModel` · `BrowserCleanerViewModel` · `EdgeOneDriveViewModel` · `DefenderViewModel` · `NotificationBlockerViewModel` |
 | Customization | `ContextMenuViewModel` · `DarkModeViewModel` · `AudioMixerViewModel` |
 | Info | `DriversViewModel` · `BatteryHealthViewModel` · `LogsViewModel` · `SystemReportViewModel` · `LegacyPanelsViewModel` · `AboutViewModel` |
 | Advanced | `ProfileViewModel` · `EnvironmentVariablesViewModel` · `CliInterfaceViewModel` |
@@ -122,7 +123,7 @@ Thin wrappers around the underlying platform. Each service is designed to be
 unit-testable. Services that a view-model needs to substitute in tests sit behind
 an interface seam — currently `IPowerShellRunner` (PowerShellRunner), `IWingetService` (WingetService),
 `IAppBlockerService` (AppBlockerService), `IDialogService` (DialogService),
-`ICpuAffinityService`, `IFileLockService`, `ISettingsWatchdogService`,
+`ICpuAffinityService`, `IFileLockService`, `INotificationBlockerService`, `ISettingsWatchdogService`,
 `ITimerResolutionService`, `ITweaksHubService`, `IWindowsThemeService`,
 `IAudioMixerService`, and `IGamingProfileService` — each registered against its
 implementation and mock-substitutable (see `ServiceRegistration.cs`).
@@ -192,6 +193,10 @@ Key services:
   FileSystemWatcher and registry polling.
 - `AppBlockerService` — blocks/unblocks app execution via Image File
   Execution Options (IFEO) debugger redirect.
+- `NotificationBlockerService` — mutes app notification nags via the documented
+  per-user registry switches Windows Settings writes (per-app `Enabled` under
+  `Notifications\Settings`, plus the `ToastEnabled` master toggle). Injectable
+  registry root for tests; per-user, reversible, no window hooking.
 - `BatteryService` — battery health, charge cycles, wear level, and
   power report generation via WMI and `powercfg /batteryreport`.
 - `DialogService` — centralized confirmation/message dialogs (replaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.56.0] - 2026-07-23
+
+### Added
+- **Notification Blocker — the last work-in-progress tab is now implemented** (Privacy & Security). Mute the apps that nag you with pop-up notifications — update reminders, trial offers, "rate us" prompts — without digging through Windows Settings:
+  - **Per-app mute switches** for every app Windows has recorded as a notification sender, sorted most-recently-active first and showing each app's recent notification count so the noisy ones stand out. Flipping a switch writes the same documented per-user setting as Windows Settings > System > Notifications — nothing is hooked, injected, or hacked, and Windows itself enforces the mute.
+  - **Master switch** to silence all notifications at once, with an explicit warning that it also mutes calendar and reminder alerts until turned back on.
+  - **Pending-changes flow** (like the Privacy & Telemetry tab): switch flips stay local until you press Apply, a confirmation summarises what changes, Discard backs out, and a failed write stays visibly pending instead of silently vanishing.
+  - Everything is per-user (no administrator), fully reversible by flipping the switch back, and searchable. App names resolve from Windows' own AppUserModelId registrations, falling back to a readable form of the sender ID.
+  - Scope note: the original idea (#340) included intercepting arbitrary pop-up windows; that requires manipulating other processes' windows — invasive, fragile, and malware-adjacent — so this tab deliberately sticks to the supported notification channel. Closes #340.
+
 ## [1.55.1] - 2026-07-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ fully open source.
 ### Sidebar navigation
 The sidebar organises 58 feature tabs into 12 groups — 11 collapsible groups
 plus a flat top-level Dashboard entry — so you can find what you need without
-scrolling through a flat list. 57 tabs are fully implemented; 1 is a
-work-in-progress placeholder marked with ⚙️:
+scrolling through a flat list. All 58 tabs are fully implemented:
 
 | Group | Tabs |
 |-------|------|
@@ -101,13 +100,12 @@ work-in-progress placeholder marked with ⚙️:
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS & Hosts |
 | 📦 Apps | App Updates · Bulk Installer · Uninstaller |
-| 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover · Defender Tweaks · Notification Blocker ⚙️ |
+| 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover · Defender Tweaks · Notification Blocker 🔬 |
 | 🎨 Customization | Context Menu · Dark Mode Scheduler · Volume Control |
 | ℹ️ Info | Drivers · Battery Health · System Logs · System Report · Legacy Panels · About |
 | ⚙️ Advanced | Profile Export/Import · CLI Interface 🔬 · Environment Variables |
 
 > 🔬 = Preview — fully implemented and usable, marked in-app while it settles in.
-> ⚙️ = Work in Progress — placeholder tab visible in the sidebar, implementation coming in future updates.
 
 Groups expand and collapse with a click. Collapsed groups show a child count
 badge, a subtitle with abbreviated child labels, and a tooltip with the full
@@ -600,6 +598,20 @@ Manage Microsoft Defender without digging through Windows Security:
   after reading it back and confirming Windows actually applied it
 - Changes need administrator and are confirmed first; lowering a protection is
   always an explicit, reversible choice
+
+### Notification Blocker
+Mute the apps that nag you with pop-up notifications — update reminders, trial
+offers, "rate us" prompts:
+- **Lists every app that has shown a notification**, most recently active first,
+  with how many notifications it sent recently so the noisy ones stand out
+- **Mute per app** with a switch — it flips the same per-app setting as Windows
+  Settings > Notifications, so nothing is hooked or hacked, and Windows itself
+  honors it
+- **Master switch** to silence everything at once (with a clear warning that it
+  also mutes calendar and reminder alerts)
+- **Pending-changes flow** — flips stay local until you press Apply, with a
+  confirmation and a Discard to back out
+- Fully reversible (flip the switch back), per-user, no administrator needed
 
 ### Battery Health
 - Charge %, health %, wear level, cycle count, chemistry

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -521,4 +521,16 @@ public class MainWindowViewModelTests
         Assert.IsType<TweaksHubViewModel>(item.Content);
         Assert.True(item.IsInDevelopment);
     }
+
+    // Notification Blocker (#340) — graduated from the last WIP placeholder to a real
+    // view/VM, flagged PREVIEW. With this, no PlaceholderView tabs remain in the sidebar.
+    [Fact]
+    public void NavLeaf_NotificationBlocker_IsImplementedAndInPreview()
+    {
+        var vm = new MainWindowViewModel();
+        var item = vm.NavItems.First(n => n.Id == "nav-notification-blocker");
+        Assert.Equal(typeof(SysManager.Views.NotificationBlockerView), item.ViewType);
+        Assert.IsType<NotificationBlockerViewModel>(item.Content);
+        Assert.True(item.IsInDevelopment);
+    }
 }

--- a/SysManager/SysManager.Tests/NotificationBlockerServiceTests.cs
+++ b/SysManager/SysManager.Tests/NotificationBlockerServiceTests.cs
@@ -1,0 +1,199 @@
+// SysManager · NotificationBlockerServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using Microsoft.Win32;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Round-trip tests for <see cref="NotificationBlockerService"/>. The service takes an
+/// injectable registry root; here we point it at a disposable HKCU subkey so the per-app
+/// and master toggles can be verified against a real hive without touching the machine's
+/// actual notification settings (mirrors <see cref="AppBlockerServiceRegistryTests"/>).
+/// </summary>
+public sealed class NotificationBlockerServiceTests : IDisposable
+{
+    private readonly string _rootName = @"Software\SysManagerTests\NotifBlocker_" + Guid.NewGuid().ToString("N");
+    private readonly RegistryKey _root;
+    private readonly NotificationBlockerService _svc;
+
+    public NotificationBlockerServiceTests()
+    {
+        _root = Registry.CurrentUser.CreateSubKey(_rootName, writable: true)!;
+        _svc = new NotificationBlockerService(_root);
+    }
+
+    public void Dispose()
+    {
+        _root.Dispose();
+        try { Registry.CurrentUser.DeleteSubKeyTree(_rootName, throwOnMissingSubKey: false); } catch { /* best-effort cleanup */ }
+    }
+
+    private RegistryKey CreateSender(string aumid, Action<RegistryKey>? seed = null)
+    {
+        var key = _root.CreateSubKey($@"{NotificationBlockerService.SettingsPath}\{aumid}", writable: true)!;
+        seed?.Invoke(key);
+        return key;
+    }
+
+    // ── Master toggle ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsGlobalToastEnabled_NoValue_DefaultsTrue()
+    {
+        Assert.True(_svc.IsGlobalToastEnabled());
+    }
+
+    [Fact]
+    public void SetGlobalToastEnabled_False_WritesZero_AndReadsBack()
+    {
+        Assert.True(_svc.SetGlobalToastEnabled(false));
+        Assert.False(_svc.IsGlobalToastEnabled());
+
+        using var key = _root.OpenSubKey(NotificationBlockerService.PushKeyPath);
+        Assert.Equal(0, key!.GetValue(NotificationBlockerService.ToastValueName));
+    }
+
+    [Fact]
+    public void SetGlobalToastEnabled_True_DeletesValue_RestoringWindowsDefault()
+    {
+        _svc.SetGlobalToastEnabled(false);
+        Assert.True(_svc.SetGlobalToastEnabled(true));
+        Assert.True(_svc.IsGlobalToastEnabled());
+
+        // The exact prior state is "value absent", not "value = 1" — same restore
+        // convention as the Gaming Profile NotificationsTweak.
+        using var key = _root.OpenSubKey(NotificationBlockerService.PushKeyPath);
+        Assert.Null(key!.GetValue(NotificationBlockerService.ToastValueName));
+    }
+
+    // ── Per-app senders ────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetApps_EmptyRoot_ReturnsEmpty()
+    {
+        Assert.Empty(_svc.GetApps());
+    }
+
+    [Fact]
+    public void GetApps_ReadsSender_WithDefaultsWhenValuesAbsent()
+    {
+        using var _ = CreateSender("com.example.someapp");
+
+        var apps = _svc.GetApps();
+
+        var app = Assert.Single(apps);
+        Assert.Equal("com.example.someapp", app.Aumid);
+        Assert.True(app.IsEnabled);           // absent Enabled = allowed
+        Assert.Equal(0, app.RecentCount);
+        Assert.Null(app.LastNotification);
+    }
+
+    [Fact]
+    public void GetApps_ReadsCountTimestampAndMutedState()
+    {
+        var stamp = new DateTime(2026, 7, 20, 14, 30, 0, DateTimeKind.Local);
+        using var _ = CreateSender("Chrome", k =>
+        {
+            k.SetValue("Enabled", 0, RegistryValueKind.DWord);
+            k.SetValue("PeriodicNotificationCount", 42, RegistryValueKind.DWord);
+            k.SetValue("LastNotificationAddedTime", stamp.ToFileTime(), RegistryValueKind.QWord);
+        });
+
+        var app = Assert.Single(_svc.GetApps());
+        Assert.False(app.IsEnabled);
+        Assert.Equal(42, app.RecentCount);
+        Assert.Equal(stamp, app.LastNotification);
+    }
+
+    [Fact]
+    public void GetApps_OrdersByLastNotification_MostRecentFirst()
+    {
+        var older = new DateTime(2026, 7, 1, 8, 0, 0, DateTimeKind.Local);
+        var newer = new DateTime(2026, 7, 20, 8, 0, 0, DateTimeKind.Local);
+        using var _1 = CreateSender("old.app", k => k.SetValue("LastNotificationAddedTime", older.ToFileTime(), RegistryValueKind.QWord));
+        using var _2 = CreateSender("new.app", k => k.SetValue("LastNotificationAddedTime", newer.ToFileTime(), RegistryValueKind.QWord));
+        using var _3 = CreateSender("never.app");
+
+        var apps = _svc.GetApps();
+
+        Assert.Equal(["new.app", "old.app", "never.app"], apps.Select(a => a.Aumid));
+    }
+
+    [Fact]
+    public void GetApps_SkipsCorruptTimestamp_LeavesNull()
+    {
+        using var _ = CreateSender("corrupt.app", k =>
+            k.SetValue("LastNotificationAddedTime", long.MaxValue, RegistryValueKind.QWord));
+
+        var app = Assert.Single(_svc.GetApps());
+        Assert.Null(app.LastNotification);
+    }
+
+    [Fact]
+    public void SetAppEnabled_False_WritesZero_AndGetAppsSeesIt()
+    {
+        using var _ = CreateSender("Slack");
+
+        Assert.True(_svc.SetAppEnabled("Slack", false));
+
+        var app = Assert.Single(_svc.GetApps());
+        Assert.False(app.IsEnabled);
+    }
+
+    [Fact]
+    public void SetAppEnabled_True_DeletesValue_RestoringWindowsDefault()
+    {
+        using var _ = CreateSender("Slack", k => k.SetValue("Enabled", 0, RegistryValueKind.DWord));
+
+        Assert.True(_svc.SetAppEnabled("Slack", true));
+
+        using var key = _root.OpenSubKey($@"{NotificationBlockerService.SettingsPath}\Slack");
+        Assert.Null(key!.GetValue(NotificationBlockerService.EnabledValueName));
+        Assert.True(Assert.Single(_svc.GetApps()).IsEnabled);
+    }
+
+    [Fact]
+    public void SetAppEnabled_UnknownAumid_ReturnsFalse()
+    {
+        Assert.False(_svc.SetAppEnabled("does.not.exist", false));
+    }
+
+    // Negative: the seam's write API must never escape the Settings subtree via a
+    // crafted AUMID — separators are rejected before any registry access.
+    [Theory]
+    [InlineData(@"..\..\Run")]
+    [InlineData(@"evil\sub")]
+    [InlineData("evil/sub")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SetAppEnabled_RejectsPathSeparatorsAndBlank(string aumid)
+    {
+        Assert.False(_svc.SetAppEnabled(aumid, false));
+    }
+
+    // ── Display-name resolution ────────────────────────────────────────────
+
+    [Fact]
+    public void ResolveDisplayName_UsesAumidRegistration_WhenPresent()
+    {
+        using (var reg = _root.CreateSubKey(@"Software\Classes\AppUserModelId\com.example.app", writable: true))
+            reg!.SetValue("DisplayName", "Example App");
+
+        Assert.Equal("Example App", _svc.ResolveDisplayName("com.example.app"));
+    }
+
+    [Theory]
+    [InlineData("com.squirrel.slack.slack", "Slack")]
+    [InlineData("Windows.SystemToast.StartupApp", "StartupApp")]
+    [InlineData("Microsoft.Office.OUTLOOK.EXE.15", "OUTLOOK")]
+    [InlineData("Microsoft.WindowsStore_8wekyb3d8bbwe!App", "WindowsStore")]
+    [InlineData("Chrome", "Chrome")]
+    [InlineData("Zoom", "Zoom")]
+    public void PrettifyAumid_ProducesReadableNames(string aumid, string expected)
+    {
+        Assert.Equal(expected, NotificationBlockerService.PrettifyAumid(aumid));
+    }
+}

--- a/SysManager/SysManager.Tests/NotificationBlockerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/NotificationBlockerViewModelTests.cs
@@ -1,0 +1,251 @@
+// SysManager · NotificationBlockerViewModelTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using NSubstitute;
+using SysManager.Models;
+using SysManager.Services;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="NotificationBlockerViewModel"/>: sender population, search filter,
+/// pending-change tracking (per-app and master), the confirm gate, partial-failure baseline
+/// handling, and discard — all against a substituted service (no registry).
+/// </summary>
+[Collection("DialogService")]
+public class NotificationBlockerViewModelTests
+{
+    private static NotificationApp App(string aumid, bool enabled = true, string? name = null) =>
+        new() { Aumid = aumid, DisplayName = name ?? aumid, IsEnabled = enabled };
+
+    // The VM loads its senders asynchronously off the UI thread; wait for that init so tests
+    // observe the populated collections deterministically instead of racing the background load.
+    private static NotificationBlockerViewModel NewVm(INotificationBlockerService svc)
+    {
+        var vm = new NotificationBlockerViewModel(svc);
+        vm.InitializationComplete.GetAwaiter().GetResult();
+        return vm;
+    }
+
+    private static INotificationBlockerService NewService(params NotificationApp[] apps)
+    {
+        var svc = Substitute.For<INotificationBlockerService>();
+        svc.GetApps().Returns(apps);
+        svc.IsGlobalToastEnabled().Returns(true);
+        svc.SetAppEnabled(Arg.Any<string>(), Arg.Any<bool>()).Returns(true);
+        svc.SetGlobalToastEnabled(Arg.Any<bool>()).Returns(true);
+        return svc;
+    }
+
+    [Fact]
+    public void Constructor_PopulatesAppsAndMaster()
+    {
+        var vm = NewVm(NewService(App("a.app"), App("b.app", enabled: false)));
+
+        Assert.Equal(2, vm.Apps.Count);
+        Assert.Equal(2, vm.FilteredApps.Count);
+        Assert.True(vm.MasterEnabled);
+        Assert.Equal(0, vm.PendingChangeCount);
+        Assert.False(vm.HasPendingChanges);
+    }
+
+    [Fact]
+    public void SearchText_FiltersByDisplayNameAndAumid()
+    {
+        var vm = NewVm(NewService(
+            App("com.squirrel.slack.slack", name: "Slack"),
+            App("Chrome", name: "Google Chrome"),
+            App("other.app", name: "Other")));
+
+        vm.SearchText = "slack";
+        Assert.Single(vm.FilteredApps);
+
+        vm.SearchText = "chrome";
+        Assert.Single(vm.FilteredApps);
+
+        vm.SearchText = "";
+        Assert.Equal(3, vm.FilteredApps.Count);
+    }
+
+    [Fact]
+    public void TogglingApp_TracksPendingChange_AndTogglingBackClearsIt()
+    {
+        var vm = NewVm(NewService(App("a.app")));
+
+        vm.Apps[0].IsEnabled = false;
+        Assert.Equal(1, vm.PendingChangeCount);
+        Assert.True(vm.HasPendingChanges);
+
+        vm.Apps[0].IsEnabled = true;
+        Assert.Equal(0, vm.PendingChangeCount);
+    }
+
+    [Fact]
+    public void TogglingMaster_TracksPendingChange()
+    {
+        var vm = NewVm(NewService(App("a.app")));
+
+        vm.MasterEnabled = false;
+        Assert.Equal(1, vm.PendingChangeCount);
+
+        vm.MasterEnabled = true;
+        Assert.Equal(0, vm.PendingChangeCount);
+    }
+
+    [Fact]
+    public void ApplyChanges_WhenUserDeclinesConfirm_WritesNothing()
+    {
+        var svc = NewService(App("a.app"));
+        var vm = NewVm(svc);
+        vm.Apps[0].IsEnabled = false;
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.ApplyChangesCommand.Execute(null);
+
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            svc.DidNotReceive().SetAppEnabled(Arg.Any<string>(), Arg.Any<bool>());
+            svc.DidNotReceive().SetGlobalToastEnabled(Arg.Any<bool>());
+            Assert.Equal(1, vm.PendingChangeCount); // still pending
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public void ApplyChanges_WhenUserConfirms_WritesAppAndMaster_AndRebaselines()
+    {
+        var svc = NewService(App("a.app"));
+        var vm = NewVm(svc);
+        vm.Apps[0].IsEnabled = false;
+        vm.MasterEnabled = false;
+        Assert.Equal(2, vm.PendingChangeCount);
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.ApplyChangesCommand.Execute(null);
+
+            svc.Received(1).SetAppEnabled("a.app", false);
+            svc.Received(1).SetGlobalToastEnabled(false);
+            Assert.Equal(0, vm.PendingChangeCount); // rebased — nothing pending
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public void ApplyChanges_FailedWrite_StaysPending()
+    {
+        var svc = NewService(App("a.app"), App("b.app"));
+        svc.SetAppEnabled("a.app", Arg.Any<bool>()).Returns(false); // this write is denied
+        var vm = NewVm(svc);
+        vm.Apps.First(a => a.Aumid == "a.app").IsEnabled = false;
+        vm.Apps.First(a => a.Aumid == "b.app").IsEnabled = false;
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.ApplyChangesCommand.Execute(null);
+
+            // b.app applied and rebased; a.app failed and must remain pending.
+            Assert.Equal(1, vm.PendingChangeCount);
+            Assert.Contains("failed", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public void ApplyChanges_MutingMaster_WarnsAboutSilencingEverything()
+    {
+        var svc = NewService(App("a.app"));
+        var vm = NewVm(svc);
+        vm.MasterEnabled = false;
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.ApplyChangesCommand.Execute(null);
+
+            dialog.Received(1).Confirm(
+                Arg.Is<string>(m => m != null && m.Contains("ALL notifications")),
+                Arg.Any<string>());
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public void DiscardChanges_RestoresBaseline()
+    {
+        var vm = NewVm(NewService(App("a.app"), App("b.app", enabled: false)));
+        vm.Apps[0].IsEnabled = false;
+        vm.Apps[1].IsEnabled = true;
+        vm.MasterEnabled = false;
+        Assert.Equal(3, vm.PendingChangeCount);
+
+        vm.DiscardChangesCommand.Execute(null);
+
+        Assert.True(vm.Apps[0].IsEnabled);
+        Assert.False(vm.Apps[1].IsEnabled);
+        Assert.True(vm.MasterEnabled);
+        Assert.Equal(0, vm.PendingChangeCount);
+    }
+
+    [Fact]
+    public async Task Refresh_ReloadsFromService_AndClearsPending()
+    {
+        var svc = NewService(App("a.app"));
+        var vm = NewVm(svc);
+        vm.Apps[0].IsEnabled = false; // pending
+
+        svc.GetApps().Returns([App("a.app"), App("new.app")]);
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.Equal(2, vm.Apps.Count);
+        Assert.Equal(0, vm.PendingChangeCount); // fresh baseline
+    }
+
+    [Fact]
+    public void NotificationApp_ActivitySummary_CoversAllShapes()
+    {
+        var never = new NotificationApp { Aumid = "a", DisplayName = "a" };
+        Assert.Equal("no recent activity", never.ActivitySummary);
+
+        var countOnly = new NotificationApp { Aumid = "b", DisplayName = "b", RecentCount = 5 };
+        Assert.Equal("5 recent", countOnly.ActivitySummary);
+
+        var full = new NotificationApp
+        {
+            Aumid = "c",
+            DisplayName = "c",
+            RecentCount = 3,
+            LastNotification = new DateTime(2026, 7, 20, 14, 30, 0),
+        };
+        Assert.StartsWith("3 recent · last ", full.ActivitySummary);
+    }
+}

--- a/SysManager/SysManager/Models/NotificationApp.cs
+++ b/SysManager/SysManager/Models/NotificationApp.cs
@@ -1,0 +1,36 @@
+// SysManager · NotificationApp — model for a per-app notification sender
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SysManager.Models;
+
+/// <summary>
+/// One application that has shown Windows toast notifications, backed by its
+/// per-app subkey under <c>HKCU\...\Notifications\Settings</c>. <see cref="IsEnabled"/>
+/// mirrors the same per-app switch Windows Settings exposes (true = notifications
+/// allowed, which is also the default when the underlying value is absent).
+/// </summary>
+public sealed partial class NotificationApp : ObservableObject
+{
+    /// <summary>Whether Windows may show this app's notifications (the Settings per-app switch).</summary>
+    [ObservableProperty] private bool _isEnabled;
+
+    /// <summary>The Application User Model ID — the registry subkey name identifying the sender.</summary>
+    public required string Aumid { get; init; }
+
+    /// <summary>Human-readable name resolved from the AUMID registration (or prettified from the AUMID).</summary>
+    public required string DisplayName { get; init; }
+
+    /// <summary>Windows' rolling count of notifications this app sent recently (read-only telemetry Windows keeps).</summary>
+    public int RecentCount { get; init; }
+
+    /// <summary>When this app last showed a notification, if Windows recorded it.</summary>
+    public DateTime? LastNotification { get; init; }
+
+    /// <summary>One-line activity caption for the UI row (recent count + last-seen time).</summary>
+    public string ActivitySummary => LastNotification is { } t
+        ? $"{RecentCount} recent · last {t:g}"
+        : RecentCount > 0 ? $"{RecentCount} recent" : "no recent activity";
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -89,6 +89,7 @@ public static class ServiceRegistration
         services.AddSingleton<ITweaksHubService, TweaksHubService>();
         services.AddSingleton<IAudioMixerService, AudioMixerService>();
         services.AddSingleton<VolumePresetService>();
+        services.AddSingleton<INotificationBlockerService, NotificationBlockerService>();
         // Gaming Profile orchestrates the audited services above; it needs the process's
         // elevation state at construction (a value DI can't resolve), hence the factory.
         services.AddSingleton<IGamingProfileService>(sp => new GamingProfileService(
@@ -159,6 +160,7 @@ public static class ServiceRegistration
         services.AddSingleton<TweaksHubViewModel>();
         services.AddSingleton<AudioMixerViewModel>();
         services.AddSingleton<GamingProfileViewModel>();
+        services.AddSingleton<NotificationBlockerViewModel>();
 
         return services;
     }

--- a/SysManager/SysManager/Services/INotificationBlockerService.cs
+++ b/SysManager/SysManager/Services/INotificationBlockerService.cs
@@ -1,0 +1,27 @@
+// SysManager · INotificationBlockerService — testable seam for the Notification Blocker
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Seam over <see cref="NotificationBlockerService"/> so the ViewModel can be unit-tested with a
+/// substituted implementation (no real registry). Mirrors the established interface-seam pattern
+/// (<see cref="IAppBlockerService"/>, <see cref="ISettingsWatchdogService"/>).
+/// </summary>
+public interface INotificationBlockerService
+{
+    /// <summary>Whether Windows toast notifications are enabled machine-wide for this user.</summary>
+    bool IsGlobalToastEnabled();
+
+    /// <summary>Turns all toast notifications on/off for this user. Returns true on success.</summary>
+    bool SetGlobalToastEnabled(bool enabled);
+
+    /// <summary>Every app Windows has recorded as a notification sender, most-active first.</summary>
+    IReadOnlyList<NotificationApp> GetApps();
+
+    /// <summary>Allows or mutes one app's notifications. Returns true on success.</summary>
+    bool SetAppEnabled(string aumid, bool enabled);
+}

--- a/SysManager/SysManager/Services/NotificationBlockerService.cs
+++ b/SysManager/SysManager/Services/NotificationBlockerService.cs
@@ -1,0 +1,228 @@
+// SysManager · NotificationBlockerService — per-app and global toast notification control
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using Microsoft.Win32;
+using Serilog;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Mutes app notification nags using the same documented HKCU registry values the Windows
+/// Settings &gt; System &gt; Notifications page writes — nothing deeper. Two levers:
+/// the per-app <c>Enabled</c> DWORD under <c>Notifications\Settings\&lt;AUMID&gt;</c>
+/// (the per-app switch) and the user-wide <c>PushNotifications\ToastEnabled</c> master
+/// toggle (shared with <see cref="NotificationsTweak"/> in the Gaming Profile).
+///
+/// Deliberately NOT here: window-hooking/pop-up interception (issue #340's original idea) —
+/// that would mean injecting into or manipulating other processes' windows, which is
+/// invasive, fragile, and indistinguishable from malware heuristics. Muting an app's toast
+/// channel is the safe, supported way Windows itself offers; everything is per-user
+/// (no admin) and reversible by flipping the same switch back.
+///
+/// The registry root is injectable (defaulting to <see cref="Registry.CurrentUser"/>) so the
+/// logic is unit-testable against a redirected subkey (mirrors <see cref="AppBlockerService"/>,
+/// <see cref="WindowsUpdatePolicyService"/>).
+/// </summary>
+public sealed class NotificationBlockerService : INotificationBlockerService
+{
+    // Per-app senders live one subkey per AUMID under this path; the per-app switch in
+    // Windows Settings writes an "Enabled" DWORD (0 = muted, absent/1 = allowed) there.
+    internal const string SettingsPath = @"Software\Microsoft\Windows\CurrentVersion\Notifications\Settings";
+    internal const string EnabledValueName = "Enabled";
+
+    // The user-wide master toggle (same values NotificationsTweak uses for Gaming Profile).
+    internal const string PushKeyPath = @"Software\Microsoft\Windows\CurrentVersion\PushNotifications";
+    internal const string ToastValueName = "ToastEnabled";
+
+    // Display names for AUMIDs are registered here by desktop apps that show toasts.
+    private const string AumidClassesPath = @"Software\Classes\AppUserModelId";
+
+    // Windows' own housekeeping subkeys under Notifications\Settings that are not app senders.
+    private static readonly HashSet<string> NonAppSubkeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Microsoft.Explorer.Notification", // legacy shell bucket, not a user-facing sender
+    };
+
+    private readonly RegistryKey _baseKey;
+
+    /// <summary>
+    /// Creates the service over a registry root. Defaults to <see cref="Registry.CurrentUser"/>
+    /// (the real per-user notification settings); tests pass a redirected root (a disposable
+    /// HKCU subkey) so reads/writes never touch the machine's real configuration.
+    /// </summary>
+    public NotificationBlockerService(RegistryKey? baseKey = null)
+        => _baseKey = baseKey ?? Registry.CurrentUser;
+
+    /// <inheritdoc />
+    public bool IsGlobalToastEnabled()
+    {
+        try
+        {
+            using var key = _baseKey.OpenSubKey(PushKeyPath);
+            // Absent value = notifications on (Windows default).
+            return key?.GetValue(ToastValueName) is not int v || v != 0;
+        }
+        catch (System.Security.SecurityException ex) { Log.Debug("Toast master read denied: {Error}", ex.Message); return true; }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Toast master read denied: {Error}", ex.Message); return true; }
+    }
+
+    /// <inheritdoc />
+    public bool SetGlobalToastEnabled(bool enabled)
+    {
+        try
+        {
+            using var key = _baseKey.CreateSubKey(PushKeyPath, writable: true);
+            if (enabled)
+                key.DeleteValue(ToastValueName, throwOnMissingValue: false); // absent = default = on
+            else
+                key.SetValue(ToastValueName, 0, RegistryValueKind.DWord);
+            Log.Information("Notifications: master toggle set to {Enabled}", enabled);
+            return true;
+        }
+        catch (System.Security.SecurityException ex) { Log.Warning("Toast master write denied: {Error}", ex.Message); return false; }
+        catch (UnauthorizedAccessException ex) { Log.Warning("Toast master write denied: {Error}", ex.Message); return false; }
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<NotificationApp> GetApps()
+    {
+        List<NotificationApp> apps = [];
+        try
+        {
+            using var settings = _baseKey.OpenSubKey(SettingsPath);
+            if (settings is null) return apps;
+
+            foreach (var aumid in settings.GetSubKeyNames())
+            {
+                if (NonAppSubkeys.Contains(aumid)) continue;
+
+                try
+                {
+                    using var appKey = settings.OpenSubKey(aumid);
+                    if (appKey is null) continue;
+
+                    // Absent Enabled value = notifications allowed (Windows default).
+                    var enabled = appKey.GetValue(EnabledValueName) is not int e || e != 0;
+                    var count = appKey.GetValue("PeriodicNotificationCount") is int c ? c : 0;
+
+                    DateTime? last = null;
+                    // FILETIME (100ns ticks since 1601) stored as QWORD; registry returns it as long.
+                    if (appKey.GetValue("LastNotificationAddedTime") is long ft && ft > 0)
+                    {
+                        try { last = DateTime.FromFileTime(ft); }
+                        catch (ArgumentOutOfRangeException) { /* corrupt timestamp — leave null */ }
+                    }
+
+                    apps.Add(new NotificationApp
+                    {
+                        Aumid = aumid,
+                        DisplayName = ResolveDisplayName(aumid),
+                        RecentCount = count,
+                        LastNotification = last,
+                        IsEnabled = enabled,
+                    });
+                }
+                catch (System.Security.SecurityException) { /* skip unreadable sender */ }
+                catch (UnauthorizedAccessException) { /* skip unreadable sender */ }
+                catch (System.IO.IOException) { /* skip unreadable sender */ }
+            }
+        }
+        catch (System.Security.SecurityException ex) { Log.Debug("Notification senders read denied: {Error}", ex.Message); }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Notification senders read denied: {Error}", ex.Message); }
+        catch (System.IO.IOException ex) { Log.Debug("Notification senders read failed: {Error}", ex.Message); }
+
+        return apps
+            .OrderByDescending(a => a.LastNotification ?? DateTime.MinValue)
+            .ThenByDescending(a => a.RecentCount)
+            .ToList();
+    }
+
+    /// <inheritdoc />
+    public bool SetAppEnabled(string aumid, bool enabled)
+    {
+        if (string.IsNullOrWhiteSpace(aumid)) return false;
+        // AUMIDs are registry subkey names we enumerated ourselves, but the write API is
+        // public on the seam — refuse separators so a caller can never escape SettingsPath.
+        if (aumid.Contains('\\') || aumid.Contains('/')) return false;
+
+        try
+        {
+            using var settings = _baseKey.OpenSubKey(SettingsPath, writable: true);
+            using var appKey = settings?.OpenSubKey(aumid, writable: true);
+            if (appKey is null) return false;
+
+            if (enabled)
+                appKey.DeleteValue(EnabledValueName, throwOnMissingValue: false); // absent = default = on
+            else
+                appKey.SetValue(EnabledValueName, 0, RegistryValueKind.DWord);
+
+            Log.Information("Notifications: {Aumid} set to {Enabled}", aumid, enabled);
+            return true;
+        }
+        catch (System.Security.SecurityException ex) { Log.Warning("Notification toggle denied for {Aumid}: {Error}", aumid, ex.Message); return false; }
+        catch (UnauthorizedAccessException ex) { Log.Warning("Notification toggle denied for {Aumid}: {Error}", aumid, ex.Message); return false; }
+        catch (System.IO.IOException ex) { Log.Warning("Notification toggle failed for {Aumid}: {Error}", aumid, ex.Message); return false; }
+    }
+
+    /// <summary>
+    /// Best human-readable name for an AUMID: the DisplayName a desktop app registered under
+    /// <c>HKCU\Software\Classes\AppUserModelId</c>, else a prettified tail of the AUMID itself
+    /// (e.g. <c>com.squirrel.slack.slack</c> → <c>Slack</c>).
+    /// </summary>
+    internal string ResolveDisplayName(string aumid)
+    {
+        try
+        {
+            using var reg = _baseKey.OpenSubKey($@"{AumidClassesPath}\{aumid}");
+            if (reg?.GetValue("DisplayName") is string name && !string.IsNullOrWhiteSpace(name))
+                return name;
+        }
+        catch (System.Security.SecurityException) { /* fall through to prettify */ }
+        catch (UnauthorizedAccessException) { /* fall through to prettify */ }
+
+        return PrettifyAumid(aumid);
+    }
+
+    /// <summary>
+    /// Derives a readable label from an AUMID when no DisplayName registration exists.
+    /// Handles the common shapes: reverse-DNS (<c>com.squirrel.slack.slack</c>),
+    /// packaged-app family names (<c>Microsoft.WindowsStore_8wekyb…!App</c>), and
+    /// system toasts (<c>Windows.SystemToast.StartupApp</c>).
+    /// </summary>
+    internal static string PrettifyAumid(string aumid)
+    {
+        if (string.IsNullOrWhiteSpace(aumid)) return aumid;
+
+        var s = aumid;
+
+        // Packaged apps: strip the "!App" entry-point suffix and the publisher-hash suffix.
+        var bang = s.IndexOf('!');
+        if (bang > 0) s = s[..bang];
+        var underscore = s.IndexOf('_');
+        if (underscore > 0) s = s[..underscore];
+
+        // System toasts read better without the fixed prefix.
+        const string systemToast = "Windows.SystemToast.";
+        if (s.StartsWith(systemToast, StringComparison.OrdinalIgnoreCase))
+            s = s[systemToast.Length..];
+
+        // Reverse-DNS and dotted family names: the last segment is the app name
+        // (com.squirrel.slack.slack → slack; Microsoft.Office.OUTLOOK.EXE.15 → keep readable tail).
+        var parts = s.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length > 1)
+        {
+            // Numeric or "EXE"-style tails aren't names — walk back to the last wordy segment.
+            var last = Array.FindLast(parts, p =>
+                p.Length > 2 && !int.TryParse(p, out _) &&
+                !p.Equals("exe", StringComparison.OrdinalIgnoreCase)) ?? parts[^1];
+            s = last;
+        }
+
+        // Capitalize the first letter so "slack" reads as "Slack".
+        return s.Length > 0 && char.IsLower(s[0])
+            ? char.ToUpperInvariant(s[0]) + s[1..]
+            : s;
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.55.1</Version>
-    <FileVersion>1.55.1.0</FileVersion>
-    <AssemblyVersion>1.55.1.0</AssemblyVersion>
+    <Version>1.56.0</Version>
+    <FileVersion>1.56.0.0</FileVersion>
+    <AssemblyVersion>1.56.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -50,10 +50,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     [ObservableProperty] private bool _isElevated;
     [ObservableProperty] private string _elevationBadge = "";
 
-    // Placeholder VMs for planned features (cheap; built once, referenced by their NavItems).
-    private readonly PlaceholderViewModel _wipNotificationBlocker =
-        new("Notification Blocker", "Suppress annoying app pop-ups (update nags, trial reminders) with allowlist.", "#340");
-
     private bool _disposed;
 
     /// <summary>
@@ -211,7 +207,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Tab<BrowserCleanerViewModel>("nav-browser-cleaner", "Browser Cleaner",   typeof(Views.BrowserCleanerView)),
             Tab<EdgeOneDriveViewModel>("nav-edge-onedrive", "Edge/OneDrive Remover", typeof(Views.EdgeOneDriveView)),
             Tab<DefenderViewModel>("nav-defender-tweaks",   "Defender Tweaks",       typeof(Views.DefenderView)),
-            EagerItem("nav-notification-blocker", "Notification Blocker", typeof(Views.PlaceholderView), _wipNotificationBlocker, inDevelopment: true)),
+            Tab<NotificationBlockerViewModel>("nav-notification-blocker", "Notification Blocker", typeof(Views.NotificationBlockerView), inDevelopment: true)),
 
         Group("grp-customization", "Customization",
             Tab<ContextMenuViewModel>("nav-context-menu",   "Context Menu",          typeof(Views.ContextMenuView)),
@@ -411,6 +407,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             [typeof(ScheduledMaintenanceViewModel)] = new ScheduledMaintenanceViewModel(new MaintenanceSchedulerService(new PowerShellRunner())),
             [typeof(TweaksHubViewModel)] = new TweaksHubViewModel(new TweaksHubService(new PrivacyService(), restorePoints)),
             [typeof(AudioMixerViewModel)] = new AudioMixerViewModel(new AudioMixerService(), new VolumePresetService()),
+            [typeof(NotificationBlockerViewModel)] = new NotificationBlockerViewModel(new NotificationBlockerService()),
             [typeof(GamingProfileViewModel)] = new GamingProfileViewModel(
                 new GamingProfileService(
                     new PerformanceService(runner, restorePoints),

--- a/SysManager/SysManager/ViewModels/NotificationBlockerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/NotificationBlockerViewModel.cs
@@ -1,0 +1,209 @@
+// SysManager · NotificationBlockerViewModel — mute app notification nags per app
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.ViewModels;
+
+/// <summary>
+/// Notification Blocker tab. Lists every app Windows has recorded as a notification
+/// sender and lets the user mute the nagging ones (or everything at once) using the
+/// same per-user switches Windows Settings writes. Switch flips update local state
+/// only; the user must explicitly press "Apply" to write changes — mirroring the
+/// pending-change flow of its sibling <see cref="PrivacyViewModel"/>.
+/// </summary>
+public sealed partial class NotificationBlockerViewModel : ViewModelBase
+{
+    private readonly INotificationBlockerService _service;
+    private readonly Dictionary<NotificationApp, bool> _baselineStates = [];
+    private bool _masterBaseline = true;
+
+    public BulkObservableCollection<NotificationApp> Apps { get; } = new();
+    public BulkObservableCollection<NotificationApp> FilteredApps { get; } = new();
+
+    [ObservableProperty] private string _searchText = "";
+
+    /// <summary>The user-wide master toggle (true = Windows may show any toasts at all).</summary>
+    [ObservableProperty] private bool _masterEnabled = true;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasPendingChanges))]
+    private int _pendingChangeCount;
+
+    public bool HasPendingChanges => PendingChangeCount > 0;
+
+    public NotificationBlockerViewModel(INotificationBlockerService service)
+    {
+        _service = service;
+        // Walk the notification-senders registry tree off the UI thread so first open
+        // doesn't block; the UI update runs back on the UI thread (ConfigureAwait true).
+        InitializeAsync(LoadAppsAsync);
+    }
+
+    private async Task LoadAppsAsync()
+    {
+        var (apps, master) = await Task.Run(() => (_service.GetApps(), _service.IsGlobalToastEnabled()))
+            .ConfigureAwait(true);
+        LoadApps(apps, master);
+    }
+
+    private void LoadApps(IReadOnlyList<NotificationApp> apps, bool masterEnabled)
+    {
+        foreach (var a in Apps)
+            a.PropertyChanged -= OnAppPropertyChanged;
+
+        Apps.ReplaceWith(apps);
+
+        _baselineStates.Clear();
+        foreach (var a in Apps)
+        {
+            _baselineStates[a] = a.IsEnabled;
+            a.PropertyChanged += OnAppPropertyChanged;
+        }
+
+        // Baseline first: assigning MasterEnabled fires OnMasterEnabledChanged → RecomputePendingChanges,
+        // which must compare against the NEW baseline, not last load's.
+        _masterBaseline = masterEnabled;
+        MasterEnabled = masterEnabled;
+
+        ApplyFilter();
+        RecomputePendingChanges();
+        UpdateStatus();
+    }
+
+    partial void OnSearchTextChanged(string value) => ApplyFilter();
+
+    partial void OnMasterEnabledChanged(bool value)
+    {
+        RecomputePendingChanges();
+        UpdateStatus();
+    }
+
+    private void ApplyFilter()
+    {
+        IEnumerable<NotificationApp> source = Apps;
+
+        if (!string.IsNullOrWhiteSpace(SearchText))
+            source = source.Where(a =>
+                a.DisplayName.Contains(SearchText, StringComparison.OrdinalIgnoreCase) ||
+                a.Aumid.Contains(SearchText, StringComparison.OrdinalIgnoreCase));
+
+        FilteredApps.ReplaceWith(source);
+    }
+
+    private void OnAppPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(NotificationApp.IsEnabled)) return;
+        RecomputePendingChanges();
+        UpdateStatus();
+    }
+
+    private void RecomputePendingChanges()
+    {
+        var pending = MasterEnabled != _masterBaseline ? 1 : 0;
+        foreach (var a in Apps)
+            if (_baselineStates.TryGetValue(a, out var baseline) && baseline != a.IsEnabled)
+                pending++;
+        PendingChangeCount = pending;
+    }
+
+    [RelayCommand]
+    private void ApplyChanges()
+    {
+        if (PendingChangeCount == 0)
+        {
+            StatusMessage = "No changes to apply.";
+            return;
+        }
+
+        var changedApps = Apps
+            .Where(a => _baselineStates.TryGetValue(a, out var baseline) && baseline != a.IsEnabled)
+            .ToList();
+        var masterChanged = MasterEnabled != _masterBaseline;
+
+        var muteAllWarning = masterChanged && !MasterEnabled
+            ? "\n\nTurning the master switch off silences ALL notifications — including calendar and reminder alerts — until you turn it back on."
+            : "";
+
+        if (!DialogService.Instance.Confirm(
+                $"Apply {PendingChangeCount} notification change{(PendingChangeCount == 1 ? "" : "s")}?\n\n" +
+                "Every change can be undone by switching it back and pressing Apply again." + muteAllWarning,
+                "Confirm Notification Changes"))
+        {
+            StatusMessage = "Apply cancelled.";
+            return;
+        }
+
+        // Only rebase the baseline for writes that actually succeeded — a failed write
+        // stays "pending" so the user sees it wasn't applied rather than it silently vanishing.
+        var applied = 0;
+        var failed = 0;
+
+        if (masterChanged)
+        {
+            if (_service.SetGlobalToastEnabled(MasterEnabled)) { _masterBaseline = MasterEnabled; applied++; }
+            else failed++;
+        }
+
+        foreach (var a in changedApps)
+        {
+            if (_service.SetAppEnabled(a.Aumid, a.IsEnabled)) { _baselineStates[a] = a.IsEnabled; applied++; }
+            else failed++;
+        }
+
+        RecomputePendingChanges();
+        StatusMessage = failed == 0
+            ? $"Applied {applied} change{(applied == 1 ? "" : "s")}."
+            : $"Applied {applied} change{(applied == 1 ? "" : "s")}; {failed} failed — see the log for details.";
+        Log.Information("Notification Blocker: applied {Applied} changes, {Failed} failed", applied, failed);
+    }
+
+    [RelayCommand]
+    private void DiscardChanges()
+    {
+        foreach (var a in Apps)
+            if (_baselineStates.TryGetValue(a, out var baseline))
+                a.IsEnabled = baseline;
+        MasterEnabled = _masterBaseline;
+        RecomputePendingChanges();
+        StatusMessage = "Pending changes discarded.";
+    }
+
+    [RelayCommand]
+    private async Task RefreshAsync()
+    {
+        // Re-read off the UI thread — mirrors the async initial load.
+        var (apps, master) = await Task.Run(() => (_service.GetApps(), _service.IsGlobalToastEnabled()))
+            .ConfigureAwait(true);
+        LoadApps(apps, master);
+        StatusMessage = "Notification senders refreshed.";
+        Log.Information("Notification Blocker: refreshed sender list ({Count} apps)", Apps.Count);
+    }
+
+    private void UpdateStatus()
+    {
+        var muted = Apps.Count(a => !a.IsEnabled);
+        var summary = MasterEnabled
+            ? $"{Apps.Count} notification sender{(Apps.Count == 1 ? "" : "s")} found · {muted} muted."
+            : $"All notifications are muted by the master switch · {Apps.Count} sender{(Apps.Count == 1 ? "" : "s")} found.";
+        if (PendingChangeCount > 0)
+            summary += $" {PendingChangeCount} pending change{(PendingChangeCount == 1 ? "" : "s")} — press Apply.";
+        StatusMessage = summary;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            foreach (var a in Apps)
+                a.PropertyChanged -= OnAppPropertyChanged;
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/SysManager/SysManager/Views/NotificationBlockerView.xaml
+++ b/SysManager/SysManager/Views/NotificationBlockerView.xaml
@@ -1,0 +1,145 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.NotificationBlockerView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views"
+             xmlns:vm="clr-namespace:SysManager.ViewModels"
+             d:DataContext="{d:DesignInstance vm:NotificationBlockerViewModel}"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             Background="{DynamicResource Surface0}">
+
+    <Grid Margin="28,24,28,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Preview banner -->
+        <v:DevelopmentBanner Grid.Row="0" Margin="0,0,0,12"/>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="1" Margin="0,0,0,16">
+            <TextBlock Text="Notification Blocker" Style="{StaticResource Display}"/>
+            <TextBlock Text="Mute the apps that nag you with pop-up notifications — update reminders, trial offers, 'rate us' prompts. Uses the same per-app switches as Windows Settings, so nothing is hacked and every change is one flip away from undone. No administrator needed."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap" MaxWidth="820" HorizontalAlignment="Left"/>
+        </StackPanel>
+
+        <!-- Master switch -->
+        <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="14,12">
+            <DockPanel>
+                <ToggleButton DockPanel.Dock="Right" Style="{StaticResource ToggleSwitch}"
+                              IsChecked="{Binding MasterEnabled}"
+                              AutomationProperties.Name="Allow notifications from all apps"
+                              VerticalAlignment="Center" Margin="8,0,0,0"
+                              ToolTip="Turn all Windows notifications on or off for your account"/>
+                <StackPanel VerticalAlignment="Center">
+                    <TextBlock Text="Allow notifications" FontWeight="SemiBold" FontSize="13"/>
+                    <TextBlock Text="The master switch. Off silences every notification — including calendar and reminder alerts — until you turn it back on."
+                               FontSize="11" Foreground="{DynamicResource TextMuted}"
+                               TextWrapping="Wrap" Margin="0,2,16,0"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- Toolbar -->
+        <Border Grid.Row="3" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
+            <WrapPanel>
+                <Button Content="Apply" Command="{Binding ApplyChangesCommand}"
+                        IsEnabled="{Binding HasPendingChanges}"
+                        AutomationProperties.Name="Apply pending notification changes"
+                        Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"
+                        ToolTip="Write pending switch changes to Windows."/>
+                <Button Content="Discard" Command="{Binding DiscardChangesCommand}"
+                        IsEnabled="{Binding HasPendingChanges}"
+                        AutomationProperties.Name="Discard pending notification changes"
+                        Style="{StaticResource GhostButton}" Margin="0,0,8,0"
+                        ToolTip="Revert pending switch changes back to the last applied state."/>
+                <Button Content="Refresh" Command="{Binding RefreshCommand}"
+                        AutomationProperties.Name="Refresh notification sender list"
+                        Style="{StaticResource GhostButton}" Margin="0,0,16,0"
+                        ToolTip="Re-read the sender list and switch states from Windows."/>
+
+                <TextBlock Text="Search:" VerticalAlignment="Center" Margin="8,0,8,0"
+                           Style="{StaticResource Subtle}"/>
+                <Grid Width="200" Margin="0,0,12,0">
+                    <TextBox Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                             AutomationProperties.Name="Filter notification senders"/>
+                    <TextBlock Text="Search apps…" IsHitTestVisible="False"
+                               Foreground="{DynamicResource TextMuted}" Margin="6,0,0,0"
+                               VerticalAlignment="Center" FontSize="12"
+                               Visibility="{Binding SearchText, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                </Grid>
+            </WrapPanel>
+        </Border>
+
+        <!-- Sender list (each row mirrors the Privacy & Telemetry toggle rows) -->
+        <Border Grid.Row="4" Style="{StaticResource Card}" Padding="0">
+            <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="16,12">
+                <ItemsControl ItemsSource="{Binding FilteredApps}"
+                              AutomationProperties.Name="Notification senders">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Margin="0,2" Padding="12,10" CornerRadius="8"
+                                    BorderThickness="1">
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Setter Property="Background" Value="{DynamicResource Surface2}"/>
+                                        <Setter Property="BorderBrush" Value="{DynamicResource Border1}"/>
+                                        <Style.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter Property="Background" Value="{DynamicResource Surface3}"/>
+                                                <Setter Property="BorderBrush" Value="{DynamicResource Border2}"/>
+                                            </Trigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+
+                                    <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                        <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" FontSize="13"/>
+                                        <TextBlock Text="{Binding ActivitySummary, Mode=OneTime}" FontSize="11"
+                                                   Foreground="{DynamicResource TextMuted}"
+                                                   TextWrapping="Wrap" Margin="0,2,16,0"/>
+                                        <TextBlock Text="{Binding Aumid, Mode=OneTime}" FontSize="10"
+                                                   Foreground="{DynamicResource TextMuted}"
+                                                   Margin="0,2,0,0" Opacity="0.6"/>
+                                    </StackPanel>
+
+                                    <ToggleButton Grid.Column="1" Style="{StaticResource ToggleSwitch}"
+                                                  IsChecked="{Binding IsEnabled}"
+                                                  AutomationProperties.Name="{Binding DisplayName, StringFormat='Allow notifications from: {0}'}"
+                                                  VerticalAlignment="Center" Margin="8,0,0,0"
+                                                  ToolTip="Allow or mute this app's notifications"/>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </Border>
+
+        <!-- Empty state -->
+        <v:EmptyState Grid.Row="4" Glyph="&#xEA8F;"
+                      Title="No notification senders found"
+                      Message="Apps appear here after they show their first notification — or nothing matches your search."
+                      Visibility="{Binding FilteredApps.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+
+        <!-- Status bar -->
+        <DockPanel Grid.Row="5" Margin="0,8,0,0">
+            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+                         IsIndeterminate="{Binding IsProgressIndeterminate}"
+                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/NotificationBlockerView.xaml.cs
+++ b/SysManager/SysManager/Views/NotificationBlockerView.xaml.cs
@@ -1,0 +1,12 @@
+// SysManager · NotificationBlockerView
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+public partial class NotificationBlockerView : UserControl
+{
+    public NotificationBlockerView() => InitializeComponent();
+}


### PR DESCRIPTION
## Summary

Implements the **Notification Blocker** tab — the last remaining work-in-progress placeholder in the sidebar. With this, all 58 tabs are fully implemented.

Closes #340.

### Scope decision (safe by design)
The original issue proposed intercepting arbitrary app pop-ups (window-title/process rules). That requires hooking or manipulating other processes' windows — invasive, fragile across Windows builds, and indistinguishable from malware heuristics. This implementation deliberately sticks to the supported channel: the same per-user registry switches Windows Settings > System > Notifications writes. Windows itself enforces the mute; nothing is hooked or injected.

### What it does
- **Per-app mute switches** for every recorded notification sender (`HKCU\...\Notifications\Settings`), sorted most-recently-active first with recent-count so the noisy apps stand out. Display names resolve from `AppUserModelId` registrations, falling back to a prettified sender ID.
- **Master switch** (`PushNotifications\ToastEnabled`, the same value the Gaming Profile tweak uses) with an explicit warning that muting all also silences calendar/reminder alerts.
- **Pending-changes flow** mirroring the sibling Privacy & Telemetry tab: flips stay local until Apply, confirmation via `DialogService`, Discard reverts, failed writes stay visibly pending.
- Per-user (no admin), fully reversible, searchable. Marked PREVIEW (`inDevelopment`) until QA-verified, per convention.

### Architecture
- `NotificationBlockerService` behind `INotificationBlockerService` (Gate-ARCH seam), constructor-injected, **injectable registry root** — round-trip tested against a disposable HKCU subkey like `AppBlockerService`/`WindowsUpdatePolicyService`.
- Model `NotificationApp` (ObservableObject), VM with the established `BulkObservableCollection` + baseline/pending pattern.
- AUMID write path rejects path separators so the seam can never escape the Settings subtree (negative-tested).

### Tests
- `NotificationBlockerServiceTests` — 15 registry round-trip tests: master toggle default/write/delete-restores-default, sender enumeration (defaults, values, ordering, corrupt-timestamp), per-app mute/unmute, unknown AUMID, path-separator injection rejection, display-name resolution + AUMID prettifying.
- `NotificationBlockerViewModelTests` — 12 VM tests: population, search filter, pending tracking (per-app + master + toggle-back), confirm-gate accept/decline, mute-all warning content, partial-failure keeps failed writes pending, discard, refresh rebaseline, ActivitySummary shapes.
- Integration: `NavLeaf_NotificationBlocker_IsImplementedAndInPreview` pins the graduation (real view/VM, PREVIEW) so a regression to the placeholder fails loudly.

### Docs (same PR)
- README: feature section added; sidebar table 🔬; "57 implemented + 1 WIP" → "all 58 implemented"; ⚙️ legend removed.
- ARCHITECTURE: VM table, service list, interface-seam list updated.
- CHANGELOG: 1.56.0 entry. Version bump 1.55.1 → 1.56.0.

## Verification
- `dotnet build -c Release` — 0 errors / 0 warnings on all 4 projects (main, Tests, IntegrationTests, UITests).
- Unit tests run in CI (`dotnet test` is CI-only by policy).
- UI smoke row for `nav-notification-blocker` already existed and now exercises the real view.