### PR TITLE
fix: harden elevated execution boundaries

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -181,7 +181,9 @@ Key services:
 - `WindowsFeaturesService` — list, enable, disable Windows optional features
   via `Get-WindowsOptionalFeature` / `Enable-WindowsOptionalFeature` PowerShell.
 - `UninstallerService` — winget-based uninstall + registry UninstallString
-  fallback for local apps not in winget.
+  fallback for local apps not in winget. Uninstall execution is standard-session
+  only; validated local commands use the shell runner so their own manifests own
+  any UAC request instead of inheriting SysManager elevation.
 - `PerformanceService` — power plan, visual effects, Game Mode, Xbox
   Game Bar, NVIDIA GPU, processor state, restore point creation, RAM
   working set trim, hibernation toggle. Snapshot-based restore.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.56.1] - 2026-07-28
+
+### Security
+- **Hardened elevated command execution at every affected trust boundary.** The Uninstaller now preserves each registry command's hive and view, gives machine-wide entries precedence, and refuses per-user or unknown commands while elevated. Executable and DLL validation uses canonical Windows locations, rejects reparse-point traversal, and verifies that unprivileged users cannot replace protected payloads or their parent directories. MSI and rundll32 commands are accepted only when their complete argument list matches the supported uninstall grammar.
+- **Isolated PowerShell module discovery from user-controlled process state.** Every in-process and external PowerShell invocation receives a canonical module path: elevated runs use machine module roots only, while non-elevated runs retain the standard per-user roots. PSWindowsUpdate is installed for all users when administrator rights are required.
+- **Made cancellation effective before process or runspace startup.** Already-cancelled operations now return without starting privileged work.
+
+### Fixed
+- **Kept existing uninstall compatibility without inheriting unsafe registry data.** Non-elevated per-user uninstallers remain available, protected machine uninstallers keep working, and conflicting per-user metadata can no longer replace a machine command.
+
 ## [1.56.0] - 2026-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [1.56.1] - 2026-07-28
 
 ### Security
-- **Hardened elevated command execution at every affected trust boundary.** The Uninstaller now preserves each registry command's hive and view, gives machine-wide entries precedence, and refuses per-user or unknown commands while elevated. Executable and DLL validation uses canonical Windows locations, rejects reparse-point traversal, and verifies that unprivileged users cannot replace protected payloads or their parent directories. MSI and rundll32 commands are accepted only when their complete argument list matches the supported uninstall grammar.
-- **Isolated PowerShell module discovery from user-controlled process state.** Every in-process and external PowerShell invocation receives a canonical module path: elevated runs use machine module roots only, while non-elevated runs retain the standard per-user roots. PSWindowsUpdate is installed for all users when administrator rights are required.
-- **Made cancellation effective before process or runspace startup.** Already-cancelled operations now return without starting privileged work.
+- **Prevented the Uninstaller from acting as a privileged execution broker.** Scan remains available in an administrator session, but uninstall actions are disabled until SysManager is reopened normally. This applies to both direct registry commands and the WinGet route, so user-controlled package metadata can no longer inherit SysManager's elevated token.
+- **Hardened registry-command validation.** Trusted shared-data paths now come from the canonical Windows known folder instead of the mutable `ProgramData` environment variable. Local commands must identify the canonical absolute executable that is actually launched, bare `rundll32` payloads resolve only from System32, and Windows Installer product-code commands must match the complete supported argument grammar; appended packages, transforms, and other payloads are rejected.
 
 ### Fixed
-- **Kept existing uninstall compatibility without inheriting unsafe registry data.** Non-elevated per-user uninstallers remain available, protected machine uninstallers keep working, and conflicting per-user metadata can no longer replace a machine command.
+- **Let each local uninstaller own its UAC request.** In an unelevated SysManager session, validated registry uninstallers now launch through the Windows shell. An uninstaller whose manifest requires administrator rights can therefore show its own Windows UAC prompt without requiring SysManager itself to remain elevated.
+- **Made cancellation and batch outcomes truthful.** Cancelling while WinGet or a local uninstaller is queued now prevents an unobserved process start, completed processes win a late cancellation race, cancelled or failed batches retain partial progress, and successful removals that require a restart are reported as success with restart guidance.
 
 ## [1.56.0] - 2026-07-23
 

--- a/README.md
+++ b/README.md
@@ -625,6 +625,7 @@ offers, "rate us" prompts:
 - Sort by name, size, or publisher via clickable column headers
 - Select/deselect all, batch uninstall with confirmation dialog
 - Local app support — uninstalls apps not in winget via registry UninstallString
+- Runs uninstall actions only from an unelevated SysManager session; each package requests its own UAC elevation when required
 - Live console output from winget
 
 ### Gaming Profile 🔬

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.55.x   | :white_check_mark: |
-| < 1.55   | :x:                |
+| 1.56.x   | :white_check_mark: |
+| < 1.56   | :x:                |
 
 ## Reporting a vulnerability
 

--- a/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
@@ -10,6 +10,8 @@ namespace SysManager.IntegrationTests;
 [Collection("Network")]
 public class PowerShellRunnerTests
 {
+    private const string UntrustedModulePath = @"C:\Users\Public\SysManager-UntrustedModules";
+
     [Fact]
     public async Task RunAsync_SimpleExpression_ReturnsResult()
     {
@@ -118,6 +120,33 @@ public class PowerShellRunnerTests
         var exit = await runner.RunScriptViaPwshAsync("exit 42", cts.Token);
         Assert.Equal(42, exit);
     }
+
+    [Fact]
+    public async Task RunAsync_DoesNotInheritUserControlledModulePath()
+    {
+        var original = Environment.GetEnvironmentVariable("PSModulePath");
+        try
+        {
+            Environment.SetEnvironmentVariable(
+                "PSModulePath",
+                string.IsNullOrEmpty(original)
+                    ? UntrustedModulePath
+                    : UntrustedModulePath + System.IO.Path.PathSeparator + original);
+
+            var output = await new PowerShellRunner().RunAsync("$env:PSModulePath");
+
+            var modulePath = Assert.Single(output).BaseObject?.ToString() ?? string.Empty;
+            Assert.DoesNotContain(
+                UntrustedModulePath,
+                modulePath,
+                StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PSModulePath", original);
+        }
+    }
+
 
     [Fact]
     public void IsClixmlNoise_Detects_AllKnownPatterns()

--- a/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
@@ -10,8 +10,6 @@ namespace SysManager.IntegrationTests;
 [Collection("Network")]
 public class PowerShellRunnerTests
 {
-    private const string UntrustedModulePath = @"C:\Users\Public\SysManager-UntrustedModules";
-
     [Fact]
     public async Task RunAsync_SimpleExpression_ReturnsResult()
     {
@@ -83,6 +81,75 @@ public class PowerShellRunnerTests
     }
 
     [Fact]
+    public async Task RunProcessWithShellAsync_CmdExitZero_ReturnsZero()
+    {
+        var runner = new PowerShellRunner();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var code = await runner.RunProcessWithShellAsync("cmd.exe", "/c exit 0", cts.Token);
+
+        Assert.Equal(0, code);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ProcessCancellationObservedAfterExit_ReturnsExitCode(bool useShell)
+    {
+        using var cancellation = new CancellationTokenSource();
+        var runner = new PowerShellRunner(
+            action => Task.Run(action),
+            async (process, token) =>
+            {
+                await process.WaitForExitAsync(CancellationToken.None);
+                cancellation.Cancel();
+                throw new OperationCanceledException(token);
+            });
+
+        var exitCode = useShell
+            ? await runner.RunProcessWithShellAsync("cmd.exe", "/c exit 42", cancellation.Token)
+            : await runner.RunProcessAsync("cmd.exe", "/c exit 42", cancellation.Token);
+
+        Assert.Equal(42, exitCode);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ProcessCancellation_WhenTreeTerminationPartiallyFails_ReportsProcessMayRemain(
+        bool useShell)
+    {
+        using var cancellation = new CancellationTokenSource();
+        var runner = new PowerShellRunner(
+            action => Task.Run(action),
+            (_, token) =>
+            {
+                cancellation.Cancel();
+                return Task.FromException(new OperationCanceledException(token));
+            },
+            process =>
+            {
+                process.Kill(entireProcessTree: false);
+                process.WaitForExit();
+                throw new AggregateException("A descendant could not be terminated.");
+            });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            useShell
+                ? runner.RunProcessWithShellAsync(
+                    "powershell.exe",
+                    "-NoProfile -NonInteractive -Command Start-Sleep -Seconds 60",
+                    cancellation.Token)
+                : runner.RunProcessAsync(
+                    "powershell.exe",
+                    "-NoProfile -NonInteractive -Command Start-Sleep -Seconds 60",
+                    cancellation.Token));
+
+        Assert.Contains("may still be running", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.IsType<AggregateException>(exception.InnerException);
+    }
+
+    [Fact]
     public async Task RunProcessAsync_MissingExe_Throws()
     {
         var runner = new PowerShellRunner();
@@ -120,33 +187,6 @@ public class PowerShellRunnerTests
         var exit = await runner.RunScriptViaPwshAsync("exit 42", cts.Token);
         Assert.Equal(42, exit);
     }
-
-    [Fact]
-    public async Task RunAsync_DoesNotInheritUserControlledModulePath()
-    {
-        var original = Environment.GetEnvironmentVariable("PSModulePath");
-        try
-        {
-            Environment.SetEnvironmentVariable(
-                "PSModulePath",
-                string.IsNullOrEmpty(original)
-                    ? UntrustedModulePath
-                    : UntrustedModulePath + System.IO.Path.PathSeparator + original);
-
-            var output = await new PowerShellRunner().RunAsync("$env:PSModulePath");
-
-            var modulePath = Assert.Single(output).BaseObject?.ToString() ?? string.Empty;
-            Assert.DoesNotContain(
-                UntrustedModulePath,
-                modulePath,
-                StringComparison.OrdinalIgnoreCase);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("PSModulePath", original);
-        }
-    }
-
 
     [Fact]
     public void IsClixmlNoise_Detects_AllKnownPatterns()

--- a/SysManager/SysManager.Tests/GamingProfileServiceTests.cs
+++ b/SysManager/SysManager.Tests/GamingProfileServiceTests.cs
@@ -323,8 +323,12 @@ public class GamingProfileServiceTests
         // restarts a WSearch this run never stopped (the Audit-1 over-revert defect).
         var requested = new GamingProfile
         {
-            UltimatePerformancePlan = true, DisableVisualEffects = true, FinestTimerResolution = true,
-            PurgeStandbyMemory = true, PauseSearchIndexing = true, SilenceNotifications = true,
+            UltimatePerformancePlan = true,
+            DisableVisualEffects = true,
+            FinestTimerResolution = true,
+            PurgeStandbyMemory = true,
+            PauseSearchIndexing = true,
+            SilenceNotifications = true,
         };
         var applied = new IGamingTweak[]
         {

--- a/SysManager/SysManager.Tests/NavGroupTests.cs
+++ b/SysManager/SysManager.Tests/NavGroupTests.cs
@@ -87,8 +87,11 @@ public class NavGroupTests
     {
         var item = new NavItem
         {
-            Id = "a", Label = "A", Glyph = "A",
-            Content = new object(), ViewType = typeof(object),
+            Id = "a",
+            Label = "A",
+            Glyph = "A",
+            Content = new object(),
+            ViewType = typeof(object),
         };
         Assert.False(item.IsInDevelopment);
     }
@@ -98,8 +101,11 @@ public class NavGroupTests
     {
         var item = new NavItem
         {
-            Id = "a", Label = "A", Glyph = "A",
-            Content = new object(), ViewType = typeof(object),
+            Id = "a",
+            Label = "A",
+            Glyph = "A",
+            Content = new object(),
+            ViewType = typeof(object),
             IsInDevelopment = true,
         };
         Assert.True(item.IsInDevelopment);

--- a/SysManager/SysManager.Tests/PowerShellRunnerTests.cs
+++ b/SysManager/SysManager.Tests/PowerShellRunnerTests.cs
@@ -46,6 +46,88 @@ public class PowerShellRunnerTests
     }
 
     [Fact]
+    public async Task RunProcessAsync_PreCancelled_DoesNotStartProcess()
+    {
+        var runner = new PowerShellRunner();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            runner.RunProcessAsync(
+                "must-not-start.exe",
+                string.Empty,
+                cancellation.Token));
+    }
+
+    [Fact]
+    public async Task RunProcessAsync_CancelledWhileStartQueued_DoesNotStartProcess()
+    {
+        var startQueued = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseStart = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var runner = new PowerShellRunner(async startProcess =>
+        {
+            startQueued.TrySetResult(true);
+            await releaseStart.Task;
+            startProcess();
+        });
+        using var cancellation = new CancellationTokenSource();
+
+        var runTask = runner.RunProcessAsync(
+            "must-not-start.exe",
+            string.Empty,
+            cancellation.Token);
+
+        await startQueued.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        releaseStart.TrySetResult(true);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => runTask);
+    }
+
+    [Fact]
+    public async Task RunProcessWithShellAsync_PreCancelled_DoesNotStartProcess()
+    {
+        var runner = new PowerShellRunner();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            runner.RunProcessWithShellAsync(
+                "must-not-start.exe",
+                string.Empty,
+                cancellation.Token));
+    }
+
+    [Fact]
+    public async Task RunProcessWithShellAsync_CancelledWhileStartQueued_DoesNotStartProcess()
+    {
+        var startQueued = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseStart = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var runner = new PowerShellRunner(async startProcess =>
+        {
+            startQueued.TrySetResult(true);
+            await releaseStart.Task;
+            startProcess();
+        });
+        using var cancellation = new CancellationTokenSource();
+
+        var runTask = runner.RunProcessWithShellAsync(
+            "must-not-start.exe",
+            string.Empty,
+            cancellation.Token);
+
+        await startQueued.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        releaseStart.TrySetResult(true);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => runTask);
+    }
+
+    [Fact]
     public void LineReceived_CanSubscribeAndUnsubscribe()
     {
         var runner = new PowerShellRunner();

--- a/SysManager/SysManager.Tests/TestCollections.cs
+++ b/SysManager/SysManager.Tests/TestCollections.cs
@@ -32,3 +32,9 @@ public class IconCacheCollection { }
 /// </summary>
 [CollectionDefinition("DialogService", DisableParallelization = true)]
 public class DialogServiceCollection { }
+
+/// <summary>
+/// Groups tests that temporarily replace process environment variables.
+/// </summary>
+[CollectionDefinition("ProcessEnvironment", DisableParallelization = true)]
+public class ProcessEnvironmentCollection { }

--- a/SysManager/SysManager.Tests/TweaksHubServiceTests.cs
+++ b/SysManager/SysManager.Tests/TweaksHubServiceTests.cs
@@ -11,8 +11,14 @@ public class TweaksHubServiceTests
 {
     private static PrivacyToggle Toggle(string name, string path, bool enabled) => new()
     {
-        Name = name, Description = "d", Category = "c",
-        RegistryPath = path, ValueName = "v", EnabledValue = 1, DisabledValue = 0, IsEnabled = enabled,
+        Name = name,
+        Description = "d",
+        Category = "c",
+        RegistryPath = path,
+        ValueName = "v",
+        EnabledValue = 1,
+        DisabledValue = 0,
+        IsEnabled = enabled,
     };
 
     private static TweakItem Item(string path, bool selected, bool applied)

--- a/SysManager/SysManager.Tests/TweaksHubViewModelTests.cs
+++ b/SysManager/SysManager.Tests/TweaksHubViewModelTests.cs
@@ -17,9 +17,14 @@ public class TweaksHubViewModelTests
     {
         var toggle = new PrivacyToggle
         {
-            Name = name, Description = "d", Category = "c",
-            RegistryPath = $@"{hive}\Software\Test\{name}", ValueName = "v",
-            EnabledValue = 1, DisabledValue = 0, IsEnabled = applied,
+            Name = name,
+            Description = "d",
+            Category = "c",
+            RegistryPath = $@"{hive}\Software\Test\{name}",
+            ValueName = "v",
+            EnabledValue = 1,
+            DisabledValue = 0,
+            IsEnabled = applied,
         };
         return TweakItem.From(toggle);
     }

--- a/SysManager/SysManager.Tests/UninstallerDescribeFailureTests.cs
+++ b/SysManager/SysManager.Tests/UninstallerDescribeFailureTests.cs
@@ -22,7 +22,6 @@ public class UninstallerDescribeFailureTests
     [InlineData(1603, "fatal error")]
     [InlineData(1605, "not currently installed")]
     [InlineData(1618, "another installation")]
-    [InlineData(3010, "reboot is required")]
     public void KnownExitCode_ContainsExpectedPhrase(int exitCode, string expectedPhrase)
     {
         var result = UninstallerViewModel.DescribeUninstallFailure(exitCode, "TestApp");
@@ -48,16 +47,11 @@ public class UninstallerDescribeFailureTests
     }
 
     [Fact]
-    public void ExitCode3010_MentionsReboot()
-    {
-        var result = UninstallerViewModel.DescribeUninstallFailure(3010, "TestApp");
-        Assert.Contains("reboot", result, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public void ExitCode5_MentionsAdministrator()
+    public void ExitCode5_DoesNotRecommendRunningSysManagerAsAdministrator()
     {
         var result = UninstallerViewModel.DescribeUninstallFailure(5, "TestApp");
-        Assert.Contains("Administrator", result);
+
+        Assert.Contains("Windows UAC prompt", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("SysManager as Administrator", result, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/SysManager/SysManager.Tests/UninstallerServiceTests.cs
+++ b/SysManager/SysManager.Tests/UninstallerServiceTests.cs
@@ -11,6 +11,7 @@ namespace SysManager.Tests;
 /// Tests for <see cref="UninstallerService"/>. Focuses on the table parser
 /// since winget calls are integration-level.
 /// </summary>
+[Collection("ProcessEnvironment")]
 public class UninstallerServiceTests
 {
     // ── IsUnderTrustedDirectory (regression: prefix-boundary bypass) ──
@@ -36,6 +37,24 @@ public class UninstallerServiceTests
     [Fact]
     public void IsUnderTrustedDirectory_UntrustedLocation_IsNotTrusted()
         => Assert.False(UninstallerService.IsUnderTrustedDirectory(@"C:\Temp\random\app.exe", isElevated: false));
+
+    [Fact]
+    public void IsUnderTrustedDirectory_ForgedProgramDataVariable_IsNotTrustedWhenElevated()
+    {
+        var original = Environment.GetEnvironmentVariable("ProgramData");
+        var forgedRoot = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "SysManagerProgramDataTest_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Environment.SetEnvironmentVariable("ProgramData", forgedRoot);
+            var plantedBinary = System.IO.Path.Combine(forgedRoot, "Vendor", "uninstall.exe");
+
+            Assert.False(UninstallerService.IsUnderTrustedDirectory(plantedBinary, isElevated: true));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ProgramData", original);
+        }
+    }
 
     // ── SEC-LPE: user-writable per-user location is trusted only when NOT elevated ──
 
@@ -119,6 +138,17 @@ public class UninstallerServiceTests
     {
         var ex = Record.Exception(() =>
             UninstallerService.ValidateTrustedBinaryArgs("MsiExec.exe", args, isElevated: false));
+        Assert.IsType<InvalidOperationException>(ex);
+    }
+
+    [Theory]
+    [InlineData(@"/X{0F2C3A4B-1234-5678-9ABC-DEF012345678} C:\Temp\evil.msi")]
+    [InlineData(@"/X{0F2C3A4B-1234-5678-9ABC-DEF012345678} /quiet TRANSFORMS=C:\Temp\evil.mst")]
+    public void ValidateTrustedBinaryArgs_MsiExec_TrailingPayload_Throws(string args)
+    {
+        var ex = Record.Exception(() =>
+            UninstallerService.ValidateTrustedBinaryArgs("MsiExec.exe", args, isElevated: false));
+
         Assert.IsType<InvalidOperationException>(ex);
     }
 

--- a/SysManager/SysManager.Tests/UninstallerServiceTests.cs
+++ b/SysManager/SysManager.Tests/UninstallerServiceTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using NSubstitute;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -14,6 +15,113 @@ namespace SysManager.Tests;
 [Collection("ProcessEnvironment")]
 public class UninstallerServiceTests
 {
+    [Fact]
+    public async Task UninstallAsync_WhenElevated_RejectsBeforeWingetLaunch()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        var service = new UninstallerService(runner, () => true);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.UninstallAsync("Vendor.Package"));
+
+        Assert.Contains("running as administrator", exception.Message, StringComparison.OrdinalIgnoreCase);
+        await runner.DidNotReceiveWithAnyArgs()
+            .RunProcessAsync(default!, default!, default, default);
+        await runner.DidNotReceiveWithAnyArgs()
+            .RunProcessWithShellAsync(default!, default!, default);
+    }
+
+    [Fact]
+    public async Task UninstallLocalAsync_WhenElevated_RejectsWindowsCommandBeforeLaunch()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        var service = new UninstallerService(runner, () => true);
+        var app = new InstalledApp
+        {
+            Name = "Forged registration",
+            UninstallString =
+                @"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile"
+        };
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.UninstallLocalAsync(app));
+
+        Assert.Contains("running as administrator", exception.Message, StringComparison.OrdinalIgnoreCase);
+        await runner.DidNotReceiveWithAnyArgs()
+            .RunProcessAsync(default!, default!, default, default);
+        await runner.DidNotReceiveWithAnyArgs()
+            .RunProcessWithShellAsync(default!, default!, default);
+    }
+
+    [Fact]
+    public async Task UninstallAsync_WhenNotElevated_UsesWingetRunner()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunProcessAsync(
+                "winget",
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<System.Text.Encoding?>())
+            .Returns(0);
+        var service = new UninstallerService(runner, () => false);
+
+        var exitCode = await service.UninstallAsync("Vendor.Package");
+
+        Assert.Equal(0, exitCode);
+        await runner.Received(1).RunProcessAsync(
+            "winget",
+            Arg.Is<string>(args => args != null && args.Contains("Vendor.Package", StringComparison.Ordinal)),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<System.Text.Encoding?>());
+    }
+
+    [Fact]
+    public async Task UninstallLocalAsync_WhenNotElevated_UsesShellRunnerForOwnedUac()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunProcessWithShellAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(0);
+        var service = new UninstallerService(runner, () => false);
+        var executable = System.IO.Path.Combine(Environment.SystemDirectory, "where.exe");
+        var app = new InstalledApp
+        {
+            Name = "Local app",
+            UninstallString = $"\"{executable}\" cmd.exe"
+        };
+
+        var exitCode = await service.UninstallLocalAsync(app);
+
+        Assert.Equal(0, exitCode);
+        await runner.Received(1).RunProcessWithShellAsync(
+            executable,
+            "cmd.exe",
+            Arg.Any<CancellationToken>());
+        await runner.DidNotReceiveWithAnyArgs()
+            .RunProcessAsync(default!, default!, default, default);
+    }
+
+    [Fact]
+    public async Task UninstallLocalAsync_RelativeExecutable_RejectsBeforeShellLaunch()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        var service = new UninstallerService(runner, () => false);
+        var app = new InstalledApp
+        {
+            Name = "Relative registration",
+            UninstallString = @".\where.exe cmd.exe"
+        };
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.UninstallLocalAsync(app));
+
+        Assert.Contains("not absolute", exception.Message, StringComparison.OrdinalIgnoreCase);
+        await runner.DidNotReceiveWithAnyArgs()
+            .RunProcessWithShellAsync(default!, default!, default);
+    }
+
     // ── IsUnderTrustedDirectory (regression: prefix-boundary bypass) ──
 
     [Fact]
@@ -39,10 +147,20 @@ public class UninstallerServiceTests
         => Assert.False(UninstallerService.IsUnderTrustedDirectory(@"C:\Temp\random\app.exe", isElevated: false));
 
     [Fact]
+    public void IsUnderTrustedDirectory_ProgramData_IsTrustedOnlyAtStandardIntegrity()
+    {
+        var programData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+        var executable = System.IO.Path.Combine(programData, "Vendor", "uninstall.exe");
+
+        Assert.True(UninstallerService.IsUnderTrustedDirectory(executable, isElevated: false));
+        Assert.False(UninstallerService.IsUnderTrustedDirectory(executable, isElevated: true));
+    }
+
+    [Fact]
     public void IsUnderTrustedDirectory_ForgedProgramDataVariable_IsNotTrustedWhenElevated()
     {
         var original = Environment.GetEnvironmentVariable("ProgramData");
-        var forgedRoot = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "SysManagerProgramDataTest_" + Guid.NewGuid().ToString("N"));
+        var forgedRoot = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "SysManagerProgramDataTest_Forged");
         try
         {
             Environment.SetEnvironmentVariable("ProgramData", forgedRoot);
@@ -92,13 +210,26 @@ public class UninstallerServiceTests
     }
 
     [Fact]
-    public void ValidateTrustedBinaryArgs_Rundll32_DllUnderWindows_IsAllowed()
+    public void ValidateTrustedBinaryArgs_Rundll32_DllUnderWindows_IsCanonicalized()
     {
         var sys = Environment.GetFolderPath(Environment.SpecialFolder.System);
         var dll = System.IO.Path.Combine(sys, "shell32.dll");
-        var ex = Record.Exception(() =>
-            UninstallerService.ValidateTrustedBinaryArgs("rundll32.exe", $"\"{dll}\",Control_RunDLL", isElevated: false));
-        Assert.Null(ex);
+
+        var args = UninstallerService.ValidateTrustedBinaryArgs(
+            "rundll32.exe", $"\"{dll}\",Control_RunDLL", isElevated: false);
+
+        Assert.Equal($"\"{dll}\",Control_RunDLL", args);
+    }
+
+    [Fact]
+    public void ValidateTrustedBinaryArgs_Rundll32_BareSystemDll_ResolvesToSystem32()
+    {
+        var dll = System.IO.Path.Combine(Environment.SystemDirectory, "shell32.dll");
+
+        var args = UninstallerService.ValidateTrustedBinaryArgs(
+            "rundll32.exe", "shell32.dll,Control_RunDLL", isElevated: false);
+
+        Assert.Equal($"\"{dll}\",Control_RunDLL", args);
     }
 
     [Fact]
@@ -111,6 +242,26 @@ public class UninstallerServiceTests
         var ex = Record.Exception(() =>
             UninstallerService.ValidateTrustedBinaryArgs("rundll32.exe", $"\"{dll}\",EntryPoint", isElevated: true));
         Assert.IsType<InvalidOperationException>(ex);
+    }
+
+    [Fact]
+    public void ValidateTrustedBinaryArgs_Rundll32_RelativeDll_Throws()
+    {
+        var ex = Record.Exception(() =>
+            UninstallerService.ValidateTrustedBinaryArgs(
+                "rundll32.exe", @"subdir\shell32.dll,Control_RunDLL", isElevated: false));
+
+        Assert.IsType<InvalidOperationException>(ex);
+    }
+
+    [Fact]
+    public void ValidateTrustedBinaryArgs_Rundll32_DriveRelativeDll_ThrowsAsNonAbsolute()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            UninstallerService.ValidateTrustedBinaryArgs(
+                "rundll32.exe", @"C:shell32.dll,Control_RunDLL", isElevated: false));
+
+        Assert.Contains("not absolute", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -147,7 +298,7 @@ public class UninstallerServiceTests
     public void ValidateTrustedBinaryArgs_MsiExec_TrailingPayload_Throws(string args)
     {
         var ex = Record.Exception(() =>
-            UninstallerService.ValidateTrustedBinaryArgs("MsiExec.exe", args, isElevated: false));
+            UninstallerService.ValidateTrustedBinaryArgs("MsiExec.exe", args, isElevated: true));
 
         Assert.IsType<InvalidOperationException>(ex);
     }

--- a/SysManager/SysManager.Tests/UninstallerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/UninstallerViewModelTests.cs
@@ -15,7 +15,12 @@ namespace SysManager.Tests;
 /// </summary>
 public class UninstallerViewModelTests
 {
-    private static UninstallerViewModel NewVm() => new(new UninstallerService(new PowerShellRunner()));
+    private static UninstallerViewModel NewVm()
+    {
+        var viewModel = new UninstallerViewModel(new UninstallerService(new PowerShellRunner()));
+        viewModel.IsElevated = false;
+        return viewModel;
+    }
 
     [Fact]
     public void Constructor_Commands_Exist()
@@ -67,11 +72,24 @@ public class UninstallerViewModelTests
     }
 
     [Fact]
+    public void UninstallCommand_DisabledWhenSysManagerIsElevated()
+    {
+        var viewModel = NewVm();
+        viewModel.AllApps.Add(new InstalledApp { Name = "App", Id = "Vendor.App" });
+        viewModel.FilterText = "App";
+
+        Assert.True(viewModel.UninstallSelectedCommand.CanExecute(null));
+
+        viewModel.IsElevated = true;
+
+        Assert.False(viewModel.UninstallSelectedCommand.CanExecute(null));
+    }
+
+    [Fact]
     public void DescribeUninstallFailure_KnownCodes()
     {
         Assert.Contains("Access denied", UninstallerViewModel.DescribeUninstallFailure(5, "Test"));
         Assert.Contains("cancelled", UninstallerViewModel.DescribeUninstallFailure(1602, "Test"));
-        Assert.Contains("reboot", UninstallerViewModel.DescribeUninstallFailure(3010, "Test"));
     }
 
     [Fact]
@@ -83,17 +101,21 @@ public class UninstallerViewModelTests
 }
 
 /// <summary>
-/// Confirmation-gate coverage for the Uninstaller. These swap the process-wide
-/// <see cref="DialogService.Instance"/>, so they run in the serialized
-/// "DialogService" collection. <see cref="UninstallerService"/> takes a concrete
-/// <see cref="PowerShellRunner"/> (not mockable), so the "confirm DOES uninstall"
-/// direction belongs in integration tests; here we cover the decline path and the
-/// pure-VM select-all guard, which are fully deterministic.
+/// Confirmation-gate and terminal-status coverage for the Uninstaller. These tests
+/// swap the process-wide <see cref="DialogService.Instance"/>, so they run in the
+/// serialized "DialogService" collection. Process execution is substituted through
+/// <see cref="IPowerShellRunner"/> so success, failure, and cancellation stay deterministic.
 /// </summary>
 [Collection("DialogService")]
 public class UninstallerViewModelGateTests
 {
-    private static UninstallerViewModel NewVm() => new(new UninstallerService(new PowerShellRunner()));
+    private static UninstallerViewModel NewVm(IPowerShellRunner? runner = null)
+    {
+        var viewModel = new UninstallerViewModel(
+            new UninstallerService(runner ?? new PowerShellRunner(), () => false));
+        viewModel.IsElevated = false;
+        return viewModel;
+    }
 
     // Populate FilteredApps deterministically through the public filter path:
     // add to AllApps, then toggle FilterText so ApplyFilter() repopulates.
@@ -156,6 +178,170 @@ public class UninstallerViewModelGateTests
         finally
         {
             DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public async Task UninstallSelected_AllSucceed_ReportsCompletion()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunProcessAsync(
+                "winget",
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<System.Text.Encoding?>())
+            .Returns(0);
+        var vm = NewVm(runner);
+        Seed(vm, 1);
+        vm.FilteredApps[0].Source = "winget";
+        vm.FilteredApps[0].IsSelected = true;
+
+        var previousDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            await vm.UninstallSelectedCommand.ExecuteAsync(null);
+
+            Assert.Equal(100, vm.Progress);
+            Assert.Equal("Completed 1/1 uninstalls.", vm.StatusMessage);
+            Assert.Empty(vm.AllApps);
+        }
+        finally
+        {
+            DialogService.Instance = previousDialog;
+        }
+    }
+
+    [Fact]
+    public async Task UninstallSelected_WhenRunnerFails_ReportsErrorsNotCompletion()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunProcessAsync(
+                "winget",
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<System.Text.Encoding?>())
+            .Returns(5);
+        var vm = NewVm(runner);
+        Seed(vm, 1);
+        vm.FilteredApps[0].Source = "winget";
+        vm.FilteredApps[0].IsSelected = true;
+
+        var previousDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            await vm.UninstallSelectedCommand.ExecuteAsync(null);
+
+            Assert.Equal(100, vm.Progress);
+            Assert.Contains("finished with errors", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("failed 1", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Uninstall complete", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Windows UAC prompt", vm.FilteredApps[0].Status, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            DialogService.Instance = previousDialog;
+        }
+    }
+
+    [Theory]
+    [InlineData(1641)]
+    [InlineData(3010)]
+    public async Task UninstallSelected_WhenRestartIsRequired_ReportsSuccessfulRemoval(int exitCode)
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunProcessAsync(
+                "winget",
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<System.Text.Encoding?>())
+            .Returns(exitCode);
+        var vm = NewVm(runner);
+        Seed(vm, 1);
+        vm.FilteredApps[0].Source = "winget";
+        vm.FilteredApps[0].IsSelected = true;
+
+        var previousDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            await vm.UninstallSelectedCommand.ExecuteAsync(null);
+
+            Assert.Equal(100, vm.Progress);
+            Assert.Contains("Completed 1/1", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("restart required", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("failed", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.Empty(vm.AllApps);
+        }
+        finally
+        {
+            DialogService.Instance = previousDialog;
+        }
+    }
+
+    [Fact]
+    public async Task UninstallSelected_WhenCancelled_StopsBatchAndReportsPartialProgress()
+    {
+        var started = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var pending = new TaskCompletionSource<int>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var callCount = 0;
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunProcessAsync(
+                "winget",
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<System.Text.Encoding?>())
+            .Returns(callInfo =>
+            {
+                if (Interlocked.Increment(ref callCount) == 1)
+                    return Task.FromResult(0);
+
+                var token = callInfo.ArgAt<CancellationToken>(2);
+                token.Register(() => pending.TrySetCanceled(token));
+                started.TrySetResult(true);
+                return pending.Task;
+            });
+        var vm = NewVm(runner);
+        Seed(vm, 2);
+        foreach (var app in vm.FilteredApps)
+        {
+            app.Source = "winget";
+            app.IsSelected = true;
+        }
+
+        var previousDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            var execution = vm.UninstallSelectedCommand.ExecuteAsync(null);
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            vm.CancelCommand.Execute(null);
+            await execution;
+
+            Assert.Equal(50, vm.Progress);
+            Assert.Contains("cancelled after 1/2 completed", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.Single(vm.FilteredApps);
+            Assert.Equal("Cancelled", vm.FilteredApps[0].Status);
+            await runner.Received(2).RunProcessAsync(
+                "winget",
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<System.Text.Encoding?>());
+        }
+        finally
+        {
+            DialogService.Instance = previousDialog;
         }
     }
 

--- a/SysManager/SysManager.UITests/AdminBannerUiTests.cs
+++ b/SysManager/SysManager.UITests/AdminBannerUiTests.cs
@@ -23,7 +23,6 @@ public class AdminBannerUiTests
         // Originally had the banner (reference implementations)
         new object[] { "nav-services" },
         new object[] { "nav-dns-hosts" },
-        new object[] { "nav-uninstaller" },
         // Added by the uniformity fix (v1.43.0) — these regressed silently before
         new object[] { "nav-processes" },
         new object[] { "nav-startup" },

--- a/SysManager/SysManager.UITests/UninstallerUiTests.cs
+++ b/SysManager/SysManager.UITests/UninstallerUiTests.cs
@@ -1,0 +1,30 @@
+// SysManager · UninstallerUiTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.UITests;
+
+[Collection("App")]
+public class UninstallerUiTests
+{
+    private readonly AppFixture _fixture;
+
+    public UninstallerUiTests(AppFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public void CurrentSession_ShowsMatchingGuidanceWithoutAdminRelaunchButton()
+    {
+        _fixture.GoToTab("nav-uninstaller");
+
+        Assert.NotNull(_fixture.FindButton("Uninstall selected"));
+        Assert.Null(_fixture.FindButton("Run as administrator", timeoutSeconds: 1));
+        Assert.Null(_fixture.FindButton("Relaunch as administrator", timeoutSeconds: 1));
+
+        var expectedGuidance = Helpers.AdminHelper.IsElevated()
+            ? "Uninstall is disabled in administrator sessions. Reopen SysManager normally to continue."
+            : "Uninstallers request administrator access themselves when needed.";
+        Assert.True(
+            _fixture.HasText(expectedGuidance),
+            "The Uninstaller did not show the guidance for the current integrity level.");
+    }
+}

--- a/SysManager/SysManager/AssemblyInfo.cs
+++ b/SysManager/SysManager/AssemblyInfo.cs
@@ -10,6 +10,7 @@ using System.Windows;
 // Title / Description / Product / Company / Copyright come from csproj.
 [assembly: AssemblyTrademark("SysManager by laurentiu021")]
 [assembly: InternalsVisibleTo("SysManager.Tests")]
+[assembly: InternalsVisibleTo("SysManager.IntegrationTests")]
 
 [assembly: ThemeInfo(
     ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located

--- a/SysManager/SysManager/Services/AudioMixerService.cs
+++ b/SysManager/SysManager/Services/AudioMixerService.cs
@@ -610,7 +610,8 @@ public sealed class AudioMixerService : IAudioMixerService, IDisposable
     [ComImport, Guid("D666063F-1587-4E43-81F1-B948E807363F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     private interface IMMDevice
     {
-        [PreserveSig] int Activate(ref Guid iid, uint dwClsCtx, IntPtr pActivationParams,
+        [PreserveSig]
+        int Activate(ref Guid iid, uint dwClsCtx, IntPtr pActivationParams,
             [MarshalAs(UnmanagedType.IUnknown)] out object ppInterface);
         // Slots 2-4, declared to preserve vtable order (device enumeration reads name + id).
         [PreserveSig] int OpenPropertyStore(uint stgmAccess, out IPropertyStore ppProperties);

--- a/SysManager/SysManager/Services/AudioPolicyConfig.cs
+++ b/SysManager/SysManager/Services/AudioPolicyConfig.cs
@@ -162,7 +162,8 @@ internal static class AudioPolicyConfigFactory
 
         // Slot 19: the one we call. deviceId is a plain LPWStr (the EarTrumpet-observed marshaling on
         // Win10 1803+ and Win11); an empty string clears the per-app override.
-        [PreserveSig] int SetPersistedDefaultAudioEndpoint(
+        [PreserveSig]
+        int SetPersistedDefaultAudioEndpoint(
             uint processId, EDataFlow flow, ERole role,
             [MarshalAs(UnmanagedType.LPWStr)] string deviceId);
     }

--- a/SysManager/SysManager/Services/DiskHealthService.cs
+++ b/SysManager/SysManager/Services/DiskHealthService.cs
@@ -4,9 +4,8 @@
 
 using System.Management;
 using Serilog;
-using SysManager.Models;
-
 using SysManager.Helpers;
+using SysManager.Models;
 
 namespace SysManager.Services;
 

--- a/SysManager/SysManager/Services/IPowerShellRunner.cs
+++ b/SysManager/SysManager/Services/IPowerShellRunner.cs
@@ -58,4 +58,14 @@ public interface IPowerShellRunner
         string arguments,
         CancellationToken cancellationToken = default,
         Encoding? outputEncoding = null);
+
+    /// <summary>
+    /// Run a validated executable through the Windows shell so its own manifest can
+    /// request elevation. Use only after the caller has validated both the executable
+    /// and arguments at its trust boundary.
+    /// </summary>
+    Task<int> RunProcessWithShellAsync(
+        string fileName,
+        string arguments,
+        CancellationToken cancellationToken = default);
 }

--- a/SysManager/SysManager/Services/PowerShellRunner.cs
+++ b/SysManager/SysManager/Services/PowerShellRunner.cs
@@ -25,6 +25,28 @@ namespace SysManager.Services;
 /// </summary>
 public sealed class PowerShellRunner : IPowerShellRunner
 {
+    private readonly Func<Action, Task> _scheduleProcessStart;
+    private readonly Func<System.Diagnostics.Process, CancellationToken, Task> _waitForProcessExit;
+    private readonly Action<System.Diagnostics.Process> _terminateProcessTree;
+
+    public PowerShellRunner()
+        : this(action => Task.Run(action))
+    {
+    }
+
+    internal PowerShellRunner(
+        Func<Action, Task> scheduleProcessStart,
+        Func<System.Diagnostics.Process, CancellationToken, Task>? waitForProcessExit = null,
+        Action<System.Diagnostics.Process>? terminateProcessTree = null)
+    {
+        _scheduleProcessStart = scheduleProcessStart
+            ?? throw new ArgumentNullException(nameof(scheduleProcessStart));
+        _waitForProcessExit = waitForProcessExit
+            ?? (static (process, cancellationToken) => process.WaitForExitAsync(cancellationToken));
+        _terminateProcessTree = terminateProcessTree
+            ?? (static process => process.Kill(entireProcessTree: true));
+    }
+
     /// <summary>
     /// Raised for each line of output from any stream (stdout, stderr, information,
     /// warning, error, verbose, debug, progress). Fires on a thread-pool thread —
@@ -172,6 +194,8 @@ public sealed class PowerShellRunner : IPowerShellRunner
         CancellationToken cancellationToken = default,
         System.Text.Encoding? outputEncoding = null)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         // Always launch from a neutral system directory so the spawned
         // process never inherits a "locked" CWD (e.g. a user's Downloads
         // folder on another drive, which causes "Access is denied" when
@@ -212,26 +236,33 @@ public sealed class PowerShellRunner : IPowerShellRunner
                 LineReceived?.Invoke(PowerShellLine.Err(e.Data));
         };
 
-        // Start the process on a thread-pool thread so the potentially slow
-        // Process.Start() (especially powershell.exe) never blocks the UI.
-        await Task.Run(() =>
+        // Start on a worker thread. The second token check closes the queueing race:
+        // cancellation before this delegate runs cannot start the executable.
+        await _scheduleProcessStart(() =>
         {
+            cancellationToken.ThrowIfCancellationRequested();
             proc.Start();
             proc.BeginOutputReadLine();
             proc.BeginErrorReadLine();
         }).ConfigureAwait(false);
 
-        using var reg = cancellationToken.Register(() =>
+        try
         {
-            // Kill(entireProcessTree: true) can throw Win32Exception (access denied) or
-            // AggregateException (a descendant couldn't be terminated) as well as
-            // InvalidOperationException — swallow all three so a failed cancel-kill never
-            // escapes out of cts.Cancel() to whoever requested cancellation.
-            try { if (!proc.HasExited) proc.Kill(entireProcessTree: true); }
-            catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception or AggregateException) { }
-        });
-        await proc.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+            await _waitForProcessExit(proc, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            if (await TryTerminateForCancellationAsync(
+                    proc,
+                    "Cancellation was requested, but the process may still be running.")
+                .ConfigureAwait(false))
+            {
+                throw;
+            }
 
+            // The process completed before cancellation could terminate it. Completion
+            // wins so callers receive the real exit code instead of a false cancellation.
+        }
         // WaitForExitAsync returns when the process exits, but the asynchronous
         // BeginOutputReadLine/BeginErrorReadLine pumps may not have raised their final
         // lines yet — callers that snapshot captured output immediately can lose the
@@ -241,6 +272,90 @@ public sealed class PowerShellRunner : IPowerShellRunner
         await Task.Run(proc.WaitForExit, CancellationToken.None).ConfigureAwait(false);
 
         return proc.ExitCode;
+    }
+
+    /// <summary>
+    /// Runs a validated executable through ShellExecute. Unlike
+    /// <see cref="RunProcessAsync"/>, this lets an executable whose manifest requires
+    /// administrator rights display its own UAC prompt instead of inheriting
+    /// SysManager's token.
+    /// </summary>
+    public async Task<int> RunProcessWithShellAsync(
+        string fileName,
+        string arguments,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var workingDir = Environment.GetFolderPath(Environment.SpecialFolder.System);
+        if (string.IsNullOrWhiteSpace(workingDir) || !System.IO.Directory.Exists(workingDir))
+            workingDir = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = SysManager.Helpers.SystemPaths.ResolveSystemTool(fileName),
+            Arguments = arguments,
+            UseShellExecute = true,
+            WorkingDirectory = workingDir
+        };
+
+        using var process = new System.Diagnostics.Process { StartInfo = psi };
+        await _scheduleProcessStart(() =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!process.Start())
+                throw new InvalidOperationException($"Failed to start '{fileName}'.");
+        }).ConfigureAwait(false);
+
+        try
+        {
+            await _waitForProcessExit(process, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            if (await TryTerminateForCancellationAsync(
+                    process,
+                    "Cancellation was requested, but the uninstaller may still be running.")
+                .ConfigureAwait(false))
+            {
+                throw;
+            }
+
+            // Shell execution finished before cancellation could take effect. Preserve
+            // the completed uninstaller's exit code and terminal state.
+        }
+
+        return process.ExitCode;
+    }
+
+    private async Task<bool> TryTerminateForCancellationAsync(
+        System.Diagnostics.Process process,
+        string failureMessage)
+    {
+        if (process.HasExited)
+            return false;
+
+        try
+        {
+            _terminateProcessTree(process);
+        }
+        catch (InvalidOperationException) when (process.HasExited)
+        {
+            // The process completed between the state check and the termination call.
+            return false;
+        }
+        catch (Exception ex) when (
+            ex is InvalidOperationException or
+            System.ComponentModel.Win32Exception or
+            AggregateException)
+        {
+            // A tree-termination failure can leave descendants running even when the
+            // parent has exited. Never downgrade that partial failure to completion.
+            throw new InvalidOperationException(failureMessage, ex);
+        }
+
+        await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+        return true;
     }
 
     private static bool IsClixmlNoise(string line)

--- a/SysManager/SysManager/Services/ProfileService.cs
+++ b/SysManager/SysManager/Services/ProfileService.cs
@@ -92,7 +92,7 @@ public sealed class ProfileService
     /// <summary>Builds a profile from the given sections (defaults to all available).</summary>
     public ConfigProfile BuildProfile(DateTime exportedAt, IReadOnlyList<ConfigSection>? sections = null)
         => new(CurrentSchemaVersion, UpdateService.CurrentVersion.ToString(3), exportedAt)
-           { Sections = sections ?? AvailableSections() };
+        { Sections = sections ?? AvailableSections() };
 
     /// <summary>Serializes a profile to indented JSON.</summary>
     public static string Serialize(ConfigProfile profile) => JsonSerializer.Serialize(profile, JsonOptions);

--- a/SysManager/SysManager/Services/UninstallerService.cs
+++ b/SysManager/SysManager/Services/UninstallerService.cs
@@ -15,8 +15,18 @@ namespace SysManager.Services;
 public sealed partial class UninstallerService
 {
     private readonly IPowerShellRunner _runner;
+    private readonly Func<bool> _isElevated;
 
-    public UninstallerService(IPowerShellRunner runner) => _runner = runner;
+    public UninstallerService(IPowerShellRunner runner)
+        : this(runner, Helpers.AdminHelper.IsElevated)
+    {
+    }
+
+    internal UninstallerService(IPowerShellRunner runner, Func<bool> isElevated)
+    {
+        _runner = runner;
+        _isElevated = isElevated;
+    }
 
     public event Action<PowerShellLine>? LineReceived
     {
@@ -57,6 +67,8 @@ public sealed partial class UninstallerService
         // Validate packageId before interpolating it into the winget command line.
         if (!WingetId.IsValid(packageId))
             throw new ArgumentException("Invalid package ID.", nameof(packageId));
+
+        EnsureStandardIntegrity();
 
         var args = $"uninstall --id \"{packageId}\" -e --silent --accept-source-agreements --disable-interactivity";
         return await _runner.RunProcessAsync("winget", args, ct).ConfigureAwait(false);
@@ -207,6 +219,8 @@ public sealed partial class UninstallerService
     /// </summary>
     public async Task<int> UninstallLocalAsync(InstalledApp app, CancellationToken ct = default)
     {
+        EnsureStandardIntegrity();
+
         var command = !string.IsNullOrWhiteSpace(app.QuietUninstallString)
             ? app.QuietUninstallString
             : app.UninstallString;
@@ -219,13 +233,11 @@ public sealed partial class UninstallerService
         // Handles both quoted paths ("C:\path\uninstall.exe" /S) and unquoted.
         var (exe, args) = ParseUninstallCommand(command);
 
-        // SEC-LPE: capture our own elevation up front. The UninstallString (and any
-        // rundll32 DLL path it carries) comes from a registry key that a standard user
-        // can write — HKCU especially. When SysManager itself runs elevated, executing
-        // a binary from a user-writable location would let an unprivileged attacker who
-        // planted it gain our elevation (local privilege escalation). The trusted-path
-        // checks below therefore tighten when elevated.
-        var isElevated = Helpers.AdminHelper.IsElevated();
+        // Uninstall execution is restricted to a standard-integrity SysManager process
+        // before registry data is parsed. Keep that state explicit for the shared path and
+        // payload validators; the selected uninstaller may request its own elevation later
+        // through the Windows shell.
+        const bool runningElevated = false;
 
         // SEC-002: Validate the executable exists and is a real file (not a
         // script or arbitrary command). HKCU uninstall keys can be modified
@@ -251,34 +263,54 @@ public sealed partial class UninstallerService
             // SEC-LPE: resolving the binary to System32 is NOT enough — rundll32 and
             // MsiExec take their payload from the (HKCU-writable) arguments. rundll32
             // will load ANY DLL at ANY entry point, and MsiExec will run an arbitrary
-            // package; both inherit our elevation. Validate the payload before launch.
-            ValidateTrustedBinaryArgs(resolvedName, args, isElevated);
+            // package. Validate the payload before handing the command to the shell.
+            args = ValidateTrustedBinaryArgs(resolvedName, args, runningElevated);
         }
         else
         {
-            if (!System.IO.File.Exists(exe))
+            // Registry uninstall commands must identify the exact executable. A relative
+            // path would be checked against SysManager's current directory but resolved by
+            // ShellExecute against its working directory, so reject it before any file check.
+            if (!System.IO.Path.IsPathFullyQualified(exe))
+                throw new InvalidOperationException(
+                    $"Uninstall executable path is not absolute: '{exe}'. Refusing to run for security.");
+
+            var fullPath = System.IO.Path.GetFullPath(exe);
+            if (!System.IO.File.Exists(fullPath))
                 throw new InvalidOperationException(
                     $"Uninstall executable not found: '{exe}'. The app may have been removed already.");
 
-            var ext = System.IO.Path.GetExtension(exe);
+            var ext = System.IO.Path.GetExtension(fullPath);
             if (!ext.Equals(".exe", StringComparison.OrdinalIgnoreCase))
                 throw new InvalidOperationException(
                     $"Uninstall target is not an executable (.exe): '{exe}'. Refusing to run for security.");
 
             // SEC-H2 / SEC-LPE: Validate the executable resides under a trusted directory.
             // Registry uninstall keys (especially HKCU) can be modified without admin,
-            // so we must not execute arbitrary paths. Admin-protected dirs (Program Files,
-            // Windows, ProgramData) are always trusted; the user-writable per-user location
-            // (LocalApplicationData) is trusted ONLY when we are not elevated — otherwise an
-            // unprivileged attacker who dropped a binary there would gain our elevation.
-            var fullPath = System.IO.Path.GetFullPath(exe);
-            if (!IsUnderTrustedDirectory(fullPath, isElevated))
+            // so we must not execute arbitrary paths. Windows installation roots are always
+            // trusted; shared and per-user application-data roots are accepted only while
+            // SysManager is at standard integrity.
+            if (!IsUnderTrustedDirectory(fullPath, runningElevated))
                 throw new InvalidOperationException(
                     $"Uninstall executable is outside trusted directories: '{exe}'. Refusing to run for security.");
+
+            // Launch the same canonical path that passed every check above. This binds
+            // validation to execution and avoids current-directory or dot-segment drift.
+            exe = fullPath;
         }
 
         Log.Information("Uninstalling local app '{Name}' via: {Exe} {Args}", app.Name, exe, args);
-        return await _runner.RunProcessAsync(exe, args, ct).ConfigureAwait(false);
+        return await _runner.RunProcessWithShellAsync(exe, args, ct).ConfigureAwait(false);
+    }
+
+    private void EnsureStandardIntegrity()
+    {
+        if (_isElevated())
+        {
+            throw new InvalidOperationException(
+                "Uninstall actions are disabled while SysManager is running as administrator. " +
+                "Reopen SysManager normally so each uninstaller can request only the privileges it needs.");
+        }
     }
 
     /// <summary>
@@ -371,12 +403,10 @@ public sealed partial class UninstallerService
     }
 
     /// <summary>
-    /// Checks whether the given absolute path resides under a trusted directory.
-    /// Admin-protected directories (Program Files, Windows, ProgramData) are always
-    /// trusted. The user-writable per-user location (LocalApplicationData) is trusted
-    /// ONLY when <paramref name="isElevated"/> is false — when we run elevated, a binary
-    /// there could have been planted by an unprivileged attacker, so trusting it would
-    /// be a local privilege-escalation vector (SEC-LPE).
+    /// Checks whether the given absolute path resides under an approved directory.
+    /// Windows installation roots are accepted in either integrity mode. Shared and
+    /// per-user application-data roots are accepted only when <paramref name="isElevated"/>
+    /// is false because their contents can be created by an unprivileged user.
     /// </summary>
     internal static bool IsUnderTrustedDirectory(string fullPath, bool isElevated)
     {
@@ -384,15 +414,17 @@ public sealed partial class UninstallerService
         {
             Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
             Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
-            Environment.GetFolderPath(Environment.SpecialFolder.Windows),
-            Environment.GetEnvironmentVariable("ProgramData") ?? @"C:\ProgramData"
+            Environment.GetFolderPath(Environment.SpecialFolder.Windows)
         };
 
-        // Per-user install locations (e.g. VS Code, Discord) are writable without admin.
-        // Trust them only when we are NOT elevated, so an elevated uninstall can never
-        // execute an attacker-planted binary from a user-writable directory.
+        // Shared and per-user app-data locations can contain user-created payloads.
+        // Accept them only at standard integrity, where executing such a payload cannot
+        // inherit an administrator token from SysManager.
         if (!isElevated)
+        {
+            trustedDirs.Add(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData));
             trustedDirs.Add(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
+        }
 
         // Compare on a directory boundary, not a raw prefix. A bare StartsWith lets
         // "C:\Program Files Evil\x.exe" pass the "C:\Program Files" check — so append
@@ -409,7 +441,7 @@ public sealed partial class UninstallerService
     /// <summary>
     /// SEC-LPE: validates the arguments passed to a trusted system binary (rundll32 /
     /// MsiExec) before launch, because those arguments come from the HKCU-writable
-    /// registry UninstallString and the binary executes them with our elevation.
+    /// registry UninstallString and can select an arbitrary executable payload.
     /// </summary>
     /// <remarks>
     /// rundll32: the leading token (before the first comma) is the DLL path; it must
@@ -417,25 +449,57 @@ public sealed partial class UninstallerService
     /// must be a product-code uninstall (/X{GUID}); anything else (e.g. an arbitrary
     /// package path or /I install) is rejected.
     /// </remarks>
-    internal static void ValidateTrustedBinaryArgs(string resolvedExeName, string args, bool isElevated)
+    internal static string ValidateTrustedBinaryArgs(
+        string resolvedExeName,
+        string args,
+        bool isElevated)
     {
         if (resolvedExeName.Equals("rundll32.exe", StringComparison.OrdinalIgnoreCase))
         {
-            // rundll32 syntax: <dll>[,<entrypoint> [<args>]]. Extract the DLL path.
-            var dll = args.Split(',', 2)[0].Trim().Trim('"');
+            // rundll32 syntax: <dll>[,<entrypoint> [<args>]]. Bind validation and
+            // execution to one canonical DLL path before passing it to the system binary.
+            var commaIndex = args.IndexOf(',');
+            var dllToken = commaIndex >= 0 ? args[..commaIndex] : args;
+            var dll = dllToken.Trim().Trim('"');
             if (string.IsNullOrWhiteSpace(dll))
                 throw new InvalidOperationException(
-                    "rundll32 uninstall command has no DLL path — refusing to run for security.");
+                    "rundll32 uninstall command has no DLL path - refusing to run for security.");
+
+            string dllFullPath;
+            if (System.IO.Path.IsPathFullyQualified(dll))
+            {
+                dllFullPath = System.IO.Path.GetFullPath(dll);
+            }
+            else if (!System.IO.Path.IsPathRooted(dll) &&
+                     !dll.Contains('\\') &&
+                     !dll.Contains('/'))
+            {
+                // Bare DLL names are a common Windows uninstall form. Resolve them only
+                // against System32, never PATH or SysManager's current directory.
+                dllFullPath = System.IO.Path.Combine(Environment.SystemDirectory, dll);
+            }
+            else
+            {
+                throw new InvalidOperationException(
+                    $"rundll32 DLL path is not absolute: '{dll}'. Refusing to run for security.");
+            }
+
+            if (!System.IO.File.Exists(dllFullPath))
+                throw new InvalidOperationException(
+                    $"rundll32 DLL was not found: '{dllFullPath}'. Refusing to run for security.");
 
             // Same SEC-LPE rule as the executable check: a user-writable DLL path is only
             // trusted when not elevated, so rundll32 can't load attacker-planted DLLs with
             // our elevation.
-            var dllFullPath = System.IO.Path.GetFullPath(dll);
             if (!IsUnderTrustedDirectory(dllFullPath, isElevated))
                 throw new InvalidOperationException(
                     $"rundll32 would load a DLL outside trusted directories: '{dll}'. Refusing to run for security.");
+
+            var suffix = commaIndex >= 0 ? args[commaIndex..] : string.Empty;
+            return $"\"{dllFullPath}\"{suffix}";
         }
-        else if (resolvedExeName.Equals("MsiExec.exe", StringComparison.OrdinalIgnoreCase))
+
+        if (resolvedExeName.Equals("MsiExec.exe", StringComparison.OrdinalIgnoreCase))
         {
             // Only allow a product-code uninstall (/X{GUID}); reject arbitrary packages.
             if (!MsiUninstallArgsPattern().IsMatch(args))
@@ -443,12 +507,15 @@ public sealed partial class UninstallerService
                     $"MsiExec uninstall arguments are not a recognized product-code uninstall: '{args}'. " +
                     "Refusing to run for security.");
         }
+
+        return args;
     }
 
     // Matches a product-code uninstall such as "/X{0F2C3A4B-...}" optionally followed
     // by /quiet, /qn, /norestart and similar switches. Requires the /X{GUID} form so a
     // crafted UninstallString cannot make MsiExec run an arbitrary package path.
-    [GeneratedRegex(@"^\s*/x\s*\{[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\}",
-        RegexOptions.IgnoreCase)]
+    [GeneratedRegex(
+        @"^\s*/x\s*\{[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\}(?:\s+/(?:quiet|passive|norestart|promptrestart|forcerestart|q(?:n|b[+!]?|r|f)))*\s*$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex MsiUninstallArgsPattern();
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.56.0</Version>
-    <FileVersion>1.56.0.0</FileVersion>
-    <AssemblyVersion>1.56.0.0</AssemblyVersion>
+    <Version>1.56.1</Version>
+    <FileVersion>1.56.1.0</FileVersion>
+    <AssemblyVersion>1.56.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
@@ -60,8 +60,11 @@ public sealed partial class UninstallerViewModel : ViewModelBase
     /// </summary>
     private bool HasApps => AppCount > 0;
 
-    /// <summary>Uninstall needs both a populated list and no long-running command in flight.</summary>
-    private bool CanUninstall => NotBusy && HasApps;
+    /// <summary>
+    /// Uninstall needs a populated list, no active command, and an unelevated
+    /// SysManager process. The selected package owns any UAC request it needs.
+    /// </summary>
+    private bool CanUninstall => NotBusy && HasApps && !IsElevated;
 
     private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
@@ -79,12 +82,8 @@ public sealed partial class UninstallerViewModel : ViewModelBase
         DeselectAllCommand.NotifyCanExecuteChanged();
     }
 
-    [RelayCommand]
-    private void RelaunchAsAdmin()
-    {
-        if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
-    }
+    partial void OnIsElevatedChanged(bool value) =>
+        UninstallSelectedCommand.NotifyCanExecuteChanged();
 
     [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task ScanAsync()
@@ -151,7 +150,11 @@ public sealed partial class UninstallerViewModel : ViewModelBase
         IsBusy = true;
         _cts?.Dispose();
         _cts = new CancellationTokenSource();
-        int done = 0;
+        int completed = 0;
+        int removed = 0;
+        int failed = 0;
+        int restartRequired = 0;
+        bool cancellationRequested = false;
         UninstallEtaText = string.Empty;
         _uninstallEta.Reset();
 
@@ -159,11 +162,17 @@ public sealed partial class UninstallerViewModel : ViewModelBase
         {
             foreach (var app in toRemove)
             {
-                if (_cts.IsCancellationRequested) break;
-                app.Status = "Uninstalling…";
-                StatusMessage = $"Uninstalling {app.Name} ({done + 1}/{toRemove.Count})…";
-                Progress = (int)(done * 100.0 / toRemove.Count);
+                if (_cts.IsCancellationRequested)
+                {
+                    cancellationRequested = true;
+                    break;
+                }
+
+                app.Status = "Uninstalling...";
+                StatusMessage = $"Uninstalling {app.Name} ({completed + 1}/{toRemove.Count})...";
+                Progress = (int)(completed * 100.0 / toRemove.Count);
                 UninstallEtaText = _uninstallEta.Update(Progress);
+                var currentCompleted = false;
 
                 try
                 {
@@ -172,34 +181,115 @@ public sealed partial class UninstallerViewModel : ViewModelBase
                         ? await _service.UninstallLocalAsync(app, _cts.Token)
                         : await _service.UninstallAsync(app.Id, _cts.Token);
 
-                    if (code == 0)
+                    currentCompleted = true;
+                    if (IsSuccessfulUninstallExitCode(code))
                     {
-                        app.Status = "Removed";
+                        var needsRestart = RequiresRestartAfterUninstall(code);
+                        app.Status = needsRestart ? "Removed - restart required" : "Removed";
+                        removed++;
+                        if (needsRestart)
+                            restartRequired++;
                         AllApps.Remove(app);
                         FilteredApps.Remove(app);
                     }
                     else
                     {
                         app.Status = DescribeUninstallFailure(code, app.Name);
+                        failed++;
                     }
                 }
-                catch (OperationCanceledException) { app.Status = "Cancelled"; break; }
-                catch (InvalidOperationException ex) { app.Status = $"Error: {ex.Message}"; }
+                catch (OperationCanceledException)
+                {
+                    app.Status = "Cancelled";
+                    cancellationRequested = true;
+                    break;
+                }
+                catch (InvalidOperationException ex)
+                {
+                    app.Status = $"Error: {ex.Message}";
+                    failed++;
+                    currentCompleted = !_cts.IsCancellationRequested;
+                }
                 // A failed uninstaller launch (missing/blocked exe) must not abort the
-                // whole batch — record it on the row and continue with the next app.
-                catch (System.ComponentModel.Win32Exception ex) { app.Status = $"Error: {ex.Message}"; }
-                catch (System.IO.IOException ex) { app.Status = $"Error: {ex.Message}"; }
+                // whole batch - record it on the row and continue with the next app.
+                catch (System.ComponentModel.Win32Exception ex)
+                {
+                    app.Status = $"Error: {ex.Message}";
+                    failed++;
+                    currentCompleted = true;
+                }
+                catch (System.IO.IOException ex)
+                {
+                    app.Status = $"Error: {ex.Message}";
+                    failed++;
+                    currentCompleted = true;
+                }
                 // An unparseable package Id (e.g. an ARP GUID) throws ArgumentException from
                 // UninstallAsync before any process runs; record it and continue the batch.
-                catch (ArgumentException ex) { app.Status = $"Error: {ex.Message}"; }
-                done++;
+                catch (ArgumentException ex)
+                {
+                    app.Status = $"Error: {ex.Message}";
+                    failed++;
+                    currentCompleted = true;
+                }
+
+                if (currentCompleted)
+                    completed++;
+
+                Progress = (int)(completed * 100.0 / toRemove.Count);
+                UninstallEtaText = _uninstallEta.Update(Progress);
+
+                if (_cts.IsCancellationRequested && completed < toRemove.Count)
+                {
+                    cancellationRequested = true;
+                    break;
+                }
             }
 
-            Progress = 100;
             UninstallEtaText = string.Empty;
-            StatusMessage = $"Completed {done}/{toRemove.Count} uninstalls.";
-            ToastService.Instance.Show("Uninstall complete", $"Completed {done}/{toRemove.Count} uninstalls");
-            Log.Information("Uninstall batch completed: {Done}/{Total}", done, toRemove.Count);
+            var restartMessage = restartRequired switch
+            {
+                0 => string.Empty,
+                1 => " Restart required for 1 app.",
+                _ => $" Restart required for {restartRequired} apps."
+            };
+            if (cancellationRequested)
+            {
+                StatusMessage = $"Uninstall cancelled after {completed}/{toRemove.Count} completed. Removed {removed}; failed {failed}.{restartMessage}";
+
+                Log.Information(
+                    "Uninstall batch cancelled: {Completed}/{Total} completed, {Removed} removed, {Failed} failed, {RestartRequired} need restart",
+                    completed,
+                    toRemove.Count,
+                    removed,
+                    failed,
+                    restartRequired);
+            }
+            else if (failed > 0)
+            {
+                Progress = 100;
+                StatusMessage = $"Uninstall finished with errors. Removed {removed}; failed {failed}.{restartMessage}";
+
+                Log.Warning(
+                    "Uninstall batch finished with errors: {Removed} removed, {Failed} failed, {RestartRequired} need restart, {Total} total",
+                    removed,
+                    failed,
+                    restartRequired,
+                    toRemove.Count);
+            }
+            else
+            {
+                Progress = 100;
+                StatusMessage = $"Completed {removed}/{toRemove.Count} uninstalls.{restartMessage}";
+                ToastService.Instance.Show(
+                    "Uninstall complete",
+                    $"Completed {removed}/{toRemove.Count} uninstalls.{restartMessage}");
+                Log.Information(
+                    "Uninstall batch completed: {Removed}/{Total}, {RestartRequired} need restart",
+                    removed,
+                    toRemove.Count,
+                    restartRequired);
+            }
         }
         finally
         {
@@ -263,6 +353,13 @@ public sealed partial class UninstallerViewModel : ViewModelBase
         Summary = $"{AppCount} apps{(AllApps.Count != AppCount ? $" (of {AllApps.Count} total)" : "")}";
     }
 
+    // Windows Installer uses 1641 and 3010 for successful removal that requires a restart.
+    private static bool IsSuccessfulUninstallExitCode(int exitCode) =>
+        exitCode is 0 or 1641 or 3010;
+
+    private static bool RequiresRestartAfterUninstall(int exitCode) =>
+        exitCode is 1641 or 3010;
+
     /// <summary>
     /// Translates a winget uninstall exit code into a human-readable message
     /// so the user knows why the uninstall failed and what to try next.
@@ -273,13 +370,12 @@ public sealed partial class UninstallerViewModel : ViewModelBase
         {
             1 => "The app's uninstaller reported a generic error.",
             2 => "The uninstall was cancelled by the user or a UAC prompt was declined.",
-            5 => "Access denied — try running SysManager as Administrator.",
+            5 => "Access denied - retry and accept the uninstaller's Windows UAC prompt, or remove the app from Windows Settings.",
             87 => "Invalid parameter — the app may require a manual uninstall.",
             1602 => "The uninstall was cancelled by the user.",
             1603 => "The app's installer encountered a fatal error during removal.",
             1605 => "The app is not currently installed (already removed?).",
             1618 => "Another installation is in progress — wait and try again.",
-            3010 => "Uninstall succeeded but a reboot is required to complete removal.",
             _ => $"The app's uninstaller returned exit code {exitCode}."
         };
 

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -32,12 +32,10 @@
                 BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Some applications require administrator privileges to uninstall."
+                    <TextBlock Text="Uninstallers request administrator access themselves when needed."
                                Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
                 </StackPanel>
             </DockPanel>
@@ -52,7 +50,7 @@
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center" Foreground="{DynamicResource WarningText}"/>
-                    <TextBlock Text="Running as administrator — you can uninstall any application."
+                    <TextBlock Text="Uninstall is disabled in administrator sessions. Reopen SysManager normally to continue."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>
             </Grid>


### PR DESCRIPTION
## Summary
- block WinGet and registry-backed uninstall actions when SysManager is already elevated, while keeping scans available
- launch validated local uninstallers through Windows ShellExecute so each package owns any UAC request it needs
- bind execution to canonical absolute executable and DLL paths, pin bare rundll32 payloads to System32, and fully anchor the allowed MSI uninstall grammar
- close pre-start, queued-start, late-completion, and partial tree-termination cancellation races
- report failed, cancelled, and restart-required batch outcomes accurately without success-styled notifications
- replace the Uninstaller's administrator relaunch control with integrity-appropriate guidance and command gating

## Security rationale
HKCU uninstall metadata is writable by the current user. An elevated SysManager process must not turn that metadata, or WinGet package metadata, into inherited administrator execution. The service now enforces standard-integrity execution independently of the UI; validated uninstallers may request their own elevation through the normal Windows consent boundary.

## Regression evidence
The test-only baseline commit produced a genuine red CI run: the forged `ProgramData` case and both trailing MSI payload cases failed against the previous implementation. The implementation commit makes those cases pass and adds coverage for elevated service guards, canonical launch binding, relative-path rejection, ShellExecute routing, cancellation ordering, partial tree-termination failure, restart exit codes, batch accounting, command gating, and the two integrity-level UI states.

## Verification
- all four projects pass `dotnet format --verify-no-changes`
- all four projects build in Release with 0 warnings and 0 errors
- deterministic process/service harness: 24/24 checks, repeated twice after the final change
- exact release publish path succeeds without launching the app: single-file executable, version `1.56.1.0`, 80.1 MiB
- author headers, added-line quality scan, propagation scan, identity/leak scan, and `git diff --check` pass
- source review sign-off: security, debugging/cancellation, and WPF surfaces have no confirmed blockers

The formatter also normalized eight pre-existing files required for a clean all-project format gate; those edits are mechanical and behavior-neutral.

## Runtime scope
Application launch and local UI automation are intentionally deferred to the secondary Windows workstation. The pull request CI runs the blocking unit suite and the same-repository UI automation job.