### PR TITLE
fix: isolate elevated PowerShell module discovery

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -135,7 +135,10 @@ Key services:
   auto-downloaded on first use.
 - `PowerShellRunner` — wraps `System.Management.Automation` to run scripts
   and stream output line-by-line. Always launches spawned processes from
-  `System32` so `Access is denied` never bites on `chkdsk` etc.
+  `System32` so `Access is denied` never bites on `chkdsk` etc. Normal sessions
+  use an in-process runspace and retain per-user modules. Elevated sessions use
+  an isolated Windows PowerShell 5.1 child with module discovery limited to canonical
+  machine-owned roots, avoiding process-global environment mutation.
 - `WingetService` — shells out to `winget` and parses its table output.
 - `WindowsUpdateService` — drives Windows Update through the WUA COM API
   (scan, select, install) with progress reporting; backs `WindowsUpdateViewModel`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.56.2] - 2026-07-29
+
+### Security
+- **Blocked per-user PowerShell module hijacking in administrator sessions.** Since the initial v0.3.0 runner, both in-process runspaces and child `powershell.exe` processes inherited the caller's `PSModulePath`, whose first entry normally points to the current user's writable Documents folder. A planted module could therefore be auto-loaded with SysManager's administrator token when a built-in command such as `Get-NetAdapter` was resolved. Elevated in-process work now moves into an isolated Windows PowerShell 5.1 child whose environment contains only canonical machine-owned module roots under Program Files and System32; existing child-process execution receives the same restriction. Normal unelevated sessions retain per-user module support, and the parent process environment is never rewritten.
+
+### Fixed
+- **Kept optional Windows Update history installation on the correct privilege boundary.** SysManager now installs PSWindowsUpdate only from a normal, non-administrator session into the current user's module directory. The installer verifies the canonical PowerShell Gallery endpoint and explicitly selects `PSGallery`; an elevated session refuses the install instead of consuming user-writable PowerShellGet repository state with an administrator token. Failed module imports now expose installation guidance instead of reporting a successful empty history.
+
 ## [1.56.1] - 2026-07-28
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - **Kept optional Windows Update history installation on the correct privilege boundary.** SysManager now installs PSWindowsUpdate only from a normal, non-administrator session into the current user's module directory. The installer verifies the canonical PowerShell Gallery endpoint and explicitly selects `PSGallery`; an elevated session refuses the install instead of consuming user-writable PowerShellGet repository state with an administrator token. Failed module imports now expose installation guidance instead of reporting a successful empty history.
+- **Handled locked-down systems without a working Windows PowerShell 5.1 host.** If policy, installation damage, or a disabled executable prevents the isolated administrator runspace from starting, the runner now maps that failure to the existing unavailable/failed service states. External PowerShell launches remain pinned to the canonical system path even when the host is missing, preventing executable search-order fallback. The runner deliberately does not fall back to an elevated in-process runspace, which would weaken the module-discovery boundary.
+- **Preserved PowerShell parameter and task-result semantics.** Defender mutation scripts now declare every bound parameter instead of silently receiving null variables, and Scheduled Maintenance correctly decodes unsigned high-bit Task Scheduler result codes after out-of-process serialization.
+- **Reported partial elevated operations honestly.** Edge disable/restore now reports failure when its registry policy changes but scheduled-task updates cannot run, and restore-point creation returns a clean failure state when the isolated PowerShell host is unavailable.
 
 ## [1.56.1] - 2026-07-28
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,9 @@ a confirmation before it runs:
 - Reboot detection — toast notification if any update requires reboot
 - Pending-reboot check, update history (last 30 — via PSWindowsUpdate)
 - Admin banner with a one-click "Run as Administrator" relaunch
-- PSWindowsUpdate is optional now (used only for the History view)
+- PSWindowsUpdate is optional now (used only for the History view); install it
+  from a normal, non-administrator SysManager session. The installer validates
+  the official PowerShell Gallery endpoint and uses the current-user module directory
 - **Update timing & deferral** — defer feature updates by N days while security
   patches keep flowing, pause all updates for a bounded window (max 35 days, then
   Windows auto-resumes), or restore defaults. Uses the documented Windows Update

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -97,6 +97,12 @@ What the app can and cannot do by design:
 
 - **PowerShell execution**: Windows Update and SMART features invoke
   PowerShell. Scripts are bundled with the app, not downloaded at runtime.
+  Administrator sessions isolate PowerShell runspaces in Windows PowerShell 5.1
+  child processes whose
+  module discovery is restricted to canonical machine-owned locations under
+  Program Files and System32, without changing the parent process environment.
+  Per-user modules and optional module installation remain available only when
+  the app runs without elevation.
 - **External CLI downloads**: the Ookla speed-test CLI is downloaded from
   `install.speedtest.net` the first time it's used. If that URL changes,
   the feature fails safely rather than substituting an alternative.

--- a/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using System.Reflection;
 using SysManager.Services;
 
@@ -17,6 +18,146 @@ public class PowerShellRunnerTests
         var result = await runner.RunAsync("2 + 2");
         Assert.NotEmpty(result);
         Assert.Equal(4, (int)result[0].BaseObject);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenElevated_IsolatesModuleDiscoveryInChildProcess()
+    {
+        const string marker = "UNTRUSTED_MODULE_EXECUTED";
+        var tempRoot = Path.Combine(
+            Path.GetTempPath(),
+            $"sysmanager-psmodule-test-{Guid.NewGuid():N}");
+        var moduleRoot = Path.Combine(tempRoot, "SysManagerProbe");
+        var parentModulePath = Environment.GetEnvironmentVariable("PSModulePath");
+
+        try
+        {
+            Directory.CreateDirectory(moduleRoot);
+            await File.WriteAllTextAsync(
+                Path.Combine(moduleRoot, "SysManagerProbe.psd1"),
+                "@{ RootModule='SysManagerProbe.psm1'; ModuleVersion='1.0.0'; " +
+                "FunctionsToExport=@('Invoke-SysManagerProbe') }");
+            await File.WriteAllTextAsync(
+                Path.Combine(moduleRoot, "SysManagerProbe.psm1"),
+                $"function Invoke-SysManagerProbe {{ '{marker}' }}; " +
+                "Export-ModuleMember -Function Invoke-SysManagerProbe");
+
+            var inheritedModulePath = string.Join(
+                Path.PathSeparator,
+                new[] { tempRoot, parentModulePath }
+                    .Where(static path => !string.IsNullOrWhiteSpace(path)));
+            Environment.SetEnvironmentVariable("PSModulePath", inheritedModulePath);
+
+            var runner = new PowerShellRunner(
+                action => Task.Run(action),
+                isElevated: static () => true);
+            var sawCommandNotFound = false;
+            runner.LineReceived += line =>
+                sawCommandNotFound |= line.Kind == Models.OutputKind.Error;
+
+            var injectedResult = await runner.RunAsync("Invoke-SysManagerProbe");
+            var trustedResult = await runner.RunAsync(
+                "(Get-Command Get-NetAdapter -ErrorAction Stop).Source");
+
+            Assert.DoesNotContain(injectedResult, item =>
+                string.Equals(item.BaseObject?.ToString(), marker, StringComparison.Ordinal));
+            Assert.True(sawCommandNotFound);
+            Assert.Contains(trustedResult, item =>
+                string.Equals(
+                    item.BaseObject?.ToString(),
+                    "NetAdapter",
+                    StringComparison.OrdinalIgnoreCase));
+            Assert.Equal(
+                inheritedModulePath,
+                Environment.GetEnvironmentVariable("PSModulePath"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PSModulePath", parentModulePath);
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ElevatedPowerShell_WhenStartupWouldRestorePersonalModules_ReassertsTrustedPath()
+    {
+        var machineModulePath = Environment.GetEnvironmentVariable(
+            "PSModulePath",
+            EnvironmentVariableTarget.Machine);
+        var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        Assert.False(string.IsNullOrWhiteSpace(machineModulePath));
+        Assert.False(string.IsNullOrWhiteSpace(documents));
+
+        var suffix = Guid.NewGuid().ToString("N");
+        var moduleName = $"SysManagerPersonalProbe_{suffix}";
+        var commandName = $"Invoke-SysManagerPersonalProbe{suffix}";
+        var marker = $"UNTRUSTED_PERSONAL_MODULE_{suffix}";
+        var windowsPowerShellRoot = Path.Combine(documents, "WindowsPowerShell");
+        var personalModulesRoot = Path.Combine(windowsPowerShellRoot, "Modules");
+        var moduleRoot = Path.Combine(personalModulesRoot, moduleName);
+        var windowsPowerShellRootExisted = Directory.Exists(windowsPowerShellRoot);
+        var personalModulesRootExisted = Directory.Exists(personalModulesRoot);
+        var parentModulePath = Environment.GetEnvironmentVariable("PSModulePath");
+
+        try
+        {
+            Directory.CreateDirectory(moduleRoot);
+            await File.WriteAllTextAsync(
+                Path.Combine(moduleRoot, $"{moduleName}.psd1"),
+                $"@{{ RootModule='{moduleName}.psm1'; ModuleVersion='1.0.0'; " +
+                $"FunctionsToExport=@('{commandName}') }}");
+            await File.WriteAllTextAsync(
+                Path.Combine(moduleRoot, $"{moduleName}.psm1"),
+                $"function {commandName} {{ '{marker}' }}; " +
+                $"Export-ModuleMember -Function {commandName}");
+
+            var runner = new PowerShellRunner(
+                action => Task.Run(action),
+                isElevated: static () => true,
+                trustedPowerShellModulePath: machineModulePath);
+            var lines = new List<Models.PowerShellLine>();
+            runner.LineReceived += lines.Add;
+
+            var runspaceResults = await runner.RunAsync(commandName);
+            Assert.DoesNotContain(
+                runspaceResults,
+                item => string.Equals(
+                    item.BaseObject?.ToString(),
+                    marker,
+                    StringComparison.Ordinal));
+            Assert.Contains(lines, line => line.Kind == Models.OutputKind.Error);
+
+            lines.Clear();
+            var childExitCode = await runner.RunScriptViaPwshAsync(
+                $"$ErrorActionPreference='Stop'; {commandName}");
+            Assert.NotEqual(0, childExitCode);
+            Assert.DoesNotContain(
+                lines,
+                line => line.Text.Contains(marker, StringComparison.Ordinal));
+            Assert.Equal(
+                parentModulePath,
+                Environment.GetEnvironmentVariable("PSModulePath"));
+        }
+        finally
+        {
+            if (Directory.Exists(moduleRoot))
+                Directory.Delete(moduleRoot, recursive: true);
+
+            if (!personalModulesRootExisted &&
+                Directory.Exists(personalModulesRoot) &&
+                !Directory.EnumerateFileSystemEntries(personalModulesRoot).Any())
+            {
+                Directory.Delete(personalModulesRoot);
+            }
+
+            if (!windowsPowerShellRootExisted &&
+                Directory.Exists(windowsPowerShellRoot) &&
+                !Directory.EnumerateFileSystemEntries(windowsPowerShellRoot).Any())
+            {
+                Directory.Delete(windowsPowerShellRoot);
+            }
+        }
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/DefenderServiceTests.cs
+++ b/SysManager/SysManager.Tests/DefenderServiceTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Collections;
 using System.Management.Automation;
 using SysManager.Services;
 
@@ -40,6 +41,21 @@ public class DefenderServiceTests
     {
         Assert.Single(DefenderService.ToStringList(@"C:\One"));
         Assert.Empty(DefenderService.ToStringList(null));
+    }
+
+    [Fact]
+    public void ToStringList_FromRemotingCollectionShape()
+    {
+        var deserialized = new PSObject(new ArrayList
+        {
+            new PSObject(@"C:\Games"),
+            new PSObject(@"D:\Steam"),
+            new PSObject("")
+        });
+
+        var list = DefenderService.ToStringList(deserialized);
+
+        Assert.Equal(new[] { @"C:\Games", @"D:\Steam" }, list);
     }
 
     [Theory]

--- a/SysManager/SysManager.Tests/DefenderServiceTests.cs
+++ b/SysManager/SysManager.Tests/DefenderServiceTests.cs
@@ -3,7 +3,9 @@
 // License: MIT
 
 using System.Collections;
+using System.Collections.ObjectModel;
 using System.Management.Automation;
+using NSubstitute;
 using SysManager.Services;
 
 namespace SysManager.Tests;
@@ -56,6 +58,45 @@ public class DefenderServiceTests
         var list = DefenderService.ToStringList(deserialized);
 
         Assert.Equal(new[] { @"C:\Games", @"D:\Steam" }, list);
+    }
+
+    [Fact]
+    public async Task MutationScripts_DeclareAndBindTheirParameters()
+    {
+        const string path = @"C:\Games";
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunAsync(
+                Arg.Any<string>(),
+                Arg.Any<IDictionary<string, object?>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new Collection<PSObject>());
+        var service = new DefenderService(runner);
+
+        await service.SetPuaProtectionAsync(1);
+        await service.SetControlledFolderAccessAsync(2);
+        await service.AddExclusionPathAsync(path);
+        await service.RemoveExclusionPathAsync(path);
+
+        await runner.Received(1).RunAsync(
+            "param([int]$Value) Set-MpPreference -PUAProtection $Value",
+            Arg.Is<IDictionary<string, object?>?>(values =>
+                values != null && Equals(values["Value"], 1)),
+            Arg.Any<CancellationToken>());
+        await runner.Received(1).RunAsync(
+            "param([int]$Value) Set-MpPreference -EnableControlledFolderAccess $Value",
+            Arg.Is<IDictionary<string, object?>?>(values =>
+                values != null && Equals(values["Value"], 2)),
+            Arg.Any<CancellationToken>());
+        await runner.Received(1).RunAsync(
+            "param([string]$Path) Add-MpPreference -ExclusionPath $Path",
+            Arg.Is<IDictionary<string, object?>?>(values =>
+                values != null && Equals(values["Path"], path)),
+            Arg.Any<CancellationToken>());
+        await runner.Received(1).RunAsync(
+            "param([string]$Path) Remove-MpPreference -ExclusionPath $Path",
+            Arg.Is<IDictionary<string, object?>?>(values =>
+                values != null && Equals(values["Path"], path)),
+            Arg.Any<CancellationToken>());
     }
 
     [Theory]

--- a/SysManager/SysManager.Tests/DnsServiceTests.cs
+++ b/SysManager/SysManager.Tests/DnsServiceTests.cs
@@ -191,6 +191,24 @@ public class DnsServiceTests
         Assert.Equal("Unknown", current);
     }
 
+    [Fact]
+    public async Task GetCurrentDnsAsync_PowerShellHostUnavailable_ReturnsUnavailable()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunAsync(
+                Arg.Any<string>(),
+                Arg.Any<IDictionary<string, object?>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns<Task<Collection<PSObject>>>(
+                _ => throw new RuntimeException(
+                    "Windows PowerShell 5.1 is unavailable."));
+        using var svc = new DnsService(runner);
+
+        var current = await svc.GetCurrentDnsAsync();
+
+        Assert.Equal("Unavailable", current);
+    }
+
     // ---------- presets (pure) ----------
 
     [Fact]

--- a/SysManager/SysManager.Tests/EdgeOneDriveServiceTests.cs
+++ b/SysManager/SysManager.Tests/EdgeOneDriveServiceTests.cs
@@ -131,6 +131,45 @@ public sealed class EdgeOneDriveServiceTests : IDisposable
             Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task DisableEdgeAsync_TaskMutationFails_ReturnsFailedInsteadOfPartialSuccess()
+    {
+        _runner.RunAsync(
+                Arg.Any<string>(),
+                Arg.Any<IDictionary<string, object?>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns<Task<Collection<PSObject>>>(
+                _ => throw new RuntimeException("Windows PowerShell is unavailable."));
+
+        var outcome = await _svc.DisableEdgeAsync();
+
+        Assert.Equal(EdgeOneDriveOutcome.Failed, outcome);
+        Assert.Equal(0, ReadEdgePolicy("BackgroundModeEnabled"));
+        Assert.Equal(0, ReadEdgePolicy("StartupBoostEnabled"));
+    }
+
+    [Fact]
+    public async Task RestoreEdgeAsync_TaskMutationFails_ReturnsFailedInsteadOfPartialSuccess()
+    {
+        using (var key = _root.CreateSubKey(EdgePolicyPath, writable: true)!)
+        {
+            key.SetValue("BackgroundModeEnabled", 0, RegistryValueKind.DWord);
+            key.SetValue("StartupBoostEnabled", 0, RegistryValueKind.DWord);
+        }
+        _runner.RunAsync(
+                Arg.Any<string>(),
+                Arg.Any<IDictionary<string, object?>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns<Task<Collection<PSObject>>>(
+                _ => throw new RuntimeException("Windows PowerShell is unavailable."));
+
+        var outcome = await _svc.RestoreEdgeAsync();
+
+        Assert.Equal(EdgeOneDriveOutcome.Failed, outcome);
+        Assert.Null(ReadEdgePolicy("BackgroundModeEnabled"));
+        Assert.Null(ReadEdgePolicy("StartupBoostEnabled"));
+    }
+
     // ── GetStatusAsync reads the redirected registry back ───────────────────
 
     [Fact]

--- a/SysManager/SysManager.Tests/MaintenanceSchedulerServiceTests.cs
+++ b/SysManager/SysManager.Tests/MaintenanceSchedulerServiceTests.cs
@@ -126,6 +126,17 @@ public class MaintenanceSchedulerServiceTests
     }
 
     [Fact]
+    public async Task GetStatusAsync_MapsUnsignedFailureResultFromRemoting()
+    {
+        var (svc, _) = NewService(
+            StatusRow("Ready", unchecked((uint)0x80070002)));
+
+        var status = await svc.GetStatusAsync();
+
+        Assert.Equal("Last run failed (file not found)", status.LastResultDescription);
+    }
+
+    [Fact]
     public async Task GetStatusAsync_PowerShellThrows_ReturnsExistsFalse()
     {
         var ps = Substitute.For<IPowerShellRunner>();

--- a/SysManager/SysManager.Tests/PowerShellRunnerTests.cs
+++ b/SysManager/SysManager.Tests/PowerShellRunnerTests.cs
@@ -4,6 +4,8 @@
 
 using System.Diagnostics;
 using System.IO;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
 using System.Reflection;
 using SysManager.Services;
 
@@ -115,6 +117,200 @@ public class PowerShellRunnerTests
         Assert.Equal(
             "$env:PSModulePath='C:\\Program Files\\Owner''s Modules';",
             assignment);
+    }
+
+    [Fact]
+    public async Task RunAsync_ElevatedHostOpenFailure_IsNormalizedToRuntimeException()
+    {
+        var runner = CreateRunnerWithOpenFailure(
+            new PSInvalidOperationException("Windows PowerShell was blocked."));
+
+        var exception = await Assert.ThrowsAsync<RuntimeException>(
+            () => runner.RunAsync("'never-runs'"));
+
+        Assert.Contains(
+            "Windows PowerShell 5.1 is unavailable",
+            exception.Message,
+            StringComparison.Ordinal);
+        Assert.IsType<PSInvalidOperationException>(exception.InnerException);
+    }
+
+    [Fact]
+    public async Task RunAsync_ElevatedTransportFailure_IsNormalizedToRuntimeException()
+    {
+        var runner = CreateRunnerWithOpenFailure(
+            new System.Management.Automation.Remoting.PSRemotingTransportException(
+                "The child-process transport failed."));
+
+        var exception = await Assert.ThrowsAsync<RuntimeException>(
+            () => runner.RunAsync("'never-runs'"));
+
+        Assert.Contains(
+            "Windows PowerShell 5.1 is unavailable",
+            exception.Message,
+            StringComparison.Ordinal);
+        Assert.IsType<System.Management.Automation.Remoting.PSRemotingTransportException>(
+            exception.InnerException);
+    }
+
+    [Fact]
+    public async Task RunAsync_ElevatedHostCreationFailure_IsNormalizedToRuntimeException()
+    {
+        var failure = new PSInvalidOperationException(
+            "Windows PowerShell is unavailable.");
+        var runner = new PowerShellRunner(
+            action => Task.Run(action),
+            isElevated: static () => true,
+            trustedPowerShellModulePath:
+                @"C:\Program Files\WindowsPowerShell\Modules;" +
+                @"C:\Windows\System32\WindowsPowerShell\v1.0\Modules",
+            createRunspace: () => throw failure);
+
+        var exception = await Assert.ThrowsAsync<RuntimeException>(
+            () => runner.RunAsync("'never-runs'"));
+
+        Assert.Contains(
+            "Windows PowerShell 5.1 is unavailable",
+            exception.Message,
+            StringComparison.Ordinal);
+        Assert.Same(failure, exception.InnerException);
+    }
+
+    [Fact]
+    public async Task RunAsync_ElevatedHostRegistrationFailure_IsNormalizedToRuntimeException()
+    {
+        var registrationFailure = new System.Security.SecurityException(
+            "Windows PowerShell registration is inaccessible.");
+        var failure = new TypeInitializationException(
+            typeof(PowerShellProcessInstance).FullName,
+            registrationFailure);
+        var runner = new PowerShellRunner(
+            action => Task.Run(action),
+            isElevated: static () => true,
+            trustedPowerShellModulePath:
+                @"C:\Program Files\WindowsPowerShell\Modules;" +
+                @"C:\Windows\System32\WindowsPowerShell\v1.0\Modules",
+            createRunspace: () => throw failure);
+
+        var exception = await Assert.ThrowsAsync<RuntimeException>(
+            () => runner.RunAsync("'never-runs'"));
+
+        var wrappedFailure = Assert.IsType<TypeInitializationException>(
+            exception.InnerException);
+        Assert.Same(failure, wrappedFailure);
+        Assert.Same(registrationFailure, wrappedFailure.InnerException);
+    }
+
+    [Fact]
+    public async Task RunAsync_ElevatedHostOpenFailure_DisposesInjectedProcessResources()
+    {
+        var order = new List<string>();
+        var processInstance = new RecordingDisposable("process instance", order);
+        var process = new RecordingDisposable("process", order);
+        var runspace = RunspaceFactory.CreateRunspace(InitialSessionState.Create());
+        var runner = new PowerShellRunner(
+            action => Task.Run(action),
+            isElevated: static () => true,
+            trustedPowerShellModulePath:
+                @"C:\Program Files\WindowsPowerShell\Modules;" +
+                @"C:\Windows\System32\WindowsPowerShell\v1.0\Modules",
+            openRunspace: _ => Task.FromException(
+                new PSInvalidOperationException("Windows PowerShell was blocked.")),
+            createRunspace: () => (runspace, processInstance, process));
+
+        await Assert.ThrowsAsync<RuntimeException>(
+            () => runner.RunAsync("'never-runs'"));
+
+        Assert.Equal(["process instance", "process"], order);
+    }
+
+    [Fact]
+    public void DisposeRunspaceResources_DisposesInDependencyOrder()
+    {
+        var order = new List<string>();
+        var runspace = new RecordingDisposable("runspace", order);
+        var processInstance = new RecordingDisposable("process instance", order);
+        var process = new RecordingDisposable("process", order);
+
+        PowerShellRunner.DisposeRunspaceResources(
+            runspace,
+            processInstance,
+            process);
+
+        Assert.Equal(
+            ["runspace", "process instance", "process"],
+            order);
+    }
+
+    [Fact]
+    public void DisposeRunspaceResources_RunspaceDisposeFails_StillDisposesProcessResources()
+    {
+        var order = new List<string>();
+        var failure = new InvalidOperationException("Runspace disposal failed.");
+        var runspace = new RecordingDisposable("runspace", order, failure);
+        var processInstance = new RecordingDisposable("process instance", order);
+        var process = new RecordingDisposable("process", order);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            PowerShellRunner.DisposeRunspaceResources(
+                runspace,
+                processInstance,
+                process));
+
+        Assert.Same(failure, exception);
+        Assert.Equal(
+            ["runspace", "process instance", "process"],
+            order);
+    }
+
+    [Fact]
+    public async Task DefenderStatus_ElevatedHostOpenFailure_ReturnsUnavailable()
+    {
+        var runner = CreateRunnerWithOpenFailure(
+            new PSInvalidOperationException("Windows PowerShell was blocked."));
+        var service = new DefenderService(runner);
+
+        var status = await service.GetStatusAsync();
+
+        Assert.False(status.Available);
+    }
+
+    [Fact]
+    public async Task DnsStatus_ElevatedHostOpenFailure_ReturnsUnavailable()
+    {
+        var runner = CreateRunnerWithOpenFailure(
+            new PSInvalidOperationException("Windows PowerShell was blocked."));
+        using var service = new DnsService(runner);
+
+        var status = await service.GetCurrentDnsAsync();
+
+        Assert.Equal("Unavailable", status);
+    }
+
+    private static PowerShellRunner CreateRunnerWithOpenFailure(Exception exception)
+    {
+        var runspace = RunspaceFactory.CreateRunspace(InitialSessionState.Create());
+        return new PowerShellRunner(
+            action => Task.Run(action),
+            isElevated: static () => true,
+            trustedPowerShellModulePath:
+                @"C:\Program Files\WindowsPowerShell\Modules;" +
+                @"C:\Windows\System32\WindowsPowerShell\v1.0\Modules",
+            openRunspace: _ => Task.FromException(exception),
+            createRunspace: () => (runspace, null, null));
+    }
+
+    private sealed class RecordingDisposable(
+        string name,
+        ICollection<string> order,
+        Exception? exception = null) : IDisposable
+    {
+        public void Dispose()
+        {
+            order.Add(name);
+            if (exception is not null)
+                throw exception;
+        }
     }
 
     [Theory]

--- a/SysManager/SysManager.Tests/PowerShellRunnerTests.cs
+++ b/SysManager/SysManager.Tests/PowerShellRunnerTests.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Diagnostics;
+using System.IO;
 using System.Reflection;
 using SysManager.Services;
 
@@ -43,6 +45,125 @@ public class PowerShellRunnerTests
     {
         var runner = new PowerShellRunner();
         Assert.NotNull(runner);
+    }
+
+    [Fact]
+    public void BuildTrustedPowerShellModulePath_UsesOnlyMachineOwnedRoots()
+    {
+        var path = PowerShellRunner.BuildTrustedPowerShellModulePath(
+            @"C:\Program Files",
+            @"C:\Windows\System32");
+
+        var roots = path.Split(Path.PathSeparator);
+        Assert.Equal(
+            new[]
+            {
+                @"C:\Program Files\WindowsPowerShell\Modules",
+                @"C:\Windows\System32\WindowsPowerShell\v1.0\Modules",
+                @"C:\Program Files\PowerShell\Modules"
+            },
+            roots);
+        Assert.DoesNotContain(roots, root =>
+            root.Contains(@"C:\Users", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void EnsureDistinctFromMachinePowerShellModulePath_WhenEqual_AppendsMachineOwnedGuard()
+    {
+        const string machinePath =
+            @"C:\Program Files\WindowsPowerShell\Modules;" +
+            @"C:\Windows\System32\WindowsPowerShell\v1.0\Modules";
+
+        var path = PowerShellRunner.EnsureDistinctFromMachinePowerShellModulePath(
+            machinePath,
+            machinePath,
+            @"C:\Program Files");
+
+        Assert.NotEqual(machinePath, path);
+        Assert.Equal(
+            new[]
+            {
+                @"C:\Program Files\WindowsPowerShell\Modules",
+                @"C:\Windows\System32\WindowsPowerShell\v1.0\Modules",
+                @"C:\Program Files\SysManager\PowerShellModules"
+            },
+            path.Split(Path.PathSeparator));
+        Assert.DoesNotContain(
+            path.Split(Path.PathSeparator),
+            root => root.Contains(@"\Users\", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void EnsureDistinctFromMachinePowerShellModulePath_WhenAlreadyDistinct_PreservesPath()
+    {
+        const string trustedPath = @"C:\Program Files\WindowsPowerShell\Modules";
+
+        var path = PowerShellRunner.EnsureDistinctFromMachinePowerShellModulePath(
+            trustedPath,
+            @"C:\Windows\System32\WindowsPowerShell\v1.0\Modules",
+            @"C:\Program Files");
+
+        Assert.Equal(trustedPath, path);
+    }
+
+    [Fact]
+    public void BuildPowerShellModulePathAssignment_EscapesSingleQuotes()
+    {
+        var assignment = PowerShellRunner.BuildPowerShellModulePathAssignment(
+            @"C:\Program Files\Owner's Modules");
+
+        Assert.Equal(
+            "$env:PSModulePath='C:\\Program Files\\Owner''s Modules';",
+            assignment);
+    }
+
+    [Theory]
+    [InlineData("powershell")]
+    [InlineData("powershell.exe")]
+    [InlineData(@"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe")]
+    [InlineData("pwsh")]
+    [InlineData("pwsh.exe")]
+    public void ApplyTrustedPowerShellModulePath_ElevatedPowerShellChild_ReplacesInheritedValue(
+        string executable)
+    {
+        const string inheritedPath = @"C:\Users\Example\Documents\WindowsPowerShell\Modules";
+        const string trustedPath = @"C:\Program Files\WindowsPowerShell\Modules";
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executable,
+            UseShellExecute = false
+        };
+        startInfo.Environment["PSModulePath"] = inheritedPath;
+
+        PowerShellRunner.ApplyTrustedPowerShellModulePath(
+            startInfo,
+            isElevated: true,
+            trustedPath);
+
+        Assert.Equal(trustedPath, startInfo.Environment["PSModulePath"]);
+    }
+
+    [Theory]
+    [InlineData(false, "powershell.exe")]
+    [InlineData(true, "cmd.exe")]
+    public void ApplyTrustedPowerShellModulePath_NonPrivilegedBoundary_PreservesInheritedValue(
+        bool isElevated,
+        string executable)
+    {
+        const string inheritedPath = @"C:\Users\Example\Documents\WindowsPowerShell\Modules";
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executable,
+            UseShellExecute = false
+        };
+        startInfo.Environment["PSModulePath"] = inheritedPath;
+
+        PowerShellRunner.ApplyTrustedPowerShellModulePath(
+            startInfo,
+            isElevated,
+            @"C:\Program Files\WindowsPowerShell\Modules");
+
+        Assert.Equal(inheritedPath, startInfo.Environment["PSModulePath"]);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/RestorePointServiceTests.cs
+++ b/SysManager/SysManager.Tests/RestorePointServiceTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Management.Automation;
+using NSubstitute;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -92,6 +93,24 @@ public class RestorePointServiceTests
     [Fact]
     public void Parse_EmptyInput_ReturnsEmpty()
         => Assert.Empty(RestorePointService.ParseRestorePoints([]));
+
+    [Fact]
+    public async Task CreateAsync_PowerShellHostUnavailable_ReturnsFalse()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunAsync(
+                Arg.Any<string>(),
+                Arg.Any<IDictionary<string, object?>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns<Task<System.Collections.ObjectModel.Collection<PSObject>>>(
+                _ => throw new RuntimeException(
+                    "Windows PowerShell 5.1 is unavailable."));
+        var service = new RestorePointService(runner);
+
+        var created = await service.CreateAsync("Before changes");
+
+        Assert.False(created);
+    }
 
     // ---------- TypeDisplay mapping ----------
 

--- a/SysManager/SysManager.Tests/SystemPathsTests.cs
+++ b/SysManager/SysManager.Tests/SystemPathsTests.cs
@@ -48,6 +48,27 @@ public class SystemPathsTests
         Assert.EndsWith("powershell.exe", resolved, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData("powershell")]
+    [InlineData("powershell.exe")]
+    [InlineData("POWERSHELL.EXE")]
+    public void ResolveSystemTool_PowerShellMissing_ReturnsRootedFailClosedPath(string name)
+    {
+        const string trustedSystemDirectory = @"C:\TrustedWindows\System32";
+
+        var resolved = SystemPaths.ResolveSystemTool(
+            name,
+            trustedSystemDirectory,
+            static _ => false);
+
+        Assert.Equal(
+            @"C:\TrustedWindows\System32\WindowsPowerShell\v1.0\powershell.exe",
+            resolved,
+            ignoreCase: true);
+        Assert.True(Path.IsPathRooted(resolved));
+        Assert.NotEqual(name, resolved);
+    }
+
     [Fact]
     public void ResolveSystemTool_BareSystem32NameWithoutExe_ResolvesToRootedExistingPath()
     {

--- a/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
+++ b/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
@@ -57,6 +57,255 @@ public class WindowsUpdateViewModelTests
         Assert.Equal(0, vm.UpdateCount);
     }
 
+    [Fact]
+    public void PsWindowsUpdateInstallScript_PinsGalleryAndUsesCurrentUserScope()
+    {
+        Assert.Contains(
+            "https://www.powershellgallery.com/api/v2",
+            WindowsUpdateViewModel.PsWindowsUpdateInstallScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "$ErrorActionPreference = 'Stop'",
+            WindowsUpdateViewModel.PsWindowsUpdateInstallScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Install-PackageProvider -Name NuGet -Force -Scope CurrentUser",
+            WindowsUpdateViewModel.PsWindowsUpdateInstallScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Install-Module -Name PSWindowsUpdate -Force -Scope CurrentUser -Repository PSGallery",
+            WindowsUpdateViewModel.PsWindowsUpdateInstallScript,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "AllUsers",
+            WindowsUpdateViewModel.PsWindowsUpdateInstallScript,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task InstallModule_WhenElevated_RefusesWithoutRunningPowerShell()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        var vm = new WindowsUpdateViewModel(
+            runner,
+            new WindowsUpdateService(),
+            new WindowsUpdatePolicyService(),
+            static () => true);
+
+        await vm.InstallModuleCommand.ExecuteAsync(null);
+
+        await runner.DidNotReceiveWithAnyArgs()
+            .RunScriptViaPwshAsync(default!, default);
+        Assert.Contains("non-administrator", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task InstallModule_WhenNotElevated_RunsPinnedCurrentUserInstall()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunScriptViaPwshAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(0);
+        var vm = new WindowsUpdateViewModel(
+            runner,
+            new WindowsUpdateService(),
+            new WindowsUpdatePolicyService(),
+            static () => false);
+
+        await vm.InstallModuleCommand.ExecuteAsync(null);
+
+        await runner.Received(1).RunScriptViaPwshAsync(
+            Arg.Is<string>(script =>
+                script != null &&
+                script.Contains("-Scope CurrentUser", StringComparison.Ordinal) &&
+                script.Contains("-Repository PSGallery", StringComparison.Ordinal)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallModule_WhenPowerShellFails_ExposesFailureAndModuleRemediation()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunScriptViaPwshAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(1);
+        var vm = new WindowsUpdateViewModel(
+            runner,
+            new WindowsUpdateService(),
+            new WindowsUpdatePolicyService(),
+            static () => false);
+
+        await vm.InstallModuleCommand.ExecuteAsync(null);
+
+        Assert.False(vm.ModuleAvailable);
+        Assert.Contains("failed", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        await runner.Received(1).RunScriptViaPwshAsync(
+            WindowsUpdateViewModel.PsWindowsUpdateInstallScript,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ShowHistory_WhenModuleImportFails_DoesNotReportEmptySuccess()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunScriptViaPwshAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(WindowsUpdateViewModel.HistoryModuleImportFailedExitCode);
+        var vm = new WindowsUpdateViewModel(
+            runner,
+            new WindowsUpdateService(),
+            new WindowsUpdatePolicyService(),
+            static () => false);
+        vm.Updates.Add(new UpdateEntry { Title = "Previous result" });
+        vm.UpdateCount = 1;
+        vm.TableSummary = "1 history entries.";
+
+        await vm.ShowHistoryCommand.ExecuteAsync(null);
+
+        Assert.False(vm.ModuleAvailable);
+        Assert.Empty(vm.Updates);
+        Assert.Equal(0, vm.UpdateCount);
+        Assert.Equal("Update history unavailable.", vm.TableSummary);
+        Assert.Contains("not installed", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.True(vm.ShowConsole);
+        Assert.NotEqual("Done", vm.StatusMessage);
+    }
+
+    [Fact]
+    public async Task ShowHistory_WhenQueryFails_PreservesModuleAvailabilityAndClearsPriorState()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunScriptViaPwshAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(WindowsUpdateViewModel.HistoryQueryFailedExitCode);
+        var vm = new WindowsUpdateViewModel(
+            runner,
+            new WindowsUpdateService(),
+            new WindowsUpdatePolicyService(),
+            static () => false);
+        vm.Updates.Add(new UpdateEntry { Title = "Previous result" });
+        vm.UpdateCount = 1;
+        vm.TableSummary = "1 history entries.";
+
+        await vm.ShowHistoryCommand.ExecuteAsync(null);
+
+        Assert.True(vm.ModuleAvailable);
+        Assert.Empty(vm.Updates);
+        Assert.Equal(0, vm.UpdateCount);
+        Assert.Equal("Update history unavailable.", vm.TableSummary);
+        Assert.Contains("query failed", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("not installed", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.True(vm.ShowConsole);
+        Assert.NotEqual("Done", vm.StatusMessage);
+    }
+
+    [Fact]
+    public void PsWindowsUpdateHistoryScript_UsesDistinctImportAndQueryExitCodes()
+    {
+        Assert.Contains(
+            $"exit {WindowsUpdateViewModel.HistoryModuleImportFailedExitCode}",
+            WindowsUpdateViewModel.PsWindowsUpdateHistoryScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            $"exit {WindowsUpdateViewModel.HistoryQueryFailedExitCode}",
+            WindowsUpdateViewModel.PsWindowsUpdateHistoryScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Get-WUHistory -Last 30 -ErrorAction Stop",
+            WindowsUpdateViewModel.PsWindowsUpdateHistoryScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "[Console]::Error.WriteLine",
+            WindowsUpdateViewModel.PsWindowsUpdateHistoryScript,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "Write-Error",
+            WindowsUpdateViewModel.PsWindowsUpdateHistoryScript,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ShowHistory_WhenOutputIsInvalid_DoesNotReportSuccess()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunScriptViaPwshAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                runner.LineReceived += Raise.Event<Action<PowerShellLine>>(
+                    PowerShellLine.Output("not json"));
+                return 0;
+            });
+        var vm = new WindowsUpdateViewModel(
+            runner,
+            new WindowsUpdateService(),
+            new WindowsUpdatePolicyService(),
+            static () => false);
+        vm.Updates.Add(new UpdateEntry { Title = "Previous result" });
+        vm.UpdateCount = 1;
+        vm.TableSummary = "1 history entries.";
+
+        await vm.ShowHistoryCommand.ExecuteAsync(null);
+
+        Assert.True(vm.ModuleAvailable);
+        Assert.Empty(vm.Updates);
+        Assert.Equal(0, vm.UpdateCount);
+        Assert.Equal("Update history unavailable.", vm.TableSummary);
+        Assert.Contains("invalid data", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.True(vm.ShowConsole);
+        Assert.NotEqual("Done", vm.StatusMessage);
+    }
+
+    [Fact]
+    public async Task ShowHistory_WhenProcessFails_ReportsUnknownAvailabilityAndClearsPriorState()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunScriptViaPwshAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(1);
+        var vm = new WindowsUpdateViewModel(
+            runner,
+            new WindowsUpdateService(),
+            new WindowsUpdatePolicyService(),
+            static () => false);
+        vm.Updates.Add(new UpdateEntry { Title = "Previous result" });
+        vm.UpdateCount = 1;
+
+        await vm.ShowHistoryCommand.ExecuteAsync(null);
+
+        Assert.False(vm.ModuleAvailable);
+        Assert.Empty(vm.Updates);
+        Assert.Equal(0, vm.UpdateCount);
+        Assert.Equal("Update history unavailable.", vm.TableSummary);
+        Assert.Contains("could not be confirmed", vm.ModuleStatus, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("could not be loaded", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.True(vm.ShowConsole);
+        Assert.NotEqual("Done", vm.StatusMessage);
+    }
+
+    [Fact]
+    public async Task ShowHistory_WhenRunnerThrows_ClearsAvailabilityAndPriorState()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunScriptViaPwshAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Task<int>>(_ => throw new InvalidOperationException("process failed"));
+        var vm = new WindowsUpdateViewModel(
+            runner,
+            new WindowsUpdateService(),
+            new WindowsUpdatePolicyService(),
+            static () => false);
+        vm.Updates.Add(new UpdateEntry { Title = "Previous result" });
+        vm.UpdateCount = 1;
+
+        await vm.ShowHistoryCommand.ExecuteAsync(null);
+
+        Assert.False(vm.ModuleAvailable);
+        Assert.Empty(vm.Updates);
+        Assert.Equal(0, vm.UpdateCount);
+        Assert.Equal("Update history unavailable.", vm.TableSummary);
+        Assert.Contains(
+            "could not be confirmed",
+            vm.ModuleStatus,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("process failed", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.True(vm.ShowConsole);
+        Assert.NotEqual("Done", vm.StatusMessage);
+    }
+
     // ---------- commands exist ----------
 
     [Theory]

--- a/SysManager/SysManager/Helpers/SystemPaths.cs
+++ b/SysManager/SysManager/Helpers/SystemPaths.cs
@@ -27,9 +27,17 @@ internal static class SystemPaths
     /// Returns the full trusted path for a bare Windows tool name that exists under System32
     /// (or the boxed Windows PowerShell 5.1 folder). Names that are already rooted / contain a
     /// path separator, or that are not found in a trusted location, are returned unchanged so
-    /// callers of non-system executables and explicit paths are never altered.
+    /// callers of non-system executables and explicit paths are never altered. Windows PowerShell
+    /// is always mapped to its rooted canonical path, even when missing, so execution fails closed
+    /// instead of falling back to the Win32 executable search order.
     /// </summary>
     public static string ResolveSystemTool(string fileName)
+        => ResolveSystemTool(fileName, System32, File.Exists);
+
+    internal static string ResolveSystemTool(
+        string fileName,
+        string systemDirectory,
+        Func<string, bool> fileExists)
     {
         if (string.IsNullOrEmpty(fileName)) return fileName;
         if (Path.IsPathRooted(fileName) || fileName.Contains('\\') || fileName.Contains('/'))
@@ -43,24 +51,26 @@ internal static class SystemPaths
             fileName.Equals("winget.exe", StringComparison.OrdinalIgnoreCase))
             return ResolveWinget();
 
-        // Try the name as given, then with a ".exe" suffix. Callers that pass a bare name
-        // WITHOUT the extension (e.g. "powershell") would otherwise never match on disk —
-        // File.Exists("...\\powershell") is false, only "...\\powershell.exe" exists — so the
-        // method would fall through and return the unrooted bare name, re-opening the exact
-        // binary-planting/LPE vector this helper exists to close. Probing "<name>.exe" as a
-        // fallback makes the guard robust to that mistake (defense-in-depth).
+        if (fileName.Equals("powershell", StringComparison.OrdinalIgnoreCase) ||
+            fileName.Equals("powershell.exe", StringComparison.OrdinalIgnoreCase))
+        {
+            return Path.Combine(
+                systemDirectory,
+                "WindowsPowerShell",
+                "v1.0",
+                "powershell.exe");
+        }
+
+        // Try the name as given, then with a ".exe" suffix so extensionless built-in names
+        // such as "cmd" still resolve to their machine-owned executable.
         var candidates = fileName.Contains('.')
             ? new[] { fileName }
             : new[] { fileName, fileName + ".exe" };
 
         foreach (var name in candidates)
         {
-            var direct = Path.Combine(System32, name);
-            if (File.Exists(direct)) return direct;
-
-            // Windows PowerShell 5.1 lives in a System32 subfolder, not System32 itself.
-            var powerShell = Path.Combine(System32, "WindowsPowerShell", "v1.0", name);
-            if (File.Exists(powerShell)) return powerShell;
+            var direct = Path.Combine(systemDirectory, name);
+            if (fileExists(direct)) return direct;
         }
 
         return fileName;

--- a/SysManager/SysManager/Services/DefenderService.cs
+++ b/SysManager/SysManager/Services/DefenderService.cs
@@ -83,11 +83,11 @@ public sealed class DefenderService
     /// re-read status; compare its PuaProtection to confirm success.
     /// </summary>
     public Task<DefenderStatus> SetPuaProtectionAsync(int value, CancellationToken ct = default)
-        => ApplyAndVerifyAsync("Set-MpPreference -PUAProtection $Value", new() { ["Value"] = ClampTri(value) }, ct);
+        => ApplyAndVerifyAsync("param([int]$Value) Set-MpPreference -PUAProtection $Value", new() { ["Value"] = ClampTri(value) }, ct);
 
     /// <summary>Set Controlled Folder Access (0/1/2) and verify.</summary>
     public Task<DefenderStatus> SetControlledFolderAccessAsync(int value, CancellationToken ct = default)
-        => ApplyAndVerifyAsync("Set-MpPreference -EnableControlledFolderAccess $Value", new() { ["Value"] = ClampTri(value) }, ct);
+        => ApplyAndVerifyAsync("param([int]$Value) Set-MpPreference -EnableControlledFolderAccess $Value", new() { ["Value"] = ClampTri(value) }, ct);
 
     /// <summary>Add a folder exclusion (additive — never replaces the array). Verifies.</summary>
     public Task<DefenderStatus> AddExclusionPathAsync(string path, CancellationToken ct = default)
@@ -97,7 +97,7 @@ public sealed class DefenderService
         // exclusion ("*", "C:\?") can never weaken Defender, even via a non-UI caller.
         if (!IsValidExclusionPath(path))
             throw new ArgumentException("Exclusion path must be a rooted path without wildcards.", nameof(path));
-        return ApplyAndVerifyAsync("Add-MpPreference -ExclusionPath $Path", new() { ["Path"] = path }, ct);
+        return ApplyAndVerifyAsync("param([string]$Path) Add-MpPreference -ExclusionPath $Path", new() { ["Path"] = path }, ct);
     }
 
     /// <summary>
@@ -113,7 +113,7 @@ public sealed class DefenderService
 
     /// <summary>Remove a folder exclusion. Verifies.</summary>
     public Task<DefenderStatus> RemoveExclusionPathAsync(string path, CancellationToken ct = default)
-        => ApplyAndVerifyAsync("Remove-MpPreference -ExclusionPath $Path", new() { ["Path"] = path }, ct);
+        => ApplyAndVerifyAsync("param([string]$Path) Remove-MpPreference -ExclusionPath $Path", new() { ["Path"] = path }, ct);
 
     /// <summary>
     /// Run a hard-coded Set/Add/Remove script with bound parameters (never interpolated),

--- a/SysManager/SysManager/Services/DefenderService.cs
+++ b/SysManager/SysManager/Services/DefenderService.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Collections;
 using System.Collections.ObjectModel;
 using System.Management.Automation;
 using Serilog;
@@ -151,14 +152,28 @@ public sealed class DefenderService
         catch (OverflowException) { return 0; }
     }
 
-    internal static IReadOnlyList<string> ToStringList(object? v)
+    internal static IReadOnlyList<string> ToStringList(object? value)
     {
-        if (v is null) return [];
-        if (v is object[] arr)
-            return arr.Where(x => x is not null).Select(x => x.ToString() ?? "").Where(s => s.Length > 0).ToList();
-        string single = v.ToString() ?? "";
+        value = UnwrapPsObject(value);
+        if (value is null) return [];
+        if (value is string text)
+            return text.Length > 0 ? [text] : [];
+        if (value is IEnumerable values)
+        {
+            return values.Cast<object?>()
+                .Select(UnwrapPsObject)
+                .Where(item => item is not null)
+                .Select(item => item!.ToString() ?? "")
+                .Where(item => item.Length > 0)
+                .ToList();
+        }
+
+        string single = value.ToString() ?? "";
         return single.Length > 0 ? [single] : [];
     }
+
+    private static object? UnwrapPsObject(object? value)
+        => value is PSObject psObject ? psObject.BaseObject : value;
 
     internal static int ClampTri(int value) => value is >= 0 and <= 2 ? value : 0;
 }

--- a/SysManager/SysManager/Services/DnsService.cs
+++ b/SysManager/SysManager/Services/DnsService.cs
@@ -5,6 +5,7 @@
 using System.Collections.ObjectModel;
 using System.Management.Automation;
 using System.Net;
+using Serilog;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -72,6 +73,11 @@ public sealed class DnsService : IDisposable
                 .ConfigureAwait(false);
 
             return results.Count > 0 ? results[0]?.ToString() ?? "Unknown" : "Unknown";
+        }
+        catch (RuntimeException ex)
+        {
+            Log.Debug("DNS status read failed: {Error}", ex.Message);
+            return "Unavailable";
         }
         finally { _gate.Release(); }
     }

--- a/SysManager/SysManager/Services/EdgeOneDriveService.cs
+++ b/SysManager/SysManager/Services/EdgeOneDriveService.cs
@@ -191,7 +191,11 @@ public sealed partial class EdgeOneDriveService
     {
         if (!TrySetEdgeBackgroundDisabled(true)) return EdgeOneDriveOutcome.NeedsAdmin;
         try { await _ps.RunAsync(BuildSetEdgeTasksScript(enabled: false), cancellationToken: ct).ConfigureAwait(false); }
-        catch (System.Management.Automation.RuntimeException ex) { Log.Debug("Edge: disable update tasks failed: {Error}", ex.Message); }
+        catch (System.Management.Automation.RuntimeException ex)
+        {
+            Log.Warning("Edge: policy was disabled, but update tasks could not be disabled: {Error}", ex.Message);
+            return EdgeOneDriveOutcome.Failed;
+        }
         Log.Information("Edge: disabled background/startup-boost and update tasks");
         return EdgeOneDriveOutcome.Success;
     }
@@ -205,7 +209,11 @@ public sealed partial class EdgeOneDriveService
     {
         if (!TrySetEdgeBackgroundDisabled(false)) return EdgeOneDriveOutcome.NeedsAdmin;
         try { await _ps.RunAsync(BuildSetEdgeTasksScript(enabled: true), cancellationToken: ct).ConfigureAwait(false); }
-        catch (System.Management.Automation.RuntimeException ex) { Log.Debug("Edge: enable update tasks failed: {Error}", ex.Message); }
+        catch (System.Management.Automation.RuntimeException ex)
+        {
+            Log.Warning("Edge: policy was restored, but update tasks could not be enabled: {Error}", ex.Message);
+            return EdgeOneDriveOutcome.Failed;
+        }
         Log.Information("Edge: restored background/startup-boost and update tasks");
         return EdgeOneDriveOutcome.Success;
     }

--- a/SysManager/SysManager/Services/IPowerShellRunner.cs
+++ b/SysManager/SysManager/Services/IPowerShellRunner.cs
@@ -33,7 +33,7 @@ public interface IPowerShellRunner
     event Action<int>? ProgressChanged;
 
     /// <summary>
-    /// Execute a script in-process and return the collected PSObject results.
+    /// Execute a script and return the collected PSObject results.
     /// All streams are forwarded via <see cref="LineReceived"/> for live UI display.
     /// </summary>
     Task<Collection<PSObject>> RunAsync(

--- a/SysManager/SysManager/Services/IPowerShellRunner.cs
+++ b/SysManager/SysManager/Services/IPowerShellRunner.cs
@@ -34,6 +34,10 @@ public interface IPowerShellRunner
 
     /// <summary>
     /// Execute a script and return the collected PSObject results.
+    /// When SysManager is elevated, execution uses Windows PowerShell 5.1 and crosses
+    /// an out-of-process remoting boundary. Scripts must remain PowerShell 5.1-compatible,
+    /// project complex results to explicit properties, and callers must not rely on live
+    /// object identity or methods after deserialization.
     /// All streams are forwarded via <see cref="LineReceived"/> for live UI display.
     /// </summary>
     Task<Collection<PSObject>> RunAsync(

--- a/SysManager/SysManager/Services/MaintenanceSchedulerService.cs
+++ b/SysManager/SysManager/Services/MaintenanceSchedulerService.cs
@@ -164,10 +164,17 @@ public sealed class MaintenanceSchedulerService
 
     private static string DescribeResult(PSObject row)
     {
-        var v = row.Properties["LastTaskResult"]?.Value;
-        if (v is null) return DescribeResultCode(null);
-        if (v is int i) return DescribeResultCode(i);
-        return int.TryParse(v.ToString(), out var parsed) ? DescribeResultCode(parsed) : DescribeResultCode(null);
+        var value = row.Properties["LastTaskResult"]?.Value;
+        if (value is null) return DescribeResultCode(null);
+        if (value is int signed) return DescribeResultCode(signed);
+        if (value is uint unsigned) return DescribeResultCode(unchecked((int)unsigned));
+
+        var text = value.ToString();
+        if (int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out signed))
+            return DescribeResultCode(signed);
+        return uint.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out unsigned)
+            ? DescribeResultCode(unchecked((int)unsigned))
+            : DescribeResultCode(null);
     }
 
     private static string? Str(PSObject? obj, string property) => obj?.Properties[property]?.Value?.ToString();

--- a/SysManager/SysManager/Services/PowerShellRunner.cs
+++ b/SysManager/SysManager/Services/PowerShellRunner.cs
@@ -28,6 +28,8 @@ public sealed class PowerShellRunner : IPowerShellRunner
     private readonly Func<Action, Task> _scheduleProcessStart;
     private readonly Func<System.Diagnostics.Process, CancellationToken, Task> _waitForProcessExit;
     private readonly Action<System.Diagnostics.Process> _terminateProcessTree;
+    private readonly Func<Runspace, Task> _openRunspace;
+    private readonly Func<(Runspace Runspace, IDisposable? ProcessInstance, IDisposable? Process)> _createRunspace;
     private readonly bool _isElevated;
     private readonly string _trustedPowerShellModulePath;
 
@@ -41,7 +43,9 @@ public sealed class PowerShellRunner : IPowerShellRunner
         Func<System.Diagnostics.Process, CancellationToken, Task>? waitForProcessExit = null,
         Action<System.Diagnostics.Process>? terminateProcessTree = null,
         Func<bool>? isElevated = null,
-        string? trustedPowerShellModulePath = null)
+        string? trustedPowerShellModulePath = null,
+        Func<Runspace, Task>? openRunspace = null,
+        Func<(Runspace Runspace, IDisposable? ProcessInstance, IDisposable? Process)>? createRunspace = null)
     {
         _scheduleProcessStart = scheduleProcessStart
             ?? throw new ArgumentNullException(nameof(scheduleProcessStart));
@@ -49,6 +53,8 @@ public sealed class PowerShellRunner : IPowerShellRunner
             ?? (static (process, cancellationToken) => process.WaitForExitAsync(cancellationToken));
         _terminateProcessTree = terminateProcessTree
             ?? (static process => process.Kill(entireProcessTree: true));
+        _openRunspace = openRunspace
+            ?? (static runspace => Task.Run(() => runspace.Open()));
 
         var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
         _isElevated = (isElevated ?? Helpers.AdminHelper.IsElevated)();
@@ -62,6 +68,7 @@ public sealed class PowerShellRunner : IPowerShellRunner
                 "PSModulePath",
                 EnvironmentVariableTarget.Machine),
             programFiles);
+        _createRunspace = createRunspace ?? CreateRunspace;
     }
 
     /// <summary>
@@ -102,12 +109,11 @@ public sealed class PowerShellRunner : IPowerShellRunner
         IDictionary<string, object?>? parameters = null,
         CancellationToken cancellationToken = default)
     {
-        var (runspace, processInstance) = CreateRunspace();
-        using var processLifetime = processInstance;
-        using var runspaceLifetime = runspace;
+        using var resources = CreateRunspaceResources();
+        var runspace = resources.Runspace;
         // Open the runspace on a thread-pool thread — this can take
         // several hundred milliseconds and must not block the UI.
-        await Task.Run(() => runspace.Open()).ConfigureAwait(false);
+        await OpenRunspaceAsync(runspace).ConfigureAwait(false);
 
         using var ps = PowerShell.Create();
         ps.Runspace = runspace;
@@ -472,13 +478,13 @@ public sealed class PowerShellRunner : IPowerShellRunner
         return $"$env:PSModulePath='{escapedPath}';";
     }
 
-    private (Runspace Runspace, PowerShellProcessInstance? ProcessInstance) CreateRunspace()
+    private (Runspace Runspace, IDisposable? ProcessInstance, IDisposable? Process) CreateRunspace()
     {
         if (!_isElevated)
         {
             var initialSessionState = InitialSessionState.CreateDefault2();
             initialSessionState.ExecutionPolicy = Microsoft.PowerShell.ExecutionPolicy.Bypass;
-            return (RunspaceFactory.CreateRunspace(initialSessionState), null);
+            return (RunspaceFactory.CreateRunspace(initialSessionState), null, null);
         }
 
         var processInstance = new PowerShellProcessInstance(
@@ -487,6 +493,7 @@ public sealed class PowerShellRunner : IPowerShellRunner
             initializationScript: ScriptBlock.Create(
                 BuildPowerShellModulePathAssignment(_trustedPowerShellModulePath)),
             useWow64: false);
+        var process = processInstance.Process;
         Runspace? runspace = null;
         try
         {
@@ -498,13 +505,101 @@ public sealed class PowerShellRunner : IPowerShellRunner
             runspace = RunspaceFactory.CreateOutOfProcessRunspace(
                 TypeTable.LoadDefaultTypeFiles(),
                 processInstance);
-            return (runspace, processInstance);
+            return (runspace, processInstance, process);
         }
         finally
         {
             if (runspace is null)
-                processInstance.Dispose();
+                DisposeRunspaceResources(null, processInstance, process);
         }
+    }
+
+    private RunspaceResources CreateRunspaceResources()
+    {
+        try
+        {
+            var (runspace, processInstance, process) = _createRunspace();
+            return new RunspaceResources(runspace, processInstance, process);
+        }
+        catch (Exception ex) when (_isElevated && IsPowerShellHostUnavailable(ex))
+        {
+            throw CreatePowerShellHostUnavailableException(ex);
+        }
+    }
+
+    private async Task OpenRunspaceAsync(Runspace runspace)
+    {
+        try
+        {
+            await _openRunspace(runspace).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (_isElevated && IsPowerShellHostUnavailable(ex))
+        {
+            // Keep the isolation boundary fail-closed. Callers already map RuntimeException
+            // to their established unavailable/failed states; an in-process fallback here
+            // would reintroduce per-user module discovery under the administrator token.
+            throw CreatePowerShellHostUnavailableException(ex);
+        }
+    }
+
+    private static bool IsPowerShellHostUnavailable(Exception exception)
+        => exception is System.Management.Automation.Remoting.PSRemotingTransportException or
+            PSInvalidOperationException or
+            System.ComponentModel.Win32Exception or
+            System.IO.FileNotFoundException or
+            UnauthorizedAccessException ||
+            exception is TypeInitializationException { InnerException: { } innerException } &&
+            (IsPowerShellHostUnavailable(innerException) ||
+             innerException is ArgumentException or
+                 System.Security.SecurityException or
+                 System.IO.IOException);
+
+    private static RuntimeException CreatePowerShellHostUnavailableException(Exception innerException)
+        => new(
+            "Windows PowerShell 5.1 is unavailable or blocked by system policy.",
+            innerException);
+
+    internal static void DisposeRunspaceResources(
+        IDisposable? runspace,
+        IDisposable? processInstance,
+        IDisposable? process)
+    {
+        try
+        {
+            runspace?.Dispose();
+        }
+        finally
+        {
+            try
+            {
+                processInstance?.Dispose();
+            }
+            finally
+            {
+                process?.Dispose();
+            }
+        }
+    }
+
+    private sealed class RunspaceResources : IDisposable
+    {
+        private readonly IDisposable? _processInstance;
+        private readonly IDisposable? _process;
+
+        public RunspaceResources(
+            Runspace runspace,
+            IDisposable? processInstance,
+            IDisposable? process)
+        {
+            Runspace = runspace ?? throw new ArgumentNullException(nameof(runspace));
+            _processInstance = processInstance;
+            _process = process;
+        }
+
+        public Runspace Runspace { get; }
+
+        public void Dispose()
+            => DisposeRunspaceResources(Runspace, _processInstance, _process);
     }
 
     internal static void ApplyTrustedPowerShellModulePath(

--- a/SysManager/SysManager/Services/PowerShellRunner.cs
+++ b/SysManager/SysManager/Services/PowerShellRunner.cs
@@ -10,13 +10,13 @@ using SysManager.Models;
 namespace SysManager.Services;
 
 /// <summary>
-/// Runs PowerShell scripts in-process with live streaming of all output streams.
-/// Uses System.Management.Automation so we don't spawn external pwsh.exe processes.
+/// Runs PowerShell scripts with live streaming of all output streams. Normal sessions
+/// use an in-process runspace; elevated sessions use an isolated Windows PowerShell 5.1
+/// child so per-user module paths never enter an administrator runspace.
 ///
-/// <para><b>Security note (SEC-005 / SEC-M8):</b> ExecutionPolicy is set to Bypass for
-/// in-process runspaces because SysManager only executes its own static scripts — never
-/// user-supplied or downloaded scripts. RunScriptViaPwshAsync also uses -ExecutionPolicy
-/// Bypass for the same reason.</para>
+/// <para><b>Security note (SEC-005 / SEC-M8):</b> ExecutionPolicy is set to Bypass because
+/// SysManager only executes its own static scripts — never user-supplied or downloaded
+/// scripts. Elevated child processes also receive a machine-owned-only module path.</para>
 ///
 /// <para><b>SECURITY CONTRACT:</b> Callers MUST only pass hard-coded script strings to
 /// RunAsync and RunScriptViaPwshAsync. User input MUST NEVER be interpolated into scripts.
@@ -28,6 +28,8 @@ public sealed class PowerShellRunner : IPowerShellRunner
     private readonly Func<Action, Task> _scheduleProcessStart;
     private readonly Func<System.Diagnostics.Process, CancellationToken, Task> _waitForProcessExit;
     private readonly Action<System.Diagnostics.Process> _terminateProcessTree;
+    private readonly bool _isElevated;
+    private readonly string _trustedPowerShellModulePath;
 
     public PowerShellRunner()
         : this(action => Task.Run(action))
@@ -37,7 +39,9 @@ public sealed class PowerShellRunner : IPowerShellRunner
     internal PowerShellRunner(
         Func<Action, Task> scheduleProcessStart,
         Func<System.Diagnostics.Process, CancellationToken, Task>? waitForProcessExit = null,
-        Action<System.Diagnostics.Process>? terminateProcessTree = null)
+        Action<System.Diagnostics.Process>? terminateProcessTree = null,
+        Func<bool>? isElevated = null,
+        string? trustedPowerShellModulePath = null)
     {
         _scheduleProcessStart = scheduleProcessStart
             ?? throw new ArgumentNullException(nameof(scheduleProcessStart));
@@ -45,6 +49,19 @@ public sealed class PowerShellRunner : IPowerShellRunner
             ?? (static (process, cancellationToken) => process.WaitForExitAsync(cancellationToken));
         _terminateProcessTree = terminateProcessTree
             ?? (static process => process.Kill(entireProcessTree: true));
+
+        var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        _isElevated = (isElevated ?? Helpers.AdminHelper.IsElevated)();
+        var configuredModulePath = trustedPowerShellModulePath
+            ?? BuildTrustedPowerShellModulePath(
+                programFiles,
+                Environment.SystemDirectory);
+        _trustedPowerShellModulePath = EnsureDistinctFromMachinePowerShellModulePath(
+            configuredModulePath,
+            Environment.GetEnvironmentVariable(
+                "PSModulePath",
+                EnvironmentVariableTarget.Machine),
+            programFiles);
     }
 
     /// <summary>
@@ -76,7 +93,8 @@ public sealed class PowerShellRunner : IPowerShellRunner
     }
 
     /// <summary>
-    /// Execute a script and return the collected PSObject results.
+    /// Execute a script and return the collected PSObject results. Elevated execution
+    /// is isolated in a child process with a sanitized module path.
     /// All streams are forwarded via <see cref="LineReceived"/> for live UI display.
     /// </summary>
     public async Task<Collection<PSObject>> RunAsync(
@@ -84,10 +102,9 @@ public sealed class PowerShellRunner : IPowerShellRunner
         IDictionary<string, object?>? parameters = null,
         CancellationToken cancellationToken = default)
     {
-        var iss = InitialSessionState.CreateDefault2();
-        iss.ExecutionPolicy = Microsoft.PowerShell.ExecutionPolicy.Bypass;
-
-        using var runspace = RunspaceFactory.CreateRunspace(iss);
+        var (runspace, processInstance) = CreateRunspace();
+        using var processLifetime = processInstance;
+        using var runspaceLifetime = runspace;
         // Open the runspace on a thread-pool thread — this can take
         // several hundred milliseconds and must not block the UI.
         await Task.Run(() => runspace.Open()).ConfigureAwait(false);
@@ -156,7 +173,7 @@ public sealed class PowerShellRunner : IPowerShellRunner
         {
             // Cancellation calls ps.Stop(), which makes EndInvoke throw PipelineStoppedException.
             // Surface the standard cancellation signal so callers that catch OperationCanceledException
-            // treat a cancelled in-process run as cancelled rather than as an error.
+            // treat a cancelled PowerShell run as cancelled rather than as an error.
             throw new OperationCanceledException(cancellationToken);
         }
 
@@ -175,8 +192,11 @@ public sealed class PowerShellRunner : IPowerShellRunner
     {
         // Prefix to silence progress (which gets serialized as CLIXML in stderr
         // when pwsh runs under a non-PS host) and set UTF-8 for clean text.
+        var modulePathInitialization = _isElevated
+            ? BuildPowerShellModulePathAssignment(_trustedPowerShellModulePath)
+            : string.Empty;
         var wrapped =
-            "$ProgressPreference='SilentlyContinue';" +
+            modulePathInitialization + "$ProgressPreference='SilentlyContinue';" +
             "$WarningPreference='Continue';" +
             "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;" +
             script;
@@ -223,6 +243,10 @@ public sealed class PowerShellRunner : IPowerShellRunner
             StandardOutputEncoding = enc,
             StandardErrorEncoding = enc,
         };
+        ApplyTrustedPowerShellModulePath(
+            psi,
+            _isElevated,
+            _trustedPowerShellModulePath);
 
         using var proc = new System.Diagnostics.Process { StartInfo = psi, EnableRaisingEvents = true };
         proc.OutputDataReceived += (_, e) =>
@@ -356,6 +380,152 @@ public sealed class PowerShellRunner : IPowerShellRunner
 
         await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
         return true;
+    }
+
+    internal static string BuildTrustedPowerShellModulePath(
+        string programFiles,
+        string systemDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(programFiles) ||
+            !System.IO.Path.IsPathFullyQualified(programFiles))
+        {
+            throw new ArgumentException(
+                "Program Files must be a fully qualified path.",
+                nameof(programFiles));
+        }
+
+        if (string.IsNullOrWhiteSpace(systemDirectory) ||
+            !System.IO.Path.IsPathFullyQualified(systemDirectory))
+        {
+            throw new ArgumentException(
+                "The system directory must be a fully qualified path.",
+                nameof(systemDirectory));
+        }
+
+        var trustedRoots = new[]
+        {
+            System.IO.Path.Combine(programFiles, "WindowsPowerShell", "Modules"),
+            System.IO.Path.Combine(
+                systemDirectory,
+                "WindowsPowerShell",
+                "v1.0",
+                "Modules"),
+            System.IO.Path.Combine(programFiles, "PowerShell", "Modules")
+        };
+
+        return string.Join(
+            System.IO.Path.PathSeparator,
+            trustedRoots
+                .Select(System.IO.Path.GetFullPath)
+                .Distinct(StringComparer.OrdinalIgnoreCase));
+    }
+
+    internal static string EnsureDistinctFromMachinePowerShellModulePath(
+        string trustedModulePath,
+        string? machineModulePath,
+        string programFiles)
+    {
+        if (string.IsNullOrWhiteSpace(trustedModulePath))
+        {
+            throw new ArgumentException(
+                "The trusted PowerShell module path cannot be empty.",
+                nameof(trustedModulePath));
+        }
+
+        if (!string.Equals(
+                trustedModulePath,
+                machineModulePath,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return trustedModulePath;
+        }
+
+        if (string.IsNullOrWhiteSpace(programFiles) ||
+            !System.IO.Path.IsPathFullyQualified(programFiles))
+        {
+            throw new ArgumentException(
+                "Program Files must be a fully qualified path.",
+                nameof(programFiles));
+        }
+
+        var guardRoot = System.IO.Path.GetFullPath(
+            System.IO.Path.Combine(
+                programFiles,
+                "SysManager",
+                "PowerShellModules"));
+        return string.Join(
+            System.IO.Path.PathSeparator,
+            trustedModulePath,
+            guardRoot);
+    }
+
+    internal static string BuildPowerShellModulePathAssignment(string trustedModulePath)
+    {
+        if (string.IsNullOrWhiteSpace(trustedModulePath))
+        {
+            throw new ArgumentException(
+                "The trusted PowerShell module path cannot be empty.",
+                nameof(trustedModulePath));
+        }
+
+        var escapedPath = trustedModulePath.Replace("'", "''", StringComparison.Ordinal);
+        return $"$env:PSModulePath='{escapedPath}';";
+    }
+
+    private (Runspace Runspace, PowerShellProcessInstance? ProcessInstance) CreateRunspace()
+    {
+        if (!_isElevated)
+        {
+            var initialSessionState = InitialSessionState.CreateDefault2();
+            initialSessionState.ExecutionPolicy = Microsoft.PowerShell.ExecutionPolicy.Bypass;
+            return (RunspaceFactory.CreateRunspace(initialSessionState), null);
+        }
+
+        var processInstance = new PowerShellProcessInstance(
+            new Version(5, 1),
+            credential: null,
+            initializationScript: ScriptBlock.Create(
+                BuildPowerShellModulePathAssignment(_trustedPowerShellModulePath)),
+            useWow64: false);
+        Runspace? runspace = null;
+        try
+        {
+            ApplyTrustedPowerShellModulePath(
+                processInstance.Process.StartInfo,
+                isElevated: true,
+                _trustedPowerShellModulePath);
+
+            runspace = RunspaceFactory.CreateOutOfProcessRunspace(
+                TypeTable.LoadDefaultTypeFiles(),
+                processInstance);
+            return (runspace, processInstance);
+        }
+        finally
+        {
+            if (runspace is null)
+                processInstance.Dispose();
+        }
+    }
+
+    internal static void ApplyTrustedPowerShellModulePath(
+        System.Diagnostics.ProcessStartInfo startInfo,
+        bool isElevated,
+        string trustedModulePath)
+    {
+        ArgumentNullException.ThrowIfNull(startInfo);
+        if (!isElevated || !IsPowerShellExecutable(startInfo.FileName))
+            return;
+
+        startInfo.Environment["PSModulePath"] = trustedModulePath;
+    }
+
+    private static bool IsPowerShellExecutable(string fileName)
+    {
+        var leafName = System.IO.Path.GetFileName(fileName);
+        return leafName.Equals("powershell", StringComparison.OrdinalIgnoreCase)
+            || leafName.Equals("powershell.exe", StringComparison.OrdinalIgnoreCase)
+            || leafName.Equals("pwsh", StringComparison.OrdinalIgnoreCase)
+            || leafName.Equals("pwsh.exe", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsClixmlNoise(string line)

--- a/SysManager/SysManager/Services/RestorePointService.cs
+++ b/SysManager/SysManager/Services/RestorePointService.cs
@@ -105,11 +105,19 @@ public sealed class RestorePointService
             $"Checkpoint-Computer -Description '{safeDesc}' -RestorePointType 'MODIFY_SETTINGS' -ErrorAction Stop; " +
             $"'{CreateOkSentinel}' " +
             "} catch { Write-Error $_; exit 1 }";
-        var results = await _ps.RunAsync(script, cancellationToken: ct).ConfigureAwait(false);
-        var ok = results.Any(o => string.Equals(o?.BaseObject?.ToString(), CreateOkSentinel, StringComparison.Ordinal));
-        if (!ok)
-            Log.Warning("RestorePoint: Checkpoint-Computer did not confirm success (it may be rate-limited to one per 24h).");
-        return ok;
+        try
+        {
+            var results = await _ps.RunAsync(script, cancellationToken: ct).ConfigureAwait(false);
+            var ok = results.Any(o => string.Equals(o?.BaseObject?.ToString(), CreateOkSentinel, StringComparison.Ordinal));
+            if (!ok)
+                Log.Warning("RestorePoint: Checkpoint-Computer did not confirm success (it may be rate-limited to one per 24h).");
+            return ok;
+        }
+        catch (RuntimeException ex)
+        {
+            Log.Warning("RestorePoint: creation failed: {Error}", ex.Message);
+            return false;
+        }
     }
 
     /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.56.1</Version>
-    <FileVersion>1.56.1.0</FileVersion>
-    <AssemblyVersion>1.56.1.0</AssemblyVersion>
+    <Version>1.56.2</Version>
+    <FileVersion>1.56.2.0</FileVersion>
+    <AssemblyVersion>1.56.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -15,6 +15,56 @@ namespace SysManager.ViewModels;
 
 public sealed partial class WindowsUpdateViewModel : ViewModelBase
 {
+    internal const string PsWindowsUpdateInstallScript = """
+        $ErrorActionPreference = 'Stop'
+        Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+        $gallery = Get-PSRepository -Name PSGallery -ErrorAction Stop
+        $gallerySource = ([string]$gallery.SourceLocation).TrimEnd('/')
+        if ($gallerySource -ne 'https://www.powershellgallery.com/api/v2') {
+            throw "PSGallery points to an unexpected source: $gallerySource"
+        }
+        if (-not (Get-PackageProvider -Name NuGet -ErrorAction SilentlyContinue)) {
+            Install-PackageProvider -Name NuGet -Force -Scope CurrentUser | Out-Null
+        }
+        Install-Module -Name PSWindowsUpdate -Force -Scope CurrentUser -Repository PSGallery -AllowClobber
+        Import-Module PSWindowsUpdate
+        'INSTALLED'
+        """;
+
+    internal const int HistoryModuleImportFailedExitCode = 41;
+    internal const int HistoryQueryFailedExitCode = 42;
+
+    internal const string PsWindowsUpdateHistoryScript = """
+        $ErrorActionPreference = 'Stop'
+        try {
+            Import-Module PSWindowsUpdate -ErrorAction Stop
+        }
+        catch {
+            [Console]::Error.WriteLine("PSWindowsUpdate import failed: $($_.Exception.Message)")
+            exit 41
+        }
+
+        try {
+            $hist = Get-WUHistory -Last 30 -ErrorAction Stop
+        }
+        catch {
+            [Console]::Error.WriteLine("PSWindowsUpdate history query failed: $($_.Exception.Message)")
+            exit 42
+        }
+
+        if (-not $hist -or $hist.Count -eq 0) { '[]' }
+        else {
+            $hist | Select-Object @{N='Title';E={$_.Title}},
+                @{N='KB';E={if($_.KBArticleIDs){('KB'+($_.KBArticleIDs -join ','))}else{''}}},
+                @{N='Size';E={''}},
+                @{N='Status';E={$_.Result}},
+                @{N='Date';E={if($_.Date){$_.Date.ToString('yyyy-MM-dd')}else{''}}},
+                @{N='IsHidden';E={$false}},
+                @{N='Category';E={'History'}} |
+            ConvertTo-Json -Compress
+        }
+        """;
+
     private readonly IPowerShellRunner _runner;
     private readonly WindowsUpdateService _wu;
     private readonly WindowsUpdatePolicyService _policy;
@@ -43,7 +93,19 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
     [ObservableProperty] private int _deferDays = 30;
     [ObservableProperty] private int _pauseDays = 7;
 
-    public WindowsUpdateViewModel(IPowerShellRunner runner, WindowsUpdateService wu, WindowsUpdatePolicyService policy)
+    public WindowsUpdateViewModel(
+        IPowerShellRunner runner,
+        WindowsUpdateService wu,
+        WindowsUpdatePolicyService policy)
+        : this(runner, wu, policy, AdminHelper.IsElevated)
+    {
+    }
+
+    internal WindowsUpdateViewModel(
+        IPowerShellRunner runner,
+        WindowsUpdateService wu,
+        WindowsUpdatePolicyService policy,
+        Func<bool> isElevated)
     {
         _runner = runner;
         _wu = wu;
@@ -55,7 +117,7 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
         // long-running commands' CanExecute (disabling them while one runs prevents
         // a second command disposing the shared CTS the first is still awaiting).
         PropertyChanged += OnVmPropertyChanged;
-        IsElevated = AdminHelper.IsElevated();
+        IsElevated = (isElevated ?? throw new ArgumentNullException(nameof(isElevated)))();
         // PSWindowsUpdate is only needed for the History view, so we don't
         // probe for it at startup — the History command checks itself if
         // the module is missing. This keeps the constructor side-effect-free
@@ -162,43 +224,58 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
     // Gated on NotBusy like the other runner-driven commands: CheckModule and
     // InstallModule stream through the shared _runner into the same console, so letting
     // them start while another update operation is running would cross-contaminate output
-    // (and race on the shared CTS). The internal call from InstallModuleAsync uses the
-    // method directly, so it is unaffected by this command-level gate.
+    // and race on the shared cancellation state.
     [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task CheckModuleAsync()
     {
         IsBusy = true;
         try
         {
-            var found = false;
-            void Listen(PowerShellLine l)
-            {
-                if (l.Kind == OutputKind.Output && l.Text.Contains("AVAILABLE")) found = true;
-            }
-            _runner.LineReceived += Listen;
-            try
-            {
-                await _runner.RunScriptViaPwshAsync(
-                    "if (Get-Module -ListAvailable -Name PSWindowsUpdate) { 'AVAILABLE' } else { 'MISSING' }");
-            }
-            finally { _runner.LineReceived -= Listen; }
-            ModuleAvailable = found;
+            ModuleAvailable = await ProbeModuleAvailabilityAsync();
             ModuleStatus = ModuleAvailable
                 ? "PSWindowsUpdate is available (used for update history)."
-                : "PSWindowsUpdate not installed — history view will be unavailable. Click Install Module if needed.";
+                : MissingModuleStatus();
         }
         catch (InvalidOperationException ex) { ModuleStatus = $"Check failed: {ex.Message}"; }
         catch (OperationCanceledException) { ModuleStatus = "Module check cancelled."; }
         finally { IsBusy = false; }
     }
 
+    private async Task<bool> ProbeModuleAvailabilityAsync()
+    {
+        var found = false;
+        void Listen(PowerShellLine line)
+        {
+            if (line.Kind == OutputKind.Output &&
+                line.Text.Contains("AVAILABLE", StringComparison.Ordinal))
+            {
+                found = true;
+            }
+        }
+
+        _runner.LineReceived += Listen;
+        try
+        {
+            var exitCode = await _runner.RunScriptViaPwshAsync(
+                "if (Get-Module -ListAvailable -Name PSWindowsUpdate) { 'AVAILABLE' } else { 'MISSING' }");
+            return exitCode == 0 && found;
+        }
+        finally
+        {
+            _runner.LineReceived -= Listen;
+        }
+    }
+
+    private string MissingModuleStatus() => IsElevated
+        ? "Update history is unavailable in administrator mode. Reopen SysManager normally to install or use the current-user module."
+        : "PSWindowsUpdate is not installed. Install it to enable update history.";
+
     [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task InstallModuleAsync()
     {
-        if (!AdminHelper.IsElevated())
+        if (IsElevated)
         {
-            StatusMessage = "Requesting admin rights...";
-            if (AdminHelper.RelaunchAsAdmin()) System.Windows.Application.Current?.Shutdown();
+            StatusMessage = "Install PSWindowsUpdate from a normal, non-administrator SysManager session.";
             return;
         }
         IsBusy = true;
@@ -207,16 +284,20 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
         ShowConsole = true;
         try
         {
-            await _runner.RunScriptViaPwshAsync(@"
-                Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
-                if (-not (Get-PackageProvider -Name NuGet -ErrorAction SilentlyContinue)) {
-                    Install-PackageProvider -Name NuGet -Force -Scope CurrentUser | Out-Null
-                }
-                Install-Module -Name PSWindowsUpdate -Force -Scope CurrentUser -AllowClobber
-                Import-Module PSWindowsUpdate
-                'INSTALLED'
-            ");
-            await CheckModuleAsync();
+            var exitCode = await _runner.RunScriptViaPwshAsync(PsWindowsUpdateInstallScript);
+            if (exitCode != 0)
+            {
+                ModuleAvailable = false;
+                ModuleStatus = "PSWindowsUpdate installation failed. Review the console output.";
+                StatusMessage = ModuleStatus;
+                return;
+            }
+
+            ModuleAvailable = await ProbeModuleAvailabilityAsync();
+            ModuleStatus = ModuleAvailable
+                ? "PSWindowsUpdate is available (used for update history)."
+                : "Installation completed, but PSWindowsUpdate could not be loaded.";
+            StatusMessage = ModuleStatus;
         }
         catch (InvalidOperationException ex) { StatusMessage = $"Error: {ex.Message}"; }
         catch (OperationCanceledException) { StatusMessage = "Module install cancelled."; }
@@ -274,6 +355,9 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
         IsShowingHistory = true;
         StatusMessage = "Loading update history…";
         Updates.Clear();
+        UpdateCount = 0;
+        TableSummary = "";
+        AllSelected = false;
         ShowConsole = false;
         _cts?.Dispose();
         _cts = new CancellationTokenSource();
@@ -290,33 +374,65 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
             _runner.LineReceived += Capture;
             try
             {
-                await _runner.RunScriptViaPwshAsync(@"
-                    Import-Module PSWindowsUpdate -ErrorAction Stop
-                    $hist = Get-WUHistory -Last 30 -ErrorAction SilentlyContinue
-                    if (-not $hist -or $hist.Count -eq 0) { '[]' }
-                    else {
-                        $hist | Select-Object @{N='Title';E={$_.Title}},
-                            @{N='KB';E={if($_.KBArticleIDs){('KB'+($_.KBArticleIDs -join ','))}else{''}}},
-                            @{N='Size';E={''}},
-                            @{N='Status';E={$_.Result}},
-                            @{N='Date';E={if($_.Date){$_.Date.ToString('yyyy-MM-dd')}else{''}}},
-                            @{N='IsHidden';E={$false}},
-                            @{N='Category';E={'History'}} |
-                        ConvertTo-Json -Compress
-                    }
-                ", cancellationToken: _cts.Token);
+                var exitCode = await _runner.RunScriptViaPwshAsync(
+                    PsWindowsUpdateHistoryScript,
+                    cancellationToken: _cts.Token);
+                if (exitCode != 0)
+                {
+                    SetHistoryFailureState(exitCode);
+                    return;
+                }
             }
             finally { _runner.LineReceived -= Capture; }
 
-            ParseUpdateJson(json.ToString());
+            ModuleAvailable = true;
+            ModuleStatus = "PSWindowsUpdate is available (used for update history).";
+            if (!ParseUpdateJson(json.ToString()))
+            {
+                TableSummary = "Update history unavailable.";
+                ShowConsole = true;
+                StatusMessage = "Update history returned invalid data.";
+                return;
+            }
             UpdateCount = Updates.Count;
             TableSummary = $"{UpdateCount} history entries.";
             StatusMessage = "Done";
             ToastService.Instance.Show("Update History complete", $"{UpdateCount} history entries");
         }
         catch (OperationCanceledException) { StatusMessage = "Cancelled."; }
-        catch (InvalidOperationException ex) { StatusMessage = $"Error: {ex.Message}"; }
+        catch (InvalidOperationException ex)
+        {
+            TableSummary = "Update history unavailable.";
+            ModuleAvailable = false;
+            ModuleStatus = "PSWindowsUpdate availability could not be confirmed.";
+            ShowConsole = true;
+            StatusMessage = $"Error: {ex.Message}";
+        }
         finally { IsBusy = false; IsProgressIndeterminate = false; }
+    }
+
+    private void SetHistoryFailureState(int exitCode)
+    {
+        TableSummary = "Update history unavailable.";
+        ShowConsole = true;
+        switch (exitCode)
+        {
+            case HistoryModuleImportFailedExitCode:
+                ModuleAvailable = false;
+                ModuleStatus = MissingModuleStatus();
+                StatusMessage = ModuleStatus;
+                break;
+            case HistoryQueryFailedExitCode:
+                ModuleAvailable = true;
+                ModuleStatus = "PSWindowsUpdate is available (used for update history).";
+                StatusMessage = "Update history query failed. Review the console output.";
+                break;
+            default:
+                ModuleAvailable = false;
+                ModuleStatus = "PSWindowsUpdate availability could not be confirmed.";
+                StatusMessage = "Update history could not be loaded. Review the console output.";
+                break;
+        }
     }
 
     [RelayCommand(CanExecute = nameof(NotBusy))]
@@ -451,9 +567,9 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
     [RelayCommand]
     private void Cancel() => _cts?.Cancel();
 
-    private void ParseUpdateJson(string raw)
+    private bool ParseUpdateJson(string raw)
     {
-        if (string.IsNullOrWhiteSpace(raw)) return;
+        if (string.IsNullOrWhiteSpace(raw)) return false;
 
         try
         {
@@ -477,11 +593,12 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
             {
                 Updates.Add(entry);
             }
+            return true;
         }
         catch (JsonException ex)
         {
             Log.Warning("Failed to parse update JSON: {Error}", ex.Message);
-            StatusMessage = "Parse error — some updates may not be shown.";
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary

- isolate elevated `RunAsync` work in a Windows PowerShell 5.1 child with machine-owned module discovery only
- normalize missing, blocked, or broken Windows PowerShell host startup into the services' established unavailable/failed states
- fail closed when the host is unavailable: no elevated in-process fallback, and external PowerShell launches stay pinned to the canonical System32 path
- preserve bound-parameter and CLIXML semantics across the process boundary, including Defender mutations and high-bit Task Scheduler result codes
- report partial Edge and restore-point operations as failures instead of success
- keep optional PSWindowsUpdate installation unelevated, current-user scoped, and pinned to the canonical PowerShell Gallery endpoint
- update version and public documentation for 1.56.2

## Root cause

Elevated PowerShell execution inherited module discovery paths that normally include a user-writable Documents directory. A planted module could therefore auto-load with the administrator token when a built-in command was resolved. Moving elevated work out of process closed that boundary, but host creation/open failures and CLIXML behavior also needed explicit handling.

## Failure handling decision

Known Windows PowerShell creation and transport failures are normalized at the runner boundary to `RuntimeException`, which existing service contracts map to unavailable or failed outcomes. The implementation deliberately does not fall back to an elevated in-process runspace because that would reintroduce per-user module discovery. Runspace, process-instance, and underlying process resources are disposed deterministically on success and failure.

Windows PowerShell is resolved to its rooted System32 path even when absent, so a missing host cannot fall back to an executable planted beside the portable application or elsewhere in the search path.

## Compatibility and performance

Elevated scripts must remain Windows PowerShell 5.1-compatible and project complex results to explicit primitive properties. The full `RunAsync` consumer set was checked for concrete casts, nested objects, method calls, dates, enums, and unsigned values. Call sites are tab loads or user-triggered operations rather than polling loops, so per-call process isolation is retained instead of introducing a shared privileged runspace with concurrency and lifetime risk.

## Verification

- all four projects compile in Release with 0 warnings and 0 errors
- all four project formatting gates pass with `--verify-no-changes`
- targeted non-xUnit harness confirms injected `PSRemotingTransportException` and `PSInvalidOperationException` failures produce graceful DNS and Defender unavailable states
- regression coverage covers host creation/open failures, wrapped registration failures, disposal order, rooted missing-host resolution, affected consumer states, Defender binding, and unsigned task results
- exact 1.56.2 single-file publish script completes successfully
- CI passed 3,709/3,709 unit tests and CodeQL analysis
- the non-blocking UI suite reported 82 passed / 49 failed, matching the current `main` baseline; the differing test names also fail on historical `main` runs, so no PR-specific UI regression was identified