### PR TITLE
chore: resolve SystemPaths CodeQL note

### DIFF
--- a/SysManager/SysManager/Helpers/SystemPaths.cs
+++ b/SysManager/SysManager/Helpers/SystemPaths.cs
@@ -67,9 +67,8 @@ internal static class SystemPaths
             ? new[] { fileName }
             : new[] { fileName, fileName + ".exe" };
 
-        foreach (var name in candidates)
+        foreach (var direct in candidates.Select(name => Path.Combine(systemDirectory, name)))
         {
-            var direct = Path.Combine(systemDirectory, name);
             if (fileExists(direct)) return direct;
         }
 


### PR DESCRIPTION
## Summary

- express the trusted System32 candidate projection directly with `Select`
- resolve CodeQL alert #1708 without changing path-resolution behavior

## Verification

- all four projects build in Release with 0 warnings and 0 errors
- solution-wide `dotnet format --verify-no-changes` passes
- existing `SystemPathsTests` coverage pins extensionless, known, and unknown tool-name behavior; CI will execute it

## Release

No changelog or version bump: this is a behavior-preserving maintainability cleanup.