### PR TITLE
fix: enforce environment backup trust boundaries

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -236,10 +236,14 @@ Key services:
   (OS, CPU, memory, GPU, motherboard, storage health, network) into a
   `SystemReportData` payload, then renders it to plain text, self-contained
   HTML, or JSON so all three exports share a single source of truth.
-- `EnvironmentVariableService` — reads/writes User and Machine environment
-  variables via `Environment.SetEnvironmentVariable` (which broadcasts
-  WM_SETTINGCHANGE), with name validation, pure PATH split/join/dedupe helpers,
-  and a one-time JSON backup of the original environment before the first write.
+- `EnvironmentVariableService`: reads/writes User and Machine environment
+  variables directly through HKCU/HKLM so `REG_EXPAND_SZ` values round-trip
+  without flattening, then broadcasts `WM_SETTINGCHANGE`. It provides name
+  validation and pure PATH split/join/dedupe helpers. Reversibility uses
+  independent one-time snapshots in matching registry hives: User state under
+  HKCU and Machine state in access-controlled HKLM storage. Legacy LocalAppData
+  data remains read-only compatibility input for User restore and is never
+  authoritative for an elevated Machine restore.
 - `RestorePointService` — lists (`Get-ComputerRestorePoint`), creates
   (`Checkpoint-Computer`), and restores (`Restore-Computer`) System Restore points
   through the `IPowerShellRunner` seam; the output parser is a pure, unit-tested

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.56.3] - 2026-07-30
+
+### Security
+- **Prevented per-user backup data from authorizing elevated machine-wide registry changes.** Environment restore, introduced in v1.33.3, kept both User and Machine snapshots in a LocalAppData JSON file. An unprivileged process could edit that file and, when SysManager was later restored as administrator, choose valid Machine variable values and which Machine variables were deleted. New User snapshots now live under HKCU, while System snapshots are stored under an owner- and ACL-validated `HKLM\SOFTWARE\SysManagerEnvironmentBackup` key. Only that protected snapshot can drive HKLM restore; legacy LocalAppData data remains read-only compatibility input for User restore, and its `Machine` section is never migrated or trusted.
+
+### Fixed
+- **Rejected malformed environment backups before any restore write.** User and protected Machine snapshots are now parsed with bounded file, entry-count, name, value-length, and registry-kind validation. Null or missing sections, wrong JSON types, null values, duplicate names, unsupported registry kinds, and oversized content produce a safe invalid-backup result instead of a `NullReferenceException` or a partial restore.
+- **Preserved pristine backups across partial and scope-specific operations.** Present-but-invalid snapshots are never mistaken for missing data or overwritten, restore validates every present scope before its first write, and a System-only change no longer creates a User snapshot. Existing valid User files remain compatible, while new registry values publish atomically without an elevated write into a user-controlled filesystem path.
+
 ## [1.56.2] - 2026-07-29
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -140,8 +140,10 @@ Edit Windows environment variables without the cramped built-in dialog:
 - **Dedicated PATH editor** for PATH-like variables — reorder directories, remove
   entries, and strip duplicates in one click
 - **Missing folders highlighted** so you can spot dead PATH entries at a glance
-- **Local until Apply** — changes are staged; a one-time JSON backup of every
-  variable is written before the first write so the original environment is recoverable
+- **Local until Apply:** changes are staged and each scope gets a one-time safety
+  snapshot before its first write. New User snapshots stay under HKCU; System
+  snapshots use access-controlled HKLM storage, and only that protected source can
+  restore machine-wide variables
 - Changes broadcast to Windows, so new terminals pick them up without a reboot
 - System-scope edits need administrator rights (standard elevation banner); user
   variables can be edited without it

--- a/SysManager/SysManager.Tests/EnvironmentVariableServiceTests.cs
+++ b/SysManager/SysManager.Tests/EnvironmentVariableServiceTests.cs
@@ -635,6 +635,32 @@ public class EnvironmentVariableServiceTests
     }
 
     [Fact]
+    public void RestoreFromBackup_AggregatesCountsAcrossUserAndMachineScopes()
+    {
+        using var env = new RedirectedEnvironment();
+        env.SetUser("SAFE_USER", "original-user");
+        env.SetMachine("SAFE_MACHINE", "original-machine");
+        env.Service.EnsureBackup(includeUser: true, includeMachine: true);
+
+        env.SetUser("SAFE_USER", "changed-user");
+        env.SetUser("ADDED_USER", "added-user");
+        env.SetMachine("SAFE_MACHINE", "changed-machine");
+        env.SetMachine("ADDED_MACHINE", "added-machine");
+
+        var result = env.Service.RestoreFromBackup();
+
+        Assert.True(result.HadBackup);
+        Assert.False(result.InvalidBackup);
+        Assert.Equal(2, result.Restored);
+        Assert.Equal(2, result.Removed);
+        Assert.Equal(0, result.Failed);
+        Assert.Equal("original-user", env.GetUser("SAFE_USER"));
+        Assert.Null(env.GetUser("ADDED_USER"));
+        Assert.Equal("original-machine", env.GetMachine("SAFE_MACHINE"));
+        Assert.Null(env.GetMachine("ADDED_MACHINE"));
+    }
+
+    [Fact]
     public void ReadBackup_ExactDuplicateNames_ReturnsNull()
     {
         using var env = new RedirectedEnvironment();

--- a/SysManager/SysManager.Tests/EnvironmentVariableServiceTests.cs
+++ b/SysManager/SysManager.Tests/EnvironmentVariableServiceTests.cs
@@ -3,6 +3,8 @@
 // License: MIT
 
 using System.IO;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Text.Json;
 using Microsoft.Win32;
 using SysManager.Models;
@@ -12,9 +14,9 @@ namespace SysManager.Tests;
 
 /// <summary>
 /// Tests for <see cref="EnvironmentVariableService"/>. The pure helpers (name validation,
-/// PATH split/join/dedup) and the file-backed backup/restore are exercised deterministically;
-/// the live registry read/write path is intentionally not unit-tested (it touches the machine
-/// environment and needs admin for the System scope).
+/// PATH split/join/dedup), bounded file parsing, and redirected-registry backup/restore
+/// behavior are exercised deterministically. Tests that need real environment integration
+/// use unique HKCU values and never touch the production Machine hive.
 /// </summary>
 public class EnvironmentVariableServiceTests
 {
@@ -62,6 +64,17 @@ public class EnvironmentVariableServiceTests
     {
         Assert.Equal(RegistryValueKind.String,
             EnvironmentVariableService.ChooseKind(RegistryValueKind.String, @"%SystemRoot%\x"));
+    }
+
+    [Fact]
+    public void ChooseKind_UnsupportedExistingKindFallsBackToStringKind()
+    {
+        Assert.Equal(
+            RegistryValueKind.String,
+            EnvironmentVariableService.ChooseKind(RegistryValueKind.DWord, "plain"));
+        Assert.Equal(
+            RegistryValueKind.ExpandString,
+            EnvironmentVariableService.ChooseKind(RegistryValueKind.MultiString, "%SystemRoot%"));
     }
 
     [Theory]
@@ -129,65 +142,62 @@ public class EnvironmentVariableServiceTests
 
     // ---------- Backup / restore ----------
 
-    private static (EnvironmentVariableService svc, string dir) NewServiceWithTempBackup()
-    {
-        var dir = Path.Combine(Path.GetTempPath(), "SysManagerEnvTest_" + Guid.NewGuid().ToString("N"));
-        return (new EnvironmentVariableService(dir), dir);
-    }
-
     [Fact]
     public void HasBackup_FalseBeforeEnsure_TrueAfter()
     {
-        var (svc, dir) = NewServiceWithTempBackup();
-        try
-        {
-            Assert.False(svc.HasBackup);
-            svc.EnsureBackup();
-            Assert.True(svc.HasBackup);
-            Assert.True(File.Exists(svc.BackupPath));
-        }
-        finally { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        using var env = new RedirectedEnvironment();
+
+        Assert.False(env.Service.HasBackup);
+        env.Service.EnsureBackup(includeUser: true, includeMachine: false);
+
+        Assert.True(env.Service.HasBackup);
+        Assert.True(env.HasUserRegistryBackup());
+        Assert.False(File.Exists(env.Service.BackupPath));
     }
 
     [Fact]
     public void EnsureBackup_DoesNotOverwriteExistingBackup()
     {
-        var (svc, dir) = NewServiceWithTempBackup();
-        try
-        {
-            svc.EnsureBackup();
-            var firstWrite = File.GetLastWriteTimeUtc(svc.BackupPath);
-            File.WriteAllText(svc.BackupPath, "{\"User\":{\"SENTINEL\":\"keep\"},\"Machine\":{}}");
+        using var env = new RedirectedEnvironment();
+        env.SetUser("SAFE_USER", "original");
+        env.Service.EnsureBackup(includeUser: true, includeMachine: false);
+        var originalSnapshot = env.GetUserBackupRaw();
 
-            svc.EnsureBackup(); // must be a no-op since a backup already exists
+        env.SetUser("SAFE_USER", "changed");
+        env.Service.EnsureBackup(includeUser: true, includeMachine: false);
 
-            var restored = svc.ReadBackup();
-            Assert.NotNull(restored);
-            Assert.True(restored!.User.ContainsKey("SENTINEL"));
-            Assert.Equal("keep", restored.User["SENTINEL"]);
-        }
-        finally { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        Assert.Equal(originalSnapshot, env.GetUserBackupRaw());
+        Assert.Equal("original", env.Service.ReadBackup()!.User["SAFE_USER"]);
+    }
+
+    [Fact]
+    public void EnsureBackup_ParameterlessPreservesBothScopeContract()
+    {
+        using var env = new RedirectedEnvironment();
+        env.SetUser("SAFE_USER", "user");
+        env.SetMachine("SAFE_MACHINE", "machine");
+
+        env.Service.EnsureBackup();
+
+        Assert.True(env.Service.HasUserBackup);
+        Assert.True(env.Service.HasMachineBackup);
     }
 
     [Fact]
     public void ReadBackup_NoBackup_ReturnsNull()
     {
-        var (svc, dir) = NewServiceWithTempBackup();
-        try { Assert.Null(svc.ReadBackup()); }
-        finally { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        using var env = new RedirectedEnvironment();
+
+        Assert.Null(env.Service.ReadBackup());
     }
 
     [Fact]
     public void ReadBackup_CorruptFile_ReturnsNull()
     {
-        var (svc, dir) = NewServiceWithTempBackup();
-        try
-        {
-            Directory.CreateDirectory(dir);
-            File.WriteAllText(svc.BackupPath, "{ this is not valid json ");
-            Assert.Null(svc.ReadBackup());
-        }
-        finally { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        using var env = new RedirectedEnvironment();
+        env.WriteLegacyUserBackup("{ this is not valid json ");
+
+        Assert.Null(env.Service.ReadBackup());
     }
 
     [Fact]
@@ -224,17 +234,13 @@ public class EnvironmentVariableServiceTests
     {
         // The User environment always contains at least TEMP/Path on a real Windows box,
         // but we only assert structural invariants so the test is robust on CI runners.
-        var (svc, dir) = NewServiceWithTempBackup();
-        try
-        {
-            var vars = svc.Read(EnvVarScope.User);
-            Assert.All(vars, v => Assert.Equal(EnvVarScope.User, v.Scope));
-            Assert.All(vars, v => Assert.False(string.IsNullOrEmpty(v.Name)));
-            // sorted, case-insensitive
-            var names = vars.Select(v => v.Name).ToList();
-            Assert.Equal(names.OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList(), names);
-        }
-        finally { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        var svc = new EnvironmentVariableService();
+        var vars = svc.Read(EnvVarScope.User);
+        Assert.All(vars, v => Assert.Equal(EnvVarScope.User, v.Scope));
+        Assert.All(vars, v => Assert.False(string.IsNullOrEmpty(v.Name)));
+        // sorted, case-insensitive
+        var names = vars.Select(v => v.Name).ToList();
+        Assert.Equal(names.OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList(), names);
     }
 
     // ── P2 #17 regression: TryValidateName, non-throwing restore, kind fidelity ──
@@ -342,6 +348,7 @@ public class EnvironmentVariableServiceTests
 
         Assert.NotNull(restored);
         Assert.Single(restored!.User);
+        Assert.Equal("C:\\Windows", restored.User["PATH"]);
         Assert.Single(restored.Machine);
         Assert.Null(restored.UserKinds);
         Assert.Null(restored.MachineKinds);
@@ -364,6 +371,716 @@ public class EnvironmentVariableServiceTests
         {
             using var key = Registry.CurrentUser.OpenSubKey("Environment", writable: true);
             key?.DeleteValue(name, throwOnMissingValue: false);
+        }
+    }
+
+    // ---------- Backup trust boundary ----------
+
+    [Fact]
+    public void ReadBackup_NullUserSection_ReturnsNull()
+    {
+        using var env = new RedirectedEnvironment();
+        env.WriteUserBackup("""{"User":null}""");
+
+        Assert.Null(env.Service.ReadBackup());
+    }
+
+    [Fact]
+    public void ReadBackup_MissingUserSection_ReturnsNull()
+    {
+        using var env = new RedirectedEnvironment();
+        env.WriteUserBackup("""{"Machine":{}}""");
+
+        Assert.Null(env.Service.ReadBackup());
+    }
+
+    [Fact]
+    public void ReadBackup_WrongUserType_ReturnsNull()
+    {
+        using var env = new RedirectedEnvironment();
+        env.WriteUserBackup("""{"User":[]}""");
+
+        Assert.Null(env.Service.ReadBackup());
+    }
+
+    [Fact]
+    public void ReadBackup_WindowsPermittedNonUiName_IsAccepted()
+    {
+        using var env = new RedirectedEnvironment();
+        env.WriteUserBackup("""{"User":{"BAD NAME":"value"}}""");
+
+        var backup = env.Service.ReadBackup();
+
+        Assert.NotNull(backup);
+        Assert.Equal("value", backup!.User["BAD NAME"]);
+    }
+
+    [Fact]
+    public void ReadBackup_EmbeddedNullName_ReturnsNull()
+    {
+        using var env = new RedirectedEnvironment();
+        env.WriteUserBackup("""{"User":{"BAD\u0000NAME":"value"}}""");
+
+        Assert.Null(env.Service.ReadBackup());
+    }
+
+    [Fact]
+    public void ReadBackup_NullValue_ReturnsNull()
+    {
+        using var env = new RedirectedEnvironment();
+        env.WriteUserBackup("""{"User":{"SAFE":null}}""");
+
+        Assert.Null(env.Service.ReadBackup());
+    }
+
+    [Fact]
+    public void ReadBackup_OversizedValue_ReturnsNull()
+    {
+        using var env = new RedirectedEnvironment();
+        var json = JsonSerializer.Serialize(new
+        {
+            User = new Dictionary<string, string>
+            {
+                ["SAFE"] = new string('x', EnvironmentVariableService.MaxVariableValueLength + 1)
+            }
+        });
+        env.WriteUserBackup(json);
+
+        Assert.Null(env.Service.ReadBackup());
+    }
+
+    [Fact]
+    public void ReadBackup_OversizedFile_ReturnsNull()
+    {
+        using var env = new RedirectedEnvironment();
+        env.WriteUserBackup(new string('x', EnvironmentVariableService.MaxBackupFileBytes + 1));
+
+        Assert.Null(env.Service.ReadBackup());
+    }
+
+    [Fact]
+    public void ReadBackup_TooManyVariables_ReturnsNull()
+    {
+        using var env = new RedirectedEnvironment();
+        var values = Enumerable.Range(0, EnvironmentVariableService.MaxVariableCount + 1)
+            .ToDictionary(i => $"VAR_{i}", _ => "value");
+        env.WriteUserBackup(JsonSerializer.Serialize(new { User = values }));
+
+        Assert.Null(env.Service.ReadBackup());
+    }
+
+    [Fact]
+    public void ReadBackup_UnsupportedRegistryKind_ReturnsNull()
+    {
+        using var env = new RedirectedEnvironment();
+        env.WriteUserBackup(
+            """
+            {
+              "User": { "SAFE": "value" },
+              "UserKinds": { "SAFE": 4 }
+            }
+            """);
+
+        Assert.Null(env.Service.ReadBackup());
+    }
+
+    [Fact]
+    public void ReadBackup_LegacyNullMachineSection_IsIgnored()
+    {
+        using var env = new RedirectedEnvironment();
+        env.WriteUserBackup(
+            """
+            {
+              "User": { "SAFE": "value" },
+              "Machine": null
+            }
+            """);
+
+        var backup = env.Service.ReadBackup();
+
+        Assert.NotNull(backup);
+        Assert.Equal("value", backup!.User["SAFE"]);
+    }
+
+    [Fact]
+    public void HasMachineBackup_EmptySection_ReturnsFalse()
+    {
+        using var env = new RedirectedEnvironment();
+        env.WriteMachineBackup("""{"Machine":{}}""", RegistryValueKind.String);
+
+        Assert.False(env.Service.HasMachineBackup);
+    }
+
+    [Fact]
+    public void HasMachineBackup_NullSection_ReturnsFalse()
+    {
+        using var env = new RedirectedEnvironment();
+        env.WriteMachineBackup("""{"Machine":null}""", RegistryValueKind.String);
+
+        Assert.False(env.Service.HasMachineBackup);
+    }
+
+    [Fact]
+    public void HasMachineBackup_WrongSectionType_ReturnsFalse()
+    {
+        using var env = new RedirectedEnvironment();
+        env.WriteMachineBackup("""{"Machine":[]}""", RegistryValueKind.String);
+
+        Assert.False(env.Service.HasMachineBackup);
+    }
+
+    [Fact]
+    public void HasMachineBackup_WrongRegistryType_ReturnsFalse()
+    {
+        using var env = new RedirectedEnvironment();
+        env.WriteMachineBackup(1, RegistryValueKind.DWord);
+
+        Assert.False(env.Service.HasMachineBackup);
+    }
+
+    [Fact]
+    public void HasMachineBackup_OversizedValue_ReturnsFalse()
+    {
+        using var env = new RedirectedEnvironment();
+        var json = JsonSerializer.Serialize(new
+        {
+            Machine = new Dictionary<string, string>
+            {
+                ["SAFE"] = new string('x', EnvironmentVariableService.MaxVariableValueLength + 1)
+            }
+        });
+        env.WriteMachineBackup(json, RegistryValueKind.String);
+
+        Assert.False(env.Service.HasMachineBackup);
+    }
+
+    [Fact]
+    public void HasMachineBackup_UnsupportedRegistryKind_ReturnsFalse()
+    {
+        using var env = new RedirectedEnvironment();
+        env.WriteMachineBackup(
+            """
+            {
+              "Machine": { "SAFE": "value" },
+              "MachineKinds": { "SAFE": 4 }
+            }
+            """,
+            RegistryValueKind.String);
+
+        Assert.False(env.Service.HasMachineBackup);
+    }
+
+    [Fact]
+    public void RestoreFromBackup_LegacyMachineSectionCannotChangeMachineScope()
+    {
+        using var env = new RedirectedEnvironment();
+        env.SetUser("SAFE_USER", "current");
+        env.SetMachine("SAFE_MACHINE", "current");
+        env.WriteUserBackup(
+            """
+            {
+              "User": { "SAFE_USER": "user-backup" },
+              "Machine": {
+                "SAFE_MACHINE": "attacker-value",
+                "ATTACKER_MACHINE": "owned"
+              }
+            }
+            """);
+
+        var result = env.Service.RestoreFromBackup();
+
+        Assert.True(result.HadBackup);
+        Assert.Equal("user-backup", env.GetUser("SAFE_USER"));
+        Assert.Equal("current", env.GetMachine("SAFE_MACHINE"));
+        Assert.Null(env.GetMachine("ATTACKER_MACHINE"));
+    }
+
+    [Fact]
+    public void EnsureBackup_UserSnapshotDoesNotPreventLaterMachineSnapshot()
+    {
+        using var env = new RedirectedEnvironment();
+        env.SetMachine("SAFE_MACHINE", "original");
+
+        env.Service.EnsureBackup(includeUser: true, includeMachine: false);
+        Assert.False(env.Service.HasMachineBackup);
+
+        env.Service.EnsureBackup(includeUser: true, includeMachine: true);
+        Assert.True(env.Service.HasMachineBackup);
+    }
+
+    [Fact]
+    public void RestoreFromBackup_UsesProtectedMachineSnapshotAndDoesNotOverwriteIt()
+    {
+        using var env = new RedirectedEnvironment();
+        env.SetMachine("SAFE_MACHINE", "original");
+        env.Service.EnsureBackup(includeUser: true, includeMachine: true);
+        Assert.True(env.Service.HasMachineBackup);
+        Assert.DoesNotContain("\"Machine\"", Assert.IsType<string>(env.GetUserBackupRaw()));
+        Assert.False(File.Exists(env.Service.BackupPath));
+
+        env.SetMachine("SAFE_MACHINE", "changed");
+        env.Service.EnsureBackup(includeUser: true, includeMachine: true);
+        env.WriteUserBackup(
+            """
+            {
+              "User": {},
+              "Machine": { "SAFE_MACHINE": "attacker-value" }
+            }
+            """);
+
+        var result = env.Service.RestoreFromBackup();
+
+        Assert.True(result.HadBackup);
+        Assert.Equal("original", env.GetMachine("SAFE_MACHINE"));
+    }
+
+    [Fact]
+    public void ReadBackup_ExactDuplicateNames_ReturnsNull()
+    {
+        using var env = new RedirectedEnvironment();
+        env.WriteUserBackup("""{"User":{"PATH":"first","PATH":"second"}}""");
+
+        Assert.Null(env.Service.ReadBackup());
+    }
+
+    [Fact]
+    public void ReadBackup_CaseVariantDuplicateNames_ReturnsNull()
+    {
+        using var env = new RedirectedEnvironment();
+        env.WriteUserBackup("""{"User":{"PATH":"first","Path":"second"}}""");
+
+        Assert.Null(env.Service.ReadBackup());
+    }
+
+    [Fact]
+    public void RestoreFromBackup_LegacyNullMachineSection_DoesNotTouchMachineScope()
+    {
+        using var env = new RedirectedEnvironment();
+        env.SetUser("SAFE_USER", "current");
+        env.SetMachine("SAFE_MACHINE", "current");
+        env.WriteUserBackup(
+            """
+            {
+              "User": { "SAFE_USER": "backup" },
+              "Machine": null
+            }
+            """);
+
+        var result = env.Service.RestoreFromBackup();
+
+        Assert.True(result.HadBackup);
+        Assert.Equal("backup", env.GetUser("SAFE_USER"));
+        Assert.Equal("current", env.GetMachine("SAFE_MACHINE"));
+    }
+
+    [Fact]
+    public void RestoreFromBackup_LegacyMissingKindsCountsUnsupportedLiveKindWithoutThrowing()
+    {
+        using var env = new RedirectedEnvironment();
+        env.SetUser("UNSUPPORTED", 1, RegistryValueKind.DWord);
+        env.SetUser("SAFE_USER", "current");
+        env.WriteLegacyUserBackup("""
+            {
+              "User": {
+                "UNSUPPORTED": "backup-text",
+                "SAFE_USER": "backup-safe"
+              }
+            }
+            """);
+
+        var result = env.Service.RestoreFromBackup();
+
+        Assert.False(result.InvalidBackup);
+        Assert.Equal(1, result.Restored);
+        Assert.Equal(1, result.Failed);
+        Assert.Equal(1, env.GetUser("UNSUPPORTED"));
+        Assert.Equal("backup-safe", env.GetUser("SAFE_USER"));
+    }
+
+    [Fact]
+    public void EnsureBackup_InvalidUserSnapshotIsNotReplaced()
+    {
+        using var env = new RedirectedEnvironment();
+        env.SetUser("SAFE_USER", "current");
+        env.WriteUserRegistryBackup("{ invalid json");
+        var original = env.GetUserBackupRaw();
+
+        Assert.Throws<InvalidDataException>(() =>
+            env.Service.EnsureBackup(includeUser: true, includeMachine: false));
+
+        Assert.Equal(original, env.GetUserBackupRaw());
+        Assert.Equal("current", env.GetUser("SAFE_USER"));
+    }
+
+    [Fact]
+    public void EnsureBackup_InvalidMachineSnapshotIsNotReplaced()
+    {
+        using var env = new RedirectedEnvironment();
+        env.SetMachine("SAFE_MACHINE", "current");
+        env.WriteMachineBackup("{ invalid json", RegistryValueKind.String);
+        var original = env.GetMachineBackupRaw();
+
+        Assert.Throws<InvalidDataException>(() =>
+            env.Service.EnsureBackup(includeUser: false, includeMachine: true));
+
+        Assert.Equal(original, env.GetMachineBackupRaw());
+        Assert.Equal("current", env.GetMachine("SAFE_MACHINE"));
+    }
+
+    [Fact]
+    public void RestoreFromBackup_InvalidMachineSnapshotPreventsUserMutation()
+    {
+        using var env = new RedirectedEnvironment();
+        env.SetUser("SAFE_USER", "current-user");
+        env.SetMachine("SAFE_MACHINE", "current-machine");
+        env.WriteUserRegistryBackup("""
+            { "User": { "SAFE_USER": "backup-user" } }
+            """);
+        env.WriteMachineBackup("{ invalid json", RegistryValueKind.String);
+
+        var result = env.Service.RestoreFromBackup();
+
+        Assert.True(result.InvalidBackup);
+        Assert.Equal(0, result.Restored);
+        Assert.Equal(0, result.Removed);
+        Assert.Equal("current-user", env.GetUser("SAFE_USER"));
+        Assert.Equal("current-machine", env.GetMachine("SAFE_MACHINE"));
+    }
+
+    [Fact]
+    public void RestoreFromBackup_EmptyMachineSnapshotPreventsUserMutation()
+    {
+        using var env = new RedirectedEnvironment();
+        env.SetUser("SAFE_USER", "current-user");
+        env.SetMachine("SAFE_MACHINE", "current-machine");
+        env.WriteUserRegistryBackup("""
+            { "User": { "SAFE_USER": "backup-user" } }
+            """);
+        env.WriteMachineBackup("""{ "Machine": {} }""", RegistryValueKind.String);
+
+        var result = env.Service.RestoreFromBackup();
+
+        Assert.True(result.InvalidBackup);
+        Assert.Equal(0, result.Restored);
+        Assert.Equal(0, result.Removed);
+        Assert.Equal("current-user", env.GetUser("SAFE_USER"));
+        Assert.Equal("current-machine", env.GetMachine("SAFE_MACHINE"));
+    }
+
+    [Fact]
+    public void RestoreFromBackup_InvalidUserSnapshotPreventsMachineMutation()
+    {
+        using var env = new RedirectedEnvironment();
+        env.SetUser("SAFE_USER", "current-user");
+        env.SetMachine("SAFE_MACHINE", "current-machine");
+        env.WriteUserRegistryBackup("{ invalid json");
+        env.WriteMachineBackup("""
+            { "Machine": { "SAFE_MACHINE": "backup-machine" } }
+            """, RegistryValueKind.String);
+
+        var result = env.Service.RestoreFromBackup();
+
+        Assert.True(result.InvalidBackup);
+        Assert.Equal(0, result.Restored);
+        Assert.Equal(0, result.Removed);
+        Assert.Equal("current-user", env.GetUser("SAFE_USER"));
+        Assert.Equal("current-machine", env.GetMachine("SAFE_MACHINE"));
+    }
+
+    [Fact]
+    public void EnsureBackup_MachineOnlyChangeDoesNotCreateUserSnapshot()
+    {
+        using var env = new RedirectedEnvironment();
+        env.SetMachine("SAFE_MACHINE", "original");
+
+        env.Service.EnsureBackup(includeUser: false, includeMachine: true);
+
+        Assert.True(env.Service.HasMachineBackup);
+        Assert.False(env.Service.HasUserBackup);
+        Assert.False(env.HasUserRegistryBackup());
+        Assert.False(File.Exists(env.Service.BackupPath));
+    }
+
+    [Fact]
+    public void EnsureBackup_InvalidUnrequestedUserSnapshotBlocksMachineSnapshot()
+    {
+        using var env = new RedirectedEnvironment();
+        env.SetMachine("SAFE_MACHINE", "original");
+        env.WriteUserRegistryBackup("{ invalid json");
+
+        Assert.Throws<InvalidDataException>(() =>
+            env.Service.EnsureBackup(includeUser: false, includeMachine: true));
+
+        Assert.Null(env.GetMachineBackupRaw());
+    }
+
+    [Fact]
+    public void EnsureBackup_LiveWindowsPermittedNonUiName_IsCaptured()
+    {
+        using var env = new RedirectedEnvironment();
+        env.SetUser("BAD NAME", "value");
+
+        env.Service.EnsureBackup(includeUser: true, includeMachine: false);
+
+        Assert.Equal("value", env.Service.ReadBackup()!.User["BAD NAME"]);
+    }
+
+    [Fact]
+    public void EnsureBackup_UnsupportedLiveRegistryKindPublishesNoSnapshot()
+    {
+        using var env = new RedirectedEnvironment();
+        env.SetMachine("UNSUPPORTED", 1, RegistryValueKind.DWord);
+
+        Assert.Throws<InvalidDataException>(() =>
+            env.Service.EnsureBackup(includeUser: false, includeMachine: true));
+
+        Assert.Null(env.GetMachineBackupRaw());
+    }
+
+    [Fact]
+    public void ProtectedMachineBackupAcl_AcceptsOnlyTrustedWriters()
+    {
+        var security = EnvironmentVariableService.CreateProtectedMachineBackupSecurity();
+
+        Assert.True(EnvironmentVariableService.IsProtectedMachineBackupSecurity(security));
+
+        var users = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, domainSid: null);
+        security.AddAccessRule(new RegistryAccessRule(
+            users,
+            RegistryRights.SetValue,
+            InheritanceFlags.None,
+            PropagationFlags.None,
+            AccessControlType.Allow));
+        Assert.False(EnvironmentVariableService.IsProtectedMachineBackupSecurity(security));
+    }
+
+    [Fact]
+    public void ProtectedMachineBackupAcl_RejectsUntrustedOwner()
+    {
+        var security = EnvironmentVariableService.CreateProtectedMachineBackupSecurity();
+        security.SetOwner(new SecurityIdentifier(
+            WellKnownSidType.BuiltinUsersSid,
+            domainSid: null));
+
+        Assert.False(EnvironmentVariableService.IsProtectedMachineBackupSecurity(security));
+    }
+
+    [Fact]
+    public void MachineBackup_UserWritableRegistryPathIsRejected()
+    {
+        using var env = new RedirectedEnvironment(enforceMachineBackupProtection: true);
+        env.SetMachine("SAFE_MACHINE", "current");
+        env.WriteMachineBackup("""
+            { "Machine": { "SAFE_MACHINE": "attacker-value" } }
+            """, RegistryValueKind.String);
+
+        var result = env.Service.RestoreFromBackup();
+
+        Assert.False(env.Service.HasMachineBackup);
+        Assert.True(result.InvalidBackup);
+        Assert.Equal("current", env.GetMachine("SAFE_MACHINE"));
+    }
+
+    [Fact]
+    public void MissingMachineBackup_DoesNotBlockUserOnlySnapshotOnUntrustedParent()
+    {
+        using var env = new RedirectedEnvironment(enforceMachineBackupProtection: true);
+        env.SetUser("SAFE_USER", "original");
+
+        Assert.False(env.Service.HasBackup);
+
+        env.Service.EnsureBackup(includeUser: true, includeMachine: false);
+
+        Assert.True(env.Service.HasUserBackup);
+        Assert.False(env.Service.HasMachineBackup);
+        Assert.Equal("original", env.Service.ReadBackup()!.User["SAFE_USER"]);
+    }
+
+    [Fact]
+    public void RestoreFromBackup_DeniedMachineWritesLeaveValuesUnchangedAndCountFailures()
+    {
+        using var env = new RedirectedEnvironment();
+        env.SetMachine("SAFE_MACHINE", "original");
+        env.Service.EnsureBackup(includeUser: false, includeMachine: true);
+        env.SetMachine("SAFE_MACHINE", "changed");
+        env.SetMachine("ADDED_MACHINE", "added");
+
+        using var key = env.MachineRoot.OpenSubKey(
+            EnvironmentVariableService.MachineEnvPath,
+            writable: true);
+        Assert.NotNull(key);
+        var originalSecurity = key!.GetAccessControl(
+            AccessControlSections.Owner | AccessControlSections.Access);
+        var deniedSecurity = key.GetAccessControl(
+            AccessControlSections.Owner | AccessControlSections.Access);
+        using var identity = WindowsIdentity.GetCurrent();
+        Assert.NotNull(identity.User);
+        deniedSecurity.AddAccessRule(new RegistryAccessRule(
+            identity.User!,
+            RegistryRights.SetValue,
+            InheritanceFlags.None,
+            PropagationFlags.None,
+            AccessControlType.Deny));
+        key.SetAccessControl(deniedSecurity);
+
+        try
+        {
+            var result = env.Service.RestoreFromBackup();
+
+            Assert.False(result.InvalidBackup);
+            Assert.Equal(0, result.Restored);
+            Assert.Equal(0, result.Removed);
+            Assert.Equal(2, result.Failed);
+            Assert.Equal("changed", env.GetMachine("SAFE_MACHINE"));
+            Assert.Equal("added", env.GetMachine("ADDED_MACHINE"));
+        }
+        finally
+        {
+            key.SetAccessControl(originalSecurity);
+        }
+    }
+
+    [Fact]
+    public void ReadBackup_UserRegistryWrongTypeReturnsNullAndIsNotReplaced()
+    {
+        using var env = new RedirectedEnvironment();
+        env.WriteUserRegistryBackup(1, RegistryValueKind.DWord);
+
+        Assert.Null(env.Service.ReadBackup());
+        Assert.Throws<InvalidDataException>(() =>
+            env.Service.EnsureBackup(includeUser: true, includeMachine: false));
+        Assert.Equal(1, env.GetUserBackupRaw());
+    }
+
+    private sealed class RedirectedEnvironment : IDisposable
+    {
+        private readonly string _userRootName =
+            $@"Software\SysManagerTests\Environment\User_{Guid.NewGuid():N}";
+        private readonly string _machineRootName =
+            $@"Software\SysManagerTests\Environment\Machine_{Guid.NewGuid():N}";
+
+        public RedirectedEnvironment(bool enforceMachineBackupProtection = false)
+        {
+            BackupDirectory = Path.Combine(
+                Path.GetTempPath(),
+                $"SysManagerEnvironmentTests_{Guid.NewGuid():N}");
+            UserRoot = Registry.CurrentUser.CreateSubKey(_userRootName, writable: true)
+                ?? throw new InvalidOperationException("Could not create redirected User root.");
+            MachineRoot = Registry.CurrentUser.CreateSubKey(_machineRootName, writable: true)
+                ?? throw new InvalidOperationException("Could not create redirected Machine root.");
+
+            using var userEnvironment = UserRoot.CreateSubKey(
+                EnvironmentVariableService.UserEnvPath,
+                writable: true);
+            using var machineEnvironment = MachineRoot.CreateSubKey(
+                EnvironmentVariableService.MachineEnvPath,
+                writable: true);
+
+            Service = new EnvironmentVariableService(
+                BackupDirectory,
+                UserRoot,
+                MachineRoot,
+                enforceMachineBackupProtection);
+        }
+
+        public string BackupDirectory { get; }
+        public RegistryKey UserRoot { get; }
+        public RegistryKey MachineRoot { get; }
+        public EnvironmentVariableService Service { get; }
+
+        public void WriteUserBackup(string json)
+            => WriteLegacyUserBackup(json);
+
+        public void WriteLegacyUserBackup(string json)
+        {
+            Directory.CreateDirectory(BackupDirectory);
+            File.WriteAllText(Service.BackupPath, json);
+        }
+
+        public void WriteUserRegistryBackup(object value, RegistryValueKind kind = RegistryValueKind.String)
+        {
+            using var key = UserRoot.CreateSubKey(
+                EnvironmentVariableService.UserBackupPath,
+                writable: true);
+            key!.SetValue(EnvironmentVariableService.UserBackupValueName, value, kind);
+        }
+
+        public bool HasUserRegistryBackup()
+        {
+            using var key = UserRoot.OpenSubKey(EnvironmentVariableService.UserBackupPath);
+            return key?.GetValueNames().Contains(
+                EnvironmentVariableService.UserBackupValueName,
+                StringComparer.OrdinalIgnoreCase) == true;
+        }
+
+        public object? GetUserBackupRaw()
+        {
+            using var key = UserRoot.OpenSubKey(EnvironmentVariableService.UserBackupPath);
+            return key?.GetValue(
+                EnvironmentVariableService.UserBackupValueName,
+                defaultValue: null,
+                RegistryValueOptions.DoNotExpandEnvironmentNames);
+        }
+
+        public void WriteMachineBackup(object value, RegistryValueKind kind)
+        {
+            using var key = MachineRoot.CreateSubKey(
+                EnvironmentVariableService.MachineBackupPath,
+                writable: true);
+            key!.SetValue(EnvironmentVariableService.MachineBackupValueName, value, kind);
+        }
+
+        public object? GetMachineBackupRaw()
+        {
+            using var key = MachineRoot.OpenSubKey(EnvironmentVariableService.MachineBackupPath);
+            return key?.GetValue(
+                EnvironmentVariableService.MachineBackupValueName,
+                defaultValue: null,
+                RegistryValueOptions.DoNotExpandEnvironmentNames);
+        }
+
+        public void SetUser(string name, string value)
+            => SetUser(name, value, RegistryValueKind.String);
+
+        public void SetUser(string name, object value, RegistryValueKind kind)
+        {
+            using var key = UserRoot.OpenSubKey(
+                EnvironmentVariableService.UserEnvPath,
+                writable: true);
+            key!.SetValue(name, value, kind);
+        }
+
+        public void SetMachine(string name, string value)
+            => SetMachine(name, value, RegistryValueKind.String);
+
+        public void SetMachine(string name, object value, RegistryValueKind kind)
+        {
+            using var key = MachineRoot.OpenSubKey(
+                EnvironmentVariableService.MachineEnvPath,
+                writable: true);
+            key!.SetValue(name, value, kind);
+        }
+
+        public object? GetUser(string name)
+        {
+            using var key = UserRoot.OpenSubKey(EnvironmentVariableService.UserEnvPath);
+            return key?.GetValue(name, defaultValue: null, RegistryValueOptions.DoNotExpandEnvironmentNames);
+        }
+
+        public object? GetMachine(string name)
+        {
+            using var key = MachineRoot.OpenSubKey(EnvironmentVariableService.MachineEnvPath);
+            return key?.GetValue(name, defaultValue: null, RegistryValueOptions.DoNotExpandEnvironmentNames);
+        }
+
+        public void Dispose()
+        {
+            UserRoot.Dispose();
+            MachineRoot.Dispose();
+            Registry.CurrentUser.DeleteSubKeyTree(_userRootName, throwOnMissingSubKey: false);
+            Registry.CurrentUser.DeleteSubKeyTree(_machineRootName, throwOnMissingSubKey: false);
+            if (Directory.Exists(BackupDirectory))
+                Directory.Delete(BackupDirectory, recursive: true);
         }
     }
 }

--- a/SysManager/SysManager/Services/EnvironmentVariableService.cs
+++ b/SysManager/SysManager/Services/EnvironmentVariableService.cs
@@ -454,23 +454,25 @@ public sealed partial class EnvironmentVariableService
         }
 
         EnsureMachineBackupParentIsProtected();
-        var key = _machineRoot.CreateSubKey(
-            MachineBackupPath,
-            RegistryKeyPermissionCheck.ReadWriteSubTree,
-            RegistryOptions.None,
-            CreateProtectedMachineBackupSecurity())
-            ?? throw new UnauthorizedAccessException(
-                "The protected Machine backup key could not be created.");
-
-        if (!IsProtectedMachineBackupSecurity(key.GetAccessControl(
-                AccessControlSections.Owner | AccessControlSections.Access)))
+        using (var key = _machineRoot.CreateSubKey(
+                   MachineBackupPath,
+                   RegistryKeyPermissionCheck.ReadWriteSubTree,
+                   RegistryOptions.None,
+                   CreateProtectedMachineBackupSecurity())
+               ?? throw new UnauthorizedAccessException(
+                   "The protected Machine backup key could not be created."))
         {
-            key.Dispose();
-            throw new InvalidDataException(
-                "The Machine backup key is not protected from standard-user writes.");
+            if (!IsProtectedMachineBackupSecurity(key.GetAccessControl(
+                    AccessControlSections.Owner | AccessControlSections.Access)))
+            {
+                throw new InvalidDataException(
+                    "The Machine backup key is not protected from standard-user writes.");
+            }
         }
 
-        return key;
+        return _machineRoot.OpenSubKey(MachineBackupPath, writable: true)
+            ?? throw new UnauthorizedAccessException(
+                "The protected Machine backup key could not be reopened.");
     }
 
     private void EnsureMachineBackupParentIsProtected()
@@ -624,6 +626,14 @@ public sealed partial class EnvironmentVariableService
     private sealed record ScopeBackup(
         Dictionary<string, string> Values,
         Dictionary<string, RegistryValueKind>? Kinds);
+
+    private readonly record struct ScopeRestoreCounts(int Restored, int Removed, int Failed)
+    {
+        public ScopeRestoreCounts Add(ScopeRestoreCounts other) => new(
+            Restored + other.Restored,
+            Removed + other.Removed,
+            Failed + other.Failed);
+    }
 
     private readonly record struct BackupRead<T>(bool Exists, T? Snapshot)
         where T : class
@@ -968,36 +978,32 @@ public sealed partial class EnvironmentVariableService
         if (!hasValidBackup)
             return new RestoreResult(false, 0, 0, 0);
 
-        int restored = 0, removed = 0, failed = 0;
+        var counts = default(ScopeRestoreCounts);
         if (userBackup.Snapshot is { } userSnapshot)
-            RestoreScope(
+            counts = counts.Add(RestoreScope(
                 EnvVarScope.User,
                 userSnapshot.User,
-                userSnapshot.UserKinds,
-                ref restored,
-                ref removed,
-                ref failed);
+                userSnapshot.UserKinds));
         if (machineBackup.Snapshot is { } machineSnapshot)
-            RestoreScope(
+            counts = counts.Add(RestoreScope(
                 EnvVarScope.Machine,
                 machineSnapshot.Machine,
-                machineSnapshot.MachineKinds,
-                ref restored,
-                ref removed,
-                ref failed);
+                machineSnapshot.MachineKinds));
 
-        Log.Information("Environment: restored {Restored}, removed {Removed}, failed {Failed} from backup", restored, removed, failed);
-        return new RestoreResult(true, restored, removed, failed);
+        Log.Information(
+            "Environment: restored {Restored}, removed {Removed}, failed {Failed} from backup",
+            counts.Restored,
+            counts.Removed,
+            counts.Failed);
+        return new RestoreResult(true, counts.Restored, counts.Removed, counts.Failed);
     }
 
-    private void RestoreScope(
+    private ScopeRestoreCounts RestoreScope(
         EnvVarScope scope,
         Dictionary<string, string> saved,
-        Dictionary<string, RegistryValueKind>? kinds,
-        ref int restored,
-        ref int removed,
-        ref int failed)
+        Dictionary<string, RegistryValueKind>? kinds)
     {
+        int restored = 0, removed = 0, failed = 0;
         foreach (var (name, value) in saved)
         {
             RegistryValueKind? explicitKind = kinds is not null && kinds.TryGetValue(name, out var savedKind)
@@ -1013,5 +1019,7 @@ public sealed partial class EnvironmentVariableService
             if (DeleteVariable(current.Name, scope)) removed++;
             else failed++;
         }
+
+        return new ScopeRestoreCounts(restored, removed, failed);
     }
 }

--- a/SysManager/SysManager/Services/EnvironmentVariableService.cs
+++ b/SysManager/SysManager/Services/EnvironmentVariableService.cs
@@ -4,6 +4,8 @@
 
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -29,21 +31,35 @@ namespace SysManager.Services;
 ///
 /// Machine-scope writes require administrator rights; <see cref="SetVariable"/> returns
 /// <c>false</c> (rather than throwing) when the write is denied, mirroring
-/// <see cref="PrivacyService"/>. A timestamped JSON backup of every variable is written
-/// before the first mutation so the user can fully restore the original environment.
+/// <see cref="PrivacyService"/>. New backups are stored in their matching registry hive:
+/// User state under HKCU and Machine state under access-controlled HKLM. Legacy
+/// LocalAppData backups remain read-only compatibility input for User restore only.
 /// </summary>
 public sealed partial class EnvironmentVariableService
 {
     // Registry locations of the two environment scopes.
-    private const string UserEnvPath = @"Environment";
-    private const string MachineEnvPath = @"SYSTEM\CurrentControlSet\Control\Session Manager\Environment";
+    internal const string UserEnvPath = @"Environment";
+    internal const string MachineEnvPath = @"SYSTEM\CurrentControlSet\Control\Session Manager\Environment";
+    internal const string UserBackupPath = @"SOFTWARE\SysManager\Backups\Environment";
+    internal const string UserBackupValueName = "Snapshot";
+    internal const string MachineBackupPath = @"SOFTWARE\SysManagerEnvironmentBackup";
+    internal const string MachineBackupValueName = "Snapshot";
+    internal const int MaxBackupFileBytes = 1024 * 1024;
+    internal const int MaxVariableCount = 4096;
+    internal const int MaxVariableNameLength = 16383;
+    internal const int MaxVariableValueLength = 32767;
 
     private readonly string _backupDir;
+    private readonly RegistryKey _userRoot;
+    private readonly RegistryKey _machineRoot;
+    private readonly bool _enforceMachineBackupProtection;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,
-        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        MaxDepth = 8,
+        AllowDuplicateProperties = false
     };
 
     /// <summary>
@@ -52,10 +68,26 @@ public sealed partial class EnvironmentVariableService
     /// %LOCALAPPDATA% backup location.
     /// </summary>
     public EnvironmentVariableService(string? backupDir = null)
+        : this(
+            backupDir,
+            Registry.CurrentUser,
+            Registry.LocalMachine,
+            enforceMachineBackupProtection: true)
+    {
+    }
+
+    internal EnvironmentVariableService(
+        string? backupDir,
+        RegistryKey userRoot,
+        RegistryKey machineRoot,
+        bool enforceMachineBackupProtection = false)
     {
         _backupDir = backupDir ?? Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "SysManager", "Backups", "Environment");
+        _userRoot = userRoot;
+        _machineRoot = machineRoot;
+        _enforceMachineBackupProtection = enforceMachineBackupProtection;
     }
 
     // Variable names: letters, digits, underscore and a few shell-safe punctuation
@@ -98,12 +130,26 @@ public sealed partial class EnvironmentVariableService
         return true;
     }
 
+    private static bool TryValidateBackupName(string? name, out string validatedName)
+    {
+        validatedName = "";
+        if (string.IsNullOrEmpty(name) ||
+            name.Length > MaxVariableNameLength ||
+            name.Contains('\0'))
+        {
+            return false;
+        }
+
+        validatedName = name;
+        return true;
+    }
+
     // ── Reading ──────────────────────────────────────────────────────────────
 
-    private static (RegistryKey hive, string path) Location(EnvVarScope scope) =>
+    private (RegistryKey hive, string path) Location(EnvVarScope scope) =>
         scope == EnvVarScope.Machine
-            ? (Registry.LocalMachine, MachineEnvPath)
-            : (Registry.CurrentUser, UserEnvPath);
+            ? (_machineRoot, MachineEnvPath)
+            : (_userRoot, UserEnvPath);
 
     /// <summary>
     /// Reads all variables for the given scope, sorted by name. Reads the RAW value
@@ -111,33 +157,55 @@ public sealed partial class EnvironmentVariableService
     /// are preserved for round-tripping, and records the value KIND so a write can keep
     /// REG_EXPAND_SZ intact.
     /// </summary>
-    public List<EnvVariable> Read(EnvVarScope scope)
+    public List<EnvVariable> Read(EnvVarScope scope) =>
+        ReadCore(scope, requireKey: false, requireSupportedKinds: false);
+
+    private List<EnvVariable> ReadCore(
+        EnvVarScope scope,
+        bool requireKey,
+        bool requireSupportedKinds)
     {
         List<EnvVariable> result = [];
         var (hive, path) = Location(scope);
         try
         {
             using var key = hive.OpenSubKey(path);
-            if (key is null) return result;
+            if (key is null)
+            {
+                if (requireKey)
+                    throw new IOException($"The {scope} environment registry key is unavailable.");
+                return result;
+            }
             foreach (var name in key.GetValueNames())
             {
                 if (string.IsNullOrEmpty(name)) continue;
                 var raw = key.GetValue(name, "", RegistryValueOptions.DoNotExpandEnvironmentNames);
-                var expandable = key.GetValueKind(name) == RegistryValueKind.ExpandString;
+                var kind = key.GetValueKind(name);
+                if (requireSupportedKinds &&
+                    kind is not RegistryValueKind.String and not RegistryValueKind.ExpandString)
+                {
+                    throw new InvalidDataException(
+                        $"The {scope} environment contains an unsupported registry value kind.");
+                }
+                if (requireSupportedKinds && raw is not string)
+                {
+                    throw new InvalidDataException(
+                        $"The {scope} environment contains a non-string registry value.");
+                }
                 result.Add(new EnvVariable
                 {
                     Name = name,
                     Scope = scope,
                     Value = raw?.ToString() ?? "",
-                    IsExpandable = expandable
+                    IsExpandable = kind == RegistryValueKind.ExpandString
                 });
             }
         }
-        catch (System.Security.SecurityException ex)
+        catch (System.Security.SecurityException ex) when (!requireKey)
         {
             Log.Warning(ex, "Environment: reading {Scope} scope denied", scope);
         }
-        catch (UnauthorizedAccessException ex)
+        catch (UnauthorizedAccessException ex) when (!requireKey)
         {
             Log.Warning(ex, "Environment: reading {Scope} scope denied", scope);
         }
@@ -199,7 +267,19 @@ public sealed partial class EnvironmentVariableService
                 return true;
             }
 
-            var kind = explicitKind ?? ChooseKind(ExistingKind(key, validName), value);
+            var existingKind = ExistingKind(key, validName);
+            if (explicitKind is null &&
+                existingKind is not null and not RegistryValueKind.String and not RegistryValueKind.ExpandString)
+            {
+                Log.Warning(
+                    "Environment: cannot safely overwrite {Scope} variable {Name} with unsupported kind {Kind}",
+                    scope,
+                    validName,
+                    existingKind);
+                return false;
+            }
+
+            var kind = explicitKind ?? ChooseKind(existingKind, value);
             key.SetValue(validName, value, kind);
             Log.Information("Environment: set {Scope} variable {Name} ({Kind})", scope, validName, kind);
             return true;
@@ -228,7 +308,9 @@ public sealed partial class EnvironmentVariableService
     /// REG_EXPAND_SZ when the value contains a %VAR% token, else REG_SZ. Pure for testing.
     /// </summary>
     public static RegistryValueKind ChooseKind(RegistryValueKind? existingKind, string value)
-        => existingKind ?? (value.Contains('%') ? RegistryValueKind.ExpandString : RegistryValueKind.String);
+        => existingKind is RegistryValueKind.String or RegistryValueKind.ExpandString
+            ? existingKind.Value
+            : value.Contains('%') ? RegistryValueKind.ExpandString : RegistryValueKind.String;
 
     /// <summary>Deletes a variable. Returns false if the write is denied.</summary>
     public bool DeleteVariable(string name, EnvVarScope scope) => SetVariable(name, null, scope);
@@ -295,53 +377,235 @@ public sealed partial class EnvironmentVariableService
 
     // ── Backup / restore ───────────────────────────────────────────────────────
 
-    /// <summary>Path of the pristine pre-SysManager backup (created before the first write).</summary>
+    /// <summary>Path of the legacy read-only User backup used by earlier releases.</summary>
     public string BackupPath => Path.Combine(_backupDir, "environment-backup.json");
 
-    /// <summary>True if a pristine backup already exists.</summary>
-    public bool HasBackup => File.Exists(BackupPath);
+    /// <summary>True when any backup artifact exists, including one that needs repair.</summary>
+    public bool HasBackup => ReadUserBackup().Exists || ReadMachineBackup().Exists;
+
+    /// <summary>True when a validated User snapshot exists.</summary>
+    public bool HasUserBackup => ReadUserBackup().Snapshot is not null;
+
+    /// <summary>True when a validated machine-protected snapshot exists.</summary>
+    public bool HasMachineBackup => ReadMachineBackup().Snapshot is not null;
 
     /// <summary>
-    /// Writes a one-time pristine backup of every User and Machine variable, so the
-    /// original environment can be restored later. No-op if a backup already exists
-    /// (preserving the truly-original snapshot, like <see cref="HostsFileService"/>).
+    /// Writes independent one-time snapshots before a scope's first mutation. New User
+    /// snapshots are stored under HKCU and Machine snapshots under access-controlled HKLM.
+    /// A legacy LocalAppData Machine section is never promoted across that boundary.
     /// </summary>
-    public void EnsureBackup()
+    public void EnsureBackup() => EnsureBackup(includeUser: true, includeMachine: true);
+
+    /// <summary>Ensures pristine snapshots only for the scopes about to be changed.</summary>
+    public void EnsureBackup(bool includeUser, bool includeMachine)
     {
-        if (HasBackup) return;
-        Directory.CreateDirectory(_backupDir);
-        var userVars = Read(EnvVarScope.User);
-        var machineVars = Read(EnvVarScope.Machine);
-        var snapshot = new EnvBackup(
-            User: ToDict(userVars),
-            Machine: ToDict(machineVars),
-            UserKinds: ToKindDict(userVars),
-            MachineKinds: ToKindDict(machineVars));
-        File.WriteAllText(BackupPath, JsonSerializer.Serialize(snapshot, JsonOptions),
-            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-        Log.Information("Environment: pristine backup written to {Path}", BackupPath);
+        // Validate every present artifact even when this operation will not mutate that
+        // scope. Otherwise Apply could create a snapshot that the all-or-nothing restore
+        // contract can never consume.
+        var userBackup = ReadUserBackup();
+        var machineBackup = ReadMachineBackup();
+
+        if (userBackup.IsInvalid || machineBackup.IsInvalid)
+            throw new InvalidDataException(
+                "An existing environment backup is invalid and will not be replaced.");
+
+        string? userJson = null;
+        string? machineJson = null;
+        if (includeUser && !userBackup.Exists)
+        {
+            var snapshot = CaptureScope(EnvVarScope.User);
+            userJson = SerializeBounded(new UserEnvBackup(snapshot.Values, snapshot.Kinds));
+        }
+        if (includeMachine && !machineBackup.Exists)
+        {
+            var snapshot = CaptureScope(EnvVarScope.Machine);
+            machineJson = SerializeBounded(new MachineEnvBackup(snapshot.Values, snapshot.Kinds));
+        }
+
+        // Publish only after every requested missing scope has been captured and validated.
+        if (machineJson is not null)
+            WriteMachineBackup(machineJson);
+        if (userJson is not null)
+            WriteUserBackup(userJson);
     }
 
-    private static Dictionary<string, string> ToDict(IEnumerable<EnvVariable> vars)
+    private void WriteUserBackup(string json)
     {
-        Dictionary<string, string> dict = new(StringComparer.OrdinalIgnoreCase);
-        foreach (var v in vars) dict[v.Name] = v.Value;
-        return dict;
+        using var key = _userRoot.CreateSubKey(UserBackupPath, writable: true)
+            ?? throw new UnauthorizedAccessException("The User backup key could not be created.");
+        key.SetValue(UserBackupValueName, json, RegistryValueKind.String);
+        Log.Information("Environment: pristine User backup written to HKCU storage");
     }
 
-    private static Dictionary<string, RegistryValueKind> ToKindDict(IEnumerable<EnvVariable> vars)
+    private void WriteMachineBackup(string json)
     {
-        Dictionary<string, RegistryValueKind> dict = new(StringComparer.OrdinalIgnoreCase);
-        foreach (var v in vars)
-            dict[v.Name] = v.IsExpandable ? RegistryValueKind.ExpandString : RegistryValueKind.String;
-        return dict;
+        using var key = OpenOrCreateMachineBackupKey();
+        key.SetValue(MachineBackupValueName, json, RegistryValueKind.String);
+        Log.Information("Environment: pristine Machine backup written to protected registry storage");
+    }
+
+    private RegistryKey OpenOrCreateMachineBackupKey()
+    {
+        if (!_enforceMachineBackupProtection)
+        {
+            return _machineRoot.CreateSubKey(MachineBackupPath, writable: true)
+                ?? throw new UnauthorizedAccessException(
+                    "The protected Machine backup key could not be created.");
+        }
+
+        EnsureMachineBackupParentIsProtected();
+        var key = _machineRoot.CreateSubKey(
+            MachineBackupPath,
+            RegistryKeyPermissionCheck.ReadWriteSubTree,
+            RegistryOptions.None,
+            CreateProtectedMachineBackupSecurity())
+            ?? throw new UnauthorizedAccessException(
+                "The protected Machine backup key could not be created.");
+
+        if (!IsProtectedMachineBackupSecurity(key.GetAccessControl(
+                AccessControlSections.Owner | AccessControlSections.Access)))
+        {
+            key.Dispose();
+            throw new InvalidDataException(
+                "The Machine backup key is not protected from standard-user writes.");
+        }
+
+        return key;
+    }
+
+    private void EnsureMachineBackupParentIsProtected()
+    {
+        if (!IsMachineBackupParentProtected())
+        {
+            throw new InvalidDataException(
+                "The Machine backup parent key is not protected from standard-user writes.");
+        }
+    }
+
+    private bool IsMachineBackupParentProtected()
+    {
+        using var parent = _machineRoot.OpenSubKey(
+            "SOFTWARE",
+            RegistryRights.ReadKey | RegistryRights.ReadPermissions);
+        return parent is not null && IsProtectedMachineBackupSecurity(parent.GetAccessControl(
+            AccessControlSections.Owner | AccessControlSections.Access));
+    }
+
+    internal static RegistrySecurity CreateProtectedMachineBackupSecurity()
+    {
+        var administrators = new SecurityIdentifier(
+            WellKnownSidType.BuiltinAdministratorsSid,
+            domainSid: null);
+        var system = new SecurityIdentifier(WellKnownSidType.LocalSystemSid, domainSid: null);
+        var users = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, domainSid: null);
+
+        RegistrySecurity security = new();
+        security.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+        security.SetOwner(administrators);
+        security.AddAccessRule(new RegistryAccessRule(
+            administrators,
+            RegistryRights.FullControl,
+            InheritanceFlags.None,
+            PropagationFlags.None,
+            AccessControlType.Allow));
+        security.AddAccessRule(new RegistryAccessRule(
+            system,
+            RegistryRights.FullControl,
+            InheritanceFlags.None,
+            PropagationFlags.None,
+            AccessControlType.Allow));
+        security.AddAccessRule(new RegistryAccessRule(
+            users,
+            RegistryRights.ReadKey,
+            InheritanceFlags.None,
+            PropagationFlags.None,
+            AccessControlType.Allow));
+        return security;
+    }
+
+    internal static bool IsProtectedMachineBackupSecurity(RegistrySecurity security)
+    {
+        if (security.GetOwner(typeof(SecurityIdentifier)) is not SecurityIdentifier owner ||
+            !IsTrustedMachinePrincipal(owner) ||
+            !security.AreAccessRulesCanonical)
+            return false;
+
+        const RegistryRights mutatingRights =
+            RegistryRights.SetValue |
+            RegistryRights.CreateSubKey |
+            RegistryRights.CreateLink |
+            RegistryRights.Delete |
+            RegistryRights.ChangePermissions |
+            RegistryRights.TakeOwnership;
+
+        foreach (RegistryAccessRule rule in security.GetAccessRules(
+                     includeExplicit: true,
+                     includeInherited: true,
+                     typeof(SecurityIdentifier)))
+        {
+            if (rule.AccessControlType != AccessControlType.Allow ||
+                (rule.RegistryRights & mutatingRights) == 0 ||
+                (rule.PropagationFlags & PropagationFlags.InheritOnly) != 0)
+            {
+                continue;
+            }
+
+            var principal = (SecurityIdentifier)rule.IdentityReference;
+            if (!IsTrustedMachinePrincipal(principal) &&
+                !principal.IsWellKnown(WellKnownSidType.CreatorOwnerSid))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsTrustedMachinePrincipal(SecurityIdentifier principal) =>
+        principal.IsWellKnown(WellKnownSidType.LocalSystemSid) ||
+        principal.IsWellKnown(WellKnownSidType.BuiltinAdministratorsSid);
+
+    private ScopeBackup CaptureScope(EnvVarScope scope)
+    {
+        var variables = ReadCore(
+            scope,
+            requireKey: true,
+            requireSupportedKinds: true);
+        if (scope == EnvVarScope.Machine && variables.Count == 0)
+            throw new InvalidDataException("The Machine environment is empty and cannot be backed up safely.");
+        if (variables.Count > MaxVariableCount)
+            throw new InvalidDataException($"The {scope} environment contains too many variables to back up safely.");
+
+        Dictionary<string, string> values = new(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, RegistryValueKind> kinds = new(StringComparer.OrdinalIgnoreCase);
+        foreach (var variable in variables)
+        {
+            if (!TryValidateBackupName(variable.Name, out var name))
+                throw new InvalidDataException($"The {scope} environment contains an unsupported variable name.");
+            if (variable.Value.Length > MaxVariableValueLength)
+                throw new InvalidDataException($"The {scope} environment contains an oversized variable value.");
+            if (!values.TryAdd(name, variable.Value))
+                throw new InvalidDataException($"The {scope} environment contains duplicate variable names.");
+
+            kinds.Add(
+                name,
+                variable.IsExpandable ? RegistryValueKind.ExpandString : RegistryValueKind.String);
+        }
+
+        return new ScopeBackup(values, kinds);
+    }
+
+    private static string SerializeBounded<T>(T snapshot)
+    {
+        var json = JsonSerializer.Serialize(snapshot, JsonOptions);
+        if (Encoding.UTF8.GetByteCount(json) > MaxBackupFileBytes)
+            throw new InvalidDataException("The environment backup exceeds the supported size.");
+        return json;
     }
 
     /// <summary>
-    /// A point-in-time snapshot of both environment scopes. The Kind dictionaries record
-    /// each variable's <see cref="RegistryValueKind"/> so a restore round-trips
-    /// REG_EXPAND_SZ faithfully instead of relying on the '%' heuristic. Nullable for
-    /// backward compatibility with backups written before this field was added.
+    /// A User-scope snapshot. New snapshots live under HKCU; old LocalAppData files may
+    /// contain Machine fields, but deserialization deliberately ignores those fields.
     /// </summary>
     public sealed record EnvBackup(
         Dictionary<string, string> User,
@@ -349,64 +613,405 @@ public sealed partial class EnvironmentVariableService
         Dictionary<string, RegistryValueKind>? UserKinds = null,
         Dictionary<string, RegistryValueKind>? MachineKinds = null);
 
-    /// <summary>Reads the backup snapshot, or null if there is none / it cannot be parsed.</summary>
+    private sealed record UserEnvBackup(
+        Dictionary<string, string> User,
+        Dictionary<string, RegistryValueKind>? UserKinds = null);
+
+    private sealed record MachineEnvBackup(
+        Dictionary<string, string> Machine,
+        Dictionary<string, RegistryValueKind>? MachineKinds = null);
+
+    private sealed record ScopeBackup(
+        Dictionary<string, string> Values,
+        Dictionary<string, RegistryValueKind>? Kinds);
+
+    private readonly record struct BackupRead<T>(bool Exists, T? Snapshot)
+        where T : class
+    {
+        public bool IsInvalid => Exists && Snapshot is null;
+        public static BackupRead<T> Missing => new(false, null);
+        public static BackupRead<T> Invalid => new(true, null);
+        public static BackupRead<T> Valid(T snapshot) => new(true, snapshot);
+    }
+
+    /// <summary>
+    /// Reads validated authoritative snapshots in the legacy aggregate shape. Legacy
+    /// LocalAppData Machine fields are never included; Machine data comes only from HKLM.
+    /// Returns null if a present artifact is invalid or no snapshot exists.
+    /// </summary>
     public EnvBackup? ReadBackup()
     {
-        if (!HasBackup) return null;
+        var userBackup = ReadUserBackup();
+        var machineBackup = ReadMachineBackup();
+        if (userBackup.IsInvalid || machineBackup.IsInvalid)
+            return null;
+        if (userBackup.Snapshot is null && machineBackup.Snapshot is null)
+            return null;
+
+        return new EnvBackup(
+            userBackup.Snapshot?.User ??
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            machineBackup.Snapshot?.Machine ??
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            userBackup.Snapshot?.UserKinds,
+            machineBackup.Snapshot?.MachineKinds);
+    }
+
+    private BackupRead<UserEnvBackup> ReadUserBackup()
+    {
+        var registryBackup = ReadUserRegistryBackup();
+        return registryBackup.Exists
+            ? registryBackup
+            : ReadLegacyUserBackup();
+    }
+
+    private BackupRead<UserEnvBackup> ReadUserRegistryBackup()
+    {
         try
         {
-            return JsonSerializer.Deserialize<EnvBackup>(File.ReadAllText(BackupPath), JsonOptions);
+            using var key = _userRoot.OpenSubKey(UserBackupPath);
+            if (key is null || !key.GetValueNames().Contains(
+                    UserBackupValueName,
+                    StringComparer.OrdinalIgnoreCase))
+            {
+                return BackupRead<UserEnvBackup>.Missing;
+            }
+
+            var rawValue = key.GetValue(
+                UserBackupValueName,
+                defaultValue: null,
+                RegistryValueOptions.DoNotExpandEnvironmentNames);
+            if (rawValue is not string json ||
+                key.GetValueKind(UserBackupValueName) != RegistryValueKind.String)
+            {
+                Log.Warning("Environment: User backup has an invalid registry type");
+                return BackupRead<UserEnvBackup>.Invalid;
+            }
+
+            return ParseUserBackup(json, "User registry");
         }
         catch (JsonException ex)
         {
-            Log.Warning(ex, "Environment: backup file is corrupt and will be ignored");
-            return null;
+            Log.Warning(ex, "Environment: User registry backup is corrupt");
+            return BackupRead<UserEnvBackup>.Invalid;
         }
         catch (IOException ex)
         {
-            Log.Warning(ex, "Environment: backup file could not be read");
-            return null;
+            Log.Warning(ex, "Environment: User registry backup could not be read");
+            return BackupRead<UserEnvBackup>.Invalid;
+        }
+        catch (System.Security.SecurityException ex)
+        {
+            Log.Warning(ex, "Environment: User registry backup read was denied");
+            return BackupRead<UserEnvBackup>.Invalid;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Log.Warning(ex, "Environment: User registry backup read was denied");
+            return BackupRead<UserEnvBackup>.Invalid;
         }
     }
 
+    private BackupRead<UserEnvBackup> ReadLegacyUserBackup()
+    {
+        if (!File.Exists(BackupPath))
+            return BackupRead<UserEnvBackup>.Missing;
+
+        try
+        {
+            var raw = JsonSerializer.Deserialize<UserEnvBackup>(ReadBoundedBackupFile(), JsonOptions);
+            return ValidateUserBackup(raw, "legacy User file");
+        }
+        catch (InvalidDataException ex)
+        {
+            Log.Warning(ex, "Environment: legacy User backup failed validation");
+            return BackupRead<UserEnvBackup>.Invalid;
+        }
+        catch (JsonException ex)
+        {
+            Log.Warning(ex, "Environment: legacy User backup is corrupt");
+            return BackupRead<UserEnvBackup>.Invalid;
+        }
+        catch (IOException ex)
+        {
+            Log.Warning(ex, "Environment: legacy User backup could not be read");
+            return BackupRead<UserEnvBackup>.Invalid;
+        }
+        catch (System.Security.SecurityException ex)
+        {
+            Log.Warning(ex, "Environment: legacy User backup read was denied");
+            return BackupRead<UserEnvBackup>.Invalid;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Log.Warning(ex, "Environment: legacy User backup read was denied");
+            return BackupRead<UserEnvBackup>.Invalid;
+        }
+    }
+
+    private static BackupRead<UserEnvBackup> ParseUserBackup(string json, string source)
+    {
+        if (Encoding.UTF8.GetByteCount(json) is <= 0 or > MaxBackupFileBytes)
+        {
+            Log.Warning("Environment: {Source} backup has an invalid size", source);
+            return BackupRead<UserEnvBackup>.Invalid;
+        }
+
+        var raw = JsonSerializer.Deserialize<UserEnvBackup>(json, JsonOptions);
+        return ValidateUserBackup(raw, source);
+    }
+
+    private static BackupRead<UserEnvBackup> ValidateUserBackup(UserEnvBackup? raw, string source)
+    {
+        if (raw is null)
+            return BackupRead<UserEnvBackup>.Invalid;
+
+        var validated = ValidateScopeBackup(raw.User, raw.UserKinds, source);
+        return validated is null
+            ? BackupRead<UserEnvBackup>.Invalid
+            : BackupRead<UserEnvBackup>.Valid(new UserEnvBackup(validated.Values, validated.Kinds));
+    }
+
+    private byte[] ReadBoundedBackupFile()
+    {
+        using var stream = new FileStream(
+            BackupPath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 4096,
+            FileOptions.SequentialScan);
+
+        var length = stream.Length;
+        if (length is <= 0 or > MaxBackupFileBytes)
+            throw new InvalidDataException("The environment backup has an invalid size.");
+
+        var bytes = new byte[(int)length];
+        var read = 0;
+        while (read < bytes.Length)
+        {
+            var count = stream.Read(bytes, read, bytes.Length - read);
+            if (count == 0) break;
+            read += count;
+        }
+
+        if (read != bytes.Length || stream.ReadByte() != -1)
+            throw new InvalidDataException("The environment backup changed while it was being read.");
+
+        return bytes;
+    }
+
+    private BackupRead<MachineEnvBackup> ReadMachineBackup()
+    {
+        try
+        {
+            using var key = _machineRoot.OpenSubKey(MachineBackupPath);
+            if (key is null)
+                return BackupRead<MachineEnvBackup>.Missing;
+
+            if (_enforceMachineBackupProtection && !IsMachineBackupParentProtected())
+            {
+                Log.Warning("Environment: Machine backup parent key is not access-controlled");
+                return BackupRead<MachineEnvBackup>.Invalid;
+            }
+
+            if (_enforceMachineBackupProtection &&
+                !IsProtectedMachineBackupSecurity(key.GetAccessControl(
+                    AccessControlSections.Owner | AccessControlSections.Access)))
+            {
+                Log.Warning("Environment: Machine backup key is writable by an untrusted principal");
+                return BackupRead<MachineEnvBackup>.Invalid;
+            }
+
+            if (!key.GetValueNames().Contains(
+                    MachineBackupValueName,
+                    StringComparer.OrdinalIgnoreCase))
+            {
+                return BackupRead<MachineEnvBackup>.Missing;
+            }
+
+            var rawValue = key.GetValue(
+                MachineBackupValueName,
+                defaultValue: null,
+                RegistryValueOptions.DoNotExpandEnvironmentNames);
+            if (rawValue is not string json ||
+                key.GetValueKind(MachineBackupValueName) != RegistryValueKind.String)
+            {
+                Log.Warning("Environment: protected Machine backup has an invalid registry type");
+                return BackupRead<MachineEnvBackup>.Invalid;
+            }
+            if (Encoding.UTF8.GetByteCount(json) is <= 0 or > MaxBackupFileBytes)
+            {
+                Log.Warning("Environment: protected Machine backup has an invalid size");
+                return BackupRead<MachineEnvBackup>.Invalid;
+            }
+
+            var raw = JsonSerializer.Deserialize<MachineEnvBackup>(json, JsonOptions);
+            if (raw is null)
+                return BackupRead<MachineEnvBackup>.Invalid;
+
+            var validated = ValidateScopeBackup(
+                raw.Machine,
+                raw.MachineKinds,
+                "protected Machine",
+                requireNonEmpty: true);
+            return validated is null
+                ? BackupRead<MachineEnvBackup>.Invalid
+                : BackupRead<MachineEnvBackup>.Valid(
+                    new MachineEnvBackup(validated.Values, validated.Kinds));
+        }
+        catch (JsonException ex)
+        {
+            Log.Warning(ex, "Environment: protected Machine backup is corrupt");
+            return BackupRead<MachineEnvBackup>.Invalid;
+        }
+        catch (IOException ex)
+        {
+            Log.Warning(ex, "Environment: protected Machine backup could not be read");
+            return BackupRead<MachineEnvBackup>.Invalid;
+        }
+        catch (System.Security.SecurityException ex)
+        {
+            Log.Warning(ex, "Environment: protected Machine backup read was denied");
+            return BackupRead<MachineEnvBackup>.Invalid;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Log.Warning(ex, "Environment: protected Machine backup read was denied");
+            return BackupRead<MachineEnvBackup>.Invalid;
+        }
+    }
+
+    private static ScopeBackup? ValidateScopeBackup(
+        Dictionary<string, string>? values,
+        Dictionary<string, RegistryValueKind>? kinds,
+        string source,
+        bool requireNonEmpty = false)
+    {
+        if (values is null)
+            return RejectScopeBackup(source, "the variables section is missing or null");
+        if (requireNonEmpty && values.Count == 0)
+            return RejectScopeBackup(source, "the variables section is empty");
+        if (values.Count > MaxVariableCount)
+            return RejectScopeBackup(source, "the variables section has too many entries");
+
+        Dictionary<string, string> normalizedValues = new(StringComparer.OrdinalIgnoreCase);
+        foreach (var (name, value) in values)
+        {
+            if (!TryValidateBackupName(name, out var validatedName))
+                return RejectScopeBackup(source, "a variable name is invalid");
+            if (value is null)
+                return RejectScopeBackup(source, "a variable value is null");
+            if (value.Length > MaxVariableValueLength)
+                return RejectScopeBackup(source, "a variable value is oversized");
+            if (!normalizedValues.TryAdd(validatedName, value))
+                return RejectScopeBackup(source, "variable names are duplicated");
+        }
+
+        Dictionary<string, RegistryValueKind>? normalizedKinds = null;
+        if (kinds is not null)
+        {
+            if (kinds.Count > MaxVariableCount)
+                return RejectScopeBackup(source, "the value-kind section has too many entries");
+
+            normalizedKinds = new Dictionary<string, RegistryValueKind>(StringComparer.OrdinalIgnoreCase);
+            foreach (var (name, kind) in kinds)
+            {
+                if (!TryValidateBackupName(name, out var validatedName))
+                    return RejectScopeBackup(source, "a value-kind name is invalid");
+                if (!normalizedValues.ContainsKey(validatedName))
+                    return RejectScopeBackup(source, "a value kind has no matching variable");
+                if (kind != RegistryValueKind.String && kind != RegistryValueKind.ExpandString)
+                    return RejectScopeBackup(source, "a registry value kind is unsupported");
+                if (!normalizedKinds.TryAdd(validatedName, kind))
+                    return RejectScopeBackup(source, "value-kind names are duplicated");
+            }
+        }
+
+        return new ScopeBackup(normalizedValues, normalizedKinds);
+    }
+
+    private static ScopeBackup? RejectScopeBackup(string source, string reason)
+    {
+        Log.Warning("Environment: {Source} backup rejected because {Reason}", source, reason);
+        return null;
+    }
+
     /// <summary>The outcome of a <see cref="RestoreFromBackup"/> call.</summary>
-    public readonly record struct RestoreResult(bool HadBackup, int Restored, int Removed, int Failed);
+    public readonly record struct RestoreResult(
+        bool HadBackup,
+        int Restored,
+        int Removed,
+        int Failed)
+    {
+        public bool InvalidBackup { get; init; }
+    }
 
     /// <summary>
-    /// Restores the environment to the pristine backup: every backed-up variable is
-    /// written back (kind preserved for existing names), and any variable that did NOT
-    /// exist in the backup is removed. Returns counts. Machine-scope changes need admin —
-    /// those writes count as failures (not exceptions) when not elevated. The caller
-    /// should <see cref="BroadcastSettingChange"/> once afterwards.
+    /// Restores each scope only from its authoritative, fully validated snapshot. The
+    /// HKCU or legacy LocalAppData data can affect only User variables; Machine variables
+    /// are restored only from the access-controlled HKLM snapshot. Every present snapshot
+    /// is validated before the first write. Machine writes count as failures when the
+    /// process is not elevated. The caller should
+    /// <see cref="BroadcastSettingChange"/> once afterwards.
     /// </summary>
     public RestoreResult RestoreFromBackup()
     {
-        var backup = ReadBackup();
-        if (backup is null) return new RestoreResult(false, 0, 0, 0);
+        var userBackup = ReadUserBackup();
+        var machineBackup = ReadMachineBackup();
+        var hasValidBackup = userBackup.Snapshot is not null || machineBackup.Snapshot is not null;
+        if (userBackup.IsInvalid || machineBackup.IsInvalid)
+        {
+            Log.Warning("Environment: restore aborted because a present backup is invalid");
+            return new RestoreResult(hasValidBackup, 0, 0, 0) { InvalidBackup = true };
+        }
+        if (!hasValidBackup)
+            return new RestoreResult(false, 0, 0, 0);
 
         int restored = 0, removed = 0, failed = 0;
-        foreach (var scope in new[] { EnvVarScope.User, EnvVarScope.Machine })
-        {
-            var saved = scope == EnvVarScope.Machine ? backup.Machine : backup.User;
-            var kinds = scope == EnvVarScope.Machine ? backup.MachineKinds : backup.UserKinds;
+        if (userBackup.Snapshot is { } userSnapshot)
+            RestoreScope(
+                EnvVarScope.User,
+                userSnapshot.User,
+                userSnapshot.UserKinds,
+                ref restored,
+                ref removed,
+                ref failed);
+        if (machineBackup.Snapshot is { } machineSnapshot)
+            RestoreScope(
+                EnvVarScope.Machine,
+                machineSnapshot.Machine,
+                machineSnapshot.MachineKinds,
+                ref restored,
+                ref removed,
+                ref failed);
 
-            foreach (var (name, value) in saved)
-            {
-                RegistryValueKind? explicitKind = kinds is not null && kinds.TryGetValue(name, out var savedKind)
-                    ? savedKind
-                    : null;
-                if (SetVariable(name, value, scope, explicitKind)) restored++;
-                else failed++;
-            }
-
-            foreach (var current in Read(scope))
-            {
-                if (saved.ContainsKey(current.Name)) continue;
-                if (DeleteVariable(current.Name, scope)) removed++;
-                else failed++;
-            }
-        }
         Log.Information("Environment: restored {Restored}, removed {Removed}, failed {Failed} from backup", restored, removed, failed);
         return new RestoreResult(true, restored, removed, failed);
+    }
+
+    private void RestoreScope(
+        EnvVarScope scope,
+        Dictionary<string, string> saved,
+        Dictionary<string, RegistryValueKind>? kinds,
+        ref int restored,
+        ref int removed,
+        ref int failed)
+    {
+        foreach (var (name, value) in saved)
+        {
+            RegistryValueKind? explicitKind = kinds is not null && kinds.TryGetValue(name, out var savedKind)
+                ? savedKind
+                : null;
+            if (SetVariable(name, value, scope, explicitKind)) restored++;
+            else failed++;
+        }
+
+        foreach (var current in Read(scope))
+        {
+            if (saved.ContainsKey(current.Name)) continue;
+            if (DeleteVariable(current.Name, scope)) removed++;
+            else failed++;
+        }
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.56.2</Version>
-    <FileVersion>1.56.2.0</FileVersion>
-    <AssemblyVersion>1.56.2.0</AssemblyVersion>
+    <Version>1.56.3</Version>
+    <FileVersion>1.56.3.0</FileVersion>
+    <AssemblyVersion>1.56.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
@@ -330,8 +330,12 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
             return;
         }
 
-        var touchesMachine = ChangedVariables().Any(v => v.Scope == EnvVarScope.Machine)
-            || DeletedEntries().Any(e => e.scope == EnvVarScope.Machine);
+        var changedVariables = ChangedVariables().ToList();
+        var deletedEntries = DeletedEntries().ToList();
+        var touchesUser = changedVariables.Any(v => v.Scope == EnvVarScope.User)
+            || deletedEntries.Any(e => e.scope == EnvVarScope.User);
+        var touchesMachine = changedVariables.Any(v => v.Scope == EnvVarScope.Machine)
+            || deletedEntries.Any(e => e.scope == EnvVarScope.Machine);
         if (touchesMachine && !IsElevated)
         {
             StatusMessage = "Some changes affect System variables — relaunch as administrator first.";
@@ -340,14 +344,20 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
 
         if (!DialogService.Instance.Confirm(
                 $"Apply {PendingChangeCount} environment change{(PendingChangeCount == 1 ? "" : "s")}?\n\n" +
-                "A one-time backup of all variables is saved first so you can restore the original environment.",
+                "A scope-specific safety backup is saved first so you can restore the original environment.",
                 "Confirm Environment Changes"))
         {
             StatusMessage = "Apply cancelled.";
             return;
         }
 
-        try { _service.EnsureBackup(); }
+        try { _service.EnsureBackup(touchesUser, touchesMachine); }
+        catch (InvalidDataException ex)
+        {
+            StatusMessage = "The existing safety backup is invalid - no changes were made.";
+            Log.Warning(ex, "Environment: invalid safety backup; aborting apply");
+            return;
+        }
         catch (IOException ex)
         {
             StatusMessage = "Could not write the safety backup — no changes were made.";
@@ -360,13 +370,19 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
             Log.Warning(ex, "Environment: backup write denied; aborting apply");
             return;
         }
+        catch (System.Security.SecurityException ex)
+        {
+            StatusMessage = "Could not write the safety backup - no changes were made.";
+            Log.Warning(ex, "Environment: protected backup write denied; aborting apply");
+            return;
+        }
         OnPropertyChanged(nameof(HasBackup));
 
         var failures = 0;
         var applied = 0;
 
         // Deletions: original variables no longer present in the working set.
-        foreach (var (scope, name) in DeletedEntries().ToList())
+        foreach (var (scope, name) in deletedEntries)
         {
             if (_service.DeleteVariable(name, scope))
             {
@@ -378,7 +394,7 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
         }
 
         // Adds + edits.
-        foreach (var v in ChangedVariables().ToList())
+        foreach (var v in changedVariables)
         {
             if (_service.SetVariable(v.Name, v.Value, v.Scope))
             {
@@ -446,7 +462,7 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
         }
 
         // Restoring Machine-scope variables needs admin; warn early like Apply does.
-        if (!IsElevated && _service.ReadBackup() is { Machine.Count: > 0 })
+        if (!IsElevated && _service.HasMachineBackup)
         {
             // Still allow restoring User-scope vars, but tell the user System ones will be skipped.
             if (!DialogService.Instance.Confirm(
@@ -473,6 +489,17 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
         // Restore rewrites many variables and then broadcasts (up to 5 s) — both run off the
         // UI thread; the list is re-read off-thread too via LoadAsync so the window stays live.
         var r = await Task.Run(_service.RestoreFromBackup);
+        if (r.InvalidBackup)
+        {
+            StatusMessage = "The available environment backup is invalid; no changes were made.";
+            return;
+        }
+        if (!r.HadBackup)
+        {
+            StatusMessage = "There is no environment backup to restore.";
+            return;
+        }
+
         if (r.Restored > 0 || r.Removed > 0) await Task.Run(EnvironmentVariableService.BroadcastSettingChange);
         await LoadAsync();
 


### PR DESCRIPTION
## Summary
- move new User and Machine environment snapshots into their matching registry trust domains
- allow HKLM restore only from an owner- and ACL-validated Machine snapshot; legacy LocalAppData Machine data is ignored
- validate malformed, duplicate, oversized, null, and unsupported backup content before the first restore write
- preserve the existing public backup/restore contracts and scope-specific apply behavior

## Security rationale
The previous aggregate backup lived under LocalAppData. An unprivileged process could modify its Machine section and later have those values applied to HKLM when SysManager restored while elevated. Machine snapshots now live under protected HKLM storage, while user-writable legacy data can affect only HKCU.

## Verification
- `dotnet restore SysManager/SysManager.sln`
- `dotnet build SysManager/SysManager.sln -c Release --no-restore -m:1` (all four projects, 0 warnings, 0 errors)
- pre-fix console harness reproduced the null-section crash
- post-fix console harness passed malformed input, legacy Machine isolation, protected ACL, unsupported Registry kind, denied write, cross-scope validation, and scope-only backup regressions

The xUnit and UI suites are left to the pull-request workflows; their assemblies compiled successfully in the local Release build.

## Release
- bumps the application to `1.56.3`
- updates CHANGELOG, README, and ARCHITECTURE