### PR TITLE
fix: restore sidebar selection highlight

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,6 +36,10 @@ The sidebar organises tabs into 12 groups (11 collapsible + a flat top-level Das
 `Item()` helper methods. Dashboard renders as a flat top-level entry.
 Collapsed groups show a child count badge, subtitle (derived
 from child labels joined with " · "), and tooltip.
+`MainWindowViewModel.SelectedNav` mirrors selection into `NavItem.IsSelected`.
+The flat Dashboard row and grouped leaf rows consume that state through the
+shared `SidebarNavRow`, `SidebarNavText`, and `SidebarActiveMark` styles, while
+`SelectionStatus` exposes the same state to UI Automation.
 A planned-but-unbuilt feature would use `PlaceholderViewModel` with a WIP view
 (none currently — every tab is implemented).
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,9 +37,11 @@ The sidebar organises tabs into 12 groups (11 collapsible + a flat top-level Das
 Collapsed groups show a child count badge, subtitle (derived
 from child labels joined with " · "), and tooltip.
 `MainWindowViewModel.SelectedNav` mirrors selection into `NavItem.IsSelected`.
-The flat Dashboard row and grouped leaf rows consume that state through the
-shared `SidebarNavRow`, `SidebarNavText`, and `SidebarActiveMark` styles, while
-`SelectionStatus` exposes the same state to UI Automation.
+The flat Dashboard row and grouped leaf rows are invokable `SidebarNavButton`
+controls. Their inner visuals consume selection through the shared `SidebarNavRow`,
+`SidebarNavText`, and `SidebarActiveMark` styles, while `SelectionStatus` exposes
+the same state to UI Automation. Group headers are keyboard-focusable toggles;
+collapsed content is disabled so visually hidden leaves cannot receive focus.
 A planned-but-unbuilt feature would use `PlaceholderViewModel` with a WIP view
 (none currently — every tab is implemented).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.56.5] - 2026-08-03
+
+### Fixed
+- **Restored persistent selected-tab feedback throughout the sidebar.** The grouped-sidebar migration in v0.18.0 replaced the selecting `ListBox` with non-selecting `ItemsControl` rows, leaving the live accent mark permanently collapsed and making all 58 tabs look unselected once the pointer moved away. Normal navigation now keeps exactly one `NavItem` selected, and both the flat Dashboard row and every grouped leaf share one selected-state treatment: an accent bar, selected background, stronger label, and primary foreground.
+- **Exposed the active tab to assistive technology.** Sidebar automation peers now report the selected item's status, and regression coverage pins the selection handoff, both live XAML templates, and removal of the obsolete `SideNavTabItem` style that previously held an unused second copy of the intended visuals.
+
 ## [1.56.4] - 2026-08-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - **Restored persistent selected-tab feedback throughout the sidebar.** The grouped-sidebar migration in v0.18.0 replaced the selecting `ListBox` with non-selecting `ItemsControl` rows, leaving the live accent mark permanently collapsed and making all 58 tabs look unselected once the pointer moved away. Normal navigation now keeps exactly one `NavItem` selected, and both the flat Dashboard row and every grouped leaf share one selected-state treatment: an accent bar, selected background, stronger label, and primary foreground.
-- **Exposed the active tab to assistive technology.** Each sidebar entry now has one stable automation peer that reports the selected item's status. The flat Dashboard entry is an invokable keyboard button with a visible focus cue, and regression coverage pins peer uniqueness, selection handoff, both live XAML templates, and removal of the obsolete `SideNavTabItem` style that held an unused second copy of the intended visuals.
+- **Exposed the active tab to assistive technology.** Each tab entry now has one stable automation peer that reports the selected item's status. Every tab entry is now an invokable keyboard button with a visible focus cue, group headers can be focused and toggled, and collapsed groups disable their visually hidden leaves so keyboard focus cannot disappear into them. Regression coverage pins peer uniqueness, selection handoff, both live XAML templates, collapsed-group behavior, and removal of the obsolete `SideNavTabItem` style that held an unused second copy of the intended visuals.
 
 ## [1.56.4] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - **Restored persistent selected-tab feedback throughout the sidebar.** The grouped-sidebar migration in v0.18.0 replaced the selecting `ListBox` with non-selecting `ItemsControl` rows, leaving the live accent mark permanently collapsed and making all 58 tabs look unselected once the pointer moved away. Normal navigation now keeps exactly one `NavItem` selected, and both the flat Dashboard row and every grouped leaf share one selected-state treatment: an accent bar, selected background, stronger label, and primary foreground.
-- **Exposed the active tab to assistive technology.** Sidebar automation peers now report the selected item's status, and regression coverage pins the selection handoff, both live XAML templates, and removal of the obsolete `SideNavTabItem` style that previously held an unused second copy of the intended visuals.
+- **Exposed the active tab to assistive technology.** Each sidebar entry now has one stable automation peer that reports the selected item's status. The flat Dashboard entry is an invokable keyboard button with a visible focus cue, and regression coverage pins peer uniqueness, selection handoff, both live XAML templates, and removal of the obsolete `SideNavTabItem` style that held an unused second copy of the intended visuals.
 
 ## [1.56.4] - 2026-08-03
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ fully open source.
 ### Sidebar navigation
 The sidebar organises 58 feature tabs into 12 groups — 11 collapsible groups
 plus a flat top-level Dashboard entry — so you can find what you need without
-scrolling through a flat list. All 58 tabs are fully implemented:
+scrolling through a flat list. The active tab stays marked with an accent bar,
+selected background, and stronger label while you move between groups. All 58
+tabs are fully implemented:
 
 | Group | Tabs |
 |-------|------|

--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ fully open source.
 The sidebar organises 58 feature tabs into 12 groups — 11 collapsible groups
 plus a flat top-level Dashboard entry — so you can find what you need without
 scrolling through a flat list. The active tab stays marked with an accent bar,
-selected background, and stronger label while you move between groups. All 58
-tabs are fully implemented:
+selected background, and stronger label while you move between groups. Every tab
+row and every group header is also keyboard-operable with a visible focus cue. All
+58 tabs are fully implemented:
 
 | Group | Tabs |
 |-------|------|

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -198,9 +198,15 @@ public class MainWindowViewModelTests
     public void OpenAboutTabCommand_SwitchesSelection()
     {
         var vm = new MainWindowViewModel();
+        var dashboard = vm.SelectedNav!;
+
         vm.OpenAboutTabCommand.Execute(null);
+
         Assert.NotNull(vm.SelectedNav);
         Assert.Equal("nav-about", vm.SelectedNav!.Id);
+        Assert.False(dashboard.IsSelected);
+        Assert.True(vm.SelectedNav.IsSelected);
+        Assert.Single(vm.NavItems, item => item.IsSelected);
     }
 
     [Fact]
@@ -209,6 +215,23 @@ public class MainWindowViewModelTests
         var vm = new MainWindowViewModel();
         Assert.NotNull(vm.SelectedNav);
         Assert.Equal("nav-dashboard", vm.SelectedNav!.Id);
+        Assert.True(vm.SelectedNav.IsSelected);
+        Assert.Single(vm.NavItems, item => item.IsSelected);
+    }
+
+    [Fact]
+    public void SelectedNav_NullClearsSelectionState()
+    {
+        var vm = new MainWindowViewModel();
+        var dashboard = vm.SelectedNav!;
+        var dashboardViewModel = Assert.IsType<DashboardViewModel>(dashboard.Content);
+        Assert.True(dashboardViewModel.IsActive);
+
+        vm.SelectedNav = null;
+
+        Assert.False(dashboard.IsSelected);
+        Assert.DoesNotContain(vm.NavItems, item => item.IsSelected);
+        Assert.False(dashboardViewModel.IsActive);
     }
 
     [Fact]

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -367,10 +367,12 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
-    public void NavGroups_AllExpandedByDefault()
+    public void NavGroups_CollapsibleGroupsStartCollapsed()
     {
         var vm = new MainWindowViewModel();
-        Assert.All(vm.NavGroups, g => Assert.True(g.IsExpanded));
+        Assert.All(
+            vm.NavGroups.Where(group => !group.IsSingleItem),
+            group => Assert.False(group.IsExpanded));
     }
 
     // ── Data-driven contract: every leaf in the live graph is well-formed ──

--- a/SysManager/SysManager.Tests/NavGroupTests.cs
+++ b/SysManager/SysManager.Tests/NavGroupTests.cs
@@ -110,4 +110,61 @@ public class NavGroupTests
         };
         Assert.True(item.IsInDevelopment);
     }
+
+    [Fact]
+    public void NavItem_IsSelected_DefaultsFalseWithEmptyAutomationStatus()
+    {
+        var item = CreateNavItem();
+
+        Assert.False(item.IsSelected);
+        Assert.Equal(string.Empty, item.SelectionStatus);
+    }
+
+    [Fact]
+    public void NavItem_IsSelected_UpdatesAutomationStatusAndRaisesChanges()
+    {
+        var item = CreateNavItem();
+        var changed = new List<string?>();
+        item.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        item.IsSelected = true;
+
+        Assert.True(item.IsSelected);
+        Assert.Equal("Selected", item.SelectionStatus);
+        Assert.Contains(nameof(NavItem.IsSelected), changed);
+        Assert.Contains(nameof(NavItem.SelectionStatus), changed);
+    }
+
+    [Fact]
+    public void MainWindowSelection_TransfersStateBetweenItems()
+    {
+        var oldItem = CreateNavItem();
+        var newItem = CreateNavItem();
+        oldItem.IsSelected = true;
+
+        MainWindowViewModel.UpdateSelectionState(oldItem, newItem);
+
+        Assert.False(oldItem.IsSelected);
+        Assert.True(newItem.IsSelected);
+    }
+
+    [Fact]
+    public void MainWindowSelection_NullClearsOldState()
+    {
+        var oldItem = CreateNavItem();
+        oldItem.IsSelected = true;
+
+        MainWindowViewModel.UpdateSelectionState(oldItem, null);
+
+        Assert.False(oldItem.IsSelected);
+    }
+
+    private static NavItem CreateNavItem() => new()
+    {
+        Id = "a",
+        Label = "A",
+        Glyph = "A",
+        Content = new object(),
+        ViewType = typeof(object),
+    };
 }

--- a/SysManager/SysManager.Tests/SidebarSelectionContractTests.cs
+++ b/SysManager/SysManager.Tests/SidebarSelectionContractTests.cs
@@ -73,7 +73,7 @@ public class SidebarSelectionContractTests
     {
         var document = LoadProjectXaml("MainWindow.xaml");
         var singleRow = document
-            .Descendants(Presentation + "ContentControl")
+            .Descendants(Presentation + "Button")
             .Single(element => (string?)element.Attribute(Xaml + "Name") == "SingleBd");
 
         Assert.Equal(
@@ -85,6 +85,19 @@ public class SidebarSelectionContractTests
         Assert.Equal(
             "{Binding Children[0].SelectionStatus}",
             (string?)singleRow.Attribute("AutomationProperties.ItemStatus"));
+        Assert.Equal("SingleGroup_Click", (string?)singleRow.Attribute("Click"));
+        Assert.Equal(
+            "{StaticResource SidebarNavButton}",
+            (string?)singleRow.Attribute("Style"));
+        Assert.Null(singleRow.Attribute("Focusable"));
+
+        var buttonStyle = FindStyle(document, "SidebarNavButton");
+        var focusTrigger = buttonStyle
+            .Descendants(Presentation + "Trigger")
+            .Single(trigger =>
+                (string?)trigger.Attribute("Property") == "IsKeyboardFocused"
+                && (string?)trigger.Attribute("Value") == "True");
+        AssertSetter(focusTrigger, "BorderBrush", "{DynamicResource Accent}");
 
         var outerItemsControl = document
             .Descendants(Presentation + "ItemsControl")

--- a/SysManager/SysManager.Tests/SidebarSelectionContractTests.cs
+++ b/SysManager/SysManager.Tests/SidebarSelectionContractTests.cs
@@ -1,0 +1,156 @@
+// SysManager · SidebarSelectionContractTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Xml.Linq;
+
+namespace SysManager.Tests;
+
+public class SidebarSelectionContractTests
+{
+    private static readonly XNamespace Presentation =
+        "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+    private static readonly XNamespace Xaml =
+        "http://schemas.microsoft.com/winfx/2006/xaml";
+
+    [Fact]
+    public void LiveRows_ShareSelectedVisualTreatment()
+    {
+        var document = LoadProjectXaml("MainWindow.xaml");
+        var rowStyle = FindStyle(document, "SidebarNavRow");
+        var rowTrigger = FindSelectedTrigger(rowStyle);
+
+        AssertSetter(rowTrigger, "Background", "{DynamicResource AccentSoft}");
+        var hoverTrigger = rowStyle
+            .Descendants(Presentation + "Trigger")
+            .Single(trigger =>
+                (string?)trigger.Attribute("Property") == "IsMouseOver"
+                && (string?)trigger.Attribute("Value") == "True");
+        AssertSetter(hoverTrigger, "Background", "{DynamicResource RowHover}");
+
+        var textStyle = FindStyle(document, "SidebarNavText");
+        AssertSetter(textStyle, "Foreground", "{DynamicResource TextSecondary}");
+        AssertSetter(textStyle, "FontWeight", "Medium");
+        var textTrigger = FindSelectedTrigger(textStyle);
+        AssertSetter(textTrigger, "Foreground", "{DynamicResource TextPrimary}");
+        AssertSetter(textTrigger, "FontWeight", "SemiBold");
+
+        var markStyle = FindStyle(document, "SidebarActiveMark");
+        var markTrigger = FindSelectedTrigger(markStyle);
+        AssertSetter(markTrigger, "Visibility", "Visible");
+
+        var liveRows = document
+            .Descendants(Presentation + "Border")
+            .Where(element =>
+                (string?)element.Attribute("Style") == "{StaticResource SidebarNavRow}")
+            .ToList();
+        var liveMarks = document
+            .Descendants(Presentation + "Rectangle")
+            .Where(element =>
+                (string?)element.Attribute("Style") == "{StaticResource SidebarActiveMark}")
+            .ToList();
+        var liveTexts = document
+            .Descendants(Presentation + "TextBlock")
+            .Where(element =>
+                (string?)element.Attribute("Style") == "{StaticResource SidebarNavText}")
+            .ToList();
+
+        Assert.Equal(2, liveRows.Count);
+        Assert.Equal(2, liveMarks.Count);
+        Assert.Equal(4, liveTexts.Count);
+        Assert.All(liveRows, row => Assert.Null(row.Attribute("Background")));
+        Assert.All(liveMarks, mark => Assert.Null(mark.Attribute("Visibility")));
+        Assert.All(
+            liveRows,
+            row => Assert.Single(
+                row.Descendants(Presentation + "Rectangle"),
+                mark => (string?)mark.Attribute("Style") == "{StaticResource SidebarActiveMark}"));
+    }
+
+    [Fact]
+    public void LiveRows_ExposeSelectionToAutomationPeers()
+    {
+        var document = LoadProjectXaml("MainWindow.xaml");
+        var singleRow = document
+            .Descendants(Presentation + "ContentControl")
+            .Single(element => (string?)element.Attribute(Xaml + "Name") == "SingleBd");
+
+        Assert.Equal(
+            "{Binding Children[0].SelectionStatus}",
+            (string?)singleRow.Attribute("AutomationProperties.ItemStatus"));
+
+        var outerContainerStyle = document
+            .Descendants(Presentation + "ItemsControl")
+            .Single(element => (string?)element.Attribute("ItemsSource") == "{Binding NavGroups}")
+            .Elements(Presentation + "ItemsControl.ItemContainerStyle")
+            .Single()
+            .Element(Presentation + "Style")!;
+        var outerSingleItemTrigger = outerContainerStyle
+            .Descendants(Presentation + "DataTrigger")
+            .Single(trigger =>
+                (string?)trigger.Attribute("Binding") == "{Binding IsSingleItem}"
+                && (string?)trigger.Attribute("Value") == "True");
+        AssertSetter(
+            outerSingleItemTrigger,
+            "AutomationProperties.Name",
+            "{Binding Children[0].Label}");
+        AssertSetter(
+            outerSingleItemTrigger,
+            "AutomationProperties.ItemStatus",
+            "{Binding Children[0].SelectionStatus}");
+
+        var groupedContainerStyle = document
+            .Descendants(Presentation + "ItemsControl")
+            .Single(element => (string?)element.Attribute("ItemsSource") == "{Binding Children}")
+            .Elements(Presentation + "ItemsControl.ItemContainerStyle")
+            .Single()
+            .Element(Presentation + "Style")!;
+        AssertSetter(
+            groupedContainerStyle,
+            "AutomationProperties.ItemStatus",
+            "{Binding SelectionStatus}");
+    }
+
+    [Fact]
+    public void LegacyTabItemStyle_IsNotKeptAsASecondSourceOfTruth()
+    {
+        var document = LoadProjectXaml("App.xaml");
+
+        Assert.DoesNotContain(
+            document.Descendants(Presentation + "Style"),
+            style => (string?)style.Attribute(Xaml + "Key") == "SideNavTabItem");
+    }
+
+    private static XElement FindStyle(XDocument document, string key) =>
+        document
+            .Descendants(Presentation + "Style")
+            .Single(style => (string?)style.Attribute(Xaml + "Key") == key);
+
+    private static XElement FindSelectedTrigger(XElement style) =>
+        style
+            .Descendants(Presentation + "DataTrigger")
+            .Single(trigger =>
+                (string?)trigger.Attribute("Binding") == "{Binding IsSelected}"
+                && (string?)trigger.Attribute("Value") == "True");
+
+    private static void AssertSetter(XElement trigger, string property, string value) =>
+        Assert.Contains(
+            trigger.Elements(Presentation + "Setter"),
+            setter =>
+                (string?)setter.Attribute("Property") == property
+                && (string?)setter.Attribute("Value") == value);
+
+    private static XDocument LoadProjectXaml(string fileName)
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory is not null;
+             directory = directory.Parent)
+        {
+            var candidate = Path.Combine(directory.FullName, "SysManager", fileName);
+            if (File.Exists(candidate)) return XDocument.Load(candidate);
+        }
+
+        throw new FileNotFoundException($"Could not locate SysManager/{fileName} from the test output.");
+    }
+}

--- a/SysManager/SysManager.Tests/SidebarSelectionContractTests.cs
+++ b/SysManager/SysManager.Tests/SidebarSelectionContractTests.cs
@@ -77,28 +77,20 @@ public class SidebarSelectionContractTests
             .Single(element => (string?)element.Attribute(Xaml + "Name") == "SingleBd");
 
         Assert.Equal(
+            "{Binding Children[0].Id}",
+            (string?)singleRow.Attribute("AutomationProperties.AutomationId"));
+        Assert.Equal(
+            "{Binding Children[0].Label}",
+            (string?)singleRow.Attribute("AutomationProperties.Name"));
+        Assert.Equal(
             "{Binding Children[0].SelectionStatus}",
             (string?)singleRow.Attribute("AutomationProperties.ItemStatus"));
 
-        var outerContainerStyle = document
+        var outerItemsControl = document
             .Descendants(Presentation + "ItemsControl")
-            .Single(element => (string?)element.Attribute("ItemsSource") == "{Binding NavGroups}")
-            .Elements(Presentation + "ItemsControl.ItemContainerStyle")
-            .Single()
-            .Element(Presentation + "Style")!;
-        var outerSingleItemTrigger = outerContainerStyle
-            .Descendants(Presentation + "DataTrigger")
-            .Single(trigger =>
-                (string?)trigger.Attribute("Binding") == "{Binding IsSingleItem}"
-                && (string?)trigger.Attribute("Value") == "True");
-        AssertSetter(
-            outerSingleItemTrigger,
-            "AutomationProperties.Name",
-            "{Binding Children[0].Label}");
-        AssertSetter(
-            outerSingleItemTrigger,
-            "AutomationProperties.ItemStatus",
-            "{Binding Children[0].SelectionStatus}");
+            .Single(element => (string?)element.Attribute("ItemsSource") == "{Binding NavGroups}");
+        Assert.Empty(
+            outerItemsControl.Elements(Presentation + "ItemsControl.ItemContainerStyle"));
 
         var groupedContainerStyle = document
             .Descendants(Presentation + "ItemsControl")
@@ -108,8 +100,21 @@ public class SidebarSelectionContractTests
             .Element(Presentation + "Style")!;
         AssertSetter(
             groupedContainerStyle,
+            "AutomationProperties.AutomationId",
+            "{Binding Id}");
+        AssertSetter(
+            groupedContainerStyle,
+            "AutomationProperties.Name",
+            "{Binding Label}");
+        AssertSetter(
+            groupedContainerStyle,
             "AutomationProperties.ItemStatus",
             "{Binding SelectionStatus}");
+
+        var groupedRow = document
+            .Descendants(Presentation + "Border")
+            .Single(element => (string?)element.Attribute(Xaml + "Name") == "ChildBd");
+        Assert.Null(groupedRow.Attribute("AutomationProperties.AutomationId"));
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/SidebarSelectionContractTests.cs
+++ b/SysManager/SysManager.Tests/SidebarSelectionContractTests.cs
@@ -37,6 +37,7 @@ public class SidebarSelectionContractTests
         AssertSetter(textTrigger, "FontWeight", "SemiBold");
 
         var markStyle = FindStyle(document, "SidebarActiveMark");
+        AssertSetter(markStyle, "Visibility", "Collapsed");
         var markTrigger = FindSelectedTrigger(markStyle);
         AssertSetter(markTrigger, "Visibility", "Visible");
 
@@ -69,27 +70,38 @@ public class SidebarSelectionContractTests
     }
 
     [Fact]
-    public void LiveRows_ExposeSelectionToAutomationPeers()
+    public void LiveRows_ExposeSelectionToInvokableAutomationPeers()
     {
         var document = LoadProjectXaml("MainWindow.xaml");
         var singleRow = document
             .Descendants(Presentation + "Button")
             .Single(element => (string?)element.Attribute(Xaml + "Name") == "SingleBd");
+        var groupedRow = document
+            .Descendants(Presentation + "Button")
+            .Single(element => (string?)element.Attribute(Xaml + "Name") == "ChildBd");
 
+        AssertNavButton(
+            singleRow,
+            idBinding: "{Binding Children[0].Id}",
+            nameBinding: "{Binding Children[0].Label}",
+            statusBinding: "{Binding Children[0].SelectionStatus}",
+            tagBinding: "{Binding Children[0]}",
+            clickHandler: "SingleGroup_Click");
+        AssertNavButton(
+            groupedRow,
+            idBinding: "{Binding Id}",
+            nameBinding: "{Binding Label}",
+            statusBinding: "{Binding SelectionStatus}",
+            tagBinding: "{Binding}",
+            clickHandler: "NavChild_Click");
+
+        var singleVisual = singleRow
+            .Descendants(Presentation + "Border")
+            .Single(element =>
+                (string?)element.Attribute("Style") == "{StaticResource SidebarNavRow}");
         Assert.Equal(
-            "{Binding Children[0].Id}",
-            (string?)singleRow.Attribute("AutomationProperties.AutomationId"));
-        Assert.Equal(
-            "{Binding Children[0].Label}",
-            (string?)singleRow.Attribute("AutomationProperties.Name"));
-        Assert.Equal(
-            "{Binding Children[0].SelectionStatus}",
-            (string?)singleRow.Attribute("AutomationProperties.ItemStatus"));
-        Assert.Equal("SingleGroup_Click", (string?)singleRow.Attribute("Click"));
-        Assert.Equal(
-            "{StaticResource SidebarNavButton}",
-            (string?)singleRow.Attribute("Style"));
-        Assert.Null(singleRow.Attribute("Focusable"));
+            "{Binding Children[0]}",
+            (string?)singleVisual.Attribute("DataContext"));
 
         var buttonStyle = FindStyle(document, "SidebarNavButton");
         var focusTrigger = buttonStyle
@@ -99,35 +111,62 @@ public class SidebarSelectionContractTests
                 && (string?)trigger.Attribute("Value") == "True");
         AssertSetter(focusTrigger, "BorderBrush", "{DynamicResource Accent}");
 
-        var outerItemsControl = document
+        var navItemsControls = document
             .Descendants(Presentation + "ItemsControl")
-            .Single(element => (string?)element.Attribute("ItemsSource") == "{Binding NavGroups}");
-        Assert.Empty(
-            outerItemsControl.Elements(Presentation + "ItemsControl.ItemContainerStyle"));
+            .Where(element =>
+                (string?)element.Attribute("ItemsSource") is "{Binding NavGroups}" or "{Binding Children}")
+            .ToList();
+        Assert.Equal(2, navItemsControls.Count);
+        Assert.All(
+            navItemsControls,
+            itemsControl => Assert.Empty(
+                itemsControl.Elements(Presentation + "ItemsControl.ItemContainerStyle")));
+    }
 
-        var groupedContainerStyle = document
-            .Descendants(Presentation + "ItemsControl")
-            .Single(element => (string?)element.Attribute("ItemsSource") == "{Binding Children}")
-            .Elements(Presentation + "ItemsControl.ItemContainerStyle")
-            .Single()
-            .Element(Presentation + "Style")!;
-        AssertSetter(
-            groupedContainerStyle,
-            "AutomationProperties.AutomationId",
-            "{Binding Id}");
-        AssertSetter(
-            groupedContainerStyle,
-            "AutomationProperties.Name",
-            "{Binding Label}");
-        AssertSetter(
-            groupedContainerStyle,
-            "AutomationProperties.ItemStatus",
-            "{Binding SelectionStatus}");
+    [Fact]
+    public void CollapsedGroups_KeepHiddenLeavesOutOfKeyboardNavigation()
+    {
+        var appDocument = LoadProjectXaml("App.xaml");
+        var expanderStyle = FindStyle(appDocument, "SidebarExpander");
+        var header = expanderStyle
+            .Descendants(Presentation + "ToggleButton")
+            .Single(element => (string?)element.Attribute(Xaml + "Name") == "HeaderSite");
 
-        var groupedRow = document
+        Assert.Equal("True", (string?)header.Attribute("Focusable"));
+        Assert.Equal("True", (string?)header.Attribute("KeyboardNavigation.IsTabStop"));
+        Assert.Equal(
+            "{Binding Id, StringFormat={}{0}-header}",
+            (string?)header.Attribute("AutomationProperties.AutomationId"));
+        Assert.Equal(
+            "{Binding Label}",
+            (string?)header.Attribute("AutomationProperties.Name"));
+
+        var focusTrigger = header
+            .Descendants(Presentation + "Trigger")
+            .Single(trigger =>
+                (string?)trigger.Attribute("Property") == "IsKeyboardFocused"
+                && (string?)trigger.Attribute("Value") == "True");
+        Assert.Contains(
+            focusTrigger.Elements(Presentation + "Setter"),
+            setter =>
+                (string?)setter.Attribute("TargetName") == "HeaderFocusBorder"
+                && (string?)setter.Attribute("Property") == "BorderBrush"
+                && (string?)setter.Attribute("Value") == "{DynamicResource Accent}");
+
+        var contentPanel = expanderStyle
             .Descendants(Presentation + "Border")
-            .Single(element => (string?)element.Attribute(Xaml + "Name") == "ChildBd");
-        Assert.Null(groupedRow.Attribute("AutomationProperties.AutomationId"));
+            .Single(element => (string?)element.Attribute(Xaml + "Name") == "ContentPanel");
+        Assert.Equal(
+            "{Binding IsExpanded, RelativeSource={RelativeSource TemplatedParent}}",
+            (string?)contentPanel.Attribute("IsEnabled"));
+
+        var mainDocument = LoadProjectXaml("MainWindow.xaml");
+        var liveExpander = mainDocument
+            .Descendants(Presentation + "Expander")
+            .Single(element =>
+                (string?)element.Attribute("Style") == "{StaticResource SidebarExpander}");
+        Assert.Equal("{Binding Id}", (string?)liveExpander.Attribute("AutomationProperties.AutomationId"));
+        Assert.Equal("{Binding Label}", (string?)liveExpander.Attribute("AutomationProperties.Name"));
     }
 
     [Fact]
@@ -138,6 +177,23 @@ public class SidebarSelectionContractTests
         Assert.DoesNotContain(
             document.Descendants(Presentation + "Style"),
             style => (string?)style.Attribute(Xaml + "Key") == "SideNavTabItem");
+    }
+
+    private static void AssertNavButton(
+        XElement button,
+        string idBinding,
+        string nameBinding,
+        string statusBinding,
+        string tagBinding,
+        string clickHandler)
+    {
+        Assert.Equal(idBinding, (string?)button.Attribute("AutomationProperties.AutomationId"));
+        Assert.Equal(nameBinding, (string?)button.Attribute("AutomationProperties.Name"));
+        Assert.Equal(statusBinding, (string?)button.Attribute("AutomationProperties.ItemStatus"));
+        Assert.Equal(tagBinding, (string?)button.Attribute("Tag"));
+        Assert.Equal(clickHandler, (string?)button.Attribute("Click"));
+        Assert.Equal("{StaticResource SidebarNavButton}", (string?)button.Attribute("Style"));
+        Assert.Null(button.Attribute("Focusable"));
     }
 
     private static XElement FindStyle(XDocument document, string key) =>
@@ -152,9 +208,9 @@ public class SidebarSelectionContractTests
                 (string?)trigger.Attribute("Binding") == "{Binding IsSelected}"
                 && (string?)trigger.Attribute("Value") == "True");
 
-    private static void AssertSetter(XElement trigger, string property, string value) =>
+    private static void AssertSetter(XElement owner, string property, string value) =>
         Assert.Contains(
-            trigger.Elements(Presentation + "Setter"),
+            owner.Elements(Presentation + "Setter"),
             setter =>
                 (string?)setter.Attribute("Property") == property
                 && (string?)setter.Attribute("Value") == value);

--- a/SysManager/SysManager.UITests/AppFixture.cs
+++ b/SysManager/SysManager.UITests/AppFixture.cs
@@ -71,12 +71,13 @@ public sealed class AppFixture : IDisposable
         if (item is null)
             throw new InvalidOperationException($"Nav item '{navId}' not found.{DescribeNavTree()}");
 
-        // Buttons expose Invoke through UI Automation; use it so keyboard/invoke semantics
-        // are exercised directly. Legacy/DataItem rows still require a coordinate click.
-        if (item.ControlType == ControlType.Button)
-            item.AsButton().Invoke();
-        else
-            item.Click();
+        if (item.ControlType != ControlType.Button)
+            throw new InvalidOperationException(
+                $"Nav item '{navId}' is {item.ControlType}, not an invokable Button.");
+
+        // Exercise the same UI Automation Invoke contract used by keyboard and
+        // assistive-technology clients, without relying on screen coordinates.
+        item.AsButton().Invoke();
 
         Thread.Sleep(250);
     }

--- a/SysManager/SysManager.UITests/AppFixture.cs
+++ b/SysManager/SysManager.UITests/AppFixture.cs
@@ -71,7 +71,13 @@ public sealed class AppFixture : IDisposable
         if (item is null)
             throw new InvalidOperationException($"Nav item '{navId}' not found.{DescribeNavTree()}");
 
-        item.Click();
+        // Buttons expose Invoke through UI Automation; use it so keyboard/invoke semantics
+        // are exercised directly. Legacy/DataItem rows still require a coordinate click.
+        if (item.ControlType == ControlType.Button)
+            item.AsButton().Invoke();
+        else
+            item.Click();
+
         Thread.Sleep(250);
     }
 

--- a/SysManager/SysManager.UITests/SmokeUiTests.cs
+++ b/SysManager/SysManager.UITests/SmokeUiTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Definitions;
 
 namespace SysManager.UITests;
 
@@ -91,11 +92,42 @@ public class SmokeUiTests
         Assert.NotEqual("Selected", logs.ItemStatus);
     }
 
+    [Fact]
+    public void CollapsedGroup_DisablesHiddenNavButtons()
+    {
+        var group = _fx.FindById("grp-info");
+        var header = _fx.FindById("grp-info-header");
+        Assert.NotNull(group);
+        Assert.NotNull(header);
+        Assert.True(header!.Properties.IsKeyboardFocusable.ValueOrDefault);
+
+        var pattern = group!.Patterns.ExpandCollapse.PatternOrDefault;
+        Assert.NotNull(pattern);
+        var logs = FindSingleById("nav-logs");
+
+        try
+        {
+            pattern!.Collapse();
+            var disabled = FlaUI.Core.Tools.Retry.WhileFalse(
+                () => !logs.IsEnabled,
+                TimeSpan.FromSeconds(3)).Success;
+            Assert.True(disabled, "A collapsed sidebar group left its hidden nav buttons enabled.");
+        }
+        finally
+        {
+            pattern!.Expand();
+            _ = FlaUI.Core.Tools.Retry.WhileFalse(
+                () => logs.IsEnabled,
+                TimeSpan.FromSeconds(3));
+        }
+    }
+
     private AutomationElement FindSingleById(string automationId)
     {
         var matches = _fx.MainWindow.FindAllDescendants(
             condition => condition.ByAutomationId(automationId));
         Assert.Single(matches);
+        Assert.Equal(ControlType.Button, matches[0].ControlType);
         return matches[0];
     }
 

--- a/SysManager/SysManager.UITests/SmokeUiTests.cs
+++ b/SysManager/SysManager.UITests/SmokeUiTests.cs
@@ -74,6 +74,26 @@ public class SmokeUiTests
     }
 
     [Fact]
+    public void NavSelection_ExposesCurrentItemStatus()
+    {
+        var dashboard = _fx.FindById("nav-dashboard");
+        Assert.NotNull(dashboard);
+        Assert.Equal("Selected", dashboard.ItemStatus);
+
+        _fx.GoToTab("nav-logs");
+        var logs = _fx.FindById("nav-logs");
+        Assert.NotNull(logs);
+        Assert.Equal("Selected", logs.ItemStatus);
+        Assert.NotEqual("Selected", dashboard.ItemStatus);
+
+        _fx.GoToTab("nav-ping");
+        var ping = _fx.FindById("nav-ping");
+        Assert.NotNull(ping);
+        Assert.Equal("Selected", ping.ItemStatus);
+        Assert.NotEqual("Selected", logs.ItemStatus);
+    }
+
+    [Fact]
     public void Navigate_BackAndForth_NoCrash()
     {
         _fx.GoToTab("nav-logs");

--- a/SysManager/SysManager.UITests/SmokeUiTests.cs
+++ b/SysManager/SysManager.UITests/SmokeUiTests.cs
@@ -61,7 +61,7 @@ public class SmokeUiTests
             "nav-system-health", "nav-cleanup", "nav-ping",
             "nav-drivers", "nav-logs" })
         {
-            Assert.NotNull(_fx.FindById(id));
+            _ = FindSingleById(id);
         }
     }
 
@@ -76,21 +76,27 @@ public class SmokeUiTests
     [Fact]
     public void NavSelection_ExposesCurrentItemStatus()
     {
-        var dashboard = _fx.FindById("nav-dashboard");
-        Assert.NotNull(dashboard);
+        _fx.GoToTab("nav-dashboard");
+        var dashboard = FindSingleById("nav-dashboard");
         Assert.Equal("Selected", dashboard.ItemStatus);
 
         _fx.GoToTab("nav-logs");
-        var logs = _fx.FindById("nav-logs");
-        Assert.NotNull(logs);
+        var logs = FindSingleById("nav-logs");
         Assert.Equal("Selected", logs.ItemStatus);
         Assert.NotEqual("Selected", dashboard.ItemStatus);
 
         _fx.GoToTab("nav-ping");
-        var ping = _fx.FindById("nav-ping");
-        Assert.NotNull(ping);
+        var ping = FindSingleById("nav-ping");
         Assert.Equal("Selected", ping.ItemStatus);
         Assert.NotEqual("Selected", logs.ItemStatus);
+    }
+
+    private AutomationElement FindSingleById(string automationId)
+    {
+        var matches = _fx.MainWindow.FindAllDescendants(
+            condition => condition.ByAutomationId(automationId));
+        Assert.Single(matches);
+        return matches[0];
     }
 
     [Fact]

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -171,14 +171,31 @@
                                               HorizontalAlignment="Stretch"
                                               HorizontalContentAlignment="Stretch"
                                               Cursor="Hand" Padding="0" Margin="0"
-                                              Focusable="False">
+                                              Focusable="True"
+                                              KeyboardNavigation.IsTabStop="True"
+                                              AutomationProperties.AutomationId="{Binding Id, StringFormat={}{0}-header}"
+                                              AutomationProperties.Name="{Binding Label}">
                                     <ToggleButton.Template>
                                         <ControlTemplate TargetType="ToggleButton">
-                                            <ContentPresenter HorizontalAlignment="Stretch"/>
+                                            <Border x:Name="HeaderFocusBorder"
+                                                    BorderBrush="Transparent"
+                                                    BorderThickness="1"
+                                                    CornerRadius="8">
+                                                <ContentPresenter HorizontalAlignment="Stretch"/>
+                                            </Border>
+                                            <ControlTemplate.Triggers>
+                                                <Trigger Property="IsKeyboardFocused" Value="True">
+                                                    <Setter TargetName="HeaderFocusBorder"
+                                                            Property="BorderBrush"
+                                                            Value="{DynamicResource Accent}"/>
+                                                </Trigger>
+                                            </ControlTemplate.Triggers>
                                         </ControlTemplate>
                                     </ToggleButton.Template>
                                 </ToggleButton>
-                                <Border x:Name="ContentPanel" ClipToBounds="True">
+                                <Border x:Name="ContentPanel"
+                                        ClipToBounds="True"
+                                        IsEnabled="{Binding IsExpanded, RelativeSource={RelativeSource TemplatedParent}}">
                                     <ContentPresenter x:Name="ExpanderContent"
                                                       ContentSource="Content"
                                                       Margin="{TemplateBinding Padding}"/>

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -935,57 +935,6 @@
             </Style>
 
             <!-- ============================================================ -->
-            <!-- Side-nav tab style (vertical tabs with icon + label)          -->
-            <!-- ============================================================ -->
-            <Style x:Key="SideNavTabItem" TargetType="TabItem">
-                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
-                <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
-                <Setter Property="FontSize" Value="13"/>
-                <Setter Property="FontWeight" Value="Medium"/>
-                <Setter Property="Cursor" Value="Hand"/>
-                <Setter Property="HorizontalContentAlignment" Value="Left"/>
-                <Setter Property="MinWidth" Value="180"/>
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="TabItem">
-                            <Border x:Name="Bd"
-                                    Background="Transparent"
-                                    CornerRadius="{StaticResource RadiusMd}"
-                                    Margin="10,2"
-                                    Padding="14,10">
-                                <Grid>
-                                    <Rectangle x:Name="ActiveMark"
-                                               HorizontalAlignment="Left"
-                                               Width="3" Height="20"
-                                               Fill="{DynamicResource Accent}"
-                                               RadiusX="2" RadiusY="2"
-                                               Margin="-14,0,0,0"
-                                               Visibility="Collapsed"/>
-                                    <ContentPresenter ContentSource="Header"
-                                                      VerticalAlignment="Center"
-                                                      HorizontalAlignment="Left"
-                                                      TextBlock.Foreground="{TemplateBinding Foreground}"
-                                                      TextBlock.FontWeight="{TemplateBinding FontWeight}"/>
-                                </Grid>
-                            </Border>
-                            <ControlTemplate.Triggers>
-                                <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Surface2}"/>
-                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
-                                </Trigger>
-                                <Trigger Property="IsSelected" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource AccentSoft}"/>
-                                    <Setter TargetName="ActiveMark" Property="Visibility" Value="Visible"/>
-                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
-                                    <Setter Property="FontWeight" Value="SemiBold"/>
-                                </Trigger>
-                            </ControlTemplate.Triggers>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-
-            <!-- ============================================================ -->
             <!-- Pill / Badge                                                  -->
             <!-- ============================================================ -->
             <Style x:Key="Badge" TargetType="Border">

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -13,6 +13,48 @@
         <vm:MainWindowViewModel/>
     </Window.DataContext>
 
+    <Window.Resources>
+        <!-- One selected-row treatment serves both the flat Dashboard entry and grouped leaves. -->
+        <Style x:Key="SidebarNavRow" TargetType="Border">
+            <Setter Property="Background" Value="Transparent"/>
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="{DynamicResource RowHover}"/>
+                </Trigger>
+                <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                    <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="SidebarNavText" TargetType="TextBlock"
+               BasedOn="{StaticResource {x:Type TextBlock}}">
+            <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
+            <Setter Property="FontWeight" Value="Medium"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
+                    <Setter Property="FontWeight" Value="SemiBold"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="SidebarActiveMark" TargetType="Rectangle">
+            <Setter Property="HorizontalAlignment" Value="Left"/>
+            <Setter Property="Width" Value="3"/>
+            <Setter Property="Height" Value="18"/>
+            <Setter Property="Fill" Value="{DynamicResource Accent}"/>
+            <Setter Property="RadiusX" Value="2"/>
+            <Setter Property="RadiusY" Value="2"/>
+            <Setter Property="Visibility" Value="Collapsed"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                    <Setter Property="Visibility" Value="Visible"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+    </Window.Resources>
+
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="220"/>
@@ -54,6 +96,12 @@
                     <ItemsControl.ItemContainerStyle>
                         <Style TargetType="ContentPresenter">
                             <Setter Property="AutomationProperties.AutomationId" Value="{Binding Children[0].Id}"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsSingleItem}" Value="True">
+                                    <Setter Property="AutomationProperties.Name" Value="{Binding Children[0].Label}"/>
+                                    <Setter Property="AutomationProperties.ItemStatus" Value="{Binding Children[0].SelectionStatus}"/>
+                                </DataTrigger>
+                            </Style.Triggers>
                         </Style>
                     </ItemsControl.ItemContainerStyle>
                     <ItemsControl.ItemTemplate>
@@ -73,37 +121,35 @@
                                                 MouseLeftButtonUp="SingleGroup_Click"
                                                 Tag="{Binding Children[0]}"
                                                 AutomationProperties.AutomationId="{Binding Children[0].Id}"
-                                                AutomationProperties.Name="{Binding Children[0].Label}">
-                                    <Border CornerRadius="8" Padding="14,10">
-                                        <Border.Style>
-                                            <Style TargetType="Border">
-                                                <Setter Property="Background" Value="Transparent"/>
-                                                <Style.Triggers>
-                                                    <Trigger Property="IsMouseOver" Value="True">
-                                                        <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
-                                                    </Trigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </Border.Style>
-                                        <StackPanel Orientation="Horizontal">
-                                            <TextBlock Text="{Binding Glyph}"
-                                                       FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                                                       FontSize="14" Margin="0,0,12,0"
-                                                       VerticalAlignment="Center"
-                                                       Foreground="{DynamicResource TextSecondary}"/>
-                                            <TextBlock Text="{Binding Label}"
-                                                       VerticalAlignment="Center"
-                                                       FontFamily="{StaticResource UiFont}"
-                                                       FontSize="13" FontWeight="Medium"
-                                                       Foreground="{DynamicResource TextSecondary}"/>
-                                            <!-- PREVIEW pill: implemented but not yet QA-verified -->
-                                            <Border Background="{DynamicResource AccentSoft}" CornerRadius="4"
-                                                    Padding="5,1" Margin="7,0,0,0" VerticalAlignment="Center"
-                                                    Visibility="{Binding Children[0].IsInDevelopment, Converter={StaticResource BoolToVis}}">
-                                                <TextBlock Text="PREVIEW" FontSize="9" FontWeight="Bold"
-                                                           Foreground="{DynamicResource Info}"/>
-                                            </Border>
-                                        </StackPanel>
+                                                AutomationProperties.Name="{Binding Children[0].Label}"
+                                                AutomationProperties.ItemStatus="{Binding Children[0].SelectionStatus}">
+                                    <Border CornerRadius="8" Padding="14,10"
+                                            DataContext="{Binding Children[0]}"
+                                            Style="{StaticResource SidebarNavRow}">
+                                        <Grid>
+                                            <Rectangle x:Name="SingleActiveMark"
+                                                       Style="{StaticResource SidebarActiveMark}"
+                                                       Margin="-14,0,0,0"/>
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="{Binding Glyph}"
+                                                           Style="{StaticResource SidebarNavText}"
+                                                           FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                                                           FontSize="14" Margin="0,0,12,0"
+                                                           VerticalAlignment="Center"/>
+                                                <TextBlock Text="{Binding Label}"
+                                                           Style="{StaticResource SidebarNavText}"
+                                                           VerticalAlignment="Center"
+                                                           FontFamily="{StaticResource UiFont}"
+                                                           FontSize="13"/>
+                                                <!-- PREVIEW pill: implemented but not yet QA-verified -->
+                                                <Border Background="{DynamicResource AccentSoft}" CornerRadius="4"
+                                                        Padding="5,1" Margin="7,0,0,0" VerticalAlignment="Center"
+                                                        Visibility="{Binding IsInDevelopment, Converter={StaticResource BoolToVis}}">
+                                                    <TextBlock Text="PREVIEW" FontSize="9" FontWeight="Bold"
+                                                               Foreground="{DynamicResource Info}"/>
+                                                </Border>
+                                            </StackPanel>
+                                        </Grid>
                                     </Border>
                                 </ContentControl>
 
@@ -214,6 +260,7 @@
                                             <Style TargetType="ContentPresenter">
                                                 <Setter Property="AutomationProperties.AutomationId" Value="{Binding Id}"/>
                                                 <Setter Property="AutomationProperties.Name" Value="{Binding Label}"/>
+                                                <Setter Property="AutomationProperties.ItemStatus" Value="{Binding SelectionStatus}"/>
                                             </Style>
                                         </ItemsControl.ItemContainerStyle>
                                         <ItemsControl.ItemTemplate>
@@ -223,25 +270,12 @@
                                                         Cursor="Hand"
                                                         MouseLeftButtonUp="NavChild_Click"
                                                         Tag="{Binding}"
-                                                        AutomationProperties.AutomationId="{Binding Id}">
-                                                    <Border.Style>
-                                                        <Style TargetType="Border">
-                                                            <Setter Property="Background" Value="Transparent"/>
-                                                            <Style.Triggers>
-                                                                <Trigger Property="IsMouseOver" Value="True">
-                                                                    <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
-                                                                </Trigger>
-                                                            </Style.Triggers>
-                                                        </Style>
-                                                    </Border.Style>
+                                                        AutomationProperties.AutomationId="{Binding Id}"
+                                                        Style="{StaticResource SidebarNavRow}">
                                                     <Grid>
                                                         <Rectangle x:Name="ActiveMark"
-                                                                   HorizontalAlignment="Left"
-                                                                   Width="3" Height="18"
-                                                                   Fill="{DynamicResource Accent}"
-                                                                   RadiusX="2" RadiusY="2"
-                                                                   Margin="-28,0,0,0"
-                                                                   Visibility="Collapsed"/>
+                                                                   Style="{StaticResource SidebarActiveMark}"
+                                                                   Margin="-28,0,0,0"/>
                                                         <!-- DockPanel (not a horizontal StackPanel): a StackPanel gives its
                                                              children infinite width, so the label's grid never constrained and the
                                                              PREVIEW pill overflowed the 220px sidebar. Docking the glyph left lets
@@ -249,10 +283,10 @@
                                                              the pill always shows. -->
                                                         <DockPanel>
                                                             <TextBlock Text="{Binding Glyph}" DockPanel.Dock="Left"
+                                                                       Style="{StaticResource SidebarNavText}"
                                                                        FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                                                        FontSize="13" Margin="0,0,10,0"
-                                                                       VerticalAlignment="Center"
-                                                                       Foreground="{DynamicResource TextSecondary}"/>
+                                                                       VerticalAlignment="Center"/>
                                                             <StackPanel VerticalAlignment="Center">
                                                                 <!-- Label + PREVIEW pill in a 2-column grid (label = *, pill = Auto):
                                                                      a horizontal StackPanel measured with infinite width, so on a long
@@ -264,10 +298,10 @@
                                                                         <ColumnDefinition Width="Auto"/>
                                                                     </Grid.ColumnDefinitions>
                                                                     <TextBlock Grid.Column="0" Text="{Binding Label}"
+                                                                               Style="{StaticResource SidebarNavText}"
                                                                                FontFamily="{StaticResource UiFont}"
-                                                                               FontSize="13" FontWeight="Medium"
-                                                                               VerticalAlignment="Center" TextTrimming="CharacterEllipsis"
-                                                                               Foreground="{DynamicResource TextSecondary}"/>
+                                                                               FontSize="13"
+                                                                               VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
                                                                     <!-- PREVIEW pill: implemented but not yet QA-verified -->
                                                                     <Border Grid.Column="1" Background="{DynamicResource AccentSoft}" CornerRadius="4"
                                                                             Padding="5,1" Margin="7,0,0,0" VerticalAlignment="Center"

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -14,8 +14,8 @@
     </Window.DataContext>
 
     <Window.Resources>
-        <!-- The flat Dashboard entry is a real Button so it exposes one invokable UIA peer
-             and remains keyboard-operable without inheriting the app's command-button chrome. -->
+        <!-- Each leaf is a real Button so it exposes one invokable UIA peer and remains
+             keyboard-operable without inheriting the app's command-button chrome. -->
         <Style x:Key="SidebarNavButton" TargetType="Button"
                BasedOn="{StaticResource ButtonBase}">
             <Setter Property="Background" Value="Transparent"/>
@@ -173,7 +173,9 @@
                                 <!-- Multi-item group: expander with children -->
                                 <Expander Visibility="{Binding IsSingleItem, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"
                                           IsExpanded="{Binding IsExpanded, Mode=TwoWay}"
-                                          Style="{StaticResource SidebarExpander}">
+                                          Style="{StaticResource SidebarExpander}"
+                                          AutomationProperties.AutomationId="{Binding Id}"
+                                          AutomationProperties.Name="{Binding Label}">
                                     <Expander.Header>
                                         <Border CornerRadius="8" Padding="14,10" Cursor="Hand"
                                                 ToolTip="{Binding Tooltip}">
@@ -267,72 +269,63 @@
                                         </Border>
                                     </Expander.Header>
                                     <ItemsControl ItemsSource="{Binding Children}" Focusable="False">
-                                        <!-- Put the nav-item AutomationId + Name on the generated
-                                             item container (the ContentPresenter, whose peer is the
-                                             DataItem that actually appears in the UI Automation tree).
-                                             The inner Border has no automation peer, so its AutomationId
-                                             never surfaced — this is also what made the items invisible
-                                             to screen readers. -->
-                                        <ItemsControl.ItemContainerStyle>
-                                            <Style TargetType="ContentPresenter">
-                                                <Setter Property="AutomationProperties.AutomationId" Value="{Binding Id}"/>
-                                                <Setter Property="AutomationProperties.Name" Value="{Binding Label}"/>
-                                                <Setter Property="AutomationProperties.ItemStatus" Value="{Binding SelectionStatus}"/>
-                                            </Style>
-                                        </ItemsControl.ItemContainerStyle>
                                         <ItemsControl.ItemTemplate>
                                             <DataTemplate>
-                                                <Border x:Name="ChildBd"
-                                                        CornerRadius="8" Padding="28,9,14,9"
-                                                        Cursor="Hand"
-                                                        MouseLeftButtonUp="NavChild_Click"
+                                                <Button x:Name="ChildBd"
+                                                        Click="NavChild_Click"
                                                         Tag="{Binding}"
-                                                        Style="{StaticResource SidebarNavRow}">
-                                                    <Grid>
-                                                        <Rectangle x:Name="ActiveMark"
-                                                                   Style="{StaticResource SidebarActiveMark}"
-                                                                   Margin="-28,0,0,0"/>
-                                                        <!-- DockPanel (not a horizontal StackPanel): a StackPanel gives its
-                                                             children infinite width, so the label's grid never constrained and the
-                                                             PREVIEW pill overflowed the 220px sidebar. Docking the glyph left lets
-                                                             the content fill the real remaining width, so the label ellipsizes and
-                                                             the pill always shows. -->
-                                                        <DockPanel>
-                                                            <TextBlock Text="{Binding Glyph}" DockPanel.Dock="Left"
-                                                                       Style="{StaticResource SidebarNavText}"
-                                                                       FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                                                                       FontSize="13" Margin="0,0,10,0"
-                                                                       VerticalAlignment="Center"/>
-                                                            <StackPanel VerticalAlignment="Center">
-                                                                <!-- Label + PREVIEW pill in a 2-column grid (label = *, pill = Auto):
-                                                                     a horizontal StackPanel measured with infinite width, so on a long
-                                                                     label the pill was pushed past the 220px sidebar edge and clipped to
-                                                                     "PR". The label now ellipsizes and the pill always renders in full. -->
-                                                                <Grid>
-                                                                    <Grid.ColumnDefinitions>
-                                                                        <ColumnDefinition Width="*"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                    </Grid.ColumnDefinitions>
-                                                                    <TextBlock Grid.Column="0" Text="{Binding Label}"
-                                                                               Style="{StaticResource SidebarNavText}"
-                                                                               FontFamily="{StaticResource UiFont}"
-                                                                               FontSize="13"
-                                                                               VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
-                                                                    <!-- PREVIEW pill: implemented but not yet QA-verified -->
-                                                                    <Border Grid.Column="1" Background="{DynamicResource AccentSoft}" CornerRadius="4"
-                                                                            Padding="5,1" Margin="7,0,0,0" VerticalAlignment="Center"
-                                                                            Visibility="{Binding IsInDevelopment, Converter={StaticResource BoolToVis}}">
-                                                                        <TextBlock Text="PREVIEW" FontSize="9" FontWeight="Bold"
-                                                                                   Foreground="{DynamicResource Info}"/>
-                                                                    </Border>
-                                                                </Grid>
-                                                                <ProgressBar Height="2" Margin="0,3,0,0"
-                                                                             IsIndeterminate="True"
-                                                                             Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-                                                            </StackPanel>
-                                                        </DockPanel>
-                                                    </Grid>
-                                                </Border>
+                                                        Style="{StaticResource SidebarNavButton}"
+                                                        AutomationProperties.AutomationId="{Binding Id}"
+                                                        AutomationProperties.Name="{Binding Label}"
+                                                        AutomationProperties.ItemStatus="{Binding SelectionStatus}">
+                                                    <Border CornerRadius="8" Padding="28,9,14,9"
+                                                            Style="{StaticResource SidebarNavRow}">
+                                                        <Grid>
+                                                            <Rectangle x:Name="ActiveMark"
+                                                                       Style="{StaticResource SidebarActiveMark}"
+                                                                       Margin="-28,0,0,0"/>
+                                                            <!-- DockPanel (not a horizontal StackPanel): a StackPanel gives its
+                                                                 children infinite width, so the label's grid never constrained and the
+                                                                 PREVIEW pill overflowed the 220px sidebar. Docking the glyph left lets
+                                                                 the content fill the real remaining width, so the label ellipsizes and
+                                                                 the pill always shows. -->
+                                                            <DockPanel>
+                                                                <TextBlock Text="{Binding Glyph}" DockPanel.Dock="Left"
+                                                                           Style="{StaticResource SidebarNavText}"
+                                                                           FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                                                                           FontSize="13" Margin="0,0,10,0"
+                                                                           VerticalAlignment="Center"/>
+                                                                <StackPanel VerticalAlignment="Center">
+                                                                    <!-- Label + PREVIEW pill in a 2-column grid (label = *, pill = Auto):
+                                                                         a horizontal StackPanel measured with infinite width, so on a long
+                                                                         label the pill was pushed past the 220px sidebar edge and clipped to
+                                                                         "PR". The label now ellipsizes and the pill always renders in full. -->
+                                                                    <Grid>
+                                                                        <Grid.ColumnDefinitions>
+                                                                            <ColumnDefinition Width="*"/>
+                                                                            <ColumnDefinition Width="Auto"/>
+                                                                        </Grid.ColumnDefinitions>
+                                                                        <TextBlock Grid.Column="0" Text="{Binding Label}"
+                                                                                   Style="{StaticResource SidebarNavText}"
+                                                                                   FontFamily="{StaticResource UiFont}"
+                                                                                   FontSize="13"
+                                                                                   VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                                                                        <!-- PREVIEW pill: implemented but not yet QA-verified -->
+                                                                        <Border Grid.Column="1" Background="{DynamicResource AccentSoft}" CornerRadius="4"
+                                                                                Padding="5,1" Margin="7,0,0,0" VerticalAlignment="Center"
+                                                                                Visibility="{Binding IsInDevelopment, Converter={StaticResource BoolToVis}}">
+                                                                            <TextBlock Text="PREVIEW" FontSize="9" FontWeight="Bold"
+                                                                                       Foreground="{DynamicResource Info}"/>
+                                                                        </Border>
+                                                                    </Grid>
+                                                                    <ProgressBar Height="2" Margin="0,3,0,0"
+                                                                                 IsIndeterminate="True"
+                                                                                 Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+                                                                </StackPanel>
+                                                            </DockPanel>
+                                                        </Grid>
+                                                    </Border>
+                                                </Button>
                                             </DataTemplate>
                                         </ItemsControl.ItemTemplate>
                                     </ItemsControl>

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -88,22 +88,6 @@
                 <ItemsControl ItemsSource="{Binding NavGroups}"
                               Padding="10,0"
                               Focusable="False">
-                    <!-- A single-item group renders as a flat row (no expander), so the nav
-                         id has to ride on the group's own container peer — the inner Border
-                         has no automation peer. For multi-item groups Children[0].Id is just
-                         the first child's id and is harmless (those children carry their own
-                         ids via the inner ItemsControl's ItemContainerStyle below). -->
-                    <ItemsControl.ItemContainerStyle>
-                        <Style TargetType="ContentPresenter">
-                            <Setter Property="AutomationProperties.AutomationId" Value="{Binding Children[0].Id}"/>
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding IsSingleItem}" Value="True">
-                                    <Setter Property="AutomationProperties.Name" Value="{Binding Children[0].Label}"/>
-                                    <Setter Property="AutomationProperties.ItemStatus" Value="{Binding Children[0].SelectionStatus}"/>
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </ItemsControl.ItemContainerStyle>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Grid Margin="0,2">
@@ -270,7 +254,6 @@
                                                         Cursor="Hand"
                                                         MouseLeftButtonUp="NavChild_Click"
                                                         Tag="{Binding}"
-                                                        AutomationProperties.AutomationId="{Binding Id}"
                                                         Style="{StaticResource SidebarNavRow}">
                                                     <Grid>
                                                         <Rectangle x:Name="ActiveMark"

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -14,6 +14,44 @@
     </Window.DataContext>
 
     <Window.Resources>
+        <!-- The flat Dashboard entry is a real Button so it exposes one invokable UIA peer
+             and remains keyboard-operable without inheriting the app's command-button chrome. -->
+        <Style x:Key="SidebarNavButton" TargetType="Button"
+               BasedOn="{StaticResource ButtonBase}">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="FocusBorder"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="8">
+                            <ContentPresenter
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="FocusBorder" Property="Opacity" Value="0.8"/>
+                            </Trigger>
+                            <Trigger Property="IsKeyboardFocused" Value="True">
+                                <Setter TargetName="FocusBorder" Property="BorderBrush" Value="{DynamicResource Accent}"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="FocusBorder" Property="Opacity" Value="0.4"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
         <!-- One selected-row treatment serves both the flat Dashboard entry and grouped leaves. -->
         <Style x:Key="SidebarNavRow" TargetType="Border">
             <Setter Property="Background" Value="Transparent"/>
@@ -91,22 +129,17 @@
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Grid Margin="0,2">
-                                <!-- Single-item group: render as a flat clickable row.
-                                     Hosted in a ContentControl (a Control, so it produces a
-                                     ControlAutomationPeer) — a bare Border has no peer, so its
-                                     AutomationId never surfaced in the UI Automation tree (and
-                                     screen readers couldn't name it). AutomationId + Name now
-                                     ride on the ContentControl; the inner Border keeps the exact
-                                     visuals + hover. -->
-                                <ContentControl x:Name="SingleBd"
-                                                Visibility="{Binding IsSingleItem, Converter={StaticResource FlexVis}}"
-                                                Cursor="Hand"
-                                                Focusable="False"
-                                                MouseLeftButtonUp="SingleGroup_Click"
-                                                Tag="{Binding Children[0]}"
-                                                AutomationProperties.AutomationId="{Binding Children[0].Id}"
-                                                AutomationProperties.Name="{Binding Children[0].Label}"
-                                                AutomationProperties.ItemStatus="{Binding Children[0].SelectionStatus}">
+                                <!-- Single-item groups render as flat nav buttons. A Button supplies
+                                     the invokable automation peer and keyboard activation that a
+                                     ContentControl or bare Border cannot provide. -->
+                                <Button x:Name="SingleBd"
+                                        Visibility="{Binding IsSingleItem, Converter={StaticResource FlexVis}}"
+                                        Click="SingleGroup_Click"
+                                        Tag="{Binding Children[0]}"
+                                        Style="{StaticResource SidebarNavButton}"
+                                        AutomationProperties.AutomationId="{Binding Children[0].Id}"
+                                        AutomationProperties.Name="{Binding Children[0].Label}"
+                                        AutomationProperties.ItemStatus="{Binding Children[0].SelectionStatus}">
                                     <Border CornerRadius="8" Padding="14,10"
                                             DataContext="{Binding Children[0]}"
                                             Style="{StaticResource SidebarNavRow}">
@@ -135,7 +168,7 @@
                                             </StackPanel>
                                         </Grid>
                                     </Border>
-                                </ContentControl>
+                                </Button>
 
                                 <!-- Multi-item group: expander with children -->
                                 <Expander Visibility="{Binding IsSingleItem, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -105,8 +105,8 @@ public partial class MainWindow : Window
     [System.Runtime.InteropServices.LibraryImport("user32.dll", EntryPoint = "DefWindowProcW")]
     private static partial IntPtr DefWindowProc(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
 
-    /// <summary>Click on a single-item group (Dashboard, Network).</summary>
-    private void SingleGroup_Click(object sender, MouseButtonEventArgs e)
+    /// <summary>Activate the flat Dashboard navigation button.</summary>
+    private void SingleGroup_Click(object sender, RoutedEventArgs e)
     {
         if (sender is FrameworkElement fe && fe.Tag is NavItem item
             && DataContext is MainWindowViewModel vm)

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -113,8 +113,8 @@ public partial class MainWindow : Window
             vm.SelectedNav = item;
     }
 
-    /// <summary>Click on a child item inside an expanded group.</summary>
-    private void NavChild_Click(object sender, MouseButtonEventArgs e)
+    /// <summary>Activate a tab inside an expanded navigation group.</summary>
+    private void NavChild_Click(object sender, RoutedEventArgs e)
     {
         if (sender is FrameworkElement fe && fe.Tag is NavItem item
             && DataContext is MainWindowViewModel vm)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.56.4</Version>
-    <FileVersion>1.56.4.0</FileVersion>
-    <AssemblyVersion>1.56.4.0</AssemblyVersion>
+    <Version>1.56.5</Version>
+    <FileVersion>1.56.5.0</FileVersion>
+    <AssemblyVersion>1.56.5.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -242,7 +242,14 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
     partial void OnSelectedNavChanged(NavItem? oldValue, NavItem? newValue)
     {
-        if (newValue is null) return;
+        UpdateSelectionState(oldValue, newValue);
+
+        if (newValue is null)
+        {
+            if (oldValue is { IsContentCreated: true }) SetActive(oldValue.Content, false);
+            return;
+        }
+
         Log.Information("Tab navigated: {TabLabel}", newValue.Label);
 
         // Record the feature the user opened in the Dashboard's "Recent activity"
@@ -261,6 +268,12 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         // built (a never-opened lazy tab has no VM and, by definition, nothing polling).
         if (oldValue is { IsContentCreated: true }) SetActive(oldValue.Content, false);
         SetActive(newValue.Content, true); // accessing Content here materialises the entered tab's VM
+    }
+
+    internal static void UpdateSelectionState(NavItem? oldValue, NavItem? newValue)
+    {
+        if (oldValue is not null) oldValue.IsSelected = false;
+        if (newValue is not null) newValue.IsSelected = true;
     }
 
     // The three tabs with a visibility-gated poll expose an IsActive flag. Toggle it generically

--- a/SysManager/SysManager/ViewModels/NavItem.cs
+++ b/SysManager/SysManager/ViewModels/NavItem.cs
@@ -81,6 +81,13 @@ public sealed partial class NavItem : ObservableObject, IDisposable
     /// </summary>
     public bool IsInDevelopment { get; init; }
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SelectionStatus))]
+    private bool _isSelected;
+
+    /// <summary>Selection state exposed to the sidebar's UI Automation peers.</summary>
+    public string SelectionStatus => IsSelected ? "Selected" : string.Empty;
+
     [ObservableProperty] private bool _isBusy;
 
     /// <summary>


### PR DESCRIPTION
## Summary

- restore persistent selected-tab feedback across the flat Dashboard row and all grouped sidebar leaves
- keep navigation synchronized with one observable `NavItem.IsSelected` state
- make Dashboard and grouped leaves unique invokable Button/UIA peers with selected status
- keep collapsed leaves out of keyboard navigation and give group headers a visible focus cue
- remove the obsolete unused `SideNavTabItem` style, document the behavior, and prepare version 1.56.5

## Root cause

The v0.18.0 grouped-sidebar migration replaced the selecting `ListBox` with non-selecting `ItemsControl` rows. The live accent mark remained permanently collapsed, while the only selected-state trigger survived in an unused `TabItem` style. Consequently, all 58 tabs looked unselected after the pointer moved away.

## Regression coverage

- reproduced the baseline contract: zero live `IsSelected` triggers, one permanently collapsed live accent mark, and one unused legacy style
- added blocking unit coverage for selection transfer, null clearing, automation-status notifications, both live XAML templates, style application, local-value override prevention, and legacy-style removal
- added integration coverage for initial selection, tab handoff, single-selection invariants, and poll-loop deactivation when selection is cleared
- added UI automation coverage for selected status moving from Dashboard to Logs to Ping and for collapsed leaves becoming disabled
- verified all 58 nav ids remain unique across the same 12 groups

## Verification

- all four projects passed `dotnet format --verify-no-changes`
- Release builds passed for the application, unit-test, integration-test, and UI-test projects with 0 warnings and 0 errors
- blocking unit suite passed twice on the final commit: 3,804 / 3,804
- the four focused selection/keyboard contracts passed in both final CI runs:
  - `NavSelection_ExposesCurrentItemStatus`
  - `CollapsedGroup_DisablesHiddenNavButtons`
  - `LiveRows_ExposeSelectionToInvokableAutomationPeers`
  - `CollapsedGroups_KeepHiddenLeavesOutOfKeyboardNavigation`
- the non-blocking UI suite improved from the recent `main` baseline of 81-83 / 131 passing to 116 / 133 passing in two identical final runs; the remaining 17 failures are the existing shared-fixture/UIA reliability class, including `ClearButton_Exists`, which failed in two of the four inspected pre-PR `main` runs
- CodeQL passed on the final commit with no review comments
- selected text contrast passed across all 12 built-in themes; minimum computed ratio is 7.54:1
- the publish script produced the 1.56.5 self-contained single-file executable with the expected file version; repository identity, author-header, leak, changelog, version, and diff gates passed

The main workstation policy permits compiling test projects but not executing xUnit or UI automation locally. Those suites were executed on the Windows CI runner; the focused regression checks passed twice.

Closes #1487