### PR TITLE
ci: attest release provenance, publish an SBOM, and document the first-launch warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,11 @@ on:
         description: "Tag to release (e.g. v0.5.3)"
         required: true
 
+# Default for every job in this workflow: read-only. The guard job below only reads
+# release metadata, so it needs nothing more. build-and-release re-declares the
+# writes it actually needs, keeping the privileged token confined to that one job.
 permissions:
-  contents: write
-  discussions: write
+  contents: read
 
 # Serialize releases per tag so two pushes (or a tag push racing a manual dispatch)
 # can't run two release jobs that race the winget publish and Discussions post.
@@ -58,6 +60,17 @@ jobs:
     if: needs.guard.outputs.should_release == 'true'
     runs-on: windows-latest
     timeout-minutes: 30
+
+    # Scoped to this job rather than the workflow: the guard job only reads release
+    # metadata and must not be able to mint an OIDC token or write attestations.
+    # id-token/attestations exist solely so the build can sign a provenance statement
+    # binding this exe's digest to this repo, workflow and commit. Neither grants
+    # any write access to repository content.
+    permissions:
+      contents: write
+      discussions: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout
@@ -133,6 +146,55 @@ jobs:
           "hash=$hash" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           Write-Host "SHA256: $hash"
 
+      # The shipped exe is self-contained and single-file, so its contents are opaque:
+      # neither the binary nor its .sha256 says which dependencies are embedded. The SBOM
+      # is the machine-readable answer. Generated AFTER publish and with the same
+      # framework/runtime, so it reads the graph that was actually published rather than
+      # a RID-agnostic restore.
+      #
+      # Note this is a restore-graph inventory, not a byte-level manifest of the exe:
+      # verified against a real win-x64 publish, 71 components resolve, of which 14 are
+      # RID-specific placeholder packages (Linux/macOS/Android variants of
+      # System.IO.Ports and SkiaSharp/HarfBuzz native assets, all empty '_._' on this
+      # RID) plus System.IO.Hashing, a build-time transitive of SourceLink that never
+      # reaches the output. They are kept rather than filtered because a
+      # vulnerability-feed consumer wants the resolved set, and hand-maintaining an
+      # exclusion list would silently rot as the graph changes.
+      - name: Generate CycloneDX SBOM
+        shell: pwsh
+        run: |
+          $ver = "${{ steps.version.outputs.version }}"
+          # Version-pinned like every action in this workflow — an unpinned tool is an
+          # unreviewed dependency in the release path.
+          dotnet tool install --global CycloneDX --version 6.2.0
+          if ($LASTEXITCODE -ne 0) { throw "Failed to install the CycloneDX tool." }
+          dotnet-CycloneDX SysManager/SysManager/SysManager.csproj `
+            --output publish `
+            --filename "SysManager-v${ver}.sbom.json" `
+            --output-format Json `
+            --framework net10.0-windows `
+            --runtime win-x64 `
+            --exclude-dev `
+            --set-name SysManager `
+            --set-version $ver
+          if ($LASTEXITCODE -ne 0) { throw "SBOM generation failed." }
+          $sbom = "publish/SysManager-v${ver}.sbom.json"
+          if (-not (Test-Path $sbom)) { throw "Missing $sbom" }
+          $components = (Get-Content $sbom -Raw | ConvertFrom-Json).components.Count
+          if (-not $components) { throw "SBOM contains no components — refusing to publish an empty inventory." }
+          Write-Host "SBOM written with $components components."
+
+      # Binds this exact binary digest to this repository, workflow and commit in the
+      # public Sigstore transparency log. The .sha256 file cannot do this: it ships from
+      # the same release as the exe, so both share one trust root. Anyone can verify with
+      #   gh attestation verify SysManager-v<version>.exe --repo laurentiu021/SystemManager
+      # Deliberately placed BEFORE the release is created, so a failure here aborts the
+      # run instead of leaving a published release without provenance.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: publish/SysManager-v${{ steps.version.outputs.version }}.exe
+
       - name: Extract release notes from CHANGELOG
         id: notes
         shell: pwsh
@@ -159,10 +221,58 @@ jobs:
 
       - name: Append verification instructions to release notes
         shell: pwsh
+        env:
+          # Passed as data rather than interpolated into the script body, matching the
+          # tag-extraction step above.
+          VERSION: ${{ steps.version.outputs.version }}
+          HASH: ${{ steps.hash.outputs.hash }}
         run: |
-          $ver = "${{ steps.version.outputs.version }}"
-          $hash = "${{ steps.hash.outputs.hash }}"
-          Add-Content release-notes.md "`n`n---`n`n### Verify the download`n`n``````powershell`nGet-FileHash .\SysManager-v${ver}.exe -Algorithm SHA256`n```````n`nExpected SHA256: ``$hash``"
+          # A literal here-string keeps the markdown code fences readable — an expandable
+          # one would need every backtick escaped, which is what made this unreadable
+          # before. The two placeholders are substituted after the fact.
+          $template = @'
+
+          ---
+
+          ### Verify the download
+
+          ```powershell
+          Get-FileHash .\SysManager-__TAG__.exe -Algorithm SHA256
+          ```
+
+          Expected SHA256: `__HASH__`
+
+          This build is not code-signed, so Windows will warn on first launch. That is
+          expected for a small independent app: [see what the warning says and what to
+          click](https://github.com/laurentiu021/SystemManager#first-launch-windows-will-warn-you).
+
+          ### Verify where this binary came from
+
+          This exe was built by GitHub Actions from this public source, and the build is
+          recorded in the Sigstore public transparency log. With the
+          [GitHub CLI](https://cli.github.com/):
+
+          ```powershell
+          gh attestation verify .\SysManager-__TAG__.exe --repo laurentiu021/SystemManager
+          ```
+
+          That proves which commit and workflow produced this exact binary, something the
+          SHA256 file cannot show, since it is published alongside the exe it describes.
+          Each release also ships `SysManager-__TAG__.sbom.json`, a CycloneDX inventory of
+          every dependency resolved for this build.
+          '@
+          $notes = $template.Replace('__TAG__', "v$env:VERSION").Replace('__HASH__', $env:HASH)
+          # This appended block is deliberately ASCII-only. A non-ASCII character here is
+          # decoded according to how the host reads this script file, so the same text can
+          # render as mojibake under a different PowerShell host than the one used in CI.
+          # The CHANGELOG body above is untouched and keeps its punctuation; only this
+          # generated footer is constrained. Fail the release rather than publish garbled
+          # notes to both the release page and the Discussions announcement.
+          $nonAscii = [regex]::Matches($notes, '[^\x00-\x7F]')
+          if ($nonAscii.Count -gt 0) {
+              throw "The appended verification notes must be ASCII-only; found $($nonAscii.Count) non-ASCII character(s): $(($nonAscii | ForEach-Object { $_.Value }) -join ' ')"
+          }
+          Add-Content release-notes.md $notes -Encoding utf8
 
       - name: Create GitHub Release
         id: release
@@ -176,6 +286,7 @@ jobs:
           files: |
             publish/SysManager-v${{ steps.version.outputs.version }}.exe
             publish/SysManager-v${{ steps.version.outputs.version }}.exe.sha256
+            publish/SysManager-v${{ steps.version.outputs.version }}.sbom.json
 
       - name: Update winget package
         uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2

--- a/README.md
+++ b/README.md
@@ -984,9 +984,56 @@ Get-FileHash .\SysManager-v<version>.exe -Algorithm SHA256
 # Compare the output to the contents of SysManager-v<version>.exe.sha256.
 ```
 
-The build is not currently code-signed, so Windows SmartScreen may warn on
-first launch. Verifying the SHA256 matches the one on the release page is the
-recommended mitigation — see [SECURITY.md](SECURITY.md) for details.
+That check confirms the file downloaded intact. To also confirm **where the file came
+from**, each release carries a GitHub build attestation — a signed record, kept in a
+public transparency log outside this repository, tying that exact binary to the commit
+and workflow that produced it. With the [GitHub CLI](https://cli.github.com/):
+
+```powershell
+gh attestation verify .\SysManager-v<version>.exe --repo laurentiu021/SystemManager
+```
+
+This is the stronger of the two checks. The `.sha256` file is generated in the same job
+and published onto the same release as the binary it describes, so both come from one
+source — enough to catch a corrupted download, but not a substituted release asset. The
+attestation is signed by GitHub's own infrastructure at build time and logged publicly, so
+it also records *which* commit and workflow produced the file, and that record cannot be
+rewritten after the fact. Each release also ships
+`SysManager-v<version>.sbom.json`, a CycloneDX inventory of every NuGet package resolved
+for that build — useful for checking the dependency set against a vulnerability feed.
+
+### First launch: Windows will warn you
+
+The first time you run it, Windows shows a blue box titled **"Windows protected your
+PC"**. This is expected, and it is worth knowing what it does and does not mean.
+
+It means Windows does not recognise the publisher. Code-signing certificates cost money
+and require a registered identity, and SysManager is a free one-person project without
+one yet, so every build is "unknown publisher" to Windows regardless of what it contains.
+It is **not** a virus warning — Windows has not found anything wrong with the file.
+
+The dialog only offers a **Don't run** button. To continue:
+
+1. Verify the SHA256 first, using the command above. Do this before anything else — it is
+   what makes the next step safe rather than blind.
+2. Click **More info** — a small link in the dialog, easy to miss.
+3. The file name and publisher appear, along with a **Run anyway** button. Click it.
+
+Windows remembers the choice, so this only happens once per downloaded version.
+
+If you would rather avoid the warning altogether, install through winget instead:
+
+```powershell
+winget install laurentiu021.SysManager
+```
+
+winget fetches and validates the package outside the browser download path, so the
+first-launch prompt does not appear.
+
+> Only click through this warning for a file you downloaded from
+> [the official releases page](https://github.com/laurentiu021/SystemManager/releases/latest)
+> **and** whose hash you verified. The same dialog protects you from genuinely malicious
+> files, so it is worth reading rather than reflexively dismissing.
 
 ## Build from source
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -126,19 +126,44 @@ What the app can and cannot do by design:
 
 ## Verifying a release
 
-Every release on GitHub ships a versioned `SysManager-v<version>.exe` and a
-matching `SysManager-v<version>.exe.sha256` file. You can verify the binary
-before running it (replace `<version>` with the version you downloaded):
+Every release on GitHub ships a versioned `SysManager-v<version>.exe`, a matching
+`SysManager-v<version>.exe.sha256`, and a `SysManager-v<version>.sbom.json`
+dependency inventory. There are two independent checks, and they answer
+different questions.
+
+**Did the file arrive intact?** Compare the hash (replace `<version>` with the
+version you downloaded):
 
 ```powershell
 Get-FileHash .\SysManager-v<version>.exe -Algorithm SHA256
 # Compare the output to the contents of the .sha256 file from the release page.
 ```
 
-The build is **not** currently code-signed. Windows SmartScreen may show a
-warning on first launch; this is expected until a code-signing certificate
-is available. Verifying the SHA256 hash is the recommended mitigation in
-the meantime.
+**Was the file built from this source?** Every release is covered by a GitHub
+build attestation — a SLSA provenance statement signed during the build and
+recorded in the public [Sigstore](https://www.sigstore.dev/) transparency log,
+binding that binary's digest to this repository, the release workflow, and the
+commit that produced it. Verify it with the [GitHub CLI](https://cli.github.com/):
+
+```powershell
+gh attestation verify .\SysManager-v<version>.exe --repo laurentiu021/SystemManager
+```
+
+The attestation is the stronger claim. The `.sha256` file is computed and published
+from the same job and onto the same release as the binary it describes, so the two
+share a single trust root — effective against transport corruption and against
+local tampering with a cached copy, but not against a replaced release asset. The
+attestation is signed by GitHub's infrastructure at build time and its subject
+digest, source repository, workflow, and commit are recorded in an append-only
+public log, so the binding between a binary and its origin cannot be rewritten
+after publication. It does not, by itself, assert that the source was reviewed or
+that the maintainer's account was not compromised — it proves origin, not intent.
+
+The build is **not** currently code-signed, so Windows SmartScreen shows a
+warning on first launch; this is expected until a code-signing certificate is
+available. The README walks through
+[what that dialog says and what to click](README.md#first-launch-windows-will-warn-you),
+with hash verification as the precondition.
 
 ## Dependencies and supply chain
 
@@ -147,7 +172,22 @@ the meantime.
 - CI builds and runs the unit test suite on every pull request.
   Integration tests (which access real OS APIs) run locally only.
 - The release workflow builds the binary from source on a clean GitHub
-  Actions runner and publishes both the `.exe` and its SHA256 sum together.
+  Actions runner and publishes the `.exe`, its SHA256 sum, and a CycloneDX
+  SBOM together.
+- Every release carries a signed build-provenance attestation (see
+  [Verifying a release](#verifying-a-release)). The privileged token that
+  produces it is scoped to the build job alone; the workflow's default
+  permission is read-only.
+- Each release ships a CycloneDX SBOM (`SysManager-v<version>.sbom.json`) listing
+  every NuGet package resolved for the published `win-x64` build, with version,
+  package URL, and hash, so the dependency set can be audited against a
+  vulnerability feed without unpacking the single-file executable. It is a
+  resolved-dependency inventory rather than a byte-level manifest: a handful of
+  entries are RID-specific placeholders for other platforms or build-time-only
+  transitives that carry no payload into the shipped binary.
+- All GitHub Actions used in the release pipeline are pinned to full commit
+  SHAs, and release builds are deterministic
+  (`ContinuousIntegrationBuild` + `Deterministic`).
 
 ## Scope
 


### PR DESCRIPTION
Closes #1656
Closes #1657
Closes #1670

Three trust items from the audit backlog that share the same three files, so they ship as one PR rather than colliding on each other. All are free and none depend on a code-signing certificate.

## Build attestation (#1656)

The `.exe` and its `.sha256` are computed in the same job and uploaded to the same release, so they share a single trust root. That catches a corrupted download but not a substituted release asset — anyone able to replace the exe could replace the hash file beside it.

The release job now signs a SLSA provenance statement binding the exe's digest to this repository, workflow, and commit, recorded in the public Sigstore transparency log:

```powershell
gh attestation verify .\SysManager-v<version>.exe --repo laurentiu021/SystemManager
```

Placed **before** the release is created, so a failure aborts the run rather than leaving a published release without provenance.

**Permissions are now scoped per job.** The workflow default drops to `contents: read`; only `build-and-release` declares `contents`/`discussions`/`id-token`/`attestations`. Previously the `guard` job — which only reads release metadata — also carried write access, so this is a net reduction in token surface despite adding two scopes.

## SBOM (#1670)

The shipped binary is self-contained single-file, so its contents are opaque. Each release now ships `SysManager-v<version>.sbom.json` (CycloneDX 1.7), generated after publish with the same framework and runtime as the shipped build, and the step fails if the inventory comes back empty.

Verified by running the exact command against the real project:

```
Found 72 packages
1 packages being excluded as DevDependencies
Creating CycloneDX BOM
```

71 components, 71/71 with version + package URL + hash, 69 with licence data.

Described in the docs as a *resolved-dependency inventory*, not a byte-level manifest — deliberately, because probing a real `win-x64` publish showed 14 entries are empty `_._` RID placeholders for Linux/macOS/Android and one (`System.IO.Hashing`, a SourceLink transitive) never reaches the output. Filtering them would need a hand-maintained exclusion list that silently rots; a vulnerability-feed consumer wants the resolved set anyway. The comment in the workflow records this so the next reader does not have to re-derive it.

## SmartScreen walkthrough (#1657)

The docs acknowledged the warning abstractly but never named the dialog or the clicks it needs — and the only visible button is **Don't run**. README now walks a non-technical reader through it: what the dialog says, that it means "unknown publisher" rather than malware, and the **More info → Run anyway** path.

Hash verification is stated as step 1, so this is advice with a check attached rather than "click through warnings", and a closing note says to only do this for a file from the official releases page whose hash was verified. winget is offered as the route that avoids the prompt entirely. SECURITY.md links to the section instead of duplicating it.

## A bug found by running the code, not reading it

Executing the release-notes step locally revealed that the em-dash in the appended footer rendered as `â€"`. Cause: a `.ps1` without a BOM is read as cp1252 by PowerShell 5.1, so the em-dash's UTF-8 bytes decode wrong. CI uses `shell: pwsh` (PS 7) where it would have worked — but text that renders differently depending on the host is a latent defect, and this footer is copied verbatim into both the release body and the Discussions announcement.

Fixed by keeping the generated footer ASCII-only, enforced mechanically:

```powershell
$nonAscii = [regex]::Matches($notes, '[^\x00-\x7F]')
if ($nonAscii.Count -gt 0) { throw "...must be ASCII-only..." }
```

Tested both ways: passes as written, and throws before writing anything when an em-dash is injected into the template. The CHANGELOG body is untouched and keeps its punctuation — only the generated footer is constrained.

## Verification

- `release.yml` parsed with a real YAML parser; step order asserted `sbom < attest < release`; all four workflows still parse.
- Release-notes step extracted from the parsed YAML and **executed** against a sample CHANGELOG; output inspected as bytes (UTF-8 clean, no BOM, no double-encoding).
- CycloneDX command run against `SysManager.csproj` after a real restore; SBOM contents inspected; leak-scanned clean.
- `dotnet publish -r win-x64 --self-contained` run to enumerate what actually ships, which is what corrected the SBOM wording.
- All internal markdown links and anchors resolve, including the new `#first-launch-windows-will-warn-you` anchor referenced from both SECURITY.md and the release notes.
- Full leak scan over added lines: 28 terms, clean.
- No `CHANGELOG.md` or `.csproj` changes, and no paths under `SysManager/SysManager/**` — so this cannot collide with in-flight work and does not trigger auto-release. `ci:` prefix, no version bump.

## Not in scope

`README.md:764-768`, `SECURITY.md:111-113`, and `ARCHITECTURE.md:497-498` claim the updater verifies the download's Authenticode signature, which is #1660 and #1674. Left alone deliberately to keep this diff to one subject.
