### PR TITLE
fix: stabilize UI automation action contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.56.6] - 2026-08-04
+
+### Fixed
+- **Restored the UI automation safety net for action buttons.** Accessible-name improvements had silently orphaned 17 visible-text lookups across Cleanup, System Health, Logs, Services, and Ping, so 15 tests never reached the controls they were meant to verify. All positive button lookups now use unique, current-tab-scoped automation IDs while descriptive screen-reader names remain unchanged. A blocking unit contract rejects missing or duplicate asserted IDs before the warning-only UI job can mask another regression.
+- **Made the Ping interaction test exercise the real Start/Stop cycle.** The previous nullable Start lookup skipped the invocation, then failed while searching for a Stop button that could never appear. The test now normalizes its initial state, proves both UI transitions without fixed delays, invokes both commands, and restores the shared fixture to stopped state even after a failure.
+- **Corrected the two stale assertions outside the selector failures.** Windows Update now describes its deferred History-time module check instead of claiming PSWindowsUpdate is available before any probe, while keeping installation hidden until a missing module is confirmed. The `App Blocker` smoke check now validates the rendered view header inside the current content host, so the matching sidebar label cannot make a blank or wrong page pass.
+
 ## [1.56.5] - 2026-08-03
 
 ### Fixed

--- a/SysManager/SysManager.IntegrationTests/WindowsUpdateAutoCheckTests.cs
+++ b/SysManager/SysManager.IntegrationTests/WindowsUpdateAutoCheckTests.cs
@@ -19,10 +19,11 @@ public class WindowsUpdateAutoCheckTests
     }
 
     [Fact]
-    public void ModuleAvailable_DefaultsFalse()
+    public void ModuleStatus_DefersAvailabilityCheckUntilHistory()
     {
         var vm = Build();
-        Assert.False(vm.ModuleAvailable);
+        Assert.Contains("History", vm.ModuleStatus, StringComparison.Ordinal);
+        Assert.False(vm.IsBusy);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/UiAutomationContractTests.cs
+++ b/SysManager/SysManager.Tests/UiAutomationContractTests.cs
@@ -1,0 +1,144 @@
+// SysManager · UiAutomationContractTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace SysManager.Tests;
+
+public partial class UiAutomationContractTests
+{
+    private static readonly XNamespace Presentation =
+        "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+    private static readonly IReadOnlyDictionary<string, string> DescriptiveAccessibleNames =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["btn-cleanup-clean-temp"] = "Clean temporary files",
+            ["btn-cleanup-empty-recycle-bin"] = "Empty the Recycle Bin",
+            ["btn-cleanup-sfc"] = "Run SFC system file check",
+            ["btn-cleanup-dism"] = "Run DISM RestoreHealth",
+            ["btn-cleanup-cancel"] = "Cancel the running operation",
+            ["btn-system-health-scan"] = "Scan system health",
+            ["btn-system-health-smart"] = "Run SMART disk health check",
+            ["btn-system-health-memtest"] = "Schedule a memory test on next reboot",
+            ["btn-logs-refresh"] = "Refresh logs",
+            ["btn-logs-export-csv"] = "Export logs to CSV",
+            ["btn-services-refresh"] = "Refresh services",
+            ["btn-ping-start"] = "Start ping monitoring",
+            ["btn-ping-stop"] = "Stop ping monitoring",
+            ["btn-ping-clear"] = "Clear ping history",
+            ["btn-dashboard-scan-system"] = "Scan system",
+            ["btn-drivers-list"] = "List drivers",
+            ["btn-uninstaller-uninstall-selected"] = "Uninstall selected applications",
+            ["btn-windows-update-install-module"] = "Install PSWindowsUpdate for update history",
+            ["btn-windows-update-list"] = "List available Windows updates",
+            ["btn-windows-update-history"] = "Show Windows Update history",
+            ["btn-windows-update-pending-reboot"] = "Check for a pending reboot",
+            ["btn-windows-update-install-selected"] = "Install selected Windows updates",
+            ["btn-app-updates-scan"] = "Scan for updates",
+            ["btn-system-health-memory-errors"] = "Check memory errors",
+            ["btn-logs-open-event-viewer"] = "Open Event Viewer",
+            ["btn-logs-open-folder"] = "Open log folder",
+            ["btn-ping-add-target"] = "Add target"
+        };
+
+    [Fact]
+    public void AssertedButtons_HaveUniqueStableAutomationIds()
+    {
+        var solutionDirectory = FindSolutionDirectory();
+        var uiTestSource = string.Join(
+            Environment.NewLine,
+            Directory.EnumerateFiles(
+                    Path.Combine(solutionDirectory.FullName, "SysManager.UITests"),
+                    "*.cs",
+                    SearchOption.TopDirectoryOnly)
+                .Select(File.ReadAllText));
+
+        var referencedIds = FindButtonByIdCall()
+            .Matches(uiTestSource)
+            .Select(match => match.Groups["id"].Value)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.DoesNotContain("FindButton(", uiTestSource, StringComparison.Ordinal);
+
+        var sourceXaml = EnumerateSourceXaml(solutionDirectory)
+            .Select(XDocument.Load)
+            .ToArray();
+        var actionElements = sourceXaml
+            .SelectMany(document => document.Descendants())
+            .Select(element => new
+            {
+                Element = element,
+                Id = (string?)element.Attribute("AutomationProperties.AutomationId")
+            })
+            .Where(item => item.Id?.StartsWith("btn-", StringComparison.Ordinal) is true)
+            .ToArray();
+        var buttonIds = actionElements
+            .Select(item => item.Id!)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.NotEmpty(referencedIds);
+        Assert.Equal(actionElements.Length, DescriptiveAccessibleNames.Count);
+        Assert.All(actionElements, item =>
+        {
+            Assert.Equal(Presentation + "Button", item.Element.Name);
+            Assert.False(
+                string.IsNullOrWhiteSpace(
+                    (string?)item.Element.Attribute("AutomationProperties.Name")),
+                $"Button '{item.Id}' has no explicit accessible name.");
+        });
+        foreach (var (id, expectedName) in DescriptiveAccessibleNames)
+        {
+            var action = Assert.Single(actionElements, item => item.Id == id);
+            Assert.Equal(
+                expectedName,
+                (string?)action.Element.Attribute("AutomationProperties.Name"));
+        }
+        Assert.Equal(buttonIds.Distinct(StringComparer.Ordinal), buttonIds);
+        Assert.Equal(referencedIds, buttonIds);
+
+        var currentViewHost = Assert.Single(
+            sourceXaml.SelectMany(document => document.Descendants()),
+            element =>
+                (string?)element.Attribute("AutomationProperties.AutomationId")
+                == "CurrentViewHost");
+        Assert.Equal(Presentation + "UserControl", currentViewHost.Name);
+        Assert.Equal("{Binding SelectedNav.View}", (string?)currentViewHost.Attribute("Content"));
+    }
+
+    private static DirectoryInfo FindSolutionDirectory()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory is not null;
+             directory = directory.Parent)
+        {
+            if (Directory.Exists(Path.Combine(directory.FullName, "SysManager.UITests"))
+                && Directory.Exists(Path.Combine(directory.FullName, "SysManager", "Views")))
+            {
+                return directory;
+            }
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate the SysManager solution directory from the test output.");
+    }
+
+    private static IEnumerable<string> EnumerateSourceXaml(DirectoryInfo solutionDirectory)
+    {
+        var projectDirectory = Path.Combine(solutionDirectory.FullName, "SysManager");
+        return Directory
+            .EnumerateFiles(projectDirectory, "*.xaml", SearchOption.AllDirectories)
+            .Where(path => !Path.GetRelativePath(projectDirectory, path)
+                .Split(Path.DirectorySeparatorChar)
+                .Any(segment =>
+                    segment.Equals("bin", StringComparison.OrdinalIgnoreCase)
+                    || segment.Equals("obj", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [GeneratedRegex("FindButtonById\\s*\\(\\s*\"(?<id>btn-[a-z0-9-]+)\"", RegexOptions.CultureInvariant)]
+    private static partial Regex FindButtonByIdCall();
+}

--- a/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
+++ b/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
@@ -44,6 +44,16 @@ public class WindowsUpdateViewModelTests
     }
 
     [Fact]
+    public void Constructor_DefersModuleAvailabilityCheckUntilHistory()
+    {
+        var vm = NewVm();
+
+        Assert.True(vm.ModuleAvailable);
+        Assert.Contains("History", vm.ModuleStatus, StringComparison.Ordinal);
+        Assert.False(vm.IsBusy);
+    }
+
+    [Fact]
     public void Constructor_ShowConsoleFalse()
     {
         var vm = NewVm();

--- a/SysManager/SysManager.UITests/AllTabsSmokeUiTests.cs
+++ b/SysManager/SysManager.UITests/AllTabsSmokeUiTests.cs
@@ -74,7 +74,7 @@ public class AllTabsSmokeUiTests
         // ── Privacy & Security ──
         new object[] { "nav-privacy-settings", "Privacy" },
         new object[] { "nav-file-shredder", "File Shredder" },
-        new object[] { "nav-app-blocker", "Application Blocker" },
+        new object[] { "nav-app-blocker", "App Blocker" },
         new object[] { "nav-debloater", "Debloater" },
         new object[] { "nav-browser-cleaner", "Browser Cleaner" },
         new object[] { "nav-edge-onedrive", "Edge/OneDrive Remover" },
@@ -103,7 +103,7 @@ public class AllTabsSmokeUiTests
     {
         _fx.GoToTab(navId);
         Assert.True(
-            _fx.HasText(expectedHeader),
+            _fx.HasTextInCurrentTab(expectedHeader),
             $"Tab '{navId}' did not render its expected header '{expectedHeader}'.");
     }
 

--- a/SysManager/SysManager.UITests/AppFixture.cs
+++ b/SysManager/SysManager.UITests/AppFixture.cs
@@ -23,6 +23,7 @@ public sealed class AppFixture : IDisposable
     public Application App { get; }
     public UIA3Automation Automation { get; } = new();
     public Window MainWindow { get; }
+    private AutomationElement CurrentViewHost { get; }
 
     public AppFixture()
     {
@@ -43,6 +44,11 @@ public sealed class AppFixture : IDisposable
                 (App.HasExited
                     ? $"The app process EXITED with code {SafeExitCode()} — it crashed on launch rather than rendering."
                     : "The app process is still running but produced no main window within the timeout."));
+
+        CurrentViewHost = Retry.WhileNull(
+            () => FindUniqueDescendantById(MainWindow, "CurrentViewHost"),
+            TimeSpan.FromSeconds(5)).Result
+            ?? throw new InvalidOperationException("The current-view automation host was not exposed.");
 
         // Sidebar groups render as collapsed Expanders, so their child nav items aren't
         // realized in the UI Automation tree until expanded. Expand everything once up
@@ -139,21 +145,62 @@ public sealed class AppFixture : IDisposable
                     e.Name.Contains(text, StringComparison.OrdinalIgnoreCase)),
             TimeSpan.FromSeconds(timeoutSeconds)).Result;
 
-    /// <summary>
-    /// Find a Button by its exact visible content text, retrying up to
-    /// <paramref name="timeoutSeconds"/>. The retry matters on a slow CI runner: a tab's
-    /// buttons aren't realized in the automation tree the instant navigation happens, so a
-    /// single snapshot (as this used to do) returned null before the content rendered.
-    /// </summary>
-    public Button? FindButton(string text, int timeoutSeconds = 5) =>
-        Retry.WhileNull(() =>
-            MainWindow.FindAllDescendants(cf => cf.ByControlType(ControlType.Button))
-                .FirstOrDefault(b => string.Equals(b.Name, text, StringComparison.OrdinalIgnoreCase)),
-            TimeSpan.FromSeconds(timeoutSeconds)).Result?.AsButton();
-
     /// <summary>Find a control by its AutomationId.</summary>
     public AutomationElement? FindById(string automationId) =>
         MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(automationId));
+
+    /// <summary>
+    /// Find a control in the currently rendered tab by its stable AutomationId.
+    /// The retry lets the new view finish rendering after navigation on slow CI runners.
+    /// </summary>
+    public AutomationElement? FindByIdInCurrentTab(string automationId, int timeoutSeconds = 5) =>
+        Retry.WhileNull(() =>
+            FindUniqueDescendantById(CurrentViewHost, automationId),
+            TimeSpan.FromSeconds(timeoutSeconds)).Result;
+
+    /// <summary>Find a Button in the current tab by its stable AutomationId.</summary>
+    public Button? FindButtonById(string automationId, int timeoutSeconds = 5)
+    {
+        var element = FindByIdInCurrentTab(automationId, timeoutSeconds);
+        if (element is null) return null;
+        if (element.ControlType != ControlType.Button)
+        {
+            throw new InvalidOperationException(
+                $"Element '{automationId}' is {element.ControlType}, not a Button.");
+        }
+
+        return element.AsButton();
+    }
+
+    /// <summary>
+    /// Find a Button by its exact accessible name. Reserved for accessible-name assertions
+    /// and best-effort cleanup when the stable-id contract itself is under test.
+    /// </summary>
+    public Button? FindButtonByAccessibleName(string accessibleName, int timeoutSeconds = 1) =>
+        Retry.WhileNull(() =>
+            CurrentViewHost
+                .FindAllDescendants(cf => cf.ByControlType(ControlType.Button))
+                .FirstOrDefault(button =>
+                    string.Equals(button.Name, accessibleName, StringComparison.OrdinalIgnoreCase)),
+            TimeSpan.FromSeconds(timeoutSeconds)).Result?.AsButton();
+
+    /// <summary>True when the current tab exposes a Button with the exact accessible name.</summary>
+    public bool HasButtonWithName(string accessibleName, int timeoutSeconds = 1) =>
+        FindButtonByAccessibleName(accessibleName, timeoutSeconds) is not null;
+
+    private static AutomationElement? FindUniqueDescendantById(
+        AutomationElement root,
+        string automationId)
+    {
+        var matches = root.FindAllDescendants(cf => cf.ByAutomationId(automationId));
+        return matches.Length switch
+        {
+            0 => null,
+            1 => matches[0],
+            _ => throw new InvalidOperationException(
+                $"AutomationId '{automationId}' matched {matches.Length} elements; expected at most one.")
+        };
+    }
 
     /// <summary>
     /// True if any descendant's Name contains <paramref name="text"/>
@@ -162,6 +209,18 @@ public sealed class AppFixture : IDisposable
     /// </summary>
     public bool HasText(string text, int timeoutSeconds = 5)
         => WaitForText(text, timeoutSeconds) is not null;
+
+    /// <summary>Wait for named content inside the currently rendered tab only.</summary>
+    public AutomationElement? WaitForTextInCurrentTab(string text, int timeoutSeconds = 5) =>
+        Retry.WhileNull(() =>
+            CurrentViewHost.FindAllDescendants()
+                .FirstOrDefault(element =>
+                    !string.IsNullOrEmpty(element.Name)
+                    && element.Name.Contains(text, StringComparison.OrdinalIgnoreCase)),
+            TimeSpan.FromSeconds(timeoutSeconds)).Result;
+
+    public bool HasTextInCurrentTab(string text, int timeoutSeconds = 5)
+        => WaitForTextInCurrentTab(text, timeoutSeconds) is not null;
 
     /// <summary>
     /// True when the current tab shows the shared "requires administrator"

--- a/SysManager/SysManager.UITests/DashboardTabUiTests.cs
+++ b/SysManager/SysManager.UITests/DashboardTabUiTests.cs
@@ -16,7 +16,7 @@ public class DashboardTabUiTests
     public void ScanSystemButton_Exists()
     {
         GoTo();
-        Assert.NotNull(_fx.FindButton("Scan system"));
+        Assert.NotNull(_fx.FindButtonById("btn-dashboard-scan-system"));
     }
 
     [Fact]

--- a/SysManager/SysManager.UITests/FunctionalUiTests.cs
+++ b/SysManager/SysManager.UITests/FunctionalUiTests.cs
@@ -23,7 +23,7 @@ public class FunctionalUiTests
     public void Services_Refresh_PopulatesList()
     {
         _fx.GoToTab("nav-services");
-        var refresh = _fx.FindButton("Refresh");
+        var refresh = _fx.FindButtonById("btn-services-refresh");
         Assert.NotNull(refresh);
         refresh!.Invoke();
 
@@ -50,7 +50,7 @@ public class FunctionalUiTests
     public void Logs_Refresh_LoadsEventsOrReportsState()
     {
         _fx.GoToTab("nav-logs");
-        var refresh = _fx.FindButton("Refresh");
+        var refresh = _fx.FindButtonById("btn-logs-refresh");
         Assert.NotNull(refresh);
         refresh!.Invoke();
 
@@ -70,7 +70,7 @@ public class FunctionalUiTests
     public void Drivers_List_ProducesCountOrDone()
     {
         _fx.GoToTab("nav-drivers");
-        var list = _fx.FindButton("List drivers");
+        var list = _fx.FindButtonById("btn-drivers-list");
         Assert.NotNull(list);
         list!.Invoke();
 

--- a/SysManager/SysManager.UITests/LogsTabUiTests.cs
+++ b/SysManager/SysManager.UITests/LogsTabUiTests.cs
@@ -51,28 +51,28 @@ public class LogsTabUiTests
     public void RefreshButton_Exists()
     {
         GoTo();
-        Assert.NotNull(_fx.FindButton("Refresh"));
+        Assert.NotNull(_fx.FindButtonById("btn-logs-refresh"));
     }
 
     [Fact]
     public void ExportCsvButton_Exists()
     {
         GoTo();
-        Assert.NotNull(_fx.FindButton("Export CSV"));
+        Assert.NotNull(_fx.FindButtonById("btn-logs-export-csv"));
     }
 
     [Fact]
     public void OpenEventViewerButton_Exists()
     {
         GoTo();
-        Assert.NotNull(_fx.FindButton("Open Event Viewer"));
+        Assert.NotNull(_fx.FindButtonById("btn-logs-open-event-viewer"));
     }
 
     [Fact]
     public void OpenLogFolderButton_Exists()
     {
         GoTo();
-        Assert.NotNull(_fx.FindButton("Open log folder"));
+        Assert.NotNull(_fx.FindButtonById("btn-logs-open-folder"));
     }
 
     [Fact]

--- a/SysManager/SysManager.UITests/NetworkTabUiTests.cs
+++ b/SysManager/SysManager.UITests/NetworkTabUiTests.cs
@@ -53,8 +53,8 @@ public class NetworkTabUiTests
     {
         GoTo();
         // Either Start (not monitoring) or Stop (monitoring) is shown.
-        var start = _fx.FindButton("Start");
-        var stop = _fx.FindButton("Stop");
+        var start = _fx.FindButtonById("btn-ping-start", timeoutSeconds: 1);
+        var stop = _fx.FindButtonById("btn-ping-stop", timeoutSeconds: 1);
         Assert.True(start != null || stop != null);
     }
 
@@ -62,23 +62,49 @@ public class NetworkTabUiTests
     public void ClearButton_Exists()
     {
         GoTo();
-        Assert.NotNull(_fx.FindButton("Clear"));
+        Assert.NotNull(_fx.FindButtonById("btn-ping-clear"));
     }
 
     [Fact]
     public void StartStop_Cycle()
     {
         GoTo();
-        var start = _fx.FindButton("Start");
-        if (start != null)
+        var completed = false;
+        try
         {
-            start.Invoke();
-            Thread.Sleep(400);
+            var monitoringBeforeTest = _fx.FindButtonById("btn-ping-stop", timeoutSeconds: 1);
+            monitoringBeforeTest?.Invoke();
+
+            var start = _fx.FindButtonById("btn-ping-start");
+            Assert.NotNull(start);
+            start!.Invoke();
+
+            var stop = _fx.FindButtonById("btn-ping-stop");
+            Assert.NotNull(stop);
+            stop!.Invoke();
+
+            Assert.NotNull(_fx.FindButtonById("btn-ping-start"));
+            Assert.Null(_fx.FindButtonById("btn-ping-stop", timeoutSeconds: 1));
+            completed = true;
         }
-        var stop = _fx.FindButton("Stop");
-        Assert.NotNull(stop);
-        stop!.Invoke();
-        Thread.Sleep(400);
+        finally
+        {
+            // Keep the shared fixture stopped without replacing the primary test failure.
+            try
+            {
+                if (!completed)
+                {
+                    var cleanupStop = _fx.FindButtonById("btn-ping-stop", timeoutSeconds: 1)
+                        ?? _fx.FindButtonByAccessibleName("Stop ping monitoring");
+                    cleanupStop?.Invoke();
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"Ping cleanup failed without replacing the test result: {ex.Message}");
+            }
+        }
     }
 
     [Fact]
@@ -116,6 +142,6 @@ public class NetworkTabUiTests
     public void AddTargetButton_Exists()
     {
         GoTo();
-        Assert.NotNull(_fx.FindButton("Add target"));
+        Assert.NotNull(_fx.FindButtonById("btn-ping-add-target"));
     }
 }

--- a/SysManager/SysManager.UITests/OtherTabsUiTests.cs
+++ b/SysManager/SysManager.UITests/OtherTabsUiTests.cs
@@ -20,35 +20,35 @@ public class OtherTabsUiTests
     public void Cleanup_CleanTempButton_Exists()
     {
         _fx.GoToTab("nav-cleanup");
-        Assert.NotNull(_fx.FindButton("Clean TEMP"));
+        Assert.NotNull(_fx.FindButtonById("btn-cleanup-clean-temp"));
     }
 
     [Fact]
     public void Cleanup_EmptyRecycleBinButton_Exists()
     {
         _fx.GoToTab("nav-cleanup");
-        Assert.NotNull(_fx.FindButton("Empty Recycle Bin"));
+        Assert.NotNull(_fx.FindButtonById("btn-cleanup-empty-recycle-bin"));
     }
 
     [Fact]
     public void Cleanup_SfcButton_Exists()
     {
         _fx.GoToTab("nav-cleanup");
-        Assert.NotNull(_fx.FindButton("SFC /scannow"));
+        Assert.NotNull(_fx.FindButtonById("btn-cleanup-sfc"));
     }
 
     [Fact]
     public void Cleanup_DismButton_Exists()
     {
         _fx.GoToTab("nav-cleanup");
-        Assert.NotNull(_fx.FindButton("DISM RestoreHealth"));
+        Assert.NotNull(_fx.FindButtonById("btn-cleanup-dism"));
     }
 
     [Fact]
     public void Cleanup_CancelButton_Exists()
     {
         _fx.GoToTab("nav-cleanup");
-        Assert.NotNull(_fx.FindButton("Cancel"));
+        Assert.NotNull(_fx.FindButtonById("btn-cleanup-cancel"));
     }
 
     // ---------------- Drivers ----------------
@@ -57,44 +57,45 @@ public class OtherTabsUiTests
     public void Drivers_ListButton_Exists()
     {
         _fx.GoToTab("nav-drivers");
-        Assert.NotNull(_fx.FindButton("List drivers"));
+        Assert.NotNull(_fx.FindButtonById("btn-drivers-list"));
     }
 
     // ---------------- Windows Update ----------------
 
     [Fact]
-    public void WindowsUpdate_InstallModuleButton_Exists()
+    public void WindowsUpdate_ModuleAvailability_IsDeferredUntilHistory()
     {
         _fx.GoToTab("nav-windows-update");
-        Assert.NotNull(_fx.FindButton("Install PSWindowsUpdate"));
+        Assert.NotNull(_fx.WaitForTextInCurrentTab("used for the History view only"));
+        Assert.Null(_fx.FindButtonById("btn-windows-update-install-module", timeoutSeconds: 1));
     }
 
     [Fact]
     public void WindowsUpdate_ListUpdatesButton_Exists()
     {
         _fx.GoToTab("nav-windows-update");
-        Assert.NotNull(_fx.FindButton("List updates"));
+        Assert.NotNull(_fx.FindButtonById("btn-windows-update-list"));
     }
 
     [Fact]
     public void WindowsUpdate_HistoryButton_Exists()
     {
         _fx.GoToTab("nav-windows-update");
-        Assert.NotNull(_fx.FindButton("History"));
+        Assert.NotNull(_fx.FindButtonById("btn-windows-update-history"));
     }
 
     [Fact]
     public void WindowsUpdate_PendingRebootButton_Exists()
     {
         _fx.GoToTab("nav-windows-update");
-        Assert.NotNull(_fx.FindButton("Pending reboot?"));
+        Assert.NotNull(_fx.FindButtonById("btn-windows-update-pending-reboot"));
     }
 
     [Fact]
     public void WindowsUpdate_InstallUpdatesButton_Exists()
     {
         _fx.GoToTab("nav-windows-update");
-        Assert.NotNull(_fx.FindButton("Install selected"));
+        Assert.NotNull(_fx.FindButtonById("btn-windows-update-install-selected"));
     }
 
     // ---------------- System health ----------------
@@ -103,28 +104,28 @@ public class OtherTabsUiTests
     public void SystemHealth_ScanButton_Exists()
     {
         _fx.GoToTab("nav-system-health");
-        Assert.NotNull(_fx.FindButton("Scan"));
+        Assert.NotNull(_fx.FindButtonById("btn-system-health-scan"));
     }
 
     [Fact]
     public void SystemHealth_DiskHealthButton_Exists()
     {
         _fx.GoToTab("nav-system-health");
-        Assert.NotNull(_fx.FindButton("Run SMART check"));
+        Assert.NotNull(_fx.FindButtonById("btn-system-health-smart"));
     }
 
     [Fact]
     public void SystemHealth_MemoryCheckButton_Exists()
     {
         _fx.GoToTab("nav-system-health");
-        Assert.NotNull(_fx.FindButton("Check memory errors"));
+        Assert.NotNull(_fx.FindButtonById("btn-system-health-memory-errors"));
     }
 
     [Fact]
     public void SystemHealth_RunMemTestButton_Exists()
     {
         _fx.GoToTab("nav-system-health");
-        Assert.NotNull(_fx.FindButton("Run MemTest (reboot)"));
+        Assert.NotNull(_fx.FindButtonById("btn-system-health-memtest"));
     }
 
     // ---------------- App updates ----------------
@@ -133,6 +134,6 @@ public class OtherTabsUiTests
     public void AppUpdates_ScanButton_Exists()
     {
         _fx.GoToTab("nav-app-updates");
-        Assert.NotNull(_fx.FindButton("Scan for updates"));
+        Assert.NotNull(_fx.FindButtonById("btn-app-updates-scan"));
     }
 }

--- a/SysManager/SysManager.UITests/UninstallerUiTests.cs
+++ b/SysManager/SysManager.UITests/UninstallerUiTests.cs
@@ -16,9 +16,9 @@ public class UninstallerUiTests
     {
         _fixture.GoToTab("nav-uninstaller");
 
-        Assert.NotNull(_fixture.FindButton("Uninstall selected"));
-        Assert.Null(_fixture.FindButton("Run as administrator", timeoutSeconds: 1));
-        Assert.Null(_fixture.FindButton("Relaunch as administrator", timeoutSeconds: 1));
+        Assert.NotNull(_fixture.FindButtonById("btn-uninstaller-uninstall-selected"));
+        Assert.False(_fixture.HasButtonWithName("Run as administrator"));
+        Assert.False(_fixture.HasButtonWithName("Relaunch as administrator"));
 
         var expectedGuidance = Helpers.AdminHelper.IsElevated()
             ? "Uninstall is disabled in administrator sessions. Reopen SysManager normally to continue."

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -445,8 +445,10 @@
                     </Grid>
                 </Border>
 
-                <ContentControl Grid.Row="1" x:Name="ContentHost"
-                                Content="{Binding SelectedNav.View}"/>
+                <!-- UserControl supplies the UIA peer used to scope automation to the live tab. -->
+                <UserControl Grid.Row="1" x:Name="ContentHost"
+                             AutomationProperties.AutomationId="CurrentViewHost"
+                             Content="{Binding SelectedNav.View}"/>
 
             </Grid>
         </Border>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.56.5</Version>
-    <FileVersion>1.56.5.0</FileVersion>
-    <AssemblyVersion>1.56.5.0</AssemblyVersion>
+    <Version>1.56.6</Version>
+    <FileVersion>1.56.6.0</FileVersion>
+    <AssemblyVersion>1.56.6.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml
@@ -54,7 +54,7 @@
 
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,0">
             <StackPanel Orientation="Horizontal">
-                <Button Content="Scan for updates" Command="{Binding ScanCommand}" AutomationProperties.Name="Scan for updates" Style="{StaticResource PrimaryButton}"/>
+                <Button Content="Scan for updates" Command="{Binding ScanCommand}" AutomationProperties.AutomationId="btn-app-updates-scan" AutomationProperties.Name="Scan for updates" Style="{StaticResource PrimaryButton}"/>
                 <Button Content="Upgrade selected" Command="{Binding UpgradeSelectedCommand}" AutomationProperties.Name="Upgrade selected packages" Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"/>
                 <Button Content="Cancel" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel update operation" Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>
                 <CheckBox Content="Select All" IsChecked="{Binding SelectAll}" AutomationProperties.Name="Select all packages" Margin="16,0,0,0" VerticalAlignment="Center"/>

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -80,8 +80,10 @@
                            Style="{StaticResource Subtle}" Margin="0,0,0,10" TextWrapping="Wrap"/>
                 <WrapPanel Orientation="Horizontal">
                     <Button Content="Clean TEMP" Command="{Binding CleanTempCommand}" Style="{StaticResource PrimaryButton}" Margin="0,0,8,8"
+                            AutomationProperties.AutomationId="btn-cleanup-clean-temp"
                             AutomationProperties.Name="Clean temporary files"/>
                     <Button Content="Empty Recycle Bin" Command="{Binding EmptyRecycleBinCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
+                            AutomationProperties.AutomationId="btn-cleanup-empty-recycle-bin"
                             AutomationProperties.Name="Empty the Recycle Bin"/>
                     <Button Content="Rescan" Command="{Binding RescanCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
                             AutomationProperties.Name="Rescan cleanup sizes"/>
@@ -93,12 +95,15 @@
                            Style="{StaticResource Subtle}" Margin="0,0,0,10" TextWrapping="Wrap"/>
                 <WrapPanel Orientation="Horizontal">
                     <Button Content="SFC /scannow" Command="{Binding RunSfcCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
+                            AutomationProperties.AutomationId="btn-cleanup-sfc"
                             AutomationProperties.Name="Run SFC system file check"
                             IsEnabled="{Binding IsSfcRunning, Converter={StaticResource BoolInvert}}"/>
                     <Button Content="DISM RestoreHealth" Command="{Binding RunDismCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
+                            AutomationProperties.AutomationId="btn-cleanup-dism"
                             AutomationProperties.Name="Run DISM RestoreHealth"
                             IsEnabled="{Binding IsDismRunning, Converter={StaticResource BoolInvert}}"/>
                     <Button Content="Cancel" Command="{Binding CancelCommand}" Style="{StaticResource GhostButton}" Margin="0,0,8,8"
+                            AutomationProperties.AutomationId="btn-cleanup-cancel"
                             AutomationProperties.Name="Cancel the running operation"/>
                 </WrapPanel>
 

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -27,6 +27,8 @@
             <DockPanel Grid.Row="0" Margin="0,0,0,16">
                 <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
                     <Button Content="Scan system" Command="{Binding RefreshCommand}"
+                            AutomationProperties.AutomationId="btn-dashboard-scan-system"
+                            AutomationProperties.Name="Scan system"
                             Style="{StaticResource SecondaryButton}" Padding="14,8" Margin="0,0,8,0"/>
                     <Button Command="{Binding RunTuneUpCommand}"
                             AutomationProperties.Name="Quick Tune-Up"

--- a/SysManager/SysManager/Views/DriversView.xaml
+++ b/SysManager/SysManager/Views/DriversView.xaml
@@ -31,6 +31,8 @@
             <Border Grid.Row="1" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
                 <WrapPanel>
                     <Button Content="List drivers" Command="{Binding ListDriversCommand}"
+                            AutomationProperties.AutomationId="btn-drivers-list"
+                            AutomationProperties.Name="List drivers"
                             Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"/>
                     <Button Content="Cancel" Command="{Binding CancelCommand}"
                             Style="{StaticResource GhostButton}" Margin="0,0,8,0"/>

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -35,9 +35,9 @@
                            Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
             </StackPanel>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Right" VerticalAlignment="Center">
-                <Button Content="Open Event Viewer" AutomationProperties.Name="Open Event Viewer" Command="{Binding OpenEventViewerCommand}" Style="{StaticResource GhostButton}"/>
-                <Button Content="Open log folder" AutomationProperties.Name="Open log folder" Command="{Binding OpenLogFolderCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>
-                <Button Content="Export CSV" AutomationProperties.Name="Export logs to CSV" Command="{Binding ExportCsvCommand}" Style="{StaticResource SecondaryButton}" Margin="6,0,0,0"/>
+                <Button Content="Open Event Viewer" AutomationProperties.AutomationId="btn-logs-open-event-viewer" AutomationProperties.Name="Open Event Viewer" Command="{Binding OpenEventViewerCommand}" Style="{StaticResource GhostButton}"/>
+                <Button Content="Open log folder" AutomationProperties.AutomationId="btn-logs-open-folder" AutomationProperties.Name="Open log folder" Command="{Binding OpenLogFolderCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>
+                <Button Content="Export CSV" AutomationProperties.AutomationId="btn-logs-export-csv" AutomationProperties.Name="Export logs to CSV" Command="{Binding ExportCsvCommand}" Style="{StaticResource SecondaryButton}" Margin="6,0,0,0"/>
             </StackPanel>
         </DockPanel>
 
@@ -168,7 +168,7 @@
                     <TextBlock Text="Max results" Style="{StaticResource Subtle}" VerticalAlignment="Center"/>
                     <ComboBox ItemsSource="{Binding MaxResultOptions}" SelectedItem="{Binding SelectedMaxResults}" AutomationProperties.Name="Maximum results" Width="88" Margin="8,0,18,0"/>
 
-                    <Button Content="Refresh" AutomationProperties.Name="Refresh logs" Command="{Binding RefreshCommand}" Style="{StaticResource PrimaryButton}"/>
+                    <Button Content="Refresh" AutomationProperties.AutomationId="btn-logs-refresh" AutomationProperties.Name="Refresh logs" Command="{Binding RefreshCommand}" Style="{StaticResource PrimaryButton}"/>
                     <Button Content="Cancel" AutomationProperties.Name="Cancel log loading" Command="{Binding CancelCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>
                 </StackPanel>
 

--- a/SysManager/SysManager/Views/PingView.xaml
+++ b/SysManager/SysManager/Views/PingView.xaml
@@ -24,17 +24,20 @@
                         DockPanel.Dock="Right" VerticalAlignment="Center">
                 <Button Content="Start" Command="{Binding StartCommand}"
                         Style="{StaticResource PrimaryButton}"
+                        AutomationProperties.AutomationId="btn-ping-start"
                         AutomationProperties.Name="Start ping monitoring"
                         Visibility="{Binding Shared.IsMonitoring,
                             Converter={StaticResource FlexVis},
                             ConverterParameter=Inverse}"/>
                 <Button Content="Stop" Command="{Binding StopCommand}"
                         Style="{StaticResource SecondaryButton}"
+                        AutomationProperties.AutomationId="btn-ping-stop"
                         AutomationProperties.Name="Stop ping monitoring"
                         Visibility="{Binding Shared.IsMonitoring,
                             Converter={StaticResource FlexVis}}"/>
                 <Button Content="Clear" Command="{Binding ClearHistoryCommand}"
                         Style="{StaticResource GhostButton}" Margin="6,0,0,0"
+                        AutomationProperties.AutomationId="btn-ping-clear"
                         AutomationProperties.Name="Clear ping history"/>
             </StackPanel>
         </DockPanel>
@@ -167,6 +170,7 @@
                     <TextBox Text="{Binding Shared.NewTargetHost, UpdateSourceTrigger=PropertyChanged}" Width="240"
                              AutomationProperties.Name="New target host"/>
                     <Button Content="Add target" Command="{Binding AddCustomTargetCommand}" Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"
+                            AutomationProperties.AutomationId="btn-ping-add-target"
                             AutomationProperties.Name="Add target"/>
                 </StackPanel>
             </StackPanel>

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -64,6 +64,7 @@
                     <StackPanel Orientation="Horizontal">
                         <Button Content="Refresh" Command="{Binding RefreshCommand}"
                                 Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"
+                                AutomationProperties.AutomationId="btn-services-refresh"
                                 AutomationProperties.Name="Refresh services"/>
                         <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
                                  Width="240" VerticalContentAlignment="Center"

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -16,6 +16,7 @@
                                    Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
                     </StackPanel>
                     <Button Content="Scan" Command="{Binding ScanCommand}" Style="{StaticResource PrimaryButton}"
+                            AutomationProperties.AutomationId="btn-system-health-scan"
                             AutomationProperties.Name="Scan system health"
                             HorizontalAlignment="Right" DockPanel.Dock="Right"/>
                 </DockPanel>
@@ -106,9 +107,11 @@
                         </StackPanel>
                         <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
                             <Button Content="Check memory errors" Command="{Binding CheckMemoryErrorsCommand}"
+                                    AutomationProperties.AutomationId="btn-system-health-memory-errors"
                                     AutomationProperties.Name="Check memory errors"
                                     Style="{StaticResource PrimaryButton}" Padding="14,8" Margin="0,0,8,0"/>
                             <Button Content="Run MemTest (reboot)" Command="{Binding ScheduleMemoryTestCommand}"
+                                    AutomationProperties.AutomationId="btn-system-health-memtest"
                                     AutomationProperties.Name="Schedule a memory test on next reboot"
                                     Style="{StaticResource SecondaryButton}" Padding="14,8"/>
                         </StackPanel>
@@ -176,6 +179,7 @@
                         <DockPanel>
                             <TextBlock Text="Disk health (SMART)" Style="{StaticResource SectionTitle}"/>
                             <Button Content="Run SMART check" Command="{Binding CheckDiskHealthCommand}"
+                                    AutomationProperties.AutomationId="btn-system-health-smart"
                                     AutomationProperties.Name="Run SMART disk health check"
                                     Style="{StaticResource PrimaryButton}"
                                     HorizontalAlignment="Right" DockPanel.Dock="Right"/>

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -62,6 +62,8 @@
                 <Button Content="Scan" Command="{Binding ScanCommand}"
                         Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
                 <Button Content="Uninstall selected" Command="{Binding UninstallSelectedCommand}"
+                        AutomationProperties.AutomationId="btn-uninstaller-uninstall-selected"
+                        AutomationProperties.Name="Uninstall selected applications"
                         Style="{StaticResource DangerButton}" Margin="0,0,8,0"/>
                 <Button Content="Cancel" Command="{Binding CancelCommand}"
                         Style="{StaticResource GhostButton}" Margin="0,0,12,0"

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -79,17 +79,19 @@
                 </StackPanel>
                 <Button Grid.Column="1" Content="Install PSWindowsUpdate"
                         Command="{Binding InstallModuleCommand}"
+                        AutomationProperties.AutomationId="btn-windows-update-install-module"
+                        AutomationProperties.Name="Install PSWindowsUpdate for update history"
                         Style="{StaticResource PrimaryButton}"
                         Padding="18,10" FontSize="14" VerticalAlignment="Center" Margin="16,0,0,0"/>
             </Grid>
         </Border>
 
-        <!-- Module status: available (green pill) -->
+        <!-- Module status: deferred check / confirmed available -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,0"
                 Visibility="{Binding ModuleAvailable, Converter={StaticResource FlexVis}}">
             <StackPanel Orientation="Horizontal">
-                <Ellipse Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,10,0" Fill="{DynamicResource Success}"/>
-                <TextBlock Text="PSWindowsUpdate is available" FontWeight="SemiBold" Foreground="{DynamicResource Success}" VerticalAlignment="Center"/>
+                <Ellipse Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,10,0" Fill="{DynamicResource Info}"/>
+                <TextBlock Text="{Binding ModuleStatus}" FontWeight="SemiBold" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
             </StackPanel>
         </Border>
 
@@ -98,10 +100,21 @@
             <StackPanel>
                 <TextBlock Text="Actions" Style="{StaticResource SectionTitle}" Margin="0,0,0,10"/>
                 <WrapPanel Orientation="Horizontal">
-                    <Button Content="List updates" Command="{Binding ListUpdatesCommand}" Style="{StaticResource PrimaryButton}" Margin="0,0,8,8"/>
-                    <Button Content="History" Command="{Binding ShowHistoryCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"/>
-                    <Button Content="Pending reboot?" Command="{Binding CheckPendingRebootCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"/>
+                    <Button Content="List updates" Command="{Binding ListUpdatesCommand}"
+                            AutomationProperties.AutomationId="btn-windows-update-list"
+                            AutomationProperties.Name="List available Windows updates"
+                            Style="{StaticResource PrimaryButton}" Margin="0,0,8,8"/>
+                    <Button Content="History" Command="{Binding ShowHistoryCommand}"
+                            AutomationProperties.AutomationId="btn-windows-update-history"
+                            AutomationProperties.Name="Show Windows Update history"
+                            Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"/>
+                    <Button Content="Pending reboot?" Command="{Binding CheckPendingRebootCommand}"
+                            AutomationProperties.AutomationId="btn-windows-update-pending-reboot"
+                            AutomationProperties.Name="Check for a pending reboot"
+                            Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"/>
                     <Button Content="Install selected" Command="{Binding InstallUpdatesCommand}" Style="{StaticResource PrimaryButton}" Margin="0,0,8,8"
+                            AutomationProperties.AutomationId="btn-windows-update-install-selected"
+                            AutomationProperties.Name="Install selected Windows updates"
                             Visibility="{Binding IsShowingHistory, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                     <Button Content="Select All" Command="{Binding SelectAllCommand}" Style="{StaticResource GhostButton}" Margin="0,0,8,8"
                             Visibility="{Binding IsShowingHistory, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>


### PR DESCRIPTION
## Summary

- replace every positive button lookup based on a mutable UI Automation name with 27 unique action IDs scoped to the currently rendered tab
- preserve explicit screen-reader names and add a blocking source contract for ID uniqueness, element type, accessible names, host binding, and removal of the legacy lookup API
- repair the Ping Start/Stop interaction so both commands and both UI transitions are exercised without fixed delays, with non-masking cleanup on failure
- correct the stale Windows Update module-state and App Blocker header assertions, and prepare version 1.56.6

## Root cause

`FindButton(text)` compared test literals with the exact UI Automation `Name` across the whole window. WPF replaces the Content-derived name when `AutomationProperties.Name` is explicit, so accessibility wording changes orphaned the tests. The previous main-branch artifact passed 116 / 133 UI tests: 15 tests failed from selector drift, representing 17 lookup calls, while two additional assertions were stale. Because the UI test step is warning-only, that regression did not block merges.

## Regression coverage

- all positive button assertions now resolve stable IDs under one peer-backed `CurrentViewHost`
- a blocking unit contract maps the 27 asserted IDs to 27 unique production buttons, pins their accessible names, requires the live host binding, and rejects the removed `FindButton(` API
- the Ping cycle normalizes prior state, invokes Start and Stop, verifies both visibility transitions, and uses an accessible-name fallback only for best-effort cleanup if the ID contract itself fails
- a blocking ViewModel test pins the neutral deferred Windows Update module state; the UI test verifies that module installation stays hidden until History confirms the module is missing
- all-tab header checks now search only the rendered view, preventing sidebar labels from satisfying page assertions

## Verification

- Release solution build after rebasing onto current `main`: 4 projects, 0 warnings, 0 errors
- solution-wide `dotnet format --verify-no-changes`: passed
- changed XAML/XML parsing, author headers, leak scan, diff whitespace, version/changelog consistency: passed
- independent automation-contract check: 27 references, 27 unique production IDs, 27 explicit accessible names, one peer-backed live-view host
- local xUnit and FlaUI execution is prohibited on the main workstation; blocking unit tests and the full UI artifact must pass in the Windows CI runner before merge

Closes #1536

## Type of change

- [x] Bug fix (`fix:`)

## Checklist

- [x] Branch created from `main`
- [x] Code compiles with 0 errors
- [x] Tests added and updated
- [x] Author headers verified
- [x] Self-review completed
- [x] CHANGELOG and version updated
- [x] No tool references in public source or metadata