### PR TITLE
fix: restore Performance Mode recovery after restart

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -195,7 +195,9 @@ Key services:
   any UAC request instead of inheriting SysManager elevation.
 - `PerformanceService` — power plan, visual effects, Game Mode, Xbox
   Game Bar, NVIDIA GPU, processor state, restore point creation, RAM
-  working set trim, hibernation toggle. Snapshot-based restore.
+  working set trim, hibernation toggle. Its timestamped restore snapshot is
+  persisted locally, bounded and validated at load, then rehydrated by
+  `PerformanceViewModel` before live profile probes during initialization.
 - `NetworkRepairService` — DNS flush, Winsock reset, TCP/IP reset via
   system commands with live output capture.
 - `ServiceManagerService` — enumerate Windows services, gaming

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.56.7] - 2026-08-04
+
+### Fixed
+- **Restored Performance Mode's persisted `Restore All` after an app restart.** Snapshot persistence added in #431 loaded the saved baseline only when the user applied another change. Reopening SysManager therefore left `Restore All` disabled even though `%LocalAppData%\SysManager\performance-snapshot.json` still held the original settings. Performance Mode now rehydrates that snapshot first during initialization under the existing snapshot gate, so the recovery action becomes available without waiting for live `powercfg` probes and without racing a concurrent Apply.
+- **Made old recovery points clear and testable.** New snapshots record their UTC capture time and show it in local time in the `Restore All` confirmation, while snapshots created by older releases remain loadable with an explicit unknown-time label. Snapshot storage now has an injected test directory, and regression coverage recreates an app restart with a second service instance, verifies the real command reaches confirmation, and keeps legacy JSON compatible without touching the user's profile.
+- **Hardened the persisted recovery boundary and failure semantics.** Snapshot files are size-bounded, require a complete non-duplicated schema, and reject malformed GUIDs, spoofable plan names, out-of-range processor values, and unsafe GPU subkeys before enabling restore. Power-plan, processor, and GPU restore failures now remain failures instead of reporting success and deleting the only recovery point; failed snapshot saves prevent any setting change, and failed cleanup keeps `Restore All` available for a retry.
+
 ## [1.56.6] - 2026-08-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -710,8 +710,10 @@ offers, "rate us" prompts:
 - **NVIDIA GPU**: force max performance with auto-detected GPU subkey (reboot required)
 - **Processor State**: force CPU min state to 100%
 - **Overlays info**: manual instructions for Discord, Steam, NVIDIA GFE, EA App
-- **OriginalSnapshot**: captures exact system state before first change;
-  Restore All reverts to the snapshot, not hardcoded defaults
+- **OriginalSnapshot**: captures the exact system state before the first change,
+  persists it locally, and reloads it when the tab opens so Restore All remains
+  available after an app restart; persisted fields are validated before use and the
+  confirmation shows when the baseline was captured
 - Confirmation dialog before every change
 - **Restore point creation**: create a Windows System Restore point before
   making changes (requires admin)

--- a/SysManager/SysManager.Tests/PerformanceServiceTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceServiceTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using NSubstitute;
 using SysManager.Services;
 
 namespace SysManager.Tests;
@@ -12,6 +13,9 @@ namespace SysManager.Tests;
 /// </summary>
 public class PerformanceServiceTests
 {
+    private static PerformanceService NewService(IPowerShellRunner runner) =>
+        new(runner, new RestorePointService(runner));
+
     // ── ParseActivePlan ──
 
     [Fact]
@@ -269,6 +273,93 @@ public class PerformanceServiceTests
     public void UltimatePerfScheme_IsCorrect()
     {
         Assert.Equal("e9a42b02-d5df-448d-aa00-03f14749eb61", PerformanceService.UltimatePerfScheme);
+    }
+
+    // ── Snapshot trust boundary ──
+
+    [Theory]
+    [InlineData("not-a-guid", "Balanced", 5, null)]
+    [InlineData("381b4222-f694-41f0-9685-ff5bb260df2e", "", 5, null)]
+    [InlineData("381b4222-f694-41f0-9685-ff5bb260df2e", "Balanced\nSpoofed", 5, null)]
+    [InlineData("381b4222-f694-41f0-9685-ff5bb260df2e", "Balanced\u202ESpoofed", 5, null)]
+    [InlineData("381b4222-f694-41f0-9685-ff5bb260df2e", "Balanced", -1, null)]
+    [InlineData("381b4222-f694-41f0-9685-ff5bb260df2e", "Balanced", 101, null)]
+    [InlineData("381b4222-f694-41f0-9685-ff5bb260df2e", "Balanced", 5, @"..\0000")]
+    public void SnapshotValidation_RejectsUnsafeFields(
+        string guid,
+        string name,
+        int processorMinimum,
+        string? nvidiaSubKey)
+    {
+        var snapshot = new PerformanceService.OriginalSnapshot(
+            guid,
+            name,
+            true,
+            true,
+            true,
+            true,
+            true,
+            processorMinimum,
+            nvidiaSubKey);
+
+        Assert.False(PerformanceService.TryValidateSnapshot(snapshot, out _));
+    }
+
+    [Fact]
+    public void SnapshotValidation_AcceptsLegacyUnknownValues()
+    {
+        var snapshot = new PerformanceService.OriginalSnapshot(
+            PowerPlanGuid: "",
+            PowerPlanName: "Unknown",
+            UiEffectsEnabled: true,
+            GameModeEnabled: true,
+            XboxGameBarEnabled: true,
+            XboxGameDvrEnabled: true,
+            GpuDynamicPstate: true,
+            ProcessorMinPercentAc: null,
+            NvidiaSubKey: null);
+
+        Assert.True(PerformanceService.TryValidateSnapshot(snapshot, out _));
+    }
+
+    [Fact]
+    public async Task SetActivePlan_NonzeroExitCode_Throws()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunProcessAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<System.Text.Encoding?>())
+            .Returns(5);
+        using var service = NewService(runner);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.SetActivePlanAsync(PerformanceService.BalancedGuid));
+    }
+
+    [Fact]
+    public async Task SetProcessorMinimum_NonzeroExitCode_ThrowsBeforeReportingSuccess()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunProcessAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<System.Text.Encoding?>())
+            .Returns(0);
+        runner.RunProcessAsync(
+                "powercfg.exe",
+                Arg.Is<string>(args =>
+                    args != null
+                    && args.StartsWith("/setdcvalueindex", StringComparison.Ordinal)),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<System.Text.Encoding?>())
+            .Returns(7);
+        using var service = NewService(runner);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.SetProcessorMinStateAsync(5));
     }
 
     // ── OriginalSnapshot ──

--- a/SysManager/SysManager.Tests/PerformanceSnapshotRestartTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceSnapshotRestartTests.cs
@@ -1,0 +1,423 @@
+// SysManager · PerformanceSnapshotRestartTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using NSubstitute;
+using SysManager.Services;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Regression coverage for the persisted Performance Mode recovery point.
+/// Every test uses an isolated directory and never touches the real app profile.
+/// </summary>
+[Collection("DialogService")]
+public sealed class PerformanceSnapshotRestartTests
+{
+    private static IPowerShellRunner NewRunner()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunProcessAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<System.Text.Encoding?>())
+            .Returns(0);
+        return runner;
+    }
+
+    private static PerformanceService NewService(
+        string configDir,
+        IPowerShellRunner? runner = null)
+    {
+        runner ??= NewRunner();
+        return new PerformanceService(runner, new RestorePointService(runner), configDir);
+    }
+
+    private static PerformanceService.OriginalSnapshot ValidSnapshot(
+        DateTimeOffset? capturedAtUtc = null) =>
+        new(
+            PowerPlanGuid: "381b4222-f694-41f0-9685-ff5bb260df2e",
+            PowerPlanName: "Balanced",
+            UiEffectsEnabled: true,
+            GameModeEnabled: true,
+            XboxGameBarEnabled: true,
+            XboxGameDvrEnabled: true,
+            GpuDynamicPstate: true,
+            ProcessorMinPercentAc: 5,
+            NvidiaSubKey: null,
+            CapturedAtUtc: capturedAtUtc);
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(
+            Path.GetTempPath(),
+            "SysManagerPerformanceTests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    [Fact]
+    public async Task Initialization_WithPersistedSnapshot_EnablesRestoreAndShowsCaptureTime()
+    {
+        var dir = CreateTempDirectory();
+        var snapshot = ValidSnapshot(
+            new DateTimeOffset(2026, 7, 31, 12, 34, 0, TimeSpan.Zero)) with
+        {
+            XboxGameDvrEnabled = false,
+            GpuDynamicPstate = false,
+            NvidiaSubKey = "0000"
+        };
+
+        try
+        {
+            using (var writer = NewService(dir))
+                Assert.True(writer.SaveSnapshot(snapshot));
+
+            using var service = NewService(dir);
+            Assert.Equal(snapshot, service.LoadSnapshot());
+
+            using var vm = new PerformanceViewModel(service);
+            await vm.InitializationComplete;
+
+            Assert.True(vm.HasSnapshot);
+
+            var previousDialog = DialogService.Instance;
+            var dialog = Substitute.For<IDialogService>();
+            dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+            DialogService.Instance = dialog;
+            try
+            {
+                await vm.RestoreAllCommand.ExecuteAsync(null);
+
+                dialog.Received(1).Confirm(
+                    Arg.Is<string>(message =>
+                        message != null
+                        && message.Contains("Snapshot captured:", StringComparison.Ordinal)
+                        && message.Contains("2026", StringComparison.Ordinal)
+                        && message.Contains("Game DVR → OFF", StringComparison.Ordinal)
+                        && message.Contains("GPU → Max performance", StringComparison.Ordinal)),
+                    "Restore Original Settings — Confirm");
+                Assert.DoesNotContain("Nothing to restore", vm.StatusMessage, StringComparison.Ordinal);
+            }
+            finally
+            {
+                DialogService.Instance = previousDialog;
+            }
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Initialization_PersistedSnapshotIsAvailableBeforeBlockedRefreshCompletes()
+    {
+        var dir = CreateTempDirectory();
+        var refreshStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRefresh = new TaskCompletionSource<int>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        try
+        {
+            var snapshot = ValidSnapshot() with
+            {
+                NvidiaSubKey = "0000"
+            };
+            using (var writer = NewService(dir))
+                Assert.True(writer.SaveSnapshot(snapshot));
+
+            var runner = Substitute.For<IPowerShellRunner>();
+            runner.RunProcessAsync(
+                    Arg.Any<string>(),
+                    Arg.Any<string>(),
+                    Arg.Any<CancellationToken>(),
+                    Arg.Any<System.Text.Encoding?>())
+                .Returns(_ =>
+                {
+                    refreshStarted.TrySetResult(true);
+                    return releaseRefresh.Task;
+                });
+
+            using var service = NewService(dir, runner);
+            using var vm = new PerformanceViewModel(service);
+            try
+            {
+                await refreshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+                // Restore hydration precedes the blocked live probe, so recovery is immediately visible.
+                Assert.True(vm.HasSnapshot);
+
+                var previousDialog = DialogService.Instance;
+                var dialog = Substitute.For<IDialogService>();
+                dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+                DialogService.Instance = dialog;
+                try
+                {
+                    // A missing live profile cannot suppress the conservative GPU reboot warning.
+                    await vm.RestoreAllCommand.ExecuteAsync(null);
+
+                    dialog.Received(1).Confirm(
+                        Arg.Is<string>(message =>
+                            message != null
+                            && message.Contains(
+                                "GPU → Dynamic P-state (reboot needed)",
+                                StringComparison.Ordinal)),
+                        "Restore Original Settings — Confirm");
+                }
+                finally
+                {
+                    DialogService.Instance = previousDialog;
+                }
+            }
+            finally
+            {
+                releaseRefresh.TrySetResult(0);
+                await vm.InitializationComplete.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+        }
+        finally
+        {
+            releaseRefresh.TrySetResult(0);
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Initialization_WithLegacySnapshot_EnablesRestoreWithUnknownCaptureTime()
+    {
+        var dir = CreateTempDirectory();
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(dir, "performance-snapshot.json"),
+                """
+                {
+                  "PowerPlanGuid": "381b4222-f694-41f0-9685-ff5bb260df2e",
+                  "PowerPlanName": "Balanced",
+                  "UiEffectsEnabled": true,
+                  "GameModeEnabled": true,
+                  "XboxGameBarEnabled": true,
+                  "XboxGameDvrEnabled": true,
+                  "GpuDynamicPstate": true,
+                  "ProcessorMinPercentAc": 5,
+                  "NvidiaSubKey": null
+                }
+                """);
+
+            using var service = NewService(dir);
+            using var vm = new PerformanceViewModel(service);
+            await vm.InitializationComplete;
+
+            Assert.True(vm.HasSnapshot);
+            Assert.Null(service.LoadSnapshot()!.CapturedAtUtc);
+
+            var previousDialog = DialogService.Instance;
+            var dialog = Substitute.For<IDialogService>();
+            dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+            DialogService.Instance = dialog;
+            try
+            {
+                await vm.RestoreAllCommand.ExecuteAsync(null);
+
+                dialog.Received(1).Confirm(
+                    Arg.Is<string>(message =>
+                        message != null
+                        && message.Contains(
+                            "Unknown (snapshot created by an earlier SysManager version)",
+                            StringComparison.Ordinal)),
+                    "Restore Original Settings — Confirm");
+            }
+            finally
+            {
+                DialogService.Instance = previousDialog;
+            }
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RestoreFailure_PreservesPersistedSnapshotForRetry()
+    {
+        var dir = CreateTempDirectory();
+        var runner = NewRunner();
+
+        try
+        {
+            using var service = NewService(dir, runner);
+            Assert.True(service.SaveSnapshot(ValidSnapshot()));
+
+            using var vm = new PerformanceViewModel(service);
+            await vm.InitializationComplete;
+            Assert.True(vm.HasSnapshot);
+
+            runner.RunProcessAsync(
+                    "powercfg.exe",
+                    Arg.Is<string>(arguments =>
+                        arguments != null
+                        && arguments.StartsWith("/setactive ", StringComparison.Ordinal)),
+                    Arg.Any<CancellationToken>(),
+                    Arg.Any<System.Text.Encoding?>())
+                .Returns(5);
+
+            var previousDialog = DialogService.Instance;
+            var dialog = Substitute.For<IDialogService>();
+            dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+            DialogService.Instance = dialog;
+            try
+            {
+                await vm.RestoreAllCommand.ExecuteAsync(null);
+
+                Assert.True(vm.HasSnapshot);
+                Assert.NotNull(service.LoadSnapshot());
+                Assert.Contains("failed", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+            }
+            finally
+            {
+                DialogService.Instance = previousDialog;
+            }
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LoadSnapshot_MissingRequiredProperty_ReturnsNull()
+    {
+        var dir = CreateTempDirectory();
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(dir, "performance-snapshot.json"),
+                """
+                {
+                  "PowerPlanName": "Balanced",
+                  "UiEffectsEnabled": true,
+                  "GameModeEnabled": true,
+                  "XboxGameBarEnabled": true,
+                  "XboxGameDvrEnabled": true,
+                  "GpuDynamicPstate": true,
+                  "ProcessorMinPercentAc": 5,
+                  "NvidiaSubKey": null
+                }
+                """);
+
+            using var service = NewService(dir);
+            Assert.Null(service.LoadSnapshot());
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LoadSnapshot_WrongPropertyType_ReturnsNull()
+    {
+        var dir = CreateTempDirectory();
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(dir, "performance-snapshot.json"),
+                """
+                {
+                  "PowerPlanGuid": "381b4222-f694-41f0-9685-ff5bb260df2e",
+                  "PowerPlanName": "Balanced",
+                  "UiEffectsEnabled": "yes",
+                  "GameModeEnabled": true,
+                  "XboxGameBarEnabled": true,
+                  "XboxGameDvrEnabled": true,
+                  "GpuDynamicPstate": true,
+                  "ProcessorMinPercentAc": 5,
+                  "NvidiaSubKey": null
+                }
+                """);
+
+            using var service = NewService(dir);
+            Assert.Null(service.LoadSnapshot());
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LoadSnapshot_DuplicateProperty_ReturnsNull()
+    {
+        var dir = CreateTempDirectory();
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(dir, "performance-snapshot.json"),
+                """
+                {
+                  "PowerPlanGuid": "381b4222-f694-41f0-9685-ff5bb260df2e",
+                  "PowerPlanName": "Balanced",
+                  "PowerPlanName": "Spoofed",
+                  "UiEffectsEnabled": true,
+                  "GameModeEnabled": true,
+                  "XboxGameBarEnabled": true,
+                  "XboxGameDvrEnabled": true,
+                  "GpuDynamicPstate": true,
+                  "ProcessorMinPercentAc": 5,
+                  "NvidiaSubKey": null
+                }
+                """);
+
+            using var service = NewService(dir);
+            Assert.Null(service.LoadSnapshot());
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LoadSnapshot_OversizedFile_ReturnsNull()
+    {
+        var dir = CreateTempDirectory();
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(dir, "performance-snapshot.json"),
+                new string('x', PerformanceService.MaxSnapshotBytes + 1));
+
+            using var service = NewService(dir);
+            Assert.Null(service.LoadSnapshot());
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SaveSnapshot_InvalidSnapshot_ReturnsFalseAndWritesNothing()
+    {
+        var dir = CreateTempDirectory();
+        try
+        {
+            using var service = NewService(dir);
+            var invalid = ValidSnapshot() with { ProcessorMinPercentAc = 101 };
+
+            Assert.False(service.SaveSnapshot(invalid));
+            Assert.False(File.Exists(Path.Combine(dir, "performance-snapshot.json")));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using System.Reflection;
 using NSubstitute;
 using SysManager.Services;
@@ -21,10 +22,31 @@ namespace SysManager.Tests;
 [Collection("DialogService")]
 public class PerformanceViewModelTests
 {
-    private static PerformanceViewModel NewVm()
+    private static PerformanceViewModel NewVm(bool completeInitialization = false)
     {
-        var ps = new PowerShellRunner();
-        return new(new PerformanceService(ps, new RestorePointService(ps)));
+        var ps = Substitute.For<IPowerShellRunner>();
+        var processCall = ps.RunProcessAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<System.Text.Encoding?>());
+        if (completeInitialization)
+        {
+            processCall.Returns(0);
+        }
+        else
+        {
+            // Keep constructor-state tests independent of the host registry/P/Invoke state.
+            // Tests that need initialized state opt in and await InitializationComplete.
+            var pending = new TaskCompletionSource<int>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            processCall.Returns(pending.Task);
+        }
+        var configDir = Path.Combine(
+            Path.GetTempPath(),
+            "SysManagerPerformanceTests",
+            Guid.NewGuid().ToString("N"));
+        return new(new PerformanceService(ps, new RestorePointService(ps), configDir));
     }
 
     // ── Commands exist ──
@@ -73,9 +95,11 @@ public class PerformanceViewModelTests
     }
 
     [Fact]
-    public void Constructor_HasSnapshot_DefaultFalse()
+    public async Task Initialization_WithoutPersistedSnapshot_HasSnapshotFalse()
     {
-        var vm = NewVm();
+        using var vm = NewVm(completeInitialization: true);
+        await vm.InitializationComplete;
+
         Assert.False(vm.HasSnapshot);
     }
 

--- a/SysManager/SysManager/Services/PerformanceService.cs
+++ b/SysManager/SysManager/Services/PerformanceService.cs
@@ -3,10 +3,12 @@
 // License: MIT
 
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Win32;
 using Serilog;
 using SysManager.Models;
@@ -29,6 +31,7 @@ public sealed partial class PerformanceService : IDisposable
 {
     private readonly IPowerShellRunner _ps;
     private readonly RestorePointService _restorePoints;
+    private readonly string _snapshotPath;
     private readonly SemaphoreSlim _psGate = new(1, 1);
     private bool _disposed;
 
@@ -36,6 +39,14 @@ public sealed partial class PerformanceService : IDisposable
     internal const string BalancedGuid = "381b4222-f694-41f0-9685-ff5bb260df2e";
     internal const string HighPerfGuid = "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c";
     internal const string UltimatePerfScheme = "e9a42b02-d5df-448d-aa00-03f14749eb61";
+
+    internal const int MaxSnapshotBytes = 64 * 1024;
+    private static readonly JsonSerializerOptions SnapshotJsonOptions = new()
+    {
+        WriteIndented = true,
+        MaxDepth = 8,
+        AllowDuplicateProperties = false
+    };
 
     // ── Registry paths ──
     internal const string GameBarKey = @"SOFTWARE\Microsoft\GameBar";
@@ -59,9 +70,24 @@ public sealed partial class PerformanceService : IDisposable
         uint uiAction, uint uiParam, int pvParam, uint fWinIni);
 
     public PerformanceService(IPowerShellRunner ps, RestorePointService restorePoints)
+        : this(
+            ps,
+            restorePoints,
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "SysManager"))
+    {
+    }
+
+    /// <summary>Test seam for snapshot persistence without touching the real app profile.</summary>
+    internal PerformanceService(
+        IPowerShellRunner ps,
+        RestorePointService restorePoints,
+        string configDir)
     {
         _ps = ps;
         _restorePoints = restorePoints;
+        _snapshotPath = Path.Combine(configDir, "performance-snapshot.json");
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -73,15 +99,16 @@ public sealed partial class PerformanceService : IDisposable
     /// Used by Restore to revert to the exact original state.
     /// </summary>
     public sealed record OriginalSnapshot(
-        string PowerPlanGuid,
-        string PowerPlanName,
-        bool UiEffectsEnabled,
-        bool GameModeEnabled,
-        bool XboxGameBarEnabled,
-        bool XboxGameDvrEnabled,
-        bool GpuDynamicPstate,       // true = dynamic (default), false = disabled
-        int? ProcessorMinPercentAc,  // null = couldn't read (don't restore rather than guess)
-        string? NvidiaSubKey);       // null = no NVIDIA GPU
+        [property: JsonRequired] string PowerPlanGuid,
+        [property: JsonRequired] string PowerPlanName,
+        [property: JsonRequired] bool UiEffectsEnabled,
+        [property: JsonRequired] bool GameModeEnabled,
+        [property: JsonRequired] bool XboxGameBarEnabled,
+        [property: JsonRequired] bool XboxGameDvrEnabled,
+        [property: JsonRequired] bool GpuDynamicPstate,       // true = dynamic (default), false = disabled
+        [property: JsonRequired] int? ProcessorMinPercentAc,  // null = couldn't read (don't restore rather than guess)
+        [property: JsonRequired] string? NvidiaSubKey,        // null = no NVIDIA GPU
+        DateTimeOffset? CapturedAtUtc = null); // null = legacy snapshot without timestamp
 
     /// <summary>
     /// Take a snapshot of the current system state.
@@ -105,26 +132,34 @@ public sealed partial class PerformanceService : IDisposable
             XboxGameDvrEnabled: ReadXboxGameDvrEnabled(),
             GpuDynamicPstate: nvidiaKey is not null && !ReadGpuMaxPerformance(nvidiaKey),
             ProcessorMinPercentAc: await ReadProcessorMinPercentAsync(ct).ConfigureAwait(false),
-            NvidiaSubKey: nvidiaKey);
+            NvidiaSubKey: nvidiaKey,
+            CapturedAtUtc: DateTimeOffset.UtcNow);
     }
 
-    private static readonly string SnapshotPath = Path.Join(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "SysManager", "performance-snapshot.json");
-
     /// <summary>Persist a snapshot to disk so it survives app restarts.</summary>
-    public static void SaveSnapshot(OriginalSnapshot snapshot)
+    public bool SaveSnapshot(OriginalSnapshot snapshot)
     {
+        if (!TryValidateSnapshot(snapshot, out var reason))
+        {
+            Log.Warning("Refused to save invalid performance snapshot: {Reason}", reason);
+            return false;
+        }
+
         try
         {
-            var dir = Path.GetDirectoryName(SnapshotPath)!;
+            var dir = Path.GetDirectoryName(_snapshotPath)!;
             Directory.CreateDirectory(dir);
-            var json = JsonSerializer.Serialize(snapshot, JsonDefaults.Indented);
-            File.WriteAllText(SnapshotPath, json);
-            Log.Information("Performance snapshot saved to {Path}", SnapshotPath);
+            var json = JsonSerializer.SerializeToUtf8Bytes(snapshot, SnapshotJsonOptions);
+            if (json.Length > MaxSnapshotBytes)
+                throw new InvalidDataException("The performance snapshot exceeds the supported size.");
+            File.WriteAllBytes(_snapshotPath, json);
+            Log.Information("Performance snapshot saved to {Path}", _snapshotPath);
+            return true;
         }
-        catch (IOException ex) { Log.Warning(ex, "Failed to save performance snapshot"); }
-        catch (UnauthorizedAccessException ex) { Log.Warning(ex, "Failed to save performance snapshot"); }
+        catch (InvalidDataException ex) { Log.Warning(ex, "Failed to save performance snapshot"); return false; }
+        catch (IOException ex) { Log.Warning(ex, "Failed to save performance snapshot"); return false; }
+        catch (SecurityException ex) { Log.Warning(ex, "Failed to save performance snapshot"); return false; }
+        catch (UnauthorizedAccessException ex) { Log.Warning(ex, "Failed to save performance snapshot"); return false; }
     }
 
     /// <summary>
@@ -132,30 +167,108 @@ public sealed partial class PerformanceService : IDisposable
     /// Apply captures a fresh baseline instead of reloading the now-reverted pre-restore
     /// state via <see cref="LoadSnapshot"/>.
     /// </summary>
-    public static void DeleteSnapshot()
+    public bool DeleteSnapshot()
     {
         try
         {
-            if (File.Exists(SnapshotPath)) File.Delete(SnapshotPath);
-            Log.Information("Performance snapshot deleted from {Path}", SnapshotPath);
+            if (File.Exists(_snapshotPath)) File.Delete(_snapshotPath);
+            Log.Information("Performance snapshot deleted from {Path}", _snapshotPath);
+            return true;
         }
-        catch (IOException ex) { Log.Warning(ex, "Failed to delete performance snapshot"); }
-        catch (UnauthorizedAccessException ex) { Log.Warning(ex, "Failed to delete performance snapshot"); }
+        catch (IOException ex) { Log.Warning(ex, "Failed to delete performance snapshot"); return false; }
+        catch (SecurityException ex) { Log.Warning(ex, "Failed to delete performance snapshot"); return false; }
+        catch (UnauthorizedAccessException ex) { Log.Warning(ex, "Failed to delete performance snapshot"); return false; }
     }
 
-    /// <summary>Load a previously saved snapshot from disk. Returns null if none exists.</summary>
-    public static OriginalSnapshot? LoadSnapshot()
+    /// <summary>
+    /// Loads and validates a previously saved snapshot. Invalid, incomplete, or oversized
+    /// files are rejected before any value can reach a restore operation.
+    /// </summary>
+    public OriginalSnapshot? LoadSnapshot()
     {
         try
         {
-            if (!File.Exists(SnapshotPath)) return null;
-            var json = File.ReadAllText(SnapshotPath);
-            return JsonSerializer.Deserialize<OriginalSnapshot>(json);
+            if (!File.Exists(_snapshotPath)) return null;
+            var snapshot = JsonSerializer.Deserialize<OriginalSnapshot>(
+                ReadBoundedSnapshot(),
+                SnapshotJsonOptions);
+            if (!TryValidateSnapshot(snapshot, out var reason))
+            {
+                Log.Warning("Rejected invalid performance snapshot: {Reason}", reason);
+                return null;
+            }
+            return snapshot;
         }
+        catch (InvalidDataException ex) { Log.Warning(ex, "Rejected invalid performance snapshot"); return null; }
         catch (IOException ex) { Log.Warning(ex, "Failed to load performance snapshot"); return null; }
+        catch (SecurityException ex) { Log.Warning(ex, "Failed to load performance snapshot"); return null; }
         catch (UnauthorizedAccessException ex) { Log.Warning(ex, "Failed to load performance snapshot"); return null; }
         catch (JsonException ex) { Log.Warning(ex, "Failed to parse performance snapshot"); return null; }
     }
+
+    private byte[] ReadBoundedSnapshot()
+    {
+        using var stream = new FileStream(
+            _snapshotPath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 4096,
+            FileOptions.SequentialScan);
+
+        if (stream.Length is <= 0 or > MaxSnapshotBytes)
+            throw new InvalidDataException("The performance snapshot has an invalid size.");
+
+        var bytes = new byte[(int)stream.Length];
+        stream.ReadExactly(bytes);
+        if (stream.ReadByte() != -1)
+            throw new InvalidDataException("The performance snapshot changed while it was being read.");
+        return bytes;
+    }
+
+    internal static bool TryValidateSnapshot(OriginalSnapshot? snapshot, out string reason)
+    {
+        if (snapshot is null)
+            return RejectSnapshot("the document is empty", out reason);
+
+        if (snapshot.PowerPlanGuid is null)
+            return RejectSnapshot("the power-plan GUID is missing", out reason);
+        if (snapshot.PowerPlanGuid.Length > 0 &&
+            !Guid.TryParseExact(snapshot.PowerPlanGuid, "D", out _))
+        {
+            return RejectSnapshot("the power-plan GUID is not canonical", out reason);
+        }
+
+        if (string.IsNullOrWhiteSpace(snapshot.PowerPlanName) ||
+            snapshot.PowerPlanName.Length > 256 ||
+            snapshot.PowerPlanName.Any(character =>
+                char.IsControl(character) ||
+                char.GetUnicodeCategory(character) == UnicodeCategory.Format))
+        {
+            return RejectSnapshot("the power-plan name is invalid", out reason);
+        }
+
+        if (snapshot.ProcessorMinPercentAc is < 0 or > 100)
+            return RejectSnapshot("the processor minimum is outside 0-100", out reason);
+
+        if (snapshot.NvidiaSubKey is not null &&
+            !NvidiaSubKeyRegex().IsMatch(snapshot.NvidiaSubKey))
+        {
+            return RejectSnapshot("the NVIDIA registry subkey is invalid", out reason);
+        }
+
+        reason = "";
+        return true;
+    }
+
+    private static bool RejectSnapshot(string rejectionReason, out string reason)
+    {
+        reason = rejectionReason;
+        return false;
+    }
+
+    [System.Text.RegularExpressions.GeneratedRegex(@"\A[0-9]{1,8}\z")]
+    private static partial System.Text.RegularExpressions.Regex NvidiaSubKeyRegex();
 
     // ═══════════════════════════════════════════════════════════════
     //  READ — current system state
@@ -244,13 +357,22 @@ public sealed partial class PerformanceService : IDisposable
     /// <summary>Activate a power plan by GUID.</summary>
     public async Task SetActivePlanAsync(string guid, CancellationToken ct = default)
     {
+        if (!Guid.TryParseExact(guid, "D", out _))
+            throw new ArgumentException("Power-plan GUID must use canonical D format.", nameof(guid));
+
         // Serialize on the same gate the readers use: they own the shared
         // _ps.LineReceived while parsing, and a concurrent powercfg call on the
         // same runner would interleave their output stream.
         await _psGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            await _ps.RunProcessAsync("powercfg.exe", $"/setactive {guid}", ct, PowerShellRunner.OemEncoding).ConfigureAwait(false);
+            var exitCode = await _ps.RunProcessAsync(
+                "powercfg.exe",
+                $"/setactive {guid}",
+                ct,
+                PowerShellRunner.OemEncoding).ConfigureAwait(false);
+            if (exitCode != 0)
+                throw new InvalidOperationException($"powercfg failed to activate the power plan (exit code {exitCode}).");
         }
         finally { _psGate.Release(); }
     }
@@ -501,6 +623,7 @@ public sealed partial class PerformanceService : IDisposable
     /// </summary>
     public static bool SetGpuMaxPerformance(string subKey, bool maxPerformance)
     {
+        if (!IsNvidiaSubKey(subKey)) return false;
         try
         {
             using var key = Registry.LocalMachine.OpenSubKey(
@@ -517,6 +640,22 @@ public sealed partial class PerformanceService : IDisposable
             Log.Information("Registry: GPU DisableDynamicPstate set to {Value} on subkey {SubKey}",
                 maxPerformance ? 1 : 0, subKey);
             return true;
+        }
+        catch (SecurityException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+    }
+
+    internal static bool IsNvidiaSubKey(string subKey)
+    {
+        if (!NvidiaSubKeyRegex().IsMatch(subKey)) return false;
+        try
+        {
+            using var key = Registry.LocalMachine.OpenSubKey($@"{GpuClassRoot}\{subKey}");
+            if (key is null) return false;
+            var driverDesc = key.GetValue("DriverDesc")?.ToString() ?? "";
+            var provider = key.GetValue("ProviderName")?.ToString() ?? "";
+            return driverDesc.Contains("NVIDIA", StringComparison.OrdinalIgnoreCase)
+                || provider.Contains("NVIDIA", StringComparison.OrdinalIgnoreCase);
         }
         catch (SecurityException) { return false; }
         catch (UnauthorizedAccessException) { return false; }
@@ -593,15 +732,27 @@ public sealed partial class PerformanceService : IDisposable
     /// </summary>
     public async Task SetProcessorMinStateAsync(int percent, CancellationToken ct = default)
     {
+        if (percent is < 0 or > 100)
+            throw new ArgumentOutOfRangeException(nameof(percent), percent, "Processor minimum must be between 0 and 100.");
+
         // Serialize on the shared gate — see SetActivePlanAsync.
         await _psGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            await _ps.RunProcessAsync("powercfg.exe",
+            var acExitCode = await _ps.RunProcessAsync("powercfg.exe",
                 $"/setacvalueindex SCHEME_CURRENT SUB_PROCESSOR PROCTHROTTLEMIN {percent}", ct, PowerShellRunner.OemEncoding).ConfigureAwait(false);
-            await _ps.RunProcessAsync("powercfg.exe",
+            if (acExitCode != 0)
+                throw new InvalidOperationException($"powercfg failed to set the AC processor minimum (exit code {acExitCode}).");
+
+            var dcExitCode = await _ps.RunProcessAsync("powercfg.exe",
                 $"/setdcvalueindex SCHEME_CURRENT SUB_PROCESSOR PROCTHROTTLEMIN {percent}", ct, PowerShellRunner.OemEncoding).ConfigureAwait(false);
-            await _ps.RunProcessAsync("powercfg.exe", "/setactive SCHEME_CURRENT", ct, PowerShellRunner.OemEncoding).ConfigureAwait(false);
+            if (dcExitCode != 0)
+                throw new InvalidOperationException($"powercfg failed to set the DC processor minimum (exit code {dcExitCode}).");
+
+            var applyExitCode = await _ps.RunProcessAsync(
+                "powercfg.exe", "/setactive SCHEME_CURRENT", ct, PowerShellRunner.OemEncoding).ConfigureAwait(false);
+            if (applyExitCode != 0)
+                throw new InvalidOperationException($"powercfg failed to apply the processor minimum (exit code {applyExitCode}).");
         }
         finally { _psGate.Release(); }
     }
@@ -698,6 +849,9 @@ public sealed partial class PerformanceService : IDisposable
     /// </summary>
     public async Task RestoreFromSnapshotAsync(OriginalSnapshot snapshot, CancellationToken ct = default)
     {
+        if (!TryValidateSnapshot(snapshot, out var reason))
+            throw new InvalidOperationException($"The saved performance snapshot is invalid: {reason}.");
+
         // Power plan — restore the exact original plan
         if (!string.IsNullOrEmpty(snapshot.PowerPlanGuid))
             await SetActivePlanAsync(snapshot.PowerPlanGuid, ct).ConfigureAwait(false);
@@ -714,7 +868,10 @@ public sealed partial class PerformanceService : IDisposable
 
         // GPU
         if (snapshot.NvidiaSubKey is not null)
-            SetGpuMaxPerformance(snapshot.NvidiaSubKey, !snapshot.GpuDynamicPstate);
+        {
+            if (!SetGpuMaxPerformance(snapshot.NvidiaSubKey, !snapshot.GpuDynamicPstate))
+                throw new InvalidOperationException("The saved NVIDIA adapter is unavailable or could not be restored.");
+        }
 
         // Processor state — only restore if we captured a real value. A null means the
         // snapshot couldn't read the original minimum (e.g. an unparseable powercfg output),

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.56.6</Version>
-    <FileVersion>1.56.6.0</FileVersion>
-    <AssemblyVersion>1.56.6.0</AssemblyVersion>
+    <Version>1.56.7</Version>
+    <FileVersion>1.56.7.0</FileVersion>
+    <AssemblyVersion>1.56.7.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
@@ -65,6 +65,16 @@ public sealed partial class PerformanceViewModel : ViewModelBase
 
     private async Task InitAsync()
     {
+        await _snapshotGate.WaitAsync();
+        try
+        {
+            // Recovery must not wait behind live powercfg probes. A blocked or unavailable
+            // system tool must never keep a valid persisted Restore All action disabled.
+            _snapshot ??= await Task.Run(_service.LoadSnapshot);
+            HasSnapshot = _snapshot is not null;
+        }
+        finally { _snapshotGate.Release(); }
+
         try { await RefreshAsync(); }
         catch (InvalidOperationException ex) { Log.Warning("Performance auto-refresh failed: {Error}", ex.Message); }
         catch (System.Security.SecurityException ex) { Log.Warning("Performance auto-refresh failed: {Error}", ex.Message); }
@@ -74,12 +84,28 @@ public sealed partial class PerformanceViewModel : ViewModelBase
     /// <summary>Ensure snapshot exists before any change.</summary>
     private async Task EnsureSnapshotAsync()
     {
-        await _snapshotGate.WaitAsync().ConfigureAwait(false);
+        await _snapshotGate.WaitAsync();
         try
         {
-            _snapshot ??= PerformanceService.LoadSnapshot()
-                       ?? await _service.TakeSnapshotAsync();
-            PerformanceService.SaveSnapshot(_snapshot);
+            if (_snapshot is null)
+            {
+                var persisted = await Task.Run(_service.LoadSnapshot);
+                if (persisted is not null)
+                {
+                    _snapshot = persisted;
+                }
+                else
+                {
+                    var captured = await _service.TakeSnapshotAsync();
+                    var saved = await Task.Run(() => _service.SaveSnapshot(captured));
+                    if (!saved)
+                    {
+                        throw new InvalidOperationException(
+                            "The recovery snapshot could not be saved, so no setting was changed.");
+                    }
+                    _snapshot = captured;
+                }
+            }
             HasSnapshot = true;
         }
         finally { _snapshotGate.Release(); }
@@ -594,17 +620,27 @@ public sealed partial class PerformanceViewModel : ViewModelBase
             return;
         }
 
-        var gpuWasChanged = _snapshot.NvidiaSubKey is not null
-            && Profile.GpuMaxPerformance != !_snapshot.GpuDynamicPstate;
+        var gpuWillBeRestored = _snapshot.NvidiaSubKey is not null;
+        var capturedAt = _snapshot.CapturedAtUtc is DateTimeOffset timestamp
+            ? timestamp.ToLocalTime().ToString("f")
+            : "Unknown (snapshot created by an earlier SysManager version)";
+        var powerPlan = string.IsNullOrEmpty(_snapshot.PowerPlanGuid)
+            ? _snapshot.PowerPlanName
+            : $"{_snapshot.PowerPlanName} ({_snapshot.PowerPlanGuid})";
+        var gpuRestoreState = _snapshot.GpuDynamicPstate
+            ? "Dynamic P-state"
+            : "Max performance";
 
         if (!DialogService.Instance.Confirm(
             "Restore ALL settings to the state before any changes were made?\n\n"
-            + $"• Power plan → {_snapshot.PowerPlanName}\n"
+            + $"Snapshot captured: {capturedAt}\n\n"
+            + $"• Power plan → {powerPlan}\n"
             + $"• Visual effects → {(_snapshot.UiEffectsEnabled ? "Normal" : "Reduced")}\n"
             + $"• Game Mode → {(_snapshot.GameModeEnabled ? "ON" : "OFF")}\n"
             + $"• Xbox Game Bar → {(_snapshot.XboxGameBarEnabled ? "ON" : "OFF")}\n"
+            + $"• Game DVR → {(_snapshot.XboxGameDvrEnabled ? "ON" : "OFF")}\n"
             + $"• Processor min state → {(_snapshot.ProcessorMinPercentAc is int p ? $"{p}%" : "unchanged")}\n"
-            + (gpuWasChanged ? "• GPU → Dynamic P-state (reboot needed)\n" : "")
+            + (gpuWillBeRestored ? $"• GPU → {gpuRestoreState} (reboot needed)\n" : "")
             + "\nContinue?",
             "Restore Original Settings — Confirm")) return;
 
@@ -625,18 +661,27 @@ public sealed partial class PerformanceViewModel : ViewModelBase
         try
         {
             await _service.RestoreFromSnapshotAsync(_snapshot);
-            NeedsReboot = gpuWasChanged;
-            StatusMessage = NeedsReboot
-                ? "Original settings restored. Reboot required for GPU changes."
-                : "Original settings restored.";
-            Log.Information("Performance settings restored to original snapshot");
-            _snapshot = null;
-            HasSnapshot = false;
             // Delete the persisted snapshot too — otherwise the next Apply reloads the
             // now-reverted pre-restore baseline via LoadSnapshot and a later Restore All
             // would re-apply stale values.
-            PerformanceService.DeleteSnapshot();
+            var snapshotDeleted = await Task.Run(_service.DeleteSnapshot);
+            if (snapshotDeleted)
+            {
+                _snapshot = null;
+                HasSnapshot = false;
+            }
+
             await RefreshAsync();
+            NeedsReboot = gpuWillBeRestored;
+            StatusMessage = snapshotDeleted
+                ? NeedsReboot
+                    ? "Original settings restored. Reboot required for GPU changes."
+                    : "Original settings restored."
+                : "Original settings were restored, but the recovery snapshot could not be cleared. "
+                    + "Restore All remains available so the cleanup can be retried.";
+            Log.Information(
+                "Performance settings restored to original snapshot; snapshot deleted: {Deleted}",
+                snapshotDeleted);
         }
         catch (InvalidOperationException ex) { StatusMessage = $"Restore all settings failed: {ex.Message}"; }
         catch (SecurityException ex) { StatusMessage = $"Restore all settings failed: {ex.Message}"; }


### PR DESCRIPTION
## Summary

- rehydrate Performance Mode's persisted recovery snapshot before live profile probes, so `Restore All` is available immediately after an app restart
- timestamp new snapshots while preserving compatibility with snapshots created by earlier releases
- validate persisted snapshot structure and values before any restore operation
- preserve the recovery point when persistence, native commands, GPU restoration, or cleanup fails
- show the exact power-plan GUID, independent Game Bar/DVR states, GPU target, and conservative reboot warning in the confirmation

## Root cause

`PerformanceViewModel` loaded the persisted snapshot only from `EnsureSnapshotAsync`, which runs on Apply paths. Startup refreshed live settings but never hydrated `_snapshot`, leaving `HasSnapshot` false and the recovery command disabled even though the baseline still existed on disk.

## Verification

- Release build: all four projects, 0 warnings and 0 errors
- formatting: all four C# projects pass `dotnet format --verify-no-changes`
- direct regression harness: restart hydration, legacy compatibility, blocked-refresh warning, malformed input, oversized input, and restore-failure retention pass
- regression proof: the restart test fails with `Expected: True / Actual: False` when the old refresh-only initialization order is restored
- local single-file `win-x64` publish completed with file/product version `1.56.7`
- full unit and UI suites remain gated by GitHub Actions

Closes #1593
