### PR TITLE
test: deflake the Restore All lock-guard test by seeding after initialization

### DIFF
--- a/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
@@ -245,8 +245,18 @@ public class PerformanceViewModelTests
     // DeleteSelected_WhenDiskLocked_DoesNotDelete pins its Disk-lock guard: stub the dialog
     // to "Yes", hold the SystemModification lock, and prove the command bails at the guard.
 
-    private static void SeedSnapshot(PerformanceViewModel vm)
+    private static async Task SeedSnapshotAsync(PerformanceViewModel vm)
     {
+        // Await initialization BEFORE seeding. InitAsync hydrates the persisted snapshot with
+        // `_snapshot ??= await Task.Run(_service.LoadSnapshot)`, which reads the field, performs
+        // disk I/O, then assigns — so a value written during that await is overwritten by the
+        // deferred assignment. Seeding first therefore raced the load: on a fast machine the I/O
+        // finished before the seed and the test passed, on a slower runner it did not and
+        // `_snapshot` came back null, making Restore All bail at its "nothing to restore" guard
+        // before ever reaching the lock guard under test. Ordering the wait explicitly keeps
+        // this deterministic without a sleep.
+        await vm.InitializationComplete;
+
         // Restore All early-returns when _snapshot is null (before the lock guard). Seed a
         // snapshot via the private field so the command reaches the guard we're testing.
         var snapshot = new PerformanceService.OriginalSnapshot(
@@ -261,8 +271,10 @@ public class PerformanceViewModelTests
     [Fact]
     public async Task RestoreAll_WhenSystemModificationLocked_BailsAtGuard()
     {
-        var vm = NewVm();
-        SeedSnapshot(vm);
+        // completeInitialization: the seed below must happen after InitAsync has finished, and
+        // InitializationComplete only settles once the stubbed process calls return.
+        var vm = NewVm(completeInitialization: true);
+        await SeedSnapshotAsync(vm);
 
         var prevDialog = DialogService.Instance;
         var dialog = Substitute.For<IDialogService>();


### PR DESCRIPTION
Unblocks the v1.56.7 release, which failed at the unit-test gate with 3824/3825 passing.

## What happened

`RestoreAll_WhenSystemModificationLocked_BailsAtGuard` passed on #1683 and failed on the release run for the same commit. Not a regression in the shipped code — a test-ordering defect that only shows on a slower machine.

## Root cause

`PerformanceViewModel.InitAsync` hydrates the persisted snapshot with:

```csharp
_snapshot ??= await Task.Run(_service.LoadSnapshot);
```

That reads the field, performs disk I/O, then assigns the result. Anything written to `_snapshot` **during** the await is overwritten by the deferred assignment.

The test seeded `_snapshot` reflectively right after construction, while that load was still in flight:

1. `InitAsync` reads `_snapshot` (null), starts disk I/O
2. test seeds `_snapshot` via reflection
3. `InitAsync` resumes and assigns its result (null) — **the seed is gone**
4. `Restore All` hits its `_snapshot is null` guard and returns "nothing to restore" before reaching the lock guard under test
5. `Confirm` is never called, so `dialog.Received(1).Confirm(...)` fails

On a fast machine step 1 finishes before step 2 and the test passes. That is why the PR was green.

This is **not** a product defect: nothing outside the view model writes `_snapshot`, so the deferred assignment is harmless in the shipped app. No production code changed here.

## Fix

`SeedSnapshotAsync` awaits `InitializationComplete` before seeding, and the test constructs the view model with `completeInitialization: true` — necessary because the default stub returns a task that never completes, so `InitializationComplete` would never settle.

Deterministic: no `Thread.Sleep`, no `Task.Delay`, no retry.

## Verification

Both orderings run against the real view model in a throwaway harness:

```
OLD (seed, then init races it) : passed 39/40, failed 1/40
NEW (await init, then seed)    : passed 40/40, failed 0/40
```

The 1/40 failure rate matches the observed behaviour exactly — green on the PR, red on the release runner. Tests project builds with 0 warnings and 0 errors. Leak scan over added lines: 28 terms, clean.

## Same bug class elsewhere — raised separately

Checking the class rather than the instance turned up one more genuine case out of 14 candidates scanned:

`ServicesViewModelTests.CreateWithData` seeds `_allServices` reflectively at line 31 without awaiting initialization, and `ServicesViewModel.RefreshAsync:72` assigns that same field from its own awaited load. It passes today only because enumerating real Windows services is slow enough that the seed always wins the race.

Deliberately **not** fixed here — a release is blocked and this PR stays minimal. Filed as a follow-up.

The other 12 candidates are safe: they seed `CancellationTokenSource` or flag fields that no init path assigns.
