### PR TITLE
fix: ship the Performance Mode recovery work as 1.56.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.56.7] - 2026-08-04
+## [1.56.8] - 2026-08-04
+
+Version 1.56.7 was tagged but never published: its release run failed at the unit-test
+gate, so no binary, notes, or announcement for it exist. The tag is retained rather than
+moved, and the work below ships here instead.
 
 ### Fixed
 - **Restored Performance Mode's persisted `Restore All` after an app restart.** Snapshot persistence added in #431 loaded the saved baseline only when the user applied another change. Reopening SysManager therefore left `Restore All` disabled even though `%LocalAppData%\SysManager\performance-snapshot.json` still held the original settings. Performance Mode now rehydrates that snapshot first during initialization under the existing snapshot gate, so the recovery action becomes available without waiting for live `powercfg` probes and without racing a concurrent Apply.
 - **Made old recovery points clear and testable.** New snapshots record their UTC capture time and show it in local time in the `Restore All` confirmation, while snapshots created by older releases remain loadable with an explicit unknown-time label. Snapshot storage now has an injected test directory, and regression coverage recreates an app restart with a second service instance, verifies the real command reaches confirmation, and keeps legacy JSON compatible without touching the user's profile.
 - **Hardened the persisted recovery boundary and failure semantics.** Snapshot files are size-bounded, require a complete non-duplicated schema, and reject malformed GUIDs, spoofable plan names, out-of-range processor values, and unsafe GPU subkeys before enabling restore. Power-plan, processor, and GPU restore failures now remain failures instead of reporting success and deleting the only recovery point; failed snapshot saves prevent any setting change, and failed cleanup keeps `Restore All` available for a retry.
+- **Made the Performance Mode lock-guard test deterministic.** The guard test seeded the recovery snapshot while initialization was still loading the persisted one, and that load's deferred assignment overwrote the seeded value. On a fast machine the load finished first and the test passed; on a slower one it did not, so `Restore All` reported "nothing to restore" and never reached the guard under test. The test now waits for initialization before seeding. Test-only change, no effect on shipped behavior.
 
 ## [1.56.6] - 2026-08-04
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.56.7</Version>
-    <FileVersion>1.56.7.0</FileVersion>
-    <AssemblyVersion>1.56.7.0</AssemblyVersion>
+    <Version>1.56.8</Version>
+    <FileVersion>1.56.8.0</FileVersion>
+    <AssemblyVersion>1.56.8.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Recovers the release that #1683 and #1684 were meant to produce.

## Why a new version instead of retrying 1.56.7

Auto-release tagged `v1.56.7` and dispatched the release, which then **failed at the unit-test gate** on the timing-dependent test fixed in #1684. Because that gate runs before publishing, the run stopped early: there is no binary, no `.sha256`, no SBOM, no attestation, and no announcement for 1.56.7. Nothing reached a user.

The test defect is fixed, but `v1.56.7` is already pushed to origin and points at `da0413c` — the commit from *before* that fix. Re-dispatching it would fail on the same test.

Two options existed:

- **Force-move the tag.** The release workflow's `guard` job exists specifically to reject moved tags (a tag move would otherwise hijack the "Latest" flag and re-post to Discussions), so this needs a manual dispatch to bypass a safety check, and rewrites a published ref.
- **Skip to 1.56.8.** Nothing forced, nothing rewritten. Cost: one unused patch number and a tag with no release.

This PR takes the second. A skipped patch number costs nothing; a rewritten public tag does.

## Changes

- `CHANGELOG.md`: the unreleased `[1.56.7]` section becomes `[1.56.8]`, with a short note explaining the gap for anyone comparing the tag list to the releases list. Content otherwise unchanged — none of it ever shipped.
- `CHANGELOG.md`: adds the entry for #1684, which merged as `test:` and therefore had no release to attach to.
- `SysManager.csproj`: `Version`/`FileVersion`/`AssemblyVersion` → `1.56.8`.

Auto-release computes the next version from the newest tag (`v1.56.7`) and this is a `fix:`, so it will tag `v1.56.8` — matching the csproj.

## Verification

- Release build of the app project: **0 warnings, 0 errors**
- Assembly metadata read back from the built DLL: `FileVersion 1.56.8.0`, `ProductVersion 1.56.8+73f6f5b`
- Ran the release workflow's own CHANGELOG-extraction regex against the edited file: matches the `[1.56.8]` section at 2366 characters, so both the "no entry" and "empty entry" guards pass. Confirmed `[1.56.7]` no longer matches as a section header.
- Grepped every `.md`/`.csproj`/`.yml`/`.cs`/`.json` for `1.56.7`: only the explanatory CHANGELOG line remains. `SECURITY.md` covers `1.56.x`, so no change needed.
- Leak scan over added lines: 28 terms, clean.

## What this release will exercise for the first time

The regenerated `WINGET_TOKEN`. The previous one expired (secret last updated 27 May; `komac` failed with `laurentiu021 does not have the correct permissions to execute CreateRef` on the 1.56.6 run). The build attestation and SBOM steps added in #1680 already succeeded on that run, so they are proven; the winget step is not yet.
