### PR TITLE
ci: sync the winget fork before publishing and stop duplicate announcements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,6 +288,38 @@ jobs:
             publish/SysManager-v${{ steps.version.outputs.version }}.exe.sha256
             publish/SysManager-v${{ steps.version.outputs.version }}.sbom.json
 
+      # winget-releaser creates its manifest branch on our winget-pkgs fork, and that
+      # branch must descend from current upstream. When the fork drifts, the branch
+      # creation fails — which is what silently broke the 1.56.6 and 1.56.8 publishes
+      # (the fork had fallen 5452 commits behind and komac reported the failure as a
+      # token problem, sending the diagnosis down the wrong path twice). Upstream
+      # recommends an external fork-sync app; syncing here instead means the fork is
+      # current at the exact moment it is used, with no dependency on a third-party
+      # service's schedule.
+      #
+      # Non-fatal by design: a sync failure must not abort a release whose binary is
+      # already published. If the fork is genuinely broken the winget step below fails
+      # and reports it, which is the correct place for that error to surface.
+      - name: Sync the winget-pkgs fork with upstream
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          set -o pipefail
+          behind=$(gh api "repos/microsoft/winget-pkgs/compare/master...laurentiu021:winget-pkgs:master" \
+            --jq '.behind_by' 2>/dev/null || echo "unknown")
+          echo "Fork is behind upstream by: $behind commit(s)"
+          if [ "$behind" = "0" ]; then
+            echo "Already current — nothing to do."
+            exit 0
+          fi
+          gh api -X POST repos/laurentiu021/winget-pkgs/merge-upstream -f branch=master \
+            --jq '"\(.merge_type): \(.message)"'
+          after=$(gh api "repos/microsoft/winget-pkgs/compare/master...laurentiu021:winget-pkgs:master" \
+            --jq '.behind_by' 2>/dev/null || echo "unknown")
+          echo "Fork is now behind by: $after commit(s)"
+
       - name: Update winget package
         uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
@@ -323,6 +355,32 @@ jobs:
             const cat = categories.find(c => c.name === 'Announcements');
             if (!cat) { console.log('Announcements category not found, skipping.'); return; }
 
+            const title = `SysManager ${version} released`;
+
+            // Skip if this version was already announced. A manual re-dispatch is the
+            // normal recovery when a release fails partway (the guard job deliberately
+            // allows it), and without this check every retry posts another copy of the
+            // same announcement. Checking the category rather than searching keeps this
+            // exact — titles are generated here, so an existing match is definitive.
+            const existingQuery = `
+              query($owner: String!, $repo: String!, $catId: ID!) {
+                repository(owner: $owner, name: $repo) {
+                  discussions(first: 25, categoryId: $catId, orderBy: {field: CREATED_AT, direction: DESC}) {
+                    nodes { title url }
+                  }
+                }
+              }`;
+            const existing = await github.graphql(existingQuery, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              catId: cat.id,
+            });
+            const already = existing.repository.discussions.nodes.find(d => d.title === title);
+            if (already) {
+              console.log(`Already announced: ${already.url} — skipping.`);
+              return;
+            }
+
             const repoQuery = `
               query($owner: String!, $repo: String!) {
                 repository(owner: $owner, name: $repo) { id }
@@ -341,7 +399,6 @@ jobs:
                   body: $body
                 }) { discussion { url } }
               }`;
-            const title = `SysManager ${version} released`;
             const body = `## SysManager ${version} is out!\n\n[Download from GitHub Releases](${releaseUrl})\n\n${notes}`;
             await github.graphql(mutation, {
               repoId: repoResult.repository.id,


### PR DESCRIPTION
Two release-pipeline defects, both diagnosed from real failures today rather than from reading.

## The winget publish was broken by a stale fork, not a token

`winget-releaser` creates its manifest branch on our `winget-pkgs` fork, and that branch must descend from current upstream. The fork had drifted **5452 commits behind**, so branch creation failed on both the 1.56.6 and 1.56.8 releases.

What made this hard to diagnose: `komac` reported the same underlying problem two different ways.

| Run | Error |
|---|---|
| 1.56.6 | `laurentiu021 does not have the correct permissions to execute CreateRef` |
| 1.56.8 | `GitHub token is invalid` |

Both point at credentials. Neither mentions the fork. I diagnosed it as an expired token twice and was wrong both times — the token that shipped 1.56.1 through 1.56.5 was valid and still is.

Proven by elimination: synced the fork (`merge-upstream` → clean fast-forward) and resubmitted with the same `komac` v2.16.0 the action uses. [microsoft/winget-pkgs#412041](https://github.com/microsoft/winget-pkgs/pull/412041) was created on the first attempt, with no other change.

Upstream's README recommends an external fork-sync app for this. Syncing in the workflow is better here: the fork is current at the exact moment it is used, not whenever a third-party service last ran.

`continue-on-error: true` is deliberate — a sync failure must not abort a release whose binary is already published. If the fork is genuinely broken, the winget step below still fails and reports it, which is the right place for that error.

## Re-dispatch duplicated the announcement

The Discussions step called `createDiscussion` unconditionally. Manual re-dispatch is the normal recovery when a release fails partway — the `guard` job deliberately allows it — so every retry posted another copy of the same announcement.

This actively blocked the obvious recovery path for 1.56.8: re-dispatching to retry the winget step would have duplicated an announcement that was already posted, so the release had to be finished by hand instead.

The step now queries the Announcements category for an identical title and skips if found. Titles are generated by this same step, so an exact match is definitive — no fuzzy search needed.

## Verification

- `release.yml` parsed with a real YAML parser; step order asserted programmatically as **sync → winget → announce**; all four workflows still parse
- announcement script extracted from the *parsed* YAML and syntax-checked with `node --check` (it gained a second `const title`, which would have been a runtime `SyntaxError` in production — caught here)
- the dedup GraphQL query run against the **live** repository: it finds the existing `SysManager 1.56.8 released` discussion and would correctly skip
- the fork-sync API call was executed for real before this commit and fast-forwarded successfully; the fork now reports `behind_by: 0`
- leak scan over added lines: 28 terms, clean
- `ci:` prefix, no version bump, no `CHANGELOG`/`csproj` change, no paths under `SysManager/SysManager/**` — cannot trigger auto-release

## Already handled outside this PR

- 1.56.8 is submitted to winget as #412041
- the 1.56.8 announcement is posted as [#1686](https://github.com/laurentiu021/SystemManager/discussions/1686)
- the superseded 1.56.6 winget PR (#411880) is closed with an explanation of the real cause
