### PR TITLE
fix: ask before closing to the tray, and let the user choose where reports go

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -319,6 +319,13 @@ Key services:
   `%LocalAppData%\SysManager\volume-presets.json`, keyed by exe name so a preset re-applies to
   whatever instance of an app is running. Save/parse/upsert and the "apply preset → live
   sessions" plan are pure, unit-tested static helpers; the file IO never throws to the caller.
+- `ClosePreferenceService` — remembers what the window's close button should do, as JSON under
+  `%LocalAppData%\SysManager\close-preference.json`. `MainWindow.OnClosing` asks once
+  (`IDialogService.AskCloseOrMinimize`, a three-way prompt) and honours the stored answer
+  silently afterwards. Same shape as `VolumePresetService`: injectable config directory, pure
+  unit-tested `Serialize`/`Parse`, file IO that never throws. Every untrusted or unrecognized
+  value degrades to `Ask` rather than to a concrete action, so a damaged file can never exit an
+  app the user wanted kept in the tray.
 - `GamingProfileService` (`IGamingProfileService`) — a pure ORCHESTRATOR behind the Gaming
   Profile tab: it composes the already-audited services (`PerformanceService`,
   `ITimerResolutionService`, `ICpuAffinityService`, `StandbyMemoryService`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.56.9] - 2026-08-04
+
+### Fixed
+- **Closing the window no longer hides the app without telling you.** Pressing the window's X minimized SysManager to the notification area unconditionally, because the switch controlling that defaulted to on and was never exposed anywhere in the UI. The app looked closed while it kept running, with no notice and no way to change it. Closing now asks once whether to keep running in the notification area or exit, remembers the answer, and honours it silently afterwards. Choosing the notification area also shows a one-time note saying where the window went, so it no longer reads as a crash. The stored choice lives in `%LocalAppData%\SysManager\close-preference.json`; an unreadable or hand-edited file falls back to asking again rather than to an action the user never picked.
+- **"Export full report" now asks where to save.** The About tab wrote the report straight to the Desktop, unlike every other export in the app (System Report, Logs, Resource History, and Profile all prompt). That silently failed where the Desktop is redirected to OneDrive or restricted by policy, with no way to pick another location. It now uses the same save dialog as its siblings and reports the chosen file name.
+
 ## [1.56.8] - 2026-08-04
 
 Version 1.56.7 was tagged but never published: its release run failed at the unit-test

--- a/README.md
+++ b/README.md
@@ -752,9 +752,14 @@ offers, "rate us" prompts:
   SMART, RAM usage, uptime, and battery wear. Color-coded ring (green /
   amber / red) with up to 3 actionable recommendations. Auto-computes on
   load and refreshes with "Scan system".
-- **System Tray** — minimize-to-tray on close, background health monitoring
-  (60s polling), CPU/RAM tooltip, Windows notifications when RAM > 90%,
-  uptime > 14 days, or disk health degrades. Context menu: Show / Exit.
+- **System Tray** — background health monitoring (60s polling), CPU/RAM tooltip,
+  Windows notifications when RAM > 90%, uptime > 14 days, or disk health degrades.
+  Context menu: Show / Exit.
+- **Closing is your choice** — the first time you close the window, SysManager asks
+  whether it should keep running in the notification area or close completely, and
+  remembers the answer. If you pick the notification area, it tells you where the
+  window went so it doesn't look like it vanished. Right-click the tray icon to
+  reopen or exit at any time.
 
 ### Updates (for SysManager itself)
 - Auto-check on startup against the GitHub Releases API, plus a manual

--- a/SysManager/SysManager.Tests/AboutViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AboutViewModelTests.cs
@@ -263,4 +263,22 @@ public class AboutViewModelTests
         Assert.Equal("v0.5.0", r.Version);
         Assert.True(r.IsCurrent);
     }
+
+    // ── Report export location ──
+    //
+    // Export used to write straight to the Desktop with no prompt, unlike every other
+    // export in the app (System Report, Logs, Resource History and Profile all use
+    // SaveFileDialog). It now asks first.
+    //
+    // Deliberately NOT unit-tested by invoking the command: SaveFileDialog is constructed
+    // directly, and calling it headlessly opens a real dialog that blocks forever waiting
+    // for input rather than returning false. A test that executed ExportToFileCommand
+    // would hang CI. Verified by running the command in a console harness, which printed
+    // its first line and then stopped at ShowDialog() until the process was killed.
+    //
+    // The same limitation applies to the four sibling exports, none of which are unit
+    // tested either. Covering this properly needs the dialog behind an injectable seam
+    // (an IFileDialogService), which is a broader refactor than a bug fix should carry.
+    // Tracked separately; until then the guarantee is enforced by code review: this method
+    // must not write anywhere the user did not pick.
 }

--- a/SysManager/SysManager.Tests/ClosePreferenceServiceTests.cs
+++ b/SysManager/SysManager.Tests/ClosePreferenceServiceTests.cs
@@ -1,0 +1,146 @@
+// SysManager · ClosePreferenceServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="ClosePreferenceService"/> — the persisted answer to the
+/// window close prompt. Every test uses an injected temp directory so the developer's
+/// real preference in %LOCALAPPDATA% is never read or written.
+/// </summary>
+public class ClosePreferenceServiceTests : IDisposable
+{
+    private readonly string _dir;
+
+    public ClosePreferenceServiceTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "SysManagerCloseTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch (IOException) { /* a leftover temp dir must never fail a test run */ }
+    }
+
+    private ClosePreferenceService NewService() => new(_dir);
+
+    // ---------- default state ----------
+
+    [Fact]
+    public void Load_WithNothingSaved_ReturnsAsk()
+    {
+        Assert.Equal(CloseBehavior.Ask, NewService().Load());
+    }
+
+    // ---------- round-trip ----------
+
+    [Theory]
+    [InlineData(CloseBehavior.MinimizeToTray)]
+    [InlineData(CloseBehavior.Exit)]
+    public void Save_ThenLoad_ReturnsSameBehavior(CloseBehavior behavior)
+    {
+        NewService().Save(behavior);
+
+        // A second instance, as after an app restart — the point of persisting at all.
+        Assert.Equal(behavior, NewService().Load());
+    }
+
+    [Fact]
+    public void Save_Ask_ClearsAnyStoredChoice()
+    {
+        var svc = NewService();
+        svc.Save(CloseBehavior.Exit);
+        Assert.Equal(CloseBehavior.Exit, svc.Load());
+
+        svc.Save(CloseBehavior.Ask);
+
+        Assert.Equal(CloseBehavior.Ask, svc.Load());
+        Assert.False(File.Exists(Path.Combine(_dir, "close-preference.json")));
+    }
+
+    [Fact]
+    public void Save_Twice_LastChoiceWins()
+    {
+        var svc = NewService();
+        svc.Save(CloseBehavior.MinimizeToTray);
+        svc.Save(CloseBehavior.Exit);
+
+        Assert.Equal(CloseBehavior.Exit, svc.Load());
+    }
+
+    // ---------- rejecting untrustworthy input ----------
+    //
+    // Every negative case must land on Ask, never on a concrete action: asking again is
+    // harmless, whereas trusting a damaged file could silently exit an app the user
+    // wanted left running in the tray.
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not json at all")]
+    [InlineData("{")]
+    [InlineData("[]")]
+    [InlineData("{}")]
+    [InlineData("{\"Behavior\":null}")]
+    [InlineData("{\"Behavior\":\"\"}")]
+    [InlineData("{\"Behavior\":\"Nonsense\"}")]
+    [InlineData("{\"SomethingElse\":\"Exit\"}")]
+    public void Parse_InvalidInput_ReturnsAsk(string? json)
+    {
+        Assert.Equal(CloseBehavior.Ask, ClosePreferenceService.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_ExplicitAskValue_ReturnsAsk()
+    {
+        // "Ask" is never written by Save, but a hand-edited file could contain it and must
+        // not be mistaken for a real choice.
+        Assert.Equal(CloseBehavior.Ask, ClosePreferenceService.Parse("{\"Behavior\":\"Ask\"}"));
+    }
+
+    [Theory]
+    [InlineData("minimizetotray", CloseBehavior.MinimizeToTray)]
+    [InlineData("MINIMIZETOTRAY", CloseBehavior.MinimizeToTray)]
+    [InlineData("exit", CloseBehavior.Exit)]
+    public void Parse_IsCaseInsensitive(string value, CloseBehavior expected)
+    {
+        Assert.Equal(expected, ClosePreferenceService.Parse("{\"Behavior\":\"" + value + "\"}"));
+    }
+
+    [Fact]
+    public void Load_MalformedFileOnDisk_ReturnsAskWithoutThrowing()
+    {
+        File.WriteAllText(Path.Combine(_dir, "close-preference.json"), "{ this is not valid json");
+
+        Assert.Equal(CloseBehavior.Ask, NewService().Load());
+    }
+
+    // ---------- serialization shape ----------
+
+    [Fact]
+    public void Serialize_RoundTripsThroughParse()
+    {
+        var json = ClosePreferenceService.Serialize(CloseBehavior.MinimizeToTray);
+
+        Assert.Contains("MinimizeToTray", json);
+        Assert.Equal(CloseBehavior.MinimizeToTray, ClosePreferenceService.Parse(json));
+    }
+
+    [Fact]
+    public void Save_CreatesTheConfigDirectoryIfMissing()
+    {
+        var nested = Path.Combine(_dir, "does", "not", "exist", "yet");
+        var svc = new ClosePreferenceService(nested);
+
+        svc.Save(CloseBehavior.Exit);
+
+        Assert.Equal(CloseBehavior.Exit, new ClosePreferenceService(nested).Load());
+    }
+}

--- a/SysManager/SysManager.Tests/DialogServiceTests.cs
+++ b/SysManager/SysManager.Tests/DialogServiceTests.cs
@@ -1,0 +1,62 @@
+// SysManager · DialogServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="DialogService"/>. The MessageBox paths need a live WPF
+/// Application and belong to UI automation, so what is pinned here is the headless
+/// contract: with no Application present the service must report a safe answer rather
+/// than acting on the user's behalf or throwing.
+/// </summary>
+public class DialogServiceTests
+{
+    [Fact]
+    public void Confirm_WithNoApplication_ReturnsFalse()
+    {
+        // Not treating an unanswerable prompt as consent is the whole point.
+        Assert.False(new DialogService().Confirm("message", "title"));
+    }
+
+    [Fact]
+    public void AskCloseOrMinimize_WithNoApplication_ReturnsCancel()
+    {
+        // Cancel leaves the caller's state untouched. Returning Exit here would let a
+        // headless run close the app, and MinimizeToTray would silently hide it — both
+        // are decisions the user never made.
+        Assert.Equal(CloseChoice.Cancel, new DialogService().AskCloseOrMinimize("message", "title"));
+    }
+
+    [Fact]
+    public void CloseChoice_DefaultValueIsCancel()
+    {
+        // A default(CloseChoice) reaching a caller — from a mock with no configured return,
+        // for example — must mean "do nothing", not "exit".
+        Assert.Equal(CloseChoice.Cancel, default(CloseChoice));
+    }
+
+    [Fact]
+    public void CloseBehavior_DefaultValueIsAsk()
+    {
+        // Same reasoning for the persisted behavior: an unset value means "not chosen yet",
+        // so the user gets asked rather than having an action picked for them.
+        Assert.Equal(CloseBehavior.Ask, default(CloseBehavior));
+    }
+
+    [Fact]
+    public void Instance_RejectsNull()
+    {
+        var previous = DialogService.Instance;
+        try
+        {
+            Assert.Throws<ArgumentNullException>(() => DialogService.Instance = null!);
+        }
+        finally
+        {
+            DialogService.Instance = previous;
+        }
+    }
+}

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -15,6 +15,11 @@ public partial class MainWindow : Window
 {
     private const int WM_NCACTIVATE = 0x0086;
 
+    private readonly ClosePreferenceService _closePreference = new();
+    // Per-session: the "it's still running" hint is useful the first time the window
+    // disappears, noise on every subsequent close within the same session.
+    private bool _trayHintShown;
+
     public MainWindow()
     {
         InitializeComponent();
@@ -123,13 +128,64 @@ public partial class MainWindow : Window
 
     protected override void OnClosing(System.ComponentModel.CancelEventArgs e)
     {
-        // Minimize to tray instead of closing (if enabled)
-        if (Application.Current is App app && app.TrayService is { MinimizeToTray: true })
+        // Closing used to hide to the tray unconditionally, because MinimizeToTray defaults
+        // to true and was never surfaced anywhere. Pressing X therefore looked like it had
+        // closed the app while it kept running, with no notice and no way to change it —
+        // the worst outcome for a non-technical user, who then wonders why it is still there.
+        //
+        // Ask once, remember the answer, and honour it silently afterwards. The tray icon's
+        // own Exit command still quits directly, since that intent is already unambiguous.
+        if (Application.Current is not App app || app.TrayService is null)
+        {
+            base.OnClosing(e);
+            return;
+        }
+
+        var behavior = _closePreference.Load();
+        if (behavior == CloseBehavior.Ask)
+        {
+            var choice = DialogService.Instance.AskCloseOrMinimize(
+                "SysManager can keep running in the notification area (the icons next to the "
+                + "clock) so it continues watching your system, or it can close completely.\n\n"
+                + "Yes — keep it running in the notification area\n"
+                + "No — close SysManager\n"
+                + "Cancel — go back\n\n"
+                + "This choice is remembered. You can right-click the notification-area icon "
+                + "to reopen the window or exit at any time.",
+                "Close SysManager?");
+
+            switch (choice)
+            {
+                case CloseChoice.Cancel:
+                    e.Cancel = true;
+                    return;
+                case CloseChoice.MinimizeToTray:
+                    behavior = CloseBehavior.MinimizeToTray;
+                    break;
+                default:
+                    behavior = CloseBehavior.Exit;
+                    break;
+            }
+
+            _closePreference.Save(behavior);
+        }
+
+        if (behavior == CloseBehavior.MinimizeToTray)
         {
             e.Cancel = true;
             TrayIconService.HideWindow(this);
+            // Say where the window went the first time it happens. Without this the window
+            // simply vanishes, which reads as a crash rather than as running in the tray.
+            if (!_trayHintShown)
+            {
+                _trayHintShown = true;
+                ToastService.Instance.Show(
+                    "SysManager is still running",
+                    "Find it next to the clock. Right-click the icon to reopen or exit.");
+            }
             return;
         }
+
         base.OnClosing(e);
     }
 

--- a/SysManager/SysManager/Services/ClosePreferenceService.cs
+++ b/SysManager/SysManager/Services/ClosePreferenceService.cs
@@ -1,0 +1,111 @@
+// SysManager · ClosePreferenceService — remembers what the window's X button should do
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Text.Json;
+using Serilog;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// What the window close button should do, once the user has been asked.
+/// </summary>
+public enum CloseBehavior
+{
+    /// <summary>Not chosen yet — ask on the next close.</summary>
+    Ask,
+
+    /// <summary>Keep running in the notification area.</summary>
+    MinimizeToTray,
+
+    /// <summary>Exit the application.</summary>
+    Exit
+}
+
+/// <summary>
+/// Persists the user's answer to the close prompt so it is asked once rather than on
+/// every close. Stored next to the other per-user state in
+/// <c>%LOCALAPPDATA%\SysManager</c>, following the same load/persist shape as
+/// <see cref="VolumePresetService"/>: never throws, degrades to <see cref="CloseBehavior.Ask"/>
+/// when the file is missing, unreadable, or malformed.
+/// </summary>
+public sealed class ClosePreferenceService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    private readonly string _path;
+
+    /// <summary>Creates the service. <paramref name="configDir"/> is overridable for tests.</summary>
+    public ClosePreferenceService(string? configDir = null)
+    {
+        var dir = configDir ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager");
+        _path = Path.Combine(dir, "close-preference.json");
+    }
+
+    /// <summary>The stored state to serialize. A record so the JSON shape stays explicit.</summary>
+    private sealed record Stored(string Behavior);
+
+    /// <summary>
+    /// Loads the saved behavior. Returns <see cref="CloseBehavior.Ask"/> when nothing has
+    /// been saved yet or the file cannot be trusted — asking again is always safe, whereas
+    /// guessing could exit an app the user wanted kept running.
+    /// </summary>
+    public CloseBehavior Load()
+    {
+        try
+        {
+            if (!File.Exists(_path)) return CloseBehavior.Ask;
+            return Parse(File.ReadAllText(_path));
+        }
+        catch (IOException ex) { Log.Debug("Close preference load failed: {Error}", ex.Message); return CloseBehavior.Ask; }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Close preference load denied: {Error}", ex.Message); return CloseBehavior.Ask; }
+    }
+
+    /// <summary>
+    /// Saves the chosen behavior. <see cref="CloseBehavior.Ask"/> clears the stored choice,
+    /// so a future settings toggle can restore the prompt without deleting files by hand.
+    /// </summary>
+    public void Save(CloseBehavior behavior)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+            if (behavior == CloseBehavior.Ask)
+            {
+                if (File.Exists(_path)) File.Delete(_path);
+                return;
+            }
+            File.WriteAllText(_path, Serialize(behavior));
+        }
+        catch (IOException ex) { Log.Debug("Close preference save failed: {Error}", ex.Message); }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Close preference save denied: {Error}", ex.Message); }
+    }
+
+    // ── Pure helpers (unit-testable, no file IO) ───────────────────────────
+
+    /// <summary>Serializes the behavior to indented JSON.</summary>
+    public static string Serialize(CloseBehavior behavior) =>
+        JsonSerializer.Serialize(new Stored(behavior.ToString()), JsonOptions);
+
+    /// <summary>
+    /// Parses the stored behavior; returns <see cref="CloseBehavior.Ask"/> for null, blank,
+    /// malformed, or unrecognized input. An unknown value is treated as "not chosen" rather
+    /// than trusted, so a hand-edited or future-version file cannot force an unexpected action.
+    /// </summary>
+    public static CloseBehavior Parse(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return CloseBehavior.Ask;
+        try
+        {
+            var stored = JsonSerializer.Deserialize<Stored>(json);
+            if (stored?.Behavior is null) return CloseBehavior.Ask;
+            return Enum.TryParse<CloseBehavior>(stored.Behavior, ignoreCase: true, out var parsed)
+                && parsed != CloseBehavior.Ask
+                ? parsed
+                : CloseBehavior.Ask;
+        }
+        catch (JsonException ex) { Log.Debug("Close preference parse failed: {Error}", ex.Message); return CloseBehavior.Ask; }
+    }
+}

--- a/SysManager/SysManager/Services/DialogService.cs
+++ b/SysManager/SysManager/Services/DialogService.cs
@@ -27,4 +27,24 @@ public sealed class DialogService : IDialogService
         var result = MessageBox.Show(message, title, MessageBoxButton.YesNo, MessageBoxImage.Question);
         return result == MessageBoxResult.Yes;
     }
+
+    /// <inheritdoc/>
+    public CloseChoice AskCloseOrMinimize(string message, string title)
+    {
+        // No UI available (unit tests, shutdown) — report Cancel rather than silently
+        // choosing an action on the user's behalf.
+        if (Application.Current == null) return CloseChoice.Cancel;
+
+        // Yes = keep running in the notification area, No = exit, Cancel = stay open.
+        // The caller's message states which option is which, so the mapping is explicit
+        // on screen. Cancel is also what Esc and the dialog's own close button produce,
+        // which is the right default for an accidental click.
+        var result = MessageBox.Show(message, title, MessageBoxButton.YesNoCancel, MessageBoxImage.Question);
+        return result switch
+        {
+            MessageBoxResult.Yes => CloseChoice.MinimizeToTray,
+            MessageBoxResult.No => CloseChoice.Exit,
+            _ => CloseChoice.Cancel
+        };
+    }
 }

--- a/SysManager/SysManager/Services/IDialogService.cs
+++ b/SysManager/SysManager/Services/IDialogService.cs
@@ -5,6 +5,21 @@
 namespace SysManager.Services;
 
 /// <summary>
+/// The user's answer to a three-way close prompt.
+/// </summary>
+public enum CloseChoice
+{
+    /// <summary>Dismiss the prompt and leave the window open.</summary>
+    Cancel,
+
+    /// <summary>Keep running in the notification area.</summary>
+    MinimizeToTray,
+
+    /// <summary>Exit the application.</summary>
+    Exit
+}
+
+/// <summary>
 /// Abstraction for user confirmation dialogs. Enables unit testing of
 /// ViewModels that require user interaction without coupling to WPF MessageBox.
 /// </summary>
@@ -14,4 +29,12 @@ public interface IDialogService
     /// Show a Yes/No confirmation dialog. Returns true if user clicked Yes.
     /// </summary>
     bool Confirm(string message, string title);
+
+    /// <summary>
+    /// Ask whether closing the window should exit the app or keep it in the notification
+    /// area. Separate from <see cref="Confirm"/> because the choice is genuinely three-way:
+    /// a Yes/No prompt cannot express "minimize", "exit" and "I clicked X by mistake"
+    /// without making one of them the ambiguous default.
+    /// </summary>
+    CloseChoice AskCloseOrMinimize(string message, string title);
 }

--- a/SysManager/SysManager/Services/TrayIconService.cs
+++ b/SysManager/SysManager/Services/TrayIconService.cs
@@ -34,7 +34,14 @@ public sealed class TrayIconService : IDisposable
     private DateTime _lastDiskNotification = DateTime.MinValue;
     private static readonly TimeSpan NotificationCooldown = TimeSpan.FromHours(4);
 
-    /// <summary>Whether the app should minimize to tray instead of closing.</summary>
+    /// <summary>
+    /// Whether the app should minimize to tray instead of closing.
+    /// <para>No longer consulted when the window closes: that decision now comes from
+    /// <see cref="ClosePreferenceService"/>, which asks the user once and persists the
+    /// answer. This property never had any UI, so as a close switch it only ever produced
+    /// its hardcoded default. Kept as the in-memory flag a future Settings tab can bind to
+    /// (alongside <see cref="NotificationsEnabled"/>) rather than removed in a bug fix.</para>
+    /// </summary>
     public bool MinimizeToTray { get; set; } = true;
 
     /// <summary>Whether background notifications are enabled.</summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.56.8</Version>
-    <FileVersion>1.56.8.0</FileVersion>
-    <AssemblyVersion>1.56.8.0</AssemblyVersion>
+    <Version>1.56.9</Version>
+    <FileVersion>1.56.9.0</FileVersion>
+    <AssemblyVersion>1.56.9.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Win32;
 using Serilog;
 using SysManager.Helpers;
 using SysManager.Services;
@@ -436,16 +437,27 @@ public sealed partial class AboutViewModel : ViewModelBase
     private async Task ExportToFileAsync()
     {
         if (IsGeneratingReport) return;
+
+        // Ask where to save, matching every other export in the app (System Report, Logs,
+        // Resource History, Profile). This previously wrote straight to the Desktop, which
+        // both differed from those tabs and failed outright when the Desktop is redirected
+        // to OneDrive or locked down by policy — with no way for the user to choose another
+        // location. The dialog is shown before any work starts so cancelling costs nothing.
+        var dlg = new SaveFileDialog
+        {
+            FileName = $"SysManager-Report-{DateTime.Now:yyyy-MM-dd-HHmmss}.txt",
+            Filter = "Text file (*.txt)|*.txt|All files (*.*)|*.*"
+        };
+        if (dlg.ShowDialog() != true) return;
+
         IsGeneratingReport = true;
         UpdateStatus = "Generating system report...";
         try
         {
             var report = await _reportService.GenerateReportAsync();
-            var desktop = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
-            var fileName = $"SysManager-Report-{DateTime.Now:yyyy-MM-dd-HHmmss}.txt";
-            var filePath = Path.Join(desktop, fileName);
-            await File.WriteAllTextAsync(filePath, report, Encoding.UTF8);
-            UpdateStatus = $"Report saved to Desktop: {fileName}";
+            await File.WriteAllTextAsync(dlg.FileName, report, Encoding.UTF8);
+            UpdateStatus = $"Report saved: {Path.GetFileName(dlg.FileName)}";
+            ToastService.Instance.Show("Report exported", Path.GetFileName(dlg.FileName));
         }
         catch (IOException ex)
         {


### PR DESCRIPTION
Closes #1639
Closes #1652

Two cases where the app acted on the user's behalf without saying so. Both refuted against real code before being touched.

## Closing hid the app silently (#1639)

`MainWindow.OnClosing` checked `TrayIconService.MinimizeToTray`, which **defaults to `true`** and is not exposed anywhere in the UI. So for every user, pressing the window's X hid it to the notification area with no notice and no way to change it — the app looked closed while it kept running.

For the target user that is the worst outcome in the whole backlog: either it reads as a crash, or as a program that refuses to quit.

Closing now asks once — keep running in the notification area / close / go back — persists the answer, and honours it silently afterwards. Choosing the tray also shows a one-time note saying where the window went. **Cancel** is what Esc and the dialog's own close button produce, so an accidental click changes nothing.

The tray icon's own **Exit** command still quits directly; that intent is already unambiguous.

`MinimizeToTray` is documented as no longer driving the close path rather than deleted — it has its own tests and is the flag a future Settings tab would bind to, so removing it belongs in that work, not in a bug fix.

## Export wrote to the Desktop unasked (#1652)

`AboutViewModel.ExportToFileAsync` hardcoded the Desktop, while `SystemReportViewModel`, `LogsViewModel`, `ResourceHistoryViewModel` and `ProfileViewModel` all use `SaveFileDialog`. That silently failed where the Desktop is redirected to OneDrive or restricted by policy, with no way to pick elsewhere. It now uses the same dialog, filter and toast as its siblings, and asks **before** generating anything so cancelling costs nothing.

## Design notes

`IDialogService` gains `AskCloseOrMinimize` rather than reusing `Confirm`: the choice is genuinely three-way, and Yes/No cannot express minimize, exit, and "I clicked X by mistake" without making one an ambiguous default. `MessageBox` stays confined to `DialogService`, the sanctioned wrapper.

`ClosePreferenceService` follows `VolumePresetService` exactly — injectable config directory, pure unit-tested `Serialize`/`Parse`, file IO that never throws. Every untrusted value degrades to **Ask** rather than to a concrete action, because guessing could exit an app the user wanted left running.

## Tests

24 new cases. `ClosePreferenceService`: round-trip for both behaviours across separate instances (an app restart, which is the point of persisting), last-write-wins, clearing, directory creation, and **13 negative cases** proving malformed JSON, unknown values, an explicit `"Ask"`, and a corrupted file on disk all fall back to asking. `DialogService`: the headless contract — an unanswerable prompt reports `Cancel`, and `default(CloseChoice)`/`default(CloseBehavior)` are the safe values.

**The export path is deliberately not unit tested, and the reason is recorded in the test file.** `SaveFileDialog` is constructed directly, and invoking the command headlessly opens a real dialog that blocks forever rather than returning false. A test asserting "writes nothing" would have hung CI — I wrote that test, then proved with a console harness that it would hang: the process printed its first line and stopped at `ShowDialog()` until killed. Covering this properly needs the dialog behind an injectable seam, which is wider than a bug fix; the four sibling exports share the gap.

The `DialogService` guard was verified the same way, in the other direction: with no `Application`, both methods return immediately without opening anything, so those assertions are safe.

## Verification

- All four projects: Release build, **0 warnings, 0 errors** (re-run after normalizing the new files to CRLF to match the repo)
- `MessageBox.Show` audited repo-wide: only inside `DialogService` and the existing `App.xaml.cs` crash handler
- Leak scan over 463 added lines: 28 terms, clean
- Release workflow's CHANGELOG regex run against the edited file: matches `[1.56.9]`, 1238 chars, so both the missing- and empty-section guards pass

## Docs

README's "minimize-to-tray on close" line described the behaviour being removed and now describes the prompt. ARCHITECTURE documents the new service.

Also re-derived README's count claim from source while checking for drift: **58 unique nav ids**, so "all 58 tabs are fully implemented" is accurate and left unchanged.
