### PR TITLE
docs: correct the update-verification claim and three stale references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,23 +51,65 @@ body:
       multiple: true
       options:
         - Dashboard
-        - App updates
+        - System Health
         - Windows Update
-        - System health
-        - Cleanup
-        - Deep cleanup
-        - Startup
-        - Duplicates
+        - Performance Mode
+        - Services
+        - Startup Manager
+        - Windows Features
+        - Restore Points
+        - Task Scheduler
+        - Boot Analyzer
+        - System Fixes
+        - Tweaks Hub
+        - Gaming Profile
+        - Standby List Cleaner
+        - Timer Resolution
+        - CPU Core Affinity
+        - Display Profiles
+        - Process Manager
+        - Resource History
+        - Camera/Mic/Location
+        - App Alerts
+        - File Lock Detector
+        - Settings Watchdog
+        - Bandwidth Monitor
+        - Quick Cleanup
+        - Deep Cleanup
+        - Shortcut Cleaner
+        - Scheduled Maintenance
         - Disk Analyzer
-        - Processes
-        - Battery
+        - Duplicate Finder
+        - Ping
+        - Traceroute
+        - Speed Test
+        - Network Repair
+        - DNS & Hosts
+        - App Updates
+        - Bulk Installer
         - Uninstaller
-        - Performance
-        - Network
+        - Privacy & Telemetry
+        - File Shredder
+        - App Blocker
+        - Debloater & Ads
+        - Browser Cleaner
+        - Edge/OneDrive Remover
+        - Defender Tweaks
+        - Notification Blocker
+        - Context Menu
+        - Dark Mode Scheduler
+        - Volume Control
         - Drivers
-        - Logs
-        - About / updates
+        - Battery Health
+        - System Logs
+        - System Report
+        - Legacy Panels
+        - About
+        - Profile Export/Import
+        - CLI Interface
+        - Environment Variables
         - Multiple / general UI
+        - Not sure
     validations:
       required: true
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -497,7 +497,14 @@ retained). The in-app Console mirrors the same stream per tab.
 at startup and on demand. Downloads land in
 `%LOCALAPPDATA%\SysManager\updates\SysManager-{version}.exe` with a companion
 `.sha256` so re-opening the app doesn't re-download a good copy. The "Install"
-button verifies the download's SHA256 and Authenticode signature, then hands
+button verifies the download's SHA256 against the published `.sha256` — the actual
+integrity gate — and additionally inspects the file for an Authenticode signature.
+That second check is informational, not a publisher check: `VerifyAuthenticode`
+returns true both for a validly-signed binary and for one with no signature at all
+(SysManager ships unsigned), and rejects only a signature that cannot be parsed.
+`CreateFromSignedFile` reads the signer certificate without validating the file
+against it, so it cannot detect a tampered signed binary; the SHA256 comparison,
+which runs first, is what catches a modified download. It then hands
 off to `UpdateApplier`: the freshly-downloaded exe is relaunched with
 `--apply-update`, which `App.OnStartup` intercepts before any window opens. That
 process waits for the old instance to exit, swaps itself over the old executable

--- a/README.md
+++ b/README.md
@@ -861,9 +861,10 @@ offers, "rate us" prompts:
 <a href="docs/screenshots/22-file-lock.png"><img src="docs/screenshots/22-file-lock.png" width="280" alt="File Lock Detector"></a>
 </p>
 <p>
-<a href="docs/screenshots/23-settings-watchdog.png"><img src="docs/screenshots/23-settings-watchdog.png" width="280" alt="Settings Watchdog"></a>&nbsp;
-<a href="docs/screenshots/24-bandwidth-monitor.png"><img src="docs/screenshots/24-bandwidth-monitor.png" width="280" alt="Bandwidth Monitor"></a>
+<a href="docs/screenshots/23-settings-watchdog.png"><img src="docs/screenshots/23-settings-watchdog.png" width="280" alt="Settings Watchdog"></a>
 </p>
+<p><em>Bandwidth Monitor is implemented but its screenshot is still being recaptured — the
+previous one showed the tab while it was a placeholder, which no longer reflects the app.</em></p>
 </details>
 
 <details>
@@ -1136,9 +1137,10 @@ If it saved you a reinstall or a clean-up headache, you can back its development
 
 [![Sponsor](https://img.shields.io/badge/Sponsor-laurentiu021-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/laurentiu021)
 
-Sponsorships go toward a code-signing certificate, so Windows stops warning on
-first launch, plus the build pipeline and time to fix bugs and finish the tools
-that are still half-built. The app stays free either way.
+Sponsorships go toward a code-signing certificate — which makes Windows show the
+publisher's name instead of "unknown publisher", and reduces the SmartScreen warning
+as the signed builds accumulate reputation — plus the build pipeline and time to fix
+bugs and finish the tools that are still half-built. The app stays free either way.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -108,12 +108,17 @@ What the app can and cannot do by design:
   the feature fails safely rather than substituting an alternative.
 - **Auto-update**: new builds are downloaded from the official GitHub
   Releases endpoint. The app does not auto-install without an explicit
-  click. Before applying, the downloaded binary's SHA256 and Authenticode
-  signature are checked; the swap is then performed from within the
-  downloaded executable itself (no intermediate script on disk) using a
-  staged atomic file move, so an interrupted update cannot leave a
-  half-written, unstartable binary. You can also download manually and
-  verify the binary yourself.
+  click. Before applying, the downloaded binary's SHA256 is compared against
+  the `.sha256` published with the release — that comparison is the integrity
+  gate. The binary is also inspected for an Authenticode signature, but since
+  SysManager ships unsigned that check is informational: an unsigned build is
+  accepted, and a signature that cannot be parsed is rejected. It is not a
+  publisher check and does not detect a tampered signed binary; the SHA256
+  comparison is what catches a modified download. The swap is then performed
+  from within the downloaded executable itself (no intermediate script on
+  disk) using a staged atomic file move, so an interrupted update cannot
+  leave a half-written, unstartable binary. You can also download manually
+  and verify the binary yourself.
 - **Portable distribution model**: the standard distribution is a portable,
   self-contained `.exe` (also published to winget as a portable package),
   which lives in a per-user, user-writable location. This means a process

--- a/TESTING.md
+++ b/TESTING.md
@@ -35,6 +35,26 @@ The app must not already be running. The test runner launches and closes it auto
 dotnet test SysManager/SysManager.UITests/SysManager.UITests.csproj -c Release
 ```
 
+## Manual smoke test over the published exe
+
+`docs/manual-smoke.ps1` launches the published executable, walks the nav tree with
+Windows UI Automation, and fails loudly if a tab doesn't render. It complements the
+UI test project: it exercises the single-file build a user actually downloads, rather
+than a `bin` output, which is where publish-only problems (missing native assets,
+single-file extraction, trimming) surface.
+
+Needs a published exe and an interactive desktop session — a WPF app cannot render
+over SSH or in a non-interactive scheduled task.
+
+```powershell
+./publish.ps1
+./docs/manual-smoke.ps1
+```
+
+It checks 11 of the 58 tabs (the list is at the top of the script), so treat a pass as
+"the shell starts and those tabs render", not as full coverage. Add a nav id to `$navIds`
+when a new tab is worth including in the quick check.
+
 ## Running everything at once
 
 ```powershell


### PR DESCRIPTION
Closes #1660
Closes #1669
Closes #1644
Closes #1672

Four documentation accuracy problems, each refuted against current source before being changed. **No code touched**, so no release.

## The one that mattered: overstated update verification (#1660)

`SECURITY.md` and `ARCHITECTURE.md` both said the install step "verifies the download's SHA256 **and Authenticode signature**", which reads as a publisher check.

`UpdateService.VerifyAuthenticode` does not do that — and its own doc comment already says so:

> ...the binary is validly embedded-signed **OR carries no signature at all** (SysManager ships unsigned open-source builds) [...] `CreateFromSignedFile` extracts the signer certificate but **does not by itself validate the file against the signature**, so it cannot detect a tampered signed binary

So it returns `true` for signed *and* unsigned binaries, rejecting only a signature that cannot be parsed. The SHA256 comparison, which runs first, is the integrity gate.

The code was honest; the docs were not. A security document that overstates a verification invites trust the implementation does not earn — that is why this one is worth a PR on its own.

`README.md`'s equivalent passage was **already accurate** and is left alone.

## The sponsor pitch promised more than a certificate delivers (#1669)

> Sponsorships go toward a code-signing certificate, so Windows stops warning on first launch

Signing makes Windows name the publisher instead of "unknown publisher", and reduces SmartScreen warnings as reputation accrues — but it does not stop the warning on day one. Rewritten to say what actually happens. Asking for money is exactly where a claim should be conservative.

## The bug template listed 18 of 58 tabs (#1644)

A flat dropdown with names that no longer match the UI ("System health", "Processes", "Logs"), so a reporter whose tab was missing had to pick "Multiple / general UI" and describe it in prose.

Regenerated from `MainWindowViewModel`'s nav tree in declaration order: **all 58 tabs** with their exact UI labels, plus "Multiple / general UI" and a new **"Not sure"** so a reporter who cannot identify the tab is not pushed into a wrong answer.

Verified programmatically — 58/58 exact match against source, no missing entries and none that do not exist. 60 options total, within GitHub's 100 limit. The edited dropdown section was parsed to confirm `id`, `multiple: true`, and `required` survived intact.

## manual-smoke.ps1 was referenced by nothing (#1672)

CHANGELOG says it was "referenced from" the test docs, but that reference is gone — leaving a working script nobody can find. `TESTING.md` now documents it, including why it is worth running (it exercises the **published single-file exe** rather than a `bin` output, which is where publish-only failures such as missing native assets appear) and its real scope: **11 of 58 tabs**, read from the script's own `$navIds` rather than estimated.

## Partially: the stale Bandwidth Monitor screenshot (#1659)

`docs/screenshots/24-bandwidth-monitor.png` shows the tab as a **"Work in Progress" placeholder**, captured from v1.51.6. The tab is implemented now (`MainWindowViewModel.cs:178` binds `BandwidthMonitorViewModel`).

Recapturing needs the app running, which is secondary-workstation work, so the stale image is removed from the gallery and replaced with a one-line note rather than left to misrepresent a shipped feature. **#1659 stays open** for the recapture.

## Found while verifying — filed separately

The screenshot also revealed `Tracked in issue ##337` (double hash) in the placeholder view. `PlaceholderViewModel` turns out to be constructed nowhere: every tab that used it is implemented, so the bug is unreachable and the class is dead code. Filed as #1690 rather than fixed here, since deleting three files is not a docs change.

## Verification

- Every claim re-derived from source, not from the issue text. Two of the five findings differed from what the issue said: #1644 was 18 tabs (not 16), and README was already correct where the issue implied it was not.
- All internal markdown links and anchors across the four changed docs resolve.
- Leak scan over added lines: 28 terms, clean.
- `docs:` prefix, no `.cs`/`.xaml`/`.csproj` changes — cannot trigger auto-release.
