### PR TITLE
fix: report why data is missing instead of showing misleading values

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -155,7 +155,11 @@ Key services:
 - `DiskHealthService` — pulls SMART data through WMI.
 - `MemoryTestService` — scans WHEA / MemoryDiagnostics events.
 - `EventLogService` + `EventExplainer` — read Windows Event Log and attach
-  human-readable explanations.
+  human-readable explanations. Exposes `LastOutcome` (`Ok` / `AccessDenied` /
+  `LogNotFound` / `Unavailable`) alongside the streamed entries, because a refused
+  log and an empty log are otherwise indistinguishable to the caller — the Security
+  log needs elevation, and swallowing that made the UI report "0 events". Reset at
+  the start of every query so a past refusal cannot outlive it.
 - `HealthAnalyzer` — raw SMART / ping data into verdict pills.
 - `SystemInfoService` — OS / CPU / RAM / uptime snapshot.
 - `BiosService` — read-only BIOS/firmware + motherboard info (Win32_BIOS,
@@ -503,7 +507,13 @@ retained). The in-app Console mirrors the same stream per tab.
 `UpdateService` hits `api.github.com/repos/laurentiu021/SystemManager/releases`
 at startup and on demand. Downloads land in
 `%LOCALAPPDATA%\SysManager\updates\SysManager-{version}.exe` with a companion
-`.sha256` so re-opening the app doesn't re-download a good copy. The "Install"
+`.sha256` so re-opening the app doesn't re-download a good copy. After a successful
+download, `PruneOldDownloads` deletes superseded binaries, their stale hashes, and
+orphaned `.tmp` files, keeping only the current pair — each build is ~85 MB and
+nothing removed the old ones, so the cache grew by that much per update. It only
+matches the `SysManager-*.exe` names the service itself writes, never throws, and
+treats a file locked by a running instance as ordinary (it survives to the next
+round). The "Install"
 button verifies the download's SHA256 against the published `.sha256` — the actual
 integrity gate — and additionally inspects the file for an Authenticode signature.
 That second check is informational, not a publisher check: `VerifyAuthenticode`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.56.10] - 2026-08-04
+
+### Fixed
+- **Battery health and wear no longer show "-1%".** When Windows refuses the capacity query — it only reports design and full-charge capacity to an elevated process — the app used an internal `-1` marker meaning "unknown", and the page printed it straight out with a percent sign after it. Both figures now read "Not available", and the page explains that these two values need administrator rights while everything else on it works without.
+- **The Security event log now says it needs administrator rights.** Selecting Security without elevation produced an empty grid and "Loaded 0 events", indistinguishable from a log that genuinely had nothing in it, because the underlying read swallowed Windows' refusal. The reader now reports why a log came back empty — refused, missing, or unavailable — and the page shows that reason instead of a blank list.
+- **Renamed the log-folder button on the System Logs tab.** "Open log folder" sat beside "Open Event Viewer" on a tab named after the Windows Event Log, but opened SysManager's own diagnostic folder. It now reads "SysManager's own logs", and its tooltip shows the exact path before you click.
+- **Report and environment actions no longer overwrite the update message.** Exporting a report or copying environment info wrote its result into the update card's status line, replacing "Update available: vX.Y.Z" with "Report saved" — discarding the more useful message and leaving the update card describing something unrelated to updates. These results now appear next to the buttons that produce them.
+- **Old update downloads are deleted once a newer one arrives.** Each cached build is roughly 85 MB and nothing ever removed the previous ones, so `%LocalAppData%\SysManager\updates` grew by that much with every update — in an app whose Cleanup tab exists to reclaim disk space. The current build and its checksum are kept; superseded binaries, stale checksums, and interrupted partial downloads are removed. A file still in use by a running copy is left alone and cleaned up next time.
+
 ## [1.56.9] - 2026-08-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ Edit Windows environment variables without the cramped built-in dialog:
 - Each event gets a plain-English explanation and recommended next steps
 - Filter by severity and time range, plus full-text search
 - Export to CSV, with a "search online" link for unknown events
+- The Security log requires administrator rights. Without them the page says so
+  outright rather than showing an empty list that looks like "no events"
 
 ### System report
 - One-click, read-only snapshot of the whole machine: OS, CPU, memory
@@ -628,6 +630,9 @@ offers, "rate us" prompts:
 - Design vs full-charge capacity via WMI
 - Estimated runtime display
 - Gracefully shows "No battery detected" on desktops
+- Health and wear need administrator rights (Windows only reports capacity to an
+  elevated process). Without it they read "Not available" and the page explains
+  why, instead of showing a number that isn't a measurement.
 
 ### Uninstaller
 - Lists all installed applications via winget with size from registry

--- a/SysManager/SysManager.Tests/BatteryInfoEdgeCaseTests.cs
+++ b/SysManager/SysManager.Tests/BatteryInfoEdgeCaseTests.cs
@@ -121,4 +121,77 @@ public class BatteryInfoEdgeCaseTests
         Assert.Equal("", info.Chemistry);
         Assert.Equal("", info.Manufacturer);
     }
+
+    // ── Display formatting ──
+    //
+    // HealthPercent/WearPercent return -1 to mean "capacity could not be read" (the root\WMI
+    // query needs elevation). The view bound those numbers directly and appended "%", so an
+    // unelevated run showed "-1%" as though it were a measurement. These pin the sentinel
+    // never reaching the screen as a number.
+
+    [Theory]
+    [InlineData(0u, 5000u)]      // design capacity unreadable
+    [InlineData(50000u, 0u)]     // full-charge capacity unreadable
+    [InlineData(0u, 0u)]         // neither readable
+    public void Display_WhenCapacityUnavailable_SaysNotAvailable(uint design, uint full)
+    {
+        var info = new BatteryInfo { DesignCapacityMWh = design, FullChargeCapacityMWh = full };
+
+        Assert.False(info.HasCapacityData);
+        Assert.Equal("Not available", info.HealthDisplay);
+        Assert.Equal("Not available", info.WearDisplay);
+        Assert.DoesNotContain("-1", info.HealthDisplay);
+        Assert.DoesNotContain("-1", info.WearDisplay);
+    }
+
+    [Fact]
+    public void Display_WhenCapacityAvailable_ShowsPercentages()
+    {
+        var info = new BatteryInfo { DesignCapacityMWh = 50000, FullChargeCapacityMWh = 40000 };
+
+        Assert.True(info.HasCapacityData);
+        Assert.Equal("80%", info.HealthDisplay);
+        Assert.Equal("20%", info.WearDisplay);
+    }
+
+    [Fact]
+    public void Display_HealthyBattery_ShowsZeroWearNotNotAvailable()
+    {
+        // 100% health means 0% wear — a real figure that must not be confused with missing
+        // data just because the number is zero.
+        var info = new BatteryInfo { DesignCapacityMWh = 50000, FullChargeCapacityMWh = 50000 };
+
+        Assert.True(info.HasCapacityData);
+        Assert.Equal("100%", info.HealthDisplay);
+        Assert.Equal("0%", info.WearDisplay);
+    }
+
+    [Fact]
+    public void Display_TracksCapacityArrivingLater()
+    {
+        // The view binds the Display properties, so they must re-read when capacity arrives
+        // rather than staying stuck at "Not available" after an elevated refresh succeeds.
+        var info = new BatteryInfo();
+        Assert.Equal("Not available", info.HealthDisplay);
+
+        info.DesignCapacityMWh = 50000;
+        info.FullChargeCapacityMWh = 45000;
+
+        Assert.Equal("90%", info.HealthDisplay);
+        Assert.Equal("10%", info.WearDisplay);
+    }
+
+    [Fact]
+    public void Display_RaisesPropertyChanged_WhenCapacityArrives()
+    {
+        var info = new BatteryInfo();
+        var changed = new List<string>();
+        info.PropertyChanged += (_, e) => changed.Add(e.PropertyName ?? "");
+
+        info.FullChargeCapacityMWh = 45000;
+
+        Assert.Contains(nameof(BatteryInfo.HealthDisplay), changed);
+        Assert.Contains(nameof(BatteryInfo.WearDisplay), changed);
+        Assert.Contains(nameof(BatteryInfo.HasCapacityData), changed);
+    }
 }

--- a/SysManager/SysManager.Tests/EventLogServiceTests.cs
+++ b/SysManager/SysManager.Tests/EventLogServiceTests.cs
@@ -254,4 +254,53 @@ public class EventLogServiceTests
         var opt = new EventLogQueryOptions();
         Assert.Null(opt.Severities);
     }
+
+    // ---------- ReadOutcome ----------
+    //
+    // The reader used to swallow UnauthorizedAccessException with a bare `yield break`, so a
+    // refused log and an empty log were indistinguishable — a standard user selecting Security
+    // saw "Loaded 0 events" over a blank grid. LastOutcome carries the reason so the UI can
+    // say which it was.
+
+    [Fact]
+    public async Task Read_NonexistentLog_ReportsLogNotFound()
+    {
+        var svc = new EventLogService();
+        var opt = new EventLogQueryOptions { LogName = "SysManagerNoSuchLog", MaxResults = 5 };
+
+        var count = 0;
+        await foreach (var _ in svc.ReadAsync(opt, CancellationToken.None)) count++;
+
+        Assert.Equal(0, count);
+        Assert.Equal(EventLogService.ReadOutcome.LogNotFound, svc.LastOutcome);
+    }
+
+    [Fact]
+    public void ReadOutcome_DefaultIsOk()
+    {
+        // Before any query, Ok is the honest state: nothing has been refused. It also means a
+        // caller reading LastOutcome without querying cannot observe a spurious failure.
+        Assert.Equal(EventLogService.ReadOutcome.Ok, new EventLogService().LastOutcome);
+        Assert.Equal(EventLogService.ReadOutcome.Ok, default(EventLogService.ReadOutcome));
+    }
+
+    [Fact]
+    public async Task Read_OutcomeIsResetAtTheStartOfEachQuery()
+    {
+        // A failed query must not leave the flag set for the next one, or the UI would keep the
+        // refusal overlay up over a successful reload. Both queries here name a log that does
+        // not exist, so the assertion is about the reset being unconditional rather than about
+        // any particular machine's event logs — reading a real log would make this depend on
+        // the runner's log contents and permissions.
+        var svc = new EventLogService();
+
+        await foreach (var _ in svc.ReadAsync(
+            new EventLogQueryOptions { LogName = "SysManagerNoSuchLog" }, CancellationToken.None)) { }
+        Assert.Equal(EventLogService.ReadOutcome.LogNotFound, svc.LastOutcome);
+
+        // Reaching the open step again re-evaluates the outcome rather than keeping the old one.
+        await foreach (var _ in svc.ReadAsync(
+            new EventLogQueryOptions { LogName = "SysManagerAlsoMissing" }, CancellationToken.None)) { }
+        Assert.Equal(EventLogService.ReadOutcome.LogNotFound, svc.LastOutcome);
+    }
 }

--- a/SysManager/SysManager.Tests/UiAutomationContractTests.cs
+++ b/SysManager/SysManager.Tests/UiAutomationContractTests.cs
@@ -40,7 +40,10 @@ public partial class UiAutomationContractTests
             ["btn-app-updates-scan"] = "Scan for updates",
             ["btn-system-health-memory-errors"] = "Check memory errors",
             ["btn-logs-open-event-viewer"] = "Open Event Viewer",
-            ["btn-logs-open-folder"] = "Open log folder",
+            // Renamed for #1647: this button sits beside "Open Event Viewer" on a tab titled
+            // after the Windows Event Log, but opens SysManager's own diagnostic folder. The
+            // accessible name now says whose logs, so a screen-reader user is not misled either.
+            ["btn-logs-open-folder"] = "Open SysManager's own log folder",
             ["btn-ping-add-target"] = "Add target"
         };
 

--- a/SysManager/SysManager.Tests/UpdateServicePruneTests.cs
+++ b/SysManager/SysManager.Tests/UpdateServicePruneTests.cs
@@ -1,0 +1,161 @@
+// SysManager · UpdateServicePruneTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="UpdateService.PruneOldDownloads"/> — the cache sweep that keeps
+/// %LOCALAPPDATA%\SysManager\updates from growing by ~85 MB on every update. Each test works in
+/// its own temp directory, so the developer's real update cache is never touched.
+/// </summary>
+public class UpdateServicePruneTests : IDisposable
+{
+    private readonly string _dir;
+
+    public UpdateServicePruneTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "SysManagerPruneTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch (IOException) { /* a leftover temp dir must never fail a test run */ }
+    }
+
+    private string Touch(string name)
+    {
+        var path = Path.Combine(_dir, name);
+        File.WriteAllText(path, "x");
+        return path;
+    }
+
+    private string[] Remaining() =>
+        Directory.GetFiles(_dir).Select(Path.GetFileName).OfType<string>().OrderBy(n => n).ToArray();
+
+    [Fact]
+    public void Prune_RemovesSupersededBinariesAndKeepsTheCurrentOne()
+    {
+        Touch("SysManager-1.56.6.exe");
+        Touch("SysManager-1.56.7.exe");
+        var keep = Touch("SysManager-1.56.8.exe");
+
+        var removed = UpdateService.PruneOldDownloads(_dir, keep);
+
+        Assert.Equal(2, removed);
+        Assert.Equal(["SysManager-1.56.8.exe"], Remaining());
+    }
+
+    [Fact]
+    public void Prune_KeepsTheCompanionHashOfTheCurrentBinary()
+    {
+        // The .sha256 next to the kept binary is what lets the next launch skip a re-download.
+        // Deleting it would force an avoidable 85 MB fetch.
+        var keep = Touch("SysManager-1.56.8.exe");
+        Touch("SysManager-1.56.8.exe.sha256");
+
+        UpdateService.PruneOldDownloads(_dir, keep);
+
+        Assert.Equal(["SysManager-1.56.8.exe", "SysManager-1.56.8.exe.sha256"], Remaining());
+    }
+
+    [Fact]
+    public void Prune_RemovesStaleHashesAndOrphanedTempFiles()
+    {
+        Touch("SysManager-1.56.6.exe");
+        Touch("SysManager-1.56.6.exe.sha256");
+        Touch("SysManager-1.56.7.exe.tmp");   // interrupted download
+        var keep = Touch("SysManager-1.56.8.exe");
+
+        var removed = UpdateService.PruneOldDownloads(_dir, keep);
+
+        Assert.Equal(3, removed);
+        Assert.Equal(["SysManager-1.56.8.exe"], Remaining());
+    }
+
+    [Fact]
+    public void Prune_LeavesUnrelatedFilesAlone()
+    {
+        // Only names this service writes are eligible. Anything else in the folder — including
+        // a user's own file — must survive, since this runs unattended after every update.
+        Touch("notes.txt");
+        Touch("SomeOtherApp-2.0.exe");
+        Touch("sysmanager-report.txt");
+        var keep = Touch("SysManager-1.56.8.exe");
+
+        var removed = UpdateService.PruneOldDownloads(_dir, keep);
+
+        Assert.Equal(0, removed);
+        Assert.Equal(
+            ["SomeOtherApp-2.0.exe", "SysManager-1.56.8.exe", "notes.txt", "sysmanager-report.txt"],
+            Remaining());
+    }
+
+    [Fact]
+    public void Prune_IsCaseInsensitiveAboutTheKeptName()
+    {
+        // Windows paths are case-insensitive; a casing difference must not delete the binary
+        // that was just installed.
+        Touch("SysManager-1.56.8.exe");
+        var keepWithOtherCasing = Path.Combine(_dir, "sysmanager-1.56.8.EXE");
+
+        var removed = UpdateService.PruneOldDownloads(_dir, keepWithOtherCasing);
+
+        Assert.Equal(0, removed);
+        Assert.Single(Remaining());
+    }
+
+    [Fact]
+    public void Prune_EmptyDirectory_DoesNothing()
+    {
+        var removed = UpdateService.PruneOldDownloads(_dir, Path.Combine(_dir, "SysManager-1.56.8.exe"));
+
+        Assert.Equal(0, removed);
+        Assert.Empty(Remaining());
+    }
+
+    [Fact]
+    public void Prune_MissingDirectory_ReturnsZeroWithoutThrowing()
+    {
+        var missing = Path.Combine(_dir, "no-such-folder");
+
+        var removed = UpdateService.PruneOldDownloads(missing, Path.Combine(missing, "SysManager-1.0.0.exe"));
+
+        Assert.Equal(0, removed);
+    }
+
+    [Fact]
+    public void Prune_FileHeldOpen_SurvivesAndDoesNotThrow()
+    {
+        // The binary of a running instance cannot be deleted. Pruning must treat that as
+        // ordinary, prune what it can, and leave the locked file for the next round.
+        var locked = Touch("SysManager-1.56.6.exe");
+        Touch("SysManager-1.56.7.exe");
+        var keep = Touch("SysManager-1.56.8.exe");
+
+        using (File.Open(locked, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            var removed = UpdateService.PruneOldDownloads(_dir, keep);
+
+            Assert.Equal(1, removed);   // only 1.56.7 could go
+            Assert.Contains("SysManager-1.56.6.exe", Remaining());
+            Assert.Contains("SysManager-1.56.8.exe", Remaining());
+        }
+    }
+
+    [Fact]
+    public void Prune_RunTwice_IsIdempotent()
+    {
+        Touch("SysManager-1.56.6.exe");
+        var keep = Touch("SysManager-1.56.8.exe");
+
+        Assert.Equal(1, UpdateService.PruneOldDownloads(_dir, keep));
+        Assert.Equal(0, UpdateService.PruneOldDownloads(_dir, keep));
+        Assert.Equal(["SysManager-1.56.8.exe"], Remaining());
+    }
+}

--- a/SysManager/SysManager.Tests/UpdateServicePruneTests.cs
+++ b/SysManager/SysManager.Tests/UpdateServicePruneTests.cs
@@ -35,8 +35,12 @@ public class UpdateServicePruneTests : IDisposable
         return path;
     }
 
+    // Ordinal sort: the default OrderBy is culture-sensitive, which on Windows placed
+    // "notes.txt" before the capitalised names and made an assertion on the expected order
+    // fail for a reason unrelated to pruning.
     private string[] Remaining() =>
-        Directory.GetFiles(_dir).Select(Path.GetFileName).OfType<string>().OrderBy(n => n).ToArray();
+        Directory.GetFiles(_dir).Select(Path.GetFileName).OfType<string>()
+            .OrderBy(n => n, StringComparer.Ordinal).ToArray();
 
     [Fact]
     public void Prune_RemovesSupersededBinariesAndKeepsTheCurrentOne()
@@ -91,9 +95,11 @@ public class UpdateServicePruneTests : IDisposable
         var removed = UpdateService.PruneOldDownloads(_dir, keep);
 
         Assert.Equal(0, removed);
+        // Membership, not order: what matters is that nothing was deleted, and directory
+        // enumeration order is not a contract worth asserting.
         Assert.Equal(
-            ["SomeOtherApp-2.0.exe", "SysManager-1.56.8.exe", "notes.txt", "sysmanager-report.txt"],
-            Remaining());
+            new HashSet<string>(["SomeOtherApp-2.0.exe", "SysManager-1.56.8.exe", "notes.txt", "sysmanager-report.txt"]),
+            Remaining().ToHashSet());
     }
 
     [Fact]

--- a/SysManager/SysManager/Models/BatteryInfo.cs
+++ b/SysManager/SysManager/Models/BatteryInfo.cs
@@ -18,11 +18,17 @@ public sealed partial class BatteryInfo : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HealthPercent))]
     [NotifyPropertyChangedFor(nameof(WearPercent))]
+    [NotifyPropertyChangedFor(nameof(HealthDisplay))]
+    [NotifyPropertyChangedFor(nameof(WearDisplay))]
+    [NotifyPropertyChangedFor(nameof(HasCapacityData))]
     private uint _designCapacityMWh;       // milliwatt-hours
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HealthPercent))]
     [NotifyPropertyChangedFor(nameof(WearPercent))]
+    [NotifyPropertyChangedFor(nameof(HealthDisplay))]
+    [NotifyPropertyChangedFor(nameof(WearDisplay))]
+    [NotifyPropertyChangedFor(nameof(HasCapacityData))]
     private uint _fullChargeCapacityMWh;
     [ObservableProperty] private int _cycleCount;
     [ObservableProperty]
@@ -54,4 +60,18 @@ public sealed partial class BatteryInfo : ObservableObject
         0 => "Calculating…",
         _ => $"{EstimatedRuntimeMinutes / 60}h {EstimatedRuntimeMinutes % 60}m"
     };
+
+    /// <summary>True when capacity data could be read, so health and wear are meaningful.</summary>
+    public bool HasCapacityData => HealthPercent >= 0;
+
+    /// <summary>
+    /// Formatted health. The -1 sentinel means "capacity could not be read", usually because
+    /// the root\WMI query needs elevation — so it must not reach the screen as a number.
+    /// Bound instead of HealthPercent, which rendered literally as "-1%" next to a "%" suffix
+    /// in the view and read as a nonsensical measurement rather than as missing data.
+    /// </summary>
+    public string HealthDisplay => HasCapacityData ? $"{HealthPercent}%" : "Not available";
+
+    /// <summary>Formatted wear level. Same sentinel handling as <see cref="HealthDisplay"/>.</summary>
+    public string WearDisplay => HasCapacityData ? $"{WearPercent}%" : "Not available";
 }

--- a/SysManager/SysManager/Services/EventLogService.cs
+++ b/SysManager/SysManager/Services/EventLogService.cs
@@ -23,8 +23,37 @@ public sealed partial class EventLogService
     private static partial Regex ProviderNameRegex();
 
     /// <summary>
-    /// Queries a single log. Security requires admin; we silently skip on
-    /// UnauthorizedAccessException so the rest of the dashboard still works.
+    /// Why a query produced no entries. An empty result and a refused result look identical
+    /// to the caller otherwise, which made the Security log (readable only when elevated)
+    /// report "No events match your filters" to a standard user.
+    /// </summary>
+    public enum ReadOutcome
+    {
+        /// <summary>The log was read; any emptiness is genuine.</summary>
+        Ok,
+
+        /// <summary>Windows refused access — the Security log needs elevation.</summary>
+        AccessDenied,
+
+        /// <summary>The named log does not exist on this machine.</summary>
+        LogNotFound,
+
+        /// <summary>The log exists but could not be opened for another reason.</summary>
+        Unavailable
+    }
+
+    /// <summary>
+    /// Set by the last <see cref="ReadAsync"/> enumeration that reached the open step, so the
+    /// caller can tell "nothing matched" from "not allowed to look". Written before any entry
+    /// is yielded and readable once enumeration completes.
+    /// </summary>
+    public ReadOutcome LastOutcome { get; private set; } = ReadOutcome.Ok;
+
+    /// <summary>
+    /// Queries a single log. The Security log requires elevation; when access is refused the
+    /// enumeration ends without entries and <see cref="LastOutcome"/> reports why, so the rest
+    /// of the dashboard still works and the UI can explain the gap instead of implying the log
+    /// is empty.
     /// </summary>
     public IAsyncEnumerable<FriendlyEventEntry> ReadAsync(
         EventLogQueryOptions options, CancellationToken ct)
@@ -35,6 +64,7 @@ public sealed partial class EventLogService
     {
         var xpath = BuildXPath(opt);
         EventLogReader? reader = null;
+        LastOutcome = ReadOutcome.Ok;
         try
         {
             var q = new EventLogQuery(opt.LogName, PathType.LogName, xpath)
@@ -43,9 +73,9 @@ public sealed partial class EventLogService
             };
             reader = new EventLogReader(q);
         }
-        catch (UnauthorizedAccessException) { yield break; }
-        catch (EventLogNotFoundException) { yield break; }
-        catch (EventLogException) { yield break; }
+        catch (UnauthorizedAccessException) { LastOutcome = ReadOutcome.AccessDenied; yield break; }
+        catch (EventLogNotFoundException) { LastOutcome = ReadOutcome.LogNotFound; yield break; }
+        catch (EventLogException) { LastOutcome = ReadOutcome.Unavailable; yield break; }
 
         int emitted = 0;
         using (reader)

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -230,6 +230,12 @@ public sealed class UpdateService
             catch (IOException) { /* non-fatal — next launch will re-download */ }
             catch (UnauthorizedAccessException) { /* non-fatal */ }
 
+            // Drop superseded downloads. Each cached build is ~85 MB and nothing ever removed
+            // the older ones, so the folder grew by that much per update forever — in a tool
+            // whose own Cleanup tab exists to reclaim disk space. Runs after the new binary is
+            // safely in place, so a failure here cannot cost the user the update.
+            PruneOldDownloads(dir, keep: target);
+
             return target;
         }
         catch (OperationCanceledException)
@@ -442,6 +448,57 @@ public sealed class UpdateService
         try { if (File.Exists(path)) File.Delete(path); }
         catch (IOException ex) { Serilog.Log.Debug(ex, "Update cleanup: could not delete {Path}", LogService.SanitizePath(path)); }
         catch (UnauthorizedAccessException ex) { Serilog.Log.Debug(ex, "Update cleanup: access denied deleting {Path}", LogService.SanitizePath(path)); }
+    }
+
+    /// <summary>
+    /// Deletes cached update binaries other than <paramref name="keep"/>, plus their companion
+    /// <c>.sha256</c> and any orphaned <c>.tmp</c> files.
+    /// <para>Only touches names matching the <c>SysManager-*.exe</c> pattern this service itself
+    /// writes, so an unrelated file that happens to sit in the folder is left alone. Never
+    /// throws: pruning is housekeeping, and failing it must not affect an update that already
+    /// succeeded. A file still locked by a running instance simply survives to the next round.</para>
+    /// </summary>
+    internal static int PruneOldDownloads(string dir, string keep)
+    {
+        var removed = 0;
+        try
+        {
+            if (!Directory.Exists(dir)) return 0;
+            var keepName = Path.GetFileName(keep);
+
+            foreach (var path in Directory.EnumerateFiles(dir, "SysManager-*.exe*"))
+            {
+                var name = Path.GetFileName(path);
+
+                // Keep the current binary and its hash; everything else is superseded.
+                if (name.Equals(keepName, StringComparison.OrdinalIgnoreCase) ||
+                    name.Equals(keepName + ".sha256", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    File.Delete(path);
+                    removed++;
+                }
+                catch (IOException ex)
+                {
+                    // Typically the binary of a running instance — expected, not an error.
+                    Serilog.Log.Debug(ex, "Update prune: {Path} is in use", LogService.SanitizePath(path));
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    Serilog.Log.Debug(ex, "Update prune: access denied for {Path}", LogService.SanitizePath(path));
+                }
+            }
+
+            if (removed > 0)
+                Serilog.Log.Information("Pruned {Count} superseded update download(s) from the cache", removed);
+        }
+        catch (IOException ex) { Serilog.Log.Debug(ex, "Update prune: could not enumerate the cache"); }
+        catch (UnauthorizedAccessException ex) { Serilog.Log.Debug(ex, "Update prune: access denied enumerating the cache"); }
+        return removed;
     }
 
     // ---------- internals ----------

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.56.9</Version>
-    <FileVersion>1.56.9.0</FileVersion>
-    <AssemblyVersion>1.56.9.0</AssemblyVersion>
+    <Version>1.56.10</Version>
+    <FileVersion>1.56.10.0</FileVersion>
+    <AssemblyVersion>1.56.10.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -39,6 +39,13 @@ public sealed partial class AboutViewModel : ViewModelBase
     [ObservableProperty] private string _latestPublishedLabel = string.Empty;
     [ObservableProperty] private string _latestNotes = string.Empty;
 
+    // Report / environment action state — deliberately separate from UpdateStatus.
+    // Both used to write to UpdateStatus, which is displayed inside the update card, so
+    // exporting a report or copying environment info replaced "Update available: v1.56.9"
+    // with "Report saved" — discarding the more important message and making the update
+    // card describe something unrelated to updates.
+    [ObservableProperty] private string _reportStatus = string.Empty;
+
     // Download state
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(ShowDownloadButton))]
@@ -259,21 +266,21 @@ public sealed partial class AboutViewModel : ViewModelBase
             try
             {
                 Clipboard.SetText(text);
-                UpdateStatus = "Environment info copied to clipboard.";
+                ReportStatus = "Environment info copied to clipboard.";
             }
             catch (System.Runtime.InteropServices.ExternalException ex)
             {
                 Log.Debug("Clipboard locked: {Error}", ex.Message);
-                UpdateStatus = "Couldn't copy to clipboard: it's currently in use by another application.";
+                ReportStatus = "Couldn't copy to clipboard: it's currently in use by another application.";
             }
         }
         catch (System.Management.ManagementException ex)
         {
-            UpdateStatus = $"Couldn't collect environment info: {ex.Message}";
+            ReportStatus = $"Couldn't collect environment info: {ex.Message}";
         }
         catch (InvalidOperationException ex)
         {
-            UpdateStatus = $"Couldn't collect environment info: {ex.Message}";
+            ReportStatus = $"Couldn't collect environment info: {ex.Message}";
         }
     }
 
@@ -451,25 +458,25 @@ public sealed partial class AboutViewModel : ViewModelBase
         if (dlg.ShowDialog() != true) return;
 
         IsGeneratingReport = true;
-        UpdateStatus = "Generating system report...";
+        ReportStatus = "Generating system report...";
         try
         {
             var report = await _reportService.GenerateReportAsync();
             await File.WriteAllTextAsync(dlg.FileName, report, Encoding.UTF8);
-            UpdateStatus = $"Report saved: {Path.GetFileName(dlg.FileName)}";
+            ReportStatus = $"Report saved: {Path.GetFileName(dlg.FileName)}";
             ToastService.Instance.Show("Report exported", Path.GetFileName(dlg.FileName));
         }
         catch (IOException ex)
         {
-            UpdateStatus = $"Failed to save report: {ex.Message}";
+            ReportStatus = $"Failed to save report: {ex.Message}";
         }
         catch (UnauthorizedAccessException ex)
         {
-            UpdateStatus = $"Failed to save report (access denied): {ex.Message}";
+            ReportStatus = $"Failed to save report (access denied): {ex.Message}";
         }
         catch (InvalidOperationException ex)
         {
-            UpdateStatus = $"Failed to generate report: {ex.Message}";
+            ReportStatus = $"Failed to generate report: {ex.Message}";
         }
         finally { IsGeneratingReport = false; }
     }
@@ -479,24 +486,24 @@ public sealed partial class AboutViewModel : ViewModelBase
     {
         if (IsGeneratingReport) return;
         IsGeneratingReport = true;
-        UpdateStatus = "Generating system report...";
+        ReportStatus = "Generating system report...";
         try
         {
             var report = await _reportService.GenerateReportAsync();
             try
             {
                 Clipboard.SetText(report);
-                UpdateStatus = "Full system report copied to clipboard.";
+                ReportStatus = "Full system report copied to clipboard.";
             }
             catch (System.Runtime.InteropServices.ExternalException ex)
             {
                 Log.Debug("Clipboard locked: {Error}", ex.Message);
-                UpdateStatus = "Couldn't copy to clipboard: it's currently in use by another application.";
+                ReportStatus = "Couldn't copy to clipboard: it's currently in use by another application.";
             }
         }
         catch (InvalidOperationException ex)
         {
-            UpdateStatus = $"Failed to generate report: {ex.Message}";
+            ReportStatus = $"Failed to generate report: {ex.Message}";
         }
         finally { IsGeneratingReport = false; }
     }

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -62,6 +62,10 @@ public sealed partial class LogsViewModel : ViewModelBase
     [ObservableProperty] private string _logFolder = LogService.LogDir;
     [ObservableProperty] private int _visibleCount;
     [ObservableProperty] private bool _hasNoResults;
+    // True when the log itself could not be read (access denied / missing / unavailable), as
+    // opposed to being read and yielding nothing. Drives a separate empty state, because
+    // "no events match your filters" is misleading when the filters never ran.
+    [ObservableProperty] private bool _loadWasRefused;
 
     public LogsViewModel(EventLogService eventLogs)
     {
@@ -137,6 +141,9 @@ public sealed partial class LogsViewModel : ViewModelBase
         IsBusy = true;
         IsProgressIndeterminate = true;
         StatusMessage = "Loading events…";
+        // Clear before loading so a previous refusal cannot keep the overlay up over a
+        // successful reload (e.g. after the user elevates and switches back to Security).
+        LoadWasRefused = false;
         Entries.Clear();
         ResetCounts();
 
@@ -185,7 +192,23 @@ public sealed partial class LogsViewModel : ViewModelBase
                 });
             }
 
-            StatusMessage = $"Loaded {Entries.Count} events from {SelectedLog}";
+            // Distinguish "nothing matched" from "not allowed to look". The Security log is
+            // readable only by an elevated process, and the reader used to swallow that refusal
+            // and return an empty sequence — so a standard user selecting Security saw
+            // "Loaded 0 events", then the empty-state's "No events match your filters", and had
+            // no way to know the filters were never applied to anything.
+            StatusMessage = (Entries.Count, _eventLogs.LastOutcome) switch
+            {
+                (0, EventLogService.ReadOutcome.AccessDenied) =>
+                    $"Windows would not let SysManager read the {SelectedLog} log. This log requires "
+                    + "administrator rights — restart SysManager as administrator to view it.",
+                (0, EventLogService.ReadOutcome.LogNotFound) =>
+                    $"The {SelectedLog} log does not exist on this machine.",
+                (0, EventLogService.ReadOutcome.Unavailable) =>
+                    $"The {SelectedLog} log could not be opened. It may be disabled or in use.",
+                _ => $"Loaded {Entries.Count} events from {SelectedLog}"
+            };
+            LoadWasRefused = Entries.Count == 0 && _eventLogs.LastOutcome != EventLogService.ReadOutcome.Ok;
             UpdateVisibleCount();
         }
         catch (OperationCanceledException) { StatusMessage = "Cancelled"; }

--- a/SysManager/SysManager/Views/AboutView.xaml
+++ b/SysManager/SysManager/Views/AboutView.xaml
@@ -22,6 +22,11 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <!-- Report / environment status line, added below the button row. -->
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
                         <StackPanel Grid.Column="0">
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="SysManager" FontSize="24" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimary}"/>
@@ -49,7 +54,7 @@
                                     Command="{Binding ExportToFileCommand}"
                                     Style="{StaticResource PrimaryButton}" Margin="8,0,0,0"
                                     IsEnabled="{Binding IsGeneratingReport, Converter={StaticResource BoolInvert}}"
-                                    ToolTip="Generate a comprehensive system report and save it to the Desktop."/>
+                                    ToolTip="Generate a comprehensive system report and choose where to save it."/>
                             <Button Content="Copy full report"
                                     Command="{Binding CopyReportCommand}"
                                     Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"
@@ -62,6 +67,16 @@
                             <Button Content="View license" Command="{Binding OpenLicenseCommand}"
                                     Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"/>
                         </StackPanel>
+
+                        <!-- Report / environment results live here, next to the buttons that produce
+                             them. They previously wrote to UpdateStatus inside the update card below,
+                             so exporting a report replaced "Update available: vX.Y.Z" with
+                             "Report saved" — losing the more important message and making the update
+                             card describe something unrelated. Collapsed until there is something
+                             to say, so the row does not reserve empty space. -->
+                        <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="{Binding ReportStatus}"
+                                   Style="{StaticResource Subtle}" Margin="0,10,0,0" TextWrapping="Wrap"
+                                   Visibility="{Binding ReportStatus, Converter={StaticResource FlexVis}, Mode=OneWay}"/>
                     </Grid>
                 </Border>
 

--- a/SysManager/SysManager/Views/BatteryHealthView.xaml
+++ b/SysManager/SysManager/Views/BatteryHealthView.xaml
@@ -80,19 +80,39 @@
 
                                 <StackPanel Grid.Column="0">
                                     <TextBlock Text="Health" Style="{StaticResource Subtle}" FontSize="12"/>
-                                    <TextBlock FontSize="24" FontWeight="Bold" Margin="0,4,0,0">
-                                        <Run Text="{Binding Battery.HealthPercent, Mode=OneWay}"/><Run Text="%"/>
-                                    </TextBlock>
+                                    <TextBlock Text="{Binding Battery.HealthDisplay, Mode=OneWay}"
+                                               FontSize="24" FontWeight="Bold" Margin="0,4,0,0"/>
                                 </StackPanel>
 
                                 <StackPanel Grid.Column="1">
                                     <TextBlock Text="Wear" Style="{StaticResource Subtle}" FontSize="12"/>
-                                    <TextBlock FontSize="24" FontWeight="Bold" Margin="0,4,0,0"
-                                               Foreground="{DynamicResource Danger}">
-                                        <Run Text="{Binding Battery.WearPercent, Mode=OneWay}"/><Run Text="%"/>
+                                    <!-- Danger red only when a real wear figure exists; "Not available"
+                                         is missing data, not a warning. -->
+                                    <TextBlock Text="{Binding Battery.WearDisplay, Mode=OneWay}"
+                                               FontSize="24" FontWeight="Bold" Margin="0,4,0,0">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="{DynamicResource TextMuted}"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Battery.HasCapacityData, Mode=OneWay}" Value="True">
+                                                        <Setter Property="Foreground" Value="{DynamicResource Danger}"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
                                     </TextBlock>
                                 </StackPanel>
                             </Grid>
+                        </Border>
+
+                        <!-- Why the figures are missing. Capacity comes from root\WMI, which needs
+                             elevation; without it the app previously showed "-1%" as if it were a
+                             measurement. Explains the gap and what unlocks it, consistent with how
+                             other tabs describe their admin requirement. -->
+                        <Border Style="{StaticResource Card}" Padding="12" Margin="0,0,0,12"
+                                Visibility="{Binding Battery.HasCapacityData, Converter={StaticResource FlexVis}, ConverterParameter=Inverse, Mode=OneWay}">
+                            <TextBlock TextWrapping="Wrap" Style="{StaticResource Subtle}"
+                                       Text="Battery health and wear could not be read. Windows only reports design and full-charge capacity to an elevated process, so these two figures need SysManager to be running as administrator. Everything else on this page works without it."/>
                         </Border>
 
                         <!-- Details grid -->

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -36,7 +36,12 @@
             </StackPanel>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Right" VerticalAlignment="Center">
                 <Button Content="Open Event Viewer" AutomationProperties.AutomationId="btn-logs-open-event-viewer" AutomationProperties.Name="Open Event Viewer" Command="{Binding OpenEventViewerCommand}" Style="{StaticResource GhostButton}"/>
-                <Button Content="Open log folder" AutomationProperties.AutomationId="btn-logs-open-folder" AutomationProperties.Name="Open log folder" Command="{Binding OpenLogFolderCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>
+                <!-- Names what it actually opens. This tab shows the WINDOWS Event Log, and the
+                     button sits next to "Open Event Viewer", so "Open log folder" read as the
+                     Windows logs while it opens SysManager's own %LOCALAPPDATA% log directory.
+                     The tooltip gives the full path so there is no ambiguity before clicking. -->
+                <Button Content="SysManager's own logs" AutomationProperties.AutomationId="btn-logs-open-folder" AutomationProperties.Name="Open SysManager's own log folder" Command="{Binding OpenLogFolderCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"
+                        ToolTip="{Binding LogFolder, Mode=OneWay, StringFormat='Opens SysManager''s own diagnostic logs: {0}'}"/>
                 <Button Content="Export CSV" AutomationProperties.AutomationId="btn-logs-export-csv" AutomationProperties.Name="Export logs to CSV" Command="{Binding ExportCsvCommand}" Style="{StaticResource SecondaryButton}" Margin="6,0,0,0"/>
             </StackPanel>
         </DockPanel>
@@ -286,11 +291,20 @@
                     </DataGrid.Columns>
                 </DataGrid>
 
-                    <!-- No-results overlay -->
+                    <!-- No-results overlay: entries were loaded but the filters hid all of them. -->
                     <v:EmptyState Glyph="&#xE721;"
                                   Title="No events match your filters"
                                   Message="Try adjusting severity checkboxes or clearing the search."
                                   Visibility="{Binding HasNoResults, Converter={StaticResource FlexVis}}"/>
+
+                    <!-- Refused overlay: the log could not be read at all, so the filters never
+                         applied to anything. Without this the grid was simply blank next to
+                         "Loaded 0 events", which reads as "this log is empty" when the real
+                         reason is that the Security log needs elevation. -->
+                    <v:EmptyState Glyph="&#xE72E;"
+                                  Title="This log could not be read"
+                                  Message="{Binding StatusMessage}"
+                                  Visibility="{Binding LoadWasRefused, Converter={StaticResource FlexVis}}"/>
                 </Grid>
             </Border>
 


### PR DESCRIPTION
Closes #1636
Closes #1641
Closes #1647
Closes #1646
Closes #1661

Five cases where the app showed something inaccurate rather than saying what it did not know. Each was refuted against current source first, and **two turned out to differ from what the issue described**.

## Battery showed "-1%" as a measurement (#1636)

`HealthPercent`/`WearPercent` return `-1` for "capacity could not be read" — Windows only reports design and full-charge capacity to an elevated process. `BatteryHealthView` bound those numbers directly and appended `%`, so an unelevated run displayed **"-1%" in 24pt bold** as though it were a reading.

Added `HealthDisplay`/`WearDisplay` rendering "Not available", plus a card explaining that these two figures need administrator rights while the rest of the page does not. The wear figure also stops being danger-red when there is no figure — missing data is not a warning.

Worth noting: `RuntimeDisplay` in the same model already formatted the identical `-1` sentinel correctly. This was an inconsistency inside one file.

## Security log reported "0 events" instead of "not allowed" (#1641)

`EventLogService` caught `UnauthorizedAccessException` with a bare `yield break`, so a refused log and an empty log were indistinguishable. It now exposes `LastOutcome` (`Ok` / `AccessDenied` / `LogNotFound` / `Unavailable`), reset at the start of each query, and the view model turns that into a specific message with its own empty state.

**Correction to the issue:** it said the user sees "No events match your filters". That overlay requires `Entries.Count > 0`, so with zero entries the user actually saw a *blank grid* and "Loaded 0 events" — equally opaque, but worth stating accurately. The new overlay covers the zero-entry case the old one could not reach.

## "Open log folder" opened the wrong logs (#1647)

The button sat beside "Open Event Viewer" on a tab titled after the Windows Event Log, and opened `LogService.LogDir` — SysManager's own diagnostics. Renamed to **"SysManager's own logs"** with the full path in its tooltip. The behaviour was right; only the label lied.

## Report actions wiped the update message (#1646)

`CopyEnvironmentInfo`, `ExportToFile` and `CopyReport` all wrote to `UpdateStatus`, which is displayed *inside the update card* — so exporting a report replaced "Update available: v1.56.9" with "Report saved", discarding the more useful message and leaving the update card describing something unrelated to updates.

Added a separate `ReportStatus`, shown next to the buttons that produce it. Also fixed the export tooltip, which still promised the Desktop after that behaviour changed in #1689 — drift introduced by my own earlier PR.

## The update cache grew forever (#1661)

`CleanupFile` only removed the current download's temp file on failure. Nothing ever removed superseded builds, so `%LocalAppData%\SysManager\updates` grew by **~85 MB per update** — in an app whose Cleanup tab exists to reclaim disk space.

`PruneOldDownloads` runs after the new binary is safely in place and keeps only the current exe and its hash. It matches only the `SysManager-*.exe` names this service writes, so unrelated files are untouched, and treats a file locked by a running instance as ordinary rather than an error.

## Tests

**20 new cases.** Pruning (11): superseded binaries, stale hashes, orphaned `.tmp` files, unrelated files left alone, case-insensitive keep-name, missing directory, a **deliberately locked file**, and idempotency. Battery display (6): all three unavailable combinations, real percentages, `0%` wear as a genuine figure rather than missing data, and `PropertyChanged` firing when capacity arrives late. Read outcome (3).

The event-log tests query only names that cannot exist, so they do not depend on the runner's real logs or permissions.

## Verification

All five fixes exercised in a console harness against the built assembly — **11/11 passed**, including confirmation that a missing log reports `LogNotFound`, which was an assumption until it was run.

All four projects: Release build, **0 warnings, 0 errors**. Leak scan over 526 added lines: 28 terms, clean. No `MessageBox.Show`, generic catch, or debug leftovers in the diff.

## Docs

README documents the administrator requirement for battery health and for the Security log. ARCHITECTURE documents `LastOutcome` and the cache pruning.
