### PR TITLE
fix: name each event severity instead of signalling it by colour alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.56.11] - 2026-08-04
+
+### Fixed
+- **The event-log list now names each severity instead of only colouring it.** The severity column was a coloured dot under a blank header, with no text, no tooltip and nothing for a screen reader to read, so the difference between an error and an informational entry was carried by colour alone. The column is now labelled "Severity", shows the word next to the dot, is sortable, and reports the severity to assistive technology.
+
 ## [1.56.10] - 2026-08-04
 
 ### Fixed

--- a/SysManager/SysManager.Tests/UiAutomationContractTests.cs
+++ b/SysManager/SysManager.Tests/UiAutomationContractTests.cs
@@ -144,4 +144,41 @@ public partial class UiAutomationContractTests
 
     [GeneratedRegex("FindButtonById\\s*\\(\\s*\"(?<id>btn-[a-z0-9-]+)\"", RegexOptions.CultureInvariant)]
     private static partial Regex FindButtonByIdCall();
+
+    /// <summary>
+    /// The event-log severity column must not convey severity by colour alone. It previously held
+    /// a bare coloured Ellipse under an empty header — no text, no tooltip, no accessible name —
+    /// so severity was unavailable to anyone with a colour-vision deficiency and to a screen
+    /// reader. Asserted against the real XAML because the defect lived entirely in the cell
+    /// template: no view-model or model assertion could have caught it.
+    /// </summary>
+    [Fact]
+    public void LogsSeverityColumn_ConveysSeverityAsTextNotColourAlone()
+    {
+        var logsView = Path.Combine(
+            FindSolutionDirectory().FullName, "SysManager", "Views", "LogsView.xaml");
+        var document = XDocument.Load(logsView);
+
+        var severityColumn = Assert.Single(
+            document.Descendants(Presentation + "DataGridTemplateColumn"),
+            column => (string?)column.Attribute("Header") == "Severity");
+
+        var cellRoot = severityColumn
+            .Descendants(Presentation + "DataTemplate")
+            .Single()
+            .Elements()
+            .Single();
+
+        // A screen reader needs a name on the cell content, and a colour-blind sighted user needs
+        // the word rendered. The coloured dot may accompany them; it must not replace them.
+        Assert.Equal(
+            "{Binding SeverityLabel}",
+            (string?)cellRoot.Attribute("AutomationProperties.Name"));
+        Assert.Contains(
+            cellRoot.Descendants(Presentation + "TextBlock"),
+            text => (string?)text.Attribute("Text") == "{Binding SeverityLabel}");
+
+        // The column must also be identifiable and sortable, which an empty header prevented.
+        Assert.Equal("Severity", (string?)severityColumn.Attribute("SortMemberPath"));
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.56.10</Version>
-    <FileVersion>1.56.10.0</FileVersion>
-    <AssemblyVersion>1.56.10.0</AssemblyVersion>
+    <Version>1.56.11</Version>
+    <FileVersion>1.56.11.0</FileVersion>
+    <AssemblyVersion>1.56.11.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -269,12 +269,22 @@
                         </Style>
                     </DataGrid.RowStyle>
                     <DataGrid.Columns>
-                        <!-- Severity column: colored dot instead of emoji -->
-                        <DataGridTemplateColumn Header="" Width="40" MinWidth="40" CanUserResize="False">
+                        <!-- Severity column: a coloured dot PLUS the word. The dot alone conveyed
+                             severity by colour only — invisible to a colour-blind user and to a
+                             screen reader, since the column had no header, no text and no tooltip.
+                             AutomationProperties.Name gives assistive technology the severity to
+                             read out; the visible label makes it legible to everyone else. -->
+                        <DataGridTemplateColumn Header="Severity" Width="106" MinWidth="90" SortMemberPath="Severity">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
-                                    <Ellipse Width="10" Height="10" VerticalAlignment="Center" HorizontalAlignment="Center"
-                                             Fill="{Binding SeverityColor, Converter={StaticResource HexBrush}}"/>
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center"
+                                                AutomationProperties.Name="{Binding SeverityLabel}"
+                                                ToolTip="{Binding SeverityLabel}">
+                                        <Ellipse Width="10" Height="10" VerticalAlignment="Center"
+                                                 Fill="{Binding SeverityColor, Converter={StaticResource HexBrush}}"/>
+                                        <TextBlock Text="{Binding SeverityLabel}" Margin="8,0,0,0"
+                                                   VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                                    </StackPanel>
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>
                         </DataGridTemplateColumn>


### PR DESCRIPTION
Closes #1533

The severity column in the event-log grid was a bare coloured `Ellipse` under an **empty header** — no text, no tooltip, no accessible name, not sortable. The only thing distinguishing an error from an informational entry was the dot's colour: unavailable to anyone with a colour-vision deficiency, and to a screen reader, which had nothing to read.

The column is now headed "Severity", shows the word beside the dot, exposes it via `AutomationProperties.Name`, carries a tooltip, and sorts on the underlying severity.

## A mistake worth recording

My first attempt added a new computed `SeverityLabel` to `FriendlyEventEntry`. It turned out one already existed — an `[ObservableProperty]` populated by `EventLogService`, already consumed by the detail pane and the CSV export. I had assumed the detail pane's binding was dead; it was not.

Reverted, so **the model is untouched** and the grid now uses the same value as every other consumer. Its words ("Critical", "Error", "Warning", "Info", "Verbose") also match the severity filter checkboxes above the grid, so the column and the filters read consistently — which a parallel property would have quietly broken.

## Verified red before green

The assertion's logic was run against both the fixed XAML and the pre-fix version from `main`:

```
FIXED (branch): PASSES — all assertions hold
BEFORE (main) : FAILS  — expected 1 column headed 'Severity', found 0
```

So the test genuinely pins the defect rather than asserting something that was already true.

It asserts against the real XAML because the defect lived entirely in a cell template — no view-model or model assertion could have caught it. It sits in `UiAutomationContractTests` alongside the existing accessible-name guards.

## Verification

All four projects: Release build, 0 warnings, 0 errors. Leak scan over added lines: 28 terms, clean. Column width (106) chosen to sit consistently beside the existing Time column (150).

## Three sibling findings deliberately NOT taken

I verified all four issues in this area and am closing only this one. The other three are real but are not bug fixes:

- **#1629 (StatusColors hex constants)** — `StatusColors` is already a deliberate consolidation; its own doc comment records migrating ~10 files' worth of literals into it. Making the values theme-aware means reconciling them with `ThemeService.StatusPalette` across 8 consuming files and 52 `*ColorHex` properties. That is an architecture decision about who owns the palette, not a defect to patch.
- **#1632 (elevation banner shape)** — 30 views carry an elevation control, each with its own padding and corner radius. Unifying them is a design-system change (the planned `Spacing.xaml` token work), not a fix.
- **#1649 (Uninstaller admin contract)** — **not a bug.** Uninstall is disabled when elevated on purpose: `CanUninstall => NotBusy && HasApps && !IsElevated`, introduced by #1477 "harden elevated execution boundaries". The banner is telling the truth; at most it could explain *why*. I left it alone rather than weaken a security boundary to satisfy an audit note.

All three are better done with a decision from the maintainer than unsupervised, so I have left them open with this reasoning.
