### PR TITLE
fix: notify on new installs, remember auto-purge, and explain block refusals

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -330,6 +330,13 @@ Key services:
   unit-tested `Serialize`/`Parse`, file IO that never throws. Every untrusted or unrecognized
   value degrades to `Ask` rather than to a concrete action, so a damaged file can never exit an
   app the user wanted kept in the tray.
+- `StandbyPreferenceService` — persists the Standby List Cleaner's auto-purge toggle and
+  threshold as JSON under `%LocalAppData%\SysManager\standby-preference.json`. Auto-purge is a
+  set-and-forget setting, so losing it on every restart made it effectively unusable. Same shape
+  as the two above: injectable config directory, pure unit-tested `Serialize`/`Parse`, file IO
+  that never throws. An unreadable file falls back to auto-purge OFF, and an out-of-range
+  threshold resets only that field while keeping the toggle — arming an automatic system action
+  on the strength of a corrupt file would be the wrong way to fail.
 - `GamingProfileService` (`IGamingProfileService`) — a pure ORCHESTRATOR behind the Gaming
   Profile tab: it composes the already-audited services (`PerformanceService`,
   `ITimerResolutionService`, `ICpuAffinityService`, `StandbyMemoryService`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.56.12] - 2026-08-04
+
+### Fixed
+- **App Alerts now notifies you when something installs itself.** The tab detected new installations and added them to its list, but nothing surfaced them — so unless you happened to be sitting on that tab at the moment it happened, you never found out. The entire point of the feature is learning about an install you did not start. A notification now appears when one is detected.
+- **The auto-purge setting in Standby List Cleaner is remembered.** The switch and its RAM threshold lived only in memory, so arming auto-purge and closing the app silently reverted it to off at the default threshold — unusable for a set-and-forget feature. Both are now saved as soon as you change them and restored on startup. A damaged settings file falls back to auto-purge off rather than arming an automatic action you did not choose.
+- **App Blocker no longer blames your permissions for its own safety refusals.** Every failed block reported "check admin privileges", including the four cases where SysManager deliberately refused: a Windows boot-critical program, SysManager itself, an invalid name, or an executable another program already has a debugger registered for. Someone trying to block `winlogon.exe` was told to restart as administrator, where the same refusal would happen again for the same unstated reason. Each case now explains what it is and why, and the genuine permissions case says so specifically.
+
 ## [1.56.11] - 2026-08-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -549,6 +549,8 @@ a confirmation before it runs:
   detection source
 - Start/stop monitoring, acknowledge alerts, show all currently installed
   apps, clear history
+- Notifies you when a new install is detected, so you find out even when you are
+  on another tab or the window is in the notification area
 
 ### App Blocker
 - Blocks applications from executing using Image File Execution Options (IFEO)
@@ -705,6 +707,8 @@ offers, "rate us" prompts:
   cache, so clearing it loses nothing; Windows reloads from disk on next use
 - Reading stats needs no admin; purging requires administrator (it enables the
   same privilege RAMMap and ISLC use) and reports cleanly if not elevated
+- The auto-purge switch and its threshold are remembered between sessions, so
+  arming it once is enough
 
 ### Performance Mode
 - **Per-tweak Apply buttons** — each setting is independent

--- a/SysManager/SysManager.Tests/AppBlockerServiceRegistryTests.cs
+++ b/SysManager/SysManager.Tests/AppBlockerServiceRegistryTests.cs
@@ -140,4 +140,90 @@ public sealed class AppBlockerServiceRegistryTests : IDisposable
         Assert.True(svc.BlockApp("notepad.exe"));
         Assert.Equal(BlockerDebugger, ReadDebugger("notepad.exe"));
     }
+
+    // ---------- TryBlockApp: telling the refusals apart ----------
+    //
+    // BlockApp returned a bare bool for six different causes, four of them deliberate safety
+    // refusals, and the UI reported every one as "check admin privileges". These pin each cause
+    // to its own result so a refusal can never again be mistaken for a permissions problem.
+
+    [Fact]
+    public void TryBlockApp_Success_ReportsSuccess()
+    {
+        Assert.Equal(AppBlockerService.BlockResult.Success, _svc.TryBlockApp("notepad.exe"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryBlockApp_EmptyName_ReportsEmptyName(string name)
+    {
+        Assert.Equal(AppBlockerService.BlockResult.EmptyName, _svc.TryBlockApp(name));
+    }
+
+    [Theory]
+    [InlineData(@"C:\Windows\notepad.exe")]      // path separators
+    [InlineData(@"..\..\evil.exe")]              // traversal
+    [InlineData("note*pad.exe")]                 // wildcard
+    public void TryBlockApp_InvalidName_ReportsInvalidName(string name)
+    {
+        Assert.Equal(AppBlockerService.BlockResult.InvalidName, _svc.TryBlockApp(name));
+    }
+
+    [Theory]
+    [InlineData("winlogon.exe")]
+    [InlineData("lsass.exe")]
+    [InlineData("explorer.exe")]
+    [InlineData("csrss")]        // bare name; .exe is appended before the check
+    public void TryBlockApp_BootCritical_ReportsBootCritical(string name)
+    {
+        // The distinction that mattered most: this previously told the user to check their admin
+        // rights, sending them to relaunch elevated where the same guard refuses again.
+        Assert.Equal(AppBlockerService.BlockResult.BootCritical, _svc.TryBlockApp(name));
+    }
+
+    [Fact]
+    public void TryBlockApp_OwnExecutable_ReportsOwnExecutable()
+    {
+        var svc = new AppBlockerService(_root, ownExecutableName: "SysManager.exe");
+
+        Assert.Equal(AppBlockerService.BlockResult.OwnExecutable, svc.TryBlockApp("SysManager.exe"));
+    }
+
+    [Fact]
+    public void TryBlockApp_ExternalDebuggerPresent_ReportsExternalDebuggerPresent()
+    {
+        using (var appKey = _root.CreateSubKey($@"{IfeoPath}\devtool.exe", writable: true)!)
+            appKey.SetValue("Debugger", @"C:\SomeTool\attach.exe", RegistryValueKind.String);
+
+        Assert.Equal(
+            AppBlockerService.BlockResult.ExternalDebuggerPresent,
+            _svc.TryBlockApp("devtool.exe"));
+
+        // And the external value survives untouched.
+        Assert.Equal(@"C:\SomeTool\attach.exe", ReadDebugger("devtool.exe"));
+    }
+
+    [Fact]
+    public void BlockApp_StillAgreesWithTryBlockApp()
+    {
+        // The bool overload is kept for callers that only need success/failure, so the two must
+        // not drift apart.
+        Assert.True(_svc.BlockApp("notepad.exe"));
+        Assert.False(_svc.BlockApp("winlogon.exe"));
+        Assert.Equal(
+            _svc.TryBlockApp("winlogon.exe") == AppBlockerService.BlockResult.Success,
+            _svc.BlockApp("winlogon.exe"));
+    }
+
+    [Fact]
+    public void TryBlockApp_RefusalsWriteNothing()
+    {
+        // Every refusal must bail before the registry write, not write and then report failure.
+        foreach (var name in new[] { "winlogon.exe", @"C:\evil.exe", "" })
+            _svc.TryBlockApp(name);
+
+        Assert.Null(ReadDebugger("winlogon.exe"));
+        Assert.False(_svc.IsBlocked("winlogon.exe"));
+    }
 }

--- a/SysManager/SysManager.Tests/AppBlockerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppBlockerViewModelTests.cs
@@ -107,6 +107,9 @@ public class AppBlockerViewModelTests
             vm.BlockAppCommand.Execute(null);
 
             dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            // Assert on both entry points: the view model calls TryBlockApp, and asserting only
+            // the old BlockApp would leave this test passing while checking nothing.
+            blocker.DidNotReceive().TryBlockApp(Arg.Any<string>());
             blocker.DidNotReceive().BlockApp(Arg.Any<string>());
         }
         finally
@@ -119,7 +122,9 @@ public class AppBlockerViewModelTests
     public void BlockApp_WhenUserConfirms_BlocksApp()
     {
         var blocker = Substitute.For<IAppBlockerService>();
-        blocker.BlockApp(Arg.Any<string>()).Returns(true);
+        // The view model calls TryBlockApp now, so it can tell a safety refusal from a
+        // permissions problem instead of reporting every failure as "check admin privileges".
+        blocker.TryBlockApp(Arg.Any<string>()).Returns(AppBlockerService.BlockResult.Success);
         var vm = NewVm(blocker);
         vm.NewExeName = "game.exe";
 
@@ -132,7 +137,64 @@ public class AppBlockerViewModelTests
             vm.BlockAppCommand.Execute(null);
 
             dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
-            blocker.Received(1).BlockApp("game.exe");
+            blocker.Received(1).TryBlockApp("game.exe");
+            Assert.Contains("Blocked game.exe", vm.BlockStatus);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Theory]
+    [InlineData(AppBlockerService.BlockResult.BootCritical, "required for Windows to start")]
+    [InlineData(AppBlockerService.BlockResult.OwnExecutable, "SysManager itself")]
+    [InlineData(AppBlockerService.BlockResult.ExternalDebuggerPresent, "already registered a debugger")]
+    [InlineData(AppBlockerService.BlockResult.InvalidName, "not a valid executable name")]
+    public void BlockApp_SafetyRefusal_DoesNotBlameAdminRights(
+        AppBlockerService.BlockResult refusal, string expectedFragment)
+    {
+        // Each of these is SysManager deliberately declining. Reporting them as a permissions
+        // problem sent the user to relaunch elevated, where the same guard refuses again.
+        var blocker = Substitute.For<IAppBlockerService>();
+        blocker.TryBlockApp(Arg.Any<string>()).Returns(refusal);
+        var vm = NewVm(blocker);
+        vm.NewExeName = "something.exe";
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.BlockAppCommand.Execute(null);
+
+            Assert.Contains(expectedFragment, vm.BlockStatus);
+            Assert.DoesNotContain("administrator", vm.BlockStatus, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public void BlockApp_AccessDenied_IsTheOnlyCaseThatMentionsAdminRights()
+    {
+        var blocker = Substitute.For<IAppBlockerService>();
+        blocker.TryBlockApp(Arg.Any<string>()).Returns(AppBlockerService.BlockResult.AccessDenied);
+        var vm = NewVm(blocker);
+        vm.NewExeName = "something.exe";
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.BlockAppCommand.Execute(null);
+
+            Assert.Contains("administrator", vm.BlockStatus, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {

--- a/SysManager/SysManager.Tests/StandbyPreferenceServiceTests.cs
+++ b/SysManager/SysManager.Tests/StandbyPreferenceServiceTests.cs
@@ -1,0 +1,184 @@
+// SysManager · StandbyPreferenceServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="StandbyPreferenceService"/> — the persisted auto-purge settings.
+/// Every test uses an injected temp directory, so the developer's real preference in
+/// %LOCALAPPDATA% is never read or written.
+/// </summary>
+public class StandbyPreferenceServiceTests : IDisposable
+{
+    private readonly string _dir;
+
+    public StandbyPreferenceServiceTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "SysManagerStandbyTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch (IOException) { /* a leftover temp dir must never fail a test run */ }
+    }
+
+    private StandbyPreferenceService NewService() => new(_dir);
+
+    // ---------- defaults ----------
+
+    [Fact]
+    public void Load_WithNothingSaved_ReturnsSafeDefault()
+    {
+        var loaded = NewService().Load();
+
+        Assert.False(loaded.AutoPurgeEnabled);
+        Assert.Equal(StandbyPreferenceService.DefaultThresholdMb, loaded.ThresholdMb);
+    }
+
+    [Fact]
+    public void Default_HasAutoPurgeOff()
+    {
+        // Off is the only safe default: arming an automatic system action by default would purge
+        // without the user ever asking.
+        Assert.False(StandbyPreferenceService.Default.AutoPurgeEnabled);
+    }
+
+    // ---------- round-trip ----------
+
+    [Theory]
+    [InlineData(true, 2048)]
+    [InlineData(false, 512)]
+    [InlineData(true, 64)]      // exactly the minimum
+    public void Save_ThenLoad_ReturnsSameSettings(bool enabled, double threshold)
+    {
+        NewService().Save(new StandbyPreference(enabled, threshold));
+
+        // A second instance, as after an app restart — which is the whole point of persisting.
+        var loaded = NewService().Load();
+
+        Assert.Equal(enabled, loaded.AutoPurgeEnabled);
+        Assert.Equal(threshold, loaded.ThresholdMb);
+    }
+
+    [Fact]
+    public void Save_Twice_LastWriteWins()
+    {
+        var svc = NewService();
+        svc.Save(new StandbyPreference(true, 2048));
+        svc.Save(new StandbyPreference(false, 4096));
+
+        var loaded = svc.Load();
+
+        Assert.False(loaded.AutoPurgeEnabled);
+        Assert.Equal(4096, loaded.ThresholdMb);
+    }
+
+    [Fact]
+    public void Save_CreatesTheConfigDirectoryIfMissing()
+    {
+        var nested = Path.Combine(_dir, "does", "not", "exist", "yet");
+
+        new StandbyPreferenceService(nested).Save(new StandbyPreference(true, 2048));
+
+        Assert.True(new StandbyPreferenceService(nested).Load().AutoPurgeEnabled);
+    }
+
+    // ---------- rejecting untrustworthy input ----------
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not json")]
+    [InlineData("{")]
+    [InlineData("[]")]
+    public void Parse_InvalidInput_ReturnsDefault(string? json)
+    {
+        var parsed = StandbyPreferenceService.Parse(json);
+
+        Assert.False(parsed.AutoPurgeEnabled);
+        Assert.Equal(StandbyPreferenceService.DefaultThresholdMb, parsed.ThresholdMb);
+    }
+
+    [Theory]
+    [InlineData(0)]           // would make ShouldAutoPurge never fire
+    [InlineData(-500)]        // nonsense
+    [InlineData(1)]           // below the floor: would fire almost continuously
+    [InlineData(63)]          // just below the floor
+    [InlineData(2_000_000)]   // above any real machine's RAM: would fire on every tick
+    public void Parse_OutOfRangeThreshold_FallsBackToTheDefault(double threshold)
+    {
+        var json = $"{{\"AutoPurgeEnabled\":true,\"ThresholdMb\":{threshold}}}";
+
+        var parsed = StandbyPreferenceService.Parse(json);
+
+        // The toggle is still honoured — only the unusable number is replaced, so a corrupt
+        // threshold does not silently disarm a feature the user turned on.
+        Assert.True(parsed.AutoPurgeEnabled);
+        Assert.Equal(StandbyPreferenceService.DefaultThresholdMb, parsed.ThresholdMb);
+    }
+
+    [Theory]
+    [InlineData("NaN")]
+    [InlineData("Infinity")]
+    public void Parse_NonFiniteThreshold_FallsBackToTheDefault(string literal)
+    {
+        var json = $"{{\"AutoPurgeEnabled\":true,\"ThresholdMb\":\"{literal}\"}}";
+
+        var parsed = StandbyPreferenceService.Parse(json);
+
+        Assert.Equal(StandbyPreferenceService.DefaultThresholdMb, parsed.ThresholdMb);
+    }
+
+    [Theory]
+    [InlineData(64)]
+    [InlineData(1024)]
+    [InlineData(1_048_576)]   // exactly the ceiling
+    public void Parse_InRangeThreshold_IsHonoured(double threshold)
+    {
+        var json = $"{{\"AutoPurgeEnabled\":false,\"ThresholdMb\":{threshold}}}";
+
+        Assert.Equal(threshold, StandbyPreferenceService.Parse(json).ThresholdMb);
+    }
+
+    [Fact]
+    public void Load_MalformedFileOnDisk_ReturnsDefaultWithoutThrowing()
+    {
+        File.WriteAllText(Path.Combine(_dir, "standby-preference.json"), "{ not valid json");
+
+        var loaded = NewService().Load();
+
+        Assert.False(loaded.AutoPurgeEnabled);
+        Assert.Equal(StandbyPreferenceService.DefaultThresholdMb, loaded.ThresholdMb);
+    }
+
+    // ---------- serialization shape ----------
+
+    [Fact]
+    public void Serialize_RoundTripsThroughParse()
+    {
+        var original = new StandbyPreference(true, 3072);
+
+        var parsed = StandbyPreferenceService.Parse(StandbyPreferenceService.Serialize(original));
+
+        Assert.Equal(original, parsed);
+    }
+
+    [Fact]
+    public void ShouldAutoPurge_AgreesWithAPersistedThreshold()
+    {
+        // The persisted value has to be usable by the purge decision it exists to drive, so the
+        // two are checked together rather than in isolation.
+        NewService().Save(new StandbyPreference(true, 2048));
+        var loaded = NewService().Load();
+
+        Assert.True(ViewModels.StandbyMemoryViewModel.ShouldAutoPurge(1024, loaded.ThresholdMb));
+        Assert.False(ViewModels.StandbyMemoryViewModel.ShouldAutoPurge(4096, loaded.ThresholdMb));
+    }
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -82,6 +82,7 @@ public static class ServiceRegistration
         services.AddSingleton<TaskSchedulerService>();
         services.AddSingleton<IWindowsThemeService, WindowsThemeService>();
         services.AddSingleton<StandbyMemoryService>();
+        services.AddSingleton<StandbyPreferenceService>();
         services.AddSingleton<ResourceHistoryService>();
         services.AddSingleton<BandwidthHistoryService>();
         services.AddSingleton<ISettingsWatchdogService, SettingsWatchdogService>();

--- a/SysManager/SysManager/Services/AppBlockerService.cs
+++ b/SysManager/SysManager/Services/AppBlockerService.cs
@@ -91,11 +91,52 @@ public sealed partial class AppBlockerService : IAppBlockerService
     }
 
     /// <summary>
-    /// Blocks an executable from running.
+    /// Why a block attempt did not succeed. <see cref="BlockApp"/> returned a bare bool for six
+    /// distinct causes — four of them deliberate safety refusals — and the UI attributed all of
+    /// them to missing administrator rights. That sent a user who tried to block a boot-critical
+    /// executable off to relaunch elevated, where it would be refused again for the same real
+    /// reason, never stated.
     /// </summary>
-    public bool BlockApp(string exeName)
+    public enum BlockResult
     {
-        if (string.IsNullOrWhiteSpace(exeName)) return false;
+        /// <summary>The block was written.</summary>
+        Success,
+
+        /// <summary>No name was supplied.</summary>
+        EmptyName,
+
+        /// <summary>The name contains path separators or characters that are not permitted.</summary>
+        InvalidName,
+
+        /// <summary>Refused: blocking it could leave Windows unbootable.</summary>
+        BootCritical,
+
+        /// <summary>Refused: blocking SysManager itself would be unrecoverable in-app.</summary>
+        OwnExecutable,
+
+        /// <summary>Refused: another program already set a Debugger value we must not clobber.</summary>
+        ExternalDebuggerPresent,
+
+        /// <summary>Windows denied the registry write — this is the one that needs elevation.</summary>
+        AccessDenied,
+
+        /// <summary>The registry write failed for another reason.</summary>
+        RegistryFailure
+    }
+
+    /// <summary>
+    /// Blocks an executable from running. Prefer <see cref="TryBlockApp"/>, which reports why a
+    /// block was refused; this overload is kept for callers that only need success or failure.
+    /// </summary>
+    public bool BlockApp(string exeName) => TryBlockApp(exeName) == BlockResult.Success;
+
+    /// <summary>
+    /// Blocks an executable from running, reporting the specific outcome so the caller can tell a
+    /// safety refusal from a permissions problem.
+    /// </summary>
+    public BlockResult TryBlockApp(string exeName)
+    {
+        if (string.IsNullOrWhiteSpace(exeName)) return BlockResult.EmptyName;
 
         if (!exeName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
             exeName += ".exe";
@@ -104,7 +145,7 @@ public sealed partial class AppBlockerService : IAppBlockerService
         if (!ExeNamePattern().IsMatch(exeName))
         {
             Log.Warning("Rejected invalid exeName: {ExeName}", exeName);
-            return false;
+            return BlockResult.InvalidName;
         }
 
         // Never block a boot/logon-critical process: an IFEO redirection here is
@@ -113,7 +154,7 @@ public sealed partial class AppBlockerService : IAppBlockerService
         if (BootCriticalExecutables.Contains(exeName))
         {
             Log.Warning("Refusing to block boot-critical executable: {ExeName}", exeName);
-            return false;
+            return BlockResult.BootCritical;
         }
 
         // Never block SysManager's own executable. UnblockApp requires the app to be
@@ -125,13 +166,13 @@ public sealed partial class AppBlockerService : IAppBlockerService
         if (OwnExecutableName is { } self && exeName.Equals(self, StringComparison.OrdinalIgnoreCase))
         {
             Log.Warning("Refusing to block SysManager's own executable: {ExeName}", exeName);
-            return false;
+            return BlockResult.OwnExecutable;
         }
 
         try
         {
             using var ifeo = _baseKey.OpenSubKey(IfeoPath, writable: true);
-            if (ifeo is null) return false;
+            if (ifeo is null) return BlockResult.RegistryFailure;
 
             using var appKey = ifeo.CreateSubKey(exeName, writable: true);
 
@@ -144,28 +185,28 @@ public sealed partial class AppBlockerService : IAppBlockerService
             {
                 Log.Warning("Refusing to block {ExeName}: an external Debugger value is already set ({Debugger})",
                     exeName, existingDebugger);
-                return false;
+                return BlockResult.ExternalDebuggerPresent;
             }
 
             appKey.SetValue("Debugger", BlockerDebugger, RegistryValueKind.String);
 
             Log.Information("Blocked application: {ExeName}", exeName);
-            return true;
+            return BlockResult.Success;
         }
         catch (UnauthorizedAccessException ex)
         {
             Log.Warning(ex, "Failed to block {ExeName} — admin required", exeName);
-            return false;
+            return BlockResult.AccessDenied;
         }
         catch (SecurityException ex)
         {
             Log.Warning(ex, "Failed to block {ExeName} — security exception", exeName);
-            return false;
+            return BlockResult.AccessDenied;
         }
         catch (IOException ex)
         {
             Log.Warning(ex, "Failed to block {ExeName} — IO error", exeName);
-            return false;
+            return BlockResult.RegistryFailure;
         }
     }
 

--- a/SysManager/SysManager/Services/IAppBlockerService.cs
+++ b/SysManager/SysManager/Services/IAppBlockerService.cs
@@ -17,6 +17,14 @@ public interface IAppBlockerService
     /// <summary>Blocks an executable from running. Returns true on success.</summary>
     bool BlockApp(string exeName);
 
+    /// <summary>
+    /// Blocks an executable, reporting the specific outcome. Prefer this over
+    /// <see cref="BlockApp"/> anywhere the result is shown to the user: several of the failure
+    /// modes are deliberate safety refusals rather than permissions problems, and a bare bool
+    /// cannot tell them apart.
+    /// </summary>
+    AppBlockerService.BlockResult TryBlockApp(string exeName);
+
     /// <summary>Unblocks an executable, allowing it to run again. Returns true on success.</summary>
     bool UnblockApp(string exeName);
 

--- a/SysManager/SysManager/Services/StandbyPreferenceService.cs
+++ b/SysManager/SysManager/Services/StandbyPreferenceService.cs
@@ -1,0 +1,116 @@
+// SysManager · StandbyPreferenceService — remembers the standby auto-purge settings
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Text.Json;
+using Serilog;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// The user's standby-list auto-purge settings, as stored on disk.
+/// </summary>
+/// <param name="AutoPurgeEnabled">Whether auto-purge should be armed on startup.</param>
+/// <param name="ThresholdMb">Available-RAM threshold, in MB, below which auto-purge fires.</param>
+public sealed record StandbyPreference(bool AutoPurgeEnabled, double ThresholdMb);
+
+/// <summary>
+/// Persists the Standby List Cleaner's auto-purge toggle and threshold. Auto-purge is a
+/// set-and-forget setting, so losing it on every restart made it effectively unusable: the
+/// user armed it, closed the app, and it silently reverted to off at 1 GB.
+/// <para>Stored beside the other per-user state in <c>%LOCALAPPDATA%\SysManager</c>, following
+/// the same shape as <see cref="ClosePreferenceService"/> and <see cref="VolumePresetService"/>:
+/// injectable directory, pure testable Serialize/Parse, file IO that never throws. An
+/// unreadable or out-of-range value falls back to the safe default (auto-purge off) rather than
+/// arming an automatic action the user did not choose.</para>
+/// </summary>
+public sealed class StandbyPreferenceService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    /// <summary>Default threshold when nothing has been saved — 1 GB, matching the previous default.</summary>
+    public const double DefaultThresholdMb = 1024;
+
+    /// <summary>
+    /// Lowest accepted threshold. Below this, auto-purge would fire almost continuously on a
+    /// machine under memory pressure, so a value this small is treated as corrupt.
+    /// </summary>
+    internal const double MinThresholdMb = 64;
+
+    /// <summary>
+    /// Highest accepted threshold — 1 TB. Above any real machine's RAM, so auto-purge would fire
+    /// on every tick; a value this large is treated as corrupt rather than honoured.
+    /// </summary>
+    internal const double MaxThresholdMb = 1024 * 1024;
+
+    private readonly string _path;
+
+    /// <summary>Creates the service. <paramref name="configDir"/> is overridable for tests.</summary>
+    public StandbyPreferenceService(string? configDir = null)
+    {
+        var dir = configDir ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager");
+        _path = Path.Combine(dir, "standby-preference.json");
+    }
+
+    /// <summary>The safe default: auto-purge off, threshold at 1 GB.</summary>
+    public static StandbyPreference Default => new(false, DefaultThresholdMb);
+
+    /// <summary>
+    /// Loads the saved settings, or <see cref="Default"/> when nothing is stored or the file
+    /// cannot be trusted. Never throws.
+    /// </summary>
+    public StandbyPreference Load()
+    {
+        try
+        {
+            if (!File.Exists(_path)) return Default;
+            return Parse(File.ReadAllText(_path));
+        }
+        catch (IOException ex) { Log.Debug("Standby preference load failed: {Error}", ex.Message); return Default; }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Standby preference load denied: {Error}", ex.Message); return Default; }
+    }
+
+    /// <summary>Saves the settings. Never throws; a failure just means the value is not remembered.</summary>
+    public void Save(StandbyPreference preference)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+            File.WriteAllText(_path, Serialize(preference));
+        }
+        catch (IOException ex) { Log.Debug("Standby preference save failed: {Error}", ex.Message); }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Standby preference save denied: {Error}", ex.Message); }
+    }
+
+    // ── Pure helpers (unit-testable, no file IO) ───────────────────────────
+
+    /// <summary>Serializes the settings to indented JSON.</summary>
+    public static string Serialize(StandbyPreference preference) =>
+        JsonSerializer.Serialize(preference, JsonOptions);
+
+    /// <summary>
+    /// Parses the settings, falling back to <see cref="Default"/> for null, blank, or malformed
+    /// input. An out-of-range threshold resets only that field — the toggle is still honoured —
+    /// but a value that cannot be read at all disarms auto-purge, because arming an automatic
+    /// system action on the strength of a corrupt file is the wrong way to fail.
+    /// </summary>
+    public static StandbyPreference Parse(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return Default;
+        try
+        {
+            var stored = JsonSerializer.Deserialize<StandbyPreference>(json);
+            if (stored is null) return Default;
+
+            var threshold = double.IsFinite(stored.ThresholdMb)
+                && stored.ThresholdMb is >= MinThresholdMb and <= MaxThresholdMb
+                    ? stored.ThresholdMb
+                    : DefaultThresholdMb;
+
+            return new StandbyPreference(stored.AutoPurgeEnabled, threshold);
+        }
+        catch (JsonException ex) { Log.Debug("Standby preference parse failed: {Error}", ex.Message); return Default; }
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.56.11</Version>
-    <FileVersion>1.56.11.0</FileVersion>
-    <AssemblyVersion>1.56.11.0</AssemblyVersion>
+    <Version>1.56.12</Version>
+    <FileVersion>1.56.12.0</FileVersion>
+    <AssemblyVersion>1.56.12.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
@@ -142,6 +142,12 @@ public sealed partial class AppAlertsViewModel : ViewModelBase
             AlertCount = Alerts.Count;
             UnacknowledgedCount = Alerts.Count(a => !a.IsAcknowledged);
             MonitorStatus = $"New app detected: {entry.Name}";
+
+            // Surface it outside this tab. The whole point of monitoring is to learn about an
+            // install you did not start, and the user is almost never sitting on this tab when
+            // that happens — the list entry and the status line were only visible to someone
+            // already looking at them, so a detection went unnoticed.
+            ToastService.Instance.Show("New app installed", entry.Name);
         });
     }
 

--- a/SysManager/SysManager/ViewModels/AppBlockerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppBlockerViewModel.cs
@@ -90,18 +90,41 @@ public sealed partial class AppBlockerViewModel : ViewModelBase
             $"Block \"{exeName}\" from running?\n\nThis will prevent the application from launching until you unblock it.",
             "Block Application — Confirm")) return;
 
-        var success = _blocker.BlockApp(exeName);
-        if (success)
+        var result = _blocker.TryBlockApp(exeName);
+        if (result == AppBlockerService.BlockResult.Success)
         {
             NewExeName = "";
             RefreshList();
             BlockStatus = $"Blocked {exeName}.";
             Log.Information("User blocked application: {ExeName}", exeName);
+            return;
         }
-        else
+
+        // Say which refusal it was. Every failure used to be reported as "check admin
+        // privileges", so a user blocked by a deliberate safety guard was sent to relaunch
+        // elevated — where the same guard refuses again, still without explaining itself.
+        BlockStatus = result switch
         {
-            BlockStatus = $"Failed to block {exeName} — check admin privileges.";
-        }
+            AppBlockerService.BlockResult.BootCritical =>
+                $"{exeName} is required for Windows to start, so SysManager will not block it. "
+                + "Blocking it could leave the computer unable to boot, with no way to undo it from here.",
+            AppBlockerService.BlockResult.OwnExecutable =>
+                $"{exeName} is SysManager itself. Blocking it would stop SysManager from launching, "
+                + "and unblocking has to be done from inside the app — so this one is refused.",
+            AppBlockerService.BlockResult.ExternalDebuggerPresent =>
+                $"Another program has already registered a debugger for {exeName}. SysManager will not "
+                + "overwrite it, because doing so would break that program's setup and could not be undone here.",
+            AppBlockerService.BlockResult.InvalidName =>
+                $"\"{exeName}\" is not a valid executable name. Enter just the file name, "
+                + "for example notepad.exe, without a folder path.",
+            AppBlockerService.BlockResult.EmptyName =>
+                "Enter an executable name (e.g., notepad.exe).",
+            AppBlockerService.BlockResult.AccessDenied =>
+                $"Windows denied the change needed to block {exeName}. This step needs administrator "
+                + "rights — restart SysManager as administrator and try again.",
+            _ =>
+                $"Could not block {exeName}: the registry change failed. The app log has the details."
+        };
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/StandbyMemoryViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StandbyMemoryViewModel.cs
@@ -21,19 +21,34 @@ namespace SysManager.ViewModels;
 public sealed partial class StandbyMemoryViewModel : ViewModelBase
 {
     private readonly StandbyMemoryService _service;
+    private readonly StandbyPreferenceService _preferences;
     private readonly DispatcherTimer? _timer;
+    // Suppresses saving while the constructor applies the loaded values, so restoring a
+    // preference does not immediately rewrite the same file.
+    private bool _loadingPreferences;
 
     [ObservableProperty] private string _totalDisplay = "—";
     [ObservableProperty] private string _availableDisplay = "—";
     [ObservableProperty] private string _loadDisplay = "—";
     [ObservableProperty] private bool _isElevated;
     [ObservableProperty] private bool _autoPurgeEnabled;
-    [ObservableProperty] private double _thresholdMb = 1024; // default 1 GB
+    [ObservableProperty] private double _thresholdMb = StandbyPreferenceService.DefaultThresholdMb;
 
-    public StandbyMemoryViewModel(StandbyMemoryService service)
+    public StandbyMemoryViewModel(StandbyMemoryService service, StandbyPreferenceService? preferences = null)
     {
         _service = service;
+        _preferences = preferences ?? new StandbyPreferenceService();
         IsElevated = AdminHelper.IsElevated();
+
+        // Auto-purge is set-and-forget, so losing it on restart made it effectively unusable:
+        // the user armed it, closed the app, and it silently reverted to off at the default
+        // threshold. Restore before the first Refresh so the very first tick already honours it.
+        _loadingPreferences = true;
+        var saved = _preferences.Load();
+        AutoPurgeEnabled = saved.AutoPurgeEnabled;
+        ThresholdMb = saved.ThresholdMb;
+        _loadingPreferences = false;
+
         Refresh();
         StatusMessage = IsElevated
             ? "Purge the standby list to free cached memory, or enable auto-purge."
@@ -53,6 +68,18 @@ public sealed partial class StandbyMemoryViewModel : ViewModelBase
     /// <summary>Pure: should auto-purge fire? True when available RAM is below the threshold.</summary>
     public static bool ShouldAutoPurge(double availableMb, double thresholdMb)
         => thresholdMb > 0 && availableMb > 0 && availableMb < thresholdMb;
+
+    // Persist on change rather than on close: the app can be closed to the tray or killed, and a
+    // setting the user visibly toggled should survive either.
+    partial void OnAutoPurgeEnabledChanged(bool value) => SavePreferences();
+
+    partial void OnThresholdMbChanged(double value) => SavePreferences();
+
+    private void SavePreferences()
+    {
+        if (_loadingPreferences) return;
+        _preferences.Save(new StandbyPreference(AutoPurgeEnabled, ThresholdMb));
+    }
 
     [RelayCommand]
     private void Refresh()


### PR DESCRIPTION
Closes #1610
Closes #1606
Closes #1605

Three features that worked internally but never reached the user. Each refuted against current source first.

## App Alerts never told anyone (#1610)

`AppAlertService` raises `NewAppDetected` correctly, and `AppAlertsViewModel` handles it — by inserting a row and setting a status string. Both are visible **only to someone already looking at that tab**.

The point of the feature is learning about an install you did not start, which is precisely when you are not watching it. It now raises a notification through `ToastService` — already used in the same file for a far less important event ("Installed apps loaded").

## Standby auto-purge forgot itself (#1606)

`AutoPurgeEnabled` and `ThresholdMb` were plain `[ObservableProperty]` fields with no persistence anywhere in the view model. Arming auto-purge and closing the app silently reverted it to off at 1 GB — a set-and-forget feature that does not survive a restart is not usable.

Added `StandbyPreferenceService`, following `ClosePreferenceService` and `VolumePresetService` exactly: injectable directory, pure testable `Serialize`/`Parse`, file IO that never throws. Saved on change rather than on close, because the app can be closed to the tray or killed.

Failure modes lean safe in two different directions, deliberately:
- an **unreadable file** → auto-purge OFF (never arm an automatic system action on a corrupt file)
- an **out-of-range threshold** → reset that field only, keep the toggle (a bad number should not disarm a feature the user turned on)

## App Blocker blamed your permissions for its own refusals (#1605)

`BlockApp` returned a bare `bool` for **six** distinct causes — four of them deliberate safety guards — and the UI reported all of them as "check admin privileges":

| Cause | What the user was told | What it actually was |
|---|---|---|
| boot-critical exe | check admin privileges | refused: could leave Windows unbootable |
| SysManager's own exe | check admin privileges | refused: unblocking must happen in-app |
| external debugger set | check admin privileges | refused: would clobber another tool's setup |
| invalid name | check admin privileges | the name had a path or bad characters |
| registry denied | check admin privileges | ✅ genuinely about rights |

So someone blocking `winlogon.exe` was sent to restart elevated, where the boot-critical guard refuses again for the same reason — still unstated.

Added `TryBlockApp` returning a typed `BlockResult`; `BlockApp` stays as a thin wrapper for callers that only need success/failure. The view model now explains each case, and **only** `AccessDenied` mentions administrator rights.

## Tests

**26 new cases.** Standby persistence (18): round-trip across separate instances (an app restart, which is the point), last-write-wins, directory creation, and 13 negative cases covering malformed JSON, `NaN`/`Infinity`, out-of-range values, and boundaries exactly at the floor and ceiling. Block refusals (8): each cause pinned to its own result, plus proof that a refusal **writes nothing to the registry** and that the bool overload has not drifted from the typed one.

The block tests run against a redirected HKCU hive via the existing injectable registry root — no admin, no machine writes.

## Verification

Exercised against the built assembly in a console harness: **11/11**, covering every refusal path and a real save/reload cycle for the standby settings.

All four projects: Release build, **0 warnings, 0 errors**. Leak scan over 532 added lines: 28 terms, clean.

## Docs

README documents both user-visible behaviours (the install notification, and that auto-purge is remembered). ARCHITECTURE documents `StandbyPreferenceService` alongside its two siblings.
