### PR TITLE
fix: scrub the user name from the log at the sink, not per call site

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -172,7 +172,13 @@ Key services:
   wear into a single 0–100 score with color-coded verdict and recommendations.
 - `TrayIconService` — system tray icon with background monitoring (60s),
   tooltip updates, context menu, and Windows toast notifications.
-- `LogService` — Serilog wrapper with rolling file sink.
+- `LogService` — Serilog wrapper with a rolling file sink, wrapped by
+  `UserPathScrubbingSink`. That wrapper renders each event and runs the finished line through
+  `SanitizePath` before writing, so the Windows user name cannot reach the log regardless of
+  which call site produced it. Sanitizing at the sink rather than per call site is deliberate:
+  `SanitizePath` was called at 15 of 75 path-logging sites, so exposure depended on which
+  service happened to fail, and no call-site fix can reach a path inside exception text —
+  Serilog renders that separately from the message properties.
 - `FixedDriveService` — enumerate fixed NTFS/ReFS volumes.
 - `DeepCleanupService` — scan-first safe cleanup (vendor caches, gaming
   launcher caches, Windows caches). Per-file try/catch so locked files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.56.13] - 2026-08-04
+
+### Fixed
+- **Your Windows user name is now removed from every line of the diagnostic log.** The app already had a helper for this, but only 15 of the 75 places that log a file path actually called it — so whether your account name ended up in the log depended on which part of the app happened to run into trouble. The removal now happens where the log is written, so it covers every existing message, every future one, and paths that appear inside error text (which no per-message fix could reach). Log files stay local and are never uploaded; this matters for a log you choose to share yourself, for example when reporting a problem.
+
 ## [1.56.12] - 2026-08-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Everything runs on the machine itself. No cloud, no telemetry, no account.
 > winget. App icons in the Bulk Installer are an **opt-in** extra — off by default, and
 > only when you tick "Load app icons from the web" does it fetch them from Google's
 > favicon service. Nothing else leaves your PC.
+>
+> The local diagnostic log keeps 14 days of rolling files in
+> `%LocalAppData%\SysManager\logs`, and your Windows user name is replaced with `[user]`
+> in every line — including inside error messages — so a log you choose to share does
+> not carry your account name with it.
 
 Built with gamers in mind — live ping overlays for CS2, FACEIT, PUBG and streaming
 endpoints, Steam/Epic/Battle.net/Riot/GOG/EA launcher cache cleanup, and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -106,6 +106,14 @@ What the app can and cannot do by design:
 - **External CLI downloads**: the Ookla speed-test CLI is downloaded from
   `install.speedtest.net` the first time it's used. If that URL changes,
   the feature fails safely rather than substituting an alternative.
+- **Local diagnostic log**: SysManager keeps 14 days of rolling log files in
+  `%LocalAppData%\SysManager\logs`. They never leave the machine on their own —
+  there is no upload path. Your Windows user name is replaced with `[user]` on
+  every line before it is written, including inside exception messages, so a log
+  you choose to share for a bug report does not carry your account name. The
+  replacement happens in the log sink rather than at each logging call, so a new
+  code path cannot forget it. Paths outside your user profile, such as
+  `C:\Program Files\...`, are recorded as-is.
 - **Auto-update**: new builds are downloaded from the official GitHub
   Releases endpoint. The app does not auto-install without an explicit
   click. Before applying, the downloaded binary's SHA256 is compared against

--- a/SysManager/SysManager.Tests/LogServiceSinkScrubbingTests.cs
+++ b/SysManager/SysManager.Tests/LogServiceSinkScrubbingTests.cs
@@ -1,0 +1,179 @@
+// SysManager · LogServiceSinkScrubbingTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Reflection;
+using Serilog;
+using Serilog.Core;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Proves the log sink actually applies <see cref="LogService.SanitizePath"/> to what it writes.
+/// <para>The existing <c>LogServiceSanitize*Tests</c> cover the regex itself; these cover the
+/// wiring, which is where the defect was. <c>SanitizePath</c> existed and worked, but only 15 of
+/// 75 path-logging call sites called it — so whether a user name reached the log depended on
+/// which service happened to fail. Sanitizing at the sink is what makes that unconditional, and
+/// only an end-to-end assertion over the written file can show it.</para>
+/// <para>Each test writes through the real sink type into a temp file and reads the bytes back,
+/// rather than asserting on an in-memory structure: the exception text is rendered by the sink,
+/// so it is invisible to any check that inspects log-event properties.</para>
+/// </summary>
+public sealed class LogServiceSinkScrubbingTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _logPath;
+
+    public LogServiceSinkScrubbingTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "SysManagerSinkTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+        _logPath = Path.Combine(_dir, "probe.log");
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch (IOException) { /* a leftover temp dir must never fail a test run */ }
+    }
+
+    /// <summary>The real, private sink type from the app assembly — not a re-implementation.</summary>
+    private ILogEventSink NewSink()
+    {
+        var sinkType = typeof(LogService).GetNestedType("UserPathScrubbingSink", BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("UserPathScrubbingSink not found — was it renamed?");
+        return (ILogEventSink)Activator.CreateInstance(
+            sinkType, [_logPath, RollingInterval.Infinite, 14])!;
+    }
+
+    private string WriteAndRead(Action<ILogger> write)
+    {
+        var sink = NewSink();
+        using (var logger = new LoggerConfiguration().MinimumLevel.Debug().WriteTo.Sink(sink).CreateLogger())
+            write(logger);
+        (sink as IDisposable)?.Dispose();
+        return File.ReadAllText(_logPath);
+    }
+
+    /// <summary>This machine's Windows user name — what must never appear in the output.</summary>
+    private static string CurrentUserName =>
+        Path.GetFileName(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+
+    private static string UserPath(params string[] parts) =>
+        Path.Combine([Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), .. parts]);
+
+    [Fact]
+    public void Sink_ScrubsAPathPassedAsAProperty()
+    {
+        // The shape of the ~60 call sites that never called SanitizePath themselves.
+        var text = WriteAndRead(log =>
+            log.Information("New app folder detected: {Path}", UserPath("AppData", "Local", "Thing")));
+
+        Assert.DoesNotContain(CurrentUserName, text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("[user]", text);
+    }
+
+    [Fact]
+    public void Sink_ScrubsAPathInsideExceptionText()
+    {
+        // The case a per-call-site fix cannot reach, and the one my first attempt at this fix
+        // (a property enricher) missed: Serilog renders the exception separately from the
+        // message properties, so the path never passes through a property at all.
+        var text = WriteAndRead(log =>
+        {
+            try { throw new IOException($"Cannot open {UserPath("Documents", "x.txt")}"); }
+            catch (IOException ex) { log.Warning(ex, "Failed to read {File}", "x.txt"); }
+        });
+
+        Assert.Contains("Cannot open", text);          // the exception is still logged
+        Assert.DoesNotContain(CurrentUserName, text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Sink_ScrubsAPathAppearingOnlyInTheMessageText()
+    {
+        // Some call sites interpolate the path into the message rather than passing it as a
+        // property. Those are covered too, because the scrub runs over the rendered line.
+        var text = WriteAndRead(log =>
+            log.Information("Copied to " + UserPath("Desktop", "report.txt")));
+
+        Assert.DoesNotContain(CurrentUserName, text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Sink_LeavesNonPathTextAlone()
+    {
+        var text = WriteAndRead(log =>
+        {
+            log.Information("Blocked application: {ExeName}", "notepad.exe");
+            log.Information("Pruned {Count} superseded update download(s)", 3);
+        });
+
+        Assert.Contains("notepad.exe", text);
+        Assert.Contains("Pruned 3 superseded update download(s)", text);
+    }
+
+    [Fact]
+    public void Sink_PreservesTheTimestampAndLevelFormat()
+    {
+        // Scrubbing must not quietly change the log format — the file is read by a human and
+        // referenced in support instructions.
+        var text = WriteAndRead(log =>
+        {
+            log.Information("info line");
+            log.Warning("warning line");
+            log.Debug("debug line");
+        });
+
+        Assert.Contains("[INF]", text);
+        Assert.Contains("[WRN]", text);
+        Assert.Contains("[DBG]", text);
+        Assert.Matches(@"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} \[INF\] info line", text);
+    }
+
+    [Fact]
+    public void Sink_TreatsBracesInTextAsLiteralNotAsATemplate()
+    {
+        // The scrubbed line is re-written through the inner logger, so any braces in the text
+        // must not be re-parsed as a message template (which would corrupt or drop the output).
+        var text = WriteAndRead(log =>
+            log.Information("Value was {Value}", "{not a template}"));
+
+        Assert.Contains("{not a template}", text);
+    }
+
+    [Fact]
+    public void Sink_ScrubsEveryOccurrenceOnOneLine()
+    {
+        var text = WriteAndRead(log =>
+            log.Information("Moved {From} to {To}", UserPath("a.txt"), UserPath("b.txt")));
+
+        Assert.DoesNotContain(CurrentUserName, text, StringComparison.OrdinalIgnoreCase);
+        // Both paths were rewritten, not just the first.
+        Assert.Equal(2, text.Split("[user]").Length - 1);
+    }
+
+    [Fact]
+    public void Sink_HonoursTheOuterLoggerLevelFilter()
+    {
+        // The inner logger runs at Verbose so it never re-filters, which means the outer
+        // logger's level must still be what decides. Otherwise raising MinimumLevel would
+        // silently stop working.
+        var sink = NewSink();
+        using (var logger = new LoggerConfiguration()
+            .MinimumLevel.Warning()
+            .WriteTo.Sink(sink)
+            .CreateLogger())
+        {
+            logger.Debug("should not appear");
+            logger.Warning("should appear");
+        }
+        (sink as IDisposable)?.Dispose();
+
+        var text = File.ReadAllText(_logPath);
+        Assert.DoesNotContain("should not appear", text);
+        Assert.Contains("should appear", text);
+    }
+}

--- a/SysManager/SysManager/Services/LogService.cs
+++ b/SysManager/SysManager/Services/LogService.cs
@@ -2,10 +2,14 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
 using Serilog;
 using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting.Display;
+using Serilog.Parsing;
 
 namespace SysManager.Services;
 
@@ -44,16 +48,75 @@ public static partial class LogService
     public static void Init()
     {
         Directory.CreateDirectory(LogDir);
+        // Scrub the user name centrally, on the way to the file. SanitizePath already existed and
+        // was applied at 15 call sites, while 60 others logged a raw path — so whether the user's
+        // name reached the log depended on which service happened to fail. Sanitizing at the sink
+        // covers every existing call site, every future one, and (unlike a per-call-site fix or a
+        // property enricher) also the exception text, which Serilog renders separately from the
+        // message properties.
         Logger = new LoggerConfiguration()
             .MinimumLevel.Debug()
-            .WriteTo.File(
+            .WriteTo.Sink(new UserPathScrubbingSink(
                 Path.Combine(LogDir, "sysmanager-.log"),
                 rollingInterval: RollingInterval.Day,
-                retainedFileCountLimit: 14,
-                outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] {Message:lj}{NewLine}{Exception}")
+                retainedFileCountLimit: 14))
             .CreateLogger();
         Log.Logger = Logger;
         Logger.Information("SysManager started");
+    }
+
+    /// <summary>
+    /// Writes to the rolling log file with the Windows user name removed from the whole rendered
+    /// line — message, properties, and exception text alike.
+    /// <para>Sanitizing here rather than at each call site means a new <c>Log.Information(... path
+    /// ...)</c> anywhere in the app is covered by default, instead of relying on whoever writes it
+    /// to remember <see cref="SanitizePath"/>. It also catches paths inside exception messages,
+    /// which no call-site fix can reach because the exception is rendered by the sink.</para>
+    /// </summary>
+    private sealed class UserPathScrubbingSink : ILogEventSink, IDisposable
+    {
+        private const string Template =
+            "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] {Message:lj}{NewLine}{Exception}";
+
+        private readonly Logger _inner;
+
+        public UserPathScrubbingSink(
+            string path, RollingInterval rollingInterval, int retainedFileCountLimit)
+        {
+            _inner = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.File(
+                    path,
+                    rollingInterval: rollingInterval,
+                    retainedFileCountLimit: retainedFileCountLimit,
+                    outputTemplate: "{Message:lj}{NewLine}")
+                .CreateLogger();
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            // Render the event exactly as the file sink would, scrub the finished line, then write
+            // it as a single pre-formatted message. Rendering first is what makes the exception
+            // text reachable; scrubbing the rendered string is also cheaper than walking a
+            // structured tree, and cannot miss a nested or destructured value.
+            var writer = new StringWriter();
+            new MessageTemplateTextFormatter(Template, CultureInfo.InvariantCulture)
+                .Format(logEvent, writer);
+
+            var scrubbed = SanitizePath(writer.ToString().TrimEnd('\r', '\n'));
+
+            // Written through Verbose so the inner logger never re-filters an event the outer
+            // logger already allowed, and as a literal to keep any braces in the text from being
+            // read as a new message template.
+            _inner.Write(new LogEvent(
+                logEvent.Timestamp,
+                LogEventLevel.Verbose,
+                exception: null,
+                new MessageTemplateParser().Parse("{Line}"),
+                [new LogEventProperty("Line", new ScalarValue(scrubbed))]));
+        }
+
+        public void Dispose() => _inner.Dispose();
     }
 
     public static void Shutdown()

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.56.12</Version>
-    <FileVersion>1.56.12.0</FileVersion>
-    <AssemblyVersion>1.56.12.0</AssemblyVersion>
+    <Version>1.56.13</Version>
+    <FileVersion>1.56.13.0</FileVersion>
+    <AssemblyVersion>1.56.13.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #1638

`LogService.SanitizePath` existed and worked — and was called at **15 of the 75** places that log a file path. So whether the user's Windows account name reached the log depended on which service happened to fail: `UpdateService` and `SpeedTestService` sanitized; the other 60 call sites across `AppAlertService`, `DeepCleanupService`, `ContextMenuService` and the rest did not.

## Fixed at the sink, not at 60 call sites

`UserPathScrubbingSink` renders each event with the same output template the file sink used, runs the finished line through `SanitizePath`, and writes it as a pre-formatted message. One change covers every existing call site, every future one, and paths inside exception text.

## Why a sink wrapper and not an enricher

My first attempt was a property enricher. It looked right and passed the obvious checks — then failed a probe that logged an `IOException` whose message contained a path:

```
PASS  placeholder present instead
FAIL  user name absent from the whole log file
FAIL  exception-embedded path also scrubbed
```

```
System.IO.IOException: Cannot open C:\Users\<my actual user name>\Documents\x.txt
```

Serilog renders the exception **separately from the message properties**, so an enricher never sees it — and neither could any per-call-site fix. That gap only showed up because the probe wrote to a real file and read the bytes back, instead of asserting on the regex.

After moving the scrub to the sink, all six probe checks passed, including the exception case.

## One correction to the issue

The issue states that users are told to attach the log to bug reports. **They are not** — no issue template and no `SUPPORT.md` mentions the log at all. So the exposure is smaller than described: it matters when a user *chooses* to share a log, not because the project asks them to.

The inconsistency was still worth closing, and the docs now state the guarantee so that sharing a log is safe by default.

## Tests

8 cases, all asserting over the **actual written file** — anything that inspects log-event properties cannot see the rendered exception, which is precisely where the bug hid:

- a path passed as a property (the 60 unsanitized call sites)
- a path inside exception text (what the enricher missed)
- a path interpolated into the message rather than passed as an argument
- non-path text left untouched
- the timestamp and level format preserved (the log is read by humans)
- literal braces surviving the re-write (the scrubbed line is re-logged, so braces must not be re-parsed as a template)
- every occurrence on a line replaced, not just the first
- the outer logger's level filter still deciding what gets written — the inner logger runs at `Verbose` so it never re-filters, which would otherwise silently break `MinimumLevel`

Verified against the built assembly before pushing: **8/8**, mirroring each assertion.

## Verification

All four projects: Release build, **0 warnings, 0 errors**. Leak scan over 273 added lines: 28 terms, clean.

## Docs

README (network/privacy note), SECURITY (a new "Local diagnostic log" bullet in the security model), and ARCHITECTURE all document the guarantee — including the honest limit that paths outside the user profile, like `C:\Program Files\...`, are recorded as-is. The 14-day retention claim was re-derived from `RollingInterval.Day` + `retainedFileCountLimit: 14` rather than quoted.
