### PR TITLE
fix: dispose the StringWriter in the log sink and hoist its formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.56.14] - 2026-08-05
+
+### Fixed
+- **Tidied up the log writer added in 1.56.13.** It created a small text buffer for every log line without releasing it, and rebuilt its formatter on each call. Both are now handled once, so logging allocates less and leaves nothing behind. No change to what ends up in the log.
+
 ## [1.56.13] - 2026-08-04
 
 ### Fixed

--- a/SysManager/SysManager.Tests/LogServiceSinkScrubbingTests.cs
+++ b/SysManager/SysManager.Tests/LogServiceSinkScrubbingTests.cs
@@ -176,4 +176,24 @@ public sealed class LogServiceSinkScrubbingTests : IDisposable
         Assert.DoesNotContain("should not appear", text);
         Assert.Contains("should appear", text);
     }
+
+    [Fact]
+    public void Sink_IsSafeUnderConcurrentWrites()
+    {
+        // The formatter and the "{Line}" template are shared statics — they were allocated per
+        // event before, which cost an allocation and a constant-template re-parse on every log
+        // call. Both are stateless, but that has to be proven rather than assumed: logging happens
+        // from background scans, poll timers and the UI thread at once, so a shared mutable buffer
+        // here would interleave or drop lines.
+        const int writes = 400;
+
+        var text = WriteAndRead(log =>
+            Parallel.For(0, writes, i => log.Information("Line {Index} at {Path}", i, UserPath($"f{i}.txt"))));
+
+        var lines = text.Split('\n').Where(l => l.Contains("[INF]")).ToArray();
+        Assert.Equal(writes, lines.Length);
+        Assert.DoesNotContain(CurrentUserName, text, StringComparison.OrdinalIgnoreCase);
+        // Every line is individually intact — no two events rendered into each other.
+        Assert.All(lines, line => Assert.Matches(@"\[INF\] Line \d+ at ", line));
+    }
 }

--- a/SysManager/SysManager/Services/LogService.cs
+++ b/SysManager/SysManager/Services/LogService.cs
@@ -78,6 +78,15 @@ public static partial class LogService
         private const string Template =
             "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] {Message:lj}{NewLine}{Exception}";
 
+        // Both are stateless and thread-safe once constructed, and Emit runs on every log call —
+        // building them per event allocated a formatter and re-parsed a constant template each
+        // time, for no benefit.
+        private static readonly MessageTemplateTextFormatter Formatter =
+            new(Template, CultureInfo.InvariantCulture);
+
+        private static readonly MessageTemplate LineTemplate =
+            new MessageTemplateParser().Parse("{Line}");
+
         private readonly Logger _inner;
 
         public UserPathScrubbingSink(
@@ -99,11 +108,12 @@ public static partial class LogService
             // it as a single pre-formatted message. Rendering first is what makes the exception
             // text reachable; scrubbing the rendered string is also cheaper than walking a
             // structured tree, and cannot miss a nested or destructured value.
-            var writer = new StringWriter();
-            new MessageTemplateTextFormatter(Template, CultureInfo.InvariantCulture)
-                .Format(logEvent, writer);
-
-            var scrubbed = SanitizePath(writer.ToString().TrimEnd('\r', '\n'));
+            string scrubbed;
+            using (var writer = new StringWriter())
+            {
+                Formatter.Format(logEvent, writer);
+                scrubbed = SanitizePath(writer.ToString().TrimEnd('\r', '\n'));
+            }
 
             // Written through Verbose so the inner logger never re-filters an event the outer
             // logger already allowed, and as a literal to keep any braces in the text from being
@@ -112,7 +122,7 @@ public static partial class LogService
                 logEvent.Timestamp,
                 LogEventLevel.Verbose,
                 exception: null,
-                new MessageTemplateParser().Parse("{Line}"),
+                LineTemplate,
                 [new LogEventProperty("Line", new ScalarValue(scrubbed))]));
         }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.56.13</Version>
-    <FileVersion>1.56.13.0</FileVersion>
-    <AssemblyVersion>1.56.13.0</AssemblyVersion>
+    <Version>1.56.14</Version>
+    <FileVersion>1.56.14.0</FileVersion>
+    <AssemblyVersion>1.56.14.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
fix: dispose the StringWriter in the log sink and hoist its formatter

Fixes the one warning-level CodeQL alert in the repository (cs/local-not-disposed,
LogService.cs:102) — introduced by my own change in #1700, so it is a regression I shipped
rather than pre-existing debt.

The StringWriter used to render each log event was never disposed. Low impact in practice
(StringWriter over a StringBuilder holds no unmanaged handle), but it is a real leak of the
finalizable-object kind, it fires on every single log call, and leaving the repository's only
warning-level alert standing sets the wrong baseline.

While in there, hoisted two per-event allocations to static readonly fields: the
MessageTemplateTextFormatter, and the parsed "{Line}" template. Emit runs on every log call
and was constructing a formatter and re-parsing a constant template each time, for nothing.

Both are stateless, but sharing them makes concurrency a claim that has to be proven rather
than assumed — logging happens from background scans, poll timers and the UI thread at once.
Added a test that writes 400 events through Parallel.For and asserts all 400 land, none
interleave, and no user name leaks under contention.

Checked the class rather than the instance: grepped the whole app for an undisposed
StringWriter / StreamWriter / MemoryStream / StringReader and this was the only one.

Behaviour is unchanged, and verified so rather than asserted: all 8 existing sink assertions
re-run against the built assembly (property paths, exception text, message-only paths,
non-path text, the timestamp/level format, literal braces, every occurrence on a line, and
the outer level filter), plus the 3 new concurrency ones — 11/11.

All four projects build with 0 warnings and 0 errors.
