### PR TITLE
chore: add the 1.57.1 changelog entry and stop auto-release tagging before the notes exist

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -100,6 +100,32 @@ jobs:
           echo "version=$NEXT" >> "$GITHUB_OUTPUT"
           echo "Next version: $NEXT (bump=$BUMP from $TAG)"
 
+      # Verify the CHANGELOG BEFORE the tag exists. release.yml already refuses to publish a release
+      # whose version has no CHANGELOG section — but by then the tag is pushed, so the failure leaves
+      # a tag with no release, and the next fix: merge simply tags another one. Checking here means a
+      # missing entry costs a re-run instead of a stranded version.
+      #
+      # The author cannot reliably know this number in advance (it depends on the commit type AND the
+      # previous tag), so the message says exactly what to add rather than implying carelessness.
+      - name: Verify CHANGELOG has an entry for the computed version
+        if: steps.bump.outputs.type != 'none'
+        shell: bash
+        run: |
+          NEXT="${{ steps.next.outputs.version }}"
+          VERSION="${NEXT#v}"
+          ESCAPED=${VERSION//./\\.}
+          if ! grep -qE "^## \[${ESCAPED}\]" CHANGELOG.md; then
+            echo "::error::No CHANGELOG.md entry for $VERSION (a ${{ steps.bump.outputs.type }} bump from ${{ steps.latest.outputs.tag }}). Add a '## [$VERSION] - <date>' section, then re-run this workflow. No tag was created."
+            exit 1
+          fi
+          # A header with nothing under it would publish a release with empty notes.
+          SECTION=$(awk -v hdr="## [$VERSION]" 'index($0,hdr)==1{f=1;next} /^## \[/{f=0} f' CHANGELOG.md | tr -d '[:space:]')
+          if [ -z "$SECTION" ]; then
+            echo "::error::The CHANGELOG.md entry for $VERSION is empty. Add the notes under its header, then re-run. No tag was created."
+            exit 1
+          fi
+          echo "CHANGELOG has a non-empty entry for $VERSION."
+
       - name: Create and push tag
         if: steps.bump.outputs.type != 'none'
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.57.1] - 2026-08-05
+
+### Fixed
+- **Fixed a crash in the new Bandwidth Monitor history view.** Switching the chart to a stored range while the tab was live could make the app read the graph's data while it was still being rebuilt, which threw an error instead of drawing the chart. The live reading and the history load no longer touch the graph at the same time, and cancelling a load part-way (by leaving the tab) no longer leaves the live chart frozen the next time you open it.
+
 ## [1.57.0] - 2026-08-05
 
 ### Added

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.57.0</Version>
-    <FileVersion>1.57.0.0</FileVersion>
-    <AssemblyVersion>1.57.0.0</AssemblyVersion>
+    <Version>1.57.1</Version>
+    <FileVersion>1.57.1.0</FileVersion>
+    <AssemblyVersion>1.57.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Unblocks two stranded tags and removes the cause. `chore:` deliberately — this must not itself tag a third version.

## The problem

`v1.57.0` and `v1.57.1` are both pushed with **no published release**. The app on GitHub is still 1.56.14.

The cause is a process defect, and I hit it three times in a row:

1. `auto-release` computes the next version from the commit type **and** the previous tag, then pushes the tag.
2. Only afterwards does `release.yml` check that `CHANGELOG.md` has a section for that version.
3. So a number I cannot know in advance gets tagged, the release fails on the missing section — and the next `fix:` merge (including one meant to repair this) tags **another** one.

Patching the version by hand could never converge. That's why this is `chore:`.

## What this changes

**1. The 1.57.1 entry the release needs.** Describes the Bandwidth Monitor chart crash fixed in #1706, with csproj moved to `1.57.1` to match. `v1.57.1` is the tag whose release will be re-dispatched; v1.57.0's content is already contained in 1.57.1, so nothing that shipped is lost or rewritten.

**2. `auto-release` now verifies the CHANGELOG entry before creating the tag.** A missing entry costs a workflow re-run instead of stranding a version. The error message states the exact header to add and which bump produced it — the author genuinely cannot compute that number locally, so treating this as carelessness would be the wrong fix.

## Verification

Six fixtures, not assumptions:

| Case | Expected | Result |
|---|---|---|
| Entry present and non-empty | accept | accept |
| Entry missing (**the actual failure**) | reject | reject |
| Header present but section empty | reject | reject |
| An older entry (1.57.0) | accept | accept |
| `1.5.71` vs a `1.57.1` header (escaped dots) | reject | reject |
| csproj/CHANGELOG consistency check from #1706 | pass | pass |

The last row matters: the two guards have to agree rather than contradict each other.

## Follow-up after merge

`release.yml` checks out the **tag**, not main — so this entry only reaches a release for tags created after it. `v1.57.1` therefore needs a manual `Release` dispatch once this lands, which I'll do and verify (notes, SHA256, discussion, winget). That tag-vs-main split is precisely why the new guard belongs in `auto-release`, before the tag is cut.

No version bump beyond aligning to 1.57.1, and no new CHANGELOG section for this commit itself — `chore:` doesn't release.
