### PR TITLE
ci: keep the release announcement independent of winget, and serialize the bandwidth reloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,13 +320,42 @@ jobs:
             --jq '.behind_by' 2>/dev/null || echo "unknown")
           echo "Fork is now behind by: $after commit(s)"
 
+      # continue-on-error: publishing to winget depends on a third-party repository and on a PAT that
+      # can expire. When this broke on 1.57.2 ("does not have the correct permissions to execute
+      # CreateRef") it took down every step after it — so the release existed on GitHub with its
+      # binary, checksum, SBOM and attestation, but no announcement was ever posted. Telling users
+      # about a release that IS published must not depend on a second distribution channel. The
+      # failure is still surfaced: the step stays red and the step below writes a loud summary.
       - name: Update winget package
+        id: winget
+        continue-on-error: true
         uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: laurentiu021.SysManager
           installers-regex: '\.exe$'
           release-tag: ${{ steps.version.outputs.tag }}
           token: ${{ secrets.WINGET_TOKEN }}
+
+      # Make a skipped winget publish impossible to miss. With continue-on-error the job goes green
+      # (correctly — the release did publish), so without this the only trace would be one red step
+      # inside a passing run, which is exactly the kind of thing that goes unnoticed for weeks.
+      - name: Report a failed winget publish
+        if: steps.winget.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning title=winget publish failed::${{ steps.version.outputs.tag }} is published on GitHub but did NOT reach winget. Users upgrading via 'winget upgrade' will not see it until this is resolved."
+          {
+            echo "### winget publish failed"
+            echo
+            echo "\`${{ steps.version.outputs.tag }}\` **is** published on GitHub — binary, checksum, SBOM and attestation are all present."
+            echo "It did **not** reach winget, so \`winget upgrade\` will not offer it yet."
+            echo
+            echo "Most likely causes, in the order worth checking:"
+            echo "1. The \`WINGET_TOKEN\` secret has expired or been revoked — it is a PAT with a finite lifetime."
+            echo "2. The \`laurentiu021/winget-pkgs\` fork has drifted from upstream; the sync step above reports the count."
+            echo
+            echo "Re-run this workflow once fixed. The release itself does not need to be recreated."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Post announcement to Discussions
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/SysManager/SysManager.Tests/BandwidthMonitorViewModelTests.cs
+++ b/SysManager/SysManager.Tests/BandwidthMonitorViewModelTests.cs
@@ -266,6 +266,68 @@ public class BandwidthMonitorViewModelTests : IDisposable
     }
 
     [Fact]
+    public async Task ConcurrentReloadsDoNotCorruptTheChartSeries()
+    {
+        // Regression pin for a flaky CI failure that took two attempts to diagnose correctly.
+        //
+        // Assigning SelectedRange fires ReloadHistoryAsync fire-and-forget from its changed-handler,
+        // and the Refresh button fires the same command directly — so a click during a load, or two
+        // quick range changes, runs two reloads at once. Both call ReplaceWith on buffers LiveCharts
+        // is observing, and its CollectionDeepObserver updates a HashSet from the change notification;
+        // a second thread arriving mid-notification corrupts it and throws either "Collection was
+        // modified" or "Operations that change non-concurrent collections must have exclusive access".
+        //
+        // My first fix guarded the POLL LOOP against the reload, which was the wrong culprit: this
+        // test never sets IsActive, so the poll loop never samples. Reloads racing EACH OTHER is the
+        // actual mechanism, hence a gate around the whole method.
+        var now = DateTime.Now;
+        var history = SeededHistory(
+            new BandwidthSample(now.AddDays(-3), 1_048_576, 0),
+            new BandwidthSample(now.AddMinutes(-10), 2_097_152, 262_144));
+        using var vm = NewVm(history: history);
+
+        var hourly = vm.RangeOptions.First(r => r.Range == TimeSpan.FromHours(1));
+        var weekly = vm.RangeOptions.First(r => r.Range == TimeSpan.FromDays(BandwidthHistoryService.RetentionDays));
+
+        // Force the overlap deliberately: fire many reloads without awaiting between them, alternating
+        // the range so each one has real work to do.
+        var inFlight = new List<Task>();
+        for (int i = 0; i < 24; i++)
+        {
+            vm.SelectedRange = i % 2 == 0 ? hourly : weekly;           // the handler starts one
+            inFlight.Add(vm.ReloadHistoryCommand.ExecuteAsync(null));   // and this starts another
+        }
+
+        // The assertion is that none of them threw — the corruption surfaced as an exception, not as
+        // wrong data. Task.WhenAll rethrows the first failure.
+        await Task.WhenAll(inFlight);
+
+        // And the chart is still coherent afterwards: both series present and equally long.
+        var down = (vm.ThroughputSeries[0].Values as System.Collections.IEnumerable)!.Cast<object>().Count();
+        var up = (vm.ThroughputSeries[1].Values as System.Collections.IEnumerable)!.Cast<object>().Count();
+        Assert.Equal(down, up);
+    }
+
+    [Fact]
+    public async Task ARedundantRefreshOnTheSameRangeStillEndsOnThatRange()
+    {
+        // The gate drops nothing user-visible: whichever range is selected is what ends up shown, even
+        // when a second reload arrives for it.
+        var now = DateTime.Now;
+        var history = SeededHistory(
+            new BandwidthSample(now.AddDays(-3), 1_048_576, 0),
+            new BandwidthSample(now.AddMinutes(-10), 1_048_576, 0));
+        using var vm = NewVm(history: history);
+
+        vm.SelectedRange = vm.RangeOptions.First(r => r.Range == TimeSpan.FromDays(BandwidthHistoryService.RetentionDays));
+        await vm.ReloadHistoryCommand.ExecuteAsync(null);
+        await vm.ReloadHistoryCommand.ExecuteAsync(null);   // a redundant Refresh on the same range
+
+        Assert.True(vm.ShowingHistory);
+        Assert.Contains("2 recorded sample(s)", vm.StatusMessage);
+    }
+
+    [Fact]
     public async Task AStoredRangeIsDownsampledToTheChartCap()
     {
         // A week of 5-second samples is ~120k points. Handing that to LiveCharts would stall the UI,

--- a/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
@@ -147,6 +147,12 @@ public sealed partial class BandwidthMonitorViewModel : ViewModelBase
     /// </summary>
     private bool _historyOwnsChart;
 
+    /// <summary>
+    /// Serializes <see cref="ReloadHistoryAsync"/> so two reloads never rebuild the chart buffers at
+    /// once. See the comment there for why they overlap in the first place. Disposed with the VM.
+    /// </summary>
+    private readonly SemaphoreSlim _reloadGate = new(1, 1);
+
     /// <summary>Production constructor — safe source always available; ETW source built on demand when elevated.</summary>
     public BandwidthMonitorViewModel(BandwidthHistoryService history)
         : this(history, () => new ConnectionBandwidthSource(), () => new EtwBandwidthSource())
@@ -360,47 +366,63 @@ public sealed partial class BandwidthMonitorViewModel : ViewModelBase
     [RelayCommand]
     private async Task ReloadHistoryAsync()
     {
-        var range = SelectedRange;
-        if (range.IsLive)
-        {
-            _historyOwnsChart = false;
-            ShowingHistory = false;
-            HistoryIsEmpty = false;
-            HistorySummary = "";
-            // Start the live window from empty rather than showing stale points from before the
-            // history detour; the poll loop refills it within a second.
-            _downBuffer.Clear();
-            _upBuffer.Clear();
-            return;
-        }
-
-        // Claimed BEFORE the await, not after the load lands: the poll loop must stop touching the
-        // buffers for the whole span in which this method may rebuild them, otherwise its Add races
-        // ReplaceWith on a collection LiveCharts is observing.
-        _historyOwnsChart = true;
-        IsBusy = true;
+        // Serialized: two reloads must never rebuild the chart buffers at the same time. They overlap
+        // easily — picking a range fires this from OnSelectedRangeChanged (fire-and-forget), and the
+        // Refresh button fires the same command directly, so a click during a load, or two quick range
+        // changes, gives two concurrent runs. Both then call ReplaceWith on collections LiveCharts is
+        // observing, and its observer keeps a HashSet it updates from the change notification — a
+        // second thread arriving mid-notification corrupts it ("Operations that change non-concurrent
+        // collections must have exclusive access"), which is how CI caught this.
+        //
+        // A gate rather than a lock: this is an async path, so it must not block, and dropping an
+        // overlapping reload is correct behaviour — the newest selection is what the user asked for
+        // and the queued run would repaint with identical data anyway.
+        await _reloadGate.WaitAsync().ConfigureAwait(true);
         try
         {
-            var loaded = await _history.LoadAsync(range.Range, _pollCts?.Token ?? default).ConfigureAwait(true);
-            var points = BandwidthHistoryService.Downsample(loaded, MaxHistoryPoints);
+            var range = SelectedRange;
+            if (range.IsLive)
+            {
+                _historyOwnsChart = false;
+                ShowingHistory = false;
+                HistoryIsEmpty = false;
+                HistorySummary = "";
+                // Start the live window from empty rather than showing stale points from before the
+                // history detour; the poll loop refills it within a second.
+                _downBuffer.Clear();
+                _upBuffer.Clear();
+                return;
+            }
 
-            _downBuffer.ReplaceWith(points.Select(p => new DateTimePoint(p.Timestamp, p.DownBytesPerSec)));
-            _upBuffer.ReplaceWith(points.Select(p => new DateTimePoint(p.Timestamp, p.UpBytesPerSec)));
+            // Claimed BEFORE the await, not after the load lands: the poll loop must stop touching the
+            // buffers for the whole span in which this method may rebuild them, otherwise its Add
+            // races ReplaceWith on a collection LiveCharts is observing.
+            _historyOwnsChart = true;
+            IsBusy = true;
+            try
+            {
+                var loaded = await _history.LoadAsync(range.Range, _pollCts?.Token ?? default).ConfigureAwait(true);
+                var points = BandwidthHistoryService.Downsample(loaded, MaxHistoryPoints);
 
-            ShowingHistory = true;
-            HistoryIsEmpty = loaded.Count == 0;
-            HistorySummary = BuildHistorySummary(loaded);
-            StatusMessage = loaded.Count > 0
-                ? $"Showing {loaded.Count} recorded sample(s) over {range.Label.ToLowerInvariant()}."
-                : "No history recorded for that range yet — samples are saved while this tab is open.";
+                _downBuffer.ReplaceWith(points.Select(p => new DateTimePoint(p.Timestamp, p.DownBytesPerSec)));
+                _upBuffer.ReplaceWith(points.Select(p => new DateTimePoint(p.Timestamp, p.UpBytesPerSec)));
+
+                ShowingHistory = true;
+                HistoryIsEmpty = loaded.Count == 0;
+                HistorySummary = BuildHistorySummary(loaded);
+                StatusMessage = loaded.Count > 0
+                    ? $"Showing {loaded.Count} recorded sample(s) over {range.Label.ToLowerInvariant()}."
+                    : "No history recorded for that range yet — samples are saved while this tab is open.";
+            }
+            catch (OperationCanceledException)
+            {
+                // Tab closed mid-load. Hand the buffers back, or a cancelled load would leave the live
+                // chart permanently frozen the next time the tab is opened.
+                _historyOwnsChart = false;
+            }
+            finally { IsBusy = false; }
         }
-        catch (OperationCanceledException)
-        {
-            // Tab closed mid-load. Hand the buffers back, or a cancelled load would leave the live
-            // chart permanently frozen the next time the tab is opened.
-            _historyOwnsChart = false;
-        }
-        finally { IsBusy = false; }
+        finally { _reloadGate.Release(); }
     }
 
     /// <summary>
@@ -569,6 +591,7 @@ public sealed partial class BandwidthMonitorViewModel : ViewModelBase
             _pollCts = null;
             _source?.Dispose();
             _source = null;
+            _reloadGate.Dispose();
 
             ThemeService.Instance.ThemeChanged -= ApplyChartTheme;
             foreach (var s in ThroughputSeries) DisposeSeries(s);


### PR DESCRIPTION
Two things, both found while verifying the 1.57.2 release under Protocol C.

## 1. A failed winget publish suppressed the release announcement

The release published correctly — binary, checksum, SBOM, and a build attestation `gh attestation verify` accepts. But the winget step failed, and with no `continue-on-error`, **every step after it was skipped**:

```
14 Create GitHub Release: success
15 Sync the winget-pkgs fork with upstream: success
16 Update winget package: failure
17 Post announcement to Discussions: skipped      <-- collateral damage
```

A release that genuinely shipped was never announced. Those are unrelated concerns: telling users about a *published* release must not depend on a second distribution channel, in a third-party repository, behind a PAT that can expire.

**Fix:** winget is now `continue-on-error`, and a following step turns that into a loud `::warning` plus a step summary stating exactly what is and isn't true — the release **is** on GitHub, it **is not** on winget, and here are the two things worth checking. Without that second step, `continue-on-error` would leave one red step inside a green run, which is how something goes unnoticed for weeks.

Winget still runs **before** the announcement, so when it works the announcement can honestly reference both channels.

Verified by parsing the workflow: 17 steps, `continue-on-error: true` on winget, order `winget(14) → report(15) → announce(16)`.

## 2. Two history reloads could rebuild the chart simultaneously

CI threw, from inside LiveCharts:

```
Operations that change non-concurrent collections must have exclusive access.
  at System.Collections.Generic.HashSet`1.Add
  at LiveChartsCore.Kernel.Observers.CollectionDeepObserver.OnItemsAdded
  at SysManager.Helpers.BulkObservableCollection`1.ReplaceWith
  at SysManager.ViewModels.BandwidthMonitorViewModel.ReloadHistoryAsync
```

The branch it appeared on changed **only a workflow file**, so this flake is in main. Main has passed 5/5 recent runs, so it's roughly 1-in-6.

**Mechanism:** assigning `SelectedRange` starts a reload fire-and-forget from its changed-handler, and the Refresh button fires the same command — two independent entry points into a method calling `ReplaceWith` on two collections LiveCharts observes. Its observer maintains a `HashSet` updated from the change notification; a second caller arriving mid-notification corrupts it. `ReloadHistoryAsync` now runs behind a `SemaphoreSlim`, disposed with the VM.

### Two earlier diagnoses of this same failure were wrong

Stating this because it's why the commit message quotes the stack trace rather than reasoning:

1. **"`ReplaceWith` lets a Reset subscriber see a half-rebuilt collection"** — disproved: notification suppression means the Reset fires *after* the rebuild. (That investigation did surface two genuine `ReplaceWith` defects, fixed in #1706.)
2. **"The poll loop races the reload"** — disproved: the failing test never sets `IsActive`, so the poll loop never samples.

### What is NOT proven

**That this closes the flake.** A harness ran 40 rounds of overlapping reloads against the built assembly, through both entry points, and stayed green **with** the gate — but also stayed green **with the gate disabled**. So it does not reproduce the failure and is not a red/green proof. Likely because this machine has 32 cores vs the runner's 4, and because `AsyncRelayCommand` drops a concurrent invocation rather than running it.

Two regression tests are added at the seam regardless. **CI is the only place this fault has ever appeared, so CI is where it has to be judged.** If it recurs, the next step is instrumentation, not a fourth guess.

What the gate *does* provably fix: two reloads can no longer interleave their `ReplaceWith` calls. That's a real invariant for a UI-bound collection with an external observer, worth holding either way.

## Not fixed here

The underlying winget failure. `does not have the correct permissions to execute CreateRef` is **not** fork drift (0 commits behind upstream; the in-workflow sync succeeded, so #1687's fix works) and **not** repo permissions (the account has `admin`/`push` on the fork). The same secret published 1.56.8 → 1.56.14, so the PAT has expired or been revoked — that needs a new token, not code. **1.57.2 is on GitHub but not on winget until then.**

Both projects build with 0 warnings and 0 errors. Leak scan across all 32 patterns: zero hits.
