### PR TITLE
fix: explain why a bulk install failed instead of printing its exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.57.3] - 2026-08-06
+
+### Fixed
+- **Bulk Installer now explains why an install failed.** It wrote things like "Failed (exit 1618)" into the row, or the raw Windows error text — neither of which tells you what to do. The same numbers were already being translated into plain sentences on the Uninstaller tab, so that translation is now shared: "Another installation is already in progress — wait for it to finish and try again", "Access denied — retry and accept the installer's Windows UAC prompt", and so on. If a PC does not have App Installer at all, all three app tabs now say so in the same words instead of one of them showing an internal error.
+- **Switching the Bandwidth Monitor chart between ranges no longer risks an error.** Changing the range while another change was still loading could have both of them redraw the graph at the same time, which could fail instead of drawing. Only one redraw runs at a time now.
+
 ## [1.57.2] - 2026-08-06
 
 ### Fixed

--- a/SysManager/SysManager.Tests/WingetFailureTests.cs
+++ b/SysManager/SysManager.Tests/WingetFailureTests.cs
@@ -1,0 +1,135 @@
+// SysManager · WingetFailureTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Helpers;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="WingetFailure"/> — the shared plain-language translation of winget outcomes.
+/// <para>The defect this closes: three tabs run winget and had drifted into three levels of care.
+/// Uninstaller translated its exit codes; App Updates reused Uninstaller's missing-winget sentence;
+/// Bulk Installer did neither, writing "Failed (exit 1618)" and raw OS exception text into the row.
+/// The same underlying failure was explained on two tabs and shown as a number on the third.</para>
+/// </summary>
+public class WingetFailureTests
+{
+    // ---------- install-side codes the user can act on ----------
+
+    [Theory]
+    [InlineData(1618, "Another installation")]     // the example from the issue
+    [InlineData(5, "Access denied")]
+    [InlineData(1602, "cancelled")]
+    [InlineData(1603, "fatal error")]
+    [InlineData(1619, "corrupt")]
+    [InlineData(1638, "already installed")]
+    public void DescribeInstallFailure_ExplainsAKnownCode(int exitCode, string expected)
+    {
+        var text = WingetFailure.DescribeInstallFailure(exitCode);
+
+        Assert.Contains(expected, text, StringComparison.OrdinalIgnoreCase);
+        // Never just the number: that is the whole point of the change.
+        Assert.DoesNotContain($"exit {exitCode}", text);
+    }
+
+    [Fact]
+    public void DescribeInstallFailure_TranslatesWingetsOwnCancelledResult()
+    {
+        // winget reports its own results as large unsigned values, which surfaced as a huge negative
+        // number in the row before this.
+        var text = WingetFailure.DescribeInstallFailure(unchecked((int)0x8A150011));
+
+        Assert.Contains("cancelled", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DescribeInstallFailure_AnUnknownCodeStillReportsTheNumber()
+    {
+        // A code nobody has mapped must still be diagnosable — the fallback is a readable sentence
+        // that happens to carry the number, not a bare number.
+        var text = WingetFailure.DescribeInstallFailure(4242);
+
+        Assert.Contains("4242", text);
+        Assert.StartsWith("Failed —", text);
+    }
+
+    [Fact]
+    public void DescribeInstallFailure_AlwaysReadsAsASentence()
+    {
+        // Every branch, including the fallback, must produce something a non-technical reader parses.
+        foreach (var code in new[] { 5, 1602, 1603, 1618, 1619, 1620, 1638, 4242, 0 })
+        {
+            var text = WingetFailure.DescribeInstallFailure(code);
+            Assert.StartsWith("Failed —", text);
+            Assert.EndsWith(".", text);
+        }
+    }
+
+    // ---------- install and uninstall maps stay distinct ----------
+
+    [Fact]
+    public void InstallAndUninstallDoNotShareOneMap()
+    {
+        // 1605 means "not currently installed" for an UNINSTALL and nothing for an install; 1638 is
+        // the reverse. Sharing one map would produce confidently wrong sentences, so the two are
+        // deliberately separate — asserted so a later "simplification" cannot merge them.
+        Assert.Contains("not currently installed", WingetFailure.DescribeUninstallFailure(1605));
+        Assert.DoesNotContain("not currently installed", WingetFailure.DescribeInstallFailure(1605));
+
+        Assert.Contains("already installed", WingetFailure.DescribeInstallFailure(1638));
+        Assert.DoesNotContain("already installed", WingetFailure.DescribeUninstallFailure(1638));
+    }
+
+    [Theory]
+    [InlineData(5, "Access denied")]
+    [InlineData(1602, "cancelled")]
+    [InlineData(1618, "Another installation")]
+    public void DescribeUninstallFailure_StillExplainsWhatItAlwaysDid(int exitCode, string expected)
+    {
+        // The mapping moved into this helper; the behaviour must be unchanged.
+        Assert.Contains(expected, WingetFailure.DescribeUninstallFailure(exitCode),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TheUninstallerViewModelNowDelegatesToTheSharedMap()
+    {
+        // Proves there is ONE source of truth rather than two copies that agree today. If the VM kept
+        // a private copy, an edit to the helper would silently not reach the tab.
+        foreach (var code in new[] { 1, 2, 5, 87, 1602, 1603, 1605, 1618, 9999 })
+        {
+            Assert.Equal(
+                WingetFailure.DescribeUninstallFailure(code),
+                UninstallerViewModel.DescribeUninstallFailure(code, "AnyApp"));
+        }
+    }
+
+    // ---------- the missing-winget sentence ----------
+
+    [Fact]
+    public void AllThreeWingetTabsUseTheSameMissingWingetSentence()
+    {
+        // The literal used to live on AppUpdatesViewModel and be referenced cross-VM, which is exactly
+        // how Bulk Installer ended up not using it at all.
+        Assert.Equal(WingetFailure.WingetUnavailable, AppUpdatesViewModel.WingetUnavailableMessage);
+    }
+
+    [Fact]
+    public void TheMissingWingetSentenceNamesWhatToInstall()
+    {
+        // "winget is not available" would leave the persona stuck; it has to name App Installer and
+        // where to get it.
+        Assert.Contains("App Installer", WingetFailure.WingetUnavailable);
+        Assert.Contains("Microsoft Store", WingetFailure.WingetUnavailable);
+    }
+
+    [Fact]
+    public void TheMissingWingetSentenceDoesNotReadLikeACrash()
+    {
+        // The point of the shared string: the tab needs a prerequisite, nothing broke.
+        Assert.DoesNotContain("error", WingetFailure.WingetUnavailable, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("failed", WingetFailure.WingetUnavailable, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/SysManager/SysManager/Helpers/WingetFailure.cs
+++ b/SysManager/SysManager/Helpers/WingetFailure.cs
@@ -1,0 +1,75 @@
+// SysManager · WingetFailure — one place that translates winget outcomes into plain language
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Helpers;
+
+/// <summary>
+/// Turns winget exit codes and a missing App Installer into sentences the target persona can act on.
+/// <para>Three tabs run winget — App Updates, Uninstaller, and Bulk Installer — and they had drifted
+/// into three different levels of care. Uninstaller translated its exit codes and caught the
+/// missing-winget case; App Updates caught the missing case and reused Uninstaller's message; Bulk
+/// Installer did neither, writing <c>Failed (exit 1618)</c> and raw OS exception text into the row.
+/// The same underlying failure was explained on two tabs and shown as a number on the third.</para>
+/// <para>Everything lives here so a fourth caller cannot reintroduce the drift. The
+/// install and uninstall maps are kept SEPARATE: winget reports different codes for the two
+/// operations, so sharing one map would produce confidently wrong sentences.</para>
+/// </summary>
+public static class WingetFailure
+{
+    /// <summary>
+    /// Shown when winget itself is missing. Plain-language so the user knows the tab needs App
+    /// Installer, not that something broke.
+    /// </summary>
+    public const string WingetUnavailable =
+        "winget (App Installer) isn't available on this PC — install \"App Installer\" from the Microsoft Store to use this tab.";
+
+    /// <summary>
+    /// Explains why an INSTALL failed, and what to do next. Codes are the ones winget actually
+    /// returns for installs: the MSI set (1602/1603/1618/1619/1620/1638), Windows access denied (5),
+    /// and winget's own cancelled/no-applicable-installer results.
+    /// </summary>
+    public static string DescribeInstallFailure(int exitCode)
+    {
+        var reason = exitCode switch
+        {
+            5 => "Access denied — retry and accept the installer's Windows UAC prompt.",
+            1602 => "The installation was cancelled.",
+            1603 => "The installer hit a fatal error. It may already be partly installed — check Windows Settings ▸ Apps.",
+            1618 => "Another installation is already in progress — wait for it to finish and try again.",
+            1619 => "The installer package could not be opened; the download may be corrupt.",
+            1620 => "The installer package is not valid.",
+            1638 => "Another version of this app is already installed — remove it first, or update it instead.",
+            // winget's own results, reported as unsigned values.
+            unchecked((int)0x8A150011) => "The installation was cancelled.",
+            unchecked((int)0x8A150010) => "No installer for this app matches this PC.",
+            unchecked((int)0x8A15002B) => "No suitable installer was found for this app.",
+            unchecked((int)0x8A150044) => "The download failed — check the connection and try again.",
+            _ => $"The installer returned code {exitCode}.",
+        };
+
+        return $"Failed — {reason}";
+    }
+
+    /// <summary>
+    /// Explains why an UNINSTALL failed. Kept distinct from the install map on purpose: 1602 means
+    /// "cancelled" for both, but most other codes do not correspond.
+    /// </summary>
+    public static string DescribeUninstallFailure(int exitCode)
+    {
+        var reason = exitCode switch
+        {
+            1 => "The app's uninstaller reported a generic error.",
+            2 => "The uninstall was cancelled by the user or a UAC prompt was declined.",
+            5 => "Access denied - retry and accept the uninstaller's Windows UAC prompt, or remove the app from Windows Settings.",
+            87 => "Invalid parameter — the app may require a manual uninstall.",
+            1602 => "The uninstall was cancelled by the user.",
+            1603 => "The app's installer encountered a fatal error during removal.",
+            1605 => "The app is not currently installed (already removed?).",
+            1618 => "Another installation is in progress — wait and try again.",
+            _ => $"The app's uninstaller returned exit code {exitCode}.",
+        };
+
+        return $"Failed — {reason}";
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.57.2</Version>
-    <FileVersion>1.57.2.0</FileVersion>
-    <AssemblyVersion>1.57.2.0</AssemblyVersion>
+    <Version>1.57.3</Version>
+    <FileVersion>1.57.3.0</FileVersion>
+    <AssemblyVersion>1.57.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
@@ -23,9 +23,12 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
     /// Shown when winget.exe cannot be launched — App Installer isn't present or its
     /// execution alias is off (common on older/LTSC/Server machines). Plain-language so
     /// the non-technical persona knows the tab needs App Installer, not that something broke.
+    /// <para>Forwards to <see cref="WingetFailure.WingetUnavailable"/>. The literal used to live here
+    /// and be referenced cross-VM, which is how Bulk Installer ended up not using it at all; the
+    /// shared helper is now the single source for all three winget tabs. Kept as an alias so the
+    /// existing call sites and their tests still read naturally.</para>
     /// </summary>
-    internal const string WingetUnavailableMessage =
-        "winget (App Installer) isn't available on this PC — install \"App Installer\" from the Microsoft Store to use this tab.";
+    internal const string WingetUnavailableMessage = WingetFailure.WingetUnavailable;
 
     public BulkObservableCollection<AppPackage> Packages { get; } = new();
     public ConsoleViewModel Console { get; } = new();

--- a/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
@@ -236,7 +236,10 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
                     }
                     else
                     {
-                        app.Status = $"Failed (exit {exitCode})";
+                        // "Failed (exit 1618)" told the user nothing and read like a crash. The same
+                        // codes are already explained on the Uninstaller tab, so both now go through
+                        // one shared translator rather than a third private copy.
+                        app.Status = WingetFailure.DescribeInstallFailure(exitCode);
                         failed++;
                     }
                 }
@@ -244,6 +247,16 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
                 {
                     app.Status = "Cancelled";
                     throw;
+                }
+                // winget.exe missing entirely: Process.Start throws Win32Exception. The two sibling
+                // winget tabs already catch this and show the same sentence; this tab was surfacing
+                // raw OS text per row instead ("The system cannot find the file specified").
+                catch (System.ComponentModel.Win32Exception ex)
+                {
+                    app.Status = "Failed — winget is not available";
+                    StatusMessage = WingetFailure.WingetUnavailable;
+                    failed++;
+                    Log.Warning(ex, "winget unavailable while installing {WingetId}", app.WingetId);
                 }
                 catch (Exception ex)
                 {
@@ -306,6 +319,14 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
             // is sanitized against argument injection before it reaches the command line.
             var lines = await _service.SearchAsync(SearchQuery).ConfigureAwait(true);
             SearchResults.ReplaceWith(ParseSearchResults(string.Join("\n", lines)));
+        }
+        // Missing winget is the one search failure with a specific, actionable answer, so it is named
+        // rather than folded into "ensure winget is available" — which tells the user to check the very
+        // thing the app already knows is absent.
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            Log.Warning(ex, "winget unavailable while searching for {Query}", SearchQuery);
+            StatusMessage = WingetFailure.WingetUnavailable;
         }
         catch (Exception ex)
         {

--- a/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
@@ -361,24 +361,14 @@ public sealed partial class UninstallerViewModel : ViewModelBase
         exitCode is 1641 or 3010;
 
     /// <summary>
-    /// Translates a winget uninstall exit code into a human-readable message
-    /// so the user knows why the uninstall failed and what to try next.
+    /// Translates a winget uninstall exit code into a human-readable message so the user knows why
+    /// the uninstall failed and what to try next.
+    /// <para>The mapping itself moved to <see cref="WingetFailure.DescribeUninstallFailure"/>, next to
+    /// the install-side one, so the three winget tabs cannot drift apart again — Bulk Installer had
+    /// been writing raw exit codes while this tab explained the same numbers. This overload stays as
+    /// the call site (and its tests) already read it; <paramref name="appName"/> is not part of the
+    /// sentence, which is why it is unused here.</para>
     /// </summary>
-    internal static string DescribeUninstallFailure(int exitCode, string appName)
-    {
-        var reason = exitCode switch
-        {
-            1 => "The app's uninstaller reported a generic error.",
-            2 => "The uninstall was cancelled by the user or a UAC prompt was declined.",
-            5 => "Access denied - retry and accept the uninstaller's Windows UAC prompt, or remove the app from Windows Settings.",
-            87 => "Invalid parameter — the app may require a manual uninstall.",
-            1602 => "The uninstall was cancelled by the user.",
-            1603 => "The app's installer encountered a fatal error during removal.",
-            1605 => "The app is not currently installed (already removed?).",
-            1618 => "Another installation is in progress — wait and try again.",
-            _ => $"The app's uninstaller returned exit code {exitCode}."
-        };
-
-        return $"Failed — {reason}";
-    }
+    internal static string DescribeUninstallFailure(int exitCode, string appName) =>
+        WingetFailure.DescribeUninstallFailure(exitCode);
 }


### PR DESCRIPTION
Closes #1642. Every claim in the issue re-verified against current source first: the bare exit code at `BulkInstallerViewModel.cs:239`, raw OS text at `:250`, **zero** `Win32Exception` handlers in the file, and the shared missing-winget sentence reused by the other two winget tabs but not this one.

## Three tabs, three levels of care

- **Uninstaller** translated exit codes into sentences.
- **App Updates** caught the missing-winget case and reused Uninstaller's message.
- **Bulk Installer** did neither — it wrote `Failed (exit 1618)` into the row, or the raw Windows error text.

So the same underlying failure was explained on two tabs and shown as a number on the third. "Failed (exit 1618)" tells the target persona nothing and reads like a crash; the sentence for it was already written 200 lines away.

**Before → after:**

```
Failed (exit 1618)
Failed — Another installation is already in progress — wait for it to finish and try again.
```

## Promoted, not copied

Fixed the way the issue recommended: both mechanisms move into one `WingetFailure` helper rather than adding a third private copy, so a fourth caller can't reintroduce the drift.

- `UninstallerViewModel.DescribeUninstallFailure` now delegates — signature and existing tests unchanged.
- `AppUpdatesViewModel.WingetUnavailableMessage` forwards to the shared const.
- **A test asserts the VM and the helper return identical strings for every mapped code.** Two copies that merely agree *today* would silently diverge on the next edit.

### The two maps stay separate, and a test pins that

winget reports different codes per operation: `1605` means "not currently installed" for an *uninstall* and nothing for an *install*; `1638` is the reverse. One shared map would produce confidently wrong sentences — worse than a number.

Install codes were researched rather than copied from the uninstall side: the MSI set (`1602`/`1603`/`1618`/`1619`/`1620`/`1638`), access denied, and winget's own results. That last group arrives as large unsigned values and previously surfaced as a huge negative number in the row.

## Also: the missing `Win32Exception` handler

Added to both the install and search paths, matching what the sibling tabs already do. Without it, a PC with no App Installer got raw `The system cannot find the file specified` **per row**, where the other two tabs explain that App Installer needs installing from the Store.

## Verification

**18 checks against the built assembly**, plus 11 new xUnit tests. The harness prints the resulting strings, so the wording was read rather than assumed:

```
1618       -> Failed — Another installation is already in progress — wait for it to finish and try again.
0x8A150011 -> Failed — The installation was cancelled.
missing    -> winget (App Installer) isn't available on this PC — install "App Installer" from the
              Microsoft Store to use this tab.
```

Covered: every mapped code, winget's own cancelled result, the unmapped fallback staying diagnosable (readable sentence that still carries the number), the two maps not bleeding into each other, the VM delegating, and the shared sentence naming both *what* to install and *where*.

## Why this release also carries the bandwidth gate

The reload gate landed on main in #1709 under a `ci:` title, so `auto-release` correctly computed no version bump and it never shipped. Its CHANGELOG entry is here so the fix actually reaches users.

Both projects build with 0 warnings, 0 errors. Leak scan across all 32 patterns: zero hits.
