### PR TITLE
fix: serialize the Resource History reloads and handle an unreadable history file

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -421,7 +421,9 @@ Key services:
   every 10s as append-only NDJSON in `%LocalAppData%\SysManager\resource-history.ndjson`,
   with 7/14/30-day retention (periodic prune). Reuses `SystemInfoService` + NvAPIWrapper +
   `TemperatureService`; serialize/parse/prune/downsample/CSV are pure, unit-tested static
-  helpers. Strictly local — no system writes, nothing leaves the machine.
+  helpers, and the directory is injectable — like `BandwidthHistoryService` — so tests cover the
+  load and retention paths without touching the user's own history. Strictly local — no system
+  writes, nothing leaves the machine.
 - Bandwidth Monitor sources — `IBandwidthMonitorService` is the seam with two implementations:
   `ConnectionBandwidthSource` (default, no admin) sums `NetworkInterface` byte counters for total
   throughput and reads the extended TCP/UDP tables via iphlpapi P/Invoke (`GetExtendedTcpTable`/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.57.4] - 2026-08-06
+
+### Fixed
+- **Switching the Resource History chart between ranges no longer risks an error.** Picking a different period while another one was still loading could have both of them rebuild the five graphs at the same time, which could fail instead of drawing. Only one rebuild runs at a time now. This is the same problem that was fixed on the Bandwidth Monitor in 1.57.3 — Resource History had it too, and it was missed then.
+- **An unreadable history file no longer crashes the recorder.** Both the Resource History and Bandwidth Monitor recorders handled a disk error while reading or writing their history, but not a permission error — and a locked-down or read-only file produces the second, not the first. Because the recording runs quietly in the background, that surfaced as the app failing over something the user never started. Both now log it and carry on with an empty chart, exactly as they already did for a disk error.
+
 ## [1.57.3] - 2026-08-06
 
 ### Fixed

--- a/SysManager/SysManager.Tests/ResourceHistoryServiceTests.cs
+++ b/SysManager/SysManager.Tests/ResourceHistoryServiceTests.cs
@@ -2,6 +2,12 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using System.Threading.Tasks;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -211,4 +217,183 @@ public class ResourceHistoryServiceTests
     [Fact]
     public void RetentionOptions_AreSevenFourteenThirty()
         => Assert.Equal([7, 14, 30], ResourceHistoryService.RetentionOptions);
+}
+
+/// <summary>
+/// Disk-backed tests for <see cref="ResourceHistoryService"/>, using the injected temp directory
+/// so the developer's own history in %LOCALAPPDATA% is never read or written.
+/// <para>These could not exist before: the service pinned its paths to
+/// <see cref="Environment.SpecialFolder.LocalApplicationData"/> in <c>static readonly</c> fields, and
+/// that resolves through the Win32 known-folder API — it ignores the <c>LOCALAPPDATA</c> environment
+/// variable, so not even a child process could redirect it. Every test above had to stay on the pure
+/// helpers as a result, leaving the load/prune/retention paths uncovered.</para>
+/// </summary>
+public class ResourceHistoryServiceDiskTests : IDisposable
+{
+    private readonly string _dir;
+
+    public ResourceHistoryServiceDiskTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "SysManagerResourceHistoryTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch (IOException) { /* a leftover temp dir must never fail a test run */ }
+        GC.SuppressFinalize(this);
+    }
+
+    // skipHardwareInit: none of these tests read a sensor, and probing real hardware in a unit
+    // test would make it environment-dependent.
+    private ResourceHistoryService NewService() => new(
+        new SystemInfoService(),
+        new TemperatureService(new DiskHealthService(), skipHardwareInit: true),
+        _dir);
+
+    private string DataPath => Path.Combine(_dir, "resource-history.ndjson");
+
+    private void Seed(params ResourceSample[] samples)
+        => File.WriteAllLines(DataPath, samples.Select(ResourceHistoryService.Serialize));
+
+    private static ResourceSample At(DateTime t, double cpu = 10)
+        => new(t, cpu, 20, null, null, null);
+
+    // ── The seam itself ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LoadAsync_WithNoFile_ReturnsEmpty()
+    {
+        using var service = NewService();
+        Assert.Empty(await service.LoadAsync(TimeSpan.FromDays(7)));
+    }
+
+    [Fact]
+    public async Task LoadAsync_ReadsOnlyItsOwnDirectory()
+    {
+        var now = DateTime.Now;
+        Seed(At(now.AddMinutes(-1)));
+
+        using var mine = NewService();
+        Assert.Single(await mine.LoadAsync(TimeSpan.FromHours(1)));
+
+        // A different directory must be independently empty — proof the path is genuinely injected
+        // and not silently falling back to the shared profile location.
+        var other = Path.Combine(_dir, "other");
+        Directory.CreateDirectory(other);
+        using var elsewhere = new ResourceHistoryService(
+            new SystemInfoService(),
+            new TemperatureService(new DiskHealthService(), skipHardwareInit: true),
+            other);
+        Assert.Empty(await elsewhere.LoadAsync(TimeSpan.FromDays(30)));
+    }
+
+    // ── Load: range filtering and ordering ──────────────────────────────────
+
+    [Fact]
+    public async Task LoadAsync_ExcludesSamplesOlderThanTheRange()
+    {
+        var now = DateTime.Now;
+        Seed(
+            At(now.AddDays(-3)),      // outside a 1-hour range
+            At(now.AddMinutes(-30)),  // inside
+            At(now.AddMinutes(-5)));  // inside
+
+        using var service = NewService();
+        var loaded = await service.LoadAsync(TimeSpan.FromHours(1));
+
+        Assert.Equal(2, loaded.Count);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ReturnsOldestFirst()
+    {
+        // The file is append-only and time-ordered, and LoadAsync walks it backwards then reverses.
+        // Chart code depends on this order, so it is asserted rather than assumed.
+        var now = DateTime.Now;
+        Seed(At(now.AddMinutes(-30), cpu: 1), At(now.AddMinutes(-20), cpu: 2), At(now.AddMinutes(-10), cpu: 3));
+
+        using var service = NewService();
+        var loaded = await service.LoadAsync(TimeSpan.FromHours(1));
+
+        Assert.Equal([1d, 2d, 3d], loaded.Select(s => s.CpuPercent));
+    }
+
+    [Fact]
+    public async Task LoadAsync_SkipsMalformedLinesWithoutFailing()
+    {
+        var now = DateTime.Now;
+        File.WriteAllLines(DataPath,
+        [
+            "not json at all",
+            ResourceHistoryService.Serialize(At(now.AddMinutes(-10))),
+            "{ truncated",
+        ]);
+
+        using var service = NewService();
+        var loaded = await service.LoadAsync(TimeSpan.FromHours(1));
+
+        Assert.Single(loaded);
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenTheFileCannotBeRead_ReturnsEmptyRatherThanThrowing()
+    {
+        // UnauthorizedAccessException is a SIBLING of IOException, not a subclass, so it escaped the
+        // service's original single `catch (IOException)`. That matters because the history file is
+        // read by a background sampler the user never invoked: an unhandled throw there is a crash
+        // with no action that caused it. A deny-read ACL is what actually produces it — a directory
+        // in the file's place does not, because File.Exists returns false and the guard short-circuits.
+        Seed(At(DateTime.Now.AddMinutes(-1)));
+
+        var identity = WindowsIdentity.GetCurrent().User;
+        if (identity is null) return; // no SID to deny — nothing to assert on this host
+
+        var info = new FileInfo(DataPath);
+        var acl = info.GetAccessControl();
+        var deny = new FileSystemAccessRule(identity, FileSystemRights.Read, AccessControlType.Deny);
+        acl.AddAccessRule(deny);
+        info.SetAccessControl(acl);
+        try
+        {
+            using var service = NewService();
+            Assert.Empty(await service.LoadAsync(TimeSpan.FromDays(7)));
+        }
+        finally
+        {
+            // Remove the deny rule, or Dispose cannot delete the temp directory.
+            acl.RemoveAccessRule(deny);
+            info.SetAccessControl(acl);
+        }
+    }
+
+    // ── Retention persistence ───────────────────────────────────────────────
+
+    [Fact]
+    public void RetentionDays_DefaultsToSeven()
+    {
+        using var service = NewService();
+        Assert.Equal(7, service.RetentionDays);
+    }
+
+    [Fact]
+    public void RetentionDays_PersistsAcrossInstances()
+    {
+        using (var first = NewService())
+            first.RetentionDays = 30;
+
+        // A second instance, as after an app restart — the point of persisting at all.
+        using var second = NewService();
+        Assert.Equal(30, second.RetentionDays);
+        Assert.True(File.Exists(Path.Combine(_dir, "resource-history-config.json")));
+    }
+
+    [Fact]
+    public void RetentionDays_RejectsAValueOutsideTheOfferedOptions()
+    {
+        using var service = NewService();
+        service.RetentionDays = 999;
+        Assert.Equal(7, service.RetentionDays);
+    }
 }

--- a/SysManager/SysManager.Tests/ResourceHistoryViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ResourceHistoryViewModelTests.cs
@@ -2,7 +2,12 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using SysManager.Models;
+using SysManager.Services;
 using SysManager.ViewModels;
 
 namespace SysManager.Tests;
@@ -40,5 +45,115 @@ public class ResourceHistoryViewModelTests
         var samples = new[] { Sample(10, 10, cpuTemp: 55), Sample(10, 10, cpuTemp: 72) };
         var summary = ResourceHistoryViewModel.BuildSummary(samples);
         Assert.Contains("CPU temp peak 72°C", summary);
+    }
+}
+
+/// <summary>
+/// Tests that drive the real reload path, which needs a <see cref="ResourceHistoryService"/> pointed
+/// at a temp directory — only possible since that service gained the injectable configDir seam.
+/// </summary>
+public class ResourceHistoryViewModelReloadTests : IDisposable
+{
+    private readonly string _dir;
+
+    public ResourceHistoryViewModelReloadTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "SysManagerResourceHistoryVmTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch (IOException) { /* a leftover temp dir must never fail a test run */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private ResourceHistoryService SeededService(params ResourceSample[] samples)
+    {
+        File.WriteAllLines(
+            Path.Combine(_dir, "resource-history.ndjson"),
+            samples.Select(ResourceHistoryService.Serialize));
+        return new ResourceHistoryService(
+            new SystemInfoService(),
+            // skipHardwareInit: the reload path reads no sensor; probing real hardware would make
+            // this test depend on the machine it runs on.
+            new TemperatureService(new DiskHealthService(), skipHardwareInit: true),
+            _dir);
+    }
+
+    [Fact]
+    public async Task ConcurrentReloadsDoNotCorruptTheChartSeries()
+    {
+        // Regression pin for the same defect CI proved on BandwidthMonitorViewModel, which this VM
+        // still carried: THREE entry points can run ReloadAsync at once — the constructor's
+        // InitializeAsync, the fire-and-forget in OnSelectedRangeChanged, and the Refresh command —
+        // and each calls ReplaceWith on five buffers LiveCharts observes. Its CollectionDeepObserver
+        // updates a HashSet from the change notification, so a second thread arriving mid-notification
+        // corrupts it ("Operations that change non-concurrent collections must have exclusive access").
+        //
+        // WHAT THIS TEST CAN AND CANNOT PROVE: the corruption needs a RENDERED chart for LiveCharts to
+        // attach its observer, which never happens in a headless test — so this asserts the reachable
+        // invariant (the series stay coherent, nothing escapes) rather than reproducing the observer
+        // corruption. The gate is justified by the proven CI failure on the identical sibling.
+        var now = DateTime.Now;
+        using var service = SeededService(
+            new ResourceSample(now.AddMinutes(-30), 10, 20, 30, 40, 50),
+            new ResourceSample(now.AddMinutes(-20), 15, 25, 35, 45, 55),
+            new ResourceSample(now.AddMinutes(-10), 20, 30, 40, 50, 60));
+        using var vm = new ResourceHistoryViewModel(service);
+        await vm.InitializationComplete;
+
+        // Rapid range assignment starts a reload from the changed-handler each time, bypassing the
+        // command — that is what genuinely overlaps.
+        for (int i = 0; i < 20; i++)
+            vm.SelectedRange = vm.RangeOptions[i % vm.RangeOptions.Count];
+
+        // Fire the command mid-flight: the second, independent entry point.
+        var refresh = vm.ReloadCommand.ExecuteAsync(null);
+        for (int i = 0; i < 20; i++)
+            vm.SelectedRange = vm.RangeOptions[(i + 1) % vm.RangeOptions.Count];
+        await refresh;
+
+        // All three usage series are rebuilt from the same downsampled points, so their lengths must
+        // agree. A torn ReplaceWith is exactly what makes them diverge.
+        var lengths = vm.UsageSeries
+            .Select(s => ((System.Collections.IEnumerable)s.Values!).Cast<object>().Count())
+            .Distinct()
+            .ToList();
+        Assert.Single(lengths);
+    }
+
+    [Fact]
+    public async Task ARedundantRefreshOnTheSameRangeStillShowsThatRange()
+    {
+        // The gate drops nothing user-visible: a second reload for the already-selected range still
+        // ends on that range, with its samples counted, and releases the progress bar.
+        var now = DateTime.Now;
+        using var service = SeededService(
+            new ResourceSample(now.AddMinutes(-20), 10, 20, null, null, null),
+            new ResourceSample(now.AddMinutes(-10), 20, 30, null, null, null));
+        using var vm = new ResourceHistoryViewModel(service);
+        await vm.InitializationComplete;
+
+        vm.SelectedRange = vm.RangeOptions.First(r => r.Range == TimeSpan.FromHours(1));
+        await vm.ReloadCommand.ExecuteAsync(null);
+        await vm.ReloadCommand.ExecuteAsync(null);   // a redundant Refresh on the same range
+
+        Assert.Equal(2, vm.SampleCount);
+        Assert.True(vm.HasData);
+        Assert.False(vm.IsBusy);   // the gate released, so the progress bar cleared
+    }
+
+    [Fact]
+    public async Task ReloadWithNoHistory_ReportsTheEmptyStateRatherThanABlankChart()
+    {
+        using var service = SeededService();   // no samples at all
+        using var vm = new ResourceHistoryViewModel(service);
+        await vm.InitializationComplete;
+
+        Assert.False(vm.HasData);
+        Assert.Equal(0, vm.SampleCount);
+        Assert.Contains("No history yet", vm.StatusMessage);
     }
 }

--- a/SysManager/SysManager/Services/BandwidthHistoryService.cs
+++ b/SysManager/SysManager/Services/BandwidthHistoryService.cs
@@ -51,6 +51,11 @@ public sealed class BandwidthHistoryService
             await File.AppendAllTextAsync(_dataPath, Serialize(sample) + "\n", ct).ConfigureAwait(false);
         }
         catch (IOException ex) { Log.Debug("Bandwidth history append failed: {Error}", ex.Message); }
+        // Same reason as ResourceHistoryService: UnauthorizedAccessException is a SIBLING of
+        // IOException, so it escapes the catch above. Here an escaping throw is worse — the
+        // caller sets _historyOwnsChart before awaiting, and only OperationCanceledException
+        // hands it back, so an unhandled access error would freeze the live chart for good.
+        catch (UnauthorizedAccessException ex) { Log.Debug("Bandwidth history append denied: {Error}", ex.Message); }
         finally { _fileLock.Release(); }
     }
 
@@ -77,6 +82,7 @@ public sealed class BandwidthHistoryService
             return samples;
         }
         catch (IOException ex) { Log.Debug("Bandwidth history load failed: {Error}", ex.Message); return []; }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Bandwidth history load denied: {Error}", ex.Message); return []; }
         finally { _fileLock.Release(); }
     }
 
@@ -97,6 +103,7 @@ public sealed class BandwidthHistoryService
         }
         catch (OperationCanceledException) { /* shutdown */ }
         catch (IOException ex) { Log.Debug("Bandwidth history prune failed: {Error}", ex.Message); }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Bandwidth history prune denied: {Error}", ex.Message); }
         finally { _fileLock.Release(); }
     }
 

--- a/SysManager/SysManager/Services/ResourceHistoryService.cs
+++ b/SysManager/SysManager/Services/ResourceHistoryService.cs
@@ -31,16 +31,14 @@ public sealed class ResourceHistoryService : IDisposable
     // long-lived session doesn't let the file grow past the retention window on disk.
     private const int PruneEverySamples = 360; // 360 × 10s = 1 hour
 
-    private static readonly string DataDir = Path.Join(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager");
-    private static readonly string DataPath = Path.Join(DataDir, "resource-history.ndjson");
-    private static readonly string ConfigPath = Path.Join(DataDir, "resource-history-config.json");
-
     private static readonly JsonSerializerOptions SampleJson = new() { WriteIndented = false };
 
     private readonly SystemInfoService _sys;
     private readonly TemperatureService _temps;
     private readonly SemaphoreSlim _fileLock = new(1, 1);
+    private readonly string _dataDir;
+    private readonly string _dataPath;
+    private readonly string _configPath;
 
     private CancellationTokenSource? _cts;
     private Task? _loopTask;
@@ -54,10 +52,23 @@ public sealed class ResourceHistoryService : IDisposable
 
     private int _retentionDays = 7;
 
-    public ResourceHistoryService(SystemInfoService sys, TemperatureService temps)
+    /// <summary>
+    /// Creates the service. <paramref name="configDir"/> is overridable so tests exercise the real
+    /// append/load/prune paths against a temp directory instead of the user's own history file —
+    /// same seam as <see cref="BandwidthHistoryService"/> and <see cref="StandbyPreferenceService"/>.
+    /// <para>The paths were previously <c>static readonly</c>, which made this service impossible to
+    /// test: <see cref="Environment.SpecialFolder.LocalApplicationData"/> resolves through the Win32
+    /// known-folder API and ignores the <c>LOCALAPPDATA</c> environment variable, so not even a child
+    /// process could redirect it away from the real profile.</para>
+    /// </summary>
+    public ResourceHistoryService(SystemInfoService sys, TemperatureService temps, string? configDir = null)
     {
         _sys = sys;
         _temps = temps;
+        _dataDir = configDir ?? Path.Join(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager");
+        _dataPath = Path.Join(_dataDir, "resource-history.ndjson");
+        _configPath = Path.Join(_dataDir, "resource-history-config.json");
         _retentionDays = LoadRetention();
     }
 
@@ -184,10 +195,15 @@ public sealed class ResourceHistoryService : IDisposable
         await _fileLock.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            Directory.CreateDirectory(DataDir);
-            await File.AppendAllTextAsync(DataPath, Serialize(sample) + "\n", ct).ConfigureAwait(false);
+            Directory.CreateDirectory(_dataDir);
+            await File.AppendAllTextAsync(_dataPath, Serialize(sample) + "\n", ct).ConfigureAwait(false);
         }
         catch (IOException ex) { Log.Debug("Resource history append failed: {Error}", ex.Message); }
+        // UnauthorizedAccessException is a SIBLING of IOException, not a subclass, so it escapes the
+        // catch above. It is what File APIs raise for a read-only or ACL-denied file, which is
+        // reachable if the profile folder is locked down — and an unhandled throw here would
+        // surface as a crash from a background sampler the user never invoked.
+        catch (UnauthorizedAccessException ex) { Log.Debug("Resource history append denied: {Error}", ex.Message); }
         finally { if (!_disposed) _fileLock.Release(); }
     }
 
@@ -200,8 +216,8 @@ public sealed class ResourceHistoryService : IDisposable
         await _fileLock.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            if (!File.Exists(DataPath)) return [];
-            var lines = await File.ReadAllLinesAsync(DataPath, ct).ConfigureAwait(false);
+            if (!File.Exists(_dataPath)) return [];
+            var lines = await File.ReadAllLinesAsync(_dataPath, ct).ConfigureAwait(false);
             var cutoff = DateTime.Now - range;
             // The file is append-only and time-ordered, so the requested range is a suffix:
             // walk from the END and stop at the first line older than the cutoff. This bounds
@@ -218,6 +234,7 @@ public sealed class ResourceHistoryService : IDisposable
             return samples;
         }
         catch (IOException ex) { Log.Debug("Resource history load failed: {Error}", ex.Message); return []; }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Resource history load denied: {Error}", ex.Message); return []; }
         finally { if (!_disposed) _fileLock.Release(); }
     }
 
@@ -228,20 +245,21 @@ public sealed class ResourceHistoryService : IDisposable
         catch (OperationCanceledException) { return; }
         try
         {
-            if (!File.Exists(DataPath)) return;
-            var lines = await File.ReadAllLinesAsync(DataPath, ct).ConfigureAwait(false);
+            if (!File.Exists(_dataPath)) return;
+            var lines = await File.ReadAllLinesAsync(_dataPath, ct).ConfigureAwait(false);
             var kept = Prune(lines, DateTime.Now, TimeSpan.FromDays(_retentionDays));
             // Only rewrite when something actually changed, to avoid needless disk churn.
             if (kept.Count == lines.Length) return;
             // Atomic rewrite: write to a temp file in the same directory, then swap it in
             // with a single File.Move. A crash mid-write can then only leave a stray .tmp
-            // (never read — the sampler reads DataPath), never a truncated history file.
-            var tmp = DataPath + ".tmp";
+            // (never read — the sampler reads _dataPath), never a truncated history file.
+            var tmp = _dataPath + ".tmp";
             await File.WriteAllLinesAsync(tmp, kept, ct).ConfigureAwait(false);
-            File.Move(tmp, DataPath, overwrite: true);
+            File.Move(tmp, _dataPath, overwrite: true);
         }
         catch (OperationCanceledException) { /* shutdown */ }
         catch (IOException ex) { Log.Debug("Resource history prune failed: {Error}", ex.Message); }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Resource history prune denied: {Error}", ex.Message); }
         finally { if (!_disposed) _fileLock.Release(); }
     }
 
@@ -339,12 +357,12 @@ public sealed class ResourceHistoryService : IDisposable
 
     private sealed record RetentionConfig(int RetentionDays);
 
-    private static int LoadRetention()
+    private int LoadRetention()
     {
         try
         {
-            if (!File.Exists(ConfigPath)) return 7;
-            var cfg = JsonSerializer.Deserialize<RetentionConfig>(File.ReadAllText(ConfigPath));
+            if (!File.Exists(_configPath)) return 7;
+            var cfg = JsonSerializer.Deserialize<RetentionConfig>(File.ReadAllText(_configPath));
             return cfg is not null && RetentionOptions.Contains(cfg.RetentionDays) ? cfg.RetentionDays : 7;
         }
         catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
@@ -354,14 +372,15 @@ public sealed class ResourceHistoryService : IDisposable
         }
     }
 
-    private static void SaveRetention(int days)
+    private void SaveRetention(int days)
     {
         try
         {
-            Directory.CreateDirectory(DataDir);
-            File.WriteAllText(ConfigPath, JsonSerializer.Serialize(new RetentionConfig(days)));
+            Directory.CreateDirectory(_dataDir);
+            File.WriteAllText(_configPath, JsonSerializer.Serialize(new RetentionConfig(days)));
         }
         catch (IOException ex) { Log.Debug("Resource history config save failed: {Error}", ex.Message); }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Resource history config save denied: {Error}", ex.Message); }
     }
 
     public void Dispose()

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.57.3</Version>
-    <FileVersion>1.57.3.0</FileVersion>
-    <AssemblyVersion>1.57.3.0</AssemblyVersion>
+    <Version>1.57.4</Version>
+    <FileVersion>1.57.4.0</FileVersion>
+    <AssemblyVersion>1.57.4.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
@@ -73,6 +73,15 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
     private readonly BulkObservableCollection<DateTimePoint> _cpuTempBuffer = new();
     private readonly BulkObservableCollection<DateTimePoint> _gpuTempBuffer = new();
 
+    // Serializes ReloadAsync. Same guard, same reason as BandwidthMonitorViewModel's: three
+    // independent entry points can overlap (the constructor's InitializeAsync, the
+    // fire-and-forget from OnSelectedRangeChanged, and the Refresh button's command), and each
+    // one calls ReplaceWith on buffers LiveCharts is observing. Its observer keeps a HashSet it
+    // updates from the change notification, so a second thread arriving mid-notification
+    // corrupts it — "Operations that change non-concurrent collections must have exclusive
+    // access", which is how CI caught the identical race on the bandwidth chart.
+    private readonly SemaphoreSlim _reloadGate = new(1, 1);
+
     public ResourceHistoryViewModel(ResourceHistoryService service)
     {
         _service = service;
@@ -110,6 +119,10 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
     [RelayCommand]
     private async Task ReloadAsync()
     {
+        // A gate rather than a lock: this is an async path so it must not block the UI thread, and
+        // dropping nothing is important here — unlike a range switch, each caller may be asking for
+        // a different range, so every request runs, just strictly one at a time.
+        await _reloadGate.WaitAsync().ConfigureAwait(true);
         IsBusy = true;
         try
         {
@@ -132,7 +145,11 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
                 ? $"Showing {_loaded.Count} sample(s) over {SelectedRange.Label.ToLowerInvariant()}."
                 : "No history yet — samples are recorded every 10 seconds while the app runs.";
         }
-        finally { IsBusy = false; }
+        finally
+        {
+            IsBusy = false;
+            _reloadGate.Release();
+        }
     }
 
     /// <summary>Pure: averages/peaks for the summary strip. Testable without WPF.</summary>
@@ -252,6 +269,7 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
             (LegendBackgroundPaint as IDisposable)?.Dispose();
             (TooltipTextPaint as IDisposable)?.Dispose();
             (TooltipBackgroundPaint as IDisposable)?.Dispose();
+            _reloadGate.Dispose();
         }
         base.Dispose(disposing);
     }


### PR DESCRIPTION
## What this fixes

Two defects in the history/charting path, both found during the post-batch audit rather than reported.

### 1. The Resource History reload race (the same one fixed on Bandwidth Monitor in 1.57.3)

`ResourceHistoryViewModel.ReloadAsync` rebuilds **five** LiveCharts-observed buffers via `ReplaceWith`, and has **three** entry points that can run concurrently:

| Entry point | Where |
|---|---|
| `InitializeAsync(() => ReloadAsync())` | constructor |
| `OnSelectedRangeChanged => _ = ReloadAsync()` | fire-and-forget on range change |
| `[RelayCommand] ReloadAsync` | the Refresh button in `ResourceHistoryView.xaml` |

LiveCharts' `CollectionDeepObserver` maintains a `HashSet` updated from the change notification, so a second thread arriving mid-notification corrupts it — the exact failure CI hit on `BandwidthMonitorViewModel` ("Operations that change non-concurrent collections must have exclusive access"). That VM got a `SemaphoreSlim` gate; this one was missed. Same gate here, released in `finally`, disposed with the VM.

### 2. An unreadable history file escaped the catch

Both history services wrapped their file access in `catch (IOException)` only. `UnauthorizedAccessException` is a **sibling** of `IOException`, not a subclass, so a permission error propagated out. These run in an always-on background sampler the user never invoked, so it surfaced as a failure with no action behind it.

On the bandwidth side it was worse: `ReloadHistoryAsync` sets `_historyOwnsChart = true` before awaiting and only hands it back on `OperationCanceledException` — an escaping access error would have frozen the live chart permanently.

### 3. The service was untestable (the reason both slipped through)

`ResourceHistoryService` built its paths in `static readonly` fields from `Environment.GetFolderPath(SpecialFolder.LocalApplicationData)`. That resolves through the Win32 known-folder API and **ignores the `LOCALAPPDATA` environment variable** — verified with a probe — so neither a test nor a child process could redirect it off the real profile. Every existing test was confined to the pure helpers, leaving load, prune and retention uncovered.

It now takes the same optional `configDir` seam as `BandwidthHistoryService`, `ClosePreferenceService`, `CrashMarkerService`, `PerformanceService`, `ProfileService`, `ServiceStartupLedgerService`, `StandbyPreferenceService` and `VolumePresetService` — it was the only one of the 25 `LocalApplicationData` services still on hardcoded static paths.

## Verification

**The access-denied fix is red-before / green-after.** Proven with a deny-read ACL:

- before: `10 passed, 1 failed` — `THREW UnauthorizedAccessException: Access to the path '...\resource-history.ndjson' is denied.`
- after: `11 passed, 0 failed`

Worth recording: a **directory** in the file's place does *not* reproduce it. `File.Exists` returns false for a directory, so `LoadAsync` returns at its guard and never reaches the read — my first version of that test passed against the unfixed code and proved nothing. The deny-read ACL is the mechanism that actually raises it.

**The reload gate is not locally reproducible, on either VM.** LiveCharts only attaches its deep observer to a *rendered* chart, so the corruption cannot occur headlessly — a control build with the gate removed still passed 40 rounds x ~81 overlapping reloads. The gate is justified by CI's proven failure on the structurally identical sibling; the test asserts the reachable invariant (series stay coherent, nothing escapes) and says so in a comment rather than implying a repro.

**Regression sweep:**
- All three construction sites checked; `configDir` is optional so none needed changing.
- DI re-verified at runtime: `ResourceHistoryService` resolves, is still a singleton, `BandwidthHistoryService` still resolves, and the default path is unchanged (`%LOCALAPPDATA%\SysManager`).
- All four projects rebuild `--no-incremental`: **0 errors, 0 warnings**.
- An earlier harness returned a confident PASS that was **vacuous** (the profile's newest sample was five weeks old, so every range filtered to zero and `ReplaceWith` never did real work). A `SampleCount == 0` guard now fails that case explicitly.

## Tests added

`ResourceHistoryServiceDiskTests` (9) — the seam itself, range filtering, oldest-first ordering, malformed-line skipping, the unreadable-file path, and retention persistence across instances.
`ResourceHistoryViewModelReloadTests` (3) — concurrent reloads keep the series coherent, a redundant refresh still lands on its range and clears the progress bar, and no history reports the empty state.

## Not in this PR

The same unpaired-`IOException` gap exists at **15 other filesystem call sites** (`UpdateService` x3, `UpdateApplier`, `SpeedTestHistoryService` x3, `ProfileService`, `FileShredderService`, and others). Each needs its own reachability check, and bundling 15 files into a bug fix would break minimal-diff discipline — tracked separately. A mechanical guard is worth considering there, since the dominant house idiom is sequential paired catches (25 occurrences vs 3 of the `when (ex is A or B)` form).