### PR TITLE
fix: stop the open tab polling while the window is hidden to the tray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.57.5] - 2026-08-06
+
+### Fixed
+- **Closing SysManager to the tray now actually stops it working in the background.** Closing the window hides it rather than quitting — that is the default — but whichever tab was open kept checking your PC once a second for as long as it stayed on: re-listing every running process, or re-measuring network traffic and writing it to disk. Nothing was on screen to show it. Those checks now stop when the window is hidden or minimised and pick up again when you bring it back, so a PC left on all day is no longer doing invisible work. The background recording that is *meant* to keep running while hidden — the resource history graph, and the dark-mode schedule — is untouched.
+
 ## [1.57.4] - 2026-08-06
 
 ### Fixed

--- a/SysManager/SysManager.Tests/BandwidthMonitorViewModelTests.cs
+++ b/SysManager/SysManager.Tests/BandwidthMonitorViewModelTests.cs
@@ -492,4 +492,84 @@ public class BandwidthMonitorViewModelTests : IDisposable
     [Fact]
     public void FormatAxisTick_AtTheMaximumTickValue_YieldsAnEmptyLabel()
         => Assert.Equal("", BandwidthMonitorViewModel.FormatAxisTick(DateTime.MaxValue.Ticks, TimeSpan.Zero));
+
+    // ── The window-visibility poll gate ─────────────────────────────────────
+    // Closing to the tray calls Hide(), which does NOT deselect the open tab — so before this the
+    // selected tab's 1 Hz poll loop kept running for as long as the PC stayed on. Since "minimize
+    // to tray" is the default, that was the common all-day path.
+    //
+    // These exercise MainWindowViewModel.ApplyPollGate rather than the shell view-model itself: the
+    // shell cannot be constructed in the unit suite because About's constructor runs the startup
+    // update check (a network call), which is why its own tests live in the integration project —
+    // and CI only COMPILE-checks that project, so a regression pinned there would never run.
+
+    private static NavItem ItemFor(object content) => new()
+    {
+        Id = "nav-test",
+        Label = "Test",
+        Glyph = "",
+        ViewType = typeof(object),
+        Content = content,
+    };
+
+    [Fact]
+    public void HidingTheWindow_PausesTheTabsPollLoop()
+    {
+        var vm = NewVm();
+        vm.IsActive = true;
+
+        MainWindowViewModel.ApplyPollGate(ItemFor(vm), windowVisible: false);
+
+        Assert.False(vm.IsActive);
+    }
+
+    [Fact]
+    public void ShowingTheWindow_ResumesTheTabsPollLoop()
+    {
+        var vm = NewVm();
+        vm.IsActive = false;
+
+        MainWindowViewModel.ApplyPollGate(ItemFor(vm), windowVisible: true);
+
+        Assert.True(vm.IsActive);
+    }
+
+    [Fact]
+    public void TheGate_IgnoresATabWhoseViewModelWasNeverBuilt()
+    {
+        // Reading Content on a lazy NavItem would CONSTRUCT the view-model, undoing the lazy-startup
+        // fix — a never-opened tab has nothing polling, so the gate must skip it entirely.
+        int built = 0;
+        var lazy = new NavItem
+        {
+            Id = "nav-lazy",
+            Label = "Lazy",
+            Glyph = "",
+            ViewType = typeof(object),
+            ContentFactory = () => { built++; return new object(); },
+        };
+
+        MainWindowViewModel.ApplyPollGate(lazy, windowVisible: false);
+        MainWindowViewModel.ApplyPollGate(lazy, windowVisible: true);
+
+        Assert.Equal(0, built);
+        Assert.False(lazy.IsContentCreated);
+    }
+
+    [Fact]
+    public void TheGate_OnANullSelection_DoesNotThrow()
+    {
+        // SelectedNav is nullable and is null while the shell is still wiring up.
+        MainWindowViewModel.ApplyPollGate(null, windowVisible: false);
+        MainWindowViewModel.ApplyPollGate(null, windowVisible: true);
+    }
+
+    [Fact]
+    public void TheGate_OnATabWithNoPollLoop_IsANoOp()
+    {
+        // Most tabs are not in SetActive's switch because they have nothing to pause. Passing one
+        // must be harmless, since the gate runs for whichever tab happens to be selected.
+        MainWindowViewModel.ApplyPollGate(ItemFor(new object()), windowVisible: false);
+        MainWindowViewModel.ApplyPollGate(ItemFor(new object()), windowVisible: true);
+    }
 }

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -30,6 +30,19 @@ public partial class MainWindow : Window
 
         ToastService.Instance.ToastRequested += OnToastRequested;
         ToastService.Instance.DismissRequested += OnToastDismiss;
+
+        // Closing to the tray calls Hide(), which does NOT deselect the open tab — so its poll loop
+        // kept sampling once a second for as long as the PC stayed on. IsVisibleChanged is the right
+        // hook rather than OnClosing: it also fires on Show(), and the tray's "Volume mixer" item
+        // shows the window BEFORE it navigates, so the flag must already be true by then or that tab
+        // would open paused.
+        IsVisibleChanged += (_, e) =>
+        {
+            if (DataContext is MainWindowViewModel vm && e.NewValue is bool visible)
+                // Same combined condition as OnStateChanged: a window that is shown but still
+                // minimized is not on screen either, so one hook must never contradict the other.
+                vm.IsWindowVisible = visible && WindowState != WindowState.Minimized;
+        };
     }
 
     private void OnToastRequested(string title, string detail)
@@ -57,6 +70,19 @@ public partial class MainWindow : Window
     private void OnApplicationExit(object sender, ExitEventArgs e)
     {
         (DataContext as MainWindowViewModel)?.Dispose();
+    }
+
+    /// <summary>
+    /// Pauses the open tab's poll loop while the window is minimized, and resumes it on restore.
+    /// <para>Separate from the <c>IsVisibleChanged</c> hook in the constructor because WPF keeps
+    /// <see cref="UIElement.IsVisible"/> true for a minimized window — so minimizing to the taskbar
+    /// alone would not have triggered it.</para>
+    /// </summary>
+    protected override void OnStateChanged(EventArgs e)
+    {
+        base.OnStateChanged(e);
+        if (DataContext is MainWindowViewModel vm)
+            vm.IsWindowVisible = IsVisible && WindowState != WindowState.Minimized;
     }
 
     /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.57.4</Version>
-    <FileVersion>1.57.4.0</FileVersion>
-    <AssemblyVersion>1.57.4.0</AssemblyVersion>
+    <Version>1.57.5</Version>
+    <FileVersion>1.57.5.0</FileVersion>
+    <AssemblyVersion>1.57.5.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -53,6 +53,41 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     private bool _disposed;
 
     /// <summary>
+    /// Whether the main window is on screen. A tab's poll loop runs only while it is BOTH selected
+    /// and visible: closing to the tray hides the window without deselecting anything, so gating on
+    /// selection alone left the open tab sampling at 1 Hz for as long as the PC stayed on.
+    /// <para>Defaults to true because the window is shown before anything sets this, and the
+    /// pre-existing behaviour for a visible window must not change.</para>
+    /// </summary>
+    public bool IsWindowVisible
+    {
+        get => _isWindowVisible;
+        set
+        {
+            if (_isWindowVisible == value) return;
+            _isWindowVisible = value;
+            OnPropertyChanged();
+            ApplyPollGate(SelectedNav, value);
+        }
+    }
+
+    private bool _isWindowVisible = true;
+
+    /// <summary>
+    /// Applies the poll gate to <paramref name="item"/>: its loop runs only when the window is on
+    /// screen AND the tab is the selected one.
+    /// <para>Only touches a tab whose view-model was actually built — a never-opened lazy tab has
+    /// nothing polling, and reading <see cref="NavItem.Content"/> would construct it, undoing the
+    /// lazy-startup fix. Static and internal so the gate can be tested without the whole shell,
+    /// which cannot be constructed in the unit suite (it runs About's startup update check).</para>
+    /// </summary>
+    internal static void ApplyPollGate(NavItem? item, bool windowVisible)
+    {
+        if (item is { IsContentCreated: true } created)
+            SetActive(created.Content, windowVisible);
+    }
+
+    /// <summary>
     /// Parameterless constructor — used by XAML designer and tests.
     /// At runtime (DI container available) tab VMs are resolved LAZILY: each NavItem builds its
     /// view-model on first open, so the ~40 tabs that kick off a background scan/timer in their
@@ -267,7 +302,9 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         // we left and activate the one we entered — but only touch a tab's VM if it was actually
         // built (a never-opened lazy tab has no VM and, by definition, nothing polling).
         if (oldValue is { IsContentCreated: true }) SetActive(oldValue.Content, false);
-        SetActive(newValue.Content, true); // accessing Content here materialises the entered tab's VM
+        // Gate on visibility as well: the tray menu can navigate while the window is hidden (see
+        // NavigateTo), and starting a loop nothing can see is the very cost this gate exists to avoid.
+        SetActive(newValue.Content, IsWindowVisible); // accessing Content materialises the entered tab's VM
     }
 
     internal static void UpdateSelectionState(NavItem? oldValue, NavItem? newValue)
@@ -278,7 +315,9 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
     // The three tabs with a visibility-gated poll expose an IsActive flag. Toggle it generically
     // so this doesn't depend on eager VM properties that no longer exist for lazy tabs.
-    private static void SetActive(object content, bool active)
+    // internal (not private) so a test can pin the gate without constructing the whole shell,
+    // exactly as UpdateSelectionState above is tested.
+    internal static void SetActive(object content, bool active)
     {
         switch (content)
         {


### PR DESCRIPTION
Closes #1596.

## The problem

Poll-loop gating was wired only to tab navigation. `MainWindowViewModel.SetActive` was called **exclusively** from `OnSelectedNavChanged`, and closing the window *hides* it rather than closing it (`MinimizeToTray` is the default) — so nothing ever cleared `IsActive`.

A tab left open therefore kept sampling once a second for as long as the PC stayed on:

| Tab | What kept running, invisibly |
|---|---|
| Process Manager | re-enumerating every process + icon extraction, 1 Hz |
| Bandwidth Monitor | re-measuring throughput 1 Hz, appending to disk every 5 s |
| Dashboard | vitals poll |
| Volume mixer | peak-meter timer |

Nothing was on screen to show it. On a laptop that is battery spent on work nobody can see — for a tool whose entire pitch is making the machine run better.

## The fix

The gate already existed and every affected view-model already honours `IsActive` — it was simply never told the window went away. So this extends the existing condition to **selected AND on screen** rather than inventing a second mechanism:

- `MainWindowViewModel.IsWindowVisible`, defaulting to **true**. Defaulting to false would kill every poll loop until the user happened to minimize and restore — a worse bug than the one being fixed, and there's a test pinning the default.
- `OnSelectedNavChanged` activates the entered tab with `IsWindowVisible` instead of an unconditional `true`, because the tray menu and Dashboard quick actions can navigate while hidden.
- `MainWindow` hooks `IsVisibleChanged` **and** overrides `OnStateChanged`. Both are needed: `Hide()` flips `IsVisible`, but a minimize to the taskbar does **not** — WPF keeps `IsVisible` true for a minimized window. Both use the same combined condition so they can't contradict each other.

`IsVisibleChanged` rather than `OnClosing` for a specific reason: the tray's "Volume mixer" item calls `ShowWindow` **before** it navigates, so the flag has to already be true by then or that tab would open paused.

## Deliberately untouched

`ResourceHistoryService`'s sampler and `DarkModeViewModel`'s schedule are *supposed* to run while hidden. Neither is in `SetActive`'s switch — verified against source, not assumed. A broader "pause everything when hidden" change would have broken both.

## Testability

The gate is extracted as `ApplyPollGate` (internal static, matching the existing `UpdateSelectionState` precedent) so it can be tested without constructing the shell.

That matters: `MainWindowViewModel`'s constructor runs About's startup update check, which is a **network call**, so its existing tests live in `SysManager.IntegrationTests` — and CI only *compile-checks* that project, never runs it. A regression pinned there would never execute. I initially wrote these tests there, noticed that, and moved them to the unit suite where CI actually runs them.

Five tests added, including one proving the gate never materialises a never-opened lazy tab — reading `Content` would construct its view-model, undoing the lazy-startup fix.

## Verification

Red before / green after, against pristine main via a reflection probe that compiles against both revisions:

```
IsWindowVisible property : ABSENT
ApplyPollGate method     : ABSENT
  FAIL  the app has no way to pause polling when the window is hidden
RESULT: red   (exit 1)
```
```
IsWindowVisible property : present
ApplyPollGate method     : present
  PASS  hiding pauses the loop
RESULT: green (exit 0)
```

All four projects rebuild `--no-incremental` with **0 errors, 0 warnings**.

Not verifiable on this workstation: the actual tray interaction (hide → check idle CPU → restore) needs the app running, which is the secondary workstation's job. The logic gate itself is covered by the tests above.