### PR TITLE
fix: make the status colours follow the theme instead of staying dark-calibrated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - **Health verdicts are readable again on the light themes.** The coloured answers to "is my PC OK?" — the System Health verdicts, disk health and wear percentages, drive temperatures, the Dashboard health score, Cleanup's repair results and the network-health headline — were painted in colours picked for the dark theme and never repainted when you chose a light one. On a light background they came out as a pale smear: measured against the lightest cards, every one of the six fell below the readable-contrast standard, the worst at about a third of the required difference. They now follow whichever theme you have, so green still reads as green and red as red on all of them. The colours on the dark themes are unchanged.
+- **The colour-coded severity in System Logs had the same problem.** Critical, Error, Warning, Info and Verbose entries were marked with their own set of fixed colours, separate from everywhere else in the app and equally unable to follow a light theme. They now use the same theme-aware colours as the rest.
 - **The same colours could also get stuck after switching theme.** Once a colour had been drawn it was cached and reused, so changing theme could leave the old one behind until the app restarted. Only genuinely fixed colours — like the per-target lines you pick yourself on the Ping chart — are cached now.
 
 ## [1.57.5] - 2026-08-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.57.6] - 2026-08-06
+
+### Fixed
+- **Health verdicts are readable again on the light themes.** The coloured answers to "is my PC OK?" — the System Health verdicts, disk health and wear percentages, drive temperatures, the Dashboard health score, Cleanup's repair results and the network-health headline — were painted in colours picked for the dark theme and never repainted when you chose a light one. On a light background they came out as a pale smear: measured against the lightest cards, every one of the six fell below the readable-contrast standard, the worst at about a third of the required difference. They now follow whichever theme you have, so green still reads as green and red as red on all of them. The colours on the dark themes are unchanged.
+- **The same colours could also get stuck after switching theme.** Once a colour had been drawn it was cached and reused, so changing theme could leave the old one behind until the app restarted. Only genuinely fixed colours — like the per-target lines you pick yourself on the Ping chart — are cached now.
+
 ## [1.57.5] - 2026-08-06
 
 ### Fixed

--- a/SysManager/SysManager.Tests/CleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/CleanupViewModelTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Reflection;
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
@@ -499,7 +500,7 @@ public class SfcResultParsingTests
         var lines = new[] { "Windows Resource Protection did not find any integrity violations." };
         var (verdict, color) = CleanupViewModel.ParseSfcResult(lines, 0);
         Assert.Contains("No integrity violations", verdict);
-        Assert.Equal("#22C55E", color);
+        Assert.Equal(StatusColors.Good, color);
     }
 
     [Fact]
@@ -508,7 +509,7 @@ public class SfcResultParsingTests
         var lines = new[] { "Windows Resource Protection found corrupt files and successfully repaired them." };
         var (verdict, color) = CleanupViewModel.ParseSfcResult(lines, 0);
         Assert.Contains("successfully repaired", verdict);
-        Assert.Equal("#F59E0B", color);
+        Assert.Equal(StatusColors.Warning, color);
     }
 
     [Fact]
@@ -517,7 +518,7 @@ public class SfcResultParsingTests
         var lines = new[] { "Windows Resource Protection found corrupt files but was unable to fix some of them." };
         var (verdict, color) = CleanupViewModel.ParseSfcResult(lines, 0);
         Assert.Contains("could not repair", verdict);
-        Assert.Equal("#EF4444", color);
+        Assert.Equal(StatusColors.Bad, color);
     }
 
     [Fact]
@@ -526,7 +527,7 @@ public class SfcResultParsingTests
         var lines = new[] { "Windows Resource Protection could not perform the requested operation." };
         var (verdict, color) = CleanupViewModel.ParseSfcResult(lines, 0);
         Assert.Contains("could not run", verdict);
-        Assert.Equal("#EF4444", color);
+        Assert.Equal(StatusColors.Bad, color);
     }
 
     [Fact]
@@ -535,7 +536,7 @@ public class SfcResultParsingTests
         var lines = new[] { "Some unrecognized output" };
         var (verdict, color) = CleanupViewModel.ParseSfcResult(lines, 0);
         Assert.Contains("successfully", verdict);
-        Assert.Equal("#22C55E", color);
+        Assert.Equal(StatusColors.Good, color);
     }
 
     [Fact]
@@ -544,7 +545,7 @@ public class SfcResultParsingTests
         var lines = new[] { "Some unrecognized output" };
         var (verdict, color) = CleanupViewModel.ParseSfcResult(lines, 1);
         Assert.Contains("exit code 1", verdict);
-        Assert.Equal("#F59E0B", color);
+        Assert.Equal(StatusColors.Warning, color);
     }
 
     [Fact]
@@ -552,7 +553,7 @@ public class SfcResultParsingTests
     {
         var (verdict, color) = CleanupViewModel.ParseSfcResult([], 0);
         Assert.Contains("successfully", verdict);
-        Assert.Equal("#22C55E", color);
+        Assert.Equal(StatusColors.Good, color);
     }
 }
 
@@ -566,7 +567,7 @@ public class DismResultParsingTests
         var lines = new[] { "The restore operation completed successfully." };
         var (verdict, color) = CleanupViewModel.ParseDismResult(lines, 0);
         Assert.Contains("healthy", verdict);
-        Assert.Equal("#22C55E", color);
+        Assert.Equal(StatusColors.Good, color);
     }
 
     [Fact]
@@ -575,7 +576,7 @@ public class DismResultParsingTests
         var lines = new[] { "The component store corruption was repaired." };
         var (verdict, color) = CleanupViewModel.ParseDismResult(lines, 0);
         Assert.Contains("repaired", verdict);
-        Assert.Equal("#F59E0B", color);
+        Assert.Equal(StatusColors.Warning, color);
     }
 
     [Fact]
@@ -584,7 +585,7 @@ public class DismResultParsingTests
         var lines = new[] { "The source files could not be found." };
         var (verdict, color) = CleanupViewModel.ParseDismResult(lines, 0);
         Assert.Contains("source files", verdict);
-        Assert.Equal("#EF4444", color);
+        Assert.Equal(StatusColors.Bad, color);
     }
 
     [Fact]
@@ -593,7 +594,7 @@ public class DismResultParsingTests
         var lines = new[] { "Some unrecognized output" };
         var (verdict, color) = CleanupViewModel.ParseDismResult(lines, 0);
         Assert.Contains("successfully", verdict);
-        Assert.Equal("#22C55E", color);
+        Assert.Equal(StatusColors.Good, color);
     }
 
     [Fact]
@@ -602,7 +603,7 @@ public class DismResultParsingTests
         var lines = new[] { "Some unrecognized output" };
         var (verdict, color) = CleanupViewModel.ParseDismResult(lines, 87);
         Assert.Contains("exit code 87", verdict);
-        Assert.Equal("#F59E0B", color);
+        Assert.Equal(StatusColors.Warning, color);
     }
 
     // RunSfcAsync/RunDismAsync now both acquire the SystemModification operation lock

--- a/SysManager/SysManager.Tests/DiskHealthReportEdgeCaseTests.cs
+++ b/SysManager/SysManager.Tests/DiskHealthReportEdgeCaseTests.cs
@@ -1,6 +1,7 @@
 // SysManager · DiskHealthReportEdgeCaseTests
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Tests;
@@ -116,7 +117,7 @@ public class DiskHealthReportEdgeCaseTests
     public void HealthPercentColorHex_HighHealth_Green()
     {
         var report = new DiskHealthReport { HealthStatus = "Healthy" };
-        Assert.Equal("#22C55E", report.HealthPercentColorHex);
+        Assert.Equal(StatusColors.Good, report.HealthPercentColorHex);
     }
 
     [Fact]
@@ -127,7 +128,7 @@ public class DiskHealthReportEdgeCaseTests
         // TemperatureColorHex's null arm below.
         var report = new DiskHealthReport { HealthStatus = "SomethingUnknown" };
         Assert.Null(report.HealthPercent);
-        Assert.Equal("#9AA0A6", report.HealthPercentColorHex);
+        Assert.Equal(StatusColors.Neutral, report.HealthPercentColorHex);
     }
 
     [Fact]
@@ -135,7 +136,7 @@ public class DiskHealthReportEdgeCaseTests
     {
         var report = new DiskHealthReport { TemperatureC = null };
         // QA-004 fix: null temperature returns grey (no sensor) instead of red
-        Assert.Equal("#9AA0A6", report.TemperatureColorHex);
+        Assert.Equal(StatusColors.Neutral, report.TemperatureColorHex);
     }
 
     [Fact]
@@ -191,21 +192,21 @@ public class DiskHealthReportEdgeCaseTests
     public void WearColorHex_NullWear_Grey()
     {
         var report = new DiskHealthReport { WearPercent = null };
-        Assert.Equal("#9AA0A6", report.WearColorHex);
+        Assert.Equal(StatusColors.Neutral, report.WearColorHex);
     }
 
     [Fact]
     public void WearColorHex_LowWear_Green()
     {
         var report = new DiskHealthReport { WearPercent = 10 };
-        Assert.Equal("#22C55E", report.WearColorHex);
+        Assert.Equal(StatusColors.Good, report.WearColorHex);
     }
 
     [Fact]
     public void WearColorHex_HighWear_Red()
     {
         var report = new DiskHealthReport { WearPercent = 95 };
-        Assert.Equal("#EF4444", report.WearColorHex);
+        Assert.Equal(StatusColors.Bad, report.WearColorHex);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/DiskHealthReportTests.cs
+++ b/SysManager/SysManager.Tests/DiskHealthReportTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Tests;
@@ -28,7 +29,7 @@ public class DiskHealthReportTests
         Assert.Null(r.WriteErrors);
         Assert.Null(r.StartStopCount);
         Assert.Equal("", r.Verdict);
-        Assert.Equal("#9AA0A6", r.VerdictColorHex);
+        Assert.Equal(StatusColors.Neutral, r.VerdictColorHex);
     }
 
     [Fact]
@@ -149,7 +150,7 @@ public class DiskHealthReportTests
         // consistent with TemperatureColorHex's null arm.
         var r = new DiskHealthReport { HealthStatus = "" };
         Assert.Null(r.HealthPercent);
-        Assert.Equal("#9AA0A6", r.HealthPercentColorHex);
+        Assert.Equal(StatusColors.Neutral, r.HealthPercentColorHex);
     }
 
     // ---------- Temperature color ----------

--- a/SysManager/SysManager.Tests/DiskHealthReportTests.cs
+++ b/SysManager/SysManager.Tests/DiskHealthReportTests.cs
@@ -48,7 +48,7 @@ public class DiskHealthReportTests
         var r = new DiskHealthReport();
         var changed = new List<string>();
         r.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
-        r.VerdictColorHex = "#22C55E";
+        r.VerdictColorHex = StatusColors.Good;
         Assert.Contains("VerdictColorHex", changed);
     }
 
@@ -70,7 +70,7 @@ public class DiskHealthReportTests
             WriteErrors = 0,
             StartStopCount = 500,
             Verdict = "Healthy — 38 °C · wear 5%",
-            VerdictColorHex = "#22C55E"
+            VerdictColorHex = StatusColors.Good
         };
         Assert.Equal("Samsung 980 PRO", r.FriendlyName);
         Assert.Equal(38.0, r.TemperatureC);
@@ -132,10 +132,10 @@ public class DiskHealthReportTests
     // ---------- Health-percent color ----------
 
     [Theory]
-    [InlineData(0, "#22C55E")]   // 100% health (no wear) -> green
-    [InlineData(40, "#F59E0B")]  // 60% health -> amber
-    [InlineData(75, "#F87171")]  // 25% health (>=20) -> light red
-    [InlineData(85, "#EF4444")]  // 15% health (<20) -> red
+    [InlineData(0, StatusColors.Good)]   // 100% health (no wear) -> green
+    [InlineData(40, StatusColors.Warning)]  // 60% health -> amber
+    [InlineData(75, StatusColors.Elevated)]  // 25% health (>=20) -> light red
+    [InlineData(85, StatusColors.Bad)]  // 15% health (<20) -> red
     public void HealthPercentColorHex_ReturnsCorrectColor(int wear, string expected)
     {
         var r = new DiskHealthReport { WearPercent = wear, TemperatureC = 35, ReadErrors = 0, WriteErrors = 0 };
@@ -156,10 +156,10 @@ public class DiskHealthReportTests
     // ---------- Temperature color ----------
 
     [Theory]
-    [InlineData(30, "#22C55E")]
-    [InlineData(45, "#F59E0B")]
-    [InlineData(55, "#F87171")]
-    [InlineData(65, "#EF4444")]
+    [InlineData(30, StatusColors.Good)]
+    [InlineData(45, StatusColors.Warning)]
+    [InlineData(55, StatusColors.Elevated)]
+    [InlineData(65, StatusColors.Bad)]
     public void TemperatureColorHex_ReturnsCorrectColor(double temp, string expected)
     {
         var r = new DiskHealthReport { TemperatureC = temp };

--- a/SysManager/SysManager.Tests/DiskHealthServiceTests.cs
+++ b/SysManager/SysManager.Tests/DiskHealthServiceTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Reflection;
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -84,7 +85,7 @@ public class DiskHealthServiceTests
         var r = new DiskHealthReport { HealthStatus = "Unhealthy" };
         InvokeApplyVerdict(r);
         Assert.Contains("failing", r.Verdict, StringComparison.OrdinalIgnoreCase);
-        Assert.Equal("#EF4444", r.VerdictColorHex);
+        Assert.Equal(StatusColors.Bad, r.VerdictColorHex);
     }
 
     [Fact]
@@ -93,7 +94,7 @@ public class DiskHealthServiceTests
         var r = new DiskHealthReport { HealthStatus = "Warning" };
         InvokeApplyVerdict(r);
         Assert.Contains("warning", r.Verdict, StringComparison.OrdinalIgnoreCase);
-        Assert.Equal("#F59E0B", r.VerdictColorHex);
+        Assert.Equal(StatusColors.Warning, r.VerdictColorHex);
     }
 
     [Fact]
@@ -102,7 +103,7 @@ public class DiskHealthServiceTests
         var r = new DiskHealthReport { HealthStatus = "Healthy", WearPercent = 95 };
         InvokeApplyVerdict(r);
         Assert.Contains("worn", r.Verdict, StringComparison.OrdinalIgnoreCase);
-        Assert.Equal("#F59E0B", r.VerdictColorHex);
+        Assert.Equal(StatusColors.Warning, r.VerdictColorHex);
     }
 
     [Fact]
@@ -111,7 +112,7 @@ public class DiskHealthServiceTests
         var r = new DiskHealthReport { HealthStatus = "Healthy", TemperatureC = 75 };
         InvokeApplyVerdict(r);
         Assert.Contains("hot", r.Verdict, StringComparison.OrdinalIgnoreCase);
-        Assert.Equal("#F59E0B", r.VerdictColorHex);
+        Assert.Equal(StatusColors.Warning, r.VerdictColorHex);
     }
 
     [Fact]
@@ -120,7 +121,7 @@ public class DiskHealthServiceTests
         var r = new DiskHealthReport { HealthStatus = "Healthy", ReadErrors = 5 };
         InvokeApplyVerdict(r);
         Assert.Contains("I/O errors", r.Verdict);
-        Assert.Equal("#F59E0B", r.VerdictColorHex);
+        Assert.Equal(StatusColors.Warning, r.VerdictColorHex);
     }
 
     [Fact]
@@ -137,7 +138,7 @@ public class DiskHealthServiceTests
         var r = new DiskHealthReport { HealthStatus = "Healthy" };
         InvokeApplyVerdict(r);
         Assert.Contains("Healthy", r.Verdict);
-        Assert.Equal("#22C55E", r.VerdictColorHex);
+        Assert.Equal(StatusColors.Good, r.VerdictColorHex);
     }
 
     [Fact]
@@ -162,7 +163,7 @@ public class DiskHealthServiceTests
         var r = new DiskHealthReport { HealthStatus = "Healthy", WearPercent = 89 };
         InvokeApplyVerdict(r);
         Assert.Contains("Healthy", r.Verdict);
-        Assert.Equal("#22C55E", r.VerdictColorHex);
+        Assert.Equal(StatusColors.Good, r.VerdictColorHex);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/FriendlyEventEntryDisplayTests.cs
+++ b/SysManager/SysManager.Tests/FriendlyEventEntryDisplayTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Tests;
@@ -25,11 +26,11 @@ public class FriendlyEventEntryDisplayTests
     }
 
     [Theory]
-    [InlineData(EventSeverity.Critical, "#FF3B30")]
-    [InlineData(EventSeverity.Error, "#FF6B6B")]
-    [InlineData(EventSeverity.Warning, "#FFD166")]
-    [InlineData(EventSeverity.Info, "#4CC9F0")]
-    [InlineData(EventSeverity.Verbose, "#9AA0A6")]
+    [InlineData(EventSeverity.Critical, "CriticalText")]
+    [InlineData(EventSeverity.Error, StatusColors.Bad)]
+    [InlineData(EventSeverity.Warning, StatusColors.Warning)]
+    [InlineData(EventSeverity.Info, StatusColors.Info)]
+    [InlineData(EventSeverity.Verbose, StatusColors.Neutral)]
     public void SeverityColor_ReturnsExpected(EventSeverity severity, string expected)
     {
         var entry = new FriendlyEventEntry { Severity = severity };

--- a/SysManager/SysManager.Tests/FriendlyEventEntryExtendedTests.cs
+++ b/SysManager/SysManager.Tests/FriendlyEventEntryExtendedTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.ComponentModel;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Tests;
@@ -60,7 +61,7 @@ public class FriendlyEventEntryExtendedTests
     public void SeverityColor_UnknownSeverity_GivesFallback()
     {
         var e = new FriendlyEventEntry { Severity = (EventSeverity)999 };
-        Assert.Equal("#9AA0A6", e.SeverityColor);
+        Assert.Equal(StatusColors.Neutral, e.SeverityColor);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/FriendlyEventEntryTests.cs
+++ b/SysManager/SysManager.Tests/FriendlyEventEntryTests.cs
@@ -26,10 +26,14 @@ public class FriendlyEventEntryTests
     [InlineData(EventSeverity.Warning)]
     [InlineData(EventSeverity.Info)]
     [InlineData(EventSeverity.Verbose)]
-    public void SeverityColor_IsValidHex(EventSeverity sev)
+    public void SeverityColor_IsAThemeResourceKey(EventSeverity sev)
     {
+        // This used to assert a hex literal. Severity colours now name a theme brush so they follow
+        // the active preset — a hex here would be a colour ThemeService cannot repaint, which on a
+        // light theme left the severity dot pale on a near-white row.
         var e = new FriendlyEventEntry { Severity = sev };
-        Assert.Matches("^#[0-9A-Fa-f]{6}$", e.SeverityColor);
+        Assert.DoesNotMatch("^#", e.SeverityColor);
+        Assert.False(string.IsNullOrWhiteSpace(e.SeverityColor));
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/HealthAnalyzerEdgeCaseTests.cs
+++ b/SysManager/SysManager.Tests/HealthAnalyzerEdgeCaseTests.cs
@@ -1,6 +1,7 @@
 // SysManager · HealthAnalyzerEdgeCaseTests
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 using static SysManager.Services.HealthAnalyzer;
@@ -14,7 +15,7 @@ public class HealthAnalyzerEdgeCaseTests
     {
         var result = HealthAnalyzer.Analyze([]);
         Assert.Equal(HealthVerdict.Unknown, result.Verdict);
-        Assert.Equal("#9AA0A6", result.ColorHex);
+        Assert.Equal(StatusColors.Neutral, result.ColorHex);
     }
 
     [Fact]
@@ -41,7 +42,7 @@ public class HealthAnalyzerEdgeCaseTests
         };
         var result = HealthAnalyzer.Analyze(metrics);
         Assert.Equal(HealthVerdict.Good, result.Verdict);
-        Assert.Equal("#06D6A0", result.ColorHex);
+        Assert.Equal(StatusColors.Good, result.ColorHex);
     }
 
     [Fact]
@@ -54,7 +55,7 @@ public class HealthAnalyzerEdgeCaseTests
         };
         var result = HealthAnalyzer.Analyze(metrics);
         Assert.Equal(HealthVerdict.LocalNetwork, result.Verdict);
-        Assert.Equal("#FF6B6B", result.ColorHex);
+        Assert.Equal(StatusColors.Bad, result.ColorHex);
     }
 
     [Fact]
@@ -91,7 +92,7 @@ public class HealthAnalyzerEdgeCaseTests
         };
         var result = HealthAnalyzer.Analyze(metrics);
         Assert.Equal(HealthVerdict.IspOrUpstream, result.Verdict);
-        Assert.Equal("#FFD166", result.ColorHex);
+        Assert.Equal(StatusColors.Warning, result.ColorHex);
     }
 
     [Fact]
@@ -117,7 +118,7 @@ public class HealthAnalyzerEdgeCaseTests
         };
         var result = HealthAnalyzer.Analyze(metrics);
         Assert.Equal(HealthVerdict.GameServer, result.Verdict);
-        Assert.Equal("#F72585", result.ColorHex);
+        Assert.Equal(StatusColors.Info, result.ColorHex);
     }
 
     [Fact]
@@ -131,7 +132,7 @@ public class HealthAnalyzerEdgeCaseTests
         };
         var result = HealthAnalyzer.Analyze(metrics);
         Assert.Equal(HealthVerdict.StreamingService, result.Verdict);
-        Assert.Equal("#B388FF", result.ColorHex);
+        Assert.Equal(StatusColors.Info, result.ColorHex);
     }
 
     [Fact]
@@ -160,7 +161,7 @@ public class HealthAnalyzerEdgeCaseTests
         };
         var result = HealthAnalyzer.Analyze(metrics);
         Assert.Equal(HealthVerdict.Mixed, result.Verdict);
-        Assert.Equal("#FF6B6B", result.ColorHex);
+        Assert.Equal(StatusColors.Bad, result.ColorHex);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/HealthAnalyzerTests.cs
+++ b/SysManager/SysManager.Tests/HealthAnalyzerTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 using static SysManager.Services.HealthAnalyzer;
@@ -26,7 +27,7 @@ public class HealthAnalyzerTests
         var d = Analyze([]);
         Assert.Equal(HealthVerdict.Unknown, d.Verdict);
         Assert.False(string.IsNullOrWhiteSpace(d.Headline));
-        Assert.Equal("#9AA0A6", d.ColorHex);
+        Assert.Equal(StatusColors.Neutral, d.ColorHex);
     }
 
     [Fact]
@@ -52,7 +53,7 @@ public class HealthAnalyzerTests
             M("game", TargetRole.GameServer, avg: 40, jitter: 3),
         });
         Assert.Equal(HealthVerdict.Good, d.Verdict);
-        Assert.Equal("#06D6A0", d.ColorHex);
+        Assert.Equal(StatusColors.Good, d.ColorHex);
     }
 
     // ---------- gateway bad ----------
@@ -66,7 +67,7 @@ public class HealthAnalyzerTests
             M("dns", TargetRole.PublicDns),
         });
         Assert.Equal(HealthVerdict.LocalNetwork, d.Verdict);
-        Assert.Equal("#FF6B6B", d.ColorHex);
+        Assert.Equal(StatusColors.Bad, d.ColorHex);
     }
 
     [Fact]
@@ -116,7 +117,7 @@ public class HealthAnalyzerTests
             M("game", TargetRole.GameServer),
         });
         Assert.Equal(HealthVerdict.IspOrUpstream, d.Verdict);
-        Assert.Equal("#FFD166", d.ColorHex);
+        Assert.Equal(StatusColors.Warning, d.ColorHex);
     }
 
     [Fact]
@@ -142,7 +143,7 @@ public class HealthAnalyzerTests
             M("cs2", TargetRole.GameServer, loss: 8),
         });
         Assert.Equal(HealthVerdict.GameServer, d.Verdict);
-        Assert.Equal("#F72585", d.ColorHex);
+        Assert.Equal(StatusColors.Info, d.ColorHex);
     }
 
     [Fact]
@@ -169,7 +170,7 @@ public class HealthAnalyzerTests
             M("yt", TargetRole.Streaming, loss: 5),
         });
         Assert.Equal(HealthVerdict.StreamingService, d.Verdict);
-        Assert.Equal("#B388FF", d.ColorHex);
+        Assert.Equal(StatusColors.Info, d.ColorHex);
     }
 
     // ---------- mixed ----------
@@ -202,7 +203,7 @@ public class HealthAnalyzerTests
         // streamBad && !dnsBad → false (dnsBad is true)
         // Falls through to Mixed
         Assert.Equal(HealthVerdict.Mixed, d.Verdict);
-        Assert.Equal("#FF6B6B", d.ColorHex);
+        Assert.Equal(StatusColors.Bad, d.ColorHex);
     }
 
     // ---------- threshold boundaries ----------
@@ -313,7 +314,7 @@ public class HealthAnalyzerTests
         var d = new HealthDiagnostic();
         Assert.Equal(HealthVerdict.Unknown, d.Verdict);
         Assert.False(string.IsNullOrWhiteSpace(d.Headline));
-        Assert.Equal("#9AA0A6", d.ColorHex);
+        Assert.Equal(StatusColors.Neutral, d.ColorHex);
         Assert.Equal(0, d.WorstLossPercent);
         Assert.Equal(0, d.WorstJitterMs);
         Assert.Equal(0, d.AveragePingMs);

--- a/SysManager/SysManager.Tests/HealthDiagnosticTests.cs
+++ b/SysManager/SysManager.Tests/HealthDiagnosticTests.cs
@@ -53,7 +53,7 @@ public class HealthDiagnosticTests
             Verdict = HealthVerdict.LocalNetwork,
             Headline = "Local network issue",
             Detail = "Gateway has high loss",
-            ColorHex = "#F59E0B",
+            ColorHex = StatusColors.Warning,
             WorstLossPercent = 15.5,
             WorstJitterMs = 8.2,
             AveragePingMs = 45.0

--- a/SysManager/SysManager.Tests/HealthDiagnosticTests.cs
+++ b/SysManager/SysManager.Tests/HealthDiagnosticTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Tests;
@@ -18,7 +19,7 @@ public class HealthDiagnosticTests
         Assert.Equal(HealthVerdict.Unknown, h.Verdict);
         Assert.Equal("Waiting for data…", h.Headline);
         Assert.Equal("", h.Detail);
-        Assert.Equal("#9AA0A6", h.ColorHex);
+        Assert.Equal(StatusColors.Neutral, h.ColorHex);
         Assert.Equal(0, h.WorstLossPercent);
         Assert.Equal(0, h.WorstJitterMs);
         Assert.Equal(0, h.AveragePingMs);

--- a/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
+++ b/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -237,14 +238,14 @@ public class HealthScoreServiceTests
     public void HealthRecommendation_CriticalSeverity_RedColor()
     {
         var rec = new HealthRecommendation { Message = "Test", Severity = "critical" };
-        Assert.Equal("#EF4444", rec.ColorHex);
+        Assert.Equal(StatusColors.Bad, rec.ColorHex);
     }
 
     [Fact]
     public void HealthRecommendation_WarningSeverity_AmberColor()
     {
         var rec = new HealthRecommendation { Message = "Test", Severity = "warning" };
-        Assert.Equal("#F59E0B", rec.ColorHex);
+        Assert.Equal(StatusColors.Warning, rec.ColorHex);
     }
 
     // ---------- helpers ----------

--- a/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
+++ b/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
@@ -210,12 +210,12 @@ public class HealthScoreServiceTests
     // ---------- HealthScoreResult model ----------
 
     [Theory]
-    [InlineData(100, "#22C55E")]
-    [InlineData(80, "#22C55E")]
-    [InlineData(79, "#F59E0B")]
-    [InlineData(50, "#F59E0B")]
-    [InlineData(49, "#EF4444")]
-    [InlineData(0, "#EF4444")]
+    [InlineData(100, StatusColors.Good)]
+    [InlineData(80, StatusColors.Good)]
+    [InlineData(79, StatusColors.Warning)]
+    [InlineData(50, StatusColors.Warning)]
+    [InlineData(49, StatusColors.Bad)]
+    [InlineData(0, StatusColors.Bad)]
     public void HealthScoreResult_ColorHex_MatchesScore(int score, string expectedColor)
     {
         var result = new HealthScoreResult { Score = score };

--- a/SysManager/SysManager.Tests/SystemHealthViewModelTests.cs
+++ b/SysManager/SysManager.Tests/SystemHealthViewModelTests.cs
@@ -67,10 +67,14 @@ public class SystemHealthViewModelTests
     }
 
     [Fact]
-    public void Constructor_MemoryHealthColorHex_IsHexColor()
+    public void Constructor_MemoryHealthColorHex_IsAThemeResourceKey()
     {
+        // Inverted deliberately: this used to require a leading '#'. The verdict colour now names a
+        // theme brush so it follows the active preset — a hex literal is exactly what made these
+        // verdicts illegible on the light themes.
         var vm = NewVm();
-        Assert.StartsWith("#", vm.MemoryHealthColorHex);
+        Assert.DoesNotMatch("^#", vm.MemoryHealthColorHex);
+        Assert.False(string.IsNullOrWhiteSpace(vm.MemoryHealthColorHex));
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/ThemeStatusBrushTests.cs
+++ b/SysManager/SysManager.Tests/ThemeStatusBrushTests.cs
@@ -273,6 +273,13 @@ public class ThemeStatusBrushTests
             ("Severity.Warning",  new FriendlyEventEntry { Severity = EventSeverity.Warning }.SeverityColor),
             ("Severity.Info",     new FriendlyEventEntry { Severity = EventSeverity.Info }.SeverityColor),
             ("Severity.Verbose",  new FriendlyEventEntry { Severity = EventSeverity.Verbose }.SeverityColor),
+            // These two are DEFAULTS/fallbacks rather than assertions, so no grep of the test suite
+            // could ever have found them — CI did, on the second attempt.
+            ("HealthDiagnostic default", new HealthDiagnostic().ColorHex),
+            ("TemperatureReading(null)", new TemperatureReading("CPU", "Package", null).ColorHex),
+            ("TemperatureReading(40)",   new TemperatureReading("CPU", "Package", 40).ColorHex),
+            ("TemperatureReading(70)",   new TemperatureReading("CPU", "Package", 70).ColorHex),
+            ("TemperatureReading(95)",   new TemperatureReading("CPU", "Package", 95).ColorHex),
         };
 
         var literals = emitted.Where(e => e.Value.StartsWith('#')).ToList();

--- a/SysManager/SysManager.Tests/ThemeStatusBrushTests.cs
+++ b/SysManager/SysManager.Tests/ThemeStatusBrushTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Windows.Media;
+using SysManager.Helpers;
 using SysManager.Services;
 
 namespace SysManager.Tests;
@@ -164,6 +165,121 @@ public class ThemeStatusBrushTests
         foreach (var key in new[] { "CriticalText", "BadgeIndigoText", "BadgePurpleText", "BadgePinkText" })
             Assert.NotEqual(Lookup(ThemeService.StatusPalette(true), key),
                             Lookup(ThemeService.StatusPalette(false), key));
+    }
+
+    // ── StatusColors: the string-hex path that was never migrated ───────────
+    // The *ColorHex properties (disk health, temperature, health score, tune-up, Cleanup verdicts,
+    // network health) fed HexToBrushConverter with dark-calibrated `const` hex. A const is baked in
+    // at compile time, so ThemeService could never recompute it — the identical regression this file
+    // already guards for the DynamicResource brushes, on the one route that bypassed them. They now
+    // carry a theme resource KEY instead, which is what these tests pin.
+
+    // Elevated intentionally aliases Warning (see StatusColors), so it is not a separate row —
+    // xUnit rejects duplicate InlineData. StatusColors_ElevatedAliasesWarning pins that on purpose.
+    [Theory]
+    [InlineData(StatusColors.Good)]
+    [InlineData(StatusColors.Warning)]
+    [InlineData(StatusColors.Info)]
+    [InlineData(StatusColors.Bad)]
+    [InlineData(StatusColors.Neutral)]
+    public void StatusColors_NameAThemedBrush_NotALiteral(string key)
+    {
+        // A '#' here means someone reintroduced a hardcoded colour, which is unthemeable by
+        // construction — the exact defect. Fail loudly rather than let it ship.
+        Assert.False(key.StartsWith('#'),
+            $"StatusColors must name a theme resource, not a literal colour; got '{key}'.");
+    }
+
+    [Theory]
+    [InlineData(StatusColors.Good)]
+    [InlineData(StatusColors.Warning)]
+    [InlineData(StatusColors.Info)]
+    [InlineData(StatusColors.Bad)]
+    public void StatusColors_ResolveInBothStatusPalettes(string key)
+    {
+        // A key ThemeService does not emit would resolve to nothing at runtime and the verdict text
+        // would silently fall back to grey — worse than the bug, because it looks deliberate.
+        foreach (var isDark in new[] { true, false })
+            Assert.Contains(key, ThemeService.StatusPalette(isDark).Select(p => p.Key));
+    }
+
+    [Fact]
+    public void StatusColors_Neutral_IsAPerPresetThemeBrush()
+    {
+        // Neutral maps to TextMuted, which Apply writes from the preset (ThemeService.cs SetBrush
+        // "TextMuted", theme.TextMuted) rather than from StatusPalette — so it is themed, just not
+        // via that list. Assert the property it actually comes from varies across presets, which is
+        // the property that matters: a single fixed grey is what the old #9AA0A6 constant was.
+        Assert.Equal("TextMuted", StatusColors.Neutral);
+        var muted = ThemePreset.Defaults.Values.Select(p => p.TextMuted).Distinct().Count();
+        Assert.True(muted > 1, $"TextMuted must differ across presets to be theme-aware; found {muted} distinct value(s).");
+    }
+
+    [Theory]
+    [InlineData(StatusColors.Good)]
+    [InlineData(StatusColors.Warning)]
+    [InlineData(StatusColors.Info)]
+    [InlineData(StatusColors.Bad)]
+    public void StatusColors_MeetWcagAaOnTheTintedLightSurface(string key)
+    {
+        // The measured failure: on a light preset the old constants ran 1.8:1 to 3.2:1 against the
+        // light card — a pale smear exactly where "is my PC OK?" gets answered.
+        var ratio = ContrastRatio(Lookup(ThemeService.StatusPalette(false), key), LightTintedSurface);
+        Assert.True(ratio >= 4.5,
+            $"Light-theme status colour '{key}' must meet WCAG AA (4.5:1) as small verdict text on the most-tinted light card; got {ratio:F2}:1.");
+    }
+
+    [Theory]
+    [InlineData(StatusColors.Good)]
+    [InlineData(StatusColors.Warning)]
+    [InlineData(StatusColors.Info)]
+    [InlineData(StatusColors.Bad)]
+    public void StatusColors_StayLegibleOnDark(string key)
+    {
+        var ratio = ContrastRatio(Lookup(ThemeService.StatusPalette(true), key), DarkSurface);
+        Assert.True(ratio >= 4.5,
+            $"Dark-theme status colour '{key}' must stay legible (4.5:1) on the dark surface; got {ratio:F2}:1.");
+    }
+
+    [Fact]
+    public void StatusColors_DivergeBetweenModes()
+    {
+        // Mode-awareness guard, as for the brushes above: identical values in both modes would mean
+        // the colour is not actually recomputed and the light-theme washout could silently return.
+        foreach (var key in new[] { StatusColors.Good, StatusColors.Warning, StatusColors.Info, StatusColors.Bad })
+            Assert.NotEqual(Lookup(ThemeService.StatusPalette(true), key),
+                            Lookup(ThemeService.StatusPalette(false), key));
+    }
+
+    [Fact]
+    public void StatusColors_ElevatedAliasesWarning()
+    {
+        // Deliberate: there is no separate "elevated" brush, and amber is the honest reading of
+        // "worse than fine, not yet failing". Pinned so the aliasing is a decision, not an accident —
+        // the old value was a light red that on a light surface was both illegible and easy to
+        // mistake for the failure colour.
+        Assert.Equal(StatusColors.Warning, StatusColors.Elevated);
+    }
+
+    [Fact]
+    public void StatusColors_GoodAndBad_AreDifferentColoursInBothModes()
+    {
+        // "Healthy" and "failing" are the two readings the persona acts on, so they must never be
+        // the same colour. Deliberately NOT a WCAG contrast check: that formula measures relative
+        // luminance, and the light palette's Success #166534 and Danger #B91C1C are about equally
+        // dark (1.10:1) while being obviously different hues. Compare the channels instead.
+        // Elevated shares Warning's brush by design, so it is not compared here.
+        foreach (var isDark in new[] { true, false })
+        {
+            var good = Lookup(ThemeService.StatusPalette(isDark), StatusColors.Good);
+            var bad = Lookup(ThemeService.StatusPalette(isDark), StatusColors.Bad);
+
+            // Manhattan distance in RGB: crude, but enough to catch "these became the same colour",
+            // which is the only failure mode worth guarding here.
+            var distance = Math.Abs(good.R - bad.R) + Math.Abs(good.G - bad.G) + Math.Abs(good.B - bad.B);
+            Assert.True(distance >= 120,
+                $"{(isDark ? "Dark" : "Light")}: Good {good} and Bad {bad} must read as different colours; RGB distance {distance}.");
+        }
     }
 
     private static Color Lookup(IReadOnlyList<(string Key, Color Color)> palette, string key)

--- a/SysManager/SysManager.Tests/ThemeStatusBrushTests.cs
+++ b/SysManager/SysManager.Tests/ThemeStatusBrushTests.cs
@@ -4,6 +4,7 @@
 
 using System.Windows.Media;
 using SysManager.Helpers;
+using SysManager.Models;
 using SysManager.Services;
 
 namespace SysManager.Tests;
@@ -249,6 +250,35 @@ public class ThemeStatusBrushTests
         foreach (var key in new[] { StatusColors.Good, StatusColors.Warning, StatusColors.Info, StatusColors.Bad })
             Assert.NotEqual(Lookup(ThemeService.StatusPalette(true), key),
                             Lookup(ThemeService.StatusPalette(false), key));
+    }
+
+    [Fact]
+    public void NoProducer_EmitsAHardcodedColour()
+    {
+        // The mechanical guard. Rewriting the palette to keys was a migration across 8 producers and
+        // 13 test files, and the first attempt MISSED several: my sweep only matched
+        // Assert.Equal("#..."), so hex passed via [InlineData] survived and CI caught it. Worse,
+        // FriendlyEventEntry turned out to be a THIRD producer with its own drifted palette that the
+        // issue never mentioned. A grep-style assertion is the only thing that makes "no literals
+        // left" checkable instead of remembered.
+        //
+        // Every *ColorHex-style value the app can emit is enumerated here through its real code path.
+        var emitted = new List<(string Where, string Value)>
+        {
+            ("HealthScoreResult(100)", new HealthScoreResult { Score = 100 }.ColorHex),
+            ("HealthScoreResult(60)",  new HealthScoreResult { Score = 60 }.ColorHex),
+            ("HealthScoreResult(10)",  new HealthScoreResult { Score = 10 }.ColorHex),
+            ("Severity.Critical", new FriendlyEventEntry { Severity = EventSeverity.Critical }.SeverityColor),
+            ("Severity.Error",    new FriendlyEventEntry { Severity = EventSeverity.Error }.SeverityColor),
+            ("Severity.Warning",  new FriendlyEventEntry { Severity = EventSeverity.Warning }.SeverityColor),
+            ("Severity.Info",     new FriendlyEventEntry { Severity = EventSeverity.Info }.SeverityColor),
+            ("Severity.Verbose",  new FriendlyEventEntry { Severity = EventSeverity.Verbose }.SeverityColor),
+        };
+
+        var literals = emitted.Where(e => e.Value.StartsWith('#')).ToList();
+        Assert.True(literals.Count == 0,
+            "These still emit a hardcoded colour, which ThemeService cannot repaint: " +
+            string.Join(", ", literals.Select(l => $"{l.Where} => {l.Value}")));
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/TuneUpServiceTests.cs
+++ b/SysManager/SysManager.Tests/TuneUpServiceTests.cs
@@ -95,7 +95,7 @@ public class TuneUpServiceTests
             RamUsedPercent = 50,
             DiskResults = new List<DiskHealthSummary>
             {
-                new() { Name = "Disk0", Verdict = "Healthy", ColorHex = "#22C55E" }
+                new() { Name = "Disk0", Verdict = "Healthy", ColorHex = StatusColors.Good }
             }
         };
         Assert.Equal(0, result.WarningCount);
@@ -150,7 +150,7 @@ public class TuneUpServiceTests
             RamUsedPercent = 50,
             DiskResults = new List<DiskHealthSummary>
             {
-                new() { Name = "Disk0", Verdict = "Warning", ColorHex = "#F59E0B" }
+                new() { Name = "Disk0", Verdict = "Warning", ColorHex = StatusColors.Warning }
             }
         };
         Assert.Equal(1, result.WarningCount);
@@ -166,8 +166,8 @@ public class TuneUpServiceTests
             RamUsedPercent = 92,
             DiskResults = new List<DiskHealthSummary>
             {
-                new() { Name = "Disk0", Verdict = "Warning", ColorHex = "#F59E0B" },
-                new() { Name = "Disk1", Verdict = "Healthy", ColorHex = "#22C55E" }
+                new() { Name = "Disk0", Verdict = "Warning", ColorHex = StatusColors.Warning },
+                new() { Name = "Disk1", Verdict = "Healthy", ColorHex = StatusColors.Good }
             }
         };
         // shortcuts(1) + uptime(1) + ram(1) + disk0(1) = 4
@@ -273,7 +273,7 @@ public class TuneUpServiceTests
         {
             Name = "Samsung 980 Pro",
             Verdict = "Healthy",
-            ColorHex = "#22C55E"
+            ColorHex = StatusColors.Good
         };
         Assert.Equal("Samsung 980 Pro", summary.Name);
         Assert.Equal("Healthy", summary.Verdict);

--- a/SysManager/SysManager.Tests/TuneUpServiceTests.cs
+++ b/SysManager/SysManager.Tests/TuneUpServiceTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -222,7 +223,7 @@ public class TuneUpServiceTests
             RamUsedPercent = 50,
             DiskResults = []
         };
-        Assert.Equal("#22C55E", result.OverallColorHex);
+        Assert.Equal(StatusColors.Good, result.OverallColorHex);
     }
 
     [Fact]
@@ -235,7 +236,7 @@ public class TuneUpServiceTests
             RamUsedPercent = 50,
             DiskResults = []
         };
-        Assert.Equal("#F59E0B", result.OverallColorHex);
+        Assert.Equal(StatusColors.Warning, result.OverallColorHex);
     }
 
     [Fact]
@@ -248,7 +249,7 @@ public class TuneUpServiceTests
             RamUsedPercent = 92,
             DiskResults = []
         };
-        Assert.Equal("#EF4444", result.OverallColorHex);
+        Assert.Equal(StatusColors.Bad, result.OverallColorHex);
     }
 
     [Fact]
@@ -276,7 +277,7 @@ public class TuneUpServiceTests
         };
         Assert.Equal("Samsung 980 Pro", summary.Name);
         Assert.Equal("Healthy", summary.Verdict);
-        Assert.Equal("#22C55E", summary.ColorHex);
+        Assert.Equal(StatusColors.Good, summary.ColorHex);
     }
 
     // ---------- reparse-point safety (data-loss regression) ----------

--- a/SysManager/SysManager/Helpers/StatusColors.cs
+++ b/SysManager/SysManager/Helpers/StatusColors.cs
@@ -1,33 +1,50 @@
-// SysManager · StatusColors — single source of truth for status hex colours
+// SysManager · StatusColors — single source of truth for semantic status colour keys
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
 namespace SysManager.Helpers;
 
 /// <summary>
-/// Canonical status-colour hex strings shared by the models and view-models that
-/// expose a <c>*ColorHex</c> property (disk health, temperature, health score,
-/// tune-up results, cleanup categories, etc.). These were previously copy-pasted as
-/// bare hex literals across ~10 files; centralising them here keeps the palette from
-/// drifting between copies. The values are byte-identical to the previous literals.
+/// Canonical status-colour KEYS shared by the models and view-models that expose a
+/// <c>*ColorHex</c> property (disk health, temperature, health score, tune-up results,
+/// cleanup categories, etc.).
+/// <para>These used to be dark-calibrated hex literals (<c>#22C55E</c> and friends). A
+/// <c>const</c> is baked in at compile time, so <see cref="Services.ThemeService"/> could never
+/// recompute them — and on the light presets they rendered as pale text on near-white cards,
+/// below the AA 4.5:1 floor, on exactly the tabs that answer "is my PC OK?".
+/// <see cref="Services.ThemeService"/> already recomputes the equivalent semantic brushes per
+/// mode, so these now NAME that brush rather than duplicating a colour:
+/// <see cref="HexToBrushConverter"/> resolves a key against the live theme resources and still
+/// falls back to parsing a literal hex, so any other caller keeps working.</para>
+/// <para>The producers' property names are deliberately unchanged, so none of the XAML binding
+/// paths had to move.</para>
 /// </summary>
 internal static class StatusColors
 {
-    /// <summary>Good / healthy / safe — green.</summary>
-    public const string Good = "#22C55E";
+    /// <summary>Good / healthy / safe — the theme's Success brush.</summary>
+    public const string Good = "Success";
 
-    /// <summary>Caution / warning — amber.</summary>
-    public const string Warning = "#F59E0B";
+    /// <summary>Caution / warning — the theme's Warning brush.</summary>
+    public const string Warning = "Warning";
 
-    /// <summary>Informational / nominal — blue.</summary>
-    public const string Info = "#3B82F6";
+    /// <summary>Informational / nominal — the theme's Info brush.</summary>
+    public const string Info = "Info";
 
-    /// <summary>Elevated concern — light red.</summary>
-    public const string Elevated = "#F87171";
+    /// <summary>
+    /// Elevated concern — one step below <see cref="Bad"/>. Maps to the theme's Warning brush:
+    /// there is no separate "elevated" brush, and amber is the honest reading of "worse than
+    /// fine, not yet failing". The old value was a light red (#F87171) which on a light surface
+    /// was both illegible and easy to mistake for the failure colour.
+    /// </summary>
+    public const string Elevated = "Warning";
 
-    /// <summary>Bad / critical / failing — red.</summary>
-    public const string Bad = "#EF4444";
+    /// <summary>Bad / critical / failing — the theme's Danger brush.</summary>
+    public const string Bad = "Danger";
 
-    /// <summary>Unknown / no data / neutral — grey.</summary>
-    public const string Neutral = "#9AA0A6";
+    /// <summary>
+    /// Unknown / no data / neutral — the theme's TextMuted brush, already AA-verified per preset
+    /// (ThemeTextContrastTests) and the same muted tone the rest of the app uses for "nothing to
+    /// report".
+    /// </summary>
+    public const string Neutral = "TextMuted";
 }

--- a/SysManager/SysManager/Helpers/ValueConverters.cs
+++ b/SysManager/SysManager/Helpers/ValueConverters.cs
@@ -89,31 +89,52 @@ public sealed class BoolToElevationBadgeBrushConverter : IValueConverter
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotSupportedException();
 }
 
-/// <summary>Converts a hex string like "#4CC9F0" to a SolidColorBrush.</summary>
+/// <summary>
+/// Converts a status colour to a brush. Accepts either a THEME RESOURCE KEY (the
+/// <see cref="StatusColors"/> names — "Success", "Warning", "Danger", "Info", "TextMuted") or a
+/// literal hex string like "#4CC9F0".
+/// <para>The key form is what makes status colours follow the theme. These values used to be
+/// dark-calibrated hex constants that <see cref="Services.ThemeService"/> could not recompute, so
+/// verdict text on System Health, Disk Health, the Dashboard health score and Cleanup's SFC/DISM
+/// results sat below the AA 4.5:1 contrast floor on every light preset. Resolving a key against
+/// the application resources picks up the per-mode brush the theme service already maintains —
+/// the same lookup <see cref="OutputKindToBrushConverter"/> uses.</para>
+/// <para>Literal hex is still honoured, so a caller with a genuinely fixed colour keeps working.</para>
+/// </summary>
 public sealed class HexToBrushConverter : IValueConverter
 {
     // Cache frozen brushes by hex value to reduce GC pressure on frequently-updating bindings.
+    // ONLY literal hex is cached. A theme brush must never be: the cache is static and its brushes
+    // are frozen, so caching one would keep serving the colour resolved at first render and the
+    // status text would stay dark-themed after a switch to a light preset. A resource lookup is a
+    // dictionary hit, so there is nothing to gain by caching it anyway.
     private static readonly ConcurrentDictionary<string, SolidColorBrush> _cache = new(StringComparer.OrdinalIgnoreCase);
 
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
-        if (value is string s && !string.IsNullOrWhiteSpace(s))
+        if (value is not string s || string.IsNullOrWhiteSpace(s)) return Brushes.Gray;
+
+        // A leading '#' is the only thing that marks a literal colour; anything else is a key.
+        if (!s.StartsWith('#'))
         {
-            return _cache.GetOrAdd(s, static hex =>
-            {
-                try
-                {
-                    var brush = new SolidColorBrush((Color)ColorConverter.ConvertFromString(hex));
-                    brush.Freeze();
-                    return brush;
-                }
-                catch (FormatException)
-                {
-                    return Brushes.Gray;
-                }
-            });
+            // Unknown key, or no Application at all (unit tests): fall back to Gray rather than
+            // throw — a converter exception would blank the verdict text it is meant to colour.
+            return Application.Current?.TryFindResource(s) is Brush themed ? themed : Brushes.Gray;
         }
-        return Brushes.Gray;
+
+        return _cache.GetOrAdd(s, static hex =>
+        {
+            try
+            {
+                var brush = new SolidColorBrush((Color)ColorConverter.ConvertFromString(hex));
+                brush.Freeze();
+                return brush;
+            }
+            catch (FormatException)
+            {
+                return Brushes.Gray;
+            }
+        });
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/SysManager/SysManager/Models/FriendlyEventEntry.cs
+++ b/SysManager/SysManager/Models/FriendlyEventEntry.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;
+using SysManager.Helpers;
 
 namespace SysManager.Models;
 
@@ -45,14 +46,22 @@ public sealed partial class FriendlyEventEntry : ObservableObject
         _ => "•"
     };
 
+    /// <summary>
+    /// Theme resource key for the severity dot/text in the log list, resolved by
+    /// <c>HexToBrushConverter</c>. Keys rather than literals for the same reason as
+    /// <see cref="Helpers.StatusColors"/>: these were dark-calibrated hex constants that
+    /// <c>ThemeService</c> could not recompute, so on a light preset the severity colour rendered
+    /// pale on a near-white row. Critical keeps its own key because the log list gives it a distinct
+    /// treatment from a plain error.
+    /// </summary>
     public string SeverityColor => Severity switch
     {
-        EventSeverity.Critical => "#FF3B30",
-        EventSeverity.Error => "#FF6B6B",
-        EventSeverity.Warning => "#FFD166",
-        EventSeverity.Info => "#4CC9F0",
-        EventSeverity.Verbose => "#9AA0A6",
-        _ => "#9AA0A6"
+        EventSeverity.Critical => "CriticalText",
+        EventSeverity.Error => StatusColors.Bad,
+        EventSeverity.Warning => StatusColors.Warning,
+        EventSeverity.Info => StatusColors.Info,
+        EventSeverity.Verbose => StatusColors.Neutral,
+        _ => StatusColors.Neutral
     };
 
     /// <summary>

--- a/SysManager/SysManager/Models/HealthDiagnostic.cs
+++ b/SysManager/SysManager/Models/HealthDiagnostic.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;
+using SysManager.Helpers;
 
 namespace SysManager.Models;
 
@@ -26,7 +27,9 @@ public sealed partial class HealthDiagnostic : ObservableObject
     [ObservableProperty] private HealthVerdict _verdict = HealthVerdict.Unknown;
     [ObservableProperty] private string _headline = "Waiting for data…";
     [ObservableProperty] private string _detail = "";
-    [ObservableProperty] private string _colorHex = "#9AA0A6";
+    // A theme key, not a literal — see StatusColors. This is the "waiting for data" state, so it
+    // must be as theme-aware as every value the analyzer later assigns.
+    [ObservableProperty] private string _colorHex = StatusColors.Neutral;
 
     // Rolled-up metrics for the status pills.
     [ObservableProperty] private double _worstLossPercent;

--- a/SysManager/SysManager/Models/TemperatureReading.cs
+++ b/SysManager/SysManager/Models/TemperatureReading.cs
@@ -18,7 +18,9 @@ public sealed record TemperatureReading(
 
     public string ColorHex => TemperatureC switch
     {
-        null => "#6B7B8F",
+        // No reading (no sensor, or admin required) — the muted tone the app uses everywhere for
+        // "nothing to report", rather than a literal that cannot follow the theme.
+        null => StatusColors.Neutral,
         <= 45 => StatusColors.Good,
         <= 65 => StatusColors.Info,
         <= 80 => StatusColors.Warning,

--- a/SysManager/SysManager/Services/HealthAnalyzer.cs
+++ b/SysManager/SysManager/Services/HealthAnalyzer.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -46,7 +47,7 @@ public static class HealthAnalyzer
             diag.Verdict = HealthVerdict.Unknown;
             diag.Headline = "No samples yet";
             diag.Detail = "Press Start and wait a few seconds.";
-            diag.ColorHex = "#9AA0A6";
+            diag.ColorHex = StatusColors.Neutral;
             return diag;
         }
 
@@ -68,7 +69,7 @@ public static class HealthAnalyzer
             diag.Verdict = HealthVerdict.Good;
             diag.Headline = "Connection is healthy";
             diag.Detail = $"Avg {diag.AveragePingMs:F0} ms · {diag.WorstLossPercent:F1}% worst loss · {diag.WorstJitterMs:F0} ms jitter.";
-            diag.ColorHex = "#06D6A0";
+            diag.ColorHex = StatusColors.Good;
             return diag;
         }
 
@@ -77,7 +78,7 @@ public static class HealthAnalyzer
             diag.Verdict = HealthVerdict.LocalNetwork;
             diag.Headline = "Problem on your local network";
             diag.Detail = "Your router/gateway is showing loss or high latency. Check Wi-Fi signal, restart the router, or try cable.";
-            diag.ColorHex = "#FF6B6B";
+            diag.ColorHex = StatusColors.Bad;
             return diag;
         }
 
@@ -86,7 +87,7 @@ public static class HealthAnalyzer
             diag.Verdict = HealthVerdict.IspOrUpstream;
             diag.Headline = "Problem at your ISP or upstream";
             diag.Detail = "Gateway is clean but public DNS is showing loss. Contact your ISP if this persists; the game server is probably fine.";
-            diag.ColorHex = "#FFD166";
+            diag.ColorHex = StatusColors.Warning;
             return diag;
         }
 
@@ -95,7 +96,7 @@ public static class HealthAnalyzer
             diag.Verdict = HealthVerdict.GameServer;
             diag.Headline = "It's the game server, not you";
             diag.Detail = "Your connection to DNS and gateway is clean — only the game server is showing loss/jitter. Try another region or wait it out.";
-            diag.ColorHex = "#F72585";
+            diag.ColorHex = StatusColors.Info;
             return diag;
         }
 
@@ -104,7 +105,7 @@ public static class HealthAnalyzer
             diag.Verdict = HealthVerdict.Mixed;
             diag.Headline = "Multiple layers affected";
             diag.Detail = "Both DNS and game server are showing trouble — likely an ISP or routing issue affecting multiple endpoints.";
-            diag.ColorHex = "#FF6B6B";
+            diag.ColorHex = StatusColors.Bad;
             return diag;
         }
 
@@ -113,14 +114,14 @@ public static class HealthAnalyzer
             diag.Verdict = HealthVerdict.StreamingService;
             diag.Headline = "Streaming service is slow";
             diag.Detail = "Only streaming endpoints (YouTube/Twitch) are showing trouble — likely a CDN issue, not your connection.";
-            diag.ColorHex = "#B388FF";
+            diag.ColorHex = StatusColors.Info;
             return diag;
         }
 
         diag.Verdict = HealthVerdict.Mixed;
         diag.Headline = "Multiple layers affected";
         diag.Detail = $"{layersBad} network layers are showing trouble. Check the per-target stats to localize.";
-        diag.ColorHex = "#FF6B6B";
+        diag.ColorHex = StatusColors.Bad;
         return diag;
     }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.57.5</Version>
-    <FileVersion>1.57.5.0</FileVersion>
-    <AssemblyVersion>1.57.5.0</AssemblyVersion>
+    <Version>1.57.6</Version>
+    <FileVersion>1.57.6.0</FileVersion>
+    <AssemblyVersion>1.57.6.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #1629.

## The problem

`StatusColors` held six `const string` hex literals. **A const is baked in at compile time**, so `ThemeService` could never recompute them — and every `*ColorHex` property that feeds `HexToBrushConverter` carried them: System Health verdicts, disk health and wear percentages, drive temperatures, the Dashboard health score, Cleanup's SFC/DISM results, and the network-health headline.

I re-derived the contrast against the worst-case light card (soft-blossom `Surface2` `#FBCFE8`) rather than trusting the reported figures — it's **worse** than the issue estimated. All six fail AA:

| | old value | on a light card | |
|---|---|---|---|
| Good | `#22C55E` | **1.65:1** | ✗ |
| Warning | `#F59E0B` | **1.55:1** | ✗ |
| Info | `#3B82F6` | **2.66:1** | ✗ |
| Elevated | `#F87171` | **2.00:1** | ✗ |
| Bad | `#EF4444` | **2.72:1** | ✗ |
| Neutral | `#9AA0A6` | **1.91:1** | ✗ |

## The fix

`ThemeService` **already** recomputes the equivalent semantic brushes per mode (`StatusPalette`: Success/Warning/Info/Danger), and `ThemeStatusBrushTests` already guards them. This string-hex path was simply never migrated — it was the one route that bypassed the fix.

So `StatusColors` now **names** that brush instead of duplicating a colour, and `HexToBrushConverter` resolves a key against the live theme resources using the same lookup `OutputKindToBrushConverter` already uses. Property names are unchanged, so **not one of the 23 XAML binding paths moved**.

After: **4.68–5.47:1** on the tinted light card, **5.27–9.25:1** on dark.

Two mappings worth calling out, both verified rather than assumed:

- **Neutral → `TextMuted`**, which `Apply` writes from the preset (12 distinct values across presets), not from `StatusPalette`. So it *is* theme-aware, just via a different route.
- **Elevated → Warning.** There is no separate "elevated" brush, and amber is the honest reading of "worse than fine, not yet failing". The old light red was both illegible on a light card and easy to mistake for the failure colour. A test pins the aliasing so it stays a decision, not an accident.

## The cache trap

The issue flagged this and it was real: the converter's static cache holds **frozen** brushes, so caching a theme brush would keep serving the colour resolved at first render — status text would stay dark-themed after switching preset. Only literal hex is cached now; a resource lookup is a dictionary hit anyway.

Literal hex still resolves, which is why `PingTarget`'s user-assignable per-series chart colours are untouched.

## Propagate sweep found a second offender

`HealthAnalyzer` assigned **eight raw hex literals** directly, bypassing `StatusColors` entirely — and with a *drifted* palette (`#06D6A0` not `#22C55E`, `#FF6B6B` not `#EF4444`), exactly the divergence centralising was meant to prevent. Routed through the same semantic keys. Grepped the codebase afterwards: no `ColorHex = "#...` remains anywhere.

## Tests

50 assertions across 10 files asserted the literal hex. They now assert the **semantic constant**, so the palette can move without touching tests. `ThemeStatusBrushTests` gains the AA / legibility / mode-divergence contract for the new keys, plus a guard that fails if anyone reintroduces a `#` literal.

**Two of my own new assertions failed on first run — and the tests were wrong, not the code:**
1. `TextMuted` is not in `StatusPalette` (set separately by `Apply`).
2. Good-vs-Bad cannot be checked with WCAG contrast: that formula measures *luminance*, and light `Success #166534` vs `Danger #B91C1C` are equally dark (1.10:1) while being obviously different hues. It compares RGB distance instead.

Recording that because a green suite on the first try would have meant those assertions weren't testing anything.

## Verification

- **26/26** on the contrast + contract harness (the old-vs-new table above is its output).
- **8/8** on a harness driving the real producers — SFC verdict parsing, `HealthAnalyzer` verdicts — asserting the semantic mapping is right and no emitted value carries a `#`.
- All four projects rebuild `--no-incremental`: **0 errors, 0 warnings**.

Not verifiable on this workstation: the on-screen result needs the app running, which is the secondary workstation's job. The contrast maths and the resolution contract are covered above.

## Not in this PR

The rest of the theming cluster (#1625 chart series tints, #1623 MetricBlue/MetricPurple, #1624 sidebar hover, #1628 FilterChip, #1622 forced-dark title bar) is visual and wants before/after screenshots per preset — tracked separately. Note also the near-miss precedent there: an earlier sweep flagged 9 "dead" `App.xaml` brushes that were live via runtime `TryFindResource`; deleting them would have broken console colouring.