### PR TITLE
fix: make the OS title bar follow the active theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.57.7] - 2026-08-06
+
+### Fixed
+- **Light themes no longer come with a black title bar.** The bar across the top of the window — the one Windows draws, with the close button — was always dark, whichever theme you picked. On any of the six light themes the app was a near-white window wearing a black strip, the one part of it that never matched. It now follows your theme, and changes straight away when you switch rather than waiting for a restart.
+
 ## [1.57.6] - 2026-08-06
 
 ### Fixed

--- a/SysManager/SysManager.Tests/ThemeTextContrastTests.cs
+++ b/SysManager/SysManager.Tests/ThemeTextContrastTests.cs
@@ -68,6 +68,36 @@ public class ThemeTextContrastTests
             $"Preset '{presetId}': TextPrimary must meet WCAG AAA (7:1) on Background; got {ratio:F2}:1.");
     }
 
+    // ── The OS title bar follows the preset ─────────────────────────────────
+    // MainWindow tells DWM whether to draw the title bar dark via DWMWA_USE_IMMERSIVE_DARK_MODE, and
+    // it used to pass a hardcoded 1 exactly once at startup. So on the six light presets the app was
+    // a near-white window wearing a black title bar — the last surface still pinned to dark after
+    // every brush and control template had been migrated. The DWM call needs a real window, so what
+    // is asserted here is the SIGNAL that drives it: IsDark must classify every preset correctly, or
+    // the fix would confidently send the wrong value.
+
+    [Theory]
+    [MemberData(nameof(AllPresets))]
+    public void Preset_IsDark_AgreesWithItsOwnBackground(string presetId)
+    {
+        var p = ThemePreset.Defaults[presetId];
+        // 384 is the threshold the record itself applies to CUSTOM themes, so the built-ins must be
+        // consistent with it — otherwise a built-in and a custom theme of the same shade disagree.
+        var sum = p.Background.R + p.Background.G + p.Background.B;
+        Assert.Equal(sum < 384, p.IsDark);
+    }
+
+    [Fact]
+    public void BothDarkAndLightPresetsShip()
+    {
+        // If every preset were dark the title-bar bug could not manifest and the theory above would
+        // be silently vacuous. Pin that both kinds exist so it stays meaningful.
+        var dark = ThemePreset.Defaults.Values.Count(p => p.IsDark);
+        var light = ThemePreset.Defaults.Values.Count(p => !p.IsDark);
+        Assert.True(dark > 0, "No dark presets — the title-bar theory would be vacuous.");
+        Assert.True(light > 0, "No light presets — the title-bar bug could not manifest.");
+    }
+
     private static double ContrastRatio(Color a, Color b)
     {
         double la = RelLum(a), lb = RelLum(b);

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -97,7 +97,10 @@ public partial class MainWindow : Window
         if (PresentationSource.FromVisual(this) is HwndSource source)
         {
             source.AddHook(WndProc);
-            ApplyDarkTitleBar(source.Handle);
+            ApplyTitleBarTheme(source.Handle, ThemeService.Instance.CurrentTheme.IsDark);
+            // Re-apply on every switch: the OS title bar is not a WPF brush, so nothing else
+            // repaints it. Unsubscribed in OnClosed.
+            ThemeService.Instance.ThemeChanged += OnThemeChangedForTitleBar;
         }
 
         // Initialize tray icon after window handle is available. Pass a navigation callback so the
@@ -110,10 +113,26 @@ public partial class MainWindow : Window
             });
     }
 
-    private static void ApplyDarkTitleBar(IntPtr hwnd)
+    private void OnThemeChangedForTitleBar()
+    {
+        if (PresentationSource.FromVisual(this) is HwndSource source)
+            ApplyTitleBarTheme(source.Handle, ThemeService.Instance.CurrentTheme.IsDark);
+    }
+
+    /// <summary>
+    /// Tells the OS whether to draw the title bar dark or light.
+    /// <para>This used to pass a hardcoded 1 and run once at startup, so the title bar stayed dark
+    /// for the life of the process — on any of the six light presets the app was a near-white window
+    /// wearing a black title bar, the one piece of chrome the user could not theme. It is also the
+    /// only surface left pinned to dark after every brush, chart paint and control template was
+    /// migrated to invert per preset.</para>
+    /// <para>The return value is intentionally discarded: the attribute is unsupported before
+    /// Windows 10 1809, and failing to tint a title bar must never take the window down.</para>
+    /// </summary>
+    private static void ApplyTitleBarTheme(IntPtr hwnd, bool dark)
     {
         const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
-        int value = 1;
+        int value = dark ? 1 : 0;   // 0 is the documented default (light)
         DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, ref value, sizeof(int));
     }
 
@@ -217,6 +236,9 @@ public partial class MainWindow : Window
 
     protected override void OnClosed(EventArgs e)
     {
+        // ThemeService is a singleton that outlives the window, so a surviving subscription would
+        // keep this instance alive and fire against a dead handle on the next theme switch.
+        ThemeService.Instance.ThemeChanged -= OnThemeChangedForTitleBar;
         (DataContext as MainWindowViewModel)?.Dispose();
         base.OnClosed(e);
     }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.57.6</Version>
-    <FileVersion>1.57.6.0</FileVersion>
-    <AssemblyVersion>1.57.6.0</AssemblyVersion>
+    <Version>1.57.7</Version>
+    <FileVersion>1.57.7.0</FileVersion>
+    <AssemblyVersion>1.57.7.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #1622.

## The problem

`ApplyDarkTitleBar` passed a hardcoded `int value = 1` to `DWMWA_USE_IMMERSIVE_DARK_MODE` and ran **exactly once** from `OnSourceInitialized` — no second call site, no theme subscription. So the title bar stayed dark for the life of the process.

On any of the six light presets the app was a near-white window wearing a black strip: the one piece of chrome the user could not theme away, and the last surface still pinned to dark after every brush, chart paint and control template had already been migrated to invert per preset.

## The fix

`ApplyTitleBarTheme(hwnd, dark)` passing `dark ? 1 : 0` (0 is the documented default), called with `ThemeService.Instance.CurrentTheme.IsDark`, plus a `ThemeChanged` subscription so a switch re-applies **immediately** rather than waiting for a restart.

Unsubscribed in `OnClosed`: `ThemeService` is a singleton that outlives the window, so a surviving handler would keep this instance alive and fire against a dead handle.

## Verification

I checked the signal the fix depends on rather than trusting it. `IsDark` classifies all 12 presets correctly against the same `R+G+B < 384` threshold the record applies to custom themes — and the split is **6 dark / 6 light**, so the old hardcoded `1` was giving six presets the wrong title bar:

```
deep-ocean       bg=#050D1A sum= 44  IsDark=True  -> DWM 1
lavender         bg=#FAF5FF sum=750  IsDark=False -> DWM 0
midnight-indigo  bg=#070A0F sum= 32  IsDark=True  -> DWM 1
mint-fresh       bg=#F0FDF4 sum=737  IsDark=False -> DWM 0
neon-rose        bg=#120508 sum= 31  IsDark=True  -> DWM 1
sky-breeze       bg=#F8FAFC sum=750  IsDark=False -> DWM 0
soft-blossom     bg=#FDF2F8 sum=743  IsDark=False -> DWM 0
violet-night     bg=#0A0515 sum= 36  IsDark=True  -> DWM 1
warm-ember       bg=#0F0A04 sum= 29  IsDark=True  -> DWM 1
warm-sand        bg=#FFFBEB sum=741  IsDark=False -> DWM 0
```

15/15 on that harness. Pinned in the suite as a theory over every preset, **plus a guard that both dark and light presets ship** — if every preset were dark the theory would be silently vacuous and pass while testing nothing.

All four projects rebuild `--no-incremental` with **0 errors, 0 warnings**.

## Scope

`DwmSetWindowAttribute` needs a real window, so the on-screen result is deferred to the secondary workstation — what's checkable here is the decision feeding it. The return value stays discarded: the attribute is unsupported before Windows 10 1809, and failing to tint a title bar must never take the window down.

`MainWindow` is the only `Window` in the project, so this is the only affected frame.