### PR TITLE
ci: fail the build when a merged version was never tagged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,55 @@ jobs:
           path: TestResults/**
           retention-days: 14
 
+  # Catches a version that was never tagged — otherwise INVISIBLE. auto-release.yml serialises on a
+  # concurrency group, and GitHub keeps only ONE pending run per group, so merging two
+  # release-triggering PRs in close succession can displace the older queued run. A displaced run
+  # reports as `cancelled`, not failed, so the bump is silently dropped: main ends up claiming a
+  # version that has no tag and no release, with nothing red anywhere. That happened on the #1717
+  # merge (1.57.6) and took manual archaeology to find.
+  #
+  # A separate job on purpose, not a step in build-and-test: it waits for auto-release, which runs in
+  # parallel on the same push, and adding minutes of waiting to a job that already runs ~8 of its
+  # 10-minute budget would make CI fail for timing rather than for correctness. ubuntu-latest because
+  # this is git-only work.
+  tag-published:
+    name: Merged version is tagged
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # main only: on a PR, csproj is SUPPOSED to be ahead of the newest tag — that is the point of
+    # bumping it in the PR. It is only a defect once the merge has landed.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0   # tags are the whole point of this job
+
+      - name: Wait for the tag that matches csproj
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(grep -oE '<Version>[^<]+' SysManager/SysManager/SysManager.csproj | head -n1 | sed 's/<Version>//')
+          echo "csproj version: $VERSION"
+
+          # A chore:/docs:/ci:/test: merge does not release, so csproj legitimately still points at
+          # the version already tagged by the previous release-triggering merge. Only a MISSING tag
+          # for the current csproj version is a problem, which is exactly what this checks.
+          for attempt in $(seq 1 10); do
+            git fetch --tags --quiet origin
+            if git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+              echo "v$VERSION is tagged."
+              exit 0
+            fi
+            echo "attempt $attempt: v$VERSION not tagged yet, waiting for auto-release..."
+            sleep 30
+          done
+
+          NEWEST=$(git tag --list 'v*.*.*' --sort=-v:refname | head -n1)
+          echo "::error::csproj is at $VERSION but there is no v$VERSION tag (newest is $NEWEST). Auto-release did not tag this merge — check whether its run was CANCELLED rather than failed (a displaced queued run reports as cancelled). Recover with: git tag -a v$VERSION -m \"SysManager $VERSION\" <merge-sha> && git push origin v$VERSION — release.yml triggers on v*.*.* and publishes normally."
+          exit 1
+
   ui-tests:
     name: UI automation tests
     runs-on: windows-latest


### PR DESCRIPTION
Closes #1720.

## The problem

A release-triggering merge can silently produce **no release**.

`auto-release.yml` serialises on a concurrency group, and GitHub keeps only **one pending run** per group — so merging two `fix:`/`feat:` PRs in close succession can displace the older queued run. A displaced run reports as `cancelled`, **not failed**. The bump is dropped with nothing red anywhere: CI green, PR merged, branch deleted, and main claiming a version that has no tag and no release.

That happened on the #1717 merge: main carried `<Version>1.57.6</Version>` and a `## [1.57.6]` CHANGELOG entry with no `v1.57.6` tag. It was only found by manually comparing csproj against the tag list, days later.

## The fix

Make that comparison a gate. On a push to main, wait for a tag matching csproj; if it never appears, fail with the recovery command in the error. This catches **every** cause of a missing tag, not just cancellation.

## Why a separate job, not a step

Two reasons, both learned the hard way:

1. It has to **wait** for auto-release, which runs in parallel on the same push.
2. `build-and-test` already uses ~8 of its 10-minute budget. Adding minutes of waiting there would make CI fail for *timing* instead of correctness — which has already bitten this repo three times (two unit-test jobs killed at 10m24s and 12m43s, plus a Release run), each time showing as `fail` while the tests had actually passed.

`ubuntu-latest` because this is git-only work.

## Guarded to main-only, deliberately

On a PR, csproj is **supposed** to be ahead of the newest tag — that's the point of bumping it in the PR — so this would be a constant false alarm there.

A `chore:`/`docs:`/`ci:` merge is also fine: csproj legitimately still points at the version the previous release-triggering merge tagged. Only a **missing tag for the current csproj version** is a defect, which is exactly what's checked.

`ci.yml` checks out shallow, so the job fetches tags explicitly rather than deepening the whole clone for one comparison.

## Verification

Run against the real repository, all three cases:

| csproj version | tag state | result |
|---|---|---|
| 1.58.0 | tagged | **exit 0** — "v1.58.0 is tagged." |
| 1.58.1 | never tagged | **exit 1** |
| 1.57.6 | tag temporarily removed | **exit 1** — catches the exact bug that shipped nothing |

The third case is the important one: it reproduces the 08-06 failure and the guard fires. The temporarily-deleted local tag was restored from origin afterwards, and both the local and remote tag lists re-verified intact.

YAML validated by parsing it (`jobs: build-and-test, tag-published, ui-tests`), and the version-extraction command was run against the real csproj — it returns exactly `1.58.0`.

`ci:` so this triggers no release and needs no version bump.

## Note on the sibling problem

The other half of #1720 — that a `cancelled` conclusion renders as `fail` in `gh pr checks`, making a timing kill indistinguishable from a test failure — is not addressed here. Raising `timeout-minutes` on `build-and-test` (or splitting its four builds out) is a separate change with its own trade-offs, and this PR is deliberately the narrow, verifiable half.