### PR TITLE
ci: give the unit-test job real headroom so a slow runner is not a red test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,14 @@ jobs:
   build-and-test:
     name: Build & unit tests
     runs-on: windows-latest
-    timeout-minutes: 10
+    # 25, not 10. This job normally takes 5-8 minutes — the tests themselves are ~1 of those, the
+    # rest is checkout, SDK setup, restore and four sequential builds — so a 10-minute ceiling left
+    # only ~2 minutes of headroom. A slow runner then blew it, and a job killed by its timeout has
+    # conclusion `cancelled`, which `gh pr checks` renders as `fail`: indistinguishable from a real
+    # test failure, while the log still says "Passed! Failed: 0". That happened three times on
+    # 2026-08-06 and left a PR blocked for days over nothing. A ceiling is here to catch a HUNG job,
+    # and 25 minutes still does that. (ui-tests below already allows 30 for a ~4-minute job.)
+    timeout-minutes: 25
 
     steps:
       - name: Checkout
@@ -95,6 +102,11 @@ jobs:
       - name: Build integration tests (compile check)
         run: dotnet build SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj -c Release --no-restore
 
+      # DIAGNOSING A RED CHECK HERE: read the "Passed! - Failed: N" line in this step's log first.
+      # If it says Failed: 0, the tests passed and the JOB was killed — either by the timeout above
+      # or by a transient GitHub failure ("Failed to resolve action download info"). A killed job's
+      # conclusion is `cancelled`, which `gh pr checks` displays as `fail`, so it looks identical to
+      # a broken test. The fix in that case is `gh run rerun <id> --failed`, not a code change.
       - name: Run unit tests
         run: >
           dotnet test SysManager/SysManager.Tests/SysManager.Tests.csproj


### PR DESCRIPTION
Closes #1728.

## The problem, measured

`build-and-test` had `timeout-minutes: 10` while normally taking **5–8 minutes**:

| run | duration |
|---|---|
| 31364629054 | 5m14s |
| 31363983528 | 5m09s |
| 31362188307 | 8m15s |
| 31119468079 | 8m04s |

The tests themselves are ~1 minute of that. The rest is checkout, SDK setup, restore and four sequential builds — so about **two minutes of headroom** absorbed any runner slowness.

When exceeded, the job is killed, and a killed job's conclusion is `cancelled` — which `gh pr checks` renders as **`fail`**, indistinguishable from a genuine test failure while the log still reads `Passed! Failed: 0`.

That happened **three times on 2026-08-06**: jobs killed at 10m24s and 12m43s (with 4119/0 and 4135/0 *passing*), plus a Release run and a UI job that died in "Set up job" during a GitHub outage. It left #1722 blocked for days over nothing.

## The fix

Raised to **25**. A ceiling exists to catch a *hung* job, and 25 minutes still does that. `ui-tests` in this same file already allows **30** for a job that takes ~4 — so a generous ceiling is the existing precedent here, not a new idea.

## The diagnostic note

The issue's option 3 was to surface the distinction. I put it as a comment on the test step, where someone investigating a red check will actually be looking:

> read the `Passed! - Failed: N` line first — `Failed: 0` means the job was killed rather than broken, and the fix is `gh run rerun <id> --failed`, not a code change.

Deliberately a comment rather than a workflow step: **a step cannot run after the job it lives in has been killed**, so an "annotate the timeout" step would never execute in exactly the case it was meant to explain.

## Not done here

Splitting the four builds into separate jobs (option 2 in the issue). That is the better long-term shape and would also parallelise the integration-test compile check, but it restructures a working pipeline — so it stays a separate change rather than riding along with a one-line ceiling fix.

## Verification

YAML re-parsed after editing; all three job timeouts confirmed:

```
build-and-test: timeout=25 runs-on=windows-latest
tag-published:  timeout=15 runs-on=ubuntu-latest
ui-tests:       timeout=30 runs-on=windows-latest
```

`ci:` so this triggers no release and needs no version bump.