### PR TITLE
fix: handle access-denied on the six filesystem paths that only caught IOException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.58.1] - 2026-08-10
+
+### Fixed
+- **A file SysManager is not allowed to read no longer breaks the job it was part of.** Six places treated "the disk had a problem" and "Windows would not let me read this" as different things and only handled the first — so a single locked-down file could stop the whole operation instead of being skipped. The clearest case: exporting your settings gave up entirely if one of the files could not be read, losing the ones that could. Now the unreadable file is skipped and the rest still export. The same applies to checking a downloaded update, saving the Settings Watchdog baseline, reading the gaming-profile store, loading an app icon, and adding a file to the shredder list.
+
 ## [1.58.0] - 2026-08-10
 
 ### Added

--- a/SysManager/SysManager.Tests/ProfileServiceTests.cs
+++ b/SysManager/SysManager.Tests/ProfileServiceTests.cs
@@ -177,4 +177,44 @@ public class ProfileServiceTests : IDisposable
         Assert.NotNull(imported);
         Assert.Contains(imported!.Sections, s => s.Key == "theme" && s.Json.Contains("violet-night"));
     }
+
+    // ---------- Unreadable config files ----------
+
+    [Fact]
+    public void AvailableSections_SkipsAFileItCannotRead_RatherThanThrowing()
+    {
+        // UnauthorizedAccessException is a SIBLING of IOException, not a subclass, so the
+        // `catch (IOException)` around File.ReadAllText never covered an ACL-denied file — the
+        // exception escaped and took the whole export with it, losing the sections that WERE
+        // readable. A deny-read ACL is what actually produces it; a missing file is filtered out by
+        // the File.Exists guard before the read, so it cannot exercise this path.
+        WriteConfig("theme.json", "{\"preset\":\"midnight\"}");
+        WriteConfig("speedtest-history.json", "[1,2,3]");
+
+        var sid = System.Security.Principal.WindowsIdentity.GetCurrent().User;
+        if (sid is null) return;   // no SID to deny — nothing to assert on this host
+
+        var denied = new FileInfo(Path.Combine(_dir, "theme.json"));
+        var acl = denied.GetAccessControl();
+        var rule = new System.Security.AccessControl.FileSystemAccessRule(
+            sid,
+            System.Security.AccessControl.FileSystemRights.Read,
+            System.Security.AccessControl.AccessControlType.Deny);
+        acl.AddAccessRule(rule);
+        denied.SetAccessControl(acl);
+        try
+        {
+            var sections = _svc.AvailableSections();
+
+            // The readable one still comes through; the denied one is simply absent.
+            Assert.Contains(sections, s => s.Key == "speedtest");
+            Assert.DoesNotContain(sections, s => s.Key == "theme");
+        }
+        finally
+        {
+            // Remove the deny rule, or Dispose cannot delete the temp directory.
+            acl.RemoveAccessRule(rule);
+            denied.SetAccessControl(acl);
+        }
+    }
 }

--- a/SysManager/SysManager/Services/GamingProfileService.cs
+++ b/SysManager/SysManager/Services/GamingProfileService.cs
@@ -455,6 +455,7 @@ public sealed class GamingProfileService : IGamingProfileService, IDisposable
             return store;
         }
         catch (IOException ex) { Log.Warning(ex, "Failed to read gaming profile store"); }
+        catch (UnauthorizedAccessException ex) { Log.Warning(ex, "Access denied reading gaming profile store"); }
         catch (JsonException ex) { Log.Warning(ex, "Failed to parse gaming profile store"); }
         return new GamingProfileStore { SchemaVersion = CurrentSchemaVersion };
     }

--- a/SysManager/SysManager/Services/IconExtractorService.cs
+++ b/SysManager/SysManager/Services/IconExtractorService.cs
@@ -202,6 +202,7 @@ public sealed partial class IconExtractorService
         }
         catch (ExternalException) { return _appFallback.Value; }
         catch (IOException) { return _appFallback.Value; }
+        catch (UnauthorizedAccessException) { return _appFallback.Value; }
     }
 
     /// <summary>

--- a/SysManager/SysManager/Services/ProfileService.cs
+++ b/SysManager/SysManager/Services/ProfileService.cs
@@ -85,6 +85,7 @@ public sealed class ProfileService
             string json;
             try { json = File.ReadAllText(path); }
             catch (IOException ex) { Log.Debug("Profile: skipping {File} ({Error})", fileName, ex.Message); continue; }
+            catch (UnauthorizedAccessException ex) { Log.Debug("Profile: skipping {File} (access denied: {Error})", fileName, ex.Message); continue; }
             sections.Add(new ConfigSection(key, display, fileName, json));
         }
         return sections;

--- a/SysManager/SysManager/Services/SettingsWatchdogService.cs
+++ b/SysManager/SysManager/Services/SettingsWatchdogService.cs
@@ -186,6 +186,7 @@ public sealed class SettingsWatchdogService : ISettingsWatchdogService
             File.WriteAllText(BaselinePath, JsonSerializer.Serialize(snapshot, JsonDefaults.Indented));
         }
         catch (IOException ex) { Log.Debug("Settings baseline save failed: {Error}", ex.Message); }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Settings baseline save denied: {Error}", ex.Message); }
     }
 
     // ── Catalog ─────────────────────────────────────────────────────────────

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -331,6 +331,15 @@ public sealed class UpdateService
             Serilog.Log.Warning(ex, "Could not read downloaded file for hash verification");
             return (false, null, null);
         }
+        // UnauthorizedAccessException is a SIBLING of IOException, not a subclass, so it escaped the
+        // catch above — File.OpenRead raises it for an ACL-denied cached binary. This method's whole
+        // contract is "false means verification failed", so letting it propagate turned a safe
+        // refusal into a crash on the install path. Treated like every other failure mode here.
+        catch (UnauthorizedAccessException ex)
+        {
+            Serilog.Log.Warning(ex, "Could not read downloaded file for hash verification (access denied)");
+            return (false, null, null);
+        }
     }
 
     /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.58.0</Version>
-    <FileVersion>1.58.0.0</FileVersion>
-    <AssemblyVersion>1.58.0.0</AssemblyVersion>
+    <Version>1.58.1</Version>
+    <FileVersion>1.58.1.0</FileVersion>
+    <AssemblyVersion>1.58.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/FileShredderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/FileShredderViewModel.cs
@@ -64,6 +64,13 @@ public sealed partial class FileShredderViewModel : ViewModelBase
             {
                 Log.Warning(ex, "Could not read file info: {Path}", filePath);
             }
+            catch (UnauthorizedAccessException ex)
+            {
+                // A file the user dragged in but cannot read — skip it rather than aborting the
+                // whole drop. UnauthorizedAccessException is a sibling of IOException, not a
+                // subclass, so the catch above never covered it.
+                Log.Warning(ex, "Access denied reading file info: {Path}", filePath);
+            }
         }
     }
 


### PR DESCRIPTION
`UnauthorizedAccessException` is a **sibling** of `IOException`, not a subclass — so a `catch (IOException)` around a `File.`/`Directory.` call lets an ACL-denied file escape.

## Correcting my own earlier count

I previously logged this as **15 sites**. That was wrong, and this PR corrects it: it is **6**.

The original sweep only looked in one direction from the `catch` line. Re-scanning properly — walking the whole try/catch chain both ways, and counting single-line catches that pair on the same line — shows the other 9 were **already paired**: `UpdateService` at 261/490, `DeepCleanupService` inline, plus `FileShredderService`, `UpdateApplier` and `AboutViewModel`. 148 of the original hits were false positives. The codebase is considerably more consistent about this than I claimed.

## The 6 real ones, each checked for reachability before being touched

| Site | Operation |
|---|---|
| `UpdateService.cs:329` | `File.OpenRead` when hashing a downloaded update |
| `ProfileService.cs:87` | `File.ReadAllText` per config section on export |
| `SettingsWatchdogService.cs:188` | baseline save |
| `GamingProfileService.cs:457` | reading the profile store |
| `IconExtractorService.cs:204` | icon extraction (falls back to the app icon) |
| `FileShredderViewModel.cs:63` | `FileInfo` on a dragged-in file |

**Two matter beyond a missing log line:**

1. `VerifyHashAsync`'s whole contract is *"false means verification failed"*. An escaping throw turned a safe refusal into a **crash on the install path**.
2. `ProfileService.AvailableSections` aborted the **entire export**, discarding the sections that *were* readable.

## Verification — red before, green after

Using a deny-read ACL, which is what actually raises it. Worth noting *why*: a missing file is filtered out by the `File.Exists` guard before the read, and a directory in the file's place does not reach it either — so neither can exercise this path.

```
ProfileService, unfixed:  FAIL - THREW UnauthorizedAccessException: Access to the path
                                 '...\theme.json' is denied.
ProfileService, fixed:    PASS - export survives an unreadable config file
                          PASS - the readable section still comes through
                          PASS - the denied one is absent
```

Also confirmed independently that `File.OpenRead` genuinely raises `UnauthorizedAccessException` on such a file, so the `UpdateService` catch is guarding a real path rather than a theoretical one.

## Regression test

`AvailableSections_SkipsAFileItCannotRead_RatherThanThrowing` pins the ProfileService case with the same ACL mechanism, and removes the deny rule in a `finally` so `Dispose` can still delete the temp directory. It asserts both halves: the denied section is absent **and** the readable one still comes through — the second is the part that was actually being lost.

## After

Re-ran the corrected sweep: **0 unpaired catches remain** on any filesystem path. All four projects rebuild `--no-incremental` with 0 errors, 0 warnings.