### PR TITLE
fix: confirm three destructive commands, surface a dead Cancel, and make eight progress bars honest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.58.2] - 2026-08-10
+
+### Fixed
+- **Three ways to permanently delete something now ask first.** "Clear History" on App Alerts is a red button sitting right next to the harmless "Acknowledge All" — and it wiped the entire list of what installed itself on your PC the instant you touched it, with no question asked and no way to get it back (that list is never saved to a file, so what is on screen is the only copy). Deleting a saved preset on Volume Control and clearing your saved speed-test results behaved the same way: the file was rewritten immediately, no undo. All three now ask you to confirm and say what will be lost. If the list is already empty there is nothing to confirm, so no pointless dialog appears.
+- **The Boot Analyzer's Cancel button was missing.** Reading your boot history means walking a Windows event log, which on a large or damaged log can take a while — and the tab starts that read by itself the first time you open it. There was no way to stop it short of closing SysManager. A Cancel button now appears next to Refresh while the read is running, exactly like the other tabs in that group.
+- **Progress bars that never moved now move.** On Cleanup, Debloater and Windows Update the app worked out exactly how far along it was — 1 of 15, 2 of 15 — and then drew an empty bar that never filled. Removing fifteen preinstalled apps looked identical to the app having frozen. Those bars now fill as the work happens.
+- **Bars that could not animate at all now animate.** Defender Tweaks, Context Menu, Profile Export/Import and Startup Manager each showed a small grey rectangle during a long operation that neither filled nor moved, then vanished. Context Menu's preset apply is the worst of them: it closes every File Explorer window while showing a motionless bar, which reads as a crash. They now show activity for as long as the work lasts.
+- **Disk Analyzer no longer tells you to do what you just did.** After analysing a folder that genuinely contains no subfolders, the middle of the screen said "No results yet — pick a folder and analyze", while the summary right next to it correctly said "No subfolders found." The two now agree: before a scan it asks you to pick a folder, and after one that found nothing it says so.
+
 ## [1.58.1] - 2026-08-10
 
 ### Fixed

--- a/SysManager/SysManager.Tests/AppAlertsViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppAlertsViewModelTests.cs
@@ -8,6 +8,10 @@ using Xunit;
 
 namespace SysManager.Tests;
 
+// ClearHistory's confirmation gate swaps the global DialogService.Instance, so this class must
+// run in the serialized collection — otherwise a parallel class's substitute steals the Confirm
+// call and the gate assertions go flaky.
+[Collection("DialogService")]
 public class AppAlertsViewModelTests
 {
     [Fact]
@@ -34,16 +38,51 @@ public class AppAlertsViewModelTests
     }
 
     [Fact]
-    public void ClearHistory_RemovesAllAlerts()
+    public void ClearHistory_WhenConfirmed_RemovesAllAlerts()
     {
         var vm = new AppAlertsViewModel(new Services.AppAlertService());
         vm.Alerts.Add(new AppInstallEntry { Name = "App1" });
         vm.Alerts.Add(new AppInstallEntry { Name = "App2" });
+        vm.AlertCount = vm.Alerts.Count;   // the guard reads AlertCount, so it must be real here
 
+        using var _ = new DialogAnswer(true);
         vm.ClearHistoryCommand.Execute(null);
 
         Assert.Empty(vm.Alerts);
         Assert.Equal(0, vm.AlertCount);
+    }
+
+    [Fact]
+    public void ClearHistory_WhenDeclined_KeepsTheHistory()
+    {
+        // The alert list is never persisted, so this collection is the only record of what
+        // installed itself. Answering "No" must leave it completely untouched.
+        var vm = new AppAlertsViewModel(new Services.AppAlertService());
+        vm.Alerts.Add(new AppInstallEntry { Name = "App1" });
+        vm.Alerts.Add(new AppInstallEntry { Name = "App2" });
+        vm.AlertCount = vm.Alerts.Count;
+        vm.UnacknowledgedCount = 2;
+
+        using var _ = new DialogAnswer(false);
+        vm.ClearHistoryCommand.Execute(null);
+
+        Assert.Equal(2, vm.Alerts.Count);
+        Assert.Equal(2, vm.AlertCount);
+        Assert.Equal(2, vm.UnacknowledgedCount);
+    }
+
+    [Fact]
+    public void ClearHistory_WithNothingToLose_DoesNotPrompt()
+    {
+        // An empty list has nothing to confirm; prompting there would be pure noise. Answer
+        // "No" and assert the clear still ran — proving no dialog gated it.
+        var vm = new AppAlertsViewModel(new Services.AppAlertService());
+
+        using var answer = new DialogAnswer(false);
+        vm.ClearHistoryCommand.Execute(null);
+
+        Assert.Equal(0, answer.Calls);
+        Assert.Contains("cleared", vm.MonitorStatus);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
@@ -28,6 +28,10 @@ namespace SysManager.Tests;
 /// (not unit-tested here — it needs a real endpoint), so these tests treat the service's
 /// filtering (expired dropped, system-sounds flagged) as a contract at the seam.
 /// </summary>
+// DeletePreset's confirmation gate swaps the global DialogService.Instance, so this class must
+// run in the serialized collection — otherwise a parallel class's substitute steals the Confirm
+// call and the gate assertions go flaky.
+[Collection("DialogService")]
 public class AudioMixerViewModelTests
 {
     private static AudioSessionInfo Session(
@@ -351,6 +355,57 @@ public class AudioMixerViewModelTests
         // Behavioral post-condition: Dispose stopped the meter and zeroed the lit bar (it must
         // not leave a stale level frozen on screen).
         Assert.Equal(0f, vm.Sessions.Single().PeakLevel);
+    }
+
+    // ── Preset deletion is confirmed (the file is rewritten immediately) ────
+
+    [Fact]
+    public async Task DeletePreset_WhenDeclined_KeepsThePresetOnDisk()
+    {
+        // VolumePresetService.Delete() calls Persist() -> File.WriteAllText straight away, so a
+        // stray click was unrecoverable. Answering "No" must leave both the in-memory list and
+        // the file exactly as they were.
+        var dir = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "SysManagerTests", System.Guid.NewGuid().ToString("N"));
+        var presets = new VolumePresetService(dir);
+        var service = ServiceWith(Session("s1", pid: 10, name: "Chrome", volume: 0.8f));
+        var vm = new AudioMixerViewModel(service, presets);
+        await vm.InitializationComplete;
+
+        vm.NewPresetName = "Movie night";
+        vm.SavePresetCommand.Execute(null);
+        Assert.Single(vm.Presets);
+        vm.SelectedPreset = vm.Presets[0];
+
+        using var answer = new DialogAnswer(false);
+        vm.DeletePresetCommand.Execute(null);
+
+        Assert.Equal(1, answer.Calls);                       // the gate really ran
+        Assert.Single(vm.Presets);                           // still in the list
+        Assert.Equal("Movie night", vm.Presets[0].Name);
+        Assert.Single(presets.Load());                       // and still on disk
+    }
+
+    [Fact]
+    public async Task DeletePreset_WhenConfirmed_RemovesIt()
+    {
+        var dir = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "SysManagerTests", System.Guid.NewGuid().ToString("N"));
+        var presets = new VolumePresetService(dir);
+        var service = ServiceWith(Session("s1", pid: 10, name: "Chrome", volume: 0.8f));
+        var vm = new AudioMixerViewModel(service, presets);
+        await vm.InitializationComplete;
+
+        vm.NewPresetName = "Movie night";
+        vm.SavePresetCommand.Execute(null);
+        vm.SelectedPreset = vm.Presets[0];
+
+        using var _ = new DialogAnswer(true);
+        vm.DeletePresetCommand.Execute(null);
+
+        Assert.Empty(vm.Presets);
+        Assert.Empty(presets.Load());
+        Assert.Null(vm.SelectedPreset);
     }
 
     // ── Input validation at the trust boundary (real service, no COM) ──────

--- a/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
@@ -372,8 +372,13 @@ public class AudioMixerViewModelTests
         var vm = new AudioMixerViewModel(service, presets);
         await vm.InitializationComplete;
 
-        vm.NewPresetName = "Movie night";
-        vm.SavePresetCommand.Execute(null);
+        // Seed through the service rather than SavePresetCommand: that command derives entries from
+        // each row's exe path, and the shared Session(...) helper leaves ExePath empty, so it would
+        // correctly no-op ("No apps to save into a preset right now") and save nothing. What is under
+        // test here is the DELETE gate, so the preset is put on disk directly.
+        presets.Save(new VolumePreset("Movie night",
+            [new VolumePresetEntry("chrome.exe", "Chrome", 0.8f, false)]));
+        vm.Presets.ReplaceWith(presets.Load());
         Assert.Single(vm.Presets);
         vm.SelectedPreset = vm.Presets[0];
 
@@ -396,8 +401,10 @@ public class AudioMixerViewModelTests
         var vm = new AudioMixerViewModel(service, presets);
         await vm.InitializationComplete;
 
-        vm.NewPresetName = "Movie night";
-        vm.SavePresetCommand.Execute(null);
+        // Seeded directly for the same reason as the declined case above.
+        presets.Save(new VolumePreset("Movie night",
+            [new VolumePresetEntry("chrome.exe", "Chrome", 0.8f, false)]));
+        vm.Presets.ReplaceWith(presets.Load());
         vm.SelectedPreset = vm.Presets[0];
 
         using var _ = new DialogAnswer(true);

--- a/SysManager/SysManager.Tests/DialogAnswer.cs
+++ b/SysManager/SysManager.Tests/DialogAnswer.cs
@@ -1,0 +1,40 @@
+// SysManager · DialogAnswer
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using NSubstitute;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Scopes a canned answer over the <see cref="DialogService.Instance"/> singleton and restores
+/// the previous instance on dispose, so a test can drive a confirmation gate without a UI.
+/// <para>
+/// The restore matters: <see cref="DialogService.Instance"/> is process-wide static state, so a
+/// test that swapped it and threw would leak the substitute into every later test in the same
+/// collection. Wrapping it in a <c>using</c> makes the restore exception-safe.
+/// </para>
+/// <para>
+/// <see cref="Calls"/> exists so a test can prove a dialog was NOT shown — asserting on the
+/// side effect alone cannot tell "the user said yes" apart from "no gate ran at all".
+/// </para>
+/// </summary>
+public sealed class DialogAnswer : IDisposable
+{
+    private readonly IDialogService _previous;
+
+    /// <param name="confirm">What <see cref="IDialogService.Confirm"/> returns — the user's click.</param>
+    public DialogAnswer(bool confirm)
+    {
+        _previous = DialogService.Instance;
+        var fake = Substitute.For<IDialogService>();
+        fake.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(_ => { Calls++; return confirm; });
+        DialogService.Instance = fake;
+    }
+
+    /// <summary>How many times a confirmation was actually requested.</summary>
+    public int Calls { get; private set; }
+
+    public void Dispose() => DialogService.Instance = _previous;
+}

--- a/SysManager/SysManager.Tests/DiskAnalyzerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DiskAnalyzerViewModelTests.cs
@@ -118,4 +118,58 @@ public class DiskAnalyzerViewModelTests
         var vm = NewVm();
         Assert.False(vm.HasDriveInfo);
     }
+
+    // ── Empty state distinguishes "not run yet" from "ran, found nothing" ───
+
+    [Fact]
+    public void BeforeAnyScan_EmptyState_TellsTheUserToScan()
+    {
+        var vm = NewVm();
+        Assert.False(vm.HasScanned);
+        Assert.Equal("No results yet", vm.EmptyTitle);
+        Assert.Contains("analyze", vm.EmptyMessage);
+    }
+
+    [Fact]
+    public async Task AfterAScanThatFoundNothing_EmptyState_StopsAskingForAScan()
+    {
+        // The overlay used to hardcode "No results yet … Pick a folder and analyze", so a
+        // completed zero-result scan told the user to do the thing they had just done — while the
+        // summary card next to it correctly said "No subfolders found." Scan a genuinely empty
+        // directory and assert the two no longer contradict each other.
+        var dir = Path.Combine(Path.GetTempPath(), "SysManagerTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var vm = NewVm();
+            vm.SelectedPath = dir;
+
+            await vm.AnalyzeCommand.ExecuteAsync(null);
+
+            Assert.Empty(vm.Entries);                       // nothing found, so the overlay shows
+            Assert.True(vm.HasScanned);
+            Assert.Equal("Nothing to show", vm.EmptyTitle);
+            Assert.DoesNotContain("Pick a folder", vm.EmptyMessage);
+            Assert.Equal("No subfolders found.", vm.ScanSummary);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void HasScanned_RaisesChangeNotificationsForTheEmptyStateText()
+    {
+        // The [NotifyPropertyChangedFor] attributes are what actually refresh the overlay; without
+        // them the computed strings would change but the bound EmptyState would keep the old text.
+        var vm = NewVm();
+        var raised = new List<string>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName ?? "");
+
+        vm.HasScanned = true;
+
+        Assert.Contains(nameof(vm.EmptyTitle), raised);
+        Assert.Contains(nameof(vm.EmptyMessage), raised);
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.58.1</Version>
-    <FileVersion>1.58.1.0</FileVersion>
-    <AssemblyVersion>1.58.1.0</AssemblyVersion>
+    <Version>1.58.2</Version>
+    <FileVersion>1.58.2.0</FileVersion>
+    <AssemblyVersion>1.58.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
@@ -84,6 +84,15 @@ public sealed partial class AppAlertsViewModel : ViewModelBase
     [RelayCommand]
     private void ClearHistory()
     {
+        // The alert list is never written to disk, so this collection IS the only record of
+        // what installed itself. Confirm before discarding it — but stay frictionless when
+        // there is nothing to lose, otherwise the prompt is pure noise.
+        if (AlertCount > 0 && !DialogService.Instance.Confirm(
+                $"Clear all {AlertCount} recorded alert{(AlertCount == 1 ? "" : "s")}?\n\n" +
+                "The history is not saved to disk, so this cannot be undone.",
+                "Clear History — Confirm"))
+            return;
+
         Alerts.Clear();
         AlertCount = 0;
         UnacknowledgedCount = 0;

--- a/SysManager/SysManager/ViewModels/AudioMixerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AudioMixerViewModel.cs
@@ -241,12 +241,20 @@ public sealed partial class AudioMixerViewModel : ViewModelBase
             : $"No running apps matched \"{SelectedPreset.Name}\".";
     }
 
-    /// <summary>Delete the selected preset.</summary>
+    /// <summary>Delete the selected preset (with confirmation — the file is rewritten immediately).</summary>
     [RelayCommand]
     private void DeletePreset()
     {
         if (SelectedPreset is null) return;
         var name = SelectedPreset.Name;
+
+        // Delete() rewrites the presets file on disk straight away, so there is no undo.
+        if (!DialogService.Instance.Confirm(
+                $"Delete the preset \"{name}\"?\n\n" +
+                "The saved volume levels for its apps will be gone for good.",
+                "Delete Preset — Confirm"))
+            return;
+
         Presets.ReplaceWith(_presets.Delete(name));
         SelectedPreset = null;
         StatusMessage = $"Deleted preset \"{name}\".";

--- a/SysManager/SysManager/ViewModels/ContextMenuViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ContextMenuViewModel.cs
@@ -98,6 +98,7 @@ public sealed partial class ContextMenuViewModel : ViewModelBase
     private async Task ScanAsync()
     {
         IsBusy = true;
+        IsProgressIndeterminate = true;
         StatusMessage = "Scanning context menu entries...";
         try
         {
@@ -121,7 +122,7 @@ public sealed partial class ContextMenuViewModel : ViewModelBase
         {
             StatusMessage = $"Scan failed: {ex.Message}";
         }
-        finally { IsBusy = false; }
+        finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
     [RelayCommand]
@@ -195,6 +196,7 @@ public sealed partial class ContextMenuViewModel : ViewModelBase
             return;
 
         IsBusy = true;
+        IsProgressIndeterminate = true;
         StatusMessage = $"Applying \"{preset.Name}\"...";
 
         try
@@ -252,7 +254,7 @@ public sealed partial class ContextMenuViewModel : ViewModelBase
         {
             StatusMessage = $"Failed: {ex.Message}";
         }
-        finally { IsBusy = false; }
+        finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
     [RelayCommand(CanExecute = nameof(NotBusy))]

--- a/SysManager/SysManager/ViewModels/DefenderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DefenderViewModel.cs
@@ -78,6 +78,7 @@ public sealed partial class DefenderViewModel : ViewModelBase
     private async Task RefreshAsync()
     {
         IsBusy = true;
+        IsProgressIndeterminate = true;
         try
         {
             var status = await _service.GetStatusAsync().ConfigureAwait(true);
@@ -93,7 +94,7 @@ public sealed partial class DefenderViewModel : ViewModelBase
         // command unobserved. Surface it as a status message instead.
         catch (InvalidOperationException ex) { StatusMessage = $"Could not read Defender status: {ex.Message}"; }
         catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"Could not read Defender status: {ex.Message}"; }
-        finally { IsBusy = false; }
+        finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
     [RelayCommand(CanExecute = nameof(NotBusy))]
@@ -101,6 +102,7 @@ public sealed partial class DefenderViewModel : ViewModelBase
     {
         if (!Confirm($"{(PuaEnabled ? "Disable" : "Enable")} potentially-unwanted-app (PUA) protection?")) return;
         IsBusy = true;
+        IsProgressIndeterminate = true;
         try
         {
             int target = PuaEnabled ? 0 : 1;
@@ -110,7 +112,7 @@ public sealed partial class DefenderViewModel : ViewModelBase
         }
         catch (InvalidOperationException ex) { StatusMessage = $"Could not change PUA protection: {ex.Message}"; }
         catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"Could not change PUA protection: {ex.Message}"; }
-        finally { IsBusy = false; }
+        finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
     [RelayCommand(CanExecute = nameof(NotBusy))]
@@ -118,6 +120,7 @@ public sealed partial class DefenderViewModel : ViewModelBase
     {
         if (!Confirm($"{(CfaEnabled ? "Disable" : "Enable")} Controlled Folder Access (ransomware protection)?")) return;
         IsBusy = true;
+        IsProgressIndeterminate = true;
         try
         {
             int target = CfaEnabled ? 0 : 1;
@@ -127,7 +130,7 @@ public sealed partial class DefenderViewModel : ViewModelBase
         }
         catch (InvalidOperationException ex) { StatusMessage = $"Could not change Controlled Folder Access: {ex.Message}"; }
         catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"Could not change Controlled Folder Access: {ex.Message}"; }
-        finally { IsBusy = false; }
+        finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
     [RelayCommand(CanExecute = nameof(NotBusy))]
@@ -145,6 +148,7 @@ public sealed partial class DefenderViewModel : ViewModelBase
         if (!Confirm($"Exclude \"{path}\" from Defender scanning?\n\nFiles in an excluded folder are not scanned for malware.")) return;
 
         IsBusy = true;
+        IsProgressIndeterminate = true;
         try
         {
             var status = await _service.AddExclusionPathAsync(path).ConfigureAwait(true);
@@ -153,7 +157,7 @@ public sealed partial class DefenderViewModel : ViewModelBase
         }
         catch (InvalidOperationException ex) { StatusMessage = $"Could not add the exclusion: {ex.Message}"; }
         catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"Could not add the exclusion: {ex.Message}"; }
-        finally { IsBusy = false; }
+        finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
     [RelayCommand(CanExecute = nameof(CanRemoveExclusion))]
@@ -164,6 +168,7 @@ public sealed partial class DefenderViewModel : ViewModelBase
         if (!Confirm($"Stop excluding \"{path}\"?\n\nThe folder will be scanned for malware again.")) return;
 
         IsBusy = true;
+        IsProgressIndeterminate = true;
         try
         {
             var status = await _service.RemoveExclusionPathAsync(path).ConfigureAwait(true);
@@ -172,7 +177,7 @@ public sealed partial class DefenderViewModel : ViewModelBase
         }
         catch (InvalidOperationException ex) { StatusMessage = $"Could not remove the exclusion: {ex.Message}"; }
         catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"Could not remove the exclusion: {ex.Message}"; }
-        finally { IsBusy = false; }
+        finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
     private bool HasSelectedExclusion => SelectedExclusion is not null;

--- a/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
@@ -33,6 +33,20 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
     [ObservableProperty] private int _entryCount;
     [ObservableProperty] private string _currentFolder = "";
 
+    // Distinguishes the un-run state from a completed zero-result scan so the big empty-state overlay
+    // doesn't tell the user to "pick a folder and analyze" right after they did exactly that. Set true
+    // only after a scan actually completes (see AnalyzeAsync); a cancelled/failed scan leaves it as-is.
+    // Mirrors DuplicateFileViewModel, the sibling tab in the same Storage group.
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(EmptyTitle))]
+    [NotifyPropertyChangedFor(nameof(EmptyMessage))]
+    private bool _hasScanned;
+
+    public string EmptyTitle => HasScanned ? "Nothing to show" : "No results yet";
+    public string EmptyMessage => HasScanned
+        ? "This folder has no subfolders using measurable space."
+        : "Pick a folder and analyze to see what's using space.";
+
     // Drive-level info
     [ObservableProperty] private long _driveTotal;
     [ObservableProperty] private long _driveFree;
@@ -127,6 +141,7 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
             ScanSummary = EntryCount == 0
                 ? "No subfolders found."
                 : $"{EntryCount} folders · {FormatSize(TotalSize)} total · {TotalFiles:N0} files";
+            HasScanned = true;
             StatusMessage = "Analysis complete.";
             ToastService.Instance.Show("Disk Analysis complete", $"{EntryCount} folders, {FormatSize(TotalSize)} total");
             Log.Information("Disk analysis completed: {Folders} folders, {Size} total",

--- a/SysManager/SysManager/ViewModels/ProfileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProfileViewModel.cs
@@ -69,6 +69,7 @@ public sealed partial class ProfileViewModel : ViewModelBase
         if (dlg.ShowDialog() != true) return;
 
         IsBusy = true;
+        IsProgressIndeterminate = true;
         try
         {
             var profile = _service.BuildProfile(DateTime.Now, chosen);
@@ -79,7 +80,7 @@ public sealed partial class ProfileViewModel : ViewModelBase
         }
         catch (IOException ex) { StatusMessage = $"Export failed: {ex.Message}"; }
         catch (UnauthorizedAccessException ex) { StatusMessage = $"Export failed (access denied): {ex.Message}"; }
-        finally { IsBusy = false; }
+        finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
     [RelayCommand]
@@ -93,6 +94,7 @@ public sealed partial class ProfileViewModel : ViewModelBase
         if (dlg.ShowDialog() != true) return;
 
         IsBusy = true;
+        IsProgressIndeterminate = true;
         try
         {
             ConfigProfile? profile;
@@ -128,7 +130,7 @@ public sealed partial class ProfileViewModel : ViewModelBase
         }
         catch (IOException ex) { StatusMessage = $"Import failed: {ex.Message}"; }
         catch (UnauthorizedAccessException ex) { StatusMessage = $"Import failed (access denied): {ex.Message}"; }
-        finally { IsBusy = false; }
+        finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
@@ -155,17 +155,26 @@ public sealed partial class SpeedTestViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private async Task ClearHttpHistoryAsync()
-    {
-        await _history.ClearAsync("HTTP");
-        HttpHistory.Clear();
-    }
+    private Task ClearHttpHistoryAsync() => ClearHistoryAsync("HTTP", HttpHistory);
 
     [RelayCommand]
-    private async Task ClearOoklaHistoryAsync()
+    private Task ClearOoklaHistoryAsync() => ClearHistoryAsync("Ookla", OoklaHistory);
+
+    /// <summary>
+    /// Confirms, then drops one engine's saved results. ClearAsync rewrites the history file
+    /// immediately, so the past measurements cannot be recovered afterwards.
+    /// </summary>
+    private async Task ClearHistoryAsync(string engine, BulkObservableCollection<SpeedTestResult> history)
     {
-        await _history.ClearAsync("Ookla");
-        OoklaHistory.Clear();
+        int count = history.Count;
+        if (count > 0 && !DialogService.Instance.Confirm(
+                $"Delete all {count} saved {engine} result{(count == 1 ? "" : "s")}?\n\n" +
+                "The saved history is removed from disk and cannot be recovered.",
+                $"Clear {engine} History — Confirm"))
+            return;
+
+        await _history.ClearAsync(engine);
+        history.Clear();
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/StartupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StartupViewModel.cs
@@ -82,6 +82,7 @@ public sealed partial class StartupViewModel : ViewModelBase
     private async Task ScanAsync()
     {
         IsBusy = true;
+        IsProgressIndeterminate = true;
         StatusMessage = "Scanning startup items…";
         try
         {
@@ -120,7 +121,7 @@ public sealed partial class StartupViewModel : ViewModelBase
         {
             StatusMessage = $"Scan failed: {ex.Message}";
         }
-        finally { IsBusy = false; }
+        finally { IsBusy = false; IsProgressIndeterminate = false; }
     }
 
     [RelayCommand(CanExecute = nameof(NotBusy))]
@@ -171,6 +172,7 @@ public sealed partial class StartupViewModel : ViewModelBase
             return;
 
         IsBusy = true;
+        IsProgressIndeterminate = true;
         try
         {
             // Report the outcome honestly: SetEnabledAsync returns false (and sets the
@@ -200,6 +202,7 @@ public sealed partial class StartupViewModel : ViewModelBase
         finally
         {
             IsBusy = false;
+            IsProgressIndeterminate = false;
         }
     }
 

--- a/SysManager/SysManager/Views/BootAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/BootAnalyzerView.xaml
@@ -153,6 +153,13 @@
             <Button DockPanel.Dock="Right" Content="Refresh" Command="{Binding RefreshCommand}"
                     AutomationProperties.Name="Refresh boot history"
                     Style="{StaticResource GhostButton}" Margin="0,0,12,0" Padding="10,2"/>
+            <!-- Declared after Refresh so right-docking places it to Refresh's left, matching
+                 SystemFixesView. Reading the Diagnostics-Performance log can be slow, so surface
+                 the cancellation path the ViewModel already implements. -->
+            <Button DockPanel.Dock="Right" Content="Cancel" Command="{Binding CancelCommand}"
+                    AutomationProperties.Name="Cancel reading boot history"
+                    Style="{StaticResource GhostButton}" Margin="0,0,12,0" Padding="10,2"
+                    Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
         </DockPanel>
     </Grid>

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -158,6 +158,7 @@
         <DockPanel Grid.Row="4" Margin="28,12,28,24">
             <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
+                         Value="{Binding Progress}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
         </DockPanel>

--- a/SysManager/SysManager/Views/DebloaterView.xaml
+++ b/SysManager/SysManager/Views/DebloaterView.xaml
@@ -128,6 +128,7 @@
         <DockPanel Grid.Row="3" Margin="0,8,0,0">
             <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
+                         Value="{Binding Progress}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
         </DockPanel>

--- a/SysManager/SysManager/Views/DiskAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/DiskAnalyzerView.xaml
@@ -150,8 +150,8 @@
 
             <!-- Empty state -->
             <v:EmptyState Glyph="&#xE838;"
-                          Title="No results yet"
-                          Message="Pick a folder and analyze to see what's using space."
+                          Title="{Binding EmptyTitle}"
+                          Message="{Binding EmptyMessage}"
                           Visibility="{Binding Entries.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
             </Grid>
         </Border>

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -361,6 +361,7 @@
         <DockPanel Grid.Row="7" Margin="28,12,28,24">
             <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
+                         Value="{Binding Progress}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
         </DockPanel>

--- a/TESTING.md
+++ b/TESTING.md
@@ -92,6 +92,17 @@ collection definitions (all defined in `TestCollections.cs`, each with
 - `[Collection("IconCache")]` — tests touching the shared icon cache.
 - `[Collection("DialogService")]` — tests that swap the static `DialogService.Instance`.
 
+### Shared helpers
+
+- `DialogAnswer` — scopes a canned confirmation answer over `DialogService.Instance` and restores
+  the previous instance on dispose, so a confirmation gate can be driven without a UI:
+  `using var _ = new DialogAnswer(false);`. Its `Calls` counter lets a test assert a dialog was
+  *not* shown — asserting the side effect alone cannot distinguish "the user said yes" from
+  "no gate ran at all". Requires `[Collection("DialogService")]` on the test class.
+- `SyncProgress<T>` — a synchronous `IProgress<T>` that records reports on the calling thread, so
+  progress assertions need no `Task.Delay`.
+- `StaHelper` — runs a delegate on an STA thread for WPF-dependent types.
+
 ### Conventions
 
 - Pure logic tests (parsers, analyzers, converters) need no mocking.


### PR DESCRIPTION
Five verified defects with one thing in common: the ViewModel already did the work and the UI discarded it. Each was re-derived from current source before being touched, and each has a positive control proving the intended pattern already exists elsewhere in the app.

Closes #1597
Closes #1595
Closes #1599
Closes #1600
Closes #1598

## #1597 — three destructive commands wrote immediately with no confirmation

| Command | What it destroys | Why it is unrecoverable |
|---|---|---|
| `AppAlertsViewModel.ClearHistory` | the whole record of what installed itself | `AppAlertService` has **no persistence** — greps for `WriteAll|ReadAll|Serialize|Deserialize|SaveAsync|LoadAsync` return 0, so the in-memory collection is the only copy, and there is no export command either |
| `AudioMixerViewModel.DeletePreset` | a saved volume preset | `VolumePresetService.Delete` → `Persist()` → `File.WriteAllText` |
| `SpeedTestViewModel.Clear{Http,Ookla}HistoryAsync` | saved speed-test results | `SpeedTestHistoryService.ClearAsync` deletes/rewrites the file |

App Alerts is the sharpest case: the button is styled `DangerButton` and sits directly beside the harmless "Acknowledge All", so a mis-click is likely rather than theoretical. All three now use the standard `DialogService.Instance.Confirm` shape (em-dash `— Confirm` title, plain-language body, early `return`), and each skips the prompt when the list is already empty so an empty clear stays frictionless.

The two Speed Test commands now delegate to one private `ClearHistoryAsync(engine, history)` so the prompt wording has a single source of truth instead of being duplicated.

**Class sweep, not just the reported instance.** I scanned every destructive-named `[RelayCommand]` in every VM for a missing `Confirm`: 15 hits. Eleven are legitimately harmless — removing a row from a pending/staging list (`FileShredder.RemoveItem`, `DnsHosts.RemoveEntry`, `EnvironmentVariables.RemoveDirectory`), clearing a console pane, resetting a filter. Four write to disk irreversibly, and all four are fixed here.

## #1595 — Boot Analyzer cancellation was fully built and bound to nothing

`BootAnalyzerViewModel` has the complete path: `_cts` (:22), the token threaded into both event-log reads (:58-59), an `OperationCanceledException` handler (:74), `Cancel()` (:100), disposal (:114). `grep Cancel Views/BootAnalyzerView.xaml` returned **0** — the view bound only `RelaunchAsAdminCommand` and `RefreshCommand`.

That matters because the read is genuinely slow (`EventLogReader` walking Diagnostics-Performance for up to 20 boot + 60 degradation records) and it starts **automatically** on first tab open, so the only escape was closing SysManager.

Fixed by copying `SystemFixesView.xaml:124-127` verbatim — `GhostButton`, same margins/padding, `AutomationProperties.Name`, `Visibility` gated on `IsBusy`. Declared **after** Refresh, because `DockPanel.Dock="Right"` docks in declaration order and Cancel belongs to the left of Refresh.

## #1599 — a computed percentage drawn as an empty bar

Cross-referenced every VM assigning a non-trivial `Progress` against its view's `ProgressBar` tags:

- **Bind `Value` already (positive controls):** AppUpdates, BulkInstaller, Dashboard, DeepCleanup, SpeedTest, Uninstaller
- **Did not:** `CleanupView.xaml:159`, `DebloaterView.xaml:129`, `WindowsUpdateView.xaml:362`

Debloater is the clearest: it deliberately switches to determinate mode and computes `(i + 1) * 100.0 / targets.Count`, then the bar sat at 0 for a removal that can run minutes — indistinguishable from a hang, on one of the scariest operations in the app. One attribute each, matching the Uninstaller attribute order exactly.

`FileShredderViewModel` matched the initial grep but is a **false positive** — that `Progress` is an `IProgress<int>` callback, not the `ViewModelBase` property.

## #1600 — bars that could not animate at all

Four VMs bind `IsIndeterminate` to `IsProgressIndeterminate` and never set it, so a *visible* bar neither filled nor moved, then vanished. A frozen bar is worse than no bar: it signals "hung".

| VM | `IsBusy = true` sites |
|---|---|
| Defender | 5 (each a `Set-MpPreference` round trip + read-back) |
| Context Menu | 2 — `ApplyPresetAsync` **restarts Explorer** behind a motionless bar |
| Profile Export/Import | 2 |
| Startup Manager | 2 |

The flag is now set beside `IsBusy = true` and cleared in the **same `finally`**, matching `BrowserCleanerViewModel:63-64/84-85`, so the pair cannot drift. Verified balanced: 5/5, 2/2, 2/2, 2/2.

Startup was outside the scout tab set of the issue (the issue notes it as such) — included to fix the class rather than leave a known instance behind. I deliberately did **not** take the alternative suggestion of a `ViewModelBase` busy-scope helper: ~30 VMs use the manual pattern, so introducing a second idiom inside a bug fix would be a refactor (Protocol Q), not a minimal diff.

## #1598 — an empty state that told the user to do what they just did

`DiskAnalyzerView.xaml:152-155` hardcoded `"No results yet"` / `"Pick a folder and analyze…"` and triggered on `Entries.Count` alone. So after a completed scan of a folder with no subfolders, the big centred overlay asked for a scan while the summary card beside it correctly said `"No subfolders found."` — the two contradicted each other.

Ported the pattern from `DuplicateFileViewModel` (:41-46, :137), the sibling tab in the same Storage group, which carries a comment explaining exactly this reasoning. `HasScanned` is set only on the **success** path, so a cancelled or failed scan does not claim to have run.

Scoped to Disk Analyzer deliberately: only 3 of 33 `EmptyState` usages are adaptive today, and the rest are hardcoded legitimately (tabs with no scan concept).

## Verification

**Red ritual.** `dotnet test` is unavailable on this workstation, so a console harness exercised the same behaviours against a worktree of unfixed `origin/main` and against this branch.

Unfixed — 5 failures, each for the right reason:

```
FAIL  declining keeps the alert list        -- prompted 0x, alerts left = 0
FAIL  declining keeps AlertCount            -- AlertCount = 0
FAIL  declining keeps the preset on disk    -- prompted 0x, on disk before=1 after=0
FAIL  a prompt was actually shown           -- Calls = 0
FAIL  VM exposes HasScanned + EmptyTitle    -- HasScanned=False EmptyTitle=False
```

`alerts left = 0` and `before=1 after=0` are the data-loss bugs reproducing, not a compile error or a typo. This branch: **14/14 PASS**, including 4 assertions that only exist once fixed.

**Builds.** All four projects, Release: **0 errors, 0 warnings**.

**Binding check.** Every new `{Binding …}` target was verified to exist on the bound VM (`CancelCommand`, `Progress`, `EmptyTitle`, `EmptyMessage`), and `EmptyState.Title`/`Message` confirmed to be `DependencyProperty` registrations — a misspelled binding fails silently at runtime, not at compile time.

**Tests.** 8 new. Both dialog-swapping classes gained `[Collection("DialogService")]`, the existing convention for tests that mutate that static — **without it these tests would have been flaky in parallel**, which I caught during the docs check rather than in CI. A new shared `DialogAnswer` helper replaces the save/substitute/restore block that was open-coded in every such test file; its `Calls` counter is what lets a test prove a dialog was *not* shown, since asserting the side effect alone cannot distinguish "the user said yes" from "no gate ran at all". Documented in TESTING.md beside the existing collection list.

## One thing deliberately not done, filed instead

This PR adds **no Speed Test test**, and that is not an omission. While writing one I found that the `SpeedTestHistoryService` path is a `private static readonly` built from `SpecialFolder.LocalApplicationData`, which resolves through the Win32 known-folder API and **ignores the `LOCALAPPDATA` environment variable** — so there is no way to redirect it from a test. Its existing tests therefore operate on the real user history file: one writes fabricated results into it, another **deletes** it. The live file on this machine currently contains a single entry whose `server` field is `"roundtrip-server"` — the literal from `SaveAndLoad_RoundTrips:41`.

Writing a new test there would mutate real user data, so I filed **#1734** with the seam fix instead. The confirmation gate added here is still proven, by the harness.

I also refuted two adjacent candidates before filing rather than assuming they shared the bug: `HostsFileService` already accepts a path (`DnsHostsViewModelTests:151` passes one) and `WindowsThemeService` is guarded in tests by `SuppressSave`. `SpeedTestHistoryService` is the only unguarded instance of the eight services holding a static `SpecialFolder`-derived path.

## Not verifiable on this workstation

The visual result — the placement of the Cancel button, the bars actually animating, the new empty-state text — needs a look on the secondary workstation, since the main PC never launches the app. The behaviour behind each is covered by the harness and the unit tests.
