### PR TITLE
fix: stop the Traceroute tab claiming auto-trace is running after Ping stopped it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.58.3] - 2026-08-10
+
+### Fixed
+- **The Traceroute tab no longer lies about whether it is running.** Ping and Traceroute look like two separate tabs with their own Start and Stop buttons, but behind them sits one shared monitor. So pressing Stop on Ping silently killed a running auto-trace while Traceroute still showed "Stop auto-trace" and claimed it was running — and pressing Start on Ping quietly began tracing every target while Traceroute still offered to start it. Both tabs now read the same state, so whichever one you use, the other tells you the truth.
+
 ## [1.58.2] - 2026-08-10
 
 ### Fixed

--- a/SysManager/SysManager.IntegrationTests/NetworkSharedStateAutoTraceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/NetworkSharedStateAutoTraceTests.cs
@@ -1,0 +1,105 @@
+// SysManager · NetworkSharedStateAutoTraceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.Services;
+using SysManager.ViewModels;
+
+namespace SysManager.IntegrationTests;
+
+/// <summary>
+/// The auto-trace monitor is a SINGLE instance shared by the Ping tab and the Traceroute tab:
+/// <see cref="NetworkSharedState.StartMonitoring"/> / <see cref="NetworkSharedState.StopMonitoring"/>
+/// (what Ping's Start/Stop buttons call) drive the same <c>TraceMonitor</c> that
+/// <see cref="TracerouteViewModel"/> starts and stops. These live here rather than in the unit suite
+/// because they call the real <c>StartMonitoring</c>, which starts <see cref="PingMonitorService"/>
+/// and emits ICMP on its first tick. Every seeded target is replaced with a non-routable RFC 5737
+/// TEST-NET-1 address first, so nothing reaches the network — matching PingMonitorServiceTests.
+/// </summary>
+[Collection("Network")]
+public class NetworkSharedStateAutoTraceTests
+{
+    private const string UnreachableHost = "192.0.2.1"; // RFC 5737 TEST-NET-1
+
+    /// <summary>
+    /// Shared state whose ping targets cannot leave the machine. The constructor seeds a Gateway
+    /// target from the real routing table, so it is disabled before anything is started.
+    /// </summary>
+    private static NetworkSharedState NewIsolatedShared()
+    {
+        var shared = new NetworkSharedState(
+            new PingMonitorService { Interval = TimeSpan.FromMilliseconds(100), TimeoutMs = 300 },
+            new TracerouteService(),
+            new TracerouteMonitorService(),
+            new SpeedTestService(),
+            new NetworkRepairService(new PowerShellRunner()));
+
+        foreach (var target in shared.Targets)
+        {
+            target.IsEnabled = false;
+            target.Host = UnreachableHost;
+        }
+
+        return shared;
+    }
+
+    [Fact]
+    public void PingStop_TurnsOffTheAutoTraceFlag_SoTheTraceTabCannotClaimItIsStillRunning()
+    {
+        // The reported desync: Ping's Stop calls StopMonitoring, which really does call
+        // TraceMonitor.Stop() — yet the Traceroute tab kept showing "Stop auto-trace" and claimed
+        // "Auto-trace running" for a monitor that was already dead.
+        using var shared = NewIsolatedShared();
+        using var vm = new TracerouteViewModel(shared);
+
+        shared.StartMonitoring();                        // == the user pressing Start on Ping
+        Assert.True(shared.TraceMonitor.IsRunning);      // the monitor really is running
+        Assert.True(vm.IsAutoTraceRunning);              // …so the Traceroute tab must say so
+
+        shared.StopMonitoring();                         // == the user pressing Stop on Ping
+
+        Assert.False(shared.TraceMonitor.IsRunning);
+        Assert.False(vm.IsAutoTraceRunning);             // was stuck true before the fix
+    }
+
+    [Fact]
+    public void PingStart_TurnsOnTheAutoTraceFlag_SoTheTraceTabDoesNotOfferToStartItAgain()
+    {
+        // The other half: Start on Ping begins auto-traceroutes against every enabled target while
+        // the Traceroute tab still displayed "Start auto-trace", as if nothing were running.
+        using var shared = NewIsolatedShared();
+        using var vm = new TracerouteViewModel(shared);
+        Assert.False(vm.IsAutoTraceRunning);
+
+        shared.StartMonitoring();
+
+        Assert.True(shared.TraceMonitor.IsRunning);
+        Assert.True(vm.IsAutoTraceRunning);              // was stuck false before the fix
+
+        shared.StopMonitoring();
+    }
+
+    [Fact]
+    public void TheFlagAlwaysAgreesWithTheMonitor_AcrossBothTabsStartingAndStopping()
+    {
+        // Whichever tab acts, the flag and the monitor must never disagree — that agreement is the
+        // whole point of moving the state onto the shared object.
+        using var shared = NewIsolatedShared();
+        using var vm = new TracerouteViewModel(shared);
+
+        shared.StartMonitoring();
+        Assert.Equal(shared.TraceMonitor.IsRunning, vm.IsAutoTraceRunning);
+
+        vm.StopAutoTraceCommand.Execute(null);           // stopped from the OTHER tab
+        Assert.Equal(shared.TraceMonitor.IsRunning, vm.IsAutoTraceRunning);
+        Assert.False(vm.IsAutoTraceRunning);
+
+        shared.StartMonitoring();                        // restarted from Ping
+        Assert.Equal(shared.TraceMonitor.IsRunning, vm.IsAutoTraceRunning);
+        Assert.True(vm.IsAutoTraceRunning);
+
+        shared.StopMonitoring();
+        Assert.Equal(shared.TraceMonitor.IsRunning, vm.IsAutoTraceRunning);
+    }
+}

--- a/SysManager/SysManager.Tests/TracerouteViewModelTests.cs
+++ b/SysManager/SysManager.Tests/TracerouteViewModelTests.cs
@@ -47,4 +47,91 @@ public class TracerouteViewModelTests
         var vm = new TracerouteViewModel(shared);
         vm.CancelTraceCommand.Execute(null);
     }
+
+    // ── The auto-trace monitor is SHARED with the Ping tab ──────────────────
+    // TraceMonitor is one instance that NetworkSharedState.Start/StopMonitoring (driven by the Ping
+    // tab) and TracerouteViewModel both start and stop. When the running flag was a local
+    // [ObservableProperty] on this VM, the other tab's actions left it stale — the button lied about
+    // whether traceroutes were running. These pin the shared flag as the single source of truth.
+
+    private static NetworkSharedState NewShared() => new(
+        new Services.PingMonitorService(), new Services.TracerouteService(),
+        new Services.TracerouteMonitorService(), new Services.SpeedTestService(),
+        new Services.NetworkRepairService(new Services.PowerShellRunner()));
+
+    // NOTE ON SCOPE: these deliberately do NOT call NetworkSharedState.StartMonitoring(), even
+    // though that is the exact call the Ping tab makes. StartMonitoring starts PingMonitorService,
+    // whose pump sends a real ICMP echo on its FIRST tick (before any delay) to the targets the
+    // constructor seeds — including the machine's actual gateway. A unit test must not emit live
+    // network traffic: it would be non-deterministic, and on a workstation it can raise a firewall
+    // prompt. What the fix changes is WHERE the flag lives, so these assert the flag contract
+    // directly. That Start/StopMonitoring set it is verified by reading those two methods, and the
+    // full cross-tab path belongs in the integration suite.
+
+    [Fact]
+    public void TheFlagIsNotStoredOnThisViewModel_ItReadsTheSharedState()
+    {
+        // The root cause was a duplicated [ObservableProperty] on this VM. If the property were
+        // still local, writing the shared flag would leave the VM's value untouched — which is
+        // exactly how Ping's Stop left the tab claiming "Stop auto-trace".
+        using var shared = NewShared();
+        using var vm = new TracerouteViewModel(shared);
+        Assert.False(vm.IsAutoTraceRunning);
+
+        shared.IsAutoTraceRunning = true;             // as Start/StopMonitoring does
+
+        Assert.True(vm.IsAutoTraceRunning);           // stayed false before the fix
+
+        shared.IsAutoTraceRunning = false;
+        Assert.False(vm.IsAutoTraceRunning);
+    }
+
+    [Fact]
+    public void StoppingAutoTraceOnThisTab_IsVisibleOnTheSharedState()
+    {
+        // The reverse direction: this tab's own Stop must be observable by anything reading the
+        // shared flag, not just by this VM's local copy.
+        using var shared = NewShared();
+        using var vm = new TracerouteViewModel(shared);
+        shared.IsAutoTraceRunning = true;
+
+        vm.StopAutoTraceCommand.Execute(null);
+
+        Assert.False(shared.IsAutoTraceRunning);
+        Assert.False(vm.IsAutoTraceRunning);
+    }
+
+    [Fact]
+    public void FlippingTheSharedFlag_RaisesPropertyChangedOnThisViewModel()
+    {
+        // The forwarding property is only useful if it notifies — otherwise the bound button keeps
+        // rendering the old state even though the value changed.
+        using var shared = NewShared();
+        using var vm = new TracerouteViewModel(shared);
+        var raised = new List<string>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName ?? "");
+
+        shared.IsAutoTraceRunning = true;
+
+        Assert.Contains(nameof(vm.IsAutoTraceRunning), raised);
+    }
+
+    [Fact]
+    public void Dispose_UnsubscribesFromTheSharedState()
+    {
+        // NetworkSharedState is a DI singleton that outlives the VM, so a leaked handler would keep
+        // the VM alive for the whole session and keep raising on a disposed object.
+        using var shared = NewShared();
+        var vm = new TracerouteViewModel(shared);
+        var raised = 0;
+        vm.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(vm.IsAutoTraceRunning)) raised++; };
+
+        shared.IsAutoTraceRunning = true;
+        Assert.Equal(1, raised);
+
+        vm.Dispose();
+        shared.IsAutoTraceRunning = false;
+
+        Assert.Equal(1, raised);   // no further notifications after disposal
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.58.2</Version>
-    <FileVersion>1.58.2.0</FileVersion>
-    <AssemblyVersion>1.58.2.0</AssemblyVersion>
+    <Version>1.58.3</Version>
+    <FileVersion>1.58.3.0</FileVersion>
+    <AssemblyVersion>1.58.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/NetworkSharedState.cs
+++ b/SysManager/SysManager/ViewModels/NetworkSharedState.cs
@@ -82,6 +82,13 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
 
     [ObservableProperty] private bool _isMonitoring;
 
+    // Auto-trace state lives HERE, not on TracerouteViewModel, because TraceMonitor is a single
+    // shared instance that both the Ping tab (via Start/StopMonitoring) and the Traceroute tab can
+    // start and stop. A per-VM copy went stale the moment the other tab touched the monitor — Ping's
+    // Stop killed a running auto-trace while Traceroute still showed "Stop auto-trace". One owner of
+    // the flag means the buttons cannot disagree with the monitor.
+    [ObservableProperty] private bool _isAutoTraceRunning;
+
     public NetworkSharedState(PingMonitorService pinger, TracerouteService tracer, TracerouteMonitorService traceMonitor, SpeedTestService speed, NetworkRepairService repair)
     {
         Pinger = pinger;
@@ -330,6 +337,9 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
         TraceMonitor.Start();
         FlushTimer?.Start();
         IsMonitoring = true;
+        // Ping's Start really does start auto-traces against every enabled target, so the
+        // Traceroute tab must show that rather than still offering "Start auto-trace".
+        IsAutoTraceRunning = true;
     }
 
     public void StopMonitoring()
@@ -339,6 +349,8 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
         FlushTimer?.Stop();
         FlushPending();
         IsMonitoring = false;
+        // …and Ping's Stop really does kill a running auto-trace.
+        IsAutoTraceRunning = false;
         // Release axis limits so the chart auto-fits to remaining data
         LatencyXAxes[0].MinLimit = null;
         LatencyXAxes[0].MaxLimit = null;

--- a/SysManager/SysManager/ViewModels/TracerouteViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TracerouteViewModel.cs
@@ -11,8 +11,10 @@ using SysManager.Services;
 namespace SysManager.ViewModels;
 
 /// <summary>
-/// Auto-traceroute + manual trace. Has its own Start/Stop for the
-/// auto-trace monitor, independent of the ping monitor.
+/// Auto-traceroute + manual trace. Has its own Start/Stop for the auto-trace monitor, but that
+/// monitor is <em>shared</em> with the Ping tab: <see cref="NetworkSharedState.StartMonitoring"/>
+/// and <see cref="NetworkSharedState.StopMonitoring"/> start and stop the very same
+/// <c>TraceMonitor</c>. Running state therefore lives on <see cref="NetworkSharedState"/>, not here.
 /// </summary>
 public sealed partial class TracerouteViewModel : ViewModelBase
 {
@@ -22,11 +24,27 @@ public sealed partial class TracerouteViewModel : ViewModelBase
     [ObservableProperty] private string _traceHost = "8.8.8.8";
     [ObservableProperty] private bool _isTracing;
     [ObservableProperty] private string _traceStatus = "";
-    [ObservableProperty] private bool _isAutoTraceRunning;
+
+    /// <summary>
+    /// Whether the shared auto-trace monitor is running — a read-through to
+    /// <see cref="NetworkSharedState.IsAutoTraceRunning"/>, which is the single owner of that state.
+    /// This used to be a local <c>[ObservableProperty]</c>, which went stale the moment the Ping tab
+    /// touched the monitor: Ping's Stop killed a live auto-trace while this tab still showed
+    /// "Stop auto-trace" and claimed it was running.
+    /// </summary>
+    public bool IsAutoTraceRunning => Shared.IsAutoTraceRunning;
 
     public TracerouteViewModel(NetworkSharedState shared)
     {
         Shared = shared;
+        // Re-raise so bindings on THIS VM's property update when the other tab flips the shared flag.
+        Shared.PropertyChanged += OnSharedPropertyChanged;
+    }
+
+    private void OnSharedPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(NetworkSharedState.IsAutoTraceRunning))
+            OnPropertyChanged(nameof(IsAutoTraceRunning));
     }
 
     [RelayCommand]
@@ -39,7 +57,7 @@ public sealed partial class TracerouteViewModel : ViewModelBase
         Shared.TraceMonitor.Interval = TimeSpan.FromSeconds(
             Math.Max(10, Shared.TraceIntervalSeconds));
         Shared.TraceMonitor.Start();
-        IsAutoTraceRunning = true;
+        Shared.IsAutoTraceRunning = true;
         StatusMessage = $"Auto-trace running ({TraceHost})";
         Log.Information("Auto-traceroute started for {Host}", TraceHost);
 
@@ -51,7 +69,7 @@ public sealed partial class TracerouteViewModel : ViewModelBase
     private void StopAutoTrace()
     {
         Shared.TraceMonitor.Stop();
-        IsAutoTraceRunning = false;
+        Shared.IsAutoTraceRunning = false;
         StatusMessage = "Auto-trace stopped";
         Log.Information("Auto-traceroute stopped");
     }
@@ -110,6 +128,9 @@ public sealed partial class TracerouteViewModel : ViewModelBase
     {
         if (disposing)
         {
+            // NetworkSharedState is a DI singleton that outlives this VM, so a live handler here
+            // would keep the VM alive for the rest of the session.
+            Shared.PropertyChanged -= OnSharedPropertyChanged;
             _traceCts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/Views/TracerouteView.xaml
+++ b/SysManager/SysManager/Views/TracerouteView.xaml
@@ -20,12 +20,14 @@
             </StackPanel>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
                         DockPanel.Dock="Right" VerticalAlignment="Center">
+                <!-- Bound to Shared.* (not a per-VM copy) because the Ping tab starts and stops the
+                     same monitor — mirroring how PingView already binds Shared.IsMonitoring. -->
                 <Button Content="Start auto-trace" Command="{Binding StartAutoTraceCommand}"
                         Style="{StaticResource PrimaryButton}"
-                        Visibility="{Binding IsAutoTraceRunning, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                        Visibility="{Binding Shared.IsAutoTraceRunning, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                 <Button Content="Stop auto-trace" Command="{Binding StopAutoTraceCommand}"
                         Style="{StaticResource SecondaryButton}"
-                        Visibility="{Binding IsAutoTraceRunning, Converter={StaticResource FlexVis}}"/>
+                        Visibility="{Binding Shared.IsAutoTraceRunning, Converter={StaticResource FlexVis}}"/>
             </StackPanel>
         </DockPanel>
 


### PR DESCRIPTION
Closes #1594

Ping and Traceroute look like two independent tabs with their own Start/Stop buttons. They are not: both drive **one** shared `TracerouteMonitorService` through `NetworkSharedState`, and the running state was a per-VM copy that nothing kept in sync. The result is the worst class of bug in a diagnostic tool — the button lies about what the system is doing.

## The two desyncs

| The user does | What actually happens | What the Traceroute tab showed |
|---|---|---|
| **Stop** on Ping | `Shared.StopMonitoring()` → `TraceMonitor.Stop()` — a live auto-trace is killed | still "Stop auto-trace", still claiming "Auto-trace running" |
| **Start** on Ping | `StartMonitoring()` → `TraceMonitor.Start()` — auto-traceroutes begin against every enabled target | still "Start auto-trace", as if nothing were running |

So the user either believes traceroutes are running when they were stopped, or has no idea that background TTL scans against every target just started.

## Verified before touching anything

- `grep "TraceMonitor\.\(Start\|Stop\)"` → **5 writers**: `NetworkSharedState.cs:330` (StartMonitoring), `:338` (StopMonitoring), `:602` (Dispose), `TracerouteViewModel.cs:41`, `:53`.
- `grep IsAutoTraceRunning` → the only production writes were `TracerouteViewModel.cs:42` and `:54`.
- `grep TraceMonitor.IsRunning` → **nothing reads it.** The monitor knew the truth; no one asked.
- Both ViewModels and `NetworkSharedState` are DI singletons, so a stale flag persisted for the whole session rather than being reset by navigation.

## The fix

Move the state to its single owner rather than trying to keep two copies agreeing:

- `NetworkSharedState` gains `[ObservableProperty] private bool _isAutoTraceRunning`, set in `StartMonitoring`/`StopMonitoring` **and** by this tab's own commands.
- `TracerouteViewModel.IsAutoTraceRunning` becomes a read-through to it. The property **name is preserved**, so the existing `IsAutoTraceRunning_DefaultFalse` test still compiles and passes — the issue flagged that risk explicitly.
- `TracerouteView.xaml` binds `Shared.IsAutoTraceRunning`, mirroring `PingView.xaml:29/36`, which already binds `Shared.IsMonitoring` instead of a per-VM copy. Ping got this right; Traceroute had not. This is a one-tab deviation from the codebase's own convention, not a new design.

Two details worth calling out:

- The read-through **re-raises `PropertyChanged`** when the shared flag flips. Without that, the value would change but the bound button would keep rendering the old state — a forwarding property that does not notify is just a slower bug.
- It **unsubscribes in `Dispose`**. `NetworkSharedState` is a singleton that outlives the VM, so a live handler would pin the ViewModel for the rest of the session. There is a test for this.
- `NetworkSharedState.Dispose` (`:602`) also stops the monitor but deliberately gets **no** flag write: it runs at app teardown, where there is no UI left to update.

## Tests, and why they are split across two suites

4 unit + 3 integration.

The unit tests deliberately **do not** call `StartMonitoring`, even though that is precisely the call the Ping tab makes. Reading `PingMonitorService.PumpAsync` shows it pings on its **first** tick, before any delay, against the targets the `NetworkSharedState` constructor seeds — which includes the machine's real gateway. A unit test that emits live ICMP is non-deterministic and, on a workstation, can raise a firewall prompt. So the unit tests assert the flag contract directly (the state is not stored locally; this tab's Stop is visible on the shared object; the notification fires; the handler unsubscribes on Dispose), with a comment recording why they stop there.

The real cross-tab path — actually calling `StartMonitoring` and `StopMonitoring` and asserting the tab agrees with `TraceMonitor.IsRunning` — lives in the **integration** suite, where every seeded target is first disabled and repointed at RFC 5737 TEST-NET-1 (`192.0.2.1`) so nothing can leave the machine. That matches the existing convention in `PingMonitorServiceTests`, which uses the same address for the same reason.

## Red ritual

`dotnet test` is unavailable on this workstation, so a console harness ran against a worktree of unfixed `origin/main` and against this branch. It reads the flag by reflection so one source compiles against both trees.

Unfixed — 4 failures:

```
FAIL  Ping Start is reflected on the Traceroute tab  -- monitor running = True, tab flag = False
FAIL  after Ping Start the tab agrees with the monitor  -- flag = False, monitor = True
FAIL  NetworkSharedState owns IsAutoTraceRunning  -- property absent — flag is still per-VM
FAIL  TracerouteViewModel no longer keeps its own copy  -- local backing field still present
```

`monitor running = True, tab flag = False` is the desync reproducing exactly.

This branch: **9/9 PASS**, including `no notifications after Dispose (handler unsubscribed)`. Re-ran after rebasing onto 1.58.2 — still 9/9. All three projects build **0 errors, 0 warnings**.

## Behaviour change, stated plainly

This is intentional and user-visible: **Traceroute's buttons now flip when Ping is started or stopped.** That is the point — they were always describing the same monitor, they just disagreed about it. Worth a look at Ping and Traceroute together on the secondary workstation, since the main PC never launches the app.
