### PR TITLE
fix: make the Windows Update progress bar fill, and stop the tests touching the real speed-test history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.58.4] - 2026-08-10
+
+### Fixed
+- **The Windows Update progress bar now actually fills.** Version 1.58.2 claimed to fix this and only half did: the bar was told what percentage to show, but it was still stuck in "busy" mode, and in that mode Windows ignores the percentage completely and just sweeps back and forth. So installing updates — one of the longest things the app does — still gave no sense of how far along it was. It now switches to a real filling bar the moment Windows reports a percentage. The Cleanup and Debloater bars fixed in 1.58.2 were genuinely fixed; this was the one that was not.
+
+### Changed
+- **The app's own tests no longer touch your saved speed-test results.** Three tests were reading, writing and — in two cases — deleting the real speed-test history file, because that part of the app had no way to be pointed at a scratch location. It does now, so the tests run entirely on throwaway files. Nothing about how the app itself saves your results has changed. This only ever affected anyone running the test suite from source, not the released app, but it also meant those tests could barely check anything; they now verify the saved data properly, including that clearing one engine's results leaves the other's alone.
+
 ## [1.58.3] - 2026-08-10
 
 ### Fixed

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -58,4 +58,83 @@ public class ArchitectureTests
     [InlineData("SysManager.Views")]
     public void Models_DoNotDependOnUpperLayers(string upperLayer)
         => AssertNoDependency("SysManager.Models", upperLayer);
+
+    /// <summary>
+    /// No service may hold a resolved user-data path in STATIC state.
+    /// <para>
+    /// A <c>static readonly</c> path built from <see cref="Environment.SpecialFolder"/> is untestable
+    /// by any means: that API resolves through the Win32 known-folder function and ignores the
+    /// <c>LOCALAPPDATA</c> environment variable, so no test — not even one in a child process — can
+    /// redirect it. The consequence is not theoretical. <c>SpeedTestHistoryService</c> held its path
+    /// that way, so its tests ran against the real profile: one wrote fabricated results into the
+    /// user's live speed-test history and two deleted it outright.
+    /// </para>
+    /// <para>
+    /// The fix is the <c>string? configDir = null</c> constructor seam the persistence services
+    /// already share. This test is a RATCHET, not a clean-slate assertion: seven services still hold
+    /// their path statically and converting all of them is a refactor in its own right, so those are
+    /// listed as known. Anything NOT on that list fails immediately, and the list itself must shrink
+    /// — a name that no longer offends also fails the test, so it cannot rot into a permanent excuse.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void Services_DoNotHoldUserDataPathsInStaticFields()
+    {
+        // Known offenders, kept ONLY so this ratchet can be added without a repo-wide refactor in the
+        // same change. Of these, AppIconService, SettingsWatchdogService, ThemeService and
+        // WindowsThemeService are referenced by tests today, so they carry the same latent risk that
+        // SpeedTestHistoryService realised; ActivityLogService and LogService are not test-exercised.
+        // Removing a name from this list is the goal — tracked in issue #1741.
+        string[] known =
+        [
+            "ActivityLogService.FilePath",
+            "AppIconService.CacheDir",
+            "AppIconService.SettingsPath",
+            "LogService.<LogDir>k__BackingField",
+            "SettingsWatchdogService.BaselinePath",
+            "ThemeService.SettingsPath",
+            "WindowsThemeService.SchedulePath",
+        ];
+
+        var profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        Assert.False(string.IsNullOrEmpty(profile));   // else every check below would be vacuous
+
+        var found = new List<string>();
+
+        foreach (var type in AppAssembly.GetTypes()
+                     .Where(t => t.Namespace == "SysManager.Services" && !t.IsNested))
+        {
+            foreach (var field in type.GetFields(
+                         BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                if (field.FieldType != typeof(string)) continue;
+                if (!field.IsInitOnly && !field.IsLiteral) continue;
+
+                // A static string is only a problem when it holds a resolved user-data PATH. A bare
+                // file name ("speedtest-history.json") or a registry key is fine — what must not be
+                // baked into static state is an absolute path under the user's profile, because that
+                // is precisely what a test needs to redirect.
+                var value = field.IsLiteral
+                    ? field.GetRawConstantValue() as string
+                    : field.GetValue(null) as string;
+                if (string.IsNullOrEmpty(value)) continue;
+
+                if (value.StartsWith(profile, StringComparison.OrdinalIgnoreCase))
+                    found.Add($"{type.Name}.{field.Name}");
+            }
+        }
+
+        var added = found.Except(known).ToList();
+        Assert.True(added.Count == 0,
+            "These services bake a user-profile path into static state, which makes them impossible to " +
+            "point at a temp directory — so any test touching them would operate on REAL user data " +
+            "(exactly how SpeedTestHistoryService's tests came to delete the user's speed-test " +
+            "history). Add the `string? configDir = null` constructor seam instead:\n  " +
+            string.Join("\n  ", added));
+
+        var fixedSince = known.Except(found).ToList();
+        Assert.True(fixedSince.Count == 0,
+            "These no longer hold a static user-profile path, so remove them from the `known` list " +
+            "above — a stale allowance silently weakens this guard:\n  " + string.Join("\n  ", fixedSince));
+    }
 }

--- a/SysManager/SysManager.Tests/SpeedTestHistoryServiceTests.cs
+++ b/SysManager/SysManager.Tests/SpeedTestHistoryServiceTests.cs
@@ -2,13 +2,47 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using SysManager.Models;
 using SysManager.Services;
 
 namespace SysManager.Tests;
 
-public class SpeedTestHistoryServiceTests
+/// <summary>
+/// Every test here points the service at its own throwaway directory via the <c>configDir</c> seam.
+/// Before that seam existed the path was a <c>static readonly</c> built from
+/// <see cref="Environment.SpecialFolder.LocalApplicationData"/> — which resolves through the Win32
+/// known-folder API and ignores the <c>LOCALAPPDATA</c> environment variable — so these tests ran
+/// against the user's real <c>speedtest-history.json</c>: one wrote fabricated results into it and
+/// two deleted it. That also meant they could assert almost nothing, because the starting state was
+/// whatever happened to be on the machine. With the directory under test control they can assert
+/// exact content instead of merely "did not throw".
+/// </summary>
+public sealed class SpeedTestHistoryServiceTests : IDisposable
 {
+    private readonly string _dir;
+
+    public SpeedTestHistoryServiceTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "SysManagerTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); }
+        catch (DirectoryNotFoundException) { /* already gone — nothing to clean up */ }
+    }
+
+    private SpeedTestHistoryService NewService() => new(_dir);
+
+    private string HistoryFile => Path.Combine(_dir, "speedtest-history.json");
+
+    private static SpeedTestResult Result(
+        string engine = "HTTP", double down = 100.5, double up = 50.2, double ping = 12.3,
+        string server = "test-server", DateTime? at = null)
+        => new(engine, down, up, ping, server, at ?? new DateTime(2026, 1, 1, 12, 0, 0));
+
     [Fact]
     public void MaxPerEngine_Is20()
     {
@@ -16,50 +50,208 @@ public class SpeedTestHistoryServiceTests
     }
 
     [Fact]
-    public async Task LoadAsync_WhenNoFile_ReturnsEmptyList()
+    public async Task LoadAsync_WhenNoFile_ReturnsGenuinelyEmptyList()
     {
-        var svc = new SpeedTestHistoryService();
+        // Now actually assertable: the directory is known-empty, so "empty" means empty rather than
+        // "whatever this machine happened to have".
+        using var svc = NewService();
+        Assert.False(File.Exists(HistoryFile));
+
         var results = await svc.LoadAsync();
-        Assert.NotNull(results);
-        // May or may not be empty depending on whether a history file exists
-        // on the test machine — just verify it doesn't throw.
+
+        Assert.Empty(results);
     }
 
     [Fact]
-    public async Task SaveAsync_DoesNotThrow()
+    public async Task SaveAsync_WritesTheFile_AndCreatesTheDirectory()
     {
-        var svc = new SpeedTestHistoryService();
-        var result = new SpeedTestResult("HTTP", 100.5, 50.2, 12.3, "test-server", DateTime.Now);
-        var ex = await Record.ExceptionAsync(() => svc.SaveAsync(result));
-        Assert.Null(ex);
+        // Delete the directory first so the Directory.CreateDirectory path in SaveAsync is exercised,
+        // not just the write.
+        Directory.Delete(_dir, recursive: true);
+        using var svc = NewService();
+
+        await svc.SaveAsync(Result());
+
+        Assert.True(File.Exists(HistoryFile));
     }
 
     [Fact]
-    public async Task SaveAndLoad_RoundTrips()
+    public async Task SaveAndLoad_RoundTripsEveryField()
     {
-        var svc = new SpeedTestHistoryService();
-        var result = new SpeedTestResult("HTTP", 123.4, 56.7, 8.9, "roundtrip-server", DateTime.Now);
-        await svc.SaveAsync(result);
+        using var svc = NewService();
+        var at = new DateTime(2026, 3, 4, 5, 6, 7);
+        await svc.SaveAsync(Result("HTTP", 123.4, 56.7, 8.9, "roundtrip-server", at));
 
         var loaded = await svc.LoadAsync();
-        Assert.Contains(loaded, r =>
-            Math.Abs(r.DownloadMbps - 123.4) < 0.01 &&
-            r.Server == "roundtrip-server");
+
+        var only = Assert.Single(loaded);
+        Assert.Equal("HTTP", only.Engine);
+        Assert.Equal(123.4, only.DownloadMbps, precision: 3);
+        Assert.Equal(56.7, only.UploadMbps, precision: 3);
+        Assert.Equal(8.9, only.PingMs, precision: 3);
+        Assert.Equal("roundtrip-server", only.Server);
+        Assert.Equal(at, only.CompletedAt);
     }
 
     [Fact]
-    public async Task ClearAsync_SpecificEngine_DoesNotThrow()
+    public async Task ClearAsync_OneEngine_LeavesTheOtherEnginesResults()
     {
-        var svc = new SpeedTestHistoryService();
+        // The discriminating case the old test could not express: clearing HTTP must not take Ookla
+        // with it. Previously this only asserted "did not throw" — while deleting the user's history.
+        using var svc = NewService();
+        await svc.SaveAsync(Result("HTTP", 100, 10, 5, "http-server"));
+        await svc.SaveAsync(Result("Ookla", 200, 20, 6, "ookla-server"));
+        Assert.Equal(2, (await svc.LoadAsync()).Count);
+
+        await svc.ClearAsync("HTTP");
+
+        var remaining = await svc.LoadAsync();
+        var only = Assert.Single(remaining);
+        Assert.Equal("Ookla", only.Engine);
+        Assert.Equal("ookla-server", only.Server);
+    }
+
+    [Fact]
+    public async Task ClearAsync_OneEngine_IsCaseInsensitive()
+    {
+        using var svc = NewService();
+        await svc.SaveAsync(Result("HTTP", server: "http-server"));
+
+        await svc.ClearAsync("http");   // lower case — the service compares OrdinalIgnoreCase
+
+        Assert.Empty(await svc.LoadAsync());
+    }
+
+    [Fact]
+    public async Task ClearAsync_LastRemainingEngine_RemovesTheFileEntirely()
+    {
+        using var svc = NewService();
+        await svc.SaveAsync(Result("HTTP"));
+        Assert.True(File.Exists(HistoryFile));
+
+        await svc.ClearAsync("HTTP");
+
+        Assert.False(File.Exists(HistoryFile));   // no empty-array file left behind
+        Assert.Empty(await svc.LoadAsync());
+    }
+
+    [Fact]
+    public async Task ClearAsync_AllEngines_RemovesEverything()
+    {
+        using var svc = NewService();
+        await svc.SaveAsync(Result("HTTP"));
+        await svc.SaveAsync(Result("Ookla"));
+
+        await svc.ClearAsync(null);
+
+        Assert.False(File.Exists(HistoryFile));
+        Assert.Empty(await svc.LoadAsync());
+    }
+
+    [Fact]
+    public async Task ClearAsync_WhenNoFileExists_DoesNotThrow()
+    {
+        using var svc = NewService();
+        Assert.False(File.Exists(HistoryFile));
+
         var ex = await Record.ExceptionAsync(() => svc.ClearAsync("HTTP"));
+
         Assert.Null(ex);
     }
 
     [Fact]
-    public async Task ClearAsync_AllEngines_DoesNotThrow()
+    public async Task SaveAsync_TrimsToMaxPerEngine_KeepingTheNewest()
     {
-        var svc = new SpeedTestHistoryService();
-        var ex = await Record.ExceptionAsync(() => svc.ClearAsync(null));
-        Assert.Null(ex);
+        // MaxPerEngine is 20; save 25 with increasing timestamps and assert the oldest 5 are dropped
+        // rather than the newest. Deterministic timestamps, no wall clock.
+        using var svc = NewService();
+        var start = new DateTime(2026, 1, 1, 0, 0, 0);
+        for (int i = 0; i < 25; i++)
+            await svc.SaveAsync(Result("HTTP", down: i, server: $"s{i}", at: start.AddMinutes(i)));
+
+        var loaded = await svc.LoadAsync();
+
+        Assert.Equal(SpeedTestHistoryService.MaxPerEngine, loaded.Count);
+        Assert.Equal("s24", loaded[0].Server);                       // newest first
+        Assert.DoesNotContain(loaded, r => r.Server == "s0");        // oldest trimmed
+        Assert.DoesNotContain(loaded, r => r.Server == "s4");
+        Assert.Contains(loaded, r => r.Server == "s5");              // 25 - 20 = first kept
+    }
+
+    [Fact]
+    public async Task SaveAsync_TrimsPerEngineIndependently()
+    {
+        // The trim groups by engine, so 20 HTTP results must not evict Ookla's.
+        using var svc = NewService();
+        var start = new DateTime(2026, 1, 1, 0, 0, 0);
+        for (int i = 0; i < 22; i++)
+            await svc.SaveAsync(Result("HTTP", server: $"h{i}", at: start.AddMinutes(i)));
+        await svc.SaveAsync(Result("Ookla", server: "ookla-kept", at: start.AddMinutes(100)));
+
+        var loaded = await svc.LoadAsync();
+
+        Assert.Equal(SpeedTestHistoryService.MaxPerEngine + 1, loaded.Count);
+        Assert.Contains(loaded, r => r.Server == "ookla-kept");
+        Assert.Equal(SpeedTestHistoryService.MaxPerEngine, loaded.Count(r => r.Engine == "HTTP"));
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenFileIsMalformed_ReturnsEmptyRatherThanThrowing()
+    {
+        // A truncated or hand-edited file must not take the tab down. This is a real failure path the
+        // old tests could not reach, because they never controlled the file's contents.
+        await File.WriteAllTextAsync(HistoryFile, "{ this is not valid json");
+        using var svc = NewService();
+
+        var results = await svc.LoadAsync();
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenFileIsJsonNull_ReturnsEmpty()
+    {
+        // Deserialize returns null for the literal "null"; the service guards that explicitly.
+        await File.WriteAllTextAsync(HistoryFile, "null");
+        using var svc = NewService();
+
+        Assert.Empty(await svc.LoadAsync());
+    }
+
+    [Fact]
+    public async Task LoadAsync_MissingEngineField_DefaultsToHttp()
+    {
+        // The DTO's Engine is nullable and the loader coalesces to "HTTP"; pin that so the fallback
+        // cannot silently change and mis-bucket old entries.
+        await File.WriteAllTextAsync(HistoryFile,
+            """[{"downloadMbps":10,"uploadMbps":2,"pingMs":5,"server":"s","completedAt":"2026-01-01T00:00:00"}]""");
+        using var svc = NewService();
+
+        var only = Assert.Single(await svc.LoadAsync());
+
+        Assert.Equal("HTTP", only.Engine);
+        Assert.Equal("s", only.Server);
+    }
+
+    [Fact]
+    public async Task TwoServices_OnDifferentDirectories_DoNotSeeEachOther()
+    {
+        // Proves the seam actually isolates: the whole point of the fix.
+        var otherDir = Path.Combine(Path.GetTempPath(), "SysManagerTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(otherDir);
+        try
+        {
+            using var a = NewService();
+            using var b = new SpeedTestHistoryService(otherDir);
+
+            await a.SaveAsync(Result("HTTP", server: "in-a"));
+
+            Assert.Single(await a.LoadAsync());
+            Assert.Empty(await b.LoadAsync());
+        }
+        finally
+        {
+            Directory.Delete(otherDir, recursive: true);
+        }
     }
 }

--- a/SysManager/SysManager.Tests/SpeedTestViewModelTests.cs
+++ b/SysManager/SysManager.Tests/SpeedTestViewModelTests.cs
@@ -6,21 +6,50 @@ using SysManager.ViewModels;
 
 namespace SysManager.Tests;
 
-public class SpeedTestViewModelTests
+/// <summary>
+/// Every VM here is built with a <see cref="Services.SpeedTestHistoryService"/> pointed at a throwaway
+/// directory. The VM constructor kicks off <c>LoadHistoryAsync</c>, so before the service gained its
+/// <c>configDir</c> seam these tests READ the user's real speedtest-history.json — and their results
+/// depended on whatever that file happened to contain.
+/// </summary>
+public sealed class SpeedTestViewModelTests : IDisposable
 {
+    private readonly string _dir;
+
+    public SpeedTestViewModelTests()
+    {
+        _dir = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "SysManagerTests", Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { System.IO.Directory.Delete(_dir, recursive: true); }
+        catch (System.IO.DirectoryNotFoundException) { /* already gone */ }
+    }
+
+    private static NetworkSharedState NewShared() => new(
+        new Services.PingMonitorService(), new Services.TracerouteService(),
+        new Services.TracerouteMonitorService(), new Services.SpeedTestService(),
+        new Services.NetworkRepairService(new Services.PowerShellRunner()));
+
+    /// <summary>History service scoped to this test's temp directory — never the real profile.</summary>
+    private Services.SpeedTestHistoryService NewHistory() => new(_dir);
+
     [Fact]
     public void Constructor_SetsShared()
     {
-        var shared = new NetworkSharedState(new Services.PingMonitorService(), new Services.TracerouteService(), new Services.TracerouteMonitorService(), new Services.SpeedTestService(), new Services.NetworkRepairService(new Services.PowerShellRunner()));
-        var vm = new SpeedTestViewModel(shared, new Services.SpeedTestHistoryService());
+        var shared = NewShared();
+        var vm = new SpeedTestViewModel(shared, NewHistory());
         Assert.Same(shared, vm.Shared);
     }
 
     [Fact]
     public void DefaultState_NotTesting()
     {
-        var shared = new NetworkSharedState(new Services.PingMonitorService(), new Services.TracerouteService(), new Services.TracerouteMonitorService(), new Services.SpeedTestService(), new Services.NetworkRepairService(new Services.PowerShellRunner()));
-        var vm = new SpeedTestViewModel(shared, new Services.SpeedTestHistoryService());
+        var shared = NewShared();
+        var vm = new SpeedTestViewModel(shared, NewHistory());
         Assert.False(vm.IsSpeedTesting);
         Assert.False(vm.IsHttpTesting);
         Assert.False(vm.IsOoklaTesting);
@@ -30,40 +59,40 @@ public class SpeedTestViewModelTests
     [Fact]
     public void HttpResult_DefaultNull()
     {
-        var shared = new NetworkSharedState(new Services.PingMonitorService(), new Services.TracerouteService(), new Services.TracerouteMonitorService(), new Services.SpeedTestService(), new Services.NetworkRepairService(new Services.PowerShellRunner()));
-        var vm = new SpeedTestViewModel(shared, new Services.SpeedTestHistoryService());
+        var shared = NewShared();
+        var vm = new SpeedTestViewModel(shared, NewHistory());
         Assert.Null(vm.HttpResult);
     }
 
     [Fact]
     public void OoklaResult_DefaultNull()
     {
-        var shared = new NetworkSharedState(new Services.PingMonitorService(), new Services.TracerouteService(), new Services.TracerouteMonitorService(), new Services.SpeedTestService(), new Services.NetworkRepairService(new Services.PowerShellRunner()));
-        var vm = new SpeedTestViewModel(shared, new Services.SpeedTestHistoryService());
+        var shared = NewShared();
+        var vm = new SpeedTestViewModel(shared, NewHistory());
         Assert.Null(vm.OoklaResult);
     }
 
     [Fact]
     public void CancelSpeedCommand_DoesNotThrow()
     {
-        var shared = new NetworkSharedState(new Services.PingMonitorService(), new Services.TracerouteService(), new Services.TracerouteMonitorService(), new Services.SpeedTestService(), new Services.NetworkRepairService(new Services.PowerShellRunner()));
-        var vm = new SpeedTestViewModel(shared, new Services.SpeedTestHistoryService());
+        var shared = NewShared();
+        var vm = new SpeedTestViewModel(shared, NewHistory());
         vm.CancelSpeedCommand.Execute(null);
     }
 
     [Fact]
     public void HttpHistory_StartsEmpty()
     {
-        var shared = new NetworkSharedState(new Services.PingMonitorService(), new Services.TracerouteService(), new Services.TracerouteMonitorService(), new Services.SpeedTestService(), new Services.NetworkRepairService(new Services.PowerShellRunner()));
-        var vm = new SpeedTestViewModel(shared, new Services.SpeedTestHistoryService());
+        var shared = NewShared();
+        var vm = new SpeedTestViewModel(shared, NewHistory());
         Assert.NotNull(vm.HttpHistory);
     }
 
     [Fact]
     public void OoklaHistory_StartsEmpty()
     {
-        var shared = new NetworkSharedState(new Services.PingMonitorService(), new Services.TracerouteService(), new Services.TracerouteMonitorService(), new Services.SpeedTestService(), new Services.NetworkRepairService(new Services.PowerShellRunner()));
-        var vm = new SpeedTestViewModel(shared, new Services.SpeedTestHistoryService());
+        var shared = NewShared();
+        var vm = new SpeedTestViewModel(shared, NewHistory());
         Assert.NotNull(vm.OoklaHistory);
     }
 
@@ -75,8 +104,8 @@ public class SpeedTestViewModelTests
     [InlineData("ClearOoklaHistoryCommand")]
     public void CommandExists(string propertyName)
     {
-        var shared = new NetworkSharedState(new Services.PingMonitorService(), new Services.TracerouteService(), new Services.TracerouteMonitorService(), new Services.SpeedTestService(), new Services.NetworkRepairService(new Services.PowerShellRunner()));
-        var vm = new SpeedTestViewModel(shared, new Services.SpeedTestHistoryService());
+        var shared = NewShared();
+        var vm = new SpeedTestViewModel(shared, NewHistory());
         var prop = vm.GetType().GetProperty(propertyName);
         Assert.NotNull(prop);
         Assert.NotNull(prop!.GetValue(vm));
@@ -85,8 +114,8 @@ public class SpeedTestViewModelTests
     [Fact]
     public async Task ClearHttpHistoryCommand_DoesNotThrow()
     {
-        var shared = new NetworkSharedState(new Services.PingMonitorService(), new Services.TracerouteService(), new Services.TracerouteMonitorService(), new Services.SpeedTestService(), new Services.NetworkRepairService(new Services.PowerShellRunner()));
-        var vm = new SpeedTestViewModel(shared, new Services.SpeedTestHistoryService());
+        var shared = NewShared();
+        var vm = new SpeedTestViewModel(shared, NewHistory());
         var ex = await Record.ExceptionAsync(() => vm.ClearHttpHistoryCommand.ExecuteAsync(null));
         Assert.Null(ex);
     }
@@ -94,8 +123,8 @@ public class SpeedTestViewModelTests
     [Fact]
     public async Task ClearOoklaHistoryCommand_DoesNotThrow()
     {
-        var shared = new NetworkSharedState(new Services.PingMonitorService(), new Services.TracerouteService(), new Services.TracerouteMonitorService(), new Services.SpeedTestService(), new Services.NetworkRepairService(new Services.PowerShellRunner()));
-        var vm = new SpeedTestViewModel(shared, new Services.SpeedTestHistoryService());
+        var shared = NewShared();
+        var vm = new SpeedTestViewModel(shared, NewHistory());
         var ex = await Record.ExceptionAsync(() => vm.ClearOoklaHistoryCommand.ExecuteAsync(null));
         Assert.Null(ex);
     }

--- a/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
+++ b/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
@@ -620,6 +620,51 @@ public class WindowsUpdateViewModelTests
             DialogService.Instance = prevDialog;
         }
     }
+
+    // ---------- progress reporting ----------
+
+    [Fact]
+    public void RunnerProgress_SwitchesTheBarOutOfIndeterminateMode()
+    {
+        // WPF ignores ProgressBar.Value entirely while IsIndeterminate is true, so assigning Progress
+        // without clearing the flag leaves the bar sweeping and never filling — which is what made the
+        // Value binding added in v1.58.2 inert on this tab. Every command sets the flag true on entry
+        // and clears it in its own finally, so the handler only narrows the indeterminate window to
+        // "before the first real percentage arrives".
+        using var vm = NewVm();
+        vm.IsProgressIndeterminate = true;
+
+        InvokeRunnerProgress(vm, 42);
+
+        Assert.Equal(42, vm.Progress);
+        Assert.False(vm.IsProgressIndeterminate);
+    }
+
+    [Fact]
+    public void RunnerProgress_KeepsReportingLaterPercentages()
+    {
+        // Once determinate it must stay determinate for the rest of the operation, and the value has to
+        // track each report rather than sticking at the first one.
+        using var vm = NewVm();
+        vm.IsProgressIndeterminate = true;
+
+        InvokeRunnerProgress(vm, 10);
+        InvokeRunnerProgress(vm, 75);
+        InvokeRunnerProgress(vm, 100);
+
+        Assert.Equal(100, vm.Progress);
+        Assert.False(vm.IsProgressIndeterminate);
+    }
+
+    /// <summary>
+    /// Drives the private runner-progress handler. The event is raised by <see cref="PowerShellRunner"/>
+    /// from a live PowerShell progress stream, which a unit test cannot produce, so the handler is
+    /// invoked directly — the same reflection approach already used elsewhere in this file.
+    /// </summary>
+    private static void InvokeRunnerProgress(WindowsUpdateViewModel vm, int percent)
+        => typeof(WindowsUpdateViewModel)
+            .GetMethod("OnRunnerProgressChanged", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(vm, [percent]);
 }
 
 // ---------- UpdateEntry model ----------

--- a/SysManager/SysManager/Services/SpeedTestHistoryService.cs
+++ b/SysManager/SysManager/Services/SpeedTestHistoryService.cs
@@ -18,9 +18,7 @@ public sealed class SpeedTestHistoryService : IDisposable
 {
     public const int MaxPerEngine = 20;
 
-    private static readonly string HistoryPath = Path.Join(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "SysManager", "speedtest-history.json");
+    private readonly string _historyPath;
 
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
@@ -32,6 +30,23 @@ public sealed class SpeedTestHistoryService : IDisposable
     // calls from racing (load-modify-save is not atomic). A SemaphoreSlim(1,1)
     // acts as an async-compatible mutex.
     private readonly SemaphoreSlim _fileLock = new(1, 1);
+
+    /// <summary>
+    /// Creates the service. <paramref name="configDir"/> is overridable so tests exercise the real
+    /// save/load/clear paths against a temp directory instead of the user's own history file — same
+    /// seam as <see cref="ResourceHistoryService"/> and <see cref="ClosePreferenceService"/>.
+    /// <para>The path was previously <c>static readonly</c>, which made this service impossible to
+    /// test safely: <see cref="Environment.SpecialFolder.LocalApplicationData"/> resolves through the
+    /// Win32 known-folder API and ignores the <c>LOCALAPPDATA</c> environment variable, so nothing
+    /// could redirect it away from the real profile. The tests consequently wrote fabricated results
+    /// into the user's live history and one of them deleted it outright.</para>
+    /// </summary>
+    public SpeedTestHistoryService(string? configDir = null)
+    {
+        var dir = configDir ?? Path.Join(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager");
+        _historyPath = Path.Join(dir, "speedtest-history.json");
+    }
 
     /// <inheritdoc />
     public void Dispose() => _fileLock.Dispose();
@@ -47,10 +62,10 @@ public sealed class SpeedTestHistoryService : IDisposable
     {
         try
         {
-            if (!File.Exists(HistoryPath))
+            if (!File.Exists(_historyPath))
                 return [];
 
-            var json = await File.ReadAllTextAsync(HistoryPath, ct).ConfigureAwait(false);
+            var json = await File.ReadAllTextAsync(_historyPath, ct).ConfigureAwait(false);
             var entries = JsonSerializer.Deserialize<List<SpeedTestHistoryEntry>>(json, JsonOpts);
             if (entries is null) return [];
 
@@ -108,11 +123,11 @@ public sealed class SpeedTestHistoryService : IDisposable
                 CompletedAt = r.CompletedAt
             }).ToList();
 
-            var dir = Path.GetDirectoryName(HistoryPath)!;
+            var dir = Path.GetDirectoryName(_historyPath)!;
             Directory.CreateDirectory(dir);
 
             var json = JsonSerializer.Serialize(entries, JsonOpts);
-            await File.WriteAllTextAsync(HistoryPath, json, ct).ConfigureAwait(false);
+            await File.WriteAllTextAsync(_historyPath, json, ct).ConfigureAwait(false);
         }
         catch (IOException ex)
         {
@@ -138,8 +153,8 @@ public sealed class SpeedTestHistoryService : IDisposable
         {
             if (engine is null)
             {
-                if (File.Exists(HistoryPath))
-                    File.Delete(HistoryPath);
+                if (File.Exists(_historyPath))
+                    File.Delete(_historyPath);
                 return;
             }
 
@@ -148,8 +163,8 @@ public sealed class SpeedTestHistoryService : IDisposable
 
             if (filtered.Count == 0)
             {
-                if (File.Exists(HistoryPath))
-                    File.Delete(HistoryPath);
+                if (File.Exists(_historyPath))
+                    File.Delete(_historyPath);
                 return;
             }
 
@@ -164,7 +179,7 @@ public sealed class SpeedTestHistoryService : IDisposable
             }).ToList();
 
             var json = JsonSerializer.Serialize(entries, JsonOpts);
-            await File.WriteAllTextAsync(HistoryPath, json, ct).ConfigureAwait(false);
+            await File.WriteAllTextAsync(_historyPath, json, ct).ConfigureAwait(false);
         }
         catch (IOException ex)
         {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.58.3</Version>
-    <FileVersion>1.58.3.0</FileVersion>
-    <AssemblyVersion>1.58.3.0</AssemblyVersion>
+    <Version>1.58.4</Version>
+    <FileVersion>1.58.4.0</FileVersion>
+    <AssemblyVersion>1.58.4.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -177,7 +177,21 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
     }
 
     private void OnRunnerLineReceived(PowerShellLine l) => Console.Append(l);
-    private void OnRunnerProgressChanged(int p) => Progress = p;
+
+    /// <summary>
+    /// A real percentage arrived from the PowerShell progress stream, so switch the bar out of
+    /// indeterminate mode — WPF ignores <c>Value</c> entirely while <c>IsIndeterminate</c> is true, so
+    /// assigning <see cref="ViewModelBase.Progress"/> alone would keep the bar sweeping and never fill
+    /// it. Every command sets the flag back to true on entry and clears it in its own finally, so this
+    /// only ever narrows the indeterminate window to "before the first percentage". Mirrors
+    /// CleanupViewModel, which pairs the two assignments the same way.
+    /// </summary>
+    private void OnRunnerProgressChanged(int p)
+    {
+        Progress = p;
+        IsProgressIndeterminate = false;
+    }
+
     private void OnWuLog(string text) => Console.Append(PowerShellLine.Output(text));
 
     /// <summary>


### PR DESCRIPTION
Two defects that the post-release audit of v1.58.2/v1.58.3 found — one of them in my own shipped fix. Both are corrected before any new backlog work.

Closes #1739
Closes #1734

## #1739 — the v1.58.2 progress-bar fix was inert on Windows Update

v1.58.2 added `Value="{Binding Progress}"` to three views. Two of them work. Windows Update does not, because **WPF ignores `ProgressBar.Value` entirely while `IsIndeterminate` is `true`** — and that ViewModel never leaves indeterminate mode:

- All five `IsProgressIndeterminate = false` writes sit inside `finally` blocks (`:304`, `:347`, `:411`, `:470`, `:531`). The flag is never cleared while work is in flight.
- Yet the percentages are real: `WindowsUpdateViewModel:114` subscribes `_runner.ProgressChanged`, `:180` assigns `Progress = p`, and `PowerShellRunner:153-157` raises that event from `ps.Streams.Progress.DataAdded` with the actual `rec.PercentComplete` (guarded `>= 0`).

So the bar kept sweeping and never filled, on one of the longest operations in the app.

**Fix** — pair the two assignments in the one handler they all route through:

```csharp
private void OnRunnerProgressChanged(int p)
{
    Progress = p;
    IsProgressIndeterminate = false;
}
```

This covers all five commands, and mirrors `CleanupViewModel:392-394` / `:498-500` — which is exactly why the Cleanup half of #1599 worked and this half did not. Each command still sets the flag `true` on entry, so the change only narrows the indeterminate window to "before the first real percentage".

**The v1.58.2 release note over-claimed for this tab.** The new CHANGELOG entry says so in plain language rather than quietly re-fixing it.

## #1734 — the test suite was deleting the user's real speed-test history

`SpeedTestHistoryService`'s path was a `private static readonly` built from `SpecialFolder.LocalApplicationData`. That API resolves through the Win32 known-folder function and **ignores the `LOCALAPPDATA` environment variable** — the harness proves it: with `LOCALAPPDATA` pointed at a temp directory, `GetFolderPath` still returned the real profile. There was no way, by any means, to redirect it.

So three tests operated on live user data:

| Test | What it did to the real file |
|---|---|
| `SaveAndLoad_RoundTrips` | wrote fabricated results **into** it |
| `ClearAsync_SpecificEngine_DoesNotThrow` | **deleted** the user's HTTP results |
| `ClearAsync_AllEngines_DoesNotThrow` | **deleted** the file |

Not hypothetical: the live file on this machine still contained a single entry whose `server` field was `"roundtrip-server"` — the literal from `SaveAndLoad_RoundTrips:41`.

`SpeedTestViewModelTests` was affected too, in 10 places — the VM constructor calls `LoadHistoryAsync`, so those tests were **reading** the real file, which is also why their results depended on whatever the machine happened to hold.

**Fix** — the `string? configDir = null` seam the other persistence services already share. The parameter is optional, so no production call site changes and `AddSingleton<SpeedTestHistoryService>()` keeps resolving the real path.

**That seam is what made the tests worth having.** Three vague tests became 14 real ones. The old `LoadAsync_WhenNoFile_ReturnsEmptyList` asserted nothing at all and said why in its own comment — "May or may not be empty depending on whether a history file exists on the test machine". Now covered: exact round-trip of every field, per-engine clearing leaving the other engine intact, case-insensitive engine matching, file removal when the last engine is cleared, `MaxPerEngine` trimming keeping the **newest**, per-engine independent trimming, malformed and `null` JSON handling, the missing-engine-field default, and cross-directory isolation.

## Mechanical enforcement, because a rule in memory is a wish

`ArchitectureTests` gains `Services_DoNotHoldUserDataPathsInStaticFields`, which reflects over `SysManager.Services` and fails on any static string field holding a path under the user profile.

It is deliberately a **ratchet**, not a clean-slate assertion: seven other services still hold static profile paths, and converting them is a refactor in its own right (tracked as **#1741**, with a per-service plan and the two wrinkles I hit while surveying them). Those seven are listed as `known`. Two failure modes, both intentional:

- a path **not** on the list → fails immediately
- a listed name that **no longer offends** → also fails, so the allow-list cannot rot into a permanent excuse

**Verified to discriminate** rather than assumed. Against unfixed `origin/main` it reports exactly:

```
NEW (fails):   SpeedTestHistoryService.HistoryPath
```

…while correctly allowing the other seven. After the fix: 8 offenders becomes 7, and the guard passes. Of the remaining seven, five are referenced by tests today and carry the same latent risk; `WindowsThemeService` is currently protected only by a `SuppressSave` reflection workaround, which is a symptom of the missing seam rather than a fix.

## User-data safety

The whole point of #1734 is that user data was being destroyed, so the work itself had to not destroy it. Before touching anything I hashed `%LocalAppData%\SysManager\speedtest-history.json` (`ca5933e1…`) and copied it aside. It was re-verified **byte-identical after every edit and every harness run**, confirmed two ways — by hash and by `diff` against the backup. The harness never invokes a mutating method through the real no-arg path; on the unfixed tree, where that is the only constructor, it inspects the type's shape instead.

## Red ritual

`dotnet test` is unavailable on this workstation, so a console harness ran against a worktree of unfixed `origin/main` and against this branch, using reflection so one source compiles against both.

Unfixed:

```
FAIL  a real percentage switches the bar to determinate  -- IsProgressIndeterminate = True
FAIL  a configDir ctor exists  -- only 1 ctor(s), none taking a string — path is unredirectable
FAIL  the path is no longer static state  -- static HistoryPath still present
FAIL  the guard reports zero offenders  -- 1 offender(s)
SKIP  isolation checks — no configDir ctor on this tree (that IS the defect)
```

This branch: **ALL PASS**, including four isolation assertions that can only exist once the seam does (a save lands in its own directory; the other directory is unaffected; the file is written where told; clearing HTTP keeps Ookla).

All four projects build with **0 errors, 0 warnings**.

## Not verifiable here

The Windows Update bar actually filling needs eyes on the secondary workstation, since the main PC never launches the app. The behaviour behind it is pinned by two new unit tests plus the harness.
