### PR TITLE
fix: clean every Chromium browser profile, and disclose partly-unreadable folders in Disk Analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.58.5] - 2026-08-10
+
+### Fixed
+- **Browser Cleaner was only ever cleaning your first browser profile.** If you have more than one profile in Chrome, Edge or Brave — a personal one and a work one, or one per person in the house — only the first was scanned. The others' cache, history and cookies were never found, never counted in the total, and never cleaned. So someone clearing their browsing traces kept every trace in the other profile, with nothing on screen to hint at it. Every profile is now included, and each row says which one it belongs to ("Google Chrome — Profile 1"), so you can see exactly what you are about to clean. Cookies stay unticked by default in every profile, just as before, and cleaning one profile cannot touch another. Firefox was already handled correctly and is unchanged.
+- **Disk Analyzer now tells you when a folder was only partly readable.** Windows blocks access to parts of some folders even for you, and when that happened the folder's size was quietly reported too small with no hint anything was missing — so you could go hunting for space in the wrong place. Those folders now carry a small amber warning mark, and hovering it explains that the folder may be using more space than shown. The app already knew this; it just never said so.
+
 ## [1.58.4] - 2026-08-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -591,6 +591,10 @@ Remove preinstalled Windows Store apps you don't use:
 ### Browser Cleaner
 Reclaim space and clear browsing traces, per browser:
 - **Auto-detects** Chrome, Edge, Brave, Opera, and Firefox
+- **Every profile, not just the first** — if you keep separate Chrome/Edge/Brave profiles
+  (personal and work, or one per person), each is scanned and named in its own row
+  ("Google Chrome — Profile 1"), so you can see which one you're cleaning. Cleaning one
+  profile never touches another
 - **Per-category** with size shown: Cache, History, Cookies, Sessions
 - **Cookies/sessions are flagged and left unticked** by default — cleaning them
   signs you out, so it's always an explicit choice; cache and history are pre-selected

--- a/SysManager/SysManager.Tests/BrowserCleanerServiceTests.cs
+++ b/SysManager/SysManager.Tests/BrowserCleanerServiceTests.cs
@@ -251,4 +251,158 @@ public sealed class BrowserCleanerServiceTests : IDisposable
         Assert.True(File.Exists(Path.Combine(_local, @"Mozilla\Firefox\Profiles\abc.default-release\logins.json")));
         Assert.True(File.Exists(Path.Combine(_local, @"Mozilla\Firefox\Profiles\abc.default-release\key4.db")));
     }
+
+    // --- Multiple Chromium profiles ------------------------------------------------
+    // The profile segment used to be the literal "Default", so a second Chrome/Edge/Brave profile
+    // (personal + work, or one per family member) was never scanned, sized or cleaned. Profiles are
+    // now enumerated at scan time, the way Firefox's already were.
+
+    [Fact]
+    public async Task Scan_FindsCacheInEveryChromiumProfile_NotJustDefault()
+    {
+        WriteFile(@"Google\Chrome\User Data\Default\Cache\data_0", 1000);
+        WriteFile(@"Google\Chrome\User Data\Profile 1\Cache\data_0", 2000);
+        WriteFile(@"Google\Chrome\User Data\Profile 2\Cache\data_0", 3000);
+
+        var items = await _svc.ScanAsync();
+        var caches = items.Where(i => i.Category == "Cache" && i.Browser.StartsWith("Google Chrome")).ToList();
+
+        Assert.Equal(3, caches.Count);      // was 1 before the fix — the other 5000 bytes were invisible
+        Assert.Equal(6000, caches.Sum(c => c.SizeBytes));
+    }
+
+    [Fact]
+    public async Task Scan_NamesTheProfile_SoTheUserCanSeeWhichOne()
+    {
+        WriteFile(@"Google\Chrome\User Data\Default\Cache\data_0", 1000);
+        WriteFile(@"Google\Chrome\User Data\Profile 1\Cache\data_0", 2000);
+
+        var items = await _svc.ScanAsync();
+
+        // The default profile stays unlabelled so the common single-profile case reads as before…
+        var dflt = items.Single(i => i.Browser == "Google Chrome" && i.Category == "Cache");
+        Assert.Equal(1000, dflt.SizeBytes);
+        // …and the extra profile is named, which a flat "Google Chrome" row could never convey.
+        var second = items.Single(i => i.Browser == "Google Chrome — Profile 1" && i.Category == "Cache");
+        Assert.Equal(2000, second.SizeBytes);
+        Assert.Contains("Profile 1", second.Description);
+    }
+
+    [Fact]
+    public async Task Scan_EachProfilesPaths_StayInsideThatProfile()
+    {
+        // The load-bearing safety property: cleaning one profile must not be able to reach another.
+        WriteFile(@"Google\Chrome\User Data\Default\Cache\data_0", 1000);
+        WriteFile(@"Google\Chrome\User Data\Profile 1\Cache\data_0", 2000);
+
+        var items = await _svc.ScanAsync();
+
+        var dflt = items.Single(i => i.Browser == "Google Chrome" && i.Category == "Cache");
+        Assert.All(dflt.Paths, p => Assert.DoesNotContain(@"\Profile 1\", p));
+        var second = items.Single(i => i.Browser == "Google Chrome — Profile 1" && i.Category == "Cache");
+        Assert.All(second.Paths, p => Assert.DoesNotContain(@"\Default\", p));
+    }
+
+    [Fact]
+    public async Task Clean_OneProfile_LeavesTheOtherProfileUntouched()
+    {
+        WriteFile(@"Google\Chrome\User Data\Default\Cache\data_0", 1000);
+        WriteFile(@"Google\Chrome\User Data\Profile 1\Cache\data_0", 2000);
+
+        var items = await _svc.ScanAsync();
+        var second = items.Single(i => i.Browser == "Google Chrome — Profile 1" && i.Category == "Cache");
+
+        await _svc.CleanAsync([second]);
+
+        Assert.False(File.Exists(Path.Combine(_local, @"Google\Chrome\User Data\Profile 1\Cache\data_0")));
+        Assert.True(File.Exists(Path.Combine(_local, @"Google\Chrome\User Data\Default\Cache\data_0")));
+    }
+
+    [Fact]
+    public async Task Scan_IgnoresChromiumFoldersThatAreNotUserProfiles()
+    {
+        // Chromium keeps plenty of non-profile folders under User Data. Matching every subdirectory
+        // would point a delete at paths this tab never advertised, so only Default / "Profile N" count.
+        WriteFile(@"Google\Chrome\User Data\Default\Cache\data_0", 1000);
+        WriteFile(@"Google\Chrome\User Data\Crashpad\Cache\data_0", 1);
+        WriteFile(@"Google\Chrome\User Data\ShaderCache\Cache\data_0", 1);
+        WriteFile(@"Google\Chrome\User Data\System Profile\Cache\data_0", 1);
+        WriteFile(@"Google\Chrome\User Data\Guest Profile\Cache\data_0", 1);
+        WriteFile(@"Google\Chrome\User Data\Profile X\Cache\data_0", 1);   // not "Profile <number>"
+
+        var items = await _svc.ScanAsync();
+        var caches = items.Where(i => i.Category == "Cache" && i.Browser.StartsWith("Google Chrome")).ToList();
+
+        Assert.Single(caches);
+        Assert.Equal(1000, caches[0].SizeBytes);
+    }
+
+    [Fact]
+    public async Task Scan_MultipleProfiles_AcrossDifferentBrowsers()
+    {
+        WriteFile(@"Google\Chrome\User Data\Profile 1\Cache\data_0", 100);
+        WriteFile(@"Microsoft\Edge\User Data\Profile 3\Cache\data_0", 200);
+        WriteFile(@"BraveSoftware\Brave-Browser\User Data\Default\Cache\data_0", 300);
+
+        var items = await _svc.ScanAsync();
+
+        Assert.Contains(items, i => i.Browser == "Google Chrome — Profile 1");
+        Assert.Contains(items, i => i.Browser == "Microsoft Edge — Profile 3");
+        Assert.Contains(items, i => i.Browser == "Brave");   // Default stays unlabelled
+    }
+
+    [Fact]
+    public async Task Scan_SkipsAProfileThatIsAJunction()
+    {
+        // Same guard the Firefox expander applies: a standard user can create a junction with
+        // `mklink /J` and no elevation, so a profile-shaped link must not become a delete target.
+        WriteFile(@"Google\Chrome\User Data\Default\Cache\data_0", 1000);
+
+        var victim = Path.Combine(_local, "victim");
+        Directory.CreateDirectory(victim);
+        File.WriteAllBytes(Path.Combine(victim, "important.dat"), new byte[4096]);
+
+        var link = Path.Combine(_local, @"Google\Chrome\User Data\Profile 1");
+        Directory.CreateDirectory(Path.GetDirectoryName(link)!);
+        if (!TryCreateJunction(link, victim)) return;   // skip where junctions are unavailable
+
+        var items = await _svc.ScanAsync();
+
+        Assert.DoesNotContain(items, i => i.Browser.Contains("Profile 1"));
+        Assert.True(File.Exists(Path.Combine(victim, "important.dat")));
+    }
+
+    [Fact]
+    public async Task Scan_ProfileOrder_IsDefaultThenNumericallyStable()
+    {
+        // Filesystem enumeration order is not guaranteed; the grid should read predictably.
+        WriteFile(@"Google\Chrome\User Data\Profile 2\Cache\data_0", 20);
+        WriteFile(@"Google\Chrome\User Data\Profile 1\Cache\data_0", 10);
+        WriteFile(@"Google\Chrome\User Data\Default\Cache\data_0", 5);
+
+        var items = await _svc.ScanAsync();
+        var order = items.Where(i => i.Category == "Cache" && i.Browser.StartsWith("Google Chrome"))
+                         .Select(i => i.Browser)
+                         .ToList();
+
+        Assert.Equal(
+            ["Google Chrome", "Google Chrome — Profile 1", "Google Chrome — Profile 2"],
+            order);
+    }
+
+    [Fact]
+    public async Task Scan_SensitiveFlags_HoldPerProfile()
+    {
+        // Cookies must stay opt-in in EVERY profile, not just the default one.
+        WriteFile(@"Google\Chrome\User Data\Profile 1\Network\Cookies", 512);
+        WriteFile(@"Google\Chrome\User Data\Profile 1\Cache\data_0", 512);
+
+        var items = await _svc.ScanAsync();
+
+        var cookies = items.Single(i => i.Category == "Cookies");
+        Assert.True(cookies.IsSensitive);
+        Assert.False(cookies.IsSelected);
+        var cache = items.Single(i => i.Category == "Cache");
+        Assert.True(cache.IsSelected);
+    }
 }

--- a/SysManager/SysManager/Services/BrowserCleanerService.cs
+++ b/SysManager/SysManager/Services/BrowserCleanerService.cs
@@ -30,18 +30,86 @@ public sealed class BrowserCleanerService
 
     private sealed record Def(string Browser, string Category, string Description, bool Sensitive, string[] RelativePaths, bool Roaming = false);
 
-    // Chrome/Edge/Brave keep per-profile data under "<UserData>\Default\..." in LocalAppData.
-    private static Def[] ChromiumDefs(string browser, string userDataRel) =>
+    // Chrome/Edge/Brave keep per-profile data under "<UserData>\<profile>\..." in LocalAppData,
+    // where <profile> is "Default" for the first profile and "Profile 1", "Profile 2", … for each
+    // one the user adds. The profile segment used to be the literal "Default", so a second profile
+    // (personal + work, or one per family member) was never scanned, never sized and never cleaned —
+    // the tab reported a total that understated the real reclaimable space, and someone clearing
+    // "browsing traces" kept every trace in their other profile. Profiles are now enumerated at scan
+    // time, exactly as Firefox's already were (see ExpandFirefoxCachePaths).
+    private static Def[] ChromiumDefs(string browser, string userDataRel, string profileRel, string profileLabel) =>
     [
-        new(browser, "Cache", "Cached images and files.", false,
-            [$@"{userDataRel}\Default\Cache", $@"{userDataRel}\Default\Code Cache", $@"{userDataRel}\Default\GPUCache"]),
-        new(browser, "History", "Browsing and download history.", false,
-            [$@"{userDataRel}\Default\History", $@"{userDataRel}\Default\History-journal"]),
-        new(browser, "Cookies", "Cookies — clearing these signs you out of websites.", true,
-            [$@"{userDataRel}\Default\Network\Cookies", $@"{userDataRel}\Default\Network\Cookies-journal"]),
-        new(browser, "Sessions", "Open tabs / session restore data.", true,
-            [$@"{userDataRel}\Default\Sessions", $@"{userDataRel}\Default\Session Storage"]),
+        new(browser, "Cache", $"Cached images and files{profileLabel}.", false,
+            [$@"{profileRel}\Cache", $@"{profileRel}\Code Cache", $@"{profileRel}\GPUCache"]),
+        new(browser, "History", $"Browsing and download history{profileLabel}.", false,
+            [$@"{profileRel}\History", $@"{profileRel}\History-journal"]),
+        new(browser, "Cookies", $"Cookies{profileLabel} — clearing these signs you out of websites.", true,
+            [$@"{profileRel}\Network\Cookies", $@"{profileRel}\Network\Cookies-journal"]),
+        new(browser, "Sessions", $"Open tabs / session restore data{profileLabel}.", true,
+            [$@"{profileRel}\Sessions", $@"{profileRel}\Session Storage"]),
     ];
+
+    /// <summary>
+    /// One <see cref="Def"/> set per Chromium profile that actually exists on disk.
+    /// <para>
+    /// Only "Default" and "Profile N" directories are considered — Chromium keeps plenty of other
+    /// folders under <c>User Data</c> (<c>Crashpad</c>, <c>ShaderCache</c>, <c>System Profile</c>, …)
+    /// and none of them are user profiles, so matching every subdirectory would point a delete at
+    /// paths this tab never advertised. Reparse points are skipped and enumeration failures are
+    /// swallowed, matching <see cref="ExpandFirefoxCachePaths"/>.
+    /// </para>
+    /// <para>
+    /// When the browser is not installed this yields nothing, so no rows appear — the same outcome as
+    /// before, since ScanAsync already omits paths that do not exist.
+    /// </para>
+    /// </summary>
+    private IEnumerable<Def> ExpandChromiumDefs(string browser, string userDataRel)
+    {
+        var userDataAbs = Path.Combine(_localAppData, userDataRel);
+        if (!Directory.Exists(userDataAbs) || IsReparsePoint(userDataAbs)) yield break;
+
+        string[] candidates;
+        try { candidates = Directory.GetDirectories(userDataAbs); }
+        catch (IOException) { yield break; }
+        catch (UnauthorizedAccessException) { yield break; }
+
+        // "Default" first, then Profile 1, Profile 2, … so the grid reads in a stable, predictable
+        // order instead of whatever order the filesystem returned.
+        foreach (var dir in candidates
+                     .Select(Path.GetFileName)
+                     .Where(name => !string.IsNullOrEmpty(name) && IsProfileFolder(name!))
+                     .OrderBy(name => IsDefaultProfile(name!) ? 0 : 1)
+                     .ThenBy(name => name, StringComparer.OrdinalIgnoreCase))
+        {
+            if (IsReparsePoint(Path.Combine(userDataAbs, dir!))) continue;
+
+            // Name the profile in the Browser column so the user can see WHICH Chrome is being
+            // cleaned — the thing a flat "Google Chrome" checkbox in other cleaners never tells her.
+            // The default profile stays unlabelled, so the common single-profile case reads exactly
+            // as it did before and no existing row text changes.
+            var isDefault = IsDefaultProfile(dir!);
+            var displayName = isDefault ? browser : $"{browser} — {dir}";
+            var label = isDefault ? string.Empty : $" in {dir}";
+            foreach (var def in ChromiumDefs(displayName, userDataRel, $@"{userDataRel}\{dir}", label))
+                yield return def;
+        }
+    }
+
+    private static bool IsDefaultProfile(string name) =>
+        string.Equals(name, "Default", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// True for "Default" and "Profile N" (N a positive integer) — the only directory names Chromium
+    /// uses for user profiles.
+    /// </summary>
+    private static bool IsProfileFolder(string name)
+    {
+        if (IsDefaultProfile(name)) return true;
+        if (!name.StartsWith("Profile ", StringComparison.OrdinalIgnoreCase)) return false;
+
+        var suffix = name["Profile ".Length..];
+        return suffix.Length > 0 && suffix.All(char.IsAsciiDigit);
+    }
 
     // Opera Stable is Chromium-based but does NOT use a "\Default\" profile segment: the
     // profile lives directly under "Opera Software\Opera Stable". It also splits its data
@@ -71,9 +139,11 @@ public sealed class BrowserCleanerService
     private List<Def> BuildDefs()
     {
         List<Def> defs = [];
-        defs.AddRange(ChromiumDefs("Google Chrome", @"Google\Chrome\User Data"));
-        defs.AddRange(ChromiumDefs("Microsoft Edge", @"Microsoft\Edge\User Data"));
-        defs.AddRange(ChromiumDefs("Brave", @"BraveSoftware\Brave-Browser\User Data"));
+        // Each Chromium browser can hold several profiles; every one that exists on disk is expanded
+        // at scan time so a second profile's data is no longer invisible to this tab.
+        defs.AddRange(ExpandChromiumDefs("Google Chrome", @"Google\Chrome\User Data"));
+        defs.AddRange(ExpandChromiumDefs("Microsoft Edge", @"Microsoft\Edge\User Data"));
+        defs.AddRange(ExpandChromiumDefs("Brave", @"BraveSoftware\Brave-Browser\User Data"));
         defs.AddRange(OperaDefs());
         // Firefox keeps profiles in roaming AppData, but the cache lives under LocalAppData
         // in per-profile "<profile>\cache2" folders. We target the cache2 subfolders only —

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.58.4</Version>
-    <FileVersion>1.58.4.0</FileVersion>
-    <AssemblyVersion>1.58.4.0</AssemblyVersion>
+    <Version>1.58.5</Version>
+    <FileVersion>1.58.5.0</FileVersion>
+    <AssemblyVersion>1.58.5.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/DiskAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/DiskAnalyzerView.xaml
@@ -117,7 +117,19 @@
 
                             <!-- Name + file count -->
                             <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13"/>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13"/>
+                                    <!-- The scan already records when a folder could not be fully read
+                                         (IsAccessDenied), but nothing showed it, so the size was quietly
+                                         too small and the user was told nothing. Informational rather than
+                                         alarming: a locked AppData subfolder is a normal, common case. -->
+                                    <TextBlock Text="&#xE7BA;" FontFamily="Segoe MDL2 Assets" FontSize="11"
+                                               Foreground="{DynamicResource Warning}"
+                                               VerticalAlignment="Center" Margin="6,0,0,0"
+                                               AutomationProperties.Name="Partly unreadable"
+                                               ToolTip="Part of this folder could not be read, so it may be using more space than shown."
+                                               Visibility="{Binding IsAccessDenied, Converter={StaticResource FlexVis}}"/>
+                                </StackPanel>
                                 <TextBlock FontSize="11" Foreground="{DynamicResource TextMuted}">
                                     <Run Text="{Binding FileCount, Mode=OneWay, StringFormat='{}{0:N0} files'}"/>
                                     <Run Text=" · " Foreground="{DynamicResource TextDisabled}"/>


### PR DESCRIPTION
Closes #1576
Closes #1583

## #1576 — Browser Cleaner only ever cleaned the first browser profile

`ChromiumDefs` baked the literal `Default` segment into all four categories (`Services/BrowserCleanerService.cs:36-43`). So on any machine with a second Chrome/Edge/Brave profile — personal and work, or one per person in the house — that profile's cache, history and cookies were **never scanned, never counted, never cleaned**.

Two things made this worse than a missing feature:

- The reported total silently **understated** the reclaimable space, so the number on screen was wrong with no indication.
- Someone clearing "browsing traces" kept **every trace** in their other profile, and the success toast said the job was done. For a privacy tool that is a trust failure, not just a gap.

**The correct pattern already existed in the same file.** `ExpandFirefoxCachePaths` enumerates `Mozilla\Firefox\Profiles\*` at scan time instead of hardcoding a profile name — the exact fix this needed. Chromium now does the same through `ExpandChromiumDefs`.

Three deliberate constraints on that enumeration:

- **Only `Default` and `Profile N` qualify.** Chromium keeps `Crashpad`, `ShaderCache`, `System Profile`, `Guest Profile` and others under `User Data`. Matching every subdirectory would point a delete at paths this tab never advertised, so the filter is explicit and tested (including `Profile X`, which is *not* `Profile <number>`).
- **Reparse points are skipped** and enumeration failures swallowed, matching the Firefox expander, so a junction named `Profile 1` cannot become a delete target. A standard user can create one with `mklink /J` and no elevation — there is a test for exactly that.
- **The default profile stays unlabelled.** Only extra profiles get a name, so the common single-profile case reads exactly as before and no existing row text or test changes.

Each extra profile is named in the Browser column — `Google Chrome — Profile 1` — and in the row description. That is the part other cleaners never tell you: CCleaner's flat "Google Chrome" checkbox cannot say *which* Chrome it is about to clear. Profiles are ordered Default-first then by name, because filesystem enumeration order is not guaranteed.

## #1583 — Disk Analyzer knew a folder was partly unreadable and never said so

`DiskAnalyzerService` sets `accessDenied` on every `UnauthorizedAccessException` while walking and writes it onto each row (`:96`). `grep AccessDenied` across every `.xaml` returned **zero**. So when Windows blocked part of a folder, its size was quietly too small and the user was told nothing — which sends her hunting for space in the wrong folder. A size number that is silently wrong is worse than no number.

Added an amber warning glyph beside the folder name, gated on the flag that was already computed, using the existing `FlexVis` converter and `Warning` brush, with a tooltip: *"Part of this folder could not be read, so it may be using more space than shown."*

Deliberately **informational rather than alarming** — a locked `AppData` subfolder is a normal, common case, and the existing `EmptyDirectory_NotMarkedAsAccessDenied` test already pins the no-false-positive side.

## Tests

9 new, covering the behaviour rather than the implementation:

| What it pins |
|---|
| every profile's cache is found (3 rows, 6000 bytes — was 1 row, 1000) |
| the profile is named, and the default stays unlabelled |
| each profile's paths stay **inside** that profile |
| cleaning one profile leaves the other profiles' files on disk |
| non-profile folders are ignored, including `Profile X` |
| multiple profiles across Chrome + Edge + Brave |
| a junctioned profile is skipped and its target survives |
| ordering is Default-first and stable |
| cookies stay opt-in in **every** profile, not just the default |

## Red ritual

Harness against a worktree of unfixed `origin/main`:

```
FAIL  every profile's cache is found  -- 1 cache row(s): Google Chrome
FAIL  the reported total covers all profiles  -- total = 1000 (Default-only would report 1000)
FAIL  a second profile's history is discovered  -- not found — those traces would survive a 'clear browsing data'
FAIL  a second profile's cookies are discovered
FAIL  profiles are listed Default-first then in order  -- Google Chrome
```

`total = 1000` where 6000 bytes exist, and a second profile's history and cookies **not found at all** — the privacy failure reproducing exactly.

This branch: **10/10 PASS**, including that cleaning `Profile 1` leaves `Default` and `Profile 2` untouched on disk. Re-ran after rebasing onto 1.58.4 — still all pass. All four projects build **0 errors, 0 warnings**.

The harness builds a fake browser tree in a temp directory (the service already accepts injectable `LocalAppData`/`AppData` roots), so no real browser profile was read or touched at any point.

## Gate-DOCS

README's Browser Cleaner section now states the multi-profile behaviour — it is a user-visible change to what the tab actually covers, so leaving the docs implying "per browser" would have been a fresh inaccuracy.

## Not verifiable here

How the extra profile rows and the amber warning mark look needs eyes on the secondary workstation, since the main PC never launches the app. One judgement call worth a look: a 3-profile Chrome now produces up to 12 rows instead of 4, which is why the profile name went into the Browser column — so the grid still groups readably rather than showing four identical "Google Chrome" rows.
