### PR TITLE
fix: show the feedback four tabs already computed, and surface the Services recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.58.6] - 2026-08-10
+
+### Fixed
+- **"How long is left?" now actually appears.** Speed Test and Deep Cleanup both worked out a time estimate on every tick of a job that can run for minutes — and then had nowhere to show it, so you watched a bar with no idea whether to wait or walk away. Both now show it, the same way App Updates, Bulk Installer, Uninstaller and Quick Cleanup already did.
+- **Ping and Traceroute now confirm what they did.** These were the only two tabs in the app with no status line at all. Pressing "Clear History" on Ping emptied the chart and the whole history and said nothing, so there was no way to tell it had worked. Starting or stopping the automatic traceroute was equally silent. Both tabs now report what happened.
+- **The plain-language explanation of every service was written and never shown.** SysManager carries 25 hand-written descriptions of what a Windows service actually does and whether it is safe to turn off — "Superfetch — preloads apps into RAM. Disabling frees RAM for games and reduces disk I/O." — while the Services tab showed only Microsoft's own dense wording. The tab's own subtitle and this README both promised those explanations. Hover any row's description to read it. You can also now filter the list by recommendation ("Safe to disable", "Keep enabled", "Advanced"), which the README claimed you could but you could not — that is a separate thing from the Safe/Caution/Critical safety mark, which answers "will this break Windows" rather than "is it worth turning off".
+
 ## [1.58.5] - 2026-08-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -754,8 +754,10 @@ offers, "rate us" prompts:
 ### Services
 - Lists all Windows services with current status and startup type
 - **Gaming recommendations**: services tagged as "safe to disable", "advanced",
-  or "keep enabled" with per-service explanations
-- Filter by status (Running/Stopped), recommendation level, or free-text search
+  or "keep enabled" — hover a row's description to read why, in plain language
+  instead of Microsoft's own wording
+- Filter by status (Running/Stopped), safety level (Safe/Caution/Critical),
+  gaming recommendation, or free-text search
 - Start, stop, disable, or enable services with confirmation dialogs
 - Requires admin for all mutations
 

--- a/SysManager/SysManager.Tests/ServicesViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ServicesViewModelTests.cs
@@ -149,6 +149,60 @@ public class ServicesViewModelTests
         Assert.All(vm.Services, s => Assert.Equal(Models.SafetyLevel.Safe, s.SafetyLevel));
     }
 
+    // ── ApplyFilter: gaming recommendation ──
+    // A DIFFERENT dataset from the Safe/Caution/Critical safety level above: safety answers "will
+    // this break Windows", the recommendation answers "is this worth turning off for games, and
+    // why". Both were computed per service, but only the safety level was filterable — so README's
+    // "filter by … recommendation level" claim was untrue.
+
+    [Theory]
+    [InlineData("Safe to disable", "safe-to-disable")]
+    [InlineData("Keep enabled", "keep-enabled")]
+    [InlineData("Advanced", "advanced")]
+    public async Task ApplyFilter_Recommendation_ShowsOnlyThatRecommendation(string option, string stored)
+    {
+        var vm = await CreateWithDataAsync();
+
+        vm.SelectedFilter = option;
+
+        Assert.NotEmpty(vm.Services);   // a filter matching nothing would vacuously pass Assert.All
+        Assert.All(vm.Services, s => Assert.Equal(stored, s.Recommendation));
+    }
+
+    [Fact]
+    public async Task ApplyFilter_Recommendation_IsNotTheSafetyLevel()
+    {
+        // Discriminating assertion: "Safe to disable" must not collapse into the Safe safety level.
+        // In the fixture, Print Spooler is safe-to-disable but its SAFETY level is Caution — so a
+        // filter that confused the two datasets would drop it.
+        var vm = await CreateWithDataAsync();
+
+        vm.SelectedFilter = "Safe to disable";
+
+        Assert.Contains(vm.Services, s => s.Name == "Spooler");
+        Assert.Contains(vm.Services, s => s.SafetyLevel == Models.SafetyLevel.Caution);
+    }
+
+    [Fact]
+    public void FilterOptions_CoverEveryRecommendationTheGuideProduces()
+    {
+        // Mechanical guard: GamingGuide uses exactly three recommendation values. If a fourth is ever
+        // added, this fails rather than the new one silently having no filter — the class of bug that
+        // left these 25 explanations unreachable in the first place.
+        var produced = ServiceManagerService.GamingGuide.Values
+            .Select(v => v.Rec)
+            .Distinct()
+            .OrderBy(v => v, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(["advanced", "keep-enabled", "safe-to-disable"], produced);
+
+        var vm = new ServicesViewModel(new Services.PowerShellRunner());
+        Assert.Contains("Safe to disable", vm.FilterOptions);
+        Assert.Contains("Keep enabled", vm.FilterOptions);
+        Assert.Contains("Advanced", vm.FilterOptions);
+    }
+
     // ── ApplyFilter: text filter ──
 
     [Fact]

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.58.5</Version>
-    <FileVersion>1.58.5.0</FileVersion>
-    <AssemblyVersion>1.58.5.0</AssemblyVersion>
+    <Version>1.58.6</Version>
+    <FileVersion>1.58.6.0</FileVersion>
+    <AssemblyVersion>1.58.6.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -35,8 +35,14 @@ public sealed partial class ServicesViewModel : ViewModelBase
     [ObservableProperty] private int _cautionCount;
     [ObservableProperty] private int _criticalCount;
 
+    // "Safe to disable" / "Advanced" filter on the GAMING RECOMMENDATION, which is a different
+    // dataset from the Safe/Caution/Critical SAFETY level above it: safety says "will this break
+    // Windows", the recommendation says "is this worth turning off for games, and why". Both were
+    // computed; only the safety level was filterable, so README's "filter by recommendation level"
+    // claim was untrue.
     public string[] FilterOptions { get; } =
-        { "All", "Running", "Stopped", "Safe", "Caution", "Critical" };
+        { "All", "Running", "Stopped", "Safe", "Caution", "Critical",
+          "Safe to disable", "Keep enabled", "Advanced" };
 
     public ServicesViewModel(IPowerShellRunner ps, ServiceStartupLedgerService? ledger = null)
     {
@@ -258,6 +264,12 @@ public sealed partial class ServicesViewModel : ViewModelBase
             "Safe" => filtered.Where(s => s.SafetyLevel == SafetyLevel.Safe),
             "Caution" => filtered.Where(s => s.SafetyLevel == SafetyLevel.Caution),
             "Critical" => filtered.Where(s => s.SafetyLevel == SafetyLevel.Critical),
+            // Gaming recommendation, not safety level — see FilterOptions. The stored values are the
+            // literals from ServiceManagerService.GamingGuide, which uses exactly three:
+            // safe-to-disable (12 entries), keep-enabled (9) and advanced (4).
+            "Safe to disable" => filtered.Where(s => s.Recommendation == "safe-to-disable"),
+            "Keep enabled" => filtered.Where(s => s.Recommendation == "keep-enabled"),
+            "Advanced" => filtered.Where(s => s.Recommendation == "advanced"),
             _ => filtered
         };
 

--- a/SysManager/SysManager/Views/DeepCleanupView.xaml
+++ b/SysManager/SysManager/Views/DeepCleanupView.xaml
@@ -59,6 +59,10 @@
                                 <TextBlock Grid.Column="1" Text="{Binding ScanProgress, StringFormat={}{0}%}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center" Margin="12,0,0,0"/>
                             </Grid>
                             <ProgressBar AutomationProperties.Name="Progress" Height="6" Minimum="0" Maximum="100" Value="{Binding ScanProgress}" Margin="0,6,0,0"/>
+                            <!-- The VM already runs an EtaCalculator over ScanProgress; nothing bound the
+                                 result, so the estimate for a scan that can take minutes was discarded. -->
+                            <TextBlock Text="{Binding ScanEtaText}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="0,4,0,0"
+                                       Visibility="{Binding ScanEtaText, Converter={StaticResource FlexVis}}"/>
                         </StackPanel>
 
                         <ItemsControl ItemsSource="{Binding Categories}">
@@ -127,6 +131,10 @@
                                 <TextBlock Grid.Column="1" Text="{Binding CleanProgress, StringFormat={}{0}%}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center" Margin="12,0,0,0"/>
                             </Grid>
                             <ProgressBar AutomationProperties.Name="Progress" Height="6" Minimum="0" Maximum="100" Value="{Binding CleanProgress}" Margin="0,6,0,0"/>
+                            <!-- Same for the clean phase, which deletes real files — knowing how long is
+                                 left is what stops someone killing the app mid-delete. -->
+                            <TextBlock Text="{Binding CleanEtaText}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="0,4,0,0"
+                                       Visibility="{Binding CleanEtaText, Converter={StaticResource FlexVis}}"/>
                         </StackPanel>
                     </StackPanel>
                 </Border>

--- a/SysManager/SysManager/Views/PingView.xaml
+++ b/SysManager/SysManager/Views/PingView.xaml
@@ -11,6 +11,9 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <!-- Status line. This tab was one of only two in the app with no status line at all, so
+                 Clear History wiped the chart and history with no confirmation on screen. -->
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <!-- Header -->
@@ -205,6 +208,10 @@
                                     TooltipBackgroundPaint="{Binding Shared.TooltipBackgroundPaint}"/>
             </Grid>
         </Border>
+
+        <!-- Status -->
+        <TextBlock Grid.Row="4" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+                   Margin="28,12,28,24" TextWrapping="Wrap"/>
 
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -142,6 +142,17 @@
                     <DataGridTextColumn.ElementStyle>
                         <Style TargetType="TextBlock">
                             <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+                            <!-- Microsoft's own Description text is dense jargon. The app already carries
+                                 25 hand-written plain-language explanations (ServiceManagerService.GamingGuide
+                                 -> RecommendationReason) and nothing displayed them, so the friendly copy that
+                                 makes this tab usable was shipping dead. Shown on hover where one exists;
+                                 services outside the guide fall back to Microsoft's description. -->
+                            <Setter Property="ToolTip" Value="{Binding RecommendationReason}"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding RecommendationReason}" Value="">
+                                    <Setter Property="ToolTip" Value="{Binding Description}"/>
+                                </DataTrigger>
+                            </Style.Triggers>
                         </Style>
                     </DataGridTextColumn.ElementStyle>
                 </DataGridTextColumn>

--- a/SysManager/SysManager/Views/SpeedTestView.xaml
+++ b/SysManager/SysManager/Views/SpeedTestView.xaml
@@ -54,6 +54,12 @@
                         <TextBlock Text="{Binding OoklaResult.Server}" Style="{StaticResource Caption}" Margin="0,10,0,0" Visibility="{Binding OoklaResult, Converter={StaticResource FlexVis}}"/>
                         <ProgressBar AutomationProperties.Name="Progress" Value="{Binding SpeedProgress}" Maximum="100" Height="4" Margin="0,14,0,0" Visibility="{Binding IsOoklaTesting, Converter={StaticResource FlexVis}}"/>
                         <TextBlock Text="{Binding OoklaStatus}" Style="{StaticResource Subtle}" Margin="0,6,0,0"/>
+                        <!-- The VM already maintains an EtaCalculator and updates EstimatedTime on every
+                             progress tick; nothing bound it, so the "time remaining" for a test that can
+                             run for minutes was computed and thrown away. Same shape as the ETA lines in
+                             AppUpdatesView / BulkInstallerView / CleanupView. -->
+                        <TextBlock Text="{Binding EstimatedTime}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="0,4,0,0"
+                                   Visibility="{Binding EstimatedTime, Converter={StaticResource FlexVis}}"/>
                         <Button Content="Cancel" Command="{Binding CancelSpeedCommand}" Style="{StaticResource GhostButton}" AutomationProperties.Name="Cancel Ookla speed test" Margin="0,6,0,0" HorizontalAlignment="Left" Visibility="{Binding IsOoklaTesting, Converter={StaticResource FlexVis}}"/>
                     </StackPanel>
                 </Border>
@@ -79,6 +85,11 @@
                         </Grid>
                         <ProgressBar AutomationProperties.Name="Progress" Value="{Binding SpeedProgress}" Maximum="100" Height="4" Margin="0,14,0,0" Visibility="{Binding IsHttpTesting, Converter={StaticResource FlexVis}}"/>
                         <TextBlock Text="{Binding HttpStatus}" Style="{StaticResource Subtle}" Margin="0,6,0,0"/>
+                        <!-- Shares the single EstimatedTime property with the Ookla card above; only one
+                             engine runs at a time (both are gated on the shared SpeedProgress/CTS), so the
+                             two lines can never show conflicting figures. -->
+                        <TextBlock Text="{Binding EstimatedTime}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="0,4,0,0"
+                                   Visibility="{Binding EstimatedTime, Converter={StaticResource FlexVis}}"/>
                         <Button Content="Cancel" Command="{Binding CancelSpeedCommand}" Style="{StaticResource GhostButton}" AutomationProperties.Name="Cancel HTTP speed test" Margin="0,6,0,0" HorizontalAlignment="Left" Visibility="{Binding IsHttpTesting, Converter={StaticResource FlexVis}}"/>
                     </StackPanel>
                 </Border>

--- a/SysManager/SysManager/Views/TracerouteView.xaml
+++ b/SysManager/SysManager/Views/TracerouteView.xaml
@@ -9,6 +9,11 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <!-- Auto-trace status. Distinct from TraceStatus inside the manual-trace card below:
+                 that reports one on-demand trace ("hop 7", "Done — 12 hops"), while this reports
+                 whether the background auto-trace is running. Both writes existed; only this one
+                 had nowhere to appear. -->
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <!-- Header with own Start/Stop -->
@@ -99,6 +104,10 @@
                 </Grid>
             </Border>
         </Grid>
+
+        <!-- Status -->
+        <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+                   Margin="28,12,28,24" TextWrapping="Wrap"/>
 
     </Grid>
 </UserControl>


### PR DESCRIPTION
Closes #1612
Closes #1579

Both are the same shape as the last few batches: the ViewModel already did the work, and nothing displayed it. Every count below was re-derived from source before anything was touched.

## #1612 — four tabs computed feedback that no XAML bound

| Tab | Property | VM writes | View bound |
|---|---|---|---|
| Speed Test | `EstimatedTime` | 4 | **0** |
| Deep Cleanup | `ScanEtaText` / `CleanEtaText` | 2 | **0** |
| Ping | `StatusMessage` | 3 | **0** |
| Traceroute | `StatusMessage` | 2 | **0** |

Two of these matter more than "a missing label":

- **Speed Test and Deep Cleanup both maintain a real `EtaCalculator`** and update it on every progress tick, for jobs that run for minutes. The estimate was computed and discarded, so you watched a bar with no way to know whether to wait or walk away.
- **Ping's "Clear History" wiped the chart and the entire history and said nothing.** Ping and Traceroute were the only two tabs in the app with *no status line at all*, so there was no way to tell the click had worked.

**Fix.** The ETA lines copy the existing shape from `AppUpdatesView` / `BulkInstallerView` / `CleanupView` verbatim — `TextMuted`, `FontSize 11`, `Visibility` gated on the same property via `FlexVis`, so an empty ETA collapses instead of leaving a blank row. Ping and Traceroute each gained one `Auto` row and a `Caption` status line at the `28,12,28,24` gutter, matching the Strategy-2 views.

**Traceroute keeps its separate `TraceStatus`,** which was already bound. That reports *one on-demand trace* ("hop 7", "Done — 12 hops"); `StatusMessage` reports *whether the background auto-trace is running*. Two different facts, so both are shown rather than one replacing the other — and the harness asserts `TraceStatus` is still bound so this can't regress into a single conflated line.

## #1579 — 25 hand-written explanations shipping dead

`ServiceManagerService` looks every service up in a 25-entry `GamingGuide` and stores both halves on the model (`:77-78`). `grep Recommendation Views/ServicesView.xaml` returned **0**. So copy like this:

> *"Superfetch — preloads apps into RAM. Disabling frees RAM for games and reduces disk I/O."*

…was never shown, while the tab's own subtitle **and** `README:756-758` both advertised it. The grid showed only Microsoft's dense `Description` strings.

**Fix.** `RecommendationReason` is now the Description cell's tooltip, with a `DataTrigger` falling back to Microsoft's description for services outside the guide — so no service *loses* a tooltip it had. The recommendation is also filterable, which makes README's "filter by … recommendation level" claim true rather than aspirational.

### One correction to the issue

The issue implies two recommendation values. Reading `GamingGuide`, there are **three**: `safe-to-disable` (12 entries), `keep-enabled` (9), `advanced` (4). Wiring only the two named would have silently left **9 services unreachable** by the new filter — the same class of bug as the one being fixed. All three are wired, and a new test asserts the filter list covers every value the guide actually produces, so a fourth added later fails the test instead of quietly having no filter.

### The recommendation filter is not the safety filter

Deliberately kept distinct from the `Safe`/`Caution`/`Critical` filter beside it. Those are separate curated datasets answering different questions: safety says *"will this break Windows"*, the recommendation says *"is this worth turning off for games, and why"*. A test pins the distinction — Print Spooler is `safe-to-disable` but `Caution` safety, so a filter that conflated them would drop it.

I also **did not** take the issue's alternative suggestion of folding `GamingGuide` into `SafetyDatabase`. The issue itself says to do that separately, and it touches a security-adjacent table with existing tests.

## Verification

**Red ritual.** `dotnet test` is unavailable here, so a harness ran against a worktree of unfixed `origin/main` and against this branch. For the binding half it parses the shipped `.xaml` as text — that *is* the check that was missing, since the properties were always written and the defect was only ever "no view references them". It also asserts via reflection that each VM really exposes the property, so the check can't pass vacuously.

Unfixed — **12 failures**, and the pattern is the finding itself:

```
PASS  SpeedTestViewModel exposes EstimatedTime
FAIL  SpeedTestView binds EstimatedTime         -- the ETA for a multi-minute test
FAIL  PingView binds StatusMessage              -- so Clear History confirms on screen
FAIL  DeepCleanupView binds ScanEtaText
FAIL  ServicesView surfaces RecommendationReason -- 25 explanations were shipping dead
FAIL  'Safe to disable' selects only that recommendation -- 3 row(s): Spooler,WSearch,wuauserv
```

That last line is the unknown filter falling through `_ => filtered` and returning **all three** seeded rows instead of one.

This branch: **18/18 PASS**, including the safety-vs-recommendation discrimination.

**Tests:** 5 new — a 3-case theory over the recommendation filters (each asserting `NotEmpty` first, so `Assert.All` can't pass vacuously), the safety-vs-recommendation discrimination, and the guide-coverage guard.

All four projects build **0 errors, 0 warnings**.

## Gate-DOCS

README's Services section is corrected: it promised per-service explanations and a recommendation filter, neither of which existed. Both now do, and the wording distinguishes the safety level from the gaming recommendation so the two aren't read as one thing.

## Not verifiable here

The main PC never launches the app, so these need eyes on the secondary workstation:

- The new status rows on Ping and Traceroute add one `Auto` row each, which nudges the chart's vertical space — worth a check at a small window size, as the issue itself flagged.
- The Services tooltip on hover, and that the new filter entries read well in the dropdown.
