### PR TITLE
fix: record the six destructive operations in the activity log, and stop tab opens burying them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.58.7] - 2026-08-10
+
+### Fixed
+- **"Recent activity" on the Dashboard now shows what the app actually changed.** It listed which tabs you had opened, while leaving out the things you would genuinely want a record of: a permanent Deep Cleanup delete, a browser clean that signed you out of sites, privacy settings written to the registry, an app uninstall, files erased with the shredder, and broken shortcuts deleted. None of those left a trace. All six are now recorded, and the card refreshes when you return to the Dashboard so a new entry shows up straight away instead of looking like it never registered.
+- **Only counts and sizes are recorded — never file names.** That list is a plain text file on your PC, so writing down the name of a file you chose to erase for good would leave behind exactly the trace the shredder exists to remove, and it would outlive the file. So it says "Securely erased 3 items (7-pass overwrite)" and nothing more. The same applies to the other five: how much was cleaned, not what.
+
+### Changed
+- **Opening a tab no longer counts as "activity".** Every tab you opened used to add an entry, and only the last 20 were kept — so a few minutes of clicking around pushed out any real action. Tab visits are still recorded in the app's diagnostic log, just not on this card, and the card now keeps 60 entries so a busy session cannot bury a cleanup.
+
 ## [1.58.6] - 2026-08-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -776,8 +776,10 @@ offers, "rate us" prompts:
 - **Real-time vitals** — CPU, RAM, and GPU usage refreshed at 300 ms while
   the tab is visible (polling pauses automatically when it isn't), with live
   indicator dots.
-- **Recent Activity** — the last features you opened and actions you ran
-  (cleanups, DNS changes, app removals, restore points, …) with timestamps.
+- **Recent Activity** — what SysManager actually changed on this PC, with timestamps:
+  cleanups, deletes, uninstalls, privacy and DNS changes, restore points, shredded
+  files. Counts and sizes only — never file names, since the log is plain text on
+  your own disk. Opening a tab isn't an action, so it isn't listed.
 - **Quick Tune-Up** — one-click wizard that cleans temp files, optionally
   empties the Recycle Bin, scans for broken shortcuts, checks disk SMART
   health, flags high uptime (14+ days) and high RAM usage (85%+). Displays

--- a/SysManager/SysManager.Tests/ActivityLogServiceTests.cs
+++ b/SysManager/SysManager.Tests/ActivityLogServiceTests.cs
@@ -1,0 +1,213 @@
+// SysManager · ActivityLogServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Two halves.
+/// <para>
+/// First, the store itself, exercised through the <c>configDir</c> seam so nothing here can touch the
+/// user's real <c>activity.json</c>. Before that seam the path was <c>static readonly</c> and derived
+/// from <see cref="Environment.SpecialFolder.LocalApplicationData"/> — which ignores the
+/// <c>LOCALAPPDATA</c> environment variable — so any test calling <see cref="ActivityLogService.Log"/>
+/// would have appended to the user's own history.
+/// </para>
+/// <para>
+/// Second, a source-level guard that every destructive command still logs. <c>Instance</c> is a
+/// get-only singleton, so a ViewModel test cannot redirect the store and would write to the real file;
+/// asserting on the source is the honest way to pin "these six call the log" without that side effect.
+/// </para>
+/// </summary>
+public sealed class ActivityLogServiceTests : IDisposable
+{
+    private readonly string _dir;
+
+    public ActivityLogServiceTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "SysManagerTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); }
+        catch (DirectoryNotFoundException) { /* already gone */ }
+    }
+
+    private ActivityLogService NewLog() => new(_dir);
+
+    private string StoreFile => Path.Combine(_dir, "activity.json");
+
+    // ── the store ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Log_WritesTheEntry_AndPersistsIt()
+    {
+        var log = NewLog();
+
+        log.Log("Deep Cleanup", "Freed 1.2 GB across 400 files");
+
+        var only = Assert.Single(log.GetRecent(10));
+        Assert.Equal("Deep Cleanup", only.Action);
+        Assert.Equal("Freed 1.2 GB across 400 files", only.Detail);
+        Assert.True(File.Exists(StoreFile));
+
+        // A second instance over the same directory must see it — i.e. it really round-trips to disk.
+        Assert.Single(new ActivityLogService(_dir).GetRecent(10));
+    }
+
+    [Fact]
+    public void Log_PutsTheNewestFirst()
+    {
+        var log = NewLog();
+
+        log.Log("First", "a");
+        log.Log("Second", "b");
+
+        var recent = log.GetRecent(10);
+        Assert.Equal("Second", recent[0].Action);
+        Assert.Equal("First", recent[1].Action);
+    }
+
+    [Fact]
+    public void Log_KeepsAtMostMaxEntries_DiscardingTheOldest()
+    {
+        var log = NewLog();
+
+        for (int i = 0; i < ActivityLogService.MaxEntries + 15; i++)
+            log.Log($"Action {i}", "d");
+
+        var all = log.GetRecent(int.MaxValue);
+        Assert.Equal(ActivityLogService.MaxEntries, all.Count);
+        Assert.Equal($"Action {ActivityLogService.MaxEntries + 14}", all[0].Action);   // newest kept
+        Assert.DoesNotContain(all, e => e.Action == "Action 0");                       // oldest dropped
+    }
+
+    [Fact]
+    public void MaxEntries_LeavesRoomForRealActionsAfterNavigationStoppedLogging()
+    {
+        // The cap used to be 20 while every tab open wrote an entry, so a few minutes of clicking
+        // evicted any real action. Navigation no longer logs; this pins the headroom so the cap cannot
+        // quietly be lowered back to a value where one busy session buries a Deep Cleanup.
+        Assert.True(ActivityLogService.MaxEntries >= 50,
+            $"MaxEntries is {ActivityLogService.MaxEntries}; the activity log is the only record of what " +
+            "the app changed, so it needs room for more than a handful of actions.");
+    }
+
+    [Fact]
+    public void Load_WhenTheFileIsMalformed_StartsEmptyRatherThanThrowing()
+    {
+        File.WriteAllText(StoreFile, "{ not json");
+
+        var log = new ActivityLogService(_dir);
+
+        Assert.Empty(log.GetRecent(10));
+    }
+
+    [Fact]
+    public void GetRecent_ReturnsAtMostTheRequestedCount()
+    {
+        var log = NewLog();
+        for (int i = 0; i < 8; i++) log.Log($"A{i}", "d");
+
+        Assert.Equal(5, log.GetRecent().Count);      // default is 5, what the Dashboard card shows
+        Assert.Equal(3, log.GetRecent(3).Count);
+    }
+
+    [Fact]
+    public void TwoInstances_OnDifferentDirectories_DoNotSeeEachOther()
+    {
+        // Proves the seam isolates — the whole reason a test may call Log() at all.
+        var otherDir = Path.Combine(Path.GetTempPath(), "SysManagerTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(otherDir);
+        try
+        {
+            var a = NewLog();
+            var b = new ActivityLogService(otherDir);
+
+            a.Log("Only in A", "d");
+
+            Assert.Single(a.GetRecent(10));
+            Assert.Empty(b.GetRecent(10));
+        }
+        finally { Directory.Delete(otherDir, recursive: true); }
+    }
+
+    // ── the six destructive commands must log ───────────────────────────────
+
+    /// <summary>
+    /// Source path of a ViewModel in the app project, resolved from the test assembly location so it
+    /// works from any working directory.
+    /// </summary>
+    private static string ViewModelSource(string name)
+    {
+        var dir = new DirectoryInfo(Path.GetDirectoryName(typeof(ActivityLogService).Assembly.Location)!);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "SysManager", "ViewModels")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return Path.Combine(dir!.FullName, "SysManager", "ViewModels", name + ".cs");
+    }
+
+    [Theory]
+    [InlineData("DeepCleanupViewModel")]
+    [InlineData("BrowserCleanerViewModel")]
+    [InlineData("PrivacyViewModel")]
+    [InlineData("ShortcutCleanerViewModel")]
+    [InlineData("UninstallerViewModel")]
+    [InlineData("FileShredderViewModel")]
+    public void EveryDestructiveViewModel_WritesToTheActivityLog(string viewModel)
+    {
+        // These six are the least reversible operations in the app — a permanent delete, a browser
+        // clean that signs the user out, registry privacy writes, an uninstall, an unrecoverable
+        // shred — and every one of them used to leave no trace in the app's own history, while merely
+        // OPENING a tab logged an entry.
+        var path = ViewModelSource(viewModel);
+        Assert.True(File.Exists(path), $"could not locate {viewModel}.cs (looked at {path})");
+
+        var source = File.ReadAllText(path);
+
+        Assert.Contains("ActivityLogService.Instance.Log(", source);
+    }
+
+    [Fact]
+    public void FileShredder_LogsNoFileNameOrPath()
+    {
+        // THE load-bearing privacy check. activity.json is plain text under %LocalAppData%, so recording
+        // the name of a file the user chose to destroy beyond recovery would leave behind exactly the
+        // evidence the shred was meant to erase — and it would outlive the file. Only counts and the
+        // pass count may appear.
+        var source = File.ReadAllText(ViewModelSource("FileShredderViewModel"));
+
+        var call = Regex.Match(source,
+            @"ActivityLogService\.Instance\.Log\((?<args>.*?)\);",
+            RegexOptions.Singleline);
+        Assert.True(call.Success, "FileShredderViewModel does not call the activity log at all");
+
+        var args = call.Groups["args"].Value;
+        Assert.DoesNotContain("item.Path", args);
+        Assert.DoesNotContain("item.Name", args);
+        Assert.DoesNotContain(".Path", args);
+        Assert.DoesNotContain(".Name", args);
+    }
+
+    [Fact]
+    public void Navigation_DoesNotWriteToTheActivityLog()
+    {
+        // Tab opens are recorded in Serilog instead. If this ever comes back, the 20-entry-eviction
+        // problem comes back with it and the destructive entries added here get buried again.
+        var dir = new DirectoryInfo(Path.GetDirectoryName(typeof(ActivityLogService).Assembly.Location)!);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "SysManager", "ViewModels")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        var source = File.ReadAllText(
+            Path.Combine(dir!.FullName, "SysManager", "ViewModels", "MainWindowViewModel.cs"));
+
+        Assert.DoesNotContain("Log(\"Opened\"", source);
+    }
+}

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -80,14 +80,15 @@ public class ArchitectureTests
     [Fact]
     public void Services_DoNotHoldUserDataPathsInStaticFields()
     {
-        // Known offenders, kept ONLY so this ratchet can be added without a repo-wide refactor in the
-        // same change. Of these, AppIconService, SettingsWatchdogService, ThemeService and
-        // WindowsThemeService are referenced by tests today, so they carry the same latent risk that
-        // SpeedTestHistoryService realised; ActivityLogService and LogService are not test-exercised.
-        // Removing a name from this list is the goal — tracked in issue #1741.
+        // Known offenders, kept ONLY so this ratchet could be added without a repo-wide refactor in one
+        // change. Of these, AppIconService, SettingsWatchdogService, ThemeService and WindowsThemeService
+        // are referenced by tests today, so they carry the same latent risk SpeedTestHistoryService
+        // realised; LogService is not test-exercised.
+        // Removing a name from this list is the goal — tracked in issue #1741. ActivityLogService came
+        // off it when the destructive operations started logging: a test asserting they do would
+        // otherwise have written into the user's own activity history. Six to go.
         string[] known =
         [
-            "ActivityLogService.FilePath",
             "AppIconService.CacheDir",
             "AppIconService.SettingsPath",
             "LogService.<LogDir>k__BackingField",

--- a/SysManager/SysManager/Services/ActivityLogService.cs
+++ b/SysManager/SysManager/Services/ActivityLogService.cs
@@ -11,17 +11,38 @@ namespace SysManager.Services;
 
 public sealed class ActivityLogService
 {
-    private const int MaxEntries = 20;
-    private static readonly string FilePath = Path.Join(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "SysManager", "activity.json");
+    /// <summary>
+    /// How many entries are kept. Raised from 20 once the destructive operations started logging:
+    /// at 20 a busy session could still push a Deep Cleanup or an uninstall out of the history, and
+    /// this file is the only record of what the app changed. Each entry is a short action/detail pair,
+    /// so the JSON stays a few kilobytes.
+    /// </summary>
+    internal const int MaxEntries = 60;
 
+    private readonly string _filePath;
     private readonly Lock _lock = new();
     private List<ActivityEntry> _entries = [];
 
     public static ActivityLogService Instance { get; } = new();
 
-    private ActivityLogService() => Load();
+    private ActivityLogService() : this(null) { }
+
+    /// <summary>
+    /// Creates an instance whose store lives under <paramref name="configDir"/>. The production
+    /// singleton passes null and resolves the real profile path.
+    /// <para>The path was previously <c>static readonly</c>, which made this service impossible to
+    /// test: <see cref="Environment.SpecialFolder.LocalApplicationData"/> resolves through the Win32
+    /// known-folder API and ignores the <c>LOCALAPPDATA</c> environment variable, so a test calling
+    /// <see cref="Log"/> would have written into the user's own activity history. That is why this
+    /// seam exists — see the ratchet in ArchitectureTests and issue #1741.</para>
+    /// </summary>
+    internal ActivityLogService(string? configDir)
+    {
+        var dir = configDir ?? Path.Join(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager");
+        _filePath = Path.Join(dir, "activity.json");
+        Load();
+    }
 
     public IReadOnlyList<ActivityEntry> GetRecent(int count = 5)
     {
@@ -50,8 +71,8 @@ public sealed class ActivityLogService
     {
         try
         {
-            if (!File.Exists(FilePath)) return;
-            var json = File.ReadAllText(FilePath);
+            if (!File.Exists(_filePath)) return;
+            var json = File.ReadAllText(_filePath);
             _entries = JsonSerializer.Deserialize<List<ActivityEntry>>(json) ?? [];
         }
         catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
@@ -61,16 +82,18 @@ public sealed class ActivityLogService
         }
     }
 
-    private static void Save(List<ActivityEntry> snapshot)
+    // Instance method (was static) because the destination path is now per-instance — that is what
+    // lets a test point the store at a temp directory instead of the user's real activity history.
+    private void Save(List<ActivityEntry> snapshot)
     {
         try
         {
-            var dir = Path.GetDirectoryName(FilePath)!;
+            var dir = Path.GetDirectoryName(_filePath)!;
             Directory.CreateDirectory(dir);
             // WriteIndented = false is the default, so no options object is needed — allocating
             // one per save would only defeat System.Text.Json's per-options metadata cache.
             var json = JsonSerializer.Serialize(snapshot);
-            File.WriteAllText(FilePath, json);
+            File.WriteAllText(_filePath, json);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.58.6</Version>
-    <FileVersion>1.58.6.0</FileVersion>
-    <AssemblyVersion>1.58.6.0</AssemblyVersion>
+    <Version>1.58.7</Version>
+    <FileVersion>1.58.7.0</FileVersion>
+    <AssemblyVersion>1.58.7.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/BrowserCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BrowserCleanerViewModel.cs
@@ -122,6 +122,10 @@ public sealed partial class BrowserCleanerViewModel : ViewModelBase
             var deleted = await _service.CleanAsync(selected, _cts.Token).ConfigureAwait(true);
             StatusMessage = $"Removed {deleted} file(s). Re-scanning…";
             ToastService.Instance.Show("Browser data cleaned", $"{deleted} files removed.");
+            // Counts only. Naming the categories would record which browser/profile data the user
+            // chose to erase, and activity.json is plain text under %LocalAppData%.
+            ActivityLogService.Instance.Log("Browser Cleaner",
+                $"Removed {deleted:N0} file{(deleted == 1 ? "" : "s")} from {selected.Count} categor{(selected.Count == 1 ? "y" : "ies")}");
             Log.Information("BrowserCleaner: cleaned {Count} categories, {Deleted} files", selected.Count, deleted);
             await ScanAsync().ConfigureAwait(true);
         }

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -143,6 +143,15 @@ public sealed partial class DashboardViewModel : ViewModelBase
 
     partial void OnIsActiveChanged(bool value)
     {
+        if (value)
+        {
+            // Re-read the activity log whenever this tab is shown. The destructive tabs write their
+            // entries from their own ViewModels, and this one only reloaded on init or an explicit
+            // refresh — so coming back here after a Deep Cleanup or an uninstall showed a stale card,
+            // making the new entries look like they had not registered at all.
+            LoadActivity();
+        }
+
         if (value && _pollingCts is null)
             StartPollingLoop();
         else if (!value)

--- a/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
@@ -263,6 +263,10 @@ public sealed partial class DeepCleanupViewModel : ViewModelBase
             CleanSummary = result.Summary;
             CleanStatusLine = "Clean complete.";
             ToastService.Instance.Show("Deep cleanup complete", result.Summary);
+            // This is the least reversible operation in the app — files are deleted outright, not sent
+            // to the Recycle Bin — and it left no trace in the app's own history. Summary is counts and
+            // sizes only, never paths: activity.json is plain text under %LocalAppData%.
+            ActivityLogService.Instance.Log("Deep Cleanup", result.Summary);
             Log.Information("Deep cleanup completed");
             await ScanCoreAsync();
         }

--- a/SysManager/SysManager/ViewModels/FileShredderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/FileShredderViewModel.cs
@@ -195,6 +195,16 @@ public sealed partial class FileShredderViewModel : ViewModelBase
 
             StatusMessage = $"Complete — {completed} shredded, {failed} failed.";
             ToastService.Instance.Show("File Shredder complete", $"{completed} shredded, {failed} failed");
+
+            // COUNT ONLY — never a file name or path. activity.json is plain text under
+            // %LocalAppData%, so recording the name of a file the user chose to destroy beyond
+            // recovery would leave behind exactly the evidence the shred was meant to remove, and
+            // would outlive the file itself. The pass count is safe and is the useful part.
+            if (completed > 0)
+            {
+                ActivityLogService.Instance.Log("File Shredder",
+                    $"Securely erased {completed:N0} item{(completed == 1 ? "" : "s")} ({(int)SelectedMethod}-pass overwrite)");
+            }
         }
         catch (OperationCanceledException)
         {

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -285,13 +285,12 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             return;
         }
 
+        // Navigation is recorded here (Serilog) and NOT in the activity log. It used to write an
+        // "Opened <tab>" entry per navigation, which — against a 20-entry cap — meant a few minutes of
+        // clicking evicted every real action, so the Dashboard's "Recent activity" card listed tab
+        // visits while omitting the deletes it should have shown. The card now answers "what did this
+        // app change on my PC?" rather than "where have I clicked?".
         Log.Information("Tab navigated: {TabLabel}", newValue.Label);
-
-        // Record the feature the user opened in the Dashboard's "Recent activity"
-        // (skip Dashboard itself — Recent activity lives there, so logging every return
-        // to view it would just push real entries out of the list).
-        if (newValue.Id != "nav-dashboard")
-            ActivityLogService.Instance.Log("Opened", newValue.Label);
 
         // Auto-expand the parent group when a child is selected.
         var parentGroup = NavGroups.FirstOrDefault(g => g.Children.Contains(newValue));

--- a/SysManager/SysManager/ViewModels/PrivacyViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PrivacyViewModel.cs
@@ -164,6 +164,17 @@ public sealed partial class PrivacyViewModel : ViewModelBase
             Log.Warning("Privacy: {Applied} applied, {Failed} failed (likely elevation required)",
                 applied.Count, failed.Count);
         }
+
+        // Logged once for both branches, and only when something actually changed, so a partial apply
+        // is recorded honestly rather than claiming the full count. Counts only — naming the toggles
+        // would record which privacy settings this user cares about.
+        if (applied.Count > 0)
+        {
+            ActivityLogService.Instance.Log("Privacy",
+                failed.Count == 0
+                    ? $"Applied {applied.Count} change{(applied.Count == 1 ? "" : "s")}"
+                    : $"Applied {applied.Count} of {applied.Count + failed.Count} changes ({failed.Count} needed administrator)");
+        }
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
@@ -136,6 +136,11 @@ public sealed partial class ShortcutCleanerViewModel : ViewModelBase
         SelectedCount = BrokenShortcuts.Count(x => x.IsSelected);
         ScanStatus = $"Deleted {deleted} shortcut{(deleted == 1 ? "" : "s")}. {BrokenCount} remaining.";
         ToastService.Instance.Show("Shortcuts deleted", $"{deleted} shortcut{(deleted == 1 ? "" : "s")} removed");
+        // Records whether the shortcuts are recoverable, which is the part that matters if the user
+        // later wonders where one went. Counts only, no shortcut names.
+        ActivityLogService.Instance.Log("Shortcut Cleaner",
+            $"{(MoveToRecycleBin ? "Moved" : "Permanently deleted")} {deleted:N0} broken shortcut{(deleted == 1 ? "" : "s")}" +
+            (MoveToRecycleBin ? " to the Recycle Bin" : ""));
         Log.Information("Deleted {Count} broken shortcuts (recycle bin: {RecycleBin})", deleted, MoveToRecycleBin);
     }
 

--- a/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
@@ -290,6 +290,18 @@ public sealed partial class UninstallerViewModel : ViewModelBase
                     toRemove.Count,
                     restartRequired);
             }
+
+            // Logged once after all three branches, so a cancelled or partly-failed batch is recorded
+            // as what it actually was rather than not at all. Counts only — the app NAMES are omitted
+            // deliberately: activity.json is plain text under %LocalAppData%, and which software
+            // someone removed is more revealing than how many.
+            if (removed > 0)
+            {
+                ActivityLogService.Instance.Log("Uninstaller",
+                    $"Uninstalled {removed:N0} app{(removed == 1 ? "" : "s")}" +
+                    (failed > 0 ? $" ({failed} failed)" : string.Empty) +
+                    (cancellationRequested ? " — cancelled partway" : string.Empty));
+            }
         }
         finally
         {


### PR DESCRIPTION
Closes #1573

The Dashboard's RECENT ACTIVITY card listed **which tabs you had opened** while omitting every operation you'd actually want a record of.

Verified before touching anything: 13 ViewModels called `ActivityLogService`, and these six called it **zero** times:

| Tab | What went unrecorded |
|---|---|
| Deep Cleanup | a permanent multi-GB delete — files are **not** sent to the Recycle Bin |
| Browser Cleaner | a clean that signed the user out of sites |
| Privacy | registry writes across twelve toggles |
| Uninstaller | an app removal |
| Shortcut Cleaner | deleted shortcuts |
| File Shredder | an unrecoverable multi-pass overwrite |

Meanwhile merely **opening a tab** wrote an entry (`MainWindowViewModel.cs:294`).

## The privacy constraint — the part that must not be got wrong

`activity.json` is **plain text** under `%LocalAppData%`. Every entry records **counts and sizes only, never a file name or path.**

That matters most for File Shredder: writing down the name of a file someone chose to destroy beyond recovery would leave behind precisely the evidence the shred exists to erase — and it would **outlive the file itself**. So the entry reads:

> `Securely erased 3 items (7-pass overwrite)`

…and a test asserts that call site contains no `.Path` or `.Name`. The same rule applies to the other five: how much was cleaned, not what.

## The noise half, without which the six additions are invisible

Navigation no longer writes an entry — tab opens are already in Serilog on the line above — and `MaxEntries` goes **20 → 60**.

At 20-with-navigation, a few minutes of clicking evicted every real action. The author had already half-noticed this: there was an existing "skip Dashboard itself, or logging every return to view it would push real entries out" comment. Removing the "Opened" entries changes visible behaviour, so it's a CHANGELOG **Changed**, not a silent fix.

## The staleness the issue predicted, confirmed and fixed

`DashboardViewModel` reloaded activity only on init, on explicit refresh, and after its own quick actions (`:113`, `:763`, `:796`, `:849`) — **never on returning from another tab**. So an entry written by Deep Cleanup wouldn't appear until a manual refresh, making the new entries look like they hadn't registered.

`LoadActivity()` now also runs from the **existing** `OnIsActiveChanged` hook — no new plumbing. That hook runs on the UI thread via the shell's `SetActive` → `OnSelectedNavChanged`, so touching the bound collection there is safe (checked, not assumed).

## Mechanical enforcement needed a seam first

The issue asks for a test rather than remembered discipline. That wasn't directly possible: `ActivityLogService` held its path in a `static readonly` field, and `SpecialFolder.LocalApplicationData` **ignores `LOCALAPPDATA`** — so a test asserting the six log would have appended to the **user's real** activity history.

Added the `configDir` seam the other persistence services share (`Save` had to stop being `static`). A side benefit: `ActivityLogService` comes **off** the known-offenders list in the #1741 ratchet. Six names to go there — and because that ratchet also fails on a *stale* allowance, removing it was mandatory rather than optional.

`Instance` is a get-only singleton, so a ViewModel test still can't redirect the store. Rather than pretend otherwise, the six call-sites are pinned at **source level** — honest about what it does and doesn't prove.

## Verification

**15 new tests:** the store through the seam (round-trip to disk, newest-first, cap discards the oldest, malformed file starts empty, `GetRecent` count, cross-directory isolation, a cap-headroom guard so it can't quietly drop back to 20), a 6-case theory asserting each destructive ViewModel still calls the log, the shredder no-path assertion, and a guard that navigation never starts logging again.

**Red ritual.** Harness against unfixed `origin/main` — **10 failures**:

```
FAIL  DeepCleanupViewModel records what it did  -- no activity-log call at all
FAIL  BrowserCleanerViewModel records what it did  -- no activity-log call at all
...
FAIL  navigation no longer writes an activity entry  -- every tab open still evicts a real action
FAIL  the cap leaves room for real actions  -- MaxEntries = 20
FAIL  a configDir ctor exists  -- the path is static, so a test asserting the six log
                                 would write to the REAL activity.json
```

This branch: **ALL PASS**, and the shredder check prints the full call so the wording is visible in the log rather than taken on trust.

**User-data safety.** The real `%LocalAppData%\SysManager\activity.json` was hashed before any work (`e391888c…`), copied aside, and verified **byte-identical** afterwards — by hash and by `diff`. Same discipline as the speed-test history in v1.58.4, and for the same reason: the harness must not become the bug.

All four projects build **0 errors, 0 warnings**.

## Gate-DOCS

README's Recent Activity bullet said *"the last features you opened and actions you ran"* — wrong on **both** halves now. Corrected, and it now states the counts-not-names guarantee, since that's a promise worth being explicit about.

## Not verifiable here

The main PC never launches the app, so the card itself needs eyes on the secondary workstation: that entries appear after a real cleanup, and that returning to the Dashboard refreshes it.
