### PR TITLE
fix: render the Tune-Up results the wizard was already computing, and drop five dead nav commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.58.7] - 2026-08-10
+## [1.58.8] - 2026-08-10
+
+### Fixed
+- **Quick Tune-Up used to throw away everything it found.** You pressed the button, it cleaned temp files, emptied the Recycle Bin and checked your shortcuts, memory, uptime and disks — and then showed you nothing but a toast. The results card it was building all along (how much was freed, how many broken shortcuts, which disk needs attention, whether the PC wants a restart) now actually appears, with a plain-language line for each finding. Where something can be acted on, there's a button that takes you straight to the right tab: broken shortcuts to Shortcut Cleaner, high memory to Process Manager, more to reclaim to Deep Cleanup. If nothing needs attention it says so, rather than leaving you guessing.
+- **You can now see the Tune-Up working, and stop it.** It runs six steps and showed no progress at all while doing it. There's now a progress bar with the current step, and a Cancel button — the ability to cancel was already built, it just had no button.
+
+### Changed
+- **Removed five internal shortcuts that led nowhere.** Five "jump to this tab" commands existed in the code with nothing connected to them. They've been removed rather than left looking like features; the one that *is* used (View details on the update notice) is untouched.
 
 ### Fixed
 - **"Recent activity" on the Dashboard now shows what the app actually changed.** It listed which tabs you had opened, while leaving out the things you would genuinely want a record of: a permanent Deep Cleanup delete, a browser clean that signed you out of sites, privacy settings written to the registry, an app uninstall, files erased with the shredder, and broken shortcuts deleted. None of those left a trace. All six are now recorded, and the card refreshes when you return to the Dashboard so a new entry shows up straight away instead of looking like it never registered.

--- a/SysManager/SysManager.Tests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DashboardViewModelTests.cs
@@ -316,4 +316,64 @@ public class DashboardViewModelTests
             DialogService.Instance = prevDialog;
         }
     }
+
+    // ---------- Tune-Up result card navigation ----------
+    // Each finding on the card links to the tab that can act on it ("3 broken shortcuts" is only useful
+    // if it can take you to the cleaner). Navigation resolves through the live MainWindow DataContext,
+    // which does not exist in a unit test — so these pin what can be checked without a shell: the
+    // command exists, and it degrades quietly rather than crashing when there is nothing to navigate to.
+    // The actual tab switch is covered by the shell's own navigation tests.
+
+    [Fact]
+    public void OpenTabCommand_Exists()
+    {
+        var vm = NewVm();
+        Assert.NotNull(vm.OpenTabCommand);
+    }
+
+    [Theory]
+    [InlineData("nav-shortcut-cleaner")]
+    [InlineData("nav-processes")]
+    [InlineData("nav-deep-cleanup")]
+    public void OpenTabCommand_WithNoShell_DoesNotThrow(string navId)
+    {
+        // Application.Current.MainWindow is null under the test host, so the lookup must degrade
+        // quietly. A throw here would take down the Dashboard whenever a finding button was clicked.
+        var vm = NewVm();
+
+        var ex = Record.Exception(() => vm.OpenTabCommand.Execute(navId));
+
+        Assert.Null(ex);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("nav-does-not-exist")]
+    public void OpenTabCommand_WithNothingToOpen_IsIgnored(string? navId)
+    {
+        // Parameter contract: null/empty are rejected before the lookup, and an unknown id finds no
+        // NavItem and does nothing rather than clearing the current selection.
+        var vm = NewVm();
+
+        var ex = Record.Exception(() => vm.OpenTabCommand.Execute(navId));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void TuneUpResultCard_StartsHidden_AndDismissClearsIt()
+    {
+        // HasTuneUpResult drives the card's Visibility and TuneUpResult its content; both were computed
+        // and never rendered, and DismissTuneUpResultCommand was unbound too.
+        var vm = NewVm();
+        Assert.False(vm.HasTuneUpResult);
+        Assert.Null(vm.TuneUpResult);
+
+        vm.HasTuneUpResult = true;
+        vm.DismissTuneUpResultCommand.Execute(null);
+
+        Assert.False(vm.HasTuneUpResult);
+        Assert.Null(vm.TuneUpResult);
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.58.7</Version>
-    <FileVersion>1.58.7.0</FileVersion>
-    <AssemblyVersion>1.58.7.0</AssemblyVersion>
+    <Version>1.58.8</Version>
+    <FileVersion>1.58.8.0</FileVersion>
+    <AssemblyVersion>1.58.8.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -721,13 +721,32 @@ public sealed partial class DashboardViewModel : ViewModelBase
     private void NavigateToQuickActionTab()
     {
         if (_quickActionNavigateTarget is null) return;
-        // Navigate via MainWindowViewModel
+        SelectTab(_quickActionNavigateTarget);
+        DismissQuickAction();
+    }
+
+    /// <summary>
+    /// Opens the tab with the given nav id. Used by the Tune-Up result card so each finding links to the
+    /// tab that can act on it — "3 broken shortcuts" is only useful if it can take you to the cleaner.
+    /// <para>Shares one implementation with <see cref="NavigateToQuickActionTabCommand"/> rather than
+    /// duplicating the shell lookup, and deliberately does NOT dismiss the card: the user may want to
+    /// come back to the remaining findings.</para>
+    /// </summary>
+    [RelayCommand]
+    private void OpenTab(string? navId)
+    {
+        if (!string.IsNullOrEmpty(navId)) SelectTab(navId);
+    }
+
+    private static void SelectTab(string navId)
+    {
+        // The shell owns navigation; the Dashboard reaches it through the live MainWindow DataContext,
+        // which is the pattern this view model already used for the quick-action "go to tab" link.
         if (System.Windows.Application.Current?.MainWindow?.DataContext is MainWindowViewModel main)
         {
-            var target = main.NavItems.FirstOrDefault(n => n.Id == _quickActionNavigateTarget);
+            var target = main.NavItems.FirstOrDefault(n => n.Id == navId);
             if (target is not null) main.SelectedNav = target;
         }
-        DismissQuickAction();
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -340,23 +340,14 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     /// </summary>
     public void NavigateTo(string navId) => SelectNavById(navId);
 
+    // Only the About shortcut is bound (MainWindow.xaml's update banner, "View details"). Five
+    // sibling commands — OpenDeepCleanupTab, OpenDiskAnalyzerTab, OpenDuplicatesTab, OpenCleanupTab
+    // and OpenSystemHealthTab — existed here with no binding and no test, so they were removed rather
+    // than left looking like available navigation. Anything that needs to jump to a tab should use
+    // NavigateTo(navId) above, or DashboardViewModel's OpenTabCommand for a bindable version; one
+    // parameterised seam beats a per-tab command that has to be added by hand and can silently rot.
     [RelayCommand]
     private void OpenAboutTab() => SelectNavById("nav-about");
-
-    [RelayCommand]
-    private void OpenDeepCleanupTab() => SelectNavById("nav-deep-cleanup");
-
-    [RelayCommand]
-    private void OpenDiskAnalyzerTab() => SelectNavById("nav-disk-analyzer");
-
-    [RelayCommand]
-    private void OpenDuplicatesTab() => SelectNavById("nav-duplicates");
-
-    [RelayCommand]
-    private void OpenCleanupTab() => SelectNavById("nav-cleanup");
-
-    [RelayCommand]
-    private void OpenSystemHealthTab() => SelectNavById("nav-system-health");
 
     public void Dispose()
     {

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -15,6 +15,11 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <!-- Tune-Up progress + result. The ViewModel has computed TuneUpResult, HasTuneUpResult,
+                     TuneUpProgress, TuneUpStep and even a DismissTuneUpResult command all along; none
+                     of it was ever rendered, so the wizard ran, found problems and discarded them. -->
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -81,8 +86,136 @@
                 </Grid>
             </Border>
 
-            <!-- ═══ ROW 2: Health Score Hero ═══ -->
-            <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="20"
+            <!-- ═══ ROW 2: Tune-Up in progress ═══ -->
+            <!-- TuneUpProgress / TuneUpStep were computed on every step and never shown, so the wizard
+                 ran with no indication of what it was doing or how far along it was. Cancel is offered
+                 here because CancelTuneUpCommand already existed and was also unbound. -->
+            <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="16"
+                    Visibility="{Binding IsTuneUpRunning, Converter={StaticResource FlexVis}}">
+                <StackPanel>
+                    <DockPanel>
+                        <Button DockPanel.Dock="Right" Content="Cancel" Command="{Binding CancelTuneUpCommand}"
+                                AutomationProperties.Name="Cancel Quick Tune-Up"
+                                Style="{StaticResource GhostButton}" Padding="10,2" Margin="12,0,0,0"/>
+                        <TextBlock Text="Quick Tune-Up" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center"/>
+                    </DockPanel>
+                    <ProgressBar AutomationProperties.Name="Tune-Up progress" Height="6" Minimum="0" Maximum="100"
+                                 Value="{Binding TuneUpProgress}" Margin="0,10,0,0"/>
+                    <TextBlock Text="{Binding TuneUpStep}" Style="{StaticResource Caption}" Margin="0,6,0,0"
+                               Visibility="{Binding TuneUpStep, Converter={StaticResource FlexVis}}"/>
+                </StackPanel>
+            </Border>
+
+            <!-- ═══ ROW 3: Tune-Up results ═══ -->
+            <!-- The whole point of #1489: the wizard cleaned, scanned and computed a full TuneUpResult —
+                 including a WarningCount, an OverallVerdict and a per-disk DiskHealthSummary whose own
+                 doc comment says it is "for the Tune-Up result card" — and then threw all of it away.
+                 Each finding links to the tab that can act on it: "3 broken shortcuts" is only useful
+                 if it can take you to the cleaner. Navigation goes through OpenTabCommand, which shares
+                 the shell lookup this view model already used for the quick-action link. -->
+            <Border Grid.Row="3" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="20"
+                    Visibility="{Binding HasTuneUpResult, Converter={StaticResource FlexVis}}">
+                <StackPanel>
+                    <DockPanel Margin="0,0,0,12">
+                        <Button DockPanel.Dock="Right" Content="Dismiss" Command="{Binding DismissTuneUpResultCommand}"
+                                AutomationProperties.Name="Dismiss Tune-Up results"
+                                Style="{StaticResource GhostButton}" Padding="10,2" Margin="12,0,0,0"/>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="&#xE945;" FontFamily="Segoe Fluent Icons" FontSize="15"
+                                       VerticalAlignment="Center" Margin="0,0,8,0"
+                                       Foreground="{Binding TuneUpResult.OverallColorHex, Converter={StaticResource HexBrush}}"/>
+                            <TextBlock Text="Tune-Up complete" FontWeight="SemiBold" FontSize="15" VerticalAlignment="Center"/>
+                            <Border Background="{DynamicResource Surface2}" CornerRadius="10" Padding="8,2" Margin="10,0,0,0"
+                                    VerticalAlignment="Center">
+                                <TextBlock Text="{Binding TuneUpResult.OverallVerdict}" FontSize="11" FontWeight="SemiBold"
+                                           Foreground="{Binding TuneUpResult.OverallColorHex, Converter={StaticResource HexBrush}}"/>
+                            </Border>
+                        </StackPanel>
+                    </DockPanel>
+
+                    <!-- What it already did -->
+                    <TextBlock Style="{StaticResource Subtle}" TextWrapping="Wrap">
+                        <Run Text="Freed"/>
+                        <Run Text="{Binding TuneUpResult.FreedDisplay, Mode=OneWay}" FontWeight="SemiBold"/>
+                        <Run Text="by removing"/>
+                        <Run Text="{Binding TuneUpResult.TempFilesDeleted, Mode=OneWay, StringFormat={}{0:N0}}" FontWeight="SemiBold"/>
+                        <Run Text="temporary files."/>
+                    </TextBlock>
+                    <TextBlock Text="Recycle Bin emptied." Style="{StaticResource Subtle}" Margin="0,4,0,0"
+                               Visibility="{Binding TuneUpResult.RecycleBinEmptied, Converter={StaticResource FlexVis}}"/>
+
+                    <!-- What it found, each with the tab that can act on it -->
+                    <StackPanel Margin="0,12,0,0"
+                                Visibility="{Binding TuneUpResult.WarningCount, Converter={StaticResource FlexVis}}">
+                        <TextBlock Text="WHAT TO LOOK AT" Style="{StaticResource SectionLabel}" Margin="0,0,0,8"/>
+
+                        <!-- Broken shortcuts -->
+                        <DockPanel Margin="0,0,0,6"
+                                   Visibility="{Binding TuneUpResult.BrokenShortcutsFound, Converter={StaticResource FlexVis}}">
+                            <Button DockPanel.Dock="Right" Content="Clean up" Command="{Binding OpenTabCommand}" CommandParameter="nav-shortcut-cleaner"
+                                    AutomationProperties.Name="Open Shortcut Cleaner"
+                                    Style="{StaticResource SecondaryButton}" Padding="10,4" Margin="12,0,0,0"/>
+                            <TextBlock VerticalAlignment="Center" TextWrapping="Wrap" Foreground="{DynamicResource TextSecondary}">
+                                <Run Text="{Binding TuneUpResult.BrokenShortcutsFound, Mode=OneWay}" FontWeight="SemiBold"/>
+                                <Run Text="broken shortcut(s) point at files that no longer exist."/>
+                            </TextBlock>
+                        </DockPanel>
+
+                        <!-- Uptime -->
+                        <DockPanel Margin="0,0,0,6"
+                                   Visibility="{Binding TuneUpResult.UptimeWarning, Converter={StaticResource FlexVis}}">
+                            <TextBlock VerticalAlignment="Center" TextWrapping="Wrap" Foreground="{DynamicResource TextSecondary}"
+                                       Text="This PC has not restarted in over two weeks — a restart often clears slowdowns on its own."/>
+                        </DockPanel>
+
+                        <!-- RAM -->
+                        <DockPanel Margin="0,0,0,6"
+                                   Visibility="{Binding TuneUpResult.RamWarning, Converter={StaticResource FlexVis}}">
+                            <Button DockPanel.Dock="Right" Content="See what's running" Command="{Binding OpenTabCommand}" CommandParameter="nav-processes"
+                                    AutomationProperties.Name="Open Process Manager"
+                                    Style="{StaticResource SecondaryButton}" Padding="10,4" Margin="12,0,0,0"/>
+                            <TextBlock VerticalAlignment="Center" TextWrapping="Wrap" Foreground="{DynamicResource TextSecondary}">
+                                <Run Text="Memory is"/>
+                                <Run Text="{Binding TuneUpResult.RamUsedPercent, Mode=OneWay, StringFormat={}{0:F0}%}" FontWeight="SemiBold"/>
+                                <Run Text="full — something running may be using more than its share."/>
+                            </TextBlock>
+                        </DockPanel>
+
+                        <!-- Per-disk verdicts -->
+                        <ItemsControl ItemsSource="{Binding TuneUpResult.DiskResults}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <DockPanel Margin="0,0,0,6">
+                                        <TextBlock VerticalAlignment="Center" TextWrapping="Wrap" Foreground="{DynamicResource TextSecondary}">
+                                            <Run Text="{Binding Name, Mode=OneWay}" FontWeight="SemiBold"/>
+                                            <Run Text=" — "/>
+                                            <Run Text="{Binding Verdict, Mode=OneWay}"
+                                                 Foreground="{Binding ColorHex, Converter={StaticResource HexBrush}}"/>
+                                        </TextBlock>
+                                    </DockPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <!-- Deeper cleaning, always offered once a run has completed -->
+                        <DockPanel Margin="0,6,0,0">
+                            <Button DockPanel.Dock="Right" Content="Deep Cleanup" Command="{Binding OpenTabCommand}" CommandParameter="nav-deep-cleanup"
+                                    AutomationProperties.Name="Open Deep Cleanup"
+                                    Style="{StaticResource SecondaryButton}" Padding="10,4" Margin="12,0,0,0"/>
+                            <TextBlock VerticalAlignment="Center" TextWrapping="Wrap" Foreground="{DynamicResource TextSecondary}"
+                                       Text="Want to reclaim more? Deep Cleanup looks in places this quick pass leaves alone."/>
+                        </DockPanel>
+                    </StackPanel>
+
+                    <!-- Nothing to report -->
+                    <TextBlock Style="{StaticResource Subtle}" Margin="0,12,0,0" TextWrapping="Wrap"
+                               Text="Nothing else needs attention — no broken shortcuts, memory and disks look fine, and this PC has restarted recently."
+                               Visibility="{Binding TuneUpResult.WarningCount, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                </StackPanel>
+            </Border>
+
+            <!-- ═══ ROW 4: Health Score Hero ═══ -->
+            <Border Grid.Row="4" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="20"
                     Visibility="{Binding HasHealthScore, Converter={StaticResource FlexVis}}">
                 <Grid>
                     <Grid.ColumnDefinitions>
@@ -122,7 +255,7 @@
             </Border>
 
             <!-- Health score loading -->
-            <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="14"
+            <Border Grid.Row="4" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="14"
                     Visibility="{Binding IsHealthScoreLoading, Converter={StaticResource BoolToVis}}">
                 <StackPanel Orientation="Horizontal">
                     <ProgressBar IsIndeterminate="True" Width="80" Height="4" Margin="0,0,10,0" VerticalAlignment="Center"/>
@@ -130,8 +263,8 @@
                 </StackPanel>
             </Border>
 
-            <!-- ═══ ROW 3: Vitals (CPU, RAM, GPU) — REAL-TIME ═══ -->
-            <Grid Grid.Row="3" Margin="0,0,0,12">
+            <!-- ═══ ROW 5: Vitals (CPU, RAM, GPU) — REAL-TIME ═══ -->
+            <Grid Grid.Row="5" Margin="0,0,0,12">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="12"/>
@@ -207,8 +340,8 @@
                 </Border>
             </Grid>
 
-            <!-- ═══ ROW 4: Temperatures ═══ -->
-            <Border Grid.Row="4" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="16">
+            <!-- ═══ ROW 6: Temperatures ═══ -->
+            <Border Grid.Row="6" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="16">
                 <StackPanel>
                     <StackPanel Margin="0,0,0,12">
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
@@ -272,8 +405,8 @@
                 </StackPanel>
             </Border>
 
-            <!-- ═══ ROW 5: Storage ═══ -->
-            <Border Grid.Row="5" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="16">
+            <!-- ═══ ROW 7: Storage ═══ -->
+            <Border Grid.Row="7" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="16">
                 <StackPanel>
                     <TextBlock Text="STORAGE" FontSize="11" FontWeight="SemiBold"
                                Foreground="{DynamicResource TextMuted}" Margin="0,0,0,12"/>
@@ -303,8 +436,8 @@
                 </StackPanel>
             </Border>
 
-            <!-- ═══ ROW 6: Bottom row (Quick Actions | Alerts | Activity) ═══ -->
-            <Grid Grid.Row="6" Margin="0,0,0,12">
+            <!-- ═══ ROW 8: Bottom row (Quick Actions | Alerts | Activity) ═══ -->
+            <Grid Grid.Row="8" Margin="0,0,0,12">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="12"/>
@@ -481,8 +614,8 @@
                 </Border>
             </Grid>
 
-            <!-- ═══ ROW 7: Status bar ═══ -->
-            <TextBlock Grid.Row="7" Text="{Binding StatusMessage}" Style="{StaticResource Caption}" Margin="0,4,0,0"/>
+            <!-- ═══ ROW 9: Status bar ═══ -->
+            <TextBlock Grid.Row="9" Text="{Binding StatusMessage}" Style="{StaticResource Caption}" Margin="0,4,0,0"/>
         </Grid>
     </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
Closes #1489
Closes #1494

## #1489 — Quick Tune-Up threw away everything it found

You pressed the button, it ran six steps, cleaned temp files, emptied the Recycle Bin, checked shortcuts, memory, uptime and disks — and then showed you a toast and nothing else.

The card wasn't missing by oversight. It was **designed and never built**, and the code says so:

- `TuneUpResult` carries `WarningCount`, `OverallVerdict`, `OverallColorHex`
- `DiskHealthSummary`'s own doc comment reads *"Per-disk summary for the Tune-Up result card"*
- the ViewModel has `TuneUpResult`, `HasTuneUpResult`, `TuneUpProgress`, `TuneUpStep`, `CancelTuneUpCommand` **and** `DismissTuneUpResultCommand`

`grep TuneUpResult Views/DashboardView.xaml` → **0**. The only Tune-Up markup in the entire view was the button that starts it.

**Added two rows:**

- **Progress** — bar, current step, and Cancel. All three were computed or implemented and none were bound, so a six-step run showed no sign of life and couldn't be stopped.
- **Results** — freed space, Recycle Bin, then a plain-language line per finding. Each actionable one links to the tab that can act on it: broken shortcuts → Shortcut Cleaner, high memory → Process Manager, more to reclaim → Deep Cleanup. Because "3 broken shortcuts" is only useful if it can take you there.

A `WarningCount` of 0 renders an explicit *"nothing else needs attention"* rather than an empty card — for the target persona, silence reads as failure.

## #1494 — five commands, not six

The issue says six cross-tab navigation commands are dead. **Five are.**

`OpenAboutTab` is genuinely bound — `MainWindow.xaml:443`, the update banner's "View details" — and has an integration test at `MainWindowViewModelTests.cs:198-203`. Deleting it as the issue implies would have broken a working feature. I counted references per command before touching anything:

| Command | References |
|---|---|
| `OpenAboutTab` | **4** — binding + declaration + 2 test lines |
| `OpenDeepCleanupTab` | 1 (its own declaration) |
| `OpenDiskAnalyzerTab` | 1 |
| `OpenDuplicatesTab` | 1 |
| `OpenCleanupTab` | 1 |
| `OpenSystemHealthTab` | 1 |

The five with only a declaration are removed. `OpenAboutTab` stays, and the harness asserts it survives — a deletion that broke the update banner would be a worse bug than the dead code.

### The new card does not resurrect them

`DashboardViewModel` already reached the shell for its quick-action "go to tab" link. That lookup is now extracted and shared with a parameterised `OpenTabCommand` beside it — **one seam taking a nav id**, instead of a per-tab command that has to be hand-added for every new destination and can silently rot exactly as these five did.

That's *why* the five could go rather than being wired up: the thing replacing them is strictly better. The card deliberately does **not** dismiss itself on navigation, since you may want to come back to the remaining findings.

## Tests

8 new:

- `OpenTabCommand` exists
- a 3-case theory that it doesn't throw with **no shell** — `Application.Current.MainWindow` is null under the test host, and a throw there would take down the Dashboard on any finding click
- a 3-case theory that `null` / `""` / an unknown id are ignored rather than clearing the current selection
- the card starts hidden and Dismiss clears both flag and content

## Red ritual

Harness against a worktree of unfixed `origin/main` — **10 failures**, and the shape of them *is* the finding:

```
PASS  DashboardViewModel exposes TuneUpResult
PASS  DismissTuneUpResult command exists
FAIL  the view binds HasTuneUpResult (the card's visibility)  -- without it the card never shows
FAIL  the view renders the findings verdict
FAIL  Tune-Up progress is shown while it runs  -- the wizard ran with no visible progress
FAIL  the five unbound per-tab commands are gone  -- OpenDeepCleanupTab, OpenDiskAnalyzerTab, ...
PASS  OpenAboutTab is kept (it is genuinely bound)
```

Every ViewModel property asserted **PASS** by reflection while every view binding **FAILED** — the work was all there, unrendered.

This branch: **14/14 PASS**. Main, unit-test and integration projects all build **0 errors, 0 warnings**.

## Gate-DOCS — no change needed, for an interesting reason

`README:786` **already** claimed:

> *"Displays a summary card with freed space, warnings, and links to relevant tabs."*

It documented a card that did not exist. This PR makes the existing claim true rather than requiring a correction — worth noting, because it means the README has been promising this to users for some time.

## Not verifiable here

The main PC never launches the app. Needs eyes on the secondary workstation: the card's layout at both `WarningCount == 0` and with several findings, and that adding two rows to the Dashboard's root grid didn't disturb the rows below (the renumbering was done mechanically, highest-first, and the build is clean — but layout is visual).
