### PR TITLE
feat: show what each process actually is, and stop refusing to end Notepad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.59.0] - 2026-08-10
+
+### Fixed
+- **The app refused to end Notepad, and told you it would crash your PC.** Process Manager would not let you end 49 ordinary programs — Notepad, Calculator, Paint, Task Manager, Registry Editor, Command Prompt, PowerShell, Windows Terminal, Snipping Tool, Media Player, Explorer and more — and said each one "would cause a system crash (BSOD)". That was simply untrue. The check was reading the wrong thing: the built-in database records whether a program *ships with Windows*, and that was being used to mean "ending it will crash the machine". The processes Windows genuinely cannot survive losing (`winlogon`, `csrss`, `smss`, `services`, `lsass`, `wininit`, …) are still refused exactly as before. Everything else is now your decision.
+- **Windows components warn you honestly instead of blocking you.** Ending Explorer to fix a frozen taskbar, or Print Spooler when printing is stuck, are normal things to do. They now ask first and say what to actually expect — "will not crash Windows, but a feature may stop working until you sign out or restart" — rather than pretending it is impossible.
+
+### Added
+- **A Safety column in Process Manager, answering the question the tab exists for.** The app has always carried a 108-entry database that knows whether a process ships with Windows, is a well-known application, or is not recognised at all — and it never showed you. Every row now carries a label: **Windows**, **Known app** or **Not recognised**, each explaining on hover what that means for ending it. "Not recognised" is deliberately plain grey rather than a warning colour: most of what runs on any PC is not in a 108-entry list, and that alone says nothing bad about it. The column sorts, so everything unfamiliar can be grouped together and reviewed in one go.
+
 ## [1.58.8] - 2026-08-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -403,10 +403,14 @@ a confirmation before it runs:
 - Real-time filter by name, description, category, or PID
 - Sort by memory, CPU usage, name, or PID via clickable column headers
 - **Built-in description database** — 108 common Windows processes and popular
-  applications with plain-language descriptions, categories (System, Browser,
-  Development, Communication, Media, Gaming, etc.), and safety indicators
-  (System, Trusted, Unknown)
-- Kill process with confirmation dialog
+  applications with plain-language descriptions and categories (System, Browser,
+  Development, Communication, Media, Gaming, etc.)
+- **Safety column** — every process is labelled **Windows**, **Known app** or
+  **Not recognised**, with a hover explanation of what that means for ending it.
+  Sortable, so everything unrecognised can be grouped together at a glance
+- Kill process with confirmation dialog. Processes Windows genuinely cannot survive
+  losing (`winlogon`, `csrss`, `lsass`, …) are refused outright; other Windows
+  components can be ended after a warning that says what may stop working
 - Open file location in Explorer
 
 ### Resource History

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.58.x   | :white_check_mark: |
-| < 1.58   | :x:                |
+| 1.59.x   | :white_check_mark: |
+| < 1.59   | :x:                |
 
 ## Reporting a vulnerability
 

--- a/SysManager/SysManager.Tests/ConverterTests.cs
+++ b/SysManager/SysManager.Tests/ConverterTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Globalization;
+using System.IO;
 using System.Windows;
 using System.Windows.Media;
 using SysManager.Helpers;
@@ -314,5 +315,157 @@ public class ConverterTests
         var conv = new ProcessStatusToBrushConverter();
         Assert.Throws<NotSupportedException>(() =>
             conv.ConvertBack(Brushes.Gray, typeof(string), null!, CultureInfo.InvariantCulture));
+    }
+
+    // ---------- ProcessSafety* (Process Manager provenance chip) ----------
+    //
+    // These exist as SEPARATE converters from SafetyLevel* because ProcessEntry.SafetyLevel is a
+    // STRING (ProcessSafety: System/Trusted/Unknown) while SafetyLevel* switch on the Models
+    // SafetyLevel ENUM (Safe/Caution/Critical). Binding the string to the enum converters misses
+    // every arm and falls through to `_ => Critical`, i.e. every process rendered red. The first
+    // test below is what makes that mistake impossible to reintroduce silently.
+
+    [Theory]
+    [InlineData("System")]
+    [InlineData("Trusted")]
+    [InlineData("Unknown")]
+    public void SafetyLevelEnumConverters_CannotRenderProcessStrings(string provenance)
+    {
+        // Guard, not an endorsement: proves the enum converters treat all three provenance strings
+        // identically (the fall-through), so they are unusable here and the dedicated ones are required.
+        var text = new SafetyLevelToTextConverter();
+        Assert.Equal("Critical", text.Convert(provenance, typeof(string), null!, CultureInfo.InvariantCulture));
+    }
+
+    [Theory]
+    [InlineData("System", "Windows")]
+    [InlineData("system", "Windows")]          // database casing must not matter
+    [InlineData("Trusted", "Known app")]
+    [InlineData("Unknown", "Not recognised")]
+    [InlineData("", "Not recognised")]
+    [InlineData(null, "Not recognised")]
+    public void ProcSafetyText_UsesPlainLanguageLabels(string? provenance, string expected)
+    {
+        // The raw enum names are developer-facing. "Windows" / "Known app" / "Not recognised" answer
+        // the question the target user is actually asking.
+        var conv = new ProcessSafetyToTextConverter();
+        Assert.Equal(expected, conv.Convert(provenance!, typeof(string), null!, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void ProcSafetyBrush_ThreeProvenanceValues_AreVisuallyDistinct()
+    {
+        // If two of them resolved to the same brush the column would convey nothing.
+        var conv = new ProcessSafetyToBrushConverter();
+        var system = conv.Convert("System", typeof(Brush), null!, CultureInfo.InvariantCulture);
+        var trusted = conv.Convert("Trusted", typeof(Brush), null!, CultureInfo.InvariantCulture);
+        var unknown = conv.Convert("Unknown", typeof(Brush), null!, CultureInfo.InvariantCulture);
+
+        Assert.NotEqual(system, trusted);
+        Assert.NotEqual(system, unknown);
+        Assert.NotEqual(trusted, unknown);
+    }
+
+    [Fact]
+    public void ProcSafetyBrush_Unknown_IsMutedNotAWarningColour()
+    {
+        // The database holds 108 entries while a typical machine runs 200+ processes, so most rows are
+        // Unknown. Tinting them amber/red would make a normal machine look alarming and train the user
+        // to ignore the column. It uses the app's existing TextMuted grey — "no information", which is
+        // what Unknown means — and is asserted to be neither the warning nor the danger colour.
+        var (key, fallback) = ProcessSafetyPalette.TextBrushKey("Unknown");
+
+        Assert.Null(key);   // deliberately theme-independent
+        var muted = Assert.IsType<SolidColorBrush>(fallback);
+        Assert.Equal(Color.FromRgb(0x7B, 0x83, 0x96), muted.Color);   // TextMuted
+
+        // Desaturated: no channel dominates the way it does in an amber/red alert.
+        var max = Math.Max(muted.Color.R, Math.Max(muted.Color.G, muted.Color.B));
+        var min = Math.Min(muted.Color.R, Math.Min(muted.Color.G, muted.Color.B));
+        Assert.True(max - min < 0x30, $"spread {max - min:X} is too saturated for a neutral chip");
+    }
+
+    [Theory]
+    [InlineData("System")]
+    [InlineData("Trusted")]
+    public void ProcSafetyBrush_KnownProvenance_ResolvesThroughTheThemePalette(string provenance)
+    {
+        // Known values must go through a ThemeService.StatusPalette key so the chip stays legible on
+        // light presets, with a frozen dark brush as the design-time/unit-test fallback.
+        var (key, fallback) = ProcessSafetyPalette.TextBrushKey(provenance);
+
+        Assert.NotNull(key);
+        Assert.True(fallback.IsFrozen);
+    }
+
+    [Theory]
+    [InlineData("System", "will not crash")]
+    [InlineData("Trusted", "Safe to end")]
+    [InlineData("Unknown", "does not make it harmful")]
+    public void ProcSafetyTip_ExplainsWhetherEndingItIsSafe(string provenance, string expected)
+    {
+        // The chip is three words wide; the tooltip is where the consequence is actually stated. In
+        // particular "Windows" must not read as "do not touch" — that was the old, false, refusal.
+        var conv = new ProcessSafetyToTooltipConverter();
+        var tip = (string)conv.Convert(provenance, typeof(string), null!, CultureInfo.InvariantCulture);
+        Assert.Contains(expected, tip);
+    }
+
+    [Fact]
+    public void ProcSafety_AllConverters_ConvertBackThrows()
+    {
+        Assert.Throws<NotSupportedException>(() => new ProcessSafetyToBrushConverter()
+            .ConvertBack(Brushes.Gray, typeof(string), null!, CultureInfo.InvariantCulture));
+        Assert.Throws<NotSupportedException>(() => new ProcessSafetyToBackgroundConverter()
+            .ConvertBack(Brushes.Gray, typeof(string), null!, CultureInfo.InvariantCulture));
+        Assert.Throws<NotSupportedException>(() => new ProcessSafetyToTextConverter()
+            .ConvertBack("Windows", typeof(string), null!, CultureInfo.InvariantCulture));
+        Assert.Throws<NotSupportedException>(() => new ProcessSafetyToTooltipConverter()
+            .ConvertBack("tip", typeof(string), null!, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void ProcessManagerView_RendersTheSafetyColumn()
+    {
+        // The defect was that nothing referenced the value: the database was loaded, assigned to
+        // ProcessEntry.SafetyLevel and never displayed. Asserting the ViewModel property alone would
+        // pass on the unfixed code, so this checks the shipped markup binds it — and that the column
+        // uses the process converters rather than the enum ones.
+        var xaml = File.ReadAllText(ViewPath("ProcessManagerView.xaml"));
+
+        Assert.Contains("Header=\"Safety\"", xaml);
+        Assert.Contains("ProcSafetyText", xaml);
+        Assert.Contains("ProcSafetyBrush", xaml);
+        Assert.Contains("ProcSafetyBg", xaml);
+        Assert.Contains("ProcSafetyTip", xaml);
+        Assert.Contains("SortMemberPath=\"SafetyLevel\"", xaml);
+    }
+
+    [Fact]
+    public void App_RegistersTheProcessSafetyConverters()
+    {
+        // A binding to an unregistered StaticResource key is a runtime XAML failure, and the view test
+        // above only proves the key is USED.
+        var xaml = File.ReadAllText(ViewPath("App.xaml", inViews: false));
+
+        Assert.Contains("x:Key=\"ProcSafetyBrush\"", xaml);
+        Assert.Contains("x:Key=\"ProcSafetyBg\"", xaml);
+        Assert.Contains("x:Key=\"ProcSafetyText\"", xaml);
+        Assert.Contains("x:Key=\"ProcSafetyTip\"", xaml);
+    }
+
+    // Walks up from the test binaries to the app project — the .xaml is not copied to the output.
+    private static string ViewPath(string fileName, bool inViews = true)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "SysManager", "Views")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);   // else the assertions below would silently test nothing
+        var path = inViews
+            ? Path.Combine(dir!.FullName, "SysManager", "Views", fileName)
+            : Path.Combine(dir!.FullName, "SysManager", fileName);
+        Assert.True(File.Exists(path), $"{fileName} not found at {path}");
+        return path;
     }
 }

--- a/SysManager/SysManager.Tests/ProcessManagerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ProcessManagerViewModelTests.cs
@@ -2,8 +2,10 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using NSubstitute;
 using SysManager.Helpers;
 using SysManager.Models;
+using SysManager.Services;
 using SysManager.ViewModels;
 
 namespace SysManager.Tests;
@@ -12,6 +14,9 @@ namespace SysManager.Tests;
 /// Tests for <see cref="ProcessManagerViewModel"/>. Verifies initial state,
 /// commands, and filter logic. Sorting is handled by DataGrid column headers.
 /// </summary>
+// Serialized: the kill-guard tests swap the static DialogService.Instance, which is
+// process-wide shared state.
+[Collection("DialogService")]
 public class ProcessManagerViewModelTests
 {
     [Fact]
@@ -161,5 +166,134 @@ public class ProcessManagerViewModelTests
 
         Assert.Same(b, target[0]);
         Assert.Same(a, target[1]);
+    }
+
+    // ── Kill guard (regression: provenance was treated as criticality) ──
+    //
+    // IsKernelCritical used to return true for ANY entry whose SafetyLevel was "System". That value
+    // is PROVENANCE from the description database ("known Windows component"), and 59 of its 108
+    // entries carry it — including notepad, calc, mspaint, Taskmgr, regedit and explorer. So the app
+    // refused to end Notepad and told the user it "would cause a system crash (BSOD)", which is
+    // false. These tests pin both halves: the genuinely unkillable set still refuses, and a
+    // Windows-shipped-but-killable process reaches the confirm instead.
+    //
+    // A refusal returns BEFORE DialogService.Confirm, so "was Confirm reached?" is the observable
+    // difference between refused and allowed — no real process is ever touched because the confirm
+    // is declined.
+
+    private static ProcessEntry Named(string name, string safety) =>
+        new() { Pid = 4242, Name = name, SafetyLevel = safety };
+
+    private static bool WasRefused(ProcessEntry entry, out string status)
+    {
+        var vm = new ProcessManagerViewModel(new ProcessManagerService());
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false); // decline: never kills
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.KillProcessCommand.Execute(entry);
+            status = vm.StatusMessage;
+            return dialog.ReceivedCalls().Count() == 0;
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Theory]
+    [InlineData("winlogon.exe")]
+    [InlineData("csrss.exe")]
+    [InlineData("smss.exe")]
+    [InlineData("services.exe")]
+    [InlineData("lsass.exe")]
+    [InlineData("wininit.exe")]
+    public void KillProcess_BootCritical_IsStillRefused(string name)
+    {
+        // The true kernel set must keep refusing — this is the half of the old guard that was right.
+        var refused = WasRefused(Named(name, nameof(ProcessSafety.System)), out var status);
+
+        Assert.True(refused);
+        Assert.Contains("cannot be ended", status);
+    }
+
+    [Theory]
+    [InlineData("notepad.exe")]
+    [InlineData("calc.exe")]
+    [InlineData("mspaint.exe")]
+    [InlineData("Taskmgr.exe")]
+    [InlineData("regedit.exe")]
+    [InlineData("explorer.exe")]
+    public void KillProcess_WindowsComponentButNotBootCritical_IsNoLongerRefused(string name)
+    {
+        // Each of these is tagged "System" in the database, so each was refused with a false BSOD
+        // claim. Ending Notepad cannot crash Windows; the user must be allowed to decide.
+        var refused = WasRefused(Named(name, nameof(ProcessSafety.System)), out var status);
+
+        Assert.False(refused);
+        Assert.DoesNotContain("cannot be ended", status);
+        Assert.DoesNotContain("BSOD", status);
+    }
+
+    [Fact]
+    public void KillProcess_WindowsComponent_ConfirmExplainsTheRealConsequence()
+    {
+        // The warning has to be honest and specific: not "this will crash your PC", but "a feature
+        // may stop working until you restart" — the difference between a refusal and informed consent.
+        var vm = new ProcessManagerViewModel(new ProcessManagerService());
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.KillProcessCommand.Execute(Named("explorer.exe", nameof(ProcessSafety.System)));
+
+            dialog.Received(1).Confirm(
+                Arg.Is<string>(m => m.Contains("part of Windows") && m.Contains("will not crash")),
+                Arg.Any<string>());
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Theory]
+    [InlineData(nameof(ProcessSafety.Trusted))]
+    [InlineData(nameof(ProcessSafety.Unknown))]
+    public void KillProcess_OrdinaryProcess_GetsTheStandardConfirm(string safety)
+    {
+        // Non-Windows processes keep the original wording — the new branch must not leak into them.
+        var vm = new ProcessManagerViewModel(new ProcessManagerService());
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.KillProcessCommand.Execute(Named("SomeApp.exe", safety));
+
+            dialog.Received(1).Confirm(
+                Arg.Is<string>(m => m.Contains("unsaved data loss") && !m.Contains("part of Windows")),
+                Arg.Any<string>());
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public void KillProcess_BootCriticalWithUnknownProvenance_IsStillRefused()
+    {
+        // The refusal must not depend on the database: a boot-critical name that is NOT in it
+        // (logonui, lsaiso and userinit are all absent) has to be caught by name alone.
+        var refused = WasRefused(Named("logonui.exe", nameof(ProcessSafety.Unknown)), out var status);
+
+        Assert.True(refused);
+        Assert.Contains("cannot be ended", status);
     }
 }

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -24,6 +24,13 @@
             <h:SafetyLevelToBrushConverter x:Key="SafetyBrush"/>
             <h:SafetyLevelToBackgroundConverter x:Key="SafetyBg"/>
             <h:SafetyLevelToTextConverter x:Key="SafetyText"/>
+            <!-- Process provenance (System/Trusted/Unknown) is a STRING on ProcessEntry, not the
+                 Models.SafetyLevel enum the three above switch on — binding it to SafetyBrush/Bg/Text
+                 would miss every arm and fall through to red for all ~200 rows. Separate converters. -->
+            <h:ProcessSafetyToBrushConverter x:Key="ProcSafetyBrush"/>
+            <h:ProcessSafetyToBackgroundConverter x:Key="ProcSafetyBg"/>
+            <h:ProcessSafetyToTextConverter x:Key="ProcSafetyText"/>
+            <h:ProcessSafetyToTooltipConverter x:Key="ProcSafetyTip"/>
             <h:IntGreaterThanZeroConverter x:Key="GreaterThanZero"/>
             <h:EqualityConverter x:Key="IsEqual"/>
 

--- a/SysManager/SysManager/Helpers/ValueConverters.cs
+++ b/SysManager/SysManager/Helpers/ValueConverters.cs
@@ -250,3 +250,145 @@ public sealed class SafetyLevelToTextConverter : IValueConverter
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         => throw new NotSupportedException();
 }
+
+// ── Process provenance (Process Manager) ─────────────────────────────────────────────────────
+// Deliberately SEPARATE from the SafetyLevel* converters above. Those switch on the
+// Models.SafetyLevel enum (Safe/Caution/Critical) used by Services and Windows Features;
+// ProcessEntry.SafetyLevel is a STRING carrying ProcessSafety (System/Trusted/Unknown), so
+// binding it to those converters would miss every arm and fall through to `_ => Critical`,
+// painting all ~200 rows red. Different domain, different scale, own converters.
+
+/// <summary>
+/// Maps <see cref="SysManager.Services.ProcessSafety"/> (as a string) to the chip's text/dot brush.
+/// </summary>
+public sealed class ProcessSafetyToBrushConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => ProcessSafetyPalette.ResolveText(value as string);
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>
+/// Maps <see cref="SysManager.Services.ProcessSafety"/> (as a string) to the chip's background tint.
+/// </summary>
+public sealed class ProcessSafetyToBackgroundConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => ProcessSafetyPalette.ResolveBackground(value as string);
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>
+/// Maps <see cref="SysManager.Services.ProcessSafety"/> (as a string) to the label the user reads.
+/// The raw enum names are developer-facing; "Windows" / "Known app" / "Not recognised" say what
+/// the value actually means to someone deciding whether to end a process.
+/// </summary>
+public sealed class ProcessSafetyToTextConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => ProcessSafetyPalette.Label(value as string);
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>
+/// Explains a provenance value on hover. The chip is only three words wide; the tooltip is where the
+/// user learns whether ending the process is actually safe.
+/// </summary>
+public sealed class ProcessSafetyToTooltipConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => ProcessSafetyPalette.Tooltip(value as string);
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>
+/// The colour and wording decisions for process provenance, in one place so the three converters
+/// cannot drift apart, and so the mapping is unit-testable without a WPF Application.
+/// </summary>
+public static class ProcessSafetyPalette
+{
+    // TextMuted / Surface3 are the app's existing "no emphasis" pair, so an unrecognised process
+    // looks like ordinary de-emphasised text rather than a bespoke grey invented for this column.
+    private static readonly SolidColorBrush UnknownText = Frozen(Color.FromRgb(0x7B, 0x83, 0x96));
+    private static readonly SolidColorBrush UnknownBg = Frozen(Color.FromArgb(0x20, 0x7B, 0x83, 0x96));
+    private static readonly SolidColorBrush SystemText = Frozen(Color.FromRgb(0x7D, 0xD3, 0xFC));
+    private static readonly SolidColorBrush SystemBg = Frozen(Color.FromArgb(0x1A, 0x38, 0xBD, 0xF8));
+    private static readonly SolidColorBrush TrustedText = Frozen(Color.FromRgb(0x4A, 0xDE, 0x80));
+    private static readonly SolidColorBrush TrustedBg = Frozen(Color.FromArgb(0x1A, 0x22, 0xC5, 0x5E));
+
+    private static SolidColorBrush Frozen(Color c)
+    {
+        var b = new SolidColorBrush(c);
+        b.Freeze();
+        return b;
+    }
+
+    /// <summary>
+    /// Theme resource key + hardcoded fallback for the chip's text/dot colour. A null key means the
+    /// value is intentionally theme-independent.
+    /// </summary>
+    /// <remarks>
+    /// Unknown is deliberately neutral grey, NOT a warning colour. The database holds 108 entries
+    /// while a typical machine runs 200+ processes, so most rows are Unknown; tinting them amber
+    /// would make the whole grid look alarming and teach the user to ignore the column. Grey reads
+    /// as "no information", which is what it means.
+    /// </remarks>
+    public static (string? Key, Brush Fallback) TextBrushKey(string? safety) => safety switch
+    {
+        var s when Is(s, nameof(Services.ProcessSafety.System)) => ("InfoText", SystemText),
+        var s when Is(s, nameof(Services.ProcessSafety.Trusted)) => ("SuccessText", TrustedText),
+        _ => (null, UnknownText)
+    };
+
+    /// <summary>Theme resource key + hardcoded fallback for the chip's background tint.</summary>
+    public static (string? Key, Brush Fallback) BackgroundBrushKey(string? safety) => safety switch
+    {
+        var s when Is(s, nameof(Services.ProcessSafety.System)) => ("InfoBgSubtle", SystemBg),
+        var s when Is(s, nameof(Services.ProcessSafety.Trusted)) => ("SuccessBgSubtle", TrustedBg),
+        _ => (null, UnknownBg)
+    };
+
+    /// <summary>The user-facing label for a provenance value.</summary>
+    public static string Label(string? safety) => safety switch
+    {
+        var s when Is(s, nameof(Services.ProcessSafety.System)) => "Windows",
+        var s when Is(s, nameof(Services.ProcessSafety.Trusted)) => "Known app",
+        _ => "Not recognised"
+    };
+
+    /// <summary>The chip tooltip — says what the label means and whether ending it is safe.</summary>
+    public static string Tooltip(string? safety) => safety switch
+    {
+        var s when Is(s, nameof(Services.ProcessSafety.System)) =>
+            "Ships with Windows. Ending it will not crash your PC, but a feature may stop working " +
+            "until you sign out or restart.",
+        var s when Is(s, nameof(Services.ProcessSafety.Trusted)) =>
+            "A well-known application. Safe to end, though you may lose unsaved work.",
+        _ =>
+            "Not in the built-in database — that on its own does not make it harmful, only unrecognised. " +
+            "Use Open to see where it runs from before ending it."
+    };
+
+    public static Brush ResolveText(string? safety) => Live(TextBrushKey(safety));
+
+    public static Brush ResolveBackground(string? safety) => Live(BackgroundBrushKey(safety));
+
+    // Prefer the live theme brush (recomputed per preset by ThemeService.StatusPalette) so the chip
+    // stays legible on light themes; fall back to the frozen dark values when there is no
+    // Application, i.e. design-time and unit tests.
+    private static Brush Live((string? Key, Brush Fallback) spec)
+        => spec.Key is not null && Application.Current?.TryFindResource(spec.Key) is Brush b
+            ? b
+            : spec.Fallback;
+
+    private static bool Is(string? value, string name)
+        => string.Equals(value, name, StringComparison.OrdinalIgnoreCase);
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.58.8</Version>
-    <FileVersion>1.58.8.0</FileVersion>
-    <AssemblyVersion>1.58.8.0</AssemblyVersion>
+    <Version>1.59.0</Version>
+    <FileVersion>1.59.0.0</FileVersion>
+    <AssemblyVersion>1.59.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
@@ -213,9 +213,17 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
             return;
         }
 
-        if (!DialogService.Instance.Confirm(
-            $"Are you sure you want to kill \"{entry.Name}\" (PID {entry.Pid})?\n\nThis may cause unsaved data loss.",
-            "Kill process")) return;
+        // A Windows-shipped process that is NOT boot-critical is killable, but it deserves a
+        // stronger warning than a third-party app: ending Explorer blanks the taskbar until it
+        // restarts, and ending Print Spooler stops printing. Say what actually happens rather
+        // than refusing outright (the old behaviour) or treating it like any other app.
+        var prompt = IsWindowsComponent(entry)
+            ? $"\"{entry.Name}\" is part of Windows (PID {entry.Pid}).\n\n" +
+              "Ending it will not crash Windows, but a feature may stop working or look broken " +
+              "until you sign out or restart. Continue?"
+            : $"Are you sure you want to kill \"{entry.Name}\" (PID {entry.Pid})?\n\nThis may cause unsaved data loss.";
+
+        if (!DialogService.Instance.Confirm(prompt, "Kill process")) return;
 
         var success = ProcessManagerService.KillProcess(entry.Pid);
         if (success)
@@ -233,14 +241,28 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// True only for processes whose death actually takes Windows down, so the refusal message
+    /// ("would cause a system crash") is factually true.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately keyed on <see cref="BootCriticalProcesses"/> alone. It used to also refuse any
+    /// entry whose <see cref="ProcessEntry.SafetyLevel"/> was "System", but that value is
+    /// PROVENANCE from the description database ("known Windows component" — see
+    /// <see cref="ProcessSafety"/>), not criticality. 59 of the 108 database entries carry it,
+    /// including notepad, calc, mspaint, Taskmgr, regedit and explorer — so the app refused to end
+    /// Notepad and told the user it would blue-screen the machine. Nothing is lost by dropping it:
+    /// this set is matched by name, and covers every genuinely unkillable process.
+    /// </remarks>
     private static bool IsKernelCritical(ProcessEntry entry)
-    {
-        if (string.Equals(entry.SafetyLevel, "System", StringComparison.OrdinalIgnoreCase))
-            return true;
+        => BootCriticalProcesses.Contains(Path.GetFileNameWithoutExtension(entry.Name));
 
-        var name = Path.GetFileNameWithoutExtension(entry.Name);
-        return BootCriticalProcesses.Contains(name);
-    }
+    /// <summary>
+    /// True when the description database marks the process as a Windows component. Drives the
+    /// stronger kill warning — informational only, never a refusal.
+    /// </summary>
+    private static bool IsWindowsComponent(ProcessEntry entry)
+        => string.Equals(entry.SafetyLevel, nameof(ProcessSafety.System), StringComparison.OrdinalIgnoreCase);
 
     [RelayCommand]
     private static void OpenFileLocation(ProcessEntry? entry)

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -200,6 +200,30 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
+                    <!-- The app carries a 108-entry process database (Data/ProcessDescriptions.json) whose
+                         provenance flag was loaded, assigned to ProcessEntry.SafetyLevel and never rendered —
+                         so "is this Windows, or something I installed?", the question this tab exists to
+                         answer, was invisible. Chip structure matches the Services tab's Safety column. -->
+                    <DataGridTemplateColumn Header="Safety" Width="110" MinWidth="100" SortMemberPath="SafetyLevel">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Border CornerRadius="8" Padding="6,3"
+                                        Background="{Binding SafetyLevel, Converter={StaticResource ProcSafetyBg}}"
+                                        BorderBrush="{Binding SafetyLevel, Converter={StaticResource ProcSafetyBg}}"
+                                        BorderThickness="1" HorizontalAlignment="Left"
+                                        ToolTip="{Binding SafetyLevel, Converter={StaticResource ProcSafetyTip}}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <Ellipse Width="6" Height="6" VerticalAlignment="Center" Margin="0,0,4,0"
+                                                 Fill="{Binding SafetyLevel, Converter={StaticResource ProcSafetyBrush}}"/>
+                                        <TextBlock Text="{Binding SafetyLevel, Converter={StaticResource ProcSafetyText}}"
+                                                   FontSize="11" FontWeight="SemiBold" VerticalAlignment="Center"
+                                                   Foreground="{Binding SafetyLevel, Converter={StaticResource ProcSafetyBrush}}"/>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+
                     <DataGridTemplateColumn Header="Actions" Width="120" MinWidth="120" CanUserSort="False" CanUserResize="False">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>


### PR DESCRIPTION
Closes #1574

Both halves of the issue are real. The root cause and the proposed fix in it are not — verifying that changed the shape of this PR, so it's worth stating up front.

## The false BSOD refusal

`ProcessManagerViewModel.cs:238` refused to end any process whose `SafetyLevel` was `"System"`, with:

> ⛔ "notepad.exe" is a critical system process and cannot be ended — killing it would cause a system crash (BSOD).

That value is **provenance, not criticality**. `ProcessDescriptionService.cs:13` says so in its own doc comment — *"indicates whether it's a known Windows component"* — and the database has only two values: `System` (59 entries) and `Trusted` (49). So "ships with Windows" was being read as "ending it will crash the machine".

**49 of the 59 are not boot-critical.** Every one was refused, with a factually false warning:

`notepad` · `calc` · `mspaint` · `Taskmgr` · `regedit` · `cmd` · `powershell` · `WindowsTerminal` · `SnippingTool` · `wmplayer` · `explorer` · `GameBar` · `eventvwr` · `perfmon` · `resmon` · `mmc` · `spoolsv` · `SearchIndexer` · `wsl` · `msiexec` · `dllhost` · … (49 total)

The fix is a deletion. `BootCriticalProcesses` — 13 names, already sitting directly above the bug — becomes the only refusal. It's matched by name, so **nothing is lost**: `logonui`, `lsaiso` and `userinit` aren't even in the database, and they keep refusing.

Windows components that *are* killable now get informed consent instead of a wall:

> "explorer.exe" is part of Windows (PID 1234). Ending it will not crash Windows, but a feature may stop working or look broken until you sign out or restart. Continue?

Ending Explorer to fix a frozen taskbar is a normal thing to do. The old code made it impossible.

### PROPAGATE — the same mistake elsewhere?

`AppBlockerService.BootCriticalExecutables` is a **longer** list (it includes `explorer.exe` and `spoolsv.exe`) and that is correct, not an inconsistency: it blocks permanently via IFEO at boot, where a blocked Explorer means an unbootable machine with no way to launch this app to undo it. Killable-at-runtime and safe-to-block-forever are different questions. Two lists, both right. No other site read provenance as criticality.

## The missing column

`grep -c "Safety" Views/ProcessManagerView.xaml` → **0**. The 108-entry database was loaded, assigned to `ProcessEntry.SafetyLevel`, and never rendered — so the question this tab exists to answer ("is this Windows, or something I installed?") was invisible.

Each row now carries a chip: **Windows** / **Known app** / **Not recognised**, sortable, with a hover explanation of what it means for ending that process. Structure copied from the Services tab's Safety column.

### Why it needs its own converters

The issue suggests reusing `SafetyBg`/`SafetyBrush`/`SafetyText` from `ServicesView`. **That would paint every row red.** Those switch on `value is SafetyLevel level` — the `Models.SafetyLevel` enum (`Safe`/`Caution`/`Critical`) — while `ProcessEntry.SafetyLevel` is a **`string`** carrying `ProcessSafety` (`System`/`Trusted`/`Unknown`). Every arm is missed and each converter falls through to `_ => Critical`.

There's a test asserting exactly that fall-through, so the shortcut can't be taken later by mistake.

### "Not recognised" is grey, deliberately

The database holds 108 entries; a typical machine runs 200+ processes. **Most rows will be Unknown.** Tinting them amber would make a perfectly healthy PC look alarming and train the user to ignore the column — the opposite of the point. It uses the app's existing `TextMuted`, and the tooltip says it plainly: *"Not in the built-in database — that on its own does not make it harmful, only unrecognised."*

## Tests

23 new (14 view-model, 9 converter/palette):

- all six boot-critical names **still refused** — the half of the old guard that was right
- `notepad` / `calc` / `mspaint` / `Taskmgr` / `regedit` / `explorer` **no longer refused**
- a boot-critical name absent from the database is still caught **by name**
- the Windows-component confirm states the real consequence; an ordinary app keeps the original wording
- the enum converters fall through to `Critical` for all three provenance strings (the guard above)
- the three values are visually **distinct**; Unknown is muted and desaturated; known values resolve through the theme palette
- the shipped `ProcessManagerView.xaml` binds the column, and `App.xaml` registers all four keys

The refusal tests work by observing whether `DialogService.Confirm` was reached — a refusal returns before it. The confirm is always declined, so no real process is ever touched.

## Red ritual

Harness against a worktree of unfixed `origin/main`: **18 failures, 11 passes**. The passes are the controls, and two of them carry the whole argument:

```
PASS  [control] winlogon/csrss/smss/services/lsass/wininit are STILL refused
PASS  [control] the enum converters CANNOT render provenance strings (all fall through to Critical)
FAIL  notepad.exe can be ended (it cannot crash Windows)   -- refused with a factually false BSOD warning
FAIL  the process list has a Safety column                 -- database loaded, never displayed
```

That second control **passing on main** is the proof the issue's proposed reuse would have been a regression.

This branch: **29/29**. Main, unit-test and integration projects build **0 errors, 0 warnings**.

## Gate-DOCS

`README:407` claimed the app showed *"safety indicators (System, Trusted, Unknown)"* — documenting a column that did not exist, the same pattern as the Tune-Up card in #1751. Rewritten to describe the real behaviour, including which processes stay refused. `SECURITY.md` supported version follows the minor bump (this adds a feature, so `feat:` → 1.59.0).

## Not verifiable here

The main PC never launches the app. Needs eyes on the secondary workstation: the chip's contrast in both light and dark presets, and that a 110px column doesn't crowd the Actions buttons at a narrow window width.
