### PR TITLE
feat: suggest which duplicate to keep, instead of showing five equal rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.60.0] - 2026-08-10
+
+### Added
+- **Duplicate Finder now tells you which copy to keep.** It would find five identical photos, tell you they were wasting 4 GB, and then show them as five identical rows — leaving you to work out which one is the original, which is exactly the judgement the tab exists to help with. One file per group is now badged **Keep**: the oldest, because a copy is normally made after the file it came from. The rule is written on screen instead of applied quietly, every row shows its date so you can check the reasoning yourself, and **"Keep this one"** moves the badge when you know better — a copy that kept its original timestamp, or a file rewritten by cloud sync, will fool the guess. Groups with identical dates fall back to the copy nearest the top of the folder tree, so the badge never jumps around between scans.
+- **Still nothing is deleted.** The tab remains read-only on purpose: getting this wrong costs you your own photos and documents with no way back. It suggests a decision and points you at the file; the removing is yours to do, in Explorer.
+
 ## [1.59.0] - 2026-08-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -389,7 +389,14 @@ a confirmation before it runs:
 - Duplicate groups sorted by wasted space (descending)
 - Preset folders or custom folder selection
 - Configurable minimum file size filter
-- **Read-only** — "Show in Explorer" and "Copy path" only, no delete
+- **Suggests which copy to keep** — one file per group is badged **Keep**, chosen as the
+  oldest (usually the original). The rule is stated on screen rather than applied
+  silently, each row shows its date so you can check it, and "Keep this one" moves the
+  badge when you know better — a copy that preserved its timestamp, or a cloud-sync
+  rewrite, will fool the heuristic
+- **Read-only** — "Show in Explorer", "Copy path" and "Keep this one" only. Nothing is
+  deleted, moved or renamed; deciding which of five identical photos to remove is done by
+  you, in Explorer
 
 ### Disk Analyzer
 - Space breakdown by top-level folders with drill-down navigation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.59.x   | :white_check_mark: |
-| < 1.59   | :x:                |
+| 1.60.x   | :white_check_mark: |
+| < 1.60   | :x:                |
 
 ## Reporting a vulnerability
 

--- a/SysManager/SysManager.Tests/DuplicateFileGroupTests.cs
+++ b/SysManager/SysManager.Tests/DuplicateFileGroupTests.cs
@@ -98,7 +98,7 @@ public class DuplicateFileGroupTests
         entry.Path = @"C:\test\file.txt";
         entry.Name = "file.txt";
         entry.SizeBytes = 4096;
-        entry.LastModified = DateTime.Now;
+        entry.LastModified = new DateTime(2026, 3, 1, 12, 0, 0);
         entry.IsSelected = true;
 
         Assert.Contains("Path", changed);
@@ -106,5 +106,176 @@ public class DuplicateFileGroupTests
         Assert.Contains("SizeBytes", changed);
         Assert.Contains("LastModified", changed);
         Assert.Contains("IsSelected", changed);
+    }
+
+    // ── Keep-rule ────────────────────────────────────────────────────────────────────────────
+    //
+    // Before this, a group of five identical photos was five equal rows with no hint which one was
+    // the original, and IsSelected was declared on the model but read by nothing. The rule is
+    // "oldest wins" — a copy is normally made after its source — and it is a HEURISTIC: a
+    // timestamp-preserving copy or a cloud-sync rewrite breaks it, which is why it is shown with its
+    // reason and can be overridden rather than applied silently.
+    //
+    // Fixed dates throughout: no DateTime.Now, so the outcome cannot depend on when the suite runs.
+
+    private static DuplicateFileEntry File(string path, int year, int month = 1, int day = 1) =>
+        new()
+        {
+            Path = path,
+            Name = System.IO.Path.GetFileName(path),
+            LastModified = new DateTime(year, month, day, 0, 0, 0)
+        };
+
+    private static DuplicateFileGroup GroupOf(params DuplicateFileEntry[] files)
+    {
+        var g = new DuplicateFileGroup { FileSize = 1024 };
+        foreach (var f in files) g.Files.Add(f);
+        g.Count = g.Files.Count;
+        return g;
+    }
+
+    [Fact]
+    public void ApplySuggestedKeeper_MarksTheOldestFile()
+    {
+        var newest = File(@"C:\photos\copy.jpg", 2026);
+        var oldest = File(@"C:\photos\original.jpg", 2019);
+        var middle = File(@"C:\photos\backup.jpg", 2023);
+        var group = GroupOf(newest, oldest, middle);
+
+        group.ApplySuggestedKeeper();
+
+        Assert.True(oldest.IsSelected);
+        Assert.False(newest.IsSelected);
+        Assert.False(middle.IsSelected);
+    }
+
+    [Fact]
+    public void ApplySuggestedKeeper_MarksExactlyOne()
+    {
+        // "Which one do I keep" is a single choice. Two badges would be worse than none.
+        var group = GroupOf(
+            File(@"C:\a\x.jpg", 2020),
+            File(@"C:\b\x.jpg", 2021),
+            File(@"C:\c\x.jpg", 2022),
+            File(@"C:\d\x.jpg", 2023));
+
+        group.ApplySuggestedKeeper();
+
+        Assert.Single(group.Files, f => f.IsSelected);
+    }
+
+    [Fact]
+    public void ApplySuggestedKeeper_SameTimestamp_PrefersTheShallowerPath()
+    {
+        // A timestamp-preserving copy leaves the dates identical, which is exactly the case the
+        // heuristic cannot resolve. Falling back to the shortest path picks the file nearer the root
+        // over one buried in a "New folder (2)" — and, crucially, is deterministic.
+        var deep = File(@"C:\pics\2019\imports\copy\holiday.jpg", 2019);
+        var shallow = File(@"C:\pics\holiday.jpg", 2019);
+        var group = GroupOf(deep, shallow);
+
+        group.ApplySuggestedKeeper();
+
+        Assert.True(shallow.IsSelected);
+        Assert.False(deep.IsSelected);
+    }
+
+    [Fact]
+    public void ApplySuggestedKeeper_IsDeterministic_ForIdenticalTimestampsAndPathLengths()
+    {
+        // Last tiebreak. Without it the keeper would depend on enumeration order, so the same folder
+        // could suggest a different file on a re-scan and the user could not trust the badge.
+        var b = File(@"C:\pics\b.jpg", 2020);
+        var a = File(@"C:\pics\a.jpg", 2020);
+        var first = GroupOf(b, a);
+        var second = GroupOf(a, b);
+
+        first.ApplySuggestedKeeper();
+        second.ApplySuggestedKeeper();
+
+        Assert.Equal(@"C:\pics\a.jpg", first.Files.Single(f => f.IsSelected).Path);
+        Assert.Equal(@"C:\pics\a.jpg", second.Files.Single(f => f.IsSelected).Path);
+    }
+
+    [Fact]
+    public void ApplySuggestedKeeper_EmptyGroup_DoesNotThrow()
+    {
+        var group = new DuplicateFileGroup();
+
+        var ex = Record.Exception(group.ApplySuggestedKeeper);
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void ApplySuggestedKeeper_ClearsAStaleKeeper()
+    {
+        // Re-applying must not leave two files marked — e.g. if a group is ever re-evaluated.
+        var oldest = File(@"C:\a\x.jpg", 2018);
+        var newer = File(@"C:\b\x.jpg", 2024);
+        newer.IsSelected = true;                 // stale mark from a previous state
+        var group = GroupOf(oldest, newer);
+
+        group.ApplySuggestedKeeper();
+
+        Assert.True(oldest.IsSelected);
+        Assert.False(newer.IsSelected);
+    }
+
+    [Fact]
+    public void SetKeeper_MovesTheMarkAndClearsTheRest()
+    {
+        // The user overriding the suggestion is the whole point: "oldest" is a guess, and only they
+        // know that the 2026 file is the edited one they actually want.
+        var oldest = File(@"C:\a\x.jpg", 2019);
+        var chosen = File(@"C:\b\x.jpg", 2026);
+        var third = File(@"C:\c\x.jpg", 2022);
+        var group = GroupOf(oldest, chosen, third);
+        group.ApplySuggestedKeeper();
+        Assert.True(oldest.IsSelected);          // precondition: the suggestion took
+
+        group.SetKeeper(chosen);
+
+        Assert.True(chosen.IsSelected);
+        Assert.False(oldest.IsSelected);
+        Assert.False(third.IsSelected);
+        Assert.Single(group.Files, f => f.IsSelected);
+    }
+
+    [Fact]
+    public void SetKeeper_ForeignEntry_ChangesNothing()
+    {
+        // Guards against a stale DataTemplate binding silently clearing every badge in a group.
+        var kept = File(@"C:\a\x.jpg", 2019);
+        var other = File(@"C:\b\x.jpg", 2020);
+        var group = GroupOf(kept, other);
+        group.ApplySuggestedKeeper();
+
+        group.SetKeeper(File(@"C:\elsewhere\x.jpg", 2015));
+
+        Assert.True(kept.IsSelected);            // untouched
+        Assert.Single(group.Files, f => f.IsSelected);
+    }
+
+    [Theory]
+    [InlineData(true, "Keep")]
+    [InlineData(false, "")]
+    public void KeepLabel_ReflectsTheMark(bool isSelected, string expected)
+    {
+        // The badge collapses on non-keepers rather than rendering an empty pill.
+        var entry = new DuplicateFileEntry { IsSelected = isSelected };
+        Assert.Equal(expected, entry.KeepLabel);
+    }
+
+    [Fact]
+    public void KeepLabel_NotifiesWhenTheMarkMoves()
+    {
+        var entry = new DuplicateFileEntry();
+        var changed = new List<string>();
+        entry.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+
+        entry.IsSelected = true;
+
+        Assert.Contains("KeepLabel", changed);   // else the badge would not repaint on override
     }
 }

--- a/SysManager/SysManager.Tests/DuplicateFileViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DuplicateFileViewModelTests.cs
@@ -180,4 +180,99 @@ public class DuplicateFileViewModelTests
         group.Files.Add(new DuplicateFileEntry { Name = "test.bin" });
         Assert.Single(group.Files);
     }
+
+    // ── Keep-this override (regression: IsSelected was declared and read by nothing) ──
+
+    private static DuplicateFileGroup SeededGroup(DuplicateFileViewModel vm)
+    {
+        var group = new DuplicateFileGroup { FileSize = 1024 };
+        group.Files.Add(new DuplicateFileEntry
+        {
+            Path = @"C:\a\photo.jpg", Name = "photo.jpg", LastModified = new DateTime(2019, 1, 1)
+        });
+        group.Files.Add(new DuplicateFileEntry
+        {
+            Path = @"C:\b\photo.jpg", Name = "photo.jpg", LastModified = new DateTime(2026, 1, 1)
+        });
+        group.Count = group.Files.Count;
+        group.ApplySuggestedKeeper();
+        vm.Groups.Add(group);
+        return group;
+    }
+
+    [Fact]
+    public void KeepThisCommand_Exists()
+    {
+        var vm = NewVm();
+        Assert.NotNull(vm.KeepThisCommand);
+    }
+
+    [Fact]
+    public void KeepThis_MovesTheKeeperWithinTheOwningGroup()
+    {
+        // The per-file DataTemplate binds the ENTRY, so the VM has to find the group itself. If that
+        // lookup failed the button would appear to do nothing.
+        var vm = NewVm();
+        var group = SeededGroup(vm);
+        var newer = group.Files.Single(f => f.Path == @"C:\b\photo.jpg");
+
+        vm.KeepThisCommand.Execute(newer);
+
+        Assert.True(newer.IsSelected);
+        Assert.Single(group.Files, f => f.IsSelected);
+    }
+
+    [Fact]
+    public void KeepThis_WithNull_IsIgnored()
+    {
+        var vm = NewVm();
+        var group = SeededGroup(vm);
+
+        var ex = Record.Exception(() => vm.KeepThisCommand.Execute(null));
+
+        Assert.Null(ex);
+        Assert.Single(group.Files, f => f.IsSelected);   // the existing suggestion survives
+    }
+
+    [Fact]
+    public void KeepThis_EntryFromNoLoadedGroup_IsIgnored()
+    {
+        var vm = NewVm();
+        var group = SeededGroup(vm);
+        var stale = new DuplicateFileEntry { Path = @"C:\gone\photo.jpg", Name = "photo.jpg" };
+
+        var ex = Record.Exception(() => vm.KeepThisCommand.Execute(stale));
+
+        Assert.Null(ex);
+        Assert.False(stale.IsSelected);
+        Assert.Single(group.Files, f => f.IsSelected);
+    }
+
+    [Fact]
+    public void DuplicateFileView_ShowsTheKeeperAndTheRule()
+    {
+        // The defect was a property nothing read. Asserting the model alone would pass on the unfixed
+        // code, so this checks the shipped markup renders the badge, offers the override, and states
+        // the rule — plus that it still promises nothing is deleted.
+        var xaml = File.ReadAllText(ViewPath("DuplicateFileView.xaml"));
+
+        Assert.Contains("KeepLabel", xaml);                  // the badge
+        Assert.Contains("KeepThisCommand", xaml);            // the override
+        Assert.Contains("oldest", xaml);                     // the rule, stated
+        Assert.Contains("Nothing is deleted", xaml);         // still non-destructive
+        Assert.Contains("LastModified", xaml);               // so "oldest" is checkable by eye
+    }
+
+    // Walks up from the test binaries to the app project — .xaml is not copied to the output.
+    private static string ViewPath(string fileName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "SysManager", "Views")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);   // else the assertions above would silently test nothing
+        var path = Path.Combine(dir!.FullName, "SysManager", "Views", fileName);
+        Assert.True(File.Exists(path), $"{fileName} not found at {path}");
+        return path;
+    }
 }

--- a/SysManager/SysManager/Models/DuplicateFileGroup.cs
+++ b/SysManager/SysManager/Models/DuplicateFileGroup.cs
@@ -26,6 +26,45 @@ public sealed partial class DuplicateFileGroup : ObservableObject
 
     /// <summary>Wasted space = (count - 1) * fileSize.</summary>
     public long WastedBytes => Math.Max(Count - 1, 0) * FileSize;
+
+    /// <summary>
+    /// Marks exactly one file in the group as the suggested keeper, so five identical photos are not
+    /// presented as five equal rows with no hint which one is the original.
+    /// </summary>
+    /// <remarks>
+    /// The rule is "oldest last-modified time wins", because a copy is normally made after the file it
+    /// was copied from. It is a HEURISTIC, not a fact, and it is wrong in real cases: a copy tool that
+    /// preserves timestamps, or a cloud-sync client that rewrites them, both break it. That is exactly
+    /// why the suggestion is shown with its reason attached and can be moved by the user
+    /// (<see cref="SetKeeper"/>) instead of being applied silently.
+    ///
+    /// Ties are broken by the shortest path, then alphabetically — deterministic either way, so the
+    /// same scan never suggests a different keeper twice.
+    /// </remarks>
+    public void ApplySuggestedKeeper()
+    {
+        var keeper = Files
+            .OrderBy(f => f.LastModified)
+            .ThenBy(f => f.Path.Length)
+            .ThenBy(f => f.Path, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+
+        foreach (var f in Files)
+            f.IsSelected = ReferenceEquals(f, keeper);
+    }
+
+    /// <summary>
+    /// Moves the keeper to <paramref name="entry"/>. Exactly one file per group is kept, so this
+    /// clears the others rather than toggling — "which one do I keep" is a single choice, not a
+    /// set of independent checkboxes.
+    /// </summary>
+    public void SetKeeper(DuplicateFileEntry entry)
+    {
+        if (!Files.Contains(entry)) return;
+
+        foreach (var f in Files)
+            f.IsSelected = ReferenceEquals(f, entry);
+    }
 }
 
 /// <summary>A single file within a duplicate group.</summary>
@@ -35,5 +74,15 @@ public sealed partial class DuplicateFileEntry : ObservableObject
     [ObservableProperty] private string _name = "";
     [ObservableProperty] private long _sizeBytes;
     [ObservableProperty] private DateTime _lastModified;
-    [ObservableProperty] private bool _isSelected;
+
+    /// <summary>
+    /// True for the one file in the group suggested as the keeper. Drives the "Keep" badge and the
+    /// de-emphasis of the other rows.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(KeepLabel))]
+    private bool _isSelected;
+
+    /// <summary>Badge text — empty for non-keepers so the badge collapses.</summary>
+    public string KeepLabel => IsSelected ? "Keep" : "";
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.59.0</Version>
-    <FileVersion>1.59.0.0</FileVersion>
-    <AssemblyVersion>1.59.0.0</AssemblyVersion>
+    <Version>1.60.0</Version>
+    <FileVersion>1.60.0.0</FileVersion>
+    <AssemblyVersion>1.60.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
@@ -14,10 +14,15 @@ using SysManager.Services;
 namespace SysManager.ViewModels;
 
 /// <summary>
-/// Duplicate File Finder tab — scans a folder for files with identical
-/// content and shows them grouped by hash. Read-only: only "Show in
-/// Explorer" and "Copy path" are offered.
+/// Duplicate File Finder tab — scans a folder for files with identical content and shows them
+/// grouped by hash.
 /// </summary>
+/// <remarks>
+/// STILL NON-DESTRUCTIVE, deliberately: the actions are "Show in Explorer", "Copy path" and
+/// "Keep this one". Nothing is deleted, moved or renamed. A wrong deletion here costs the user their
+/// own photos and documents with no undo, which is the worst outcome this app can produce, so the tab
+/// suggests a decision and leaves the acting to the user in Explorer.
+/// </remarks>
 public sealed partial class DuplicateFileViewModel : ViewModelBase
 {
     private readonly DuplicateFileService _service;
@@ -128,6 +133,11 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
 
             var results = await _service.ScanAsync(SelectedFolder, minBytes, progress, ct);
 
+            // Suggest a keeper per group BEFORE binding, so no group is ever shown as N equal rows with
+            // no hint which file is the original.
+            foreach (var group in results)
+                group.ApplySuggestedKeeper();
+
             Groups.ReplaceWith(results);
 
             GroupCount = Groups.Count;
@@ -201,6 +211,21 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
         if (entry is null) return;
         try { System.Windows.Clipboard.SetText(entry.Path); }
         catch (System.Runtime.InteropServices.ExternalException ex) { Log.Debug(ex, "Failed to copy path to clipboard"); }
+    }
+
+    /// <summary>
+    /// Moves the suggested keeper within a group. "Oldest wins" is only a heuristic — a copy that
+    /// preserved its timestamp, or a cloud-sync rewrite, breaks it — so the user has to be able to
+    /// disagree with it. The group is looked up from the entry rather than passed in, because the
+    /// per-file DataTemplate binds to the entry.
+    /// </summary>
+    [RelayCommand]
+    private void KeepThis(DuplicateFileEntry? entry)
+    {
+        if (entry is null) return;
+
+        var group = Groups.FirstOrDefault(g => g.Files.Contains(entry));
+        group?.SetKeeper(entry);
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/Views/DuplicateFileView.xaml
+++ b/SysManager/SysManager/Views/DuplicateFileView.xaml
@@ -22,7 +22,7 @@
         <!-- Header -->
         <StackPanel Grid.Row="0" Margin="0,0,0,16">
             <TextBlock Text="Duplicate Finder" Style="{StaticResource Display}"/>
-            <TextBlock Text="Find files with identical content. Read-only — nothing is deleted."
+            <TextBlock Text="Find files with identical content. Nothing is deleted — we suggest which copy to keep, and you decide."
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
         </StackPanel>
 
@@ -56,7 +56,18 @@
 
         <!-- Summary bar -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
-            <TextBlock Text="{Binding ScanSummary}" FontWeight="SemiBold" FontSize="13"/>
+            <StackPanel>
+                <TextBlock Text="{Binding ScanSummary}" FontWeight="SemiBold" FontSize="13"/>
+                <!-- The keep-rule is stated, not hidden: a suggestion the user cannot see the reasoning
+                     for is one they cannot sensibly disagree with. "Oldest" is a heuristic that a
+                     timestamp-preserving copy or a cloud-sync rewrite will break, so it says "usually". -->
+                <TextBlock Style="{StaticResource Caption}" Margin="0,6,0,0" TextWrapping="Wrap"
+                           Visibility="{Binding GroupCount, Converter={StaticResource FlexVis}}">
+                    <Run Text="In each group we suggest keeping the"/>
+                    <Run Text="oldest" FontWeight="SemiBold"/>
+                    <Run Text="copy — that is usually the original. Use “Keep this one” if you know better. Nothing here deletes anything."/>
+                </TextBlock>
+            </StackPanel>
         </Border>
 
         <!-- Results: grouped list (virtualized for performance) -->
@@ -117,14 +128,37 @@
                                                             Command="{Binding DataContext.CopyPathCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                             CommandParameter="{Binding}"
                                                             Style="{StaticResource GhostButton}" Padding="4,2" FontSize="12"
-                                                            Margin="0,0,8,0"/>
+                                                            Margin="0,0,4,0"/>
+                                                    <!-- Lets the user disagree with the suggestion. Hidden on the row that is
+                                                         already the keeper, so there is never a button that does nothing. -->
+                                                    <Button Content="Keep this one" ToolTip="Suggest keeping this copy instead"
+                                                            AutomationProperties.Name="{Binding Name, Mode=OneWay, StringFormat='Keep {0} instead'}"
+                                                            Command="{Binding DataContext.KeepThisCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                            CommandParameter="{Binding}"
+                                                            Style="{StaticResource GhostButton}" Padding="4,2" FontSize="12"
+                                                            Margin="0,0,8,0"
+                                                            Visibility="{Binding IsSelected, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                                                 </StackPanel>
+                                                <!-- Keep badge: marks the one suggested copy. Uses the Success palette
+                                                     ("this is the one to keep"), not a warning colour. -->
+                                                <Border DockPanel.Dock="Left" CornerRadius="8" Padding="6,2" Margin="0,0,8,0"
+                                                        VerticalAlignment="Center"
+                                                        Background="{DynamicResource SuccessBgSubtle}"
+                                                        BorderBrush="{DynamicResource SuccessBorder}" BorderThickness="1"
+                                                        ToolTip="Oldest copy in this group — usually the original"
+                                                        Visibility="{Binding IsSelected, Converter={StaticResource FlexVis}}">
+                                                    <TextBlock Text="{Binding KeepLabel}" FontSize="11" FontWeight="SemiBold"
+                                                               Foreground="{DynamicResource SuccessText}"/>
+                                                </Border>
                                                 <TextBlock VerticalAlignment="Center" FontSize="12"
                                                            TextTrimming="CharacterEllipsis"
                                                            ToolTip="{Binding Path}">
                                                     <Run Text="{Binding Name, Mode=OneWay}" FontWeight="Medium"/>
                                                     <Run Text=" — " Foreground="{DynamicResource TextDisabled}"/>
                                                     <Run Text="{Binding Path, Mode=OneWay}" Foreground="{DynamicResource TextMuted}"/>
+                                                    <Run Text=" · " Foreground="{DynamicResource TextDisabled}"/>
+                                                    <Run Text="{Binding LastModified, Mode=OneWay, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}"
+                                                         Foreground="{DynamicResource TextMuted}"/>
                                                 </TextBlock>
                                             </DockPanel>
                                         </DataTemplate>


### PR DESCRIPTION
Closes #1520

## The problem, in the persona's terms

The tab already tells her she's wasting 4 GB. Then it shows five identical photos as **five identical rows** and leaves her to decide which one is the original — which is exactly the judgement she doesn't have. The report was unactionable.

And `DuplicateFileEntry` already declared `[ObservableProperty] private bool _isSelected`. `grep -rn IsSelected --include=*.cs --include=*.xaml | grep -i duplicate` → **nothing**. `grep -c "IsSelected\|CheckBox" Views/DuplicateFileView.xaml` → **0**. The property was dead. It's now what marks the keeper — so the fix and the cleanup are the same change.

## The rule

**Oldest `LastModified` wins**, because a copy is normally made after the file it came from. Ties break on shortest path, then alphabetically — so the suggestion is deterministic. A badge that moved between re-scans of the same folder would be worse than no badge at all.

It is a **heuristic**, and it is wrong in real cases: a copy tool that preserves timestamps, or a cloud-sync client that rewrites them, both defeat it. That fact drove every design decision here:

- the rule is **stated in the summary bar** — *"we suggest keeping the oldest copy — that is usually the original"* — rather than applied silently
- **each row now shows its own timestamp**, so she can check the reasoning herself instead of trusting it
- **"Keep this one"** moves the badge, and is hidden on the row that already holds it (no button that does nothing)
- exactly one file per group is ever marked — `SetKeeper` clears the others, because "which one do I keep" is a single choice, not a set of independent checkboxes

## Still non-destructive — deliberately

No delete, no move, no rename. The actions remain Show in Explorer, Copy path, and Keep this one.

Getting this wrong costs the user their own photos and documents **with no undo** — the worst outcome this app can produce, and the reason the tab was made read-only in the first place. The increment the issue asks for is the *rule* and the honesty about it, not a delete button. Two harness controls enforce that: one asserts the "nothing is deleted" promise survives the change, the other that no `DeleteCommand`/`RecycleCommand`/`DeleteSelected` appeared in the view.

The VM's class doc claimed read-only meant *"only Show in Explorer and Copy path"*. It now states what's actually offered and why the line is drawn where it is.

## Tests

23 new. All on **fixed dates**, never `DateTime.Now`, so the outcome can't depend on when the suite runs:

- the oldest file is marked; exactly one per group
- identical timestamps → shallower path wins (the timestamp-preserving-copy case the heuristic can't resolve)
- deterministic regardless of enumeration order — same folder, same keeper, twice
- an empty group doesn't throw; a stale mark is cleared on re-apply
- `SetKeeper` moves the mark and clears the rest; an entry from **another** group changes nothing (a stale `DataTemplate` binding must not wipe every badge)
- `KeepThisCommand` finds the owning group from the entry alone (the per-file template binds the entry, so the VM does the lookup — if it failed the button would appear inert); null and unknown entries are ignored
- `KeepLabel` is `"Keep"`/`""` and raises `PropertyChanged`, else the badge wouldn't repaint on override
- the shipped `DuplicateFileView.xaml` renders the badge, offers the override, states the rule, shows `LastModified`, and still says nothing is deleted

## Red ritual

Harness against a worktree of unfixed `origin/main`: **13 failures, 3 passes**. The three passes are the controls, and they're what make the failures meaningful:

```
PASS  [control] the model really declares IsSelected        -- so the failures are "unread", not "absent"
PASS  [control] the tab still promises nothing is deleted   -- the guarantee predates this PR
PASS  [control] no delete/recycle command was smuggled in
FAIL  the view renders a Keep badge          -- IsSelected was declared and read by nothing
FAIL  the oldest file is marked as the keeper -- five identical photos, five equal rows
FAIL  KeepLabel repaints when the mark moves
```

This branch: **16/16**. Main, unit-test and integration projects build **0 errors, 0 warnings**.

## Gate-DOCS

`README`'s *Duplicate File Finder* section described a tab with no keep-rule and *"Read-only — Show in Explorer and Copy path only"*. Updated to cover the badge, the stated rule, the override, **and** that the heuristic can be fooled — the caveat belongs in the docs, not just the code comment. `SECURITY.md` supported version follows the minor bump.

## Not verifiable here

The main PC never launches the app. Needs eyes on the secondary workstation: the Keep badge's contrast on light presets, and that adding the badge plus a third button doesn't wrap the row awkwardly at a narrow window width — the per-file row is a `DockPanel` and now carries four docked elements.
