### PR TITLE
ci: fail a PR whose newest CHANGELOG entry has no plain-English lead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,56 @@ jobs:
           }
           Write-Host "Version $csproj is consistent across csproj and CHANGELOG."
 
+      # The release workflow copies the matching CHANGELOG block VERBATIM into the release body and the
+      # auto-posted announcement, so whatever that entry starts with is the first thing a prospective
+      # user reads. When the friendly lead was a manual afterthought, five of the biggest feature
+      # releases (1.53.0, 1.54.0, 1.55.0, 1.55.1, 1.56.0) shipped opening with a bare semver heading
+      # followed by engineering prose — the ones a newcomer is most likely to open.
+      #
+      # Checked on the PR rather than at release time for the same reason as the version check above:
+      # here it costs one edit, there it blocks a release after the tag is already pushed. The release
+      # workflow keeps its own copy of this guard as the backstop, since a release can be dispatched
+      # manually without passing through this job.
+      - name: Check the newest CHANGELOG entry has a plain-English lead
+        shell: pwsh
+        run: |
+          $changelog = Get-Content CHANGELOG.md -Raw
+          $head = [regex]::Match($changelog, '(?ms)^## \[(?<ver>[0-9]+\.[0-9]+\.[0-9]+)\].*?(?=^## \[|\z)')
+          if (-not $head.Success) { throw "No versioned '## [x.y.z]' entry found in CHANGELOG.md." }
+
+          $version = $head.Groups['ver'].Value
+          $afterHeader = ($head.Value -split "(?m)^## \[.*$", 2)[1]
+          $beforeFirstCategory = ($afterHeader -split "(?m)^### ", 2)[0]
+          # Only real prose counts — blank lines and horizontal rules do not. @() keeps this an array
+          # even for a one-line lead, which PowerShell would otherwise unwrap to a bare string.
+          $leadLines = @($beforeFirstCategory -split "`r?`n" |
+              Where-Object { $_.Trim() -ne "" -and $_.Trim() -notmatch "^(-{3,}|\*{3,}|_{3,})$" })
+
+          if ($leadLines.Count -eq 0) {
+              # Built by joining rather than with a here-string: PowerShell requires a here-string's
+              # body and its closing "@ at column 0, which terminates the YAML block scalar this script
+              # lives in. The two are incompatible, and the result is a workflow that will not parse.
+              $msg = @(
+                  "The CHANGELOG entry for $version has no plain-English lead."
+                  ""
+                  "Add one or two sentences directly under the '## [$version]' header, BEFORE the first"
+                  "'###' category, describing what changed in the words a user would use. The release"
+                  "workflow copies this entry verbatim, so that paragraph becomes the opening line of"
+                  "the release page and of the announcement discussion."
+                  ""
+                  "Example:"
+                  ""
+                  "  ## [$version] - <date>"
+                  ""
+                  "  Quick Tune-Up now shows you what it found, instead of throwing the results away."
+                  ""
+                  "  ### Fixed"
+                  "  - ..."
+              ) -join [Environment]::NewLine
+              throw $msg
+          }
+          Write-Host "CHANGELOG entry for $version opens with a lead ($($leadLines.Count) line(s))."
+
       - name: Build (Release)
         run: dotnet build SysManager/SysManager/SysManager.csproj -c Release --no-restore
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,6 +216,47 @@ jobs:
               # Header exists but the section is empty (no notes beneath it).
               throw "CHANGELOG.md entry for version $version is empty. Add release notes under the '## [$version]' header before releasing."
           }
+
+          # Third guard: the entry must open with plain-English prose, before its first "###" category.
+          #
+          # The release page and the auto-posted discussion are where someone decides whether to
+          # download this, and because the block above is copied VERBATIM, whatever the entry starts
+          # with is the first thing they read. For five of the biggest feature releases (1.53.0,
+          # 1.54.0, 1.55.0, 1.55.1, 1.56.0) that was a bare semver heading followed by engineering
+          # prose, because the friendly lead was pasted in by hand afterwards and those five were
+          # missed. A convention that depends on remembering is one that lapses.
+          #
+          # Enforcing it HERE, rather than adding a step that writes a summary, keeps CHANGELOG.md the
+          # single source of truth: the lead then reaches the release body and the discussion for free.
+          $afterHeader = ($body -split "(?m)^## \[.*$", 2)[1]
+          $beforeFirstCategory = ($afterHeader -split "(?m)^### ", 2)[0]
+          # Keep only lines that are real prose: blank lines and stray markdown rules do not count.
+          # @() keeps this an array even for a one-line lead, which PowerShell would otherwise unwrap.
+          $leadLines = @($beforeFirstCategory -split "`r?`n" |
+              Where-Object { $_.Trim() -ne "" -and $_.Trim() -notmatch "^(-{3,}|\*{3,}|_{3,})$" })
+          if ($leadLines.Count -eq 0) {
+              # Joined rather than a here-string: PowerShell wants a here-string's body and closing "@
+              # at column 0, which would terminate the YAML block scalar this script lives in.
+              $msg = @(
+                  "CHANGELOG.md entry for version $version has no plain-English lead."
+                  ""
+                  "Add one or two sentences directly under the '## [$version]' header, BEFORE the first"
+                  "'###' category, describing what changed in the words a user would use. That paragraph"
+                  "becomes the first thing readers see on the release page and in the announcement"
+                  "discussion, because this step copies the entry verbatim."
+                  ""
+                  "Example:"
+                  ""
+                  "  ## [$version] - <date>"
+                  ""
+                  "  Quick Tune-Up now shows you what it found, instead of throwing the results away."
+                  ""
+                  "  ### Fixed"
+                  "  - ..."
+              ) -join [Environment]::NewLine
+              throw $msg
+          }
+
           $body | Out-File -FilePath $notesPath -Encoding utf8
           "path=$notesPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,26 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Every version entry opens with one or two sentences of plain English, before its first
+`###` category, describing what changed in the words someone using the app would use.
+That paragraph is not decoration: the release workflow copies each entry verbatim into
+the GitHub release body and the announcement discussion, so it is the first thing a
+prospective user reads. CI fails a pull request whose newest entry is missing it.
+
 ## [1.60.0] - 2026-08-10
+
+Duplicate Finder now tells you which of several identical copies to keep, and why, instead
+of listing them as equal rows and leaving the decision entirely to you.
 
 ### Added
 - **Duplicate Finder now tells you which copy to keep.** It would find five identical photos, tell you they were wasting 4 GB, and then show them as five identical rows — leaving you to work out which one is the original, which is exactly the judgement the tab exists to help with. One file per group is now badged **Keep**: the oldest, because a copy is normally made after the file it came from. The rule is written on screen instead of applied quietly, every row shows its date so you can check the reasoning yourself, and **"Keep this one"** moves the badge when you know better — a copy that kept its original timestamp, or a file rewritten by cloud sync, will fool the guess. Groups with identical dates fall back to the copy nearest the top of the folder tree, so the badge never jumps around between scans.
 - **Still nothing is deleted.** The tab remains read-only on purpose: getting this wrong costs you your own photos and documents with no way back. It suggests a decision and points you at the file; the removing is yours to do, in Explorer.
 
 ## [1.59.0] - 2026-08-10
+
+Process Manager stops misjudging what is safe to close: it no longer refuses to end
+Notepad, and every row now says whether a process is part of Windows, a known app, or
+something it does not recognise.
 
 ### Fixed
 - **The app refused to end Notepad, and told you it would crash your PC.** Process Manager would not let you end 49 ordinary programs — Notepad, Calculator, Paint, Task Manager, Registry Editor, Command Prompt, PowerShell, Windows Terminal, Snipping Tool, Media Player, Explorer and more — and said each one "would cause a system crash (BSOD)". That was simply untrue. The check was reading the wrong thing: the built-in database records whether a program *ships with Windows*, and that was being used to mean "ending it will crash the machine". The processes Windows genuinely cannot survive losing (`winlogon`, `csrss`, `smss`, `services`, `lsass`, `wininit`, …) are still refused exactly as before. Everything else is now your decision.


### PR DESCRIPTION
Closes #1666

## What was wrong

`release.yml` copies the matching `## [x.y.z]` CHANGELOG block **verbatim** into the release body and the auto-posted announcement. So whatever that entry starts with is the first thing a prospective user reads — and the friendly lead only ever existed where someone pasted it in afterwards.

The drift went in exactly the wrong direction. The releases **missing** a lead are `v1.53.0`, `v1.55.0`, `v1.55.1`, `v1.56.0` and `v1.54.0` — the biggest *feature* releases (Notification Blocker, Volume Control, Bandwidth Monitor, Edge/OneDrive Remover), i.e. the ones a newcomer is most likely to open. Those bodies begin literally with `## [1.54.0] - 2026-07-22` followed by dense engineering prose, while smaller patch releases got a lead because it happened to be remembered.

I can confirm the manual part first-hand: I hand-pasted the lead into three releases earlier today (v1.58.8, v1.59.0 and one before). That is the definition of a convention that will lapse.

## The fix

Not a step that generates a summary — the lead goes **in CHANGELOG.md**, which keeps it in the single source of truth and reaches both the release body and the discussion for free, with no change to how notes are extracted. The convention is documented at the top of the file and enforced in two places:

- **`ci.yml`**, beside the existing csproj↔CHANGELOG version-consistency check. On the PR it costs one edit; at release time it would block a release *after the tag is already pushed*. That's the same reasoning the neighbouring check already spells out in its comment.
- **`release.yml`**, as a third guard next to throw-on-missing and throw-on-empty. A release can be dispatched manually without passing through the PR job, so the backstop isn't redundant.

Only real prose counts — blank lines and horizontal rules are filtered, so an entry can't satisfy the check with an empty paragraph or a stray `---`.

## Two implementation notes worth keeping

**The message is built by joining an array, not with a here-string.** PowerShell requires a here-string's body and its closing `"@` at column 0, which *terminates the YAML block scalar the script lives in*. My first attempt made both workflow files unparseable — caught by running a YAML parser over them before committing, not by guessing.

**`@()` wraps the filtered line list** so a one-line lead stays an array instead of being unwrapped to a bare string.

## Verification

Both guards were **extracted from the committed YAML and executed**, so what ran is the shipped code rather than a hand-retyped copy:

| Input | ci.yml | release.yml |
|---|---|---|
| CHANGELOG as it stood (no lead on 1.59.0) | throws, exit 1 | throws, exit 1 |
| after adding leads to 1.59.0 + 1.60.0 | passes, exit 0 | passes, exit 0 |
| only blank lines before the first `###` | throws | throws |
| only a `---` rule before the first `###` | throws | throws |

The red state is real, not contrived: the file genuinely had no lead, because the practice was manual.

All four workflow files parse as YAML (`ci`, `release`, `auto-release`, `codeql`).

## Scope

`ci:` — no release triggered. Leads added to `1.59.0` and `1.60.0` so the gate passes on the current file.

**Not done here, deliberately:** the issue also suggests back-filling the lead into the five named published releases via `gh release edit`. That's cosmetic, touches published artifacts, and is a separate decision — worth doing, but not silently inside a CI change.
