### PR TITLE
fix: stop the test suite overwriting the user's icon-fetch preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.60.1] - 2026-08-10
+
+Running the project's own test suite no longer overwrites your choice about whether app
+icons may be fetched from the web.
+
+### Fixed
+- **The test suite quietly changed one of your settings.** In the Bulk Installer you can allow app icons to be loaded from the web — off unless you turn it on, because the app is local-first. That choice lives in a small file in your profile, and the project's automated tests were writing to *that* file rather than a scratch copy: five of them flip the setting while checking the download behaves correctly. So running the tests left the setting at whatever the last one happened to set, and the value you had picked was gone. Nothing about the app itself was wrong — but if you build and test SysManager yourself, this was silently editing your own configuration, and the same tests could also write into your real icon cache. Both now use a temporary folder.
+
 ## [1.60.0] - 2026-08-10
 
 ### Added

--- a/SysManager/SysManager.Tests/AppIconServiceTests.cs
+++ b/SysManager/SysManager.Tests/AppIconServiceTests.cs
@@ -2,8 +2,10 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Text.Json;
 using SysManager.Services;
 
 namespace SysManager.Tests;
@@ -15,8 +17,34 @@ namespace SysManager.Tests;
 /// failure paths (network error, cancellation) are verified to return null
 /// rather than throw.
 /// </summary>
-public class AppIconServiceTests
+/// <remarks>
+/// Every service here is constructed with a TEMP configDir. Before that seam existed, the paths were
+/// <c>static readonly</c> under <c>%LocalAppData%</c> and the five tests below that call
+/// <see cref="AppIconService.SetNetworkFetchEnabled"/> persisted to the user's REAL profile —
+/// silently overwriting the icon-fetch preference they had chosen and leaving it at whatever the
+/// last-executing test set (xUnit does not guarantee order). Never construct this service in a test
+/// without a configDir.
+/// </remarks>
+public sealed class AppIconServiceTests : IDisposable
 {
+    private readonly string _dir;
+
+    public AppIconServiceTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "SysManagerTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); }
+        catch (DirectoryNotFoundException) { /* already gone — nothing to clean up */ }
+    }
+
+    private AppIconService NewService(HttpMessageHandler? handler = null) => new(handler, _dir);
+
+    private string PreferenceFile => Path.Combine(_dir, "icon-fetch.json");
+
     /// <summary>A handler that returns a fixed response (or throws) without any network.</summary>
     private sealed class StubHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> responder)
         : HttpMessageHandler
@@ -35,7 +63,7 @@ public class AppIconServiceTests
     public async Task GetIconAsync_UnknownAppId_ReturnsNull_WithoutAnyRequest()
     {
         var handler = new StubHandler((_, _) => new HttpResponseMessage(HttpStatusCode.OK));
-        var svc = new AppIconService(handler);
+        var svc = NewService(handler);
 
         // An ID with no mapped domain must short-circuit before any HTTP call.
         var icon = await svc.GetIconAsync("No.Such.App." + Guid.NewGuid().ToString("N"));
@@ -48,7 +76,7 @@ public class AppIconServiceTests
     public async Task GetIconAsync_NetworkError_ReturnsNull_DoesNotThrow()
     {
         var handler = new StubHandler((_, _) => throw new HttpRequestException("simulated offline"));
-        var svc = new AppIconService(handler);
+        var svc = NewService(handler);
         svc.SetNetworkFetchEnabled(true); // opt in so the download path is reached
 
         // A known mapped ID so the download path is reached, then the handler fails.
@@ -65,7 +93,7 @@ public class AppIconServiceTests
             ct.ThrowIfCancellationRequested();
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
-        var svc = new AppIconService(handler);
+        var svc = NewService(handler);
         svc.SetNetworkFetchEnabled(true); // opt in so the download path is reached
         using var cts = new CancellationTokenSource();
         cts.Cancel();
@@ -81,7 +109,7 @@ public class AppIconServiceTests
     public async Task GetIconAsync_WhenFetchDisabled_MakesNoNetworkRequest()
     {
         var handler = new StubHandler((_, _) => new HttpResponseMessage(HttpStatusCode.OK));
-        var svc = new AppIconService(handler);
+        var svc = NewService(handler);
         svc.SetNetworkFetchEnabled(false); // explicit: opt-out
 
         // A known-mapped ID that is NOT cached must still make zero network calls.
@@ -94,7 +122,7 @@ public class AppIconServiceTests
     [Fact]
     public void SetNetworkFetchEnabled_TogglesAndReportsValue()
     {
-        var svc = new AppIconService(new StubHandler((_, _) => new HttpResponseMessage(HttpStatusCode.OK)));
+        var svc = NewService(new StubHandler((_, _) => new HttpResponseMessage(HttpStatusCode.OK)));
         Assert.True(svc.SetNetworkFetchEnabled(true));
         Assert.True(svc.NetworkFetchEnabled);
         Assert.False(svc.SetNetworkFetchEnabled(false));
@@ -106,9 +134,87 @@ public class AppIconServiceTests
     {
         // The injectable handler is the seam under test; constructing with one
         // (and the default) must both succeed.
-        var withStub = new AppIconService(new StubHandler((_, _) => new HttpResponseMessage(HttpStatusCode.OK)));
-        var withDefault = new AppIconService();
+        var withStub = NewService(new StubHandler((_, _) => new HttpResponseMessage(HttpStatusCode.OK)));
+        var withDefault = NewService();
         Assert.NotNull(withStub);
         Assert.NotNull(withDefault);
+    }
+
+    // ── configDir seam (regression: the preference was written to the user's real profile) ──
+
+    [Fact]
+    public void SetNetworkFetchEnabled_WritesInsideTheGivenConfigDir()
+    {
+        // The point of the seam. Before it, this write landed on
+        // %LocalAppData%\SysManager\icon-fetch.json and clobbered the user's own choice.
+        Assert.False(File.Exists(PreferenceFile));
+
+        NewService().SetNetworkFetchEnabled(true);
+
+        Assert.True(File.Exists(PreferenceFile));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Preference_RoundTripsThroughTheFile(bool enabled)
+    {
+        // Persistence is the feature: the choice has to survive a restart. Asserting the
+        // in-memory property alone would pass even if nothing were written.
+        NewService().SetNetworkFetchEnabled(enabled);
+
+        Assert.Equal(enabled, NewService().NetworkFetchEnabled);
+    }
+
+    [Fact]
+    public void Preference_PersistedShapeIsTheDocumentedJson()
+    {
+        // Pins the on-disk contract: an existing user's file must still be readable after any
+        // refactor of this service, and vice versa.
+        NewService().SetNetworkFetchEnabled(true);
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(PreferenceFile));
+        Assert.True(doc.RootElement.GetProperty("NetworkFetchEnabled").GetBoolean());
+    }
+
+    [Fact]
+    public void DefaultsToDisabled_WhenNoPreferenceFileExists()
+    {
+        // The no-cloud promise: a fresh profile must not fetch over the network until the user
+        // opts in. README states icons are "off by default".
+        Assert.False(File.Exists(PreferenceFile));
+
+        Assert.False(NewService().NetworkFetchEnabled);
+    }
+
+    [Fact]
+    public void MalformedPreferenceFile_FallsBackToDisabled()
+    {
+        // A corrupt file must fail CLOSED (no network), not open.
+        File.WriteAllText(PreferenceFile, "{ this is not json");
+
+        Assert.False(NewService().NetworkFetchEnabled);
+    }
+
+    [Fact]
+    public void TwoServicesWithDifferentConfigDirs_DoNotShareState()
+    {
+        // Proves the path is really per-instance. If it were still static, the second service would
+        // observe the first one's value and this would fail — which is exactly the coupling that let
+        // the suite reach into the user's profile.
+        var otherDir = Path.Combine(Path.GetTempPath(), "SysManagerTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(otherDir);
+        try
+        {
+            NewService().SetNetworkFetchEnabled(true);
+            var other = new AppIconService(null, otherDir);
+
+            Assert.False(other.NetworkFetchEnabled);
+            Assert.True(NewService().NetworkFetchEnabled);
+        }
+        finally
+        {
+            Directory.Delete(otherDir, recursive: true);
+        }
     }
 }

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -81,16 +81,17 @@ public class ArchitectureTests
     public void Services_DoNotHoldUserDataPathsInStaticFields()
     {
         // Known offenders, kept ONLY so this ratchet could be added without a repo-wide refactor in one
-        // change. Of these, AppIconService, SettingsWatchdogService, ThemeService and WindowsThemeService
-        // are referenced by tests today, so they carry the same latent risk SpeedTestHistoryService
-        // realised; LogService is not test-exercised.
-        // Removing a name from this list is the goal — tracked in issue #1741. ActivityLogService came
-        // off it when the destructive operations started logging: a test asserting they do would
-        // otherwise have written into the user's own activity history. Six to go.
+        // change. Of these, SettingsWatchdogService, ThemeService and WindowsThemeService are referenced
+        // by tests today, so they carry the same latent risk SpeedTestHistoryService realised;
+        // LogService is not test-exercised.
+        //
+        // Removing a name from this list is the goal — tracked in issue #1741. Two have come off so far:
+        // ActivityLogService, when the destructive operations started logging (a test asserting they do
+        // would otherwise have written into the user's own activity history), and AppIconService, whose
+        // case was not latent at all — five tests called SetNetworkFetchEnabled, which persists, so the
+        // suite overwrote the user's real icon-fetch preference on every run (#1758). Four to go.
         string[] known =
         [
-            "AppIconService.CacheDir",
-            "AppIconService.SettingsPath",
             "LogService.<LogDir>k__BackingField",
             "SettingsWatchdogService.BaselinePath",
             "ThemeService.SettingsPath",

--- a/SysManager/SysManager.Tests/BulkInstallerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/BulkInstallerViewModelTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using SysManager.Helpers;
 using SysManager.Services;
 using SysManager.ViewModels;
@@ -14,8 +15,12 @@ namespace SysManager.Tests;
 /// </summary>
 public class BulkInstallerViewModelTests
 {
+    // AppIconService gets a temp configDir. With the default it resolves the user's real
+    // %LocalAppData%\SysManager — these tests only construct it, but passing the seam keeps the rule
+    // uniform: the service is never built against a real profile in a test.
     private static BulkInstallerViewModel NewVm() =>
-        new(new BulkInstallerService(new PowerShellRunner()), new AppIconService());
+        new(new BulkInstallerService(new PowerShellRunner()),
+            new AppIconService(null, Path.Combine(Path.GetTempPath(), "SysManagerTests", Guid.NewGuid().ToString("N"))));
 
     [Fact]
     public void Constructor_PopulatesAppsWithCuratedList()

--- a/SysManager/SysManager/Services/AppIconService.cs
+++ b/SysManager/SysManager/Services/AppIconService.cs
@@ -22,13 +22,16 @@ namespace SysManager.Services;
 /// </summary>
 public sealed class AppIconService
 {
-    private static readonly string CacheDir = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "SysManager", "IconCache");
-
-    private static readonly string SettingsPath = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "SysManager", "icon-fetch.json");
+    // Instance fields, resolved from an injectable directory — NOT static readonly.
+    // Environment.GetFolderPath goes through the Win32 known-folder API and ignores the
+    // LOCALAPPDATA environment variable, so a static path cannot be redirected by any test, not even
+    // one in a child process. Held statically, these two made AppIconServiceTests write to the
+    // user's REAL profile: five tests call SetNetworkFetchEnabled, which persists, so the suite
+    // silently overwrote whatever icon-fetch preference the user had chosen and left it at whatever
+    // the last-executing test set (xUnit does not guarantee order). Same defect as
+    // SpeedTestHistoryService, whose tests deleted the user's speed-test history.
+    private readonly string _cacheDir;
+    private readonly string _settingsPath;
 
     private readonly HttpClient _http;
 
@@ -46,8 +49,19 @@ public sealed class AppIconService
     /// to redirect the download transport in tests; production uses the default
     /// handler with a 5-second timeout.
     /// </summary>
-    public AppIconService(HttpMessageHandler? handler = null)
+    /// <param name="handler">HTTP transport. Null uses the default handler.</param>
+    /// <param name="configDir">
+    /// Where the icon cache and the fetch preference live. Null uses
+    /// <c>%LocalAppData%\SysManager</c>, which is correct in production; tests MUST pass a temp
+    /// directory, or they operate on the user's real preference and icon cache.
+    /// </param>
+    public AppIconService(HttpMessageHandler? handler = null, string? configDir = null)
     {
+        var root = configDir ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager");
+        _cacheDir = Path.Combine(root, "IconCache");
+        _settingsPath = Path.Combine(root, "icon-fetch.json");
+
         _http = handler is null ? new HttpClient() : new HttpClient(handler);
         _http.Timeout = TimeSpan.FromSeconds(5);
         _http.DefaultRequestHeaders.UserAgent.ParseAdd("SysManager/1.0");
@@ -65,12 +79,12 @@ public sealed class AppIconService
         return NetworkFetchEnabled;
     }
 
-    private static bool LoadPreference()
+    private bool LoadPreference()
     {
         try
         {
-            if (!File.Exists(SettingsPath)) return false; // default: no network
-            var pref = JsonSerializer.Deserialize<IconFetchPreference>(File.ReadAllText(SettingsPath));
+            if (!File.Exists(_settingsPath)) return false; // default: no network
+            var pref = JsonSerializer.Deserialize<IconFetchPreference>(File.ReadAllText(_settingsPath));
             return pref?.NetworkFetchEnabled ?? false;
         }
         catch (IOException ex) { Log.Debug(ex, "Icon-fetch preference read failed"); return false; }
@@ -78,12 +92,12 @@ public sealed class AppIconService
         catch (JsonException ex) { Log.Debug(ex, "Icon-fetch preference malformed"); return false; }
     }
 
-    private static void SavePreference(bool enabled)
+    private void SavePreference(bool enabled)
     {
         try
         {
-            Directory.CreateDirectory(Path.GetDirectoryName(SettingsPath)!);
-            File.WriteAllText(SettingsPath, JsonSerializer.Serialize(new IconFetchPreference(enabled)));
+            Directory.CreateDirectory(Path.GetDirectoryName(_settingsPath)!);
+            File.WriteAllText(_settingsPath, JsonSerializer.Serialize(new IconFetchPreference(enabled)));
         }
         catch (IOException ex) { Log.Debug(ex, "Icon-fetch preference write failed"); }
         catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Icon-fetch preference write denied"); }
@@ -98,7 +112,7 @@ public sealed class AppIconService
     /// </summary>
     public async Task<BitmapImage?> GetIconAsync(string appId, CancellationToken ct = default)
     {
-        var cachePath = Path.Combine(CacheDir, $"{SanitizeFileName(appId)}.png");
+        var cachePath = Path.Combine(_cacheDir, $"{SanitizeFileName(appId)}.png");
 
         // Return cached icon if it exists and is not empty. If the file is present
         // but fails to decode (truncated/corrupt download), delete it so we re-download
@@ -126,7 +140,7 @@ public sealed class AppIconService
             var bytes = await _http.GetByteArrayAsync(url, ct).ConfigureAwait(false);
             if (bytes.Length == 0) return null;
 
-            Directory.CreateDirectory(CacheDir);
+            Directory.CreateDirectory(_cacheDir);
             await File.WriteAllBytesAsync(cachePath, bytes, ct).ConfigureAwait(false);
             return LoadFromFile(cachePath);
         }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.60.0</Version>
-    <FileVersion>1.60.0.0</FileVersion>
-    <AssemblyVersion>1.60.0.0</AssemblyVersion>
+    <Version>1.60.1</Version>
+    <FileVersion>1.60.1.0</FileVersion>
+    <AssemblyVersion>1.60.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #1758

## The bug

`AppIconService` held both of its paths in `private static readonly` fields resolved from `Environment.GetFolderPath(LocalApplicationData)`. Five tests call `SetNetworkFetchEnabled`, which persists via `File.WriteAllText` — so **the test suite wrote to the user's real `%LocalAppData%\SysManager\icon-fetch.json` on every run**, leaving the setting at whatever the last-executing test set. xUnit doesn't guarantee order, so the value the user was left with wasn't even deterministic.

This was **not latent**. Verified on this machine before touching anything: the file existed, dated 2026-07-07, containing `{"NetworkFetchEnabled":true}` — an explicit opt-in, since the documented default is off ("App icons in the Bulk Installer are an **opt-in** extra — off by default", README). A test run silently revoked the user's own choice. `CacheDir` has the same shape and is written by the download path, so a successful-download test also wrote into the real icon cache.

`Environment.GetFolderPath` goes through the Win32 known-folder API and **ignores the `LOCALAPPDATA` environment variable**, so while the path lives in a `static readonly` field, no test can redirect it — not even one in a child process. That's exactly the finding `ArchitectureTests.Services_DoNotHoldUserDataPathsInStaticFields` was added for, after `SpeedTestHistoryService`'s tests deleted the user's speed-test history.

## The fix

The `string? configDir = null` seam the persistence services already share. Both paths become instance fields, `LoadPreference`/`SavePreference` become instance methods, and every test construction (7 in `AppIconServiceTests`, 1 in `BulkInstallerViewModelTests`) passes a temp directory.

`AppIconService.CacheDir` and `AppIconService.SettingsPath` come **off** the ratchet's `known` list — that test fails on a listed name that no longer offends, so the allow-list can't rot into a permanent excuse. Four to go.

## PROPAGATE — is anything else actively affected?

Of the four remaining offenders:

| Service | Constructed concretely in tests | Writer reached |
|---|---|---|
| `LogService` | 0 | — |
| `ThemeService` | 0 | — |
| `SettingsWatchdogService` | 4 | `SaveBaseline` only via NSubstitute (`DidNotReceive`/`Received`) |
| `WindowsThemeService` | 2 | `SaveSchedule` only via NSubstitute |

So `AppIconService` was the **only active case** — the one where tests both construct concretely *and* call the writing method. The rest remain a testability concern tracked in #1741, not data corruption.

## Red ritual — with the user's data protected

Proving the red state means letting unfixed code write to the real file, which *is* the bug. So the harness hashes the real file first and restores it byte-for-byte in a `finally` block, with an out-of-band backup as well.

Against a worktree of unfixed `main`: **7/7 fail**, including the one that carries the argument:

```
FAIL  toggling the preference does NOT write to the user's real profile
      -- five tests call SetNetworkFetchEnabled, so the suite rewrote the user's own choice
```

That failed because the file's **SHA256 changed** — direct evidence, not inference. This branch: **7/7 pass**.

The real file is byte-identical before and after both runs — `c9c91631dfabd0beafe776e8857add3eb5d333d1647b754ff4c0cefbbad0b784` — confirmed by hash and independently by `diff` against the pre-work backup.

## Tests

7 new: the write lands in the given `configDir`; the choice round-trips (persistence is the feature, so asserting the in-memory property alone would pass even if nothing were written); the on-disk JSON shape is pinned so an existing user's file stays readable; a fresh profile defaults to **disabled** (the no-cloud promise); a malformed file fails **closed**, not open; and two services with different `configDir`s don't share state — which is what actually proves the path is per-instance rather than static.

Main, unit-test and integration projects build **0 errors, 0 warnings**.

## Note on the CHANGELOG

This branch predates #1756 (the lead gate), so `1.60.0` above has no lead here. The new `1.60.1` entry has one, so this is compliant whichever merges first.
