### PR TITLE
fix: say that Disk Analyzer's total leaves Windows system folders out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.60.2] - 2026-08-10
+
+Disk Analyzer now tells you that its total leaves some Windows folders out, so the number no
+longer looks wrong when you compare it against the free space Windows shows.
+
+### Fixed
+- **Disk Analyzer's total was quietly incomplete.** To stay fast, it skips four Windows areas it either cannot read or would take a long time to walk — the Recycle Bin, System Volume Information (where restore points live), and the `WinSxS` and `CSC` folders inside Windows. It also never follows shortcut-links between folders, because that would either count the same files twice or wander outside the folder you asked about. All of that is deliberate and stays. What was missing is that nothing told you: you would add up what the tab reported, compare it against the free space Windows shows, find a gap of several gigabytes — `WinSxS` alone is often that big on its own — and reasonably conclude the app was wrong. The tab now says so in one line under the summary, and hovering it names the exact folders.
+
 ## [1.60.0] - 2026-08-10
 
 Duplicate Finder now tells you which of several identical copies to keep, and why, instead

--- a/README.md
+++ b/README.md
@@ -403,7 +403,14 @@ a confirmation before it runs:
 - Drive usage bar with total/used/free
 - Preset paths (fixed drives, user profile, Program Files) or custom browse
 - Show in Explorer for each folder
-- Skips system paths automatically
+- **Says what it doesn't count** — four Windows system areas (`$Recycle.Bin`,
+  `System Volume Information`, `Windows\WinSxS`, `Windows\CSC`) are skipped because they are
+  slow or unreadable, and junctions are never followed, since following one would
+  double-count or lead outside the folder you asked about. `WinSxS` alone is often several
+  GB, so the tab states on screen that its total can be smaller than the free space Windows
+  reports, and names the exact folders on hover
+- Folders Windows wouldn't let it fully read are marked, so a partial figure never looks
+  like a complete one
 
 ### Process Manager
 - Lists running Windows processes with PID, memory, threads, and status

--- a/SysManager/SysManager.Tests/DiskAnalyzerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DiskAnalyzerViewModelTests.cs
@@ -172,4 +172,84 @@ public class DiskAnalyzerViewModelTests
         Assert.Contains(nameof(vm.EmptyTitle), raised);
         Assert.Contains(nameof(vm.EmptyMessage), raised);
     }
+
+    // ── Exclusion disclosure (the total is partial by design) ────────────────────────────────
+    //
+    // Four Windows subtrees are skipped because they are slow or unreadable, and junctions are never
+    // followed. Windows\WinSxS alone is routinely several GB, so a user comparing this total against
+    // the free space Windows reports sees a multi-gigabyte gap. Nothing in the tab said so.
+
+    [Fact]
+    public void ExclusionNote_SaysTheTotalCanBeSmallerThanWindowsReports()
+    {
+        // The one sentence that stops the number reading as a bug.
+        var note = NewVm().ExclusionNote;
+
+        Assert.False(string.IsNullOrWhiteSpace(note));
+        Assert.Contains("aren't counted", note);
+        Assert.Contains("smaller than the space Windows reports", note);
+    }
+
+    [Fact]
+    public void ExclusionDetail_NamesEveryFolderTheServiceActuallySkips()
+    {
+        // Derived from DiskAnalyzerService.ExcludedFolderNames rather than retyped, so the tooltip
+        // cannot drift from the real SkipSegments list. Adding a fifth exclusion without updating the
+        // disclosure fails here.
+        var detail = NewVm().ExclusionDetail;
+
+        Assert.NotEmpty(Services.DiskAnalyzerService.ExcludedFolderNames);
+        foreach (var name in Services.DiskAnalyzerService.ExcludedFolderNames)
+            Assert.Contains(name, detail);
+    }
+
+    [Fact]
+    public void ExclusionDetail_ExplainsWhyJunctionsAreSkipped()
+    {
+        // The reparse-point guard is a correctness property, not an oversight — say why, so it does
+        // not read as a missing feature.
+        var detail = NewVm().ExclusionDetail;
+
+        Assert.Contains("junction", detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("double-count", detail);
+    }
+
+    [Fact]
+    public void ExclusionText_IsInstanceNotStatic_SoItActuallyBinds()
+    {
+        // A {Binding} to a static member resolves to nothing and renders EMPTY — reintroducing exactly
+        // the silence this change fixes, while still compiling and still passing any test that read the
+        // property straight off the type. Nothing in Views/ uses x:Static, so instance is also uniform.
+        foreach (var name in new[] { nameof(DiskAnalyzerViewModel.ExclusionNote),
+                                     nameof(DiskAnalyzerViewModel.ExclusionDetail) })
+        {
+            var prop = typeof(DiskAnalyzerViewModel).GetProperty(name);
+            Assert.NotNull(prop);
+            Assert.False(prop!.GetGetMethod()!.IsStatic, $"{name} must be an instance property to bind.");
+        }
+    }
+
+    [Fact]
+    public void DiskAnalyzerView_ShowsTheExclusionNote()
+    {
+        // The defect was that nothing in the tab disclosed it — a grep for excluded/skip/system area in
+        // the view returned 0. Asserting the ViewModel alone would pass on the unfixed code.
+        var xaml = File.ReadAllText(ViewPath("DiskAnalyzerView.xaml"));
+
+        Assert.Contains("ExclusionNote", xaml);
+        Assert.Contains("ExclusionDetail", xaml);   // the hover naming the exact folders
+    }
+
+    // Walks up from the test binaries to the app project — .xaml is not copied to the output.
+    private static string ViewPath(string fileName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "SysManager", "Views")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);   // else the assertions above would silently test nothing
+        var path = Path.Combine(dir!.FullName, "SysManager", "Views", fileName);
+        Assert.True(File.Exists(path), $"{fileName} not found at {path}");
+        return path;
+    }
 }

--- a/SysManager/SysManager/Services/DiskAnalyzerService.cs
+++ b/SysManager/SysManager/Services/DiskAnalyzerService.cs
@@ -23,6 +23,23 @@ public sealed class DiskAnalyzerService
         @"\windows\winsxs", @"\windows\csc"
     };
 
+    /// <summary>
+    /// The excluded subtrees, in the form a user would recognise, so the UI can say exactly what is
+    /// missing from the total instead of duplicating the list above and letting the two drift.
+    /// </summary>
+    /// <remarks>
+    /// These are excluded because they are slow or unreadable, not because they are small —
+    /// <c>Windows\WinSxS</c> alone is routinely several gigabytes. A total that omits them without
+    /// saying so reads as a bug when the user compares it against the free space Windows reports.
+    /// </remarks>
+    public static IReadOnlyList<string> ExcludedFolderNames { get; } =
+    [
+        @"$Recycle.Bin",
+        @"System Volume Information",
+        @"Windows\WinSxS",
+        @"Windows\CSC"
+    ];
+
     public Task<IReadOnlyList<DiskUsageEntry>> AnalyzeAsync(
         string rootPath,
         IProgress<AnalysisProgress>? progress = null,

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.60.0</Version>
-    <FileVersion>1.60.0.0</FileVersion>
-    <AssemblyVersion>1.60.0.0</AssemblyVersion>
+    <Version>1.60.2</Version>
+    <FileVersion>1.60.2.0</FileVersion>
+    <AssemblyVersion>1.60.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
@@ -54,6 +54,26 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
     [ObservableProperty] private double _driveUsedPercent;
     [ObservableProperty] private bool _hasDriveInfo;
 
+    /// <summary>
+    /// Says that the total is partial by design. Without this the user compares it against the free
+    /// space Windows reports, finds a multi-gigabyte gap — <c>Windows\WinSxS</c> alone is routinely
+    /// several GB — and has no way to learn the difference is intentional.
+    /// </summary>
+    /// <remarks>
+    /// Instance, not static, even though the value never varies: a <c>{Binding}</c> to a static member
+    /// resolves to nothing and renders EMPTY, which would reintroduce the very silence this fixes.
+    /// (Nothing in Views/ uses <c>x:Static</c>, so an instance property is also the uniform choice.)
+    /// </remarks>
+    public string ExclusionNote =>
+        "Windows system areas and shortcut-links (junctions) aren't counted, so this total can be " +
+        "smaller than the space Windows reports.";
+
+    /// <summary>The exact excluded folders, for the curious — derived from the service's own list.</summary>
+    public string ExclusionDetail =>
+        "Not counted: " + string.Join(", ", DiskAnalyzerService.ExcludedFolderNames) +
+        ", plus any junction or symbolic link (following one would double-count, or lead outside the " +
+        "folder you asked about).";
+
     public DiskAnalyzerViewModel(DiskAnalyzerService service)
     {
         _service = service;

--- a/SysManager/SysManager/Views/DiskAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/DiskAnalyzerView.xaml
@@ -51,6 +51,16 @@
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
             <StackPanel>
                 <TextBlock Text="{Binding ScanSummary}" FontWeight="SemiBold" FontSize="13" Margin="0,0,0,6"/>
+                <!-- The total is partial BY DESIGN: four Windows system subtrees are skipped because they
+                     are slow or unreadable, and junctions are never followed (following one would
+                     double-count, or walk outside the folder that was asked about). WinSxS alone is
+                     routinely several GB, so without this line the user compares the total against the
+                     free space Windows reports, sees a multi-gigabyte gap, and reasonably concludes the
+                     app is wrong. Hover names the exact folders. Same header-level expectation-setting
+                     as Bandwidth Monitor and Deep Cleanup. -->
+                <TextBlock Text="{Binding ExclusionNote}" Style="{StaticResource Caption}"
+                           TextWrapping="Wrap" MaxWidth="820" HorizontalAlignment="Left"
+                           Margin="0,0,0,2" ToolTip="{Binding ExclusionDetail}"/>
                 <!-- Drive usage bar (visible only when drive info is available) -->
                 <Grid Visibility="{Binding HasDriveInfo, Converter={StaticResource BoolToVis}}" Margin="0,4,0,0">
                     <Grid.ColumnDefinitions>


### PR DESCRIPTION
Closes #1746

## The problem

Disk Analyzer excluded whole subtrees from its total and never said so. Two separate exclusions, both invisible:

- **four hardcoded system subtrees** (`DiskAnalyzerService.cs:20-24`) — `$Recycle.Bin`, `System Volume Information`, `Windows\WinSxS`, `Windows\CSC`
- **every reparse point** — `:77` and `:176` both `continue`, at the top-level enumeration and the recursive measure

`WinSxS` alone is routinely several gigabytes, so scanning `C:\` can omit a very large amount of real usage. And `grep -ciE "excluded|skip|system area" Views/DiskAnalyzerView.xaml` → **0**. Nothing in the tab said the number was partial by design.

The consequence is what makes this a bug rather than a nitpick: the user adds up what the tab reports, compares it against the free space Windows shows, finds a multi-gigabyte gap, and reasonably concludes the app is wrong.

## Disclosure only — the exclusions stay

Those trees are skipped because they're slow or unreadable, and **not** following junctions is a correctness and safety property: following one would either count the same files twice or walk outside the folder that was asked about.

Two harness **controls** enforce that scope, and both pass on unfixed `main` as well as on this branch:

```
PASS  [control] the four system subtrees are still skipped
PASS  [control] the service still exposes no way to disable the skipping
```

So this adds a sentence, not a setting.

## The disclosure

One line under `ScanSummary`, with the exact folders on hover. The list is exposed from the service as `ExcludedFolderNames` and the tooltip is **built from it**, so the copy can't drift from the real `SkipSegments` — adding a fifth exclusion without updating the disclosure fails a test. Placement and tone match how `BandwidthMonitorView` and `DeepCleanupView` already set expectations in their own headers, so it's an existing pattern rather than a new one.

### One trap worth naming

The note is an **instance** property, deliberately. A `{Binding}` to a `static` member resolves to nothing and renders **empty** — which would reintroduce the exact silence this fixes, while still compiling *and* still passing any test that read the value straight off the type. I wrote it static first, caught it before building, and there's now a test asserting neither property is static. Nothing in `Views/` uses `x:Static`, so instance is also the uniform choice.

## Completes a pair

#1583 (v1.58.5) fixed the **per-folder** half — a folder Windows wouldn't let the app fully read now carries a warning mark. That change deliberately left this whole-scan half out rather than bundling header copy with a per-row binding. This is the other half.

## Verification

Harness against a worktree of unfixed `main`: **6 failures, 2 passes** (the two controls). Branch: **8/8**.

5 new unit tests: the note states the total can be smaller than Windows reports; the detail names every folder the service actually skips (iterating `ExcludedFolderNames`, so it can't rot); the detail explains *why* junctions are skipped; neither property is static; and the shipped `DiskAnalyzerView.xaml` binds both — a ViewModel-only assertion would pass on the unfixed code, since the properties are new but the silence lived in the view.

Main, unit-test and integration projects build **0 errors, 0 warnings**.

## Gate-DOCS

README said only *"Skips system paths automatically"* — true, but silent on the consequence. It now names the four folders, explains the junction rule, and states that the total can read lower than Windows' own figure.

## Not verifiable here

The main PC never launches the app. Needs eyes on the secondary workstation: that the extra `Caption` line doesn't crowd the drive-usage bar in the same card at a narrow window width.
