### PR TITLE
fix: pin the update binary's publisher instead of accepting any signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.60.3] - 2026-08-10
+
+Closes a hole in the update check before it can ever matter: when SysManager starts being
+code-signed, an update signed by someone else will be refused instead of accepted.
+
+### Fixed
+- **The update check would have trusted any signature, not just ours.** When you install an update from inside the app, the download is verified against the published checksum — that part was and remains the real protection, and it is what catches a tampered file. The app also looks at the file's digital signature. That second check only confirmed *a* signature existed; it never asked **whose**. SysManager isn't signed yet, so nothing was exposed — but the moment a signing certificate arrives, the reasonable assumption would be "we sign now, so that check protects us", and it would not have: a file signed by anyone at all, including someone who made their own certificate, would have passed exactly like a genuine build. Now a signature has to belong to the expected publisher *and* trace back to a trusted authority, or the update is refused. Unsigned builds keep installing normally, so nothing changes for you today.
+
 ## [1.60.1] - 2026-08-10
 
 Running the project's own test suite no longer overwrites your choice about whether app

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -118,11 +118,19 @@ What the app can and cannot do by design:
   Releases endpoint. The app does not auto-install without an explicit
   click. Before applying, the downloaded binary's SHA256 is compared against
   the `.sha256` published with the release — that comparison is the integrity
-  gate. The binary is also inspected for an Authenticode signature, but since
-  SysManager ships unsigned that check is informational: an unsigned build is
-  accepted, and a signature that cannot be parsed is rejected. It is not a
-  publisher check and does not detect a tampered signed binary; the SHA256
-  comparison is what catches a modified download. The swap is then performed
+  gate, and it is what catches a modified download. The binary is also inspected
+  for an Authenticode signature: an unsigned build is accepted, because SysManager
+  currently ships unsigned, while a signature that cannot be parsed is rejected.
+  If a signature IS present, the signer must match the pinned publisher and its
+  certificate chain must validate to a trusted root with online revocation —
+  the same policy already applied to the third-party Ookla CLI. That pin is a
+  single constant, empty until a code-signing certificate exists, so the check
+  cannot quietly become a no-op the day signing is switched on: without it, merely
+  *carrying* a signature would pass, and a binary signed by an attacker's own
+  self-issued certificate would be accepted like a legitimate build. Note that
+  Authenticode inspection reads the signer certificate; it does not by itself
+  validate the file against the signature, which is why SHA256 remains the
+  integrity gate rather than a fallback. The swap is then performed
   from within the downloaded executable itself (no intermediate script on
   disk) using a staged atomic file move, so an interrupted update cannot
   leave a half-written, unstartable binary. You can also download manually

--- a/SysManager/SysManager.Tests/UpdateServiceAuthenticodeTests.cs
+++ b/SysManager/SysManager.Tests/UpdateServiceAuthenticodeTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.IO;
+using System.Reflection;
 using SysManager.Services;
 
 namespace SysManager.Tests;
@@ -85,5 +86,95 @@ public class UpdateServiceAuthenticodeTests
             Assert.True(UpdateService.VerifyAuthenticode(path));
         }
         finally { File.Delete(path); }
+    }
+
+    // ── Publisher pinning ────────────────────────────────────────────────────────────────────
+    //
+    // Before this, the signed branch logged cert.Subject and returned true — no subject comparison,
+    // no chain build. So once SysManager is signed, a binary signed by ANY certificate, including an
+    // attacker's own self-issued one, would pass identically to a legitimate build. The dangerous part
+    // is the assumption that arrives with the certificate: "we sign now, so the signature check
+    // protects us."
+    //
+    // The correct pattern was already in this codebase for a THIRD-PARTY download —
+    // SpeedTestService.VerifyOoklaSignature pins the subject then builds an X509Chain with online
+    // revocation, because (its own comment) "subject alone is forgeable". These tests pin that the
+    // update path now shares that shape.
+
+    [Fact]
+    public void ExpectedSignerSubject_ExistsAsASinglePinPoint()
+    {
+        // The point is that enabling signing becomes a ONE-LINE change here, not a security redesign
+        // under release pressure. If this constant disappears, the pin has gone with it.
+        var field = typeof(UpdateService).GetField("ExpectedSignerSubject",
+            BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
+
+        Assert.NotNull(field);
+        Assert.Equal(typeof(string), field!.FieldType);
+        Assert.True(field.IsLiteral, "must be a const so it cannot be reassigned at runtime");
+    }
+
+    [Fact]
+    public void ExpectedSignerSubject_IsEmptyWhileBuildsAreUnsigned()
+    {
+        // Empty means "nothing to pin against yet", which keeps the signed branch permissive for
+        // exactly as long as that is true. This is a REMINDER rather than a permanent expectation:
+        // when a certificate arrives, this is the assertion that fails, and it points at the pinning
+        // tests that will then need real signed fixtures.
+        var value = (string)typeof(UpdateService)
+            .GetField("ExpectedSignerSubject", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetRawConstantValue()!;
+
+        Assert.Equal("", value);
+    }
+
+    [Fact]
+    public void VerifyAuthenticode_PinsThePublisherAndBuildsAChain()
+    {
+        // Asserted against the source rather than by execution, deliberately and with the limitation
+        // stated: producing a genuinely signed binary with a controllable publisher needs a test
+        // certificate and signtool, which this unit-test project does not have. What CAN be checked
+        // mechanically is that the signed branch does both things the Ookla path does — compare
+        // against the pin AND validate the chain. Either one alone is bypassable.
+        var source = File.ReadAllText(ServiceSourcePath("UpdateService.cs"));
+        var start = source.IndexOf("public static bool VerifyAuthenticode", StringComparison.Ordinal);
+        Assert.True(start >= 0, "VerifyAuthenticode not found — this test would otherwise assert nothing");
+        var end = source.IndexOf("private static void CleanupFile", start, StringComparison.Ordinal);
+        Assert.True(end > start, "method boundary not found");
+        var method = source[start..end];
+
+        Assert.Contains("ExpectedSignerSubject", method);          // the pin is consulted
+        Assert.Contains("X509Chain", method);                      // the chain is built
+        Assert.Contains("X509RevocationMode.Online", method);      // revocation is checked
+        Assert.Contains("chain.Build(cert)", method);
+        Assert.Contains("return false", method);                   // and it fails closed
+    }
+
+    [Fact]
+    public void VerifyAuthenticode_UnsignedFile_StillAllowed_AfterThePinWasAdded()
+    {
+        // Regression guard on the LIVE path: SysManager's builds are unsigned today, so the
+        // no-signature branch must stay permissive. Tightening the signed branch must not block every
+        // current install — every update aborting with "invalid digital signature" is the bug this
+        // test file was originally written for.
+        var path = WriteTempFile([0x4D, 0x5A, 0x90, 0x00]);
+        try
+        {
+            Assert.True(UpdateService.VerifyAuthenticode(path));
+        }
+        finally { File.Delete(path); }
+    }
+
+    // Walks up to the app project — source is not copied to the test output.
+    private static string ServiceSourcePath(string fileName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "SysManager", "Services")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);   // else the assertions above would silently test nothing
+        var path = Path.Combine(dir!.FullName, "SysManager", "Services", fileName);
+        Assert.True(File.Exists(path), $"{fileName} not found at {path}");
+        return path;
     }
 }

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -411,10 +411,23 @@ public sealed class UpdateService
     private const int CryptENoMatch = unchecked((int)0x80092009);
 
     /// <summary>
-    /// Reports the Authenticode state of a downloaded update binary. Returns true when
-    /// the binary is validly embedded-signed OR carries no signature at all (SysManager
-    /// ships unsigned open-source builds). Returns false only when reading the signature
-    /// fails for a reason other than "no signature present".
+    /// The publisher this app's own signed builds must carry, once a code-signing certificate
+    /// exists. EMPTY means "not signing yet", which keeps the signed branch permissive exactly as
+    /// long as there is nothing to pin against.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately a single named constant so that turning signing on is a one-line change here,
+    /// rather than a security redesign made under release pressure. Pinned on the ORGANIZATION
+    /// substring rather than a thumbprint so certificate renewal — which changes the thumbprint but
+    /// not the subject — does not brick self-update for everyone.
+    /// </remarks>
+    internal const string ExpectedSignerSubject = "";
+
+    /// <summary>
+    /// Reports the Authenticode state of a downloaded update binary. Returns true when the binary
+    /// carries no signature at all (SysManager ships unsigned open-source builds), or is signed by
+    /// the expected publisher with a chain that validates. Returns false when a signature is present
+    /// but wrong, unreadable, or unverifiable.
     ///
     /// This is NOT the integrity gate: file integrity is enforced by the SHA256 check
     /// (<see cref="VerifyHashAsync"/>) against the published .sha256, which runs first in
@@ -422,18 +435,62 @@ public sealed class UpdateService
     /// does not by itself validate the file against the signature, so it cannot detect a
     /// tampered signed binary — the SHA256 comparison is what catches a modified download.
     /// </summary>
+    /// <remarks>
+    /// The signed branch pins the publisher and builds a chain, mirroring
+    /// <c>SpeedTestService.VerifyOoklaSignature</c> — which already does this for a THIRD-PARTY
+    /// download, and whose own comment notes that "subject alone is forgeable (anyone can issue a
+    /// self-signed 'Ookla' cert)". Without the pin, merely *having* a signature passed this gate, so
+    /// the day a certificate arrives, a binary signed by an attacker's self-issued cert would have
+    /// been accepted identically to a legitimate build — while the natural assumption would be "we
+    /// sign now, so the signature check protects us". Keeping the two paths symmetric is the point.
+    /// </remarks>
     public static bool VerifyAuthenticode(string filePath)
     {
         try
         {
 #pragma warning disable SYSLIB0057 // CreateFromSignedFile is obsolete
-            var cert = System.Security.Cryptography.X509Certificates.X509Certificate
+            var signer = System.Security.Cryptography.X509Certificates.X509Certificate
                 .CreateFromSignedFile(filePath);
 #pragma warning restore SYSLIB0057
             // A non-null cert means an embedded Authenticode signature was found and its
             // signer certificate could be read. (Unsigned files throw below rather than
             // returning null, so this branch is the signed case.)
-            Serilog.Log.Information("Update binary is Authenticode-signed: {Subject}", cert.Subject);
+            using var cert = new System.Security.Cryptography.X509Certificates.X509Certificate2(signer);
+
+            if (ExpectedSignerSubject.Length == 0)
+            {
+                // No certificate of our own yet, so there is nothing to compare against. Allowing a
+                // signed binary through is still safe: SHA256 against the published hash is the real
+                // gate and has already run.
+                Serilog.Log.Information(
+                    "Update binary is Authenticode-signed: {Subject} (no expected publisher pinned yet)",
+                    cert.Subject);
+                return true;
+            }
+
+            if (!cert.Subject.Contains(ExpectedSignerSubject, StringComparison.OrdinalIgnoreCase))
+            {
+                Serilog.Log.Warning(
+                    "Update binary signed by an unexpected publisher: {Subject} (expected to contain {Expected})",
+                    cert.Subject, ExpectedSignerSubject);
+                return false;
+            }
+
+            // Subject alone is forgeable — anyone can issue a self-signed certificate carrying any
+            // subject string — so validate the whole chain to a trusted root, with online
+            // revocation, and fail closed. Same policy as VerifyOoklaSignature.
+            using var chain = new System.Security.Cryptography.X509Certificates.X509Chain();
+            chain.ChainPolicy.RevocationMode = System.Security.Cryptography.X509Certificates.X509RevocationMode.Online;
+            chain.ChainPolicy.RevocationFlag = System.Security.Cryptography.X509Certificates.X509RevocationFlag.ExcludeRoot;
+            chain.ChainPolicy.VerificationFlags = System.Security.Cryptography.X509Certificates.X509VerificationFlags.NoFlag;
+            if (!chain.Build(cert))
+            {
+                var statuses = string.Join(", ", chain.ChainStatus.Select(s => s.Status.ToString()));
+                Serilog.Log.Warning("Update binary certificate chain did not validate: {Status}", statuses);
+                return false;
+            }
+
+            Serilog.Log.Information("Update binary Authenticode chain verified: {Subject}", cert.Subject);
             return true;
         }
         catch (System.Security.Cryptography.CryptographicException ex) when (ex.HResult == CryptENoMatch)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.60.1</Version>
-    <FileVersion>1.60.1.0</FileVersion>
-    <AssemblyVersion>1.60.1.0</AssemblyVersion>
+    <Version>1.60.3</Version>
+    <FileVersion>1.60.3.0</FileVersion>
+    <AssemblyVersion>1.60.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #1674

## The hole

`UpdateService.VerifyAuthenticode` extracted the signer certificate, logged `cert.Subject`, and returned `true`. No subject comparison. No chain build. So once SysManager is signed, **a binary signed by any certificate — including an attacker's own self-issued one — passes this gate identically to a legitimate build.**

Nothing is exposed *today*: builds are unsigned, so the no-signature branch is the live one, and SHA256 against the published hash is the real integrity gate. The danger is what arrives **with** the certificate. The natural assumption will be "we sign now, so the signature check protects us", and it would have been false. Fixing it before signing ships costs one function; fixing it afterwards means auditing a security control in the middle of a certificate rollout.

## The pattern was already here — for someone else's binary

`SpeedTestService.VerifyOoklaSignature` pins the subject, then builds an `X509Chain` with online revocation, because — its own comment — *"subject alone is forgeable (anyone can issue a self-signed 'Ookla' cert)"*.

That asymmetry is the finding: the **downloaded third-party** Ookla CLI got pinned subject + full chain + revocation + fail-closed deletion, while **our own self-replacing, potentially-elevated update binary** got a log line. The two paths are now symmetric, and the code comment says so explicitly so they stay that way.

## Design choices

**`ExpectedSignerSubject` is a single `const`, empty while builds are unsigned.** Enabling signing becomes a one-line change rather than a security redesign under release pressure. Empty means "nothing to pin against yet", which keeps the signed branch permissive for exactly as long as that's true.

**Pinned on the organization substring, not a thumbprint.** Certificate renewal changes the thumbprint but not the subject — pinning the thumbprint would brick self-update for every user at renewal. This is the trade-off the issue flagged, resolved in favour of not breaking people.

**The chain build only runs in the signature-present branch.** So today's unsigned flow never touches the network and can't fail closed on an offline machine — the other risk the issue raised.

## Verification

Harness against a worktree of unfixed `main`: **6 failures, 4 passes**. The four passes are controls, and they matter more than usual here:

```
PASS  [control] an unsigned binary is still accepted
PASS  [control] a larger unsigned PE-ish file is still accepted
PASS  [control] an empty/unreadable file is still rejected
PASS  [control] SHA256 remains the real integrity gate
```

Tightening the signed branch must not block every current install — *"every update aborting with invalid digital signature"* is the precise bug this test file was originally written for. Branch: **10/10**.

## Tests, and one honest limitation

4 new. The signed-but-wrong-publisher case is asserted against the **shipped source** rather than executed, and I'd rather state that than dress it up: producing a genuinely signed binary with a controllable publisher needs a test certificate and `signtool`, which this unit-test project doesn't have. What *is* pinned mechanically is that the signed branch consults the pin **and** builds a chain with online revocation — either one alone is bypassable — plus that the const exists, is a literal, and is currently empty.

That last assertion is a deliberate **tripwire**: the day a certificate arrives, it fails, and it points straight at the tests that will then need real signed fixtures.

Main, unit-test and integration projects build **0 errors, 0 warnings**.

## Gate-DOCS

`SECURITY.md` described this check as *"not a publisher check"* — accurate before, stale now. It documents the pin, the chain policy, why the pin is empty today, and why SHA256 remains the integrity gate rather than a fallback (Authenticode inspection reads the signer cert; it doesn't validate the file against the signature).
