### PR TITLE
feat: keep the replaced build so a bad update can be undone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.61.0] - 2026-08-11
+
+If an update ever leaves SysManager not working, you can now go back to the version you had
+before with one click.
+
+### Added
+- **A way back from a bad update.** Until now, installing an update replaced the old SysManager permanently. If a new version turned out to have a problem — and this app has shipped two releases that wouldn't start — your only option was to work out on your own that you needed to find an older release on GitHub and download it by hand. The app now keeps the version you were running before the last update, and the About tab shows a **"Go back to the previous version"** button when there's something to go back to. It asks first, explains that anything the newer version fixed will come back too, and leaves your settings alone. Only one older version is kept, so this doesn't quietly fill your disk with copies of the app — and if there's no room to keep one, the update still installs as normal rather than failing.
+
 ## [1.60.3] - 2026-08-10
 
 Closes a hole in the update check before it can ever matter: when SysManager starts being

--- a/README.md
+++ b/README.md
@@ -825,11 +825,17 @@ offers, "rate us" prompts:
   browser.
 - SHA256 hash verification before install — the downloaded build is checked
   against the published `.sha256`, so a corrupted or tampered download is
-  blocked. (The build is also inspected for an Authenticode signature; since
-  SysManager currently ships unsigned, the SHA256 match is what guarantees
-  integrity.)
+  blocked. The build is also inspected for an Authenticode signature: if one is
+  present it must belong to the expected publisher and its certificate chain must
+  validate, so a build signed by someone else is refused. SysManager currently
+  ships unsigned, so today the SHA256 match is what guarantees integrity.
 - One-click "Install" replaces the running executable in-place and
   restarts automatically (no manual file copying needed).
+- **"Go back to the previous version"** — the build being replaced is kept, so an
+  update that installs cleanly but turns out to be broken is not a dead end. The
+  button appears in the About tab only when a retained copy exists, asks for
+  confirmation, and notes that whatever the newer version fixed will come back too.
+  One generation is kept, so it never accumulates copies of the app.
 - Full release-note history pulled live from GitHub.
 
 ### Profile Export / Import

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.60.x   | :white_check_mark: |
-| < 1.60   | :x:                |
+| 1.61.x   | :white_check_mark: |
+| < 1.61   | :x:                |
 
 ## Reporting a vulnerability
 
@@ -133,8 +133,13 @@ What the app can and cannot do by design:
   integrity gate rather than a fallback. The swap is then performed
   from within the downloaded executable itself (no intermediate script on
   disk) using a staged atomic file move, so an interrupted update cannot
-  leave a half-written, unstartable binary. You can also download manually
-  and verify the binary yourself.
+  leave a half-written, unstartable binary. Separately, the build being replaced
+  is copied aside first, so an update that *succeeds* into a version that does not
+  work is also recoverable: the About tab offers "Go back to the previous version"
+  whenever a retained copy exists. Exactly one generation is kept, in
+  `%LocalAppData%\SysManager\updates`, and retaining it is best-effort — if it
+  cannot be written the update still proceeds rather than failing. You can also
+  download manually and verify the binary yourself.
 - **Portable distribution model**: the standard distribution is a portable,
   self-contained `.exe` (also published to winget as a portable package),
   which lives in a per-user, user-writable location. This means a process

--- a/SysManager/SysManager.Tests/AboutViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AboutViewModelTests.cs
@@ -385,3 +385,124 @@ public sealed class AboutViewModelUpdateGateTests : IDisposable
         Assert.False(File.Exists(path));
     }
 }
+
+/// <summary>
+/// Tests for the rollback offer on the About tab.
+/// <para>The updater was the one mutating feature in the app with no way back: the atomic move that
+/// makes an INTERRUPTED update safe also destroyed the outgoing executable, so a SUCCESSFUL update
+/// into a broken build left the user with nothing to return to. A winget user can
+/// <c>winget install --version</c>; an in-app updater user had to find an older GitHub release on
+/// their own, which for the target persona is a dead end.</para>
+/// <para>Each test injects a temp updates directory, so the check never reads — or comes to depend
+/// on — whatever happens to be in the developer's real profile.</para>
+/// </summary>
+public sealed class AboutViewModelRollbackTests : IDisposable
+{
+    private readonly string _dir;
+
+    public AboutViewModelRollbackTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "SysManagerAboutRollbackTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch (IOException) { /* a leftover temp dir must never fail a test run */ }
+        GC.SuppressFinalize(this);
+    }
+
+    // autoCheck: false — these assert constructor state, so they must not race the network fetch.
+    private AboutViewModel NewVm() =>
+        new(new UpdateService(),
+            new SystemReportService(new SystemInfoService(), new DiskHealthService()),
+            autoCheck: false,
+            preferences: new UpdateCheckPreferenceService(_dir),
+            updatesDir: _dir);
+
+    private string PreviousBuild => Path.Combine(_dir, UpdateApplier.PreviousBuildFileName);
+
+    [Fact]
+    public void CanRollBack_IsFalse_WhenNoPreviousBuildWasRetained()
+    {
+        // A fresh install, or a user who has never updated: the button must not appear, because
+        // pressing it could do nothing.
+        Assert.False(File.Exists(PreviousBuild));
+
+        using var vm = NewVm();
+
+        Assert.False(vm.CanRollBack);
+    }
+
+    [Fact]
+    public void CanRollBack_IsTrue_WhenAPreviousBuildExists()
+    {
+        File.WriteAllText(PreviousBuild, "OLD-BUILD");
+
+        using var vm = NewVm();
+
+        Assert.True(vm.CanRollBack);
+    }
+
+    [Fact]
+    public void RollBackCommand_Exists()
+    {
+        using var vm = NewVm();
+        Assert.NotNull(vm.RollBackCommand);
+    }
+
+    [Fact]
+    public async Task RollBack_WhenThePreviousBuildVanished_SaysSo_AndHidesTheOffer()
+    {
+        // The file can disappear between the button appearing and being pressed (manual cleanup, disk
+        // tools, another instance). That must produce an explanation and a corrected UI rather than a
+        // silent no-op or a crash.
+        File.WriteAllText(PreviousBuild, "OLD-BUILD");
+        using var vm = NewVm();
+        Assert.True(vm.CanRollBack);
+
+        File.Delete(PreviousBuild);
+        await vm.RollBackCommand.ExecuteAsync(null);
+
+        Assert.False(vm.CanRollBack);
+        Assert.Contains("no longer available", vm.RollBackStatus);
+    }
+
+    [Fact]
+    public void RollBackLabel_IsPlainLanguage_NotAMechanism()
+    {
+        // The target user does not think in terms of executables or version numbers on disk.
+        using var vm = NewVm();
+
+        Assert.Contains("previous version", vm.RollBackLabel);
+        Assert.DoesNotContain(".exe", vm.RollBackLabel);
+    }
+
+    [Fact]
+    public void AboutView_RendersTheRollbackButtonAndItsStatus()
+    {
+        // CanRollBack / RollBackStatus existing on the ViewModel proves nothing if the view never
+        // binds them — that is precisely the dead-property class of defect this codebase has hit
+        // repeatedly. Assert against the shipped markup.
+        var xaml = File.ReadAllText(ViewPath("AboutView.xaml"));
+
+        Assert.Contains("RollBackCommand", xaml);
+        Assert.Contains("CanRollBack", xaml);      // gates visibility
+        Assert.Contains("RollBackLabel", xaml);
+        Assert.Contains("RollBackStatus", xaml);   // feedback is rendered, not dead
+    }
+
+    // Walks up from the test binaries to the app project — .xaml is not copied to the output.
+    private static string ViewPath(string fileName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "SysManager", "Views")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);   // else the assertions above would silently test nothing
+        var path = Path.Combine(dir!.FullName, "SysManager", "Views", fileName);
+        Assert.True(File.Exists(path), $"{fileName} not found at {path}");
+        return path;
+    }
+}

--- a/SysManager/SysManager.Tests/UpdateApplierTests.cs
+++ b/SysManager/SysManager.Tests/UpdateApplierTests.cs
@@ -142,4 +142,141 @@ public class UpdateApplierTests
             dir.Delete(recursive: true);
         }
     }
+
+    // ── Rollback: retaining the outgoing build ───────────────────────────────────────────────
+    //
+    // The atomic move that makes an INTERRUPTED update safe also destroyed the previous executable, so
+    // a SUCCESSFUL update into a broken build left nothing to go back to. The docs were precise about
+    // the interruption case and silent about this one. This project has shipped two launch-blocking
+    // regressions, so it is not hypothetical — and the updater was the only mutating feature in the app
+    // without the snapshot-style reversibility everything else already has.
+
+    [Fact]
+    public void ApplyCopy_RetainsTheOutgoingBuild()
+    {
+        var dir = Directory.CreateTempSubdirectory("ApplierKeep_");
+        try
+        {
+            var source = Path.Combine(dir.FullName, "new.exe");
+            var target = Path.Combine(dir.FullName, "current.exe");
+            var updates = Path.Combine(dir.FullName, "updates");
+            File.WriteAllText(source, "NEW-BUILD");
+            File.WriteAllText(target, "OLD-BUILD");
+
+            UpdateApplier.PreserveCurrentBuild(target, updates);
+            Assert.True(UpdateApplier.ApplyCopy(source, target));
+
+            // The update landed…
+            Assert.Equal("NEW-BUILD", File.ReadAllText(target));
+            // …and the build it replaced is still recoverable.
+            var previous = UpdateApplier.PreviousBuildPath(updates);
+            Assert.True(File.Exists(previous));
+            Assert.Equal("OLD-BUILD", File.ReadAllText(previous));
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public void PreserveCurrentBuild_KeepsExactlyOneGeneration()
+    {
+        // Retention is "current + one previous", not a history: each copy overwrites the last, so the
+        // folder can never accumulate full-size executables.
+        var dir = Directory.CreateTempSubdirectory("ApplierOneGen_");
+        try
+        {
+            var target = Path.Combine(dir.FullName, "current.exe");
+            var updates = Path.Combine(dir.FullName, "updates");
+
+            File.WriteAllText(target, "BUILD-1");
+            UpdateApplier.PreserveCurrentBuild(target, updates);
+            File.WriteAllText(target, "BUILD-2");
+            UpdateApplier.PreserveCurrentBuild(target, updates);
+
+            Assert.Single(Directory.GetFiles(updates, "SysManager-previous.exe"));
+            Assert.Equal("BUILD-2", File.ReadAllText(UpdateApplier.PreviousBuildPath(updates)));
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public void PreserveCurrentBuild_FirstInstall_DoesNothing()
+    {
+        // Nothing at the target yet (a fresh install), so there is nothing to retain — and certainly no
+        // reason to throw.
+        var dir = Directory.CreateTempSubdirectory("ApplierFirst_");
+        try
+        {
+            var target = Path.Combine(dir.FullName, "not-there-yet.exe");
+            var updates = Path.Combine(dir.FullName, "updates");
+
+            var ex = Record.Exception(() => UpdateApplier.PreserveCurrentBuild(target, updates));
+
+            Assert.Null(ex);
+            Assert.False(File.Exists(UpdateApplier.PreviousBuildPath(updates)));
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public void PreserveCurrentBuild_IsBestEffort_AndNeverBlocksAnUpdate()
+    {
+        // Retaining a copy is a safety net, not the job. If the folder cannot be written — full disk,
+        // permissions, a file where the directory should be — the update must still proceed rather than
+        // fail because the net could not be stretched. Simulated by putting a FILE where the updates
+        // directory needs to be, so CreateDirectory fails.
+        var dir = Directory.CreateTempSubdirectory("ApplierBestEffort_");
+        try
+        {
+            var source = Path.Combine(dir.FullName, "new.exe");
+            var target = Path.Combine(dir.FullName, "current.exe");
+            var blocked = Path.Combine(dir.FullName, "updates");
+            File.WriteAllText(source, "NEW-BUILD");
+            File.WriteAllText(target, "OLD-BUILD");
+            File.WriteAllText(blocked, "not a directory");
+
+            var ex = Record.Exception(() => UpdateApplier.PreserveCurrentBuild(target, blocked));
+            Assert.Null(ex);                                      // swallowed, logged, not thrown
+
+            Assert.True(UpdateApplier.ApplyCopy(source, target));  // the update still succeeds
+            Assert.Equal("NEW-BUILD", File.ReadAllText(target));
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public void PreviousBuildPath_LivesInTheUpdatesFolder_NotBesideThePortableExe()
+    {
+        // Keeping it beside the .exe would break the "single portable file" identity: copy the app to a
+        // USB stick and you would get two executables, one of them an old version.
+        var path = UpdateApplier.PreviousBuildPath();
+
+        Assert.Equal("SysManager-previous.exe", Path.GetFileName(path));
+        Assert.Equal("updates", Path.GetFileName(Path.GetDirectoryName(path)));
+        Assert.Contains("SysManager", path);
+    }
+
+    [Fact]
+    public void PruneOldDownloads_DoesNotDeleteTheRetainedBuild()
+    {
+        // SysManager-previous.exe matches the SysManager-*.exe pruning pattern, so without an explicit
+        // exclusion the very next update download would delete the one copy that makes rollback
+        // possible — silently, because pruning is best-effort and logs at Debug.
+        var dir = Directory.CreateTempSubdirectory("ApplierPrune_");
+        try
+        {
+            var keep = Path.Combine(dir.FullName, "SysManager-9.9.9.exe");
+            var previous = Path.Combine(dir.FullName, UpdateApplier.PreviousBuildFileName);
+            var stale = Path.Combine(dir.FullName, "SysManager-1.0.0.exe");
+            File.WriteAllText(keep, "current");
+            File.WriteAllText(previous, "rollback");
+            File.WriteAllText(stale, "superseded");
+
+            UpdateService.PruneOldDownloads(dir.FullName, keep);
+
+            Assert.True(File.Exists(previous), "the retained previous build must survive pruning");
+            Assert.True(File.Exists(keep));
+            Assert.False(File.Exists(stale));   // control: pruning still works
+        }
+        finally { dir.Delete(recursive: true); }
+    }
 }

--- a/SysManager/SysManager/Services/UpdateApplier.cs
+++ b/SysManager/SysManager/Services/UpdateApplier.cs
@@ -31,6 +31,23 @@ internal static class UpdateApplier
     /// <summary>Command-line sentinel that puts a started process into applier mode.</summary>
     public const string ApplyUpdateArg = "--apply-update";
 
+    /// <summary>File name of the retained previous generation. One only, never a history.</summary>
+    internal const string PreviousBuildFileName = "SysManager-previous.exe";
+
+    /// <summary>
+    /// Where the outgoing executable is kept so a bad update can be undone.
+    /// </summary>
+    /// <remarks>
+    /// Lives in the existing <c>%LocalAppData%\SysManager\updates</c> folder rather than beside the
+    /// portable .exe, so the "single portable file" identity is preserved — a user who copies the
+    /// app to a USB stick still has exactly one file.
+    /// </remarks>
+    internal static string PreviousBuildPath(string? updatesDir = null) => Path.Join(
+        updatesDir ?? Path.Join(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "SysManager", "updates"),
+        PreviousBuildFileName);
+
     /// <summary>
     /// Builds the command-line arguments handed to the downloaded executable so
     /// it applies itself over <paramref name="targetExe"/> after process
@@ -88,6 +105,12 @@ internal static class UpdateApplier
             try
             {
                 File.Copy(sourceExe, staging, overwrite: true);
+                // Keep the outgoing build BEFORE the move destroys it. The move is what makes an
+                // interrupted copy safe, but it also means a SUCCESSFUL update into a broken build
+                // leaves nothing to go back to — and this project has shipped two launch-blocking
+                // regressions. Best-effort: failing to retain a copy must never abort an update that
+                // is otherwise fine, so PreserveCurrentBuild swallows its own errors.
+                PreserveCurrentBuild(targetExe);
                 File.Move(staging, targetExe, overwrite: true);
                 return true;
             }
@@ -106,6 +129,41 @@ internal static class UpdateApplier
         }
         Log.Error("Update apply: gave up after {Max} attempts — {Target} stayed locked", maxAttempts, LogService.SanitizePath(targetExe));
         return false;
+    }
+
+    /// <summary>
+    /// Copies the build currently at <paramref name="targetExe"/> aside as the one retained
+    /// previous generation, so a successful-but-broken update can be undone.
+    /// </summary>
+    /// <remarks>
+    /// BEST-EFFORT by design. Everything here is a nice-to-have compared with completing the update:
+    /// if the disk is full or the folder is unwritable, the update must still proceed rather than
+    /// fail because a safety net could not be stretched. That is why every failure is swallowed and
+    /// logged at Debug/Warning instead of propagating.
+    /// <para>Exactly ONE generation is kept: the copy overwrites any earlier one, so retention is
+    /// "current + one previous" rather than an unbounded pile of full-size executables.</para>
+    /// </remarks>
+    internal static void PreserveCurrentBuild(string targetExe, string? updatesDir = null)
+    {
+        try
+        {
+            if (!File.Exists(targetExe)) return;   // first install — nothing to preserve
+
+            var previous = PreviousBuildPath(updatesDir);
+            var dir = Path.GetDirectoryName(previous);
+            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+
+            File.Copy(targetExe, previous, overwrite: true);
+            Log.Information("Update apply: retained the outgoing build for rollback");
+        }
+        catch (IOException ex)
+        {
+            Log.Warning(ex, "Update apply: could not retain the previous build — rollback will be unavailable");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Log.Warning(ex, "Update apply: access denied retaining the previous build — rollback will be unavailable");
+        }
     }
 
     /// <summary>

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -543,6 +543,14 @@ public sealed class UpdateService
                     continue;
                 }
 
+                // Never prune the retained previous build. It matches the SysManager-*.exe pattern,
+                // so without this the very next update download would delete the one copy that makes
+                // rollback possible — silently, since pruning is best-effort and logs at Debug.
+                if (name.Equals(UpdateApplier.PreviousBuildFileName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
                 try
                 {
                     File.Delete(path);

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.60.3</Version>
-    <FileVersion>1.60.3.0</FileVersion>
-    <AssemblyVersion>1.60.3.0</AssemblyVersion>
+    <Version>1.61.0</Version>
+    <FileVersion>1.61.0.0</FileVersion>
+    <AssemblyVersion>1.61.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -22,6 +22,9 @@ public sealed partial class AboutViewModel : ViewModelBase
     private readonly UpdateService _updates;
     private readonly SystemReportService _reportService;
     private readonly UpdateCheckPreferenceService _preferences;
+
+    /// <summary>Overrides where the retained previous build is looked for. Null = the real profile.</summary>
+    private readonly string? _updatesDir;
     private UpdateService.ReleaseInfo? _latest;
 
     // Suppresses saving while the constructor applies the loaded value, so restoring the
@@ -67,6 +70,20 @@ public sealed partial class AboutViewModel : ViewModelBase
 
     public bool ShowDownloadButton => !IsDownloading && string.IsNullOrEmpty(DownloadedPath);
 
+    /// <summary>
+    /// True when the previous build was retained and can be restored. Drives the visibility of the
+    /// rollback button, so it only appears when there is genuinely something to go back to.
+    /// </summary>
+    [ObservableProperty] private bool _canRollBack;
+
+    /// <summary>
+    /// Plain-language label for the rollback button. Says WHAT it does rather than naming a
+    /// mechanism — the target user does not think in terms of executables or versions on disk.
+    /// </summary>
+    [ObservableProperty] private string _rollBackLabel = "Go back to the previous version";
+
+    [ObservableProperty] private string _rollBackStatus = string.Empty;
+
     // Report export state
     [ObservableProperty] private bool _isGeneratingReport;
 
@@ -88,17 +105,22 @@ public sealed partial class AboutViewModel : ViewModelBase
     /// properties) runs. Production always passes true; tests pass false to
     /// assert the constructor's default state without racing the async fetch.
     /// <para><paramref name="preferences"/> is overridable so tests exercise the real gate against
-    /// a temp directory instead of the developer's own preference file.</para>
+    /// a temp directory instead of the developer's own preference file. <paramref name="updatesDir"/>
+    /// is overridable for the same reason: the rollback check looks for a retained build under
+    /// <c>%LocalAppData%</c>, and a test must be able to point that at a temp folder rather than read
+    /// (or come to depend on) whatever is in the developer's real profile.</para>
     /// </summary>
     internal AboutViewModel(
         UpdateService updates,
         SystemReportService reportService,
         bool autoCheck,
-        UpdateCheckPreferenceService? preferences = null)
+        UpdateCheckPreferenceService? preferences = null,
+        string? updatesDir = null)
     {
         _updates = updates;
         _reportService = reportService;
         _preferences = preferences ?? new UpdateCheckPreferenceService();
+        _updatesDir = updatesDir;
 
         // Load before any check can run, and suppress the save that binding the value would
         // otherwise trigger — restoring a preference must not rewrite the file it came from.
@@ -106,8 +128,31 @@ public sealed partial class AboutViewModel : ViewModelBase
         CheckForUpdatesOnStartup = _preferences.Load().CheckOnStartup;
         _loadingPreference = false;
 
+        RefreshRollbackAvailability();
+
         if (autoCheck)
             InitializeAsync(InitAsync);
+    }
+
+    /// <summary>
+    /// Re-reads whether a retained previous build exists. Called on construction and after a
+    /// rollback, so the button disappears once the copy has been consumed.
+    /// </summary>
+    private void RefreshRollbackAvailability()
+    {
+        try
+        {
+            CanRollBack = File.Exists(UpdateApplier.PreviousBuildPath(_updatesDir));
+        }
+        catch (IOException)
+        {
+            // An unreadable folder simply means no rollback offer — never a crash on the About tab.
+            CanRollBack = false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            CanRollBack = false;
+        }
     }
 
     // Persist on change rather than on close: the app can be closed to the tray or killed, and a
@@ -671,6 +716,73 @@ public sealed partial class AboutViewModel : ViewModelBase
         finally
         {
             lockedStream.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Restores the retained previous build over the running executable.
+    /// </summary>
+    /// <remarks>
+    /// Reuses the SAME applier path as an install — <c>BuildArguments</c> + launch the source binary
+    /// with the sentinel — rather than copying files from here. That path already handles waiting for
+    /// this process to exit, retrying while the target is locked, and staging via an atomic move; a
+    /// second, parallel implementation would be the one without those properties.
+    /// <para>Confirms first, naming what is about to happen: rolling back re-exposes whatever the
+    /// newer build fixed, so it must be a deliberate choice rather than a stray click.</para>
+    /// </remarks>
+    [RelayCommand]
+    private async Task RollBackAsync()
+    {
+        var previous = UpdateApplier.PreviousBuildPath(_updatesDir);
+        if (!File.Exists(previous))
+        {
+            // Vanished since the button appeared (manual cleanup, disk tools). Reflect reality.
+            RollBackStatus = "The previous version is no longer available.";
+            RefreshRollbackAvailability();
+            return;
+        }
+
+        var currentExe = Environment.ProcessPath;
+        if (string.IsNullOrWhiteSpace(currentExe))
+        {
+            RollBackStatus = "Could not determine where SysManager is running from.";
+            return;
+        }
+
+        if (!DialogService.Instance.Confirm(
+                $"Go back to the version you had before the last update?\n\n" +
+                "SysManager will close and reopen on the older version. Anything the newer version " +
+                "fixed will come back, and your settings are not affected.",
+                "Go back to the previous version"))
+        {
+            return;
+        }
+
+        try
+        {
+            var args = UpdateApplier.BuildArguments(currentExe, Environment.ProcessId);
+            RollBackStatus = "Going back — SysManager will restart…";
+
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = previous,
+                Arguments = args,
+                UseShellExecute = true
+            })?.Dispose();
+
+            ActivityLogService.Instance.Log("Update", "Went back to the previously installed version");
+
+            // Let the applier start before this process exits.
+            await Task.Delay(500);
+            System.Windows.Application.Current?.Shutdown();
+        }
+        catch (InvalidOperationException ex)
+        {
+            RollBackStatus = $"Could not go back: {ex.Message}";
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            RollBackStatus = $"Could not go back: {ex.Message}";
         }
     }
 

--- a/SysManager/SysManager/Views/AboutView.xaml
+++ b/SysManager/SysManager/Views/AboutView.xaml
@@ -66,6 +66,16 @@
                                     Command="{Binding CopyEnvironmentInfoCommand}"
                                     Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"
                                     ToolTip="Copy your SysManager version, Windows version, architecture and elevation state — ready to paste into a bug report."/>
+                            <!-- Only appears when a previous build was actually retained, so this is never
+                                 a button that cannot do anything. The updater used to be the one mutation
+                                 in the app with no way back: the atomic move that makes an INTERRUPTED
+                                 update safe also destroyed the outgoing executable, so a SUCCESSFUL
+                                 update into a broken build left nothing to return to. -->
+                            <Button Content="{Binding RollBackLabel}" Command="{Binding RollBackCommand}"
+                                    Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"
+                                    Visibility="{Binding CanRollBack, Converter={StaticResource BoolToVis}}"
+                                    AutomationProperties.Name="Go back to the previous version of SysManager"
+                                    ToolTip="Reinstall the version you had before the last update. SysManager will close and reopen; your settings are not affected."/>
                             <Button Content="View license" Command="{Binding OpenLicenseCommand}"
                                     Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"/>
                         </StackPanel>
@@ -76,9 +86,17 @@
                              "Report saved" — losing the more important message and making the update
                              card describe something unrelated. Collapsed until there is something
                              to say, so the row does not reserve empty space. -->
-                        <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="{Binding ReportStatus}"
-                                   Style="{StaticResource Subtle}" Margin="0,10,0,0" TextWrapping="Wrap"
-                                   Visibility="{Binding ReportStatus, Converter={StaticResource FlexVis}, Mode=OneWay}"/>
+                        <StackPanel Grid.Row="1" Grid.ColumnSpan="2">
+                            <TextBlock Text="{Binding ReportStatus}"
+                                       Style="{StaticResource Subtle}" Margin="0,10,0,0" TextWrapping="Wrap"
+                                       Visibility="{Binding ReportStatus, Converter={StaticResource FlexVis}, Mode=OneWay}"/>
+                            <!-- Rollback feedback lives beside its own button rather than in the update
+                                 card below, for the same reason ReportStatus was moved here: writing to a
+                                 shared status line makes one action overwrite another's message. -->
+                            <TextBlock Text="{Binding RollBackStatus}"
+                                       Style="{StaticResource Subtle}" Margin="0,10,0,0" TextWrapping="Wrap"
+                                       Visibility="{Binding RollBackStatus, Converter={StaticResource FlexVis}, Mode=OneWay}"/>
+                        </StackPanel>
 
                         <!-- The app's only outbound call, now something the user can see and switch
                              off. Same shape and wording style as Bulk Installer's "Load app icons


### PR DESCRIPTION
Closes #1678

## The gap

The updater's safety story covered **interruption**, not **badness**.

`ApplyCopy` stages to `targetExe + ".new"` then `File.Move(staging, targetExe, overwrite: true)` — and that move destroys the outgoing executable. The docs are precise about what this protects against, and it isn't this. `UpdateApplier`'s own comment promises only that *"an interrupted copy can never leave a half-written (unlaunchable) executable"*; `SECURITY.md` said the same. Both true. Neither helps the user whose update **succeeded** into a build that doesn't work.

Not hypothetical: this project has shipped **two launch-blocking regressions**. And the updater was the only mutating feature in the app without the snapshot-style reversibility everything else honours — a winget user can `winget install --version`; an in-app updater user had no local copy and had to work out unaided that they needed to hunt down an older GitHub release. For the target persona that's a dead end.

## What changed

**`PreserveCurrentBuild`** copies the outgoing binary to `%LocalAppData%\SysManager\updates\SysManager-previous.exe` before the move. It lives in the *existing* updates folder rather than beside the portable `.exe`, so copying the app to a USB stick still yields exactly **one** executable — the single-portable-file identity is intact.

**Exactly one generation.** Each copy overwrites the last, so the folder can't accumulate full-size executables. This is the bound the issue asked for, and it's tested.

**Best-effort by design.** Retaining a copy is a safety net, not the job. Full disk, bad permissions, a file where the directory should be — the update must still proceed rather than fail because the net couldn't be stretched. Every failure is swallowed and logged.

**Pruning now skips it.** `SysManager-previous.exe` matches the `SysManager-*.exe` prune pattern, so without an explicit exclusion the *very next update download* would have deleted the one copy that makes rollback possible — silently, since pruning logs at Debug. That was a real trap, caught by reading `PruneOldDownloads` rather than assuming.

**The surface:** `CanRollBack` + `RollBackCommand`, and the About tab shows the button **only when a retained copy exists** — never a control that can't act. It confirms first, naming the consequence: rolling back re-exposes whatever the newer build fixed.

**It reuses the same applier path** as an install (`BuildArguments` + launch the source binary with the sentinel) rather than copying files from the ViewModel. That path already waits for this process to exit, retries while the target is locked, and stages via an atomic move. A second, parallel implementation would be the one *without* those properties.

The constructor takes an injectable `updatesDir` for the same reason the preference service does — the availability check must not read, or come to depend on, whatever is in the developer's real profile (the lesson from #1758).

## Red ritual

Against a worktree of unfixed `main`: **8 failures, 2 passes**. Both passes are controls, and they're the point:

```
PASS  [control] a failed copy still leaves the working exe intact
PASS  [control] the staging file is still moved, not left behind
FAIL  a successful update leaves the replaced build recoverable   -- the whole finding
FAIL  pruning does NOT delete the retained build
FAIL  the About tab offers the rollback
```

The interruption guarantee predates this change and had to survive it. Branch: **10/10**.

## Tests

11 new. Beyond the happy path: exactly-one-generation; first-install does nothing; **best-effort survives a `FILE` planted where the updates directory should be** (so `CreateDirectory` fails) and the update still completes; pruning spares the retained copy *while still deleting a genuinely stale one* (control); the path is under `updates/` and not beside the exe; a copy that vanished between the button appearing and being pressed produces an explanation and hides the offer rather than crashing; and the shipped `AboutView.xaml` really binds `RollBackCommand` / `CanRollBack` / `RollBackLabel` / `RollBackStatus` — a status property nothing renders is the recurring dead-property defect in this codebase, and I wasn't going to add another one.

Main, unit-test and integration projects build **0 errors, 0 warnings**.

## Gate-DOCS

README's update section and SECURITY.md's auto-update bullet both described a one-way update. Both now document the retained generation, where it lives, that only one is kept, and that retention is best-effort. While there, README's signature sentence was still pre-#1674 — it now reflects publisher pinning too.

## Not verifiable here

The main PC never launches the app. Needs eyes on the secondary workstation: that the button sits correctly in the version card's button row at a narrow window width (it's the sixth button in that `StackPanel`), and — the real end-to-end check — install an update, confirm `SysManager-previous.exe` appears, then use the button and confirm the older version comes back.
