### PR TITLE
fix: give the watchdog and dark-mode schedule a redirectable config path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.61.1] - 2026-08-11
+
+Two more of the project's own tests can no longer touch your real settings: the Settings
+Watchdog baseline and the dark-mode schedule.
+
+### Fixed
+- **Two more places where running the tests could overwrite your own files.** This only affects people who build and test SysManager themselves, not normal use — but it is the same problem that was fixed for app icons in 1.60.1, and it is worth closing properly. The Settings Watchdog keeps a snapshot of your chosen Windows settings, and the Dark Mode scheduler keeps your on/off times; both were stored at a location the tests had no way to redirect, so a test that saved a baseline or a schedule wrote over yours. Both now accept a scratch folder, and every test uses one. The dark-mode schedule stays exactly where it has always been for real users, so nothing of yours moves.
+
 ## [1.60.3] - 2026-08-10
 
 Closes a hole in the update check before it can ever matter: when SysManager starts being

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -81,21 +81,26 @@ public class ArchitectureTests
     public void Services_DoNotHoldUserDataPathsInStaticFields()
     {
         // Known offenders, kept ONLY so this ratchet could be added without a repo-wide refactor in one
-        // change. Of these, SettingsWatchdogService, ThemeService and WindowsThemeService are referenced
-        // by tests today, so they carry the same latent risk SpeedTestHistoryService realised;
-        // LogService is not test-exercised.
+        // change. Removing a name from this list is the goal — tracked in issue #1741. FOUR have come
+        // off so far:
+        //   · ActivityLogService — when the destructive operations started logging, a test asserting
+        //     they do would otherwise have written into the user's own activity history.
+        //   · AppIconService — not latent at all: five tests called SetNetworkFetchEnabled, which
+        //     persists, so the suite overwrote the user's real icon-fetch preference every run (#1758).
+        //   · SettingsWatchdogService and WindowsThemeService — both constructed concretely by tests,
+        //     both now behind the shared `string? configDir = null` seam.
         //
-        // Removing a name from this list is the goal — tracked in issue #1741. Two have come off so far:
-        // ActivityLogService, when the destructive operations started logging (a test asserting they do
-        // would otherwise have written into the user's own activity history), and AppIconService, whose
-        // case was not latent at all — five tests called SetNetworkFetchEnabled, which persists, so the
-        // suite overwrote the user's real icon-fetch preference on every run (#1758). Four to go.
+        // The two that remain are the two hard ones, and they are hard for different reasons:
+        //   · ThemeService is heavily static (20 static members) and is reached from XAML resource
+        //     resolution, so a constructor seam is a wider refactor than a path change.
+        //   · LogService is a `static partial class` by design — Serilog's sink is configured once per
+        //     process — so it has no instance to hang a seam on. It is also the only one no test
+        //     constructs, so its risk is the lowest of the set.
+        // Both need a design decision rather than a mechanical edit; neither is touched here.
         string[] known =
         [
             "LogService.<LogDir>k__BackingField",
-            "SettingsWatchdogService.BaselinePath",
             "ThemeService.SettingsPath",
-            "WindowsThemeService.SchedulePath",
         ];
 
         var profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);

--- a/SysManager/SysManager.Tests/DarkModeViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DarkModeViewModelTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using NSubstitute;
+using System.IO;
 using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
@@ -25,7 +26,12 @@ namespace SysManager.Tests;
 /// </summary>
 public class DarkModeViewModelTests
 {
-    private static DarkModeViewModel NewVm() => new(new WindowsThemeService());
+    // A TEMP configDir, so constructing the service never reads (or writes) the user's real
+    // %AppData%\SysManager\darkmode-schedule.json. The registry reads below are read-only and stay.
+    private static WindowsThemeService NewRealService() =>
+        new(Path.Combine(Path.GetTempPath(), "SysManagerDarkModeTests", Guid.NewGuid().ToString("N")));
+
+    private static DarkModeViewModel NewVm() => new(NewRealService());
 
     private static DarkModeViewModel NewVm(IWindowsThemeService service) => new(service);
 
@@ -60,7 +66,7 @@ public class DarkModeViewModelTests
     {
         var vm = NewVm();
         // The VM seeds IsDarkNow from the live registry read; it must agree with a direct query.
-        bool live = new WindowsThemeService().GetCurrentTheme() == WindowsTheme.Dark;
+        bool live = NewRealService().GetCurrentTheme() == WindowsTheme.Dark;
         Assert.Equal(live, vm.IsDarkNow);
     }
 

--- a/SysManager/SysManager.Tests/SettingsWatchdogServiceTests.cs
+++ b/SysManager/SysManager.Tests/SettingsWatchdogServiceTests.cs
@@ -2,13 +2,37 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using SysManager.Models;
 using SysManager.Services;
 
 namespace SysManager.Tests;
 
-public class SettingsWatchdogServiceTests
+public sealed class SettingsWatchdogServiceTests : IDisposable
 {
+    private readonly string _dir;
+
+    public SettingsWatchdogServiceTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "SysManagerWatchdogTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); }
+        catch (DirectoryNotFoundException) { /* already gone — nothing to clean up */ }
+    }
+
+    /// <summary>
+    /// Always built against a TEMP directory. With the default, the service resolves
+    /// <c>%LocalAppData%\SysManager\settings-baseline.json</c> — the user's real baseline — and
+    /// SaveBaseline would overwrite it. Never construct this service in a test without a configDir.
+    /// </summary>
+    private SettingsWatchdogService NewService() => new(_dir);
+
+    private string BaselineFile => Path.Combine(_dir, "settings-baseline.json");
+
     private static WatchedSetting Setting(string key, params (int, string)[] labels)
         => new(key, $"Name {key}", $"Desc {key}", "Cat", $@"HKCU\Software\Test\{key}", "Val",
             labels.ToDictionary(l => l.Item1, l => l.Item2));
@@ -89,7 +113,7 @@ public class SettingsWatchdogServiceTests
     [Fact]
     public void Catalog_IsNonEmpty_WithUniqueKeys()
     {
-        var svc = new SettingsWatchdogService();
+        var svc = NewService();
         Assert.NotEmpty(svc.Catalog);
         var keys = svc.Catalog.Select(s => s.Key).ToList();
         Assert.Equal(keys.Count, keys.Distinct().Count());
@@ -98,7 +122,7 @@ public class SettingsWatchdogServiceTests
     [Fact]
     public void Catalog_EverySettingHasNameAndRegistryPath()
     {
-        var svc = new SettingsWatchdogService();
+        var svc = NewService();
         Assert.All(svc.Catalog, s =>
         {
             Assert.False(string.IsNullOrWhiteSpace(s.Name));
@@ -118,7 +142,7 @@ public class SettingsWatchdogServiceTests
         // its own curated catalog. A hand-built drift pointing at an arbitrary registry
         // path must be refused BEFORE any registry write — so this returns false without
         // ever touching the registry (the path below is never opened).
-        var svc = new SettingsWatchdogService();
+        var svc = NewService();
         var rogue = new WatchedSetting(
             "rogue", "Rogue", "Not in catalog", "Cat",
             @"HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run", "Evil",
@@ -131,10 +155,82 @@ public class SettingsWatchdogServiceTests
     [Fact]
     public void Restore_NonRestorableOrNoBaseline_ReturnsFalse()
     {
-        var svc = new SettingsWatchdogService();
+        var svc = NewService();
         var known = svc.Catalog[0];
         // CanRestore=false and null baseline are both early-out false paths.
         Assert.False(svc.Restore(new SettingDrift(known, BaselineValue: 1, CurrentValue: 0, CanRestore: false)));
         Assert.False(svc.Restore(new SettingDrift(known, BaselineValue: null, CurrentValue: 0, CanRestore: true)));
+    }
+
+    // ── configDir seam ───────────────────────────────────────────────────────────────────────
+    //
+    // The baseline path used to be `static readonly` under %LocalAppData%. Environment.GetFolderPath
+    // resolves through the Win32 known-folder API and ignores the LOCALAPPDATA environment variable,
+    // so no test could redirect it — meaning any test calling SaveBaseline would overwrite the user's
+    // own saved baseline. Realised twice already in this codebase: SpeedTestHistoryService's tests
+    // deleted the user's speed-test history, and AppIconService's overwrote a real setting on every
+    // run (#1758). Tracked by ArchitectureTests.Services_DoNotHoldUserDataPathsInStaticFields.
+
+    [Fact]
+    public void SaveBaseline_WritesInsideTheGivenConfigDir()
+    {
+        Assert.False(File.Exists(BaselineFile));
+
+        NewService().SaveBaseline(new DateTime(2026, 3, 1, 12, 0, 0));
+
+        Assert.True(File.Exists(BaselineFile));
+    }
+
+    [Fact]
+    public void HasBaseline_ReflectsTheGivenConfigDir()
+    {
+        var svc = NewService();
+        Assert.False(svc.HasBaseline);
+
+        svc.SaveBaseline(new DateTime(2026, 3, 1, 12, 0, 0));
+
+        Assert.True(NewService().HasBaseline);
+    }
+
+    [Fact]
+    public void LoadBaseline_RoundTripsWhatWasSaved()
+    {
+        // Persistence is the feature — the whole point of a baseline is that it survives a restart.
+        var takenAt = new DateTime(2026, 3, 1, 12, 0, 0);   // fixed: never DateTime.Now
+        var saved = NewService().SaveBaseline(takenAt);
+
+        var loaded = NewService().LoadBaseline();
+
+        Assert.NotNull(loaded);
+        Assert.Equal(takenAt, loaded!.TakenAt);
+        Assert.Equal(saved.Count, loaded.Values.Count);
+    }
+
+    [Fact]
+    public void TwoServicesWithDifferentConfigDirs_DoNotShareABaseline()
+    {
+        // Proves the path is genuinely per-instance. If it were still static, the second service would
+        // see the first one's baseline — which is exactly the coupling that let a test reach the real
+        // profile.
+        var otherDir = Path.Combine(Path.GetTempPath(), "SysManagerWatchdogTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(otherDir);
+        try
+        {
+            NewService().SaveBaseline(new DateTime(2026, 3, 1, 12, 0, 0));
+
+            Assert.False(new SettingsWatchdogService(otherDir).HasBaseline);
+            Assert.True(NewService().HasBaseline);
+        }
+        finally { Directory.Delete(otherDir, recursive: true); }
+    }
+
+    [Fact]
+    public void LoadBaseline_MalformedFile_ReturnsNull_RatherThanThrowing()
+    {
+        // Persisted state is a trust boundary: a corrupt file must degrade to "no baseline", not crash
+        // the tab.
+        File.WriteAllText(BaselineFile, "{ this is not json");
+
+        Assert.Null(NewService().LoadBaseline());
     }
 }

--- a/SysManager/SysManager/Services/SettingsWatchdogService.cs
+++ b/SysManager/SysManager/Services/SettingsWatchdogService.cs
@@ -21,9 +21,29 @@ namespace SysManager.Services;
 /// </summary>
 public sealed class SettingsWatchdogService : ISettingsWatchdogService
 {
-    private static readonly string BaselinePath = Path.Join(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "SysManager", "settings-baseline.json");
+    // Instance, not static readonly. Environment.GetFolderPath resolves through the Win32
+    // known-folder API and ignores the LOCALAPPDATA environment variable, so a static path cannot be
+    // redirected by any test — not even one in a child process. SpeedTestHistoryService held its path
+    // that way and its tests deleted the user's real speed-test history; AppIconService did the same
+    // and its tests overwrote a real setting on every run (#1758). See
+    // ArchitectureTests.Services_DoNotHoldUserDataPathsInStaticFields.
+    private readonly string _baselinePath;
+
+    /// <summary>
+    /// Creates the service.
+    /// </summary>
+    /// <param name="configDir">
+    /// Where the baseline snapshot lives. Null uses <c>%LocalAppData%\SysManager</c>, which is
+    /// correct in production; tests MUST pass a temp directory, or they read and write the user's
+    /// real baseline.
+    /// </param>
+    public SettingsWatchdogService(string? configDir = null)
+    {
+        _baselinePath = Path.Join(
+            configDir ?? Path.Join(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager"),
+            "settings-baseline.json");
+    }
 
     /// <summary>The catalog of settings the watchdog tracks. Stable order for the UI.</summary>
     public IReadOnlyList<WatchedSetting> Catalog { get; } = BuildCatalog();
@@ -50,8 +70,8 @@ public sealed class SettingsWatchdogService : ISettingsWatchdogService
     {
         try
         {
-            if (!File.Exists(BaselinePath)) return null;
-            var snapshot = JsonSerializer.Deserialize<BaselineSnapshot>(File.ReadAllText(BaselinePath));
+            if (!File.Exists(_baselinePath)) return null;
+            var snapshot = JsonSerializer.Deserialize<BaselineSnapshot>(File.ReadAllText(_baselinePath));
             // A baseline file that parses as JSON but omits the "Values" property deserializes
             // with Values == null (System.Text.Json does not enforce non-null on positional
             // record params). Normalize it to an empty map so downstream diffing never NREs on
@@ -65,7 +85,7 @@ public sealed class SettingsWatchdogService : ISettingsWatchdogService
         }
     }
 
-    public bool HasBaseline => File.Exists(BaselinePath);
+    public bool HasBaseline => File.Exists(_baselinePath);
 
     /// <summary>
     /// Compares the saved baseline against the live system and returns the drifted settings.
@@ -178,12 +198,13 @@ public sealed class SettingsWatchdogService : ISettingsWatchdogService
         return writable ? hive.CreateSubKey(subPath, writable: true) : hive.OpenSubKey(subPath, writable: false);
     }
 
-    private static void Persist(BaselineSnapshot snapshot)
+    // Instance, because the baseline path is now per-instance (the configDir seam).
+    private void Persist(BaselineSnapshot snapshot)
     {
         try
         {
-            Directory.CreateDirectory(Path.GetDirectoryName(BaselinePath)!);
-            File.WriteAllText(BaselinePath, JsonSerializer.Serialize(snapshot, JsonDefaults.Indented));
+            Directory.CreateDirectory(Path.GetDirectoryName(_baselinePath)!);
+            File.WriteAllText(_baselinePath, JsonSerializer.Serialize(snapshot, JsonDefaults.Indented));
         }
         catch (IOException ex) { Log.Debug("Settings baseline save failed: {Error}", ex.Message); }
         catch (UnauthorizedAccessException ex) { Log.Debug("Settings baseline save denied: {Error}", ex.Message); }

--- a/SysManager/SysManager/Services/WindowsThemeService.cs
+++ b/SysManager/SysManager/Services/WindowsThemeService.cs
@@ -32,9 +32,28 @@ public sealed partial class WindowsThemeService : IWindowsThemeService
     private const string AppsValue = "AppsUseLightTheme";
     private const string SystemValue = "SystemUsesLightTheme";
 
-    private static readonly string SchedulePath = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-        "SysManager", "darkmode-schedule.json");
+    // Instance, not static readonly: Environment.GetFolderPath goes through the Win32 known-folder
+    // API and ignores the APPDATA environment variable, so a static path is unredirectable by any
+    // test. See ArchitectureTests.Services_DoNotHoldUserDataPathsInStaticFields — the realised
+    // consequences were SpeedTestHistoryService's tests deleting the user's history and
+    // AppIconService's overwriting a real setting every run (#1758).
+    private readonly string _schedulePath;
+
+    /// <summary>
+    /// Creates the service.
+    /// </summary>
+    /// <param name="configDir">
+    /// Where the dark-mode schedule lives. Null uses <c>%AppData%\SysManager</c> — note ROAMING, not
+    /// Local, which is where this file has always lived; changing that would strand an existing
+    /// user's schedule. Tests MUST pass a temp directory.
+    /// </param>
+    public WindowsThemeService(string? configDir = null)
+    {
+        _schedulePath = Path.Combine(
+            configDir ?? Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "SysManager"),
+            "darkmode-schedule.json");
+    }
 
     /// <summary>Read the current Windows app theme (absent value = Light, the OS default).</summary>
     public WindowsTheme GetCurrentTheme()
@@ -80,9 +99,9 @@ public sealed partial class WindowsThemeService : IWindowsThemeService
     {
         try
         {
-            if (File.Exists(SchedulePath))
+            if (File.Exists(_schedulePath))
             {
-                string json = File.ReadAllText(SchedulePath);
+                string json = File.ReadAllText(_schedulePath);
                 var s = JsonSerializer.Deserialize<DarkModeSchedule>(json);
                 if (s is not null) return s;
             }
@@ -98,9 +117,9 @@ public sealed partial class WindowsThemeService : IWindowsThemeService
     {
         try
         {
-            Directory.CreateDirectory(Path.GetDirectoryName(SchedulePath)!);
+            Directory.CreateDirectory(Path.GetDirectoryName(_schedulePath)!);
             string json = JsonSerializer.Serialize(schedule, JsonDefaults.Indented);
-            File.WriteAllText(SchedulePath, json);
+            File.WriteAllText(_schedulePath, json);
         }
         catch (IOException ex) { Log.Warning("Dark-mode schedule save failed: {Error}", ex.Message); }
         catch (UnauthorizedAccessException ex) { Log.Warning("Dark-mode schedule save denied: {Error}", ex.Message); }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.60.3</Version>
-    <FileVersion>1.60.3.0</FileVersion>
-    <AssemblyVersion>1.60.3.0</AssemblyVersion>
+    <Version>1.61.1</Version>
+    <FileVersion>1.61.1.0</FileVersion>
+    <AssemblyVersion>1.61.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Partially addresses #1741 — takes the ratchet from **4 remaining to 2**.

## What was wrong

Two more services held their user-data path in `static readonly` state built from `Environment.GetFolderPath`, which resolves through the Win32 known-folder API and **ignores** the `LOCALAPPDATA` / `APPDATA` environment variables. No test can redirect that — not even one in a child process. So a test calling `SaveBaseline` or `SaveSchedule` wrote over the user's own file.

Both are constructed **concretely** by tests today (`SettingsWatchdogService` ×4, `WindowsThemeService` ×2), which is the same shape that has already been realised twice here: `SpeedTestHistoryService`'s tests deleted the user's speed-test history, and `AppIconService`'s overwrote a real setting on every run (#1758).

## The fix

The same `string? configDir = null` seam the persistence services already share. Every test construction now passes a temp directory.

**The schedule stays under `%AppData%` (roaming)** — that's where it has always lived, and relocating it to Local while adding a seam would strand an existing user's schedule. A harness control asserts the roaming resolution survives, because that's the kind of thing a "cleanup" refactor breaks silently.

`SettingsWatchdogService.Persist` became an instance method: it reads the now per-instance path.

## The two that remain, and why they're left

The ratchet comment no longer leaves them as an unexplained allowance:

- **`ThemeService`** — heavily static (20 static members) and reached from XAML resource resolution, so a constructor seam is a wider refactor than a path change.
- **`LogService`** — a `static partial class` *by design*: Serilog's sink is configured once per process, so there's no instance to hang a seam on. It's also the only one no test constructs, so its risk is the lowest of the set.

Both need a design decision rather than a mechanical edit. I'd rather leave two honestly-explained entries than force a seam into a static logging class to make a list shorter.

## PROPAGATE

The two remaining concrete constructions are in `MainWindowViewModel`'s lazy VM factory — production code that *should* resolve the real path — and DI registration binds the optional parameter without change.

## Red ritual

Against a worktree of unfixed `main`: **7 failures, 2 passes**. Both passes are controls — the roaming location is preserved, and the watchdog still refuses an out-of-catalog restore (its allowlist guard predates this change and had to survive it). Branch: **9/9**.

The red run only inspects fields and constructor shapes, so proving the defect **wrote nothing** to the real profile. Confirmed afterwards: neither `settings-baseline.json` nor `darkmode-schedule.json` exists on this machine, and the three files that do (`icon-fetch`, `activity`, `speedtest-history`) are byte-identical to before.

## Tests

6 new: the baseline lands in the given `configDir`; `HasBaseline` reflects it; the snapshot round-trips (persistence *is* the feature, so asserting an in-memory value would pass even if nothing were written); two services with different dirs don't share a baseline — which is what actually proves the path is per-instance; and a malformed file degrades to `null` rather than throwing. Fixed dates throughout, no `DateTime.Now`.

Main, unit-test and integration projects build **0 errors, 0 warnings**.
