### PR TITLE
docs: state the code-signing plan and add a privacy policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,6 +286,10 @@ jobs:
           This build is not code-signed, so Windows will warn on first launch. That is
           expected for a small independent app: [see what the warning says and what to
           click](https://github.com/laurentiu021/SystemManager#first-launch-windows-will-warn-you).
+          Code signing is planned through the [SignPath Foundation](https://signpath.org/),
+          which provides free certificates to open-source projects, with signing performed by
+          [SignPath.io](https://signpath.io/). Until then, the SHA256 above and the build
+          attestation below are what establish that a download is the genuine build.
 
           ### Verify where this binary came from
 

--- a/README.md
+++ b/README.md
@@ -1104,6 +1104,26 @@ first-launch prompt does not appear.
 > **and** whose hash you verified. The same dialog protects you from genuinely malicious
 > files, so it is worth reading rather than reflexively dismissing.
 
+### Code signing
+
+Releases are currently **unsigned**, which is why the warning above appears. Code signing
+for this project is planned through the [SignPath Foundation](https://signpath.org/) — a
+programme that provides free code-signing certificates to open-source projects, with the
+signing itself performed by [SignPath.io](https://signpath.io/). Certificates issued under
+that programme are held in SignPath Foundation's name rather than an individual's.
+
+Until a certificate is in place, the two checks above — the published SHA-256 and the
+GitHub build-provenance attestation — are what establish that a download is the genuine,
+unmodified build. The attestation is the stronger of the two, and it will remain useful
+after signing arrives: it records *which commit and workflow* produced a given binary,
+which a signature alone does not.
+
+The update path is already prepared for signing. When a downloaded build carries a
+signature, the app checks that it belongs to the expected publisher and that its
+certificate chain validates, and refuses the update otherwise — so the check cannot
+quietly become a formality on the day signing is switched on. See
+[SECURITY.md](SECURITY.md#security-model) for the detail.
+
 ## Build from source
 
 Prerequisites: Windows 10 or newer and the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -150,6 +150,69 @@ What the app can and cannot do by design:
   build under `Program Files` (not user-writable) is planned alongside code
   signing once a certificate is available.
 
+## Privacy
+
+**SysManager collects nothing.** There is no telemetry, no analytics, no crash
+reporting service, no account, and no cloud component. Nothing about you, your
+machine, or your usage is transmitted anywhere — there is no server side to
+transmit it to. The application is a single portable executable that reads and
+writes only on the machine it runs on.
+
+### What the app stores, and where
+
+All of it stays on your PC, inside your own user profile. None of it is
+encrypted, because none of it is secret: you can open any of these files in a
+text editor, and you can delete any of them at any time without breaking the
+app.
+
+| What | Where | Why it exists |
+|---|---|---|
+| Appearance and theme choice | `%LocalAppData%\SysManager` | So the app looks the same next launch |
+| Dark-mode schedule | `%AppData%\SysManager` | Your chosen on/off times |
+| Speed-test history | `%LocalAppData%\SysManager` | So you can compare results over time |
+| Recent-activity list | `%LocalAppData%\SysManager` | Counts and sizes of actions you performed — never file names |
+| Settings-watchdog baseline | `%LocalAppData%\SysManager` | A snapshot of the Windows settings you chose, to detect later drift |
+| Resource history | `%LocalAppData%\SysManager` | CPU / RAM / temperature samples, for the history graphs |
+| Diagnostic log | `%LocalAppData%\SysManager\logs` | 14 days of rolling files, so a problem can be diagnosed |
+| Downloaded updates | `%LocalAppData%\SysManager\updates` | The build you downloaded, plus one previous version for rollback |
+
+Your Windows user name is replaced with `[user]` in every log line — including
+inside error messages — so a log you choose to share does not carry your account
+name with it.
+
+### When the app uses the network
+
+Only for things you explicitly ask for, plus one optional check:
+
+- **Network diagnostics** — ping, traceroute and speed test contact the servers
+  you select, because that is the measurement.
+- **App updates** — installing an application you chose downloads it through
+  winget.
+- **App icons in the Bulk Installer** — **off by default.** Only if you tick
+  "Load app icons from the web" does it fetch them from Google's favicon
+  service.
+- **Version check** — at startup the app asks GitHub's public releases endpoint
+  which release is newest, so it can tell you when a fix is available. Nothing
+  about you or your PC is sent. It runs at most once a day, and the About tab
+  has a checkbox that switches it off entirely; the manual **Check for updates**
+  button still works either way.
+
+Nothing else leaves your PC. There is no background phone-home.
+
+### Third parties
+
+The application talks to no third-party service beyond those listed above. The
+project's development infrastructure — GitHub, for source code, releases and
+discussions — is covered by GitHub's own privacy policy, which applies to you
+only if you visit the repository or download a release in a browser.
+
+### Questions
+
+Privacy questions can be raised through
+[GitHub Issues](https://github.com/laurentiu021/SystemManager/issues), or
+privately through the channel described under
+[Reporting a vulnerability](#reporting-a-vulnerability).
+
 ## Verifying a release
 
 Every release on GitHub ships a versioned `SysManager-v<version>.exe`, a matching


### PR DESCRIPTION
Prerequisites for the SignPath Foundation application. Both were genuinely missing, not merely thin.

## SECURITY.md gains a Privacy section

The repo had one sentence on the subject — *"No cloud, no telemetry, no account"* — and no addressable privacy policy, so there was no URL to give when one is asked for.

The new section states plainly that nothing is collected, then **tabulates every file the app writes**, where it lives and why it exists: theme, dark-mode schedule, speed-test history, activity list, watchdog baseline, resource history, logs, downloaded updates. It records that the activity log holds counts and sizes but **never file names**, and that the diagnostic log replaces the Windows user name with `[user]`.

It then lists the four situations in which the app touches the network, marks the icon fetch as **off by default**, and notes the version check is at most once a day and switchable. Anchor: `SECURITY.md#privacy`.

## README gains a Code signing subsection

Placed directly after *"First launch: Windows will warn you"* — that is where a reader is already asking why the warning appears.

**Deliberately future tense.** The wording SignPath asks projects to display asserts that signing is already in use; publishing that before approval would make the README claim something untrue. It becomes the required form once a certificate exists.

It also records that the update path is already prepared: a signed build must match the pinned publisher and validate its chain (v1.60.3), so the check cannot become a formality the day signing is switched on.

## The same note goes into the generated release body

`release.yml` too — because the **Releases page**, not the README, is the download page a user actually lands on, and it is the page the application form asks to carry the mention. Without this, only the README would say it.

## Verification

All four workflow files parse as YAML after the `release.yml` edit. That check is not ceremony: a mis-indented or here-string-containing edit there makes the workflow unparseable and stops CI entirely, which is how this exact kind of edit went wrong once before.

Anchors confirmed present — `## Privacy`, `## Security model`, `## Reporting a vulnerability` — so `SECURITY.md#privacy` and the two in-document links resolve.

`docs:` / `ci:` — no version bump, no CHANGELOG entry, no release triggered.