### PR TITLE
docs: name the product distinctly and correct three drifted claims

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -428,8 +428,11 @@ Key services:
 - `TemperatureService` — aggregates CPU, GPU, and disk temperatures from
   LibreHardwareMonitor (admin) and NvAPIWrapper (non-admin NVIDIA). Real-time
   polling with 2s interval.
-- `ActivityLogService` — persists last 20 user actions to JSON file for
-  Dashboard recent activity display.
+- `ActivityLogService` — persists the last 60 user actions to a JSON file for the
+  Dashboard's recent-activity card. Records the six destructive operations (deep
+  cleanup, browser clean, privacy write, uninstall, shred, shortcut delete) as
+  counts and sizes only, never file names. Takes a `configDir` seam so tests never
+  write to the user's real history.
 - `ResourceHistoryService` — always-on background sampler (started at app startup,
   runs while minimized to tray) that records CPU/RAM/GPU usage + CPU/GPU temperatures
   every 10s as append-only NDJSON in `%LocalAppData%\SysManager\resource-history.ndjson`,
@@ -578,18 +581,39 @@ treats a file locked by a running instance as ordinary (it survives to the next
 round). The "Install"
 button verifies the download's SHA256 against the published `.sha256` — the actual
 integrity gate — and additionally inspects the file for an Authenticode signature.
-That second check is informational, not a publisher check: `VerifyAuthenticode`
-returns true both for a validly-signed binary and for one with no signature at all
-(SysManager ships unsigned), and rejects only a signature that cannot be parsed.
-`CreateFromSignedFile` reads the signer certificate without validating the file
-against it, so it cannot detect a tampered signed binary; the SHA256 comparison,
-which runs first, is what catches a modified download. It then hands
-off to `UpdateApplier`: the freshly-downloaded exe is relaunched with
+`VerifyAuthenticode` accepts a binary with no signature at all — SysManager ships
+unsigned, so that is the live path — and rejects a signature that cannot be parsed.
+When a signature IS present it is now a real publisher check: the signer must
+contain `ExpectedSignerSubject` and its certificate chain must build with online
+revocation, or the method returns false. That pin is a single `const`, empty until
+a code-signing certificate exists, so the check cannot quietly become a no-op the
+day signing is switched on — without it, merely *carrying* a signature would pass,
+and an attacker's self-issued certificate would be accepted like a legitimate
+build. The policy deliberately mirrors `SpeedTestService.VerifyOoklaSignature`,
+which already pinned subject + chain for a third-party download.
+
+SHA256 remains the integrity gate rather than a fallback: `CreateFromSignedFile`
+reads the signer certificate without validating the file against it, so it cannot
+detect a tampered signed binary, and the hash comparison runs first.
+
+It then hands off to `UpdateApplier`: the freshly-downloaded exe is relaunched with
 `--apply-update`, which `App.OnStartup` intercepts before any window opens. That
 process waits for the old instance to exit, swaps itself over the old executable
 via a staged atomic move (a sibling `.new` file plus `File.Move`, so an
 interrupted copy can never leave a half-written binary), and relaunches —
 inheriting the original's elevation. No on-disk script is involved.
+
+Before that move, `PreserveCurrentBuild` copies the outgoing executable to
+`SysManager-previous.exe` in the same updates folder. The atomic move makes an
+*interrupted* update safe; it does nothing for an update that *succeeds* into a
+build that will not start, and this project has shipped two such regressions. One
+generation is retained (each copy overwrites the last), `PruneOldDownloads`
+explicitly skips that name — it matches the `SysManager-*.exe` pattern and would
+otherwise be deleted by the next download — and retention is best-effort: if the
+folder cannot be written the update still proceeds. `AboutViewModel.CanRollBack`
+surfaces a "Go back to the previous version" button only when the copy exists, and
+the rollback reuses this same applier path rather than a second file-copy
+implementation.
 
 ## Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,12 +73,19 @@ something it does not recognise.
 
 ## [1.58.8] - 2026-08-10
 
+Quick Tune-Up now shows you what it found, and lets you watch it work and stop it.
+
 ### Fixed
 - **Quick Tune-Up used to throw away everything it found.** You pressed the button, it cleaned temp files, emptied the Recycle Bin and checked your shortcuts, memory, uptime and disks — and then showed you nothing but a toast. The results card it was building all along (how much was freed, how many broken shortcuts, which disk needs attention, whether the PC wants a restart) now actually appears, with a plain-language line for each finding. Where something can be acted on, there's a button that takes you straight to the right tab: broken shortcuts to Shortcut Cleaner, high memory to Process Manager, more to reclaim to Deep Cleanup. If nothing needs attention it says so, rather than leaving you guessing.
 - **You can now see the Tune-Up working, and stop it.** It runs six steps and showed no progress at all while doing it. There's now a progress bar with the current step, and a Cancel button — the ability to cancel was already built, it just had no button.
 
 ### Changed
 - **Removed five internal shortcuts that led nowhere.** Five "jump to this tab" commands existed in the code with nothing connected to them. They've been removed rather than left looking like features; the one that *is* used (View details on the update notice) is untouched.
+
+## [1.58.7] - 2026-08-10
+
+The Dashboard's "Recent activity" card now answers the question it was always meant to:
+what did this app change on my PC?
 
 ### Fixed
 - **"Recent activity" on the Dashboard now shows what the app actually changed.** It listed which tabs you had opened, while leaving out the things you would genuinely want a record of: a permanent Deep Cleanup delete, a browser clean that signed you out of sites, privacy settings written to the registry, an app uninstall, files erased with the shredder, and broken shortcuts deleted. None of those left a trace. All six are now recorded, and the card refreshes when you return to the Dashboard so a new entry shows up straight away instead of looking like it never registered.
@@ -89,6 +96,9 @@ something it does not recognise.
 
 ## [1.58.6] - 2026-08-10
 
+Jobs that can run for minutes now tell you how long is left, instead of leaving you
+watching a bar.
+
 ### Fixed
 - **"How long is left?" now actually appears.** Speed Test and Deep Cleanup both worked out a time estimate on every tick of a job that can run for minutes — and then had nowhere to show it, so you watched a bar with no idea whether to wait or walk away. Both now show it, the same way App Updates, Bulk Installer, Uninstaller and Quick Cleanup already did.
 - **Ping and Traceroute now confirm what they did.** These were the only two tabs in the app with no status line at all. Pressing "Clear History" on Ping emptied the chart and the whole history and said nothing, so there was no way to tell it had worked. Starting or stopping the automatic traceroute was equally silent. Both tabs now report what happened.
@@ -96,11 +106,17 @@ something it does not recognise.
 
 ## [1.58.5] - 2026-08-10
 
+Browser Cleaner now finds every browser profile, not just the first one — so traces you
+asked it to clear are actually cleared.
+
 ### Fixed
 - **Browser Cleaner was only ever cleaning your first browser profile.** If you have more than one profile in Chrome, Edge or Brave — a personal one and a work one, or one per person in the house — only the first was scanned. The others' cache, history and cookies were never found, never counted in the total, and never cleaned. So someone clearing their browsing traces kept every trace in the other profile, with nothing on screen to hint at it. Every profile is now included, and each row says which one it belongs to ("Google Chrome — Profile 1"), so you can see exactly what you are about to clean. Cookies stay unticked by default in every profile, just as before, and cleaning one profile cannot touch another. Firefox was already handled correctly and is unchanged.
 - **Disk Analyzer now tells you when a folder was only partly readable.** Windows blocks access to parts of some folders even for you, and when that happened the folder's size was quietly reported too small with no hint anything was missing — so you could go hunting for space in the wrong place. Those folders now carry a small amber warning mark, and hovering it explains that the folder may be using more space than shown. The app already knew this; it just never said so.
 
 ## [1.58.4] - 2026-08-10
+
+The Windows Update progress bar now really fills, which the previous version claimed to
+fix and only half did.
 
 ### Fixed
 - **The Windows Update progress bar now actually fills.** Version 1.58.2 claimed to fix this and only half did: the bar was told what percentage to show, but it was still stuck in "busy" mode, and in that mode Windows ignores the percentage completely and just sweeps back and forth. So installing updates — one of the longest things the app does — still gave no sense of how far along it was. It now switches to a real filling bar the moment Windows reports a percentage. The Cleanup and Debloater bars fixed in 1.58.2 were genuinely fixed; this was the one that was not.
@@ -110,10 +126,15 @@ something it does not recognise.
 
 ## [1.58.3] - 2026-08-10
 
+The Ping and Traceroute tabs no longer contradict each other about whether a trace is
+running.
+
 ### Fixed
 - **The Traceroute tab no longer lies about whether it is running.** Ping and Traceroute look like two separate tabs with their own Start and Stop buttons, but behind them sits one shared monitor. So pressing Stop on Ping silently killed a running auto-trace while Traceroute still showed "Stop auto-trace" and claimed it was running — and pressing Start on Ping quietly began tracing every target while Traceroute still offered to start it. Both tabs now read the same state, so whichever one you use, the other tells you the truth.
 
 ## [1.58.2] - 2026-08-10
+
+Three buttons that permanently deleted something without asking now ask first.
 
 ### Fixed
 - **Three ways to permanently delete something now ask first.** "Clear History" on App Alerts is a red button sitting right next to the harmless "Acknowledge All" — and it wiped the entire list of what installed itself on your PC the instant you touched it, with no question asked and no way to get it back (that list is never saved to a file, so what is on screen is the only copy). Deleting a saved preset on Volume Control and clearing your saved speed-test results behaved the same way: the file was rewritten immediately, no undo. All three now ask you to confirm and say what will be lost. If the list is already empty there is nothing to confirm, so no pointless dialog appears.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SysManager
+# SysManager for Windows
 
 A modern Windows system monitoring and management toolkit: live network
 diagnostics with gamer-friendly presets, Windows updates, disk and memory


### PR DESCRIPTION
Post-release audit of the 15 versions shipped since v1.58.0. Every finding below was re-derived from current source before editing — not taken on trust from the audit that surfaced it.

## Naming

README title → **SysManager for Windows**.

The product is `SysManager` everywhere that matters: the exe, `AssemblyName`, `<Product>`, the winget ID `laurentiu021.SysManager`, 55 README mentions. But "SysManager" alone is generic and search results for it are already owned by an unrelated US company, while the repository name `SystemManager` ranks.

A compound name is searchable **without renaming the repository**, which would break: 527 release tag URLs, the `gh attestation verify --repo laurentiu021/SystemManager` command published in every release note, `PackageUrl` in already-accepted winget manifests, and the author header in every `.cs` and `.xaml` file.

## ARCHITECTURE.md was wrong about security

It still described `VerifyAuthenticode` as *"informational, not a publisher check"* — untrue since v1.60.3. **That is the file a contributor reads before touching this code**, and it under-sold a control that now fails closed. Rewritten to state the publisher pin, the chain build with online revocation, why the pin constant is empty until a certificate exists, and that SHA256 remains the integrity gate rather than a fallback.

The same section described the update flow **with no rollback** — `ARCHITECTURE.md` had zero mentions of it anywhere, while v1.61.0 shipped it as the headline feature. Added: `PreserveCurrentBuild`, the one-generation bound, the `PruneOldDownloads` exclusion (the name matches `SysManager-*.exe` and would otherwise be deleted by the next download), best-effort retention, and that rollback reuses the same applier path rather than a second file-copy implementation.

`ActivityLogService` was documented as keeping **20** actions; it has kept **60** since v1.58.7 — and that change shipped as a user-visible "Changed" entry.

## A shipped release had no CHANGELOG entry

**v1.58.7** was released with a full set of notes, but the file jumped from 1.58.8 straight to 1.58.6. Its content had been folded into the 1.58.8 block — which is why that entry carried `### Fixed` and `### Changed` **twice**, two releases concatenated under one header. Split apart: 1.58.8 covers the Tune-Up card, 1.58.7 covers the activity log, matching what each release actually shipped.

**Six entries (1.58.2–1.58.8) had no plain-English lead** before their first `###` heading. They predate the CI guard, which only inspects the *newest* entry — so nothing would ever have caught them. Each now opens with one or two sentences in the words a user would use.

Plus a missing blank line between the 1.61.1 and 1.61.0 entries, the only entry boundary in the file without one.

## Verification

Confirmed by reading the file before editing: the stale "informational" sentence, the absent 1.58.7 header, the duplicated categories inside 1.58.8, `MaxEntries = 60`, the missing blank line.

After: all **14** entries from 1.58.2 to 1.61.1 have a lead (verified by script), 1.58.8 has a single `### Fixed`, the CI lead gate extracted from `ci.yml` passes, and csproj `Version` matches the newest CHANGELOG header.

`docs:` — no version bump, no release.