### PR TITLE
fix: stop the test suite from reaching into your real SysManager data

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -374,6 +374,10 @@ Key services:
   only chance to record it) and `DashboardViewModel` consumes it on init, mirroring Gaming Profile's
   leftover-session recovery. Both sides go through the shared `CrashMarker` record rather than an
   anonymous object, so the writer and reader cannot drift into a file that parses to nothing. The
+  read DELETES the marker, so `DashboardViewModel` takes it as a REQUIRED constructor argument
+  rather than one defaulting to `new CrashMarkerService()` — the convenience default resolved the real
+  profile, so every test that built the ViewModel consumed a genuine crash report before the user was
+  ever shown it. A destructive read is exactly where an optional dependency must not be optional. The
   read DELETES the marker, so one crash notifies exactly once; markers older than 7 days, or
   future-dated ones (clock change, file copied from another machine), are dropped. It carries no
   stack trace and no paths — unlike the log, this file is not scrubbed of the user name, and it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.61.2] - 2026-08-11
+
+Nothing changes in the app itself. This closes three ways the project's own tests could reach
+into your real SysManager data — including one that could delete the copy the new
+"go back to the previous version" button depends on.
+
+### Fixed
+- **The tests could destroy your rollback copy.** Version 1.61.0 added the ability to go back to the previous version by keeping one copy of the build you were running. Running the project's own test suite overwrote that copy with a 9-byte scratch file — so the About tab would still offer "Go back to the previous version", and pressing it could not work. This only affects people who build and test SysManager themselves, not normal use. The retention step now takes a folder from whoever calls it and every test passes a temporary one; a new test asserts the real location is untouched after the applier runs, and it fails against the old code.
+- **The tests wrote into your activity history.** The Dashboard's list of recent actions is, as its own code says, the only record of what the app changed on your PC. Any test that exercised a real action — changing DNS, running Deep Cleanup, removing a shortcut — appended to *your* list instead of a scratch one, because the shared logger had no way to be pointed elsewhere. It is now redirectable and the test run redirects it once, before any test starts, so no future test can forget to.
+- **The tests consumed your crash report.** When SysManager closes unexpectedly it leaves a note so the next start can tell you. Reading that note deletes it, and every test that constructed the Dashboard read it from the real location — silently throwing away a genuine crash report before you were ever shown it. The crash-note store is now a required argument rather than one that quietly defaults to your own profile.
+- **Two test classes could corrupt each other's confirmation prompts.** Two classes swapped the shared dialog service without joining the group that runs them one at a time, so in parallel one could restore a stand-in another was still using — a test about a "are you sure?" prompt silently answering with a different test's answer. Both now join it, and a new check fails the build if a future test class forgets.
+
 ## [1.61.1] - 2026-08-11
 
 Two more of the project's own tests can no longer touch your real settings: the Settings
@@ -17,6 +29,7 @@ Watchdog baseline and the dark-mode schedule.
 
 ### Fixed
 - **Two more places where running the tests could overwrite your own files.** This only affects people who build and test SysManager themselves, not normal use — but it is the same problem that was fixed for app icons in 1.60.1, and it is worth closing properly. The Settings Watchdog keeps a snapshot of your chosen Windows settings, and the Dark Mode scheduler keeps your on/off times; both were stored at a location the tests had no way to redirect, so a test that saved a baseline or a schedule wrote over yours. Both now accept a scratch folder, and every test uses one. The dark-mode schedule stays exactly where it has always been for real users, so nothing of yours moves.
+
 ## [1.61.0] - 2026-08-11
 
 If an update ever leaves SysManager not working, you can now go back to the version you had

--- a/SysManager/SysManager.IntegrationTests/AllViewModelsSweepTests.cs
+++ b/SysManager/SysManager.IntegrationTests/AllViewModelsSweepTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using SysManager.Services;
 using SysManager.ViewModels;
 
@@ -16,7 +17,14 @@ namespace SysManager.IntegrationTests;
 [Collection("Network")]
 public class AllViewModelsSweepTests
 {
-    [Fact] public void Dashboard_Constructs() => Assert.NotNull(new DashboardViewModel(new SystemInfoService(), new TuneUpService(new ShortcutCleanerService(), new DiskHealthService(), new SystemInfoService()), new HealthScoreService(new SystemInfoService(), new DiskHealthService(), new BatteryService()), new TemperatureService(new DiskHealthService(), skipHardwareInit: true), new WingetService(new PowerShellRunner())));
+    /// <summary>
+    /// A throwaway crash-marker store. Reading a marker CONSUMES it, so a Dashboard constructed
+    /// against the real profile would delete a genuine crash report before the user saw it (#1772).
+    /// </summary>
+    private static CrashMarkerService TempCrashMarkers()
+        => new(Path.Combine(Path.GetTempPath(), "SysManagerTests", "sweep-crash"));
+
+    [Fact] public void Dashboard_Constructs() => Assert.NotNull(new DashboardViewModel(new SystemInfoService(), new TuneUpService(new ShortcutCleanerService(), new DiskHealthService(), new SystemInfoService()), new HealthScoreService(new SystemInfoService(), new DiskHealthService(), new BatteryService()), new TemperatureService(new DiskHealthService(), skipHardwareInit: true), new WingetService(new PowerShellRunner()), TempCrashMarkers()));
     [Fact] public void AppUpdates_Constructs() => Assert.NotNull(new AppUpdatesViewModel(new WingetService(new PowerShellRunner())));
     [Fact] public void WindowsUpdate_Constructs() => Assert.NotNull(new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService(), new WindowsUpdatePolicyService()));
     [Fact] public void SystemHealth_Constructs() => Assert.NotNull(new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService()));
@@ -29,7 +37,7 @@ public class AllViewModelsSweepTests
 
     [Fact]
     public void Dashboard_HasNonEmptySummaryOrEmpty()
-        => Assert.NotNull(new DashboardViewModel(new SystemInfoService(), new TuneUpService(new ShortcutCleanerService(), new DiskHealthService(), new SystemInfoService()), new HealthScoreService(new SystemInfoService(), new DiskHealthService(), new BatteryService()), new TemperatureService(new DiskHealthService(), skipHardwareInit: true), new WingetService(new PowerShellRunner())));
+        => Assert.NotNull(new DashboardViewModel(new SystemInfoService(), new TuneUpService(new ShortcutCleanerService(), new DiskHealthService(), new SystemInfoService()), new HealthScoreService(new SystemInfoService(), new DiskHealthService(), new BatteryService()), new TemperatureService(new DiskHealthService(), skipHardwareInit: true), new WingetService(new PowerShellRunner()), TempCrashMarkers()));
 
     [Fact]
     public void AppUpdates_HasCollections()

--- a/SysManager/SysManager.IntegrationTests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DashboardViewModelTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using SysManager.Services;
 using SysManager.ViewModels;
 
@@ -19,7 +20,10 @@ public class DashboardViewModelTests
             new TuneUpService(new ShortcutCleanerService(), diskHealth, sys),
             new HealthScoreService(sys, diskHealth, new BatteryService()),
             new TemperatureService(diskHealth, skipHardwareInit: true),
-            new WingetService(new PowerShellRunner()));
+            new WingetService(new PowerShellRunner()),
+            // Redirected on purpose: reading a crash marker CONSUMES it, so pointing this at the real
+            // profile would delete a genuine crash report before the user saw it (#1772).
+            new CrashMarkerService(Path.Combine(Path.GetTempPath(), "SysManagerTests", "dash-crash")));
     }
 
     [Fact]

--- a/SysManager/SysManager.IntegrationTests/TestAssemblyInit.cs
+++ b/SysManager/SysManager.IntegrationTests/TestAssemblyInit.cs
@@ -1,0 +1,44 @@
+// SysManager · TestAssemblyInit
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Runtime.CompilerServices;
+using SysManager.Services;
+
+namespace SysManager.IntegrationTests;
+
+/// <summary>
+/// Redirects the process-wide singletons that write user data, once, before any test runs.
+/// <para>
+/// This exists because per-test discipline demonstrably does not hold. The activity log had a
+/// <c>configDir</c> seam AND a test suite that used it correctly — and the real
+/// <c>%LocalAppData%\SysManager\activity.json</c> still ended up holding twenty entries, all of them
+/// DNS changes, six inside a single 60-millisecond window: <c>DnsHostsViewModelTests</c> driving
+/// <c>ApplyDnsCommand</c> through a ViewModel that logs via <c>Instance</c>. At
+/// <see cref="ActivityLogService.MaxEntries"/> that evicted the user's genuine history entirely. The
+/// seam was never the missing piece — the singleton at the call site was (#1772).
+/// </para>
+/// <para>
+/// A module initializer is the only placement a new test cannot forget. Adding a
+/// <c>[Collection]</c> attribute or a <c>using</c> scope to each of the seventeen ViewModels that log
+/// would work today and rot the first time someone writes the eighteenth. Scoped helpers
+/// (<c>ActivityLogScope</c>, <c>DialogAnswer</c>) remain the right tool when a test needs to
+/// ASSERT on what was written; this is the floor underneath them.
+/// </para>
+/// </summary>
+internal static class TestAssemblyInit
+{
+    [ModuleInitializer]
+    internal static void Init()
+    {
+        // Not CreateTempSubdirectory: this directory outlives every test in the assembly and is
+        // deliberately never cleaned up here — the run has no "after all tests" hook, and leaving a
+        // few kilobytes in TEMP is strictly better than a test writing to the real profile.
+        var dir = Path.Combine(
+            Path.GetTempPath(), "SysManagerTestRun", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        ActivityLogService.Instance = new ActivityLogService(dir);
+    }
+}

--- a/SysManager/SysManager.Tests/ActivityLogScope.cs
+++ b/SysManager/SysManager.Tests/ActivityLogScope.cs
@@ -1,0 +1,56 @@
+// SysManager · ActivityLogScope
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Points <see cref="ActivityLogService.Instance"/> at a throwaway directory for the life of the
+/// scope and restores the previous instance on dispose, so a test can drive a destructive operation
+/// without appending to the developer's real activity history.
+/// <para>
+/// The restore matters for the same reason it does in <see cref="DialogAnswer"/>: the singleton is
+/// process-wide static state, so a test that swapped it and threw would leak the temp instance into
+/// every later test in the collection.
+/// </para>
+/// <para>
+/// This exists because the seam alone was not enough. <see cref="ActivityLogService"/> already took a
+/// <c>configDir</c>, but <c>Instance</c> was get-only, so the 20+ ViewModel call sites that log
+/// through the singleton had no way to reach it. The evidence was in the file: a real
+/// <c>activity.json</c> holding twenty entries, every one of them a DNS change, six inside a single
+/// 60-millisecond window — <c>DnsHostsViewModelTests</c> driving <c>ApplyDnsCommand</c>, not a person.
+/// At <see cref="ActivityLogService.MaxEntries"/> that had evicted the user's genuine history
+/// entirely (#1772).
+/// </para>
+/// </summary>
+public sealed class ActivityLogScope : IDisposable
+{
+    private readonly ActivityLogService _previous;
+    private readonly DirectoryInfo _dir;
+
+    public ActivityLogScope()
+    {
+        _previous = ActivityLogService.Instance;
+        _dir = Directory.CreateTempSubdirectory("ActivityLog_");
+        ActivityLogService.Instance = new ActivityLogService(_dir.FullName);
+    }
+
+    /// <summary>The redirected store, so a test can assert on what was written.</summary>
+    public string Path => _dir.FullName;
+
+    public void Dispose()
+    {
+        ActivityLogService.Instance = _previous;
+        try
+        {
+            _dir.Delete(recursive: true);
+        }
+        catch (IOException)
+        {
+            // Cleanup only. A leftover temp directory must never fail a passing test.
+        }
+    }
+}

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using System.Reflection;
 using NetArchTest.Rules;
 using SysManager.Services;
@@ -143,5 +144,135 @@ public class ArchitectureTests
         Assert.True(fixedSince.Count == 0,
             "These no longer hold a static user-profile path, so remove them from the `known` list " +
             "above — a stale allowance silently weakens this guard:\n  " + string.Join("\n  ", fixedSince));
+    }
+
+    /// <summary>
+    /// Any test class that swaps <c>DialogService.Instance</c> must be in the serialized collection.
+    /// <para>
+    /// The collection exists and 24 classes use it correctly, but the attribute is easy to forget and
+    /// nothing enforced it: <c>DebloaterViewModelTests</c> and <c>DialogServiceTests</c> both touched
+    /// the static while running in PARALLEL with the serialized group, because
+    /// <c>parallelizeTestCollections</c> is true. The failure mode is not a clean crash — one class
+    /// restores the singleton to a value another class is still using, so a confirmation gate answers
+    /// with a foreign canned answer and a destructive-op test passes for the wrong reason.
+    /// </para>
+    /// <para>
+    /// Source-level, deliberately. The attribute is a compile-time fact about a test class, so a
+    /// reflection scan over the test assembly would work too — but reading the source also catches a
+    /// class that swaps the static inside a helper, and the same source-scan approach is already used
+    /// for the destructive-op logging guard in ActivityLogServiceTests.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void DialogServiceSwappers_AreInTheSerializedCollection()
+    {
+        var testDir = FindTestSourceDirectory();
+        var offenders = new List<string>();
+
+        foreach (var file in Directory.GetFiles(testDir, "*.cs"))
+        {
+            var name = Path.GetFileName(file);
+            if (name is "DialogAnswer.cs" or "ArchitectureTests.cs") continue;   // the helper and this test
+
+            var source = File.ReadAllText(file);
+
+            // Either shape counts: assigning the static directly, or using the scoped helper — both
+            // install a substitute into process-wide state for the duration of the test.
+            var swaps = source.Contains("DialogService.Instance =", StringComparison.Ordinal)
+                     || source.Contains("new DialogAnswer(", StringComparison.Ordinal);
+            if (!swaps) continue;
+
+            if (!source.Contains("[Collection(\"DialogService\")]", StringComparison.Ordinal))
+                offenders.Add(name);
+        }
+
+        Assert.True(offenders.Count == 0,
+            "These test classes swap the process-wide DialogService.Instance but are not in the " +
+            "serialized \"DialogService\" collection, so they race the classes that are — a test can " +
+            "restore a substitute another test is still using. Add [Collection(\"DialogService\")]:\n  " +
+            string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// Walks up from the test binary to the directory holding this project's sources. The build copies
+    /// no .cs files to the output, so the assembly location alone cannot answer this.
+    /// </summary>
+    private static string FindTestSourceDirectory()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "SysManager.Tests.csproj"))) return dir.FullName;
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate the SysManager.Tests source directory from " + AppContext.BaseDirectory);
+    }
+
+    /// <summary>
+    /// Every static method that RESOLVES a user-data path must let the caller redirect it.
+    /// <para>
+    /// The sibling ratchet above scans <c>static readonly</c> string FIELDS. This closes the adjacent
+    /// shape it cannot see: a static METHOD that resolves the profile with no override parameter at
+    /// all. <c>UpdateApplier.PreviousBuildPath</c> is why the gap was noticed — the field scan walked
+    /// straight past it — though that method did already take an optional <c>updatesDir</c>. The
+    /// actual #1772 defect was one level up, in its CALLER, and is pinned behaviourally by
+    /// <c>UpdateApplierTests.ApplyCopy_DoesNotTouchTheRealProfile</c>; that assertion fails against
+    /// the unfixed code, which is the evidence this reflection scan cannot provide.
+    /// </para>
+    /// <para>
+    /// The rule this encodes is the narrow, mechanically checkable half: if a static member can
+    /// produce a path under the user profile, it must at least offer an override. A default is fine —
+    /// having no parameter to override is not.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void StaticPathMethods_AcceptARedirect()
+    {
+        var profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        Assert.False(string.IsNullOrEmpty(profile));   // else every check below would be vacuous
+
+        var offenders = new List<string>();
+
+        foreach (var type in AppAssembly.GetTypes()
+                     .Where(t => t.Namespace == "SysManager.Services" && !t.IsNested))
+        {
+            foreach (var method in type.GetMethods(
+                         BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic |
+                         BindingFlags.DeclaredOnly))
+            {
+                if (method.ReturnType != typeof(string)) continue;
+                if (method.IsSpecialName) continue;   // property getters are covered by the field scan
+
+                // Only parameterless-invocable methods can be probed. One that REQUIRES arguments is
+                // not a silent default in the first place — the caller had to decide something.
+                var parameters = method.GetParameters();
+                if (parameters.Any(p => !p.IsOptional)) continue;
+
+                string? value;
+                try
+                {
+                    value = method.Invoke(null, parameters.Select(p => p.DefaultValue).ToArray()) as string;
+                }
+                catch (TargetInvocationException)
+                {
+                    continue;   // a method that throws on defaults cannot silently write anywhere
+                }
+
+                if (string.IsNullOrEmpty(value)) continue;
+                if (!value.StartsWith(profile, StringComparison.OrdinalIgnoreCase)) continue;
+
+                // It resolves under the profile — that is allowed, but ONLY if a caller can override it.
+                if (parameters.Length == 0)
+                    offenders.Add($"{type.Name}.{method.Name}() takes no override parameter");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "These static members resolve a path under the user's profile with no way for a caller to " +
+            "redirect it, so any test reaching them operates on REAL user data. Add an optional " +
+            "override parameter — and thread it through every caller, because an override nobody can " +
+            "pass is not a seam:\n  " + string.Join("\n  ", offenders));
     }
 }

--- a/SysManager/SysManager.Tests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DashboardViewModelTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using NSubstitute;
 using SysManager.Models;
 using SysManager.Services;
@@ -26,7 +27,12 @@ public class DashboardViewModelTests
             new TuneUpService(new ShortcutCleanerService(), diskHealth, sys),
             new HealthScoreService(sys, diskHealth, new BatteryService()),
             new TemperatureService(diskHealth, skipHardwareInit: true),
-            winget ?? new WingetService(new PowerShellRunner()));
+            winget ?? new WingetService(new PowerShellRunner()),
+            // Redirected on purpose. The constructor's InitAsync reads the crash marker, and reading
+            // CONSUMES it — pointed at the real profile (which is what the old optional parameter
+            // defaulted to) these tests would delete a genuine crash report before the user was ever
+            // told about it (#1772).
+            new CrashMarkerService(Path.Combine(Path.GetTempPath(), "SysManagerTests", "dash-crash")));
     }
 
     // ---------- construction & defaults ----------

--- a/SysManager/SysManager.Tests/DebloaterViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DebloaterViewModelTests.cs
@@ -17,6 +17,12 @@ namespace SysManager.Tests;
 /// zero results) so it never contradicts the status bar. Constructed with a mocked
 /// <see cref="IPowerShellRunner"/> so no real PowerShell runs.
 /// </summary>
+// Serialized: RemoveSelected_RunspaceFault swaps the static DialogService.Instance, which is
+// process-wide shared state. Without this attribute the class ran in PARALLEL with the 24 classes
+// that ARE in the collection (parallelizeTestCollections is true), so two tests could interleave
+// their save/restore and leave a foreign substitute installed in the singleton for the rest of the
+// run — a confirmation gate answering with another test's canned answer.
+[Collection("DialogService")]
 public class DebloaterViewModelTests
 {
     private static DebloaterViewModel NewVm() =>
@@ -71,27 +77,21 @@ public class DebloaterViewModelTests
         runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>>(), Arg.Any<CancellationToken>())
             .Returns<Task<Collection<PSObject>>>(_ => throw new InvalidOperationException("runspace is not open"));
 
-        var prevDialog = DialogService.Instance;
-        var dialog = Substitute.For<IDialogService>();
-        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true); // user clicks "Yes"
-        DialogService.Instance = dialog;
-        try
-        {
-            var vm = new DebloaterViewModel(new DebloaterService(runner));
-            var a = Removable("Contoso.AppA");
-            var b = Removable("Contoso.AppB");
-            vm.Apps.Add(a);
-            vm.Apps.Add(b);
+        // DialogAnswer(true) — the user clicks "Yes". The shared helper replaces a hand-rolled
+        // save/restore: it is what the other 24 classes use, and its restore is equally
+        // exception-safe.
+        using var dialog = new DialogAnswer(confirm: true);
 
-            var ex = await Record.ExceptionAsync(() => vm.RemoveSelectedCommand.ExecuteAsync(null));
+        var vm = new DebloaterViewModel(new DebloaterService(runner));
+        var a = Removable("Contoso.AppA");
+        var b = Removable("Contoso.AppB");
+        vm.Apps.Add(a);
+        vm.Apps.Add(b);
 
-            Assert.Null(ex);                       // must not fault the command
-            Assert.Equal("Failed", a.Status);      // first row failed, not frozen at "Removing…"
-            Assert.Equal("Failed", b.Status);      // batch continued to the second row
-        }
-        finally
-        {
-            DialogService.Instance = prevDialog;
-        }
+        var ex = await Record.ExceptionAsync(() => vm.RemoveSelectedCommand.ExecuteAsync(null));
+
+        Assert.Null(ex);                       // must not fault the command
+        Assert.Equal("Failed", a.Status);      // first row failed, not frozen at "Removing…"
+        Assert.Equal("Failed", b.Status);      // batch continued to the second row
     }
 }

--- a/SysManager/SysManager.Tests/DialogServiceTests.cs
+++ b/SysManager/SysManager.Tests/DialogServiceTests.cs
@@ -12,6 +12,10 @@ namespace SysManager.Tests;
 /// contract: with no Application present the service must report a safe answer rather
 /// than acting on the user's behalf or throwing.
 /// </summary>
+// Serialized: Instance_RejectsNull touches the static DialogService.Instance. The assignment is
+// rejected, so nothing is actually swapped — but the read-then-restore still races a parallel class
+// that IS mid-swap, which would restore that class's substitute after it had finished with it.
+[Collection("DialogService")]
 public class DialogServiceTests
 {
     [Fact]

--- a/SysManager/SysManager.Tests/TestAssemblyInit.cs
+++ b/SysManager/SysManager.Tests/TestAssemblyInit.cs
@@ -1,0 +1,44 @@
+// SysManager · TestAssemblyInit
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Runtime.CompilerServices;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Redirects the process-wide singletons that write user data, once, before any test runs.
+/// <para>
+/// This exists because per-test discipline demonstrably does not hold. The activity log had a
+/// <c>configDir</c> seam AND a test suite that used it correctly — and the real
+/// <c>%LocalAppData%\SysManager\activity.json</c> still ended up holding twenty entries, all of them
+/// DNS changes, six inside a single 60-millisecond window: <c>DnsHostsViewModelTests</c> driving
+/// <c>ApplyDnsCommand</c> through a ViewModel that logs via <c>Instance</c>. At
+/// <see cref="ActivityLogService.MaxEntries"/> that evicted the user's genuine history entirely. The
+/// seam was never the missing piece — the singleton at the call site was (#1772).
+/// </para>
+/// <para>
+/// A module initializer is the only placement a new test cannot forget. Adding a
+/// <c>[Collection]</c> attribute or a <c>using</c> scope to each of the seventeen ViewModels that log
+/// would work today and rot the first time someone writes the eighteenth. Scoped helpers
+/// (<see cref="ActivityLogScope"/>, <c>DialogAnswer</c>) remain the right tool when a test needs to
+/// ASSERT on what was written; this is the floor underneath them.
+/// </para>
+/// </summary>
+internal static class TestAssemblyInit
+{
+    [ModuleInitializer]
+    internal static void Init()
+    {
+        // Not CreateTempSubdirectory: this directory outlives every test in the assembly and is
+        // deliberately never cleaned up here — the run has no "after all tests" hook, and leaving a
+        // few kilobytes in TEMP is strictly better than a test writing to the real profile.
+        var dir = Path.Combine(
+            Path.GetTempPath(), "SysManagerTestRun", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        ActivityLogService.Instance = new ActivityLogService(dir);
+    }
+}

--- a/SysManager/SysManager.Tests/UpdateApplierTests.cs
+++ b/SysManager/SysManager.Tests/UpdateApplierTests.cs
@@ -18,6 +18,20 @@ namespace SysManager.Tests;
 /// </summary>
 public class UpdateApplierTests
 {
+    /// <summary>
+    /// The updates directory every <see cref="UpdateApplier.ApplyCopy"/> call in this file must be
+    /// pointed at. Omitting it is not a harmless default: ApplyCopy retains the outgoing build, and
+    /// with no override that copy lands in the REAL <c>%LocalAppData%\SysManager\updates</c> and
+    /// overwrites the developer's own rollback build with a temp fixture (#1772).
+    /// </summary>
+    private static string Updates(DirectoryInfo dir) => Path.Combine(dir.FullName, "updates");
+
+    private static string Sha256(string path)
+    {
+        using var stream = File.OpenRead(path);
+        return Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(stream));
+    }
+
     [Fact]
     public void BuildArguments_RoundTripsThroughTryParse()
     {
@@ -81,7 +95,8 @@ public class UpdateApplierTests
             File.WriteAllText(source, "NEW-BUILD");
             File.WriteAllText(target, "OLD-BUILD");
 
-            var ok = UpdateApplier.ApplyCopy(source, target, maxAttempts: 1, delayMs: 0);
+            var ok = UpdateApplier.ApplyCopy(
+                source, target, maxAttempts: 1, delayMs: 0, updatesDir: Updates(dir));
 
             Assert.True(ok);
             Assert.Equal("NEW-BUILD", File.ReadAllText(target));
@@ -104,7 +119,8 @@ public class UpdateApplierTests
             var target = Path.Combine(dir.FullName, "current.exe");
             File.WriteAllText(source, "NEW-BUILD");
 
-            var ok = UpdateApplier.ApplyCopy(source, target, maxAttempts: 1, delayMs: 0);
+            var ok = UpdateApplier.ApplyCopy(
+                source, target, maxAttempts: 1, delayMs: 0, updatesDir: Updates(dir));
 
             Assert.True(ok);
             Assert.Equal("NEW-BUILD", File.ReadAllText(target));
@@ -130,7 +146,8 @@ public class UpdateApplierTests
             // loop (it would otherwise misread FileNotFoundException as a transient lock).
             // delayMs is large on purpose — if the guard regressed and the loop ran, the
             // test would hang noticeably rather than return instantly.
-            var ok = UpdateApplier.ApplyCopy(source, target, maxAttempts: 10, delayMs: 10_000);
+            var ok = UpdateApplier.ApplyCopy(
+                source, target, maxAttempts: 10, delayMs: 10_000, updatesDir: Updates(dir));
 
             // A failed copy must never destroy the working executable.
             Assert.False(ok);
@@ -164,7 +181,7 @@ public class UpdateApplierTests
             File.WriteAllText(target, "OLD-BUILD");
 
             UpdateApplier.PreserveCurrentBuild(target, updates);
-            Assert.True(UpdateApplier.ApplyCopy(source, target));
+            Assert.True(UpdateApplier.ApplyCopy(source, target, updatesDir: updates));
 
             // The update landed…
             Assert.Equal("NEW-BUILD", File.ReadAllText(target));
@@ -237,7 +254,9 @@ public class UpdateApplierTests
             var ex = Record.Exception(() => UpdateApplier.PreserveCurrentBuild(target, blocked));
             Assert.Null(ex);                                      // swallowed, logged, not thrown
 
-            Assert.True(UpdateApplier.ApplyCopy(source, target));  // the update still succeeds
+            // Same blocked directory: the update must survive the retention failing INSIDE ApplyCopy,
+            // not merely when PreserveCurrentBuild is called separately beforehand.
+            Assert.True(UpdateApplier.ApplyCopy(source, target, updatesDir: blocked));
             Assert.Equal("NEW-BUILD", File.ReadAllText(target));
         }
         finally { dir.Delete(recursive: true); }
@@ -253,6 +272,61 @@ public class UpdateApplierTests
         Assert.Equal("SysManager-previous.exe", Path.GetFileName(path));
         Assert.Equal("updates", Path.GetFileName(Path.GetDirectoryName(path)));
         Assert.Contains("SysManager", path);
+    }
+
+    [Fact]
+    public void ApplyCopy_RetentionHonoursTheRedirectedUpdatesDirectory()
+    {
+        // The bug this pins: ApplyCopy accepted no updatesDir, so the retention step inside it always
+        // resolved the REAL profile no matter where the caller pointed source/target. A test could
+        // redirect every path it knew about and still write an executable into the user's own
+        // %LocalAppData%\SysManager\updates. Accepting the parameter is not enough — it has to reach
+        // PreserveCurrentBuild, which is what this asserts.
+        var dir = Directory.CreateTempSubdirectory("ApplierRedirect_");
+        try
+        {
+            var source = Path.Combine(dir.FullName, "new.exe");
+            var target = Path.Combine(dir.FullName, "current.exe");
+            var updates = Updates(dir);
+            File.WriteAllText(source, "NEW-BUILD");
+            File.WriteAllText(target, "OLD-BUILD");
+
+            // No separate PreserveCurrentBuild call — ApplyCopy's own retention must do the work.
+            Assert.True(UpdateApplier.ApplyCopy(source, target, maxAttempts: 1, delayMs: 0, updatesDir: updates));
+
+            Assert.Equal("OLD-BUILD", File.ReadAllText(UpdateApplier.PreviousBuildPath(updates)));
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public void ApplyCopy_DoesNotTouchTheRealProfile()
+    {
+        // The end-to-end guarantee, stated against the actual user path rather than a proxy: running
+        // the applier in a test must leave the developer's own retained build exactly as it was. This
+        // is the assertion that was failing silently — the file was being overwritten with a 9-byte
+        // fixture while every other test in the file passed.
+        var real = UpdateApplier.PreviousBuildPath();
+        var existedBefore = File.Exists(real);
+        var hashBefore = existedBefore ? Sha256(real) : null;
+
+        var dir = Directory.CreateTempSubdirectory("ApplierNoLeak_");
+        try
+        {
+            var source = Path.Combine(dir.FullName, "new.exe");
+            var target = Path.Combine(dir.FullName, "current.exe");
+            File.WriteAllText(source, "NEW-BUILD");
+            File.WriteAllText(target, "OLD-BUILD");
+
+            UpdateApplier.ApplyCopy(source, target, maxAttempts: 1, delayMs: 0, updatesDir: Updates(dir));
+        }
+        finally { dir.Delete(recursive: true); }
+
+        // Either it never existed and still does not, or it existed and is byte-identical. A length
+        // check would pass on a same-size replacement, so compare the content hash.
+        Assert.Equal(existedBefore, File.Exists(real));
+        if (existedBefore)
+            Assert.Equal(hashBefore, Sha256(real));
     }
 
     [Fact]

--- a/SysManager/SysManager/Services/ActivityLogService.cs
+++ b/SysManager/SysManager/Services/ActivityLogService.cs
@@ -23,9 +23,23 @@ public sealed class ActivityLogService
     private readonly Lock _lock = new();
     private List<ActivityEntry> _entries = [];
 
-    public static ActivityLogService Instance { get; } = new();
+    /// <summary>
+    /// Shared singleton the ViewModels log through. Settable for the same reason
+    /// <see cref="DialogService.Instance"/> is: 20+ ViewModel code paths call
+    /// <c>ActivityLogService.Instance.Log(...)</c>, and a get-only singleton made the
+    /// <see cref="ActivityLogService(string?)"/> seam unreachable from those call sites — so a test
+    /// exercising any destructive operation appended to the developer's OWN activity history and, at
+    /// <see cref="MaxEntries"/>, evicted every genuine entry. Redirecting the store alone could not
+    /// fix that; the call site needs a substitutable instance. See <c>ActivityLogScope</c> in the
+    /// test project and issue #1772.
+    /// </summary>
+    public static ActivityLogService Instance
+    {
+        get => _instance;
+        set => _instance = value ?? throw new ArgumentNullException(nameof(value));
+    }
 
-    private ActivityLogService() : this(null) { }
+    private static volatile ActivityLogService _instance = new(null);
 
     /// <summary>
     /// Creates an instance whose store lives under <paramref name="configDir"/>. The production

--- a/SysManager/SysManager/Services/UpdateApplier.cs
+++ b/SysManager/SysManager/Services/UpdateApplier.cs
@@ -88,7 +88,15 @@ internal static class UpdateApplier
     /// target path, so a failure mid-copy leaves the existing executable intact.
     /// Returns true on success.
     /// </summary>
-    internal static bool ApplyCopy(string sourceExe, string targetExe, int maxAttempts = 10, int delayMs = 500)
+    /// <param name="updatesDir">
+    /// Where the retained previous generation is written; null resolves the real profile. This
+    /// parameter exists because omitting it is not a harmless default in a test: the retained copy
+    /// went to the caller's own <c>%LocalAppData%\SysManager\updates</c> and overwrote their genuine
+    /// rollback build with a temp fixture. Redirecting <paramref name="targetExe"/> alone is not
+    /// enough — see the ratchet note in ArchitectureTests and issue #1772.
+    /// </param>
+    internal static bool ApplyCopy(
+        string sourceExe, string targetExe, int maxAttempts = 10, int delayMs = 500, string? updatesDir = null)
     {
         // A missing source is non-recoverable — without this guard File.Copy throws
         // FileNotFoundException (an IOException subtype), which the retry block below
@@ -110,7 +118,7 @@ internal static class UpdateApplier
                 // leaves nothing to go back to — and this project has shipped two launch-blocking
                 // regressions. Best-effort: failing to retain a copy must never abort an update that
                 // is otherwise fine, so PreserveCurrentBuild swallows its own errors.
-                PreserveCurrentBuild(targetExe);
+                PreserveCurrentBuild(targetExe, updatesDir);
                 File.Move(staging, targetExe, overwrite: true);
                 return true;
             }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.61.1</Version>
-    <FileVersion>1.61.1.0</FileVersion>
-    <AssemblyVersion>1.61.1.0</AssemblyVersion>
+    <Version>1.61.2</Version>
+    <FileVersion>1.61.2.0</FileVersion>
+    <AssemblyVersion>1.61.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -90,17 +90,24 @@ public sealed partial class DashboardViewModel : ViewModelBase
     // ── IsActive (pause polling when tab not visible) ────────────────────
     [ObservableProperty] private bool _isActive;
 
+    /// <param name="crashMarkers">
+    /// Required, not optional. It used to default to <c>new CrashMarkerService()</c>, which resolved
+    /// the real profile — and because <see cref="CrashMarkerService.TakePending"/> CONSUMES the marker
+    /// by deleting it, every test that constructed this ViewModel silently ate a genuine crash report
+    /// before the user could ever be told about it. The convenience of an optional argument is not
+    /// worth a defaulting path into user data; the DI container and the designer graph both have one
+    /// to hand (#1772).
+    /// </param>
     public DashboardViewModel(SystemInfoService sys, TuneUpService tuneUp,
         HealthScoreService healthScore, TemperatureService temps, IWingetService winget,
-        CrashMarkerService? crashMarkers = null)
+        CrashMarkerService crashMarkers)
     {
         _sys = sys;
         _tuneUp = tuneUp;
         _healthScore = healthScore;
         _temps = temps;
         _winget = winget;
-        // Optional so the designer/test graph can construct this VM without a crash-marker store.
-        _crashMarkers = crashMarkers ?? new CrashMarkerService();
+        _crashMarkers = crashMarkers;
         IsElevated = AdminHelper.IsElevated();
         InitializeAsync(InitAsync);
     }

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -396,7 +396,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
         return new Dictionary<Type, object>
         {
-            [typeof(DashboardViewModel)] = new DashboardViewModel(sysInfo, tuneUp, healthScore, new TemperatureService(diskHealth), winget),
+            [typeof(DashboardViewModel)] = new DashboardViewModel(sysInfo, tuneUp, healthScore, new TemperatureService(diskHealth), winget, new CrashMarkerService()),
             [typeof(AppUpdatesViewModel)] = new AppUpdatesViewModel(winget),
             [typeof(WindowsUpdateViewModel)] = new WindowsUpdateViewModel(runner, new WindowsUpdateService(), new WindowsUpdatePolicyService()),
             [typeof(SystemHealthViewModel)] = new SystemHealthViewModel(sysInfo, diskHealth, new MemoryTestService(), fixedDrives, runner, new BiosService()),


### PR DESCRIPTION
Three ways the project's own tests operated on the developer's live profile. Each was found by audit, **re-verified against current source before editing**, and **proven with a red control** — the leak was reproduced live, the leaked file captured, then removed.

All three sit in a blind spot of the `Services_DoNotHoldUserDataPathsInStaticFields` ratchet. That guard scans `static readonly` string fields and is down to two known offenders, so the shape it checks is nearly closed. None of these three had that shape — they entered through a **missing parameter**, a **get-only singleton**, and a **parameter default**.

## 1. The tests destroyed the rollback copy — CRITICAL

`ApplyCopy` had no `updatesDir` parameter, so the retention step it calls (`PreserveCurrentBuild`) resolved the real `%LocalAppData%\SysManager\updates` regardless of where the caller pointed source and target. A test could redirect everything it knew about and still write into the profile.

What that costs: v1.61.0 shipped "go back to the previous version", which depends on that one retained build. The suite overwrote it with a 9-byte fixture. `AboutViewModel.RefreshRollbackAvailability` (`AboutViewModel.cs:145`) gates the button on `File.Exists` alone — no size, no hash — so the About tab kept offering a rollback that could not work. Pressing it starts a 3-to-9-byte file and `Application.Current?.Shutdown()` fires anyway after 500 ms.

## 2. The tests wrote into the activity history — HIGH

`ActivityLogService.Instance` was get-only. The `configDir` seam existed and `ActivityLogServiceTests` used it correctly, but **29 production call sites** log through the singleton, so no ViewModel test could reach the seam. Its own tests acknowledged this and fell back to a source-level `Assert.Contains` — a grep, not isolation.

The evidence was in the file. The real `activity.json` held twenty entries, **every one a DNS change**, six inside a single 60-millisecond window: `DnsHostsViewModelTests` driving `ApplyDnsCommand`, not a person. At `MaxEntries = 60` that had evicted the genuine history entirely — from a file whose own doc comment calls it *"the only record of what the app changed"*.

## 3. The tests consumed the crash report — HIGH

`DashboardViewModel` took `CrashMarkerService? = null` and fell back to `new CrashMarkerService()`, which resolves the real profile. `TakePending` **deletes** the marker as it reads it, so every test constructing the ViewModel silently ate a genuine crash report before the user could ever be shown it. A destructive read is precisely where an optional dependency must not be optional.

## 4. Two test classes could corrupt each other's confirm prompts

`DebloaterViewModelTests` and `DialogServiceTests` both touch the process-wide `DialogService.Instance` without `[Collection("DialogService")]`, while `parallelizeTestCollections` is `true`. They therefore ran in parallel with the 24 classes that *are* serialized, so one could restore a substitute another was still using — a confirmation-gate test passing on a foreign canned answer. Debloater's hand-rolled save/restore is replaced with the existing `DialogAnswer` helper.

## Guards — each of these was a rule living only in discipline

| Guard | Catches |
|---|---|
| `ApplyCopy_DoesNotTouchTheRealProfile` | Hashes the real path, runs the applier, asserts byte-identical. **Fails against the unfixed code.** |
| `TestAssemblyInit` module initializer | Redirects the activity log once per assembly, before any test runs — the eighteenth ViewModel that logs cannot forget. |
| `StaticPathMethods_AcceptARedirect` | A static member resolving the profile with **no override parameter at all**. |
| `DialogServiceSwappers_AreInTheSerializedCollection` | A class swapping the dialog singleton without the attribute. |

A module initializer rather than a per-test scope on purpose: the activity log already *had* a working seam and correct tests, and still leaked. Per-file discipline rots at the next new file.

Honest scope of the reflection guard: it would **not** have caught defect 1 on its own — `PreviousBuildPath` already accepted an override; its *caller* didn't. That is why the behavioural test is the primary evidence and the reflection scan is the narrow mechanical half. The XML doc says so rather than overclaiming.

## Verification

**Red control** (`origin/main`, detached worktree):
```
ApplyCopy accepts updatesDir: False
  [FAIL] the REAL profile is untouched — exists False->True
    LEAKED CONTENT: OLD-BUILD (9 bytes)
  [FAIL] ActivityLogService.Instance is settable — get-only
  [FAIL] DashboardViewModel requires a CrashMarkerService — optional
=== 3 FAILED ===
restored: removed the leaked SysManager-previous.exe from the real profile
```

**Green** (this branch), run twice:
```
  [PASS] retention honoured the redirected directory
  [PASS] the REAL profile is untouched
  [PASS] ActivityLogService.Instance is settable
  [PASS] DashboardViewModel requires a CrashMarkerService
=== ALL PASS ===
```

The collection guard, simulated on both trees: **2 offenders** on `origin/main`, **0** here.

- All four projects: **0 errors, 0 warnings**.
- Breaking signature change (`CrashMarkerService` now required): all **5** call sites verified updated.
- Leak scan: **0 hits** across all 32 terms in the diff.
- Real profile confirmed clean afterwards by hash on every user file.

## Also

- ARCHITECTURE.md: documents why the crash-marker dependency is required rather than defaulted.
- CHANGELOG: restores the **missing blank line before the `## [1.61.0]` header** — a real formatting defect still on `main`, separate from the one #1770 addresses.

Closes #1772