### PR TITLE
fix: warn honestly before ending a Windows security or servicing process

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -74,7 +74,13 @@ QA-verified is marked with `IsInDevelopment` (surfaced as a PREVIEW badge) inste
 - `StartupViewModel` — startup program management (enable/disable via registry).
 - `DuplicateFileViewModel` — duplicate file finder with partial-hash pre-filter.
 - `DiskAnalyzerViewModel` — disk space breakdown by folder with drill-down.
-- `ProcessManagerViewModel` — running processes with kill, filter, sort.
+- `ProcessManagerViewModel` — running processes with kill, filter, sort. The kill path has three
+  tiers, because one message cannot be true for all of them: `BootCriticalProcesses` (13 names) is
+  refused outright, `HighConsequenceProcesses` (Defender's engine, Windows Installer and the servicing
+  processes) is confirmed with a prompt naming the real damage, and any other Windows component gets
+  the "a feature may look broken until you sign out" warning. Both sets are matched by process NAME,
+  not by the description database's `safety` field — that field is provenance, and treating it as
+  criticality is what made the app refuse to end Notepad while claiming a BSOD.
 - `BatteryHealthViewModel` — charge %, health %, wear, cycle count via WMI.
 - `UninstallerViewModel` — winget-based app uninstaller with batch support.
 - `PerformanceViewModel` — per-tweak performance tuning with snapshot restore.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.61.2] - 2026-08-11
+
+Ending a Windows security or update process now warns you about what actually happens,
+instead of saying a feature might look broken until you sign out.
+
+### Fixed
+- **The "End task" warning was too reassuring for some Windows processes.** Version 1.59.0 fixed the opposite problem — the app used to refuse to end Notepad and claimed doing so would blue-screen your PC — but the message that replaced the refusal said the same thing for every Windows process: that it "will not crash Windows" and at worst "a feature may stop working until you sign out or restart". That is true for something like Explorer, which comes back on its own. It is not true for Windows Defender's engine, where closing it is a step towards switching off your protection, and it is not true for Windows Installer and the servicing processes, where interrupting one part-way through can leave an update half-applied — and restarting does not put that right. Those now get their own prompt that says so plainly. The processes Windows genuinely cannot survive losing are still refused outright, ordinary Windows components keep the existing warning, and normal programs keep the plain one, so nothing you could end before has become harder to end.
+
 ## [1.61.1] - 2026-08-11
 
 Two more of the project's own tests can no longer touch your real settings: the Settings
@@ -17,6 +25,7 @@ Watchdog baseline and the dark-mode schedule.
 
 ### Fixed
 - **Two more places where running the tests could overwrite your own files.** This only affects people who build and test SysManager themselves, not normal use — but it is the same problem that was fixed for app icons in 1.60.1, and it is worth closing properly. The Settings Watchdog keeps a snapshot of your chosen Windows settings, and the Dark Mode scheduler keeps your on/off times; both were stored at a location the tests had no way to redirect, so a test that saved a baseline or a schedule wrote over yours. Both now accept a scratch folder, and every test uses one. The dark-mode schedule stays exactly where it has always been for real users, so nothing of yours moves.
+
 ## [1.61.0] - 2026-08-11
 
 If an update ever leaves SysManager not working, you can now go back to the version you had

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,25 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
-## [1.61.2] - 2026-08-11
+## [1.61.3] - 2026-08-11
 
 Ending a Windows security or update process now warns you about what actually happens,
 instead of saying a feature might look broken until you sign out.
 
 ### Fixed
 - **The "End task" warning was too reassuring for some Windows processes.** Version 1.59.0 fixed the opposite problem — the app used to refuse to end Notepad and claimed doing so would blue-screen your PC — but the message that replaced the refusal said the same thing for every Windows process: that it "will not crash Windows" and at worst "a feature may stop working until you sign out or restart". That is true for something like Explorer, which comes back on its own. It is not true for Windows Defender's engine, where closing it is a step towards switching off your protection, and it is not true for Windows Installer and the servicing processes, where interrupting one part-way through can leave an update half-applied — and restarting does not put that right. Those now get their own prompt that says so plainly. The processes Windows genuinely cannot survive losing are still refused outright, ordinary Windows components keep the existing warning, and normal programs keep the plain one, so nothing you could end before has become harder to end.
+
+## [1.61.2] - 2026-08-11
+
+Nothing changes in the app itself. This closes three ways the project's own tests could reach
+into your real SysManager data — including one that could delete the copy the new
+"go back to the previous version" button depends on.
+
+### Fixed
+- **The tests could destroy your rollback copy.** Version 1.61.0 added the ability to go back to the previous version by keeping one copy of the build you were running. Running the project's own test suite overwrote that copy with a 9-byte scratch file — so the About tab would still offer "Go back to the previous version", and pressing it could not work. This only affects people who build and test SysManager themselves, not normal use. The retention step now takes a folder from whoever calls it and every test passes a temporary one; a new test asserts the real location is untouched after the applier runs, and it fails against the old code.
+- **The tests wrote into your activity history.** The Dashboard's list of recent actions is, as its own code says, the only record of what the app changed on your PC. Any test that exercised a real action — changing DNS, running Deep Cleanup, removing a shortcut — appended to *your* list instead of a scratch one, because the shared logger had no way to be pointed elsewhere. It is now redirectable and the test run redirects it once, before any test starts, so no future test can forget to.
+- **The tests consumed your crash report.** When SysManager closes unexpectedly it leaves a note so the next start can tell you. Reading that note deletes it, and every test that constructed the Dashboard read it from the real location — silently throwing away a genuine crash report before you were ever shown it. The crash-note store is now a required argument rather than one that quietly defaults to your own profile.
+- **Two test classes could corrupt each other's confirmation prompts.** Two classes swapped the shared dialog service without joining the group that runs them one at a time, so in parallel one could restore a stand-in another was still using — a test about a "are you sure?" prompt silently answering with a different test's answer. Both now join it, and a new check fails the build if a future test class forgets.
 
 ## [1.61.1] - 2026-08-11
 

--- a/README.md
+++ b/README.md
@@ -422,9 +422,13 @@ a confirmation before it runs:
 - **Safety column** — every process is labelled **Windows**, **Known app** or
   **Not recognised**, with a hover explanation of what that means for ending it.
   Sortable, so everything unrecognised can be grouped together at a glance
-- Kill process with confirmation dialog. Processes Windows genuinely cannot survive
-  losing (`winlogon`, `csrss`, `lsass`, …) are refused outright; other Windows
-  components can be ended after a warning that says what may stop working
+- Kill process with confirmation dialog, and the warning matches the real cost.
+  Processes Windows genuinely cannot survive losing (`winlogon`, `csrss`, `lsass`, …)
+  are refused outright. Security and servicing processes (Defender's engine, Windows
+  Installer) can be ended, but only after a prompt that says plainly it can switch off
+  protection or interrupt an update part-way, and that a restart does not undo that.
+  Other Windows components get a warning that a feature may look broken until you
+  sign out. Everything else gets the ordinary "unsaved work may be lost" confirm
 - Open file location in Explorer
 
 ### Resource History

--- a/SysManager/SysManager.Tests/ProcessManagerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ProcessManagerViewModelTests.cs
@@ -261,6 +261,71 @@ public class ProcessManagerViewModelTests
         }
     }
 
+    // ── Third tier: security / servicing processes ──────────────────────
+    //
+    // Dropping the provenance arm from IsKernelCritical made 49 database entries killable, which was
+    // the point. But the single warning that replaced the refusal promises "will not crash Windows …
+    // a feature may stop working", and that is untrue for two groups inside those 49: Defender's
+    // engine (ending it is an AV-disable step) and Windows' servicing/installer processes (KillProcess
+    // uses entireProcessTree, so a mid-write kill can leave a corrupt component store — damage the
+    // "restart and it comes back" remedy does not repair). These pin the honest third message.
+
+    [Theory]
+    [InlineData("MsMpEng.exe")]
+    [InlineData("NisSrv.exe")]
+    [InlineData("SecurityHealthService.exe")]
+    [InlineData("TrustedInstaller.exe")]
+    [InlineData("msiexec.exe")]
+    [InlineData("WmiPrvSE.exe")]
+    public void KillProcess_SecurityOrServicing_WarnsAboutTheRealDamage(string name)
+    {
+        var vm = new ProcessManagerViewModel(new ProcessManagerService());
+        using var dialog = new DialogAnswer(confirm: false);
+
+        vm.KillProcessCommand.Execute(Named(name, nameof(ProcessSafety.System)));
+
+        // The reassurance from the ordinary Windows-component tier must NOT appear here.
+        DialogService.Instance.Received(1).Confirm(
+            Arg.Is<string>(m =>
+                m.Contains("security or servicing")
+                && m.Contains("not undone by restarting")
+                && !m.Contains("will not crash")),
+            Arg.Any<string>());
+    }
+
+    [Fact]
+    public void KillProcess_SecurityOrServicing_IsStillAskedNotRefused()
+    {
+        // The tier is a warning, not a second refusal list. These processes really can be ended, and
+        // it is the user's machine — what changed is that the prompt tells the truth about the cost.
+        var refused = WasRefused(Named("MsMpEng.exe", nameof(ProcessSafety.System)), out var status);
+
+        Assert.False(refused);
+        Assert.DoesNotContain("cannot be ended", status);
+    }
+
+    [Fact]
+    public void HighConsequenceAndBootCritical_DoNotOverlap()
+    {
+        // The tiers are checked in order, so a name in both sets would be refused and its warning
+        // never seen — making the entry look present while being dead. Asserted rather than assumed,
+        // because both sets are hand-maintained string lists.
+        var boot = PrivateNames("BootCriticalProcesses");
+        var high = PrivateNames("HighConsequenceProcesses");
+
+        Assert.NotEmpty(boot);
+        Assert.NotEmpty(high);
+        Assert.Empty(boot.Intersect(high, StringComparer.OrdinalIgnoreCase));
+    }
+
+    private static HashSet<string> PrivateNames(string fieldName)
+    {
+        var field = typeof(ProcessManagerViewModel).GetField(fieldName,
+            System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return (HashSet<string>)field.GetValue(null)!;
+    }
+
     [Theory]
     [InlineData(nameof(ProcessSafety.Trusted))]
     [InlineData(nameof(ProcessSafety.Unknown))]

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.61.1</Version>
-    <FileVersion>1.61.1.0</FileVersion>
-    <AssemblyVersion>1.61.1.0</AssemblyVersion>
+    <Version>1.61.2</Version>
+    <FileVersion>1.61.2.0</FileVersion>
+    <AssemblyVersion>1.61.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.61.2</Version>
-    <FileVersion>1.61.2.0</FileVersion>
-    <AssemblyVersion>1.61.2.0</AssemblyVersion>
+    <Version>1.61.3</Version>
+    <FileVersion>1.61.3.0</FileVersion>
+    <AssemblyVersion>1.61.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
@@ -200,6 +200,35 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
         "svchost", "ctfmon", "userinit"
     };
 
+    /// <summary>
+    /// Windows components that are killable, but whose death costs more than "a feature may look
+    /// broken until you sign out" — so the ordinary Windows-component warning would be untrue for them.
+    /// </summary>
+    /// <remarks>
+    /// Dropping the provenance arm from <see cref="IsKernelCritical"/> made 49 database entries
+    /// killable, which was the point — the app had been refusing to end Notepad. But the single warning
+    /// that replaced the refusal promises "will not crash Windows … a feature may stop working", and
+    /// that sentence is wrong for two groups inside those 49:
+    /// <list type="bullet">
+    /// <item>Security: ending <c>MsMpEng</c> or <c>SecurityHealthService</c> is an antivirus-disable
+    /// step, not a cosmetic one. (It fails on a protected-process OS — but the prompt should not be
+    /// reassuring about an attempt to switch off the machine's defences.)</item>
+    /// <item>Servicing: <c>ProcessManagerService.KillProcess</c> uses
+    /// <c>Kill(entireProcessTree: true)</c>, so ending <c>TrustedInstaller</c> or <c>msiexec</c>
+    /// mid-operation can leave a half-applied update or a corrupt component store — damage that
+    /// survives the restart the ordinary message offers as the remedy.</item>
+    /// </list>
+    /// Still a confirmation and not a refusal: it is the user's machine, and unlike the boot-critical
+    /// set these really can be ended. What changes is that the prompt names the actual risk (#1773).
+    /// </remarks>
+    private static readonly HashSet<string> HighConsequenceProcesses = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Security — Defender's engine, its network inspection service, and the Security Centre.
+        "MsMpEng", "NisSrv", "SecurityHealthService", "SecurityHealthSystray",
+        // Servicing / installers — killing these mid-write is what corrupts state.
+        "TrustedInstaller", "msiexec", "WmiPrvSE", "WUDFHost",
+    };
+
     [RelayCommand]
     private void KillProcess(ProcessEntry? entry)
     {
@@ -213,15 +242,28 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
             return;
         }
 
-        // A Windows-shipped process that is NOT boot-critical is killable, but it deserves a
-        // stronger warning than a third-party app: ending Explorer blanks the taskbar until it
-        // restarts, and ending Print Spooler stops printing. Say what actually happens rather
-        // than refusing outright (the old behaviour) or treating it like any other app.
-        var prompt = IsWindowsComponent(entry)
-            ? $"\"{entry.Name}\" is part of Windows (PID {entry.Pid}).\n\n" +
-              "Ending it will not crash Windows, but a feature may stop working or look broken " +
-              "until you sign out or restart. Continue?"
-            : $"Are you sure you want to kill \"{entry.Name}\" (PID {entry.Pid})?\n\nThis may cause unsaved data loss.";
+        // Three tiers, because one warning could not be true for all of them. Ending Explorer blanks
+        // the taskbar until it restarts — recoverable, and the ordinary Windows-component message says
+        // so honestly. Ending Defender's engine or Windows' installer mid-write is a different
+        // magnitude, and telling that user "a feature may look broken until you sign out" would be a
+        // false reassurance from the app itself. Every tier still asks rather than refusing; only the
+        // boot-critical set above is refused outright.
+        var prompt = entry switch
+        {
+            _ when IsHighConsequence(entry) =>
+                $"\"{entry.Name}\" is a Windows security or servicing process (PID {entry.Pid}).\n\n" +
+                "This is riskier than ending a normal program. Depending on what it is doing right " +
+                "now, closing it can switch off protection or interrupt a Windows update part-way " +
+                "through, and that damage is not undone by restarting.\n\n" +
+                "Only continue if you know why you need to. Continue?",
+
+            _ when IsWindowsComponent(entry) =>
+                $"\"{entry.Name}\" is part of Windows (PID {entry.Pid}).\n\n" +
+                "Ending it will not crash Windows, but a feature may stop working or look broken " +
+                "until you sign out or restart. Continue?",
+
+            _ => $"Are you sure you want to kill \"{entry.Name}\" (PID {entry.Pid})?\n\nThis may cause unsaved data loss.",
+        };
 
         if (!DialogService.Instance.Confirm(prompt, "Kill process")) return;
 
@@ -263,6 +305,19 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
     /// </summary>
     private static bool IsWindowsComponent(ProcessEntry entry)
         => string.Equals(entry.SafetyLevel, nameof(ProcessSafety.System), StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// True for the security and servicing processes in <see cref="HighConsequenceProcesses"/>, whose
+    /// consequence the ordinary Windows-component warning would understate. Drives the strongest
+    /// prompt — still a confirmation, never a refusal.
+    /// </summary>
+    /// <remarks>
+    /// Matched by NAME rather than by the database's category field, for the same reason
+    /// <see cref="IsKernelCritical"/> is: the categories are provenance, and a process absent from the
+    /// database (or renamed in it) must not silently fall out of this tier.
+    /// </remarks>
+    private static bool IsHighConsequence(ProcessEntry entry)
+        => HighConsequenceProcesses.Contains(Path.GetFileNameWithoutExtension(entry.Name));
 
     [RelayCommand]
     private static void OpenFileLocation(ProcessEntry? entry)


### PR DESCRIPTION
Follow-up to my own change in v1.59.0. That fix was right — the app had been refusing to end Notepad and telling the user it would blue-screen the machine, because `IsKernelCritical` treated the database's `SafetyLevel == "System"` (provenance) as criticality, and 59 of the 108 entries carry it.

Dropping that arm made **49** entries killable. Computed fresh from `Data/ProcessDescriptions.json` (`safety == "System"` minus the 13 boot-critical names), that set includes:

```
MsMpEng, NisSrv, SecurityHealthService, SecurityHealthSystray   <- security
TrustedInstaller, msiexec, WmiPrvSE, WUDFHost                   <- servicing
Registry, System, Idle, audiodg, spoolsv, sihost, explorer, ... <- the other 41
```

Every one of them got the same message:

> Ending it will not crash Windows, but a feature may stop working or look broken until you sign out or restart.

For `explorer` that is accurate — the taskbar comes back on its own. For the other two groups it is the app reassuring the user about something it should not:

- **Security.** Ending `MsMpEng` is a step towards switching off the machine's protection. It fails on a protected-process OS, but the prompt should not be calm about the attempt.
- **Servicing.** `ProcessManagerService.KillProcess` uses `Kill(entireProcessTree: true)` (`ProcessManagerService.cs:122`). Ending `TrustedInstaller` or `msiexec` mid-write can leave a half-applied update or a corrupt component store — damage that **survives the restart the message offers as the remedy**.

The confirmation gate was never missing. This is a wording and tiering defect: one sentence could not be true for 49 different processes.

## The three tiers

| Tier | Behaviour |
|---|---|
| `BootCriticalProcesses` (13 names) | **Refused outright** — unchanged |
| `HighConsequenceProcesses` (8 names, new) | Confirmed, with a prompt naming the real damage and stating a restart does not undo it |
| Any other Windows component | The existing "a feature may look broken until you sign out" warning — unchanged |
| Everything else | The plain "unsaved work may be lost" confirm — unchanged |

Still a confirmation, deliberately **not** a second refusal list. These really can be ended, and it is the user's machine — what changes is that the prompt tells the truth about the cost. Nothing that could be ended before has become harder to end.

Both sets match on process **name**, not on the database's `safety` field, for exactly the reason `IsKernelCritical` does: that field is provenance, and a process absent from the database (or renamed in it) must not silently fall out of a tier.

## Guards

- Six `[Theory]` cases assert the security/servicing prompt appears **and** that the `"will not crash"` reassurance does not — the negative half matters, since that string is what made the old message wrong.
- One asserts the tier still **asks** rather than refusing, so it cannot quietly drift into a second denylist.
- `HighConsequenceAndBootCritical_DoNotOverlap` — the tiers are evaluated in order, so a name in both sets would be refused and its warning never shown: config that looks present while being dead. Both sets are hand-maintained string lists, so this is asserted rather than assumed.

## Verification

**Red control** (`origin/main`, detached worktree):
```
  [FAIL] MsMpEng.exe gets the honest warning — still promises "will not crash Windows ..."
  [FAIL] NisSrv.exe ... [FAIL] SecurityHealthService.exe ...
  [FAIL] TrustedInstaller.exe ... [FAIL] msiexec.exe ... [FAIL] WmiPrvSE.exe ...
  [PASS] explorer.exe keeps the ordinary Windows-component message
  [PASS] a third-party app keeps the plain confirm
  [PASS] lsass.exe is refused before any prompt
=== 6 FAILED ===
```

**Green** (this branch), run twice: **ALL PASS (10/10)** — including the three controls above, which prove the new branch did not leak into the other tiers.

Safety of the harness itself: every prompt is **declined**, so `KillProcess` is never reached, and the PID used (`999999`) does not exist. No process on this machine was touched.

- All four projects: **0 errors, 0 warnings**.
- Leak scan: **0 hits** across all 32 terms.
- No debug code, no generic catches added.

## Docs

- README's Process Manager section described two tiers; it now describes all three.
- ARCHITECTURE.md records the tier structure **and why both sets match by name rather than by the `safety` field** — that reasoning is the thing a future change is most likely to get wrong, since undoing it is what caused the original bug.

Closes #1773