### PR TITLE
docs: add the code signing policy and uninstall instructions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,6 +291,17 @@ jobs:
           [SignPath.io](https://signpath.io/). Until then, the SHA256 above and the build
           attestation below are what establish that a download is the genuine build.
 
+          ### Code signing policy
+
+          Free code signing provided by [SignPath.io](https://signpath.io/), certificate by
+          [SignPath Foundation](https://signpath.org/). Team roles, the release-approval process
+          and the privacy policy are documented under [Code signing
+          policy](https://github.com/laurentiu021/SystemManager#code-signing-policy).
+
+          This program will not transfer any information to other networked systems unless
+          specifically requested by the user or the person installing or operating it. Full
+          [privacy policy](https://github.com/laurentiu021/SystemManager/blob/main/SECURITY.md#privacy).
+
           ### Verify where this binary came from
 
           This exe was built by GitHub Actions from this public source, and the build is

--- a/README.md
+++ b/README.md
@@ -1124,6 +1124,66 @@ certificate chain validates, and refuses the update otherwise — so the check c
 quietly become a formality on the day signing is switched on. See
 [SECURITY.md](SECURITY.md#security-model) for the detail.
 
+### Code signing policy
+
+*Free code signing provided by [SignPath.io](https://signpath.io/), certificate by
+[SignPath Foundation](https://signpath.org/).*
+
+**Team roles.** SysManager is maintained by a single developer, so all three roles below are
+held by the same person. That is stated plainly rather than dressed up as a team, because it
+is the honest description of who can change the code and who approves a release.
+
+- **Authors** (may commit to the repository): [laurentiu021](https://github.com/laurentiu021)
+- **Reviewers** (must review any change proposed by a non-committer):
+  [laurentiu021](https://github.com/laurentiu021)
+- **Approvers** (decide whether a given release may be signed):
+  [laurentiu021](https://github.com/laurentiu021)
+
+Every change reaches `main` through a pull request whose build-and-test check has passed;
+`main` is protected, requires branches to be up to date before merging, and force-pushes and
+deletions are disabled. Releases are built only by GitHub Actions from this public repository
+— no binary is ever built or uploaded from a developer machine — and each carries a SHA-256
+checksum, a CycloneDX SBOM, and a GitHub build-provenance attestation recording the exact
+commit and workflow that produced it. That attestation is the load-bearing guarantee here:
+because a single maintainer necessarily holds administrative rights, the meaningful assurance
+is not "the rules cannot be bypassed" but "every published binary is verifiably the output of
+a public workflow run against a public commit", which anyone can check with
+`gh attestation verify`.
+
+**Privacy policy.** This program will not transfer any information to other networked systems
+unless specifically requested by the user or the person installing or operating it. The full
+policy — including a table of every file the app writes on your own machine, and the four
+situations in which it uses the network at all — is in [SECURITY.md](SECURITY.md#privacy).
+
+Third-party components are listed in the SBOM published with every release. The network
+features that contact anything outside your machine do so only against a destination you
+choose (ping, traceroute and speed-test targets; app installs through winget), plus one
+optional daily version check against the GitHub Releases API that can be switched off.
+
+## Uninstalling
+
+SysManager is a single portable executable. There is no installer, nothing is copied into
+`Program Files`, and no system-wide registry keys are created for the app itself.
+
+To remove it completely:
+
+1. **Delete the executable** — `SysManager-vX.Y.Z.exe`, wherever you saved it. That is the
+   whole program.
+2. **Delete its settings and logs** (optional, a few hundred kilobytes):
+   - `%LocalAppData%\SysManager`
+   - `%AppData%\SysManager`
+3. **Remove the scheduled task, if you created one.** Only applies if you used **Scheduled
+   Maintenance**: open that tab and remove the schedule, and the app unregisters the task for
+   you. It is the only thing SysManager registers with Windows, and only ever when you
+   explicitly ask for it.
+
+If you installed through winget, `winget uninstall laurentiu021.SysManager` covers step 1.
+
+Changes you asked SysManager to make to Windows — privacy toggles, context-menu entries,
+services, tweaks — are Windows settings rather than part of the app, so they stay as you set
+them. Every tab that changes something offers the reverse action, so undo anything you want
+reverted **before** deleting the executable.
+
 ## Build from source
 
 Prerequisites: Windows 10 or newer and the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -252,7 +252,9 @@ The build is **not** currently code-signed, so Windows SmartScreen shows a
 warning on first launch; this is expected until a code-signing certificate is
 available. The README walks through
 [what that dialog says and what to click](README.md#first-launch-windows-will-warn-you),
-with hash verification as the precondition.
+with hash verification as the precondition. The
+[code signing policy](README.md#code-signing-policy) states who may commit, who
+reviews, and who approves a release for signing.
 
 ## Dependencies and supply chain
 


### PR DESCRIPTION
Two **hard requirements** of the [SignPath Foundation Code of Conduct](https://signpath.org/code-of-conduct) that this project does not currently meet. Neither is optional polish — the application is blocked on both.

## 1. "Specify a code signing policy"

The Code of Conduct requires the **exact term** "Code signing policy" as a section header on the project's home page **and** on its download/release pages, carrying three things:

- the attribution line — *"Free code signing provided by SignPath.io, certificate by SignPath Foundation"*
- **team roles**: authors, reviewers, approvers
- a **privacy policy** link, or the specific sentence *"This program will not transfer any information to other networked systems unless specifically requested by the user or the person installing or operating it"*

None of that existed. `grep -i "code signing policy"` over README.md and SECURITY.md returned nothing. The README's existing **Code signing** section explains the *plan* to get a certificate — a different thing, and not what the requirement asks for.

Added as a `### Code signing policy` subsection, with the attribution line, all three roles, and **both** the no-transfer sentence and the link to the privacy policy.

## 2. "Provide uninstallation"

> Software that includes instructions or automated facilities for installation must also include instructions or automated facilities for uninstallation.

This applies: `MaintenanceSchedulerService` registers a Windows **scheduled task** (`Register-ScheduledTask`, `MaintenanceSchedulerService.cs:120`). That is an automated installation facility.

The README documented no removal path at all — not the executable, not `%LocalAppData%`/`%AppData%`, not the scheduled task. `RemoveAsync` (`:92`, `Unregister-ScheduledTask` at `:151`) already existed in code, so this documents a capability that shipped undocumented.

New `## Uninstalling` section covers all three, plus `winget uninstall`, plus the point that Windows settings the user asked SysManager to change are not part of the app and should be reverted **before** deleting the exe.

## Two things stated precisely rather than favourably

**The roles are one person.** All three are `laurentiu021`, and the section says so in as many words. Inventing a team structure for a single-maintainer project would be a misrepresentation to a programme that puts *its own name* on the certificate — and the Code of Conduct's own note that these rules are "soft and fuzzy" is not an invitation to pad them.

**Branch protection is described as what it is.** `enforce_admins` is `false` — verified via the API — so "direct pushes are blocked" would be **false for the owner**, who is also the only committer. Rather than write a claim a reviewer could disprove in one API call, the text states what is actually enforced (protected branch, required up-to-date check, no force-push, no deletion) and then points at the guarantee that holds *regardless of who has admin*:

> because a single maintainer necessarily holds administrative rights, the meaningful assurance is not "the rules cannot be bypassed" but "every published binary is verifiably the output of a public workflow run against a public commit"

That is checkable by anyone with `gh attestation verify`, which is the strongest thing this project can honestly offer, and it is the same reasoning SignPath itself uses ("closing the gap between source code and signed binaries is key here").

## Release notes get the same section

The application form's **Download URL** is the releases page, and the requirement names download pages explicitly. The `release.yml` body template now carries the policy section, so every future release page satisfies it without hand-editing.

## Also checked against the Code of Conduct, no action needed

| Condition | Status |
|---|---|
| No malware / PUP | Clean |
| OSI-approved license, no dual-licensing | MIT |
| No proprietary components | All 23 NuGet dependencies are OSS |
| Actively maintained | 528 releases, current |
| Already released | Yes |
| Documented on the download page | Yes |
| **No hacking tools** | No port scanner, no vulnerability scanner, no exploit tooling — grepped for `portscan`/`vulnerab`/`exploit`/`CVE-`/`open port`, zero feature hits |
| Respect user privacy | No telemetry; privacy policy exists and the optional network features are opt-in |
| Announce system changes | Every mutating operation is scan-first + `DialogService.Confirm` |
| Sign your own binaries only | Built by GitHub Actions from this repo only |
| Artifact metadata (`Product`, version attributes) | `<Product>SysManager</Product>`, `Version`/`FileVersion`/`AssemblyVersion` all aligned per build |
| SBOM | CycloneDX 1.7, 71 components, published per release |

One item cannot be verified from here and is on the maintainer: **multi-factor authentication** must be enabled on the GitHub account (the API does not expose `two_factor_authentication` under the current token scopes).

## Verification

- All **four** workflow files parse as YAML after the edit (the previous attempt at editing `release.yml` in this area produced an unparseable workflow, so this is checked every time).
- All four README anchors the new text links to resolve under GitHub's anchor rules: `code-signing-policy`, `uninstalling`, `first-launch-windows-will-warn-you`, `code-signing`.
- The build-provenance claim checked against `release.yml` — `runs-on: windows-latest`, GitHub-hosted, no developer-machine build path.
- Leak scan: **0 hits** across all 32 terms.