### PR TITLE
fix: Quick Tune-Up reported "2 recommendations" on a perfectly healthy PC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.61.4] - 2026-08-11
+
+Quick Tune-Up said "2 recommendations" on a perfectly healthy PC. It now says "All good"
+when everything is actually fine.
+
+### Fixed
+- **Quick Tune-Up counted every healthy disk as a problem.** If you have two drives and nothing wrong with your PC — no broken shortcuts, plenty of free memory, recently restarted — the Tune-Up result still opened with **"2 recommendations"** in amber, showed the "what to look at" section, and then listed those same two drives with their own verdict reading *"Healthy — 38 °C"*. The headline contradicted the detail directly underneath it. The check was comparing the disk's verdict against the word "Healthy" on its own, but the app never writes that exact wording — it always adds the temperature and wear, or a full stop. So every healthy drive matched "not healthy". It now decides from the same green/amber/red signal the disk row itself uses, so a healthy PC reads "All good" and a drive that genuinely needs attention still counts.
+
 ## [1.61.2] - 2026-08-11
 
 Nothing changes in the app itself. This closes three ways the project's own tests could reach

--- a/SysManager/SysManager.Tests/TuneUpServiceTests.cs
+++ b/SysManager/SysManager.Tests/TuneUpServiceTests.cs
@@ -101,6 +101,83 @@ public class TuneUpServiceTests
         Assert.Equal(0, result.WarningCount);
     }
 
+    // ── The verdict strings DiskHealthService actually produces ──────────────────────────────────
+    //
+    // The test above passed against the old `d.Verdict != "Healthy"` check only because its fixture
+    // hand-wrote a bare "Healthy" — a value the service never emits. ApplyVerdict writes
+    // "Healthy — 38 °C · wear 2% · 4210 h on" when any SMART counter is readable, and "Healthy."
+    // (with a period) when none is. So every healthy disk on a real machine counted as a warning
+    // while this test said otherwise: the fixture was the bug's alibi. These use the real shapes,
+    // copied from DiskHealthService.ApplyVerdict, so the fixture can no longer disagree with
+    // production.
+
+    [Theory]
+    [InlineData("Healthy — 38 °C · wear 2% · 4210 h on")]   // SMART counters readable
+    [InlineData("Healthy.")]                                 // no counters available
+    public void TuneUpResult_WarningCount_HealthyDiskWithRealVerdictText_IsNotAWarning(string verdict)
+    {
+        var result = new TuneUpResult
+        {
+            BrokenShortcutsFound = 0,
+            Uptime = TimeSpan.FromDays(1),
+            RamUsedPercent = 50,
+            DiskResults = new List<DiskHealthSummary>
+            {
+                new() { Name = "Disk0", Verdict = verdict, ColorHex = StatusColors.Good }
+            }
+        };
+
+        Assert.Equal(0, result.WarningCount);
+        Assert.Equal("All good", result.OverallVerdict);
+        Assert.Equal(StatusColors.Good, result.OverallColorHex);
+    }
+
+    [Fact]
+    public void TuneUpResult_TwoHealthyDisks_DoNotReportTwoRecommendations()
+    {
+        // The exact user-visible symptom: an ordinary PC with two healthy drives and nothing else
+        // wrong reported "2 recommendations" in amber — and then listed two disks whose own text said
+        // "Healthy". The headline contradicted the detail directly beneath it.
+        var result = new TuneUpResult
+        {
+            BrokenShortcutsFound = 0,
+            Uptime = TimeSpan.FromDays(1),
+            RamUsedPercent = 50,
+            DiskResults = new List<DiskHealthSummary>
+            {
+                new() { Name = "Disk0", Verdict = "Healthy — 38 °C · wear 2% · 4210 h on", ColorHex = StatusColors.Good },
+                new() { Name = "Disk1", Verdict = "Healthy.", ColorHex = StatusColors.Good },
+            }
+        };
+
+        Assert.Equal(0, result.WarningCount);
+        Assert.Equal("All good", result.OverallVerdict);
+    }
+
+    [Theory]
+    [InlineData("Drive is failing — back up now and replace it.", StatusColors.Bad)]
+    [InlineData("SSD 87% worn out — plan a replacement.", StatusColors.Warning)]
+    [InlineData("Running hot (61 °C). Check cooling / airflow.", StatusColors.Warning)]
+    [InlineData("12 I/O errors logged. Monitor closely.", StatusColors.Warning)]
+    public void TuneUpResult_WarningCount_RealProblemVerdicts_StillCount(string verdict, string colour)
+    {
+        // The other half: keying on the colour must not stop counting genuine problems. These are the
+        // real strings from every non-healthy branch of ApplyVerdict.
+        var result = new TuneUpResult
+        {
+            BrokenShortcutsFound = 0,
+            Uptime = TimeSpan.FromDays(1),
+            RamUsedPercent = 50,
+            DiskResults = new List<DiskHealthSummary>
+            {
+                new() { Name = "Disk0", Verdict = verdict, ColorHex = colour }
+            }
+        };
+
+        Assert.Equal(1, result.WarningCount);
+        Assert.Equal("1 recommendation", result.OverallVerdict);
+    }
+
     [Fact]
     public void TuneUpResult_WarningCount_CountsBrokenShortcuts()
     {

--- a/SysManager/SysManager/Models/TuneUpResult.cs
+++ b/SysManager/SysManager/Models/TuneUpResult.cs
@@ -40,6 +40,25 @@ public sealed record TuneUpResult
     // ── Summary helpers ────────────────────────────────────────────────
     public string FreedDisplay => FormatHelper.FormatSize(TempBytesFreed);
 
+    /// <summary>
+    /// How many things the Tune-Up found worth mentioning. Drives <see cref="OverallVerdict"/> and
+    /// <see cref="OverallColorHex"/>, so it is what the user reads as the headline.
+    /// </summary>
+    /// <remarks>
+    /// A disk counts as a warning when its own <see cref="DiskHealthSummary.ColorHex"/> is not
+    /// <see cref="StatusColors.Good"/>, not by comparing the verdict text.
+    /// <para>This used to read <c>d.Verdict != "Healthy"</c>, and no code path ever produces that
+    /// exact string: <c>DiskHealthService.ApplyVerdict</c> writes <c>"Healthy — 38 °C · wear 2% ·
+    /// 4210 h on"</c> when any SMART counter is readable and <c>"Healthy."</c> — with a period —
+    /// otherwise. So every healthy disk counted as a warning, and a perfectly fine PC with two
+    /// drives reported "2 recommendations" in amber while listing two disks whose own text said
+    /// "Healthy". The comparison was written against <c>MapHealth</c>, which does return a bare
+    /// "Healthy", but that value feeds <c>HealthStatus</c> — a different property.</para>
+    /// <para>Keyed on the colour because the service sets it on every one of its six verdict
+    /// branches, exactly one of which is Good. A prefix test on the text would work today and break
+    /// the moment someone rewords a message; the colour is the field whose whole purpose is to say
+    /// "is this a problem".</para>
+    /// </remarks>
     public int WarningCount
     {
         get
@@ -48,7 +67,8 @@ public sealed record TuneUpResult
             if (BrokenShortcutsFound > 0) count++;
             if (UptimeWarning) count++;
             if (RamWarning) count++;
-            count += DiskResults.Count(d => d.Verdict != "Healthy");
+            count += DiskResults.Count(d =>
+                !string.Equals(d.ColorHex, StatusColors.Good, StringComparison.Ordinal));
             return count;
         }
     }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.61.2</Version>
-    <FileVersion>1.61.2.0</FileVersion>
-    <AssemblyVersion>1.61.2.0</AssemblyVersion>
+    <Version>1.61.4</Version>
+    <FileVersion>1.61.4.0</FileVersion>
+    <AssemblyVersion>1.61.4.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
`WarningCount` counted a disk as a warning when `d.Verdict != "Healthy"` — and `DiskHealthService.ApplyVerdict` **never produces that exact string.** It writes:

- `"Healthy — 38 °C · wear 2% · 4210 h on"` when any SMART counter is readable (`DiskHealthService.cs:176`)
- `"Healthy."` — with a period — when none is (`:177`)

So the comparison was true for **every healthy disk**, and `WarningCount` was inflated by the drive count on essentially every machine.

## What the user saw

An ordinary two-drive PC with nothing wrong — no broken shortcuts, memory under 85%, recently restarted:

- headline **"2 recommendations"** in amber (`WarningCount == 2` → `OverallColorHex` → `<= 2` → `Warning`)
- the "WHAT TO LOOK AT" section appears
- and directly beneath it, the per-disk list shows those same two drives, each reading *"Healthy — 38 °C"*

The headline contradicted the detail underneath it — on the one tab whose entire job is telling a non-technical user whether their PC is fine. For the target persona this is the worst possible failure: it manufactures anxiety and then shows its own evidence that nothing is wrong.

## Root cause

The comparison was almost certainly written against `MapHealth`, which **does** return a bare `"Healthy"` (`DiskHealthService.cs:234`). But that value feeds `HealthStatus` — a different property. Two properties, one string, conflated.

## The fix

Keyed on `ColorHex` instead of the verdict text:

```csharp
count += DiskResults.Count(d =>
    !string.Equals(d.ColorHex, StatusColors.Good, StringComparison.Ordinal));
```

The service sets `VerdictColorHex` on **every one of its six** verdict branches (`:140, :146, :154, :160, :166, :178`) and exactly one is `Good`. A prefix test like `StartsWith("Healthy")` would work today and break the first time someone rewords a message; the colour is the field whose entire purpose is to say *"is this a problem"*.

## Why the existing test did not catch it

`TuneUpResult_WarningCount_ZeroWhenAllGood` **passes on the broken code** — because its fixture hand-writes `Verdict = "Healthy"`, an input production cannot produce. The test was the bug's alibi: it asserted the correct behaviour against an impossible input, and its green tick is precisely why nobody looked.

The added cases use the **real strings copied from `ApplyVerdict`** — both healthy shapes and all four problem shapes — so the fixture can no longer disagree with production. That is the actual lesson here, and it generalises: a fixture that invents its input tests the fixture, not the code.

## Verification

**Red control** (`origin/main`, detached worktree) — reproduces it exactly:
```
[FAIL] one healthy disk (SMART readable) is not a warning — WarningCount=1, verdict="1 recommendation"
[FAIL] one healthy disk (no counters) is not a warning   — WarningCount=1, verdict="1 recommendation"
[FAIL] an ordinary two-healthy-drive PC reports "All good"
       — WarningCount=2, headline="2 recommendations", colour=Warning
[FAIL] healthy + failing counts exactly one — WarningCount=2
=== 4 FAILED ===
```

**Green** (this branch), run twice: **10/10 PASS** — and critically, the other half still holds:

| Control | Result |
|---|---|
| a failing drive (`Bad`) | still counts |
| a worn SSD (`Warning`) | still counts |
| a hot drive (`Warning`) | still counts |
| healthy + failing | counts exactly **one**, not two |
| broken shortcuts / long uptime / high RAM | all still count |

Pure model computation — the harness touches no disk, registry, network, or process.

- All four projects: **0 errors, 0 warnings**.
- Leak scan: **0 hits** across all 32 terms.

## Scope note

`WarningCount` predates v1.58.0, but it was dead code until #1751 surfaced the Tune-Up result card. That PR is what made this user-visible — so it is a regression in effect, even though the arithmetic is older.

Closes #1776