### PR TITLE
fix: ask before Enable changes a Windows service's startup type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.61.6] - 2026-08-11
+
+Turning a Windows service back on now asks first — like starting, stopping and disabling one
+already did — and it tells you what it is about to set.
+
+### Fixed
+- **"Enable" changed a Windows service without asking.** On the Services tab, Start, Stop and Disable each ask before doing anything. Enable did not: one click and the service's startup type changed. It also was not always putting things back the way they were — if SysManager had no record of how the service was set before, which is the case for anything you disabled yourself outside the app, it quietly set it to **Manual** instead. It now asks first and says exactly what it will do: either the original setting by name, or plainly that it will use Manual because the original is not known, so you can decide rather than find out afterwards.
+
 ## [1.61.4] - 2026-08-11
 
 Quick Tune-Up said "2 recommendations" on a perfectly healthy PC. It now says "All good"

--- a/SysManager/SysManager.Tests/ServicesViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ServicesViewModelTests.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Reflection;
+using NSubstitute;
 using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
@@ -19,6 +20,9 @@ namespace SysManager.Tests;
 /// constructor tests below build the view model directly and assert only on defaults, so
 /// they neither need nor use the helper.</para>
 /// </summary>
+// Serialized: the Enable-confirm tests swap the static DialogService.Instance, which is
+// process-wide shared state. Required by ArchitectureTests.DialogServiceSwappers_AreInTheSerializedCollection.
+[Collection("DialogService")]
 public class ServicesViewModelTests
 {
     private static readonly List<ServiceEntry> TestServices = new()
@@ -490,6 +494,116 @@ public class ServicesViewModelTests
         using var vm = await CreateWithLedgerAsync(scanned, ledger);
 
         Assert.Equal("Automatic", scanned[0].PreviousStartType);
+    }
+
+    // ── Enable must announce the change ─────────────────────────────────────────────────────────
+    //
+    // Start, Stop and Disable each call DialogService.Instance.Confirm. Enable was the one mutating
+    // command on this tab that did not, and its button renders on every row with no Visibility or
+    // CanExecute guard — one click to a persistent, machine-scope service change.
+    //
+    // Every assertion below holds whether or not the run is elevated. EnableServiceAsync returns at
+    // the elevation gate when not elevated and at the declined confirm when it is; neither path may
+    // reach sc.exe, which is what "did the startup type change?" measures. A test that only passed
+    // while elevated would be quarantined in CI, so the prompt-wording assertions skip explicitly
+    // when no prompt was reached rather than asserting something they cannot observe.
+
+    [Fact]
+    public async Task EnableService_WhenConfirmDeclined_ChangesNothing()
+    {
+        using var temp = new TempLedgerDir();
+        var ledger = temp.NewLedger();
+        ledger.Remember("Spooler", "Automatic", DateTimeOffset.UnixEpoch);
+
+        var scanned = new List<ServiceEntry>
+        {
+            new() { Name = "Spooler", DisplayName = "Print Spooler", Status = "Stopped", StartType = "Disabled" },
+        };
+        using var vm = await CreateWithLedgerAsync(scanned, ledger);
+        using var dialog = new DialogAnswer(confirm: false);
+
+        await vm.EnableServiceCommand.ExecuteAsync(scanned[0]);
+
+        // Nothing applied: the entry still reads Disabled and the ledger still remembers the type,
+        // so a later accepted Enable can still restore it rather than falling back to Manual.
+        Assert.Equal("Disabled", scanned[0].StartType);
+        Assert.Equal("Automatic", ledger.PreviousStartTypeFor("Spooler"));
+    }
+
+    [Fact]
+    public async Task EnableService_WithNoRememberedType_SaysItWillBeSetToManual()
+    {
+        // The wording carries the weight. With no ledger entry — a service the user disabled outside
+        // SysManager — `previous` is null and StartTypeToScToken's `_ => "demand"` fallback sets the
+        // service to MANUAL. A prompt saying "restored" would describe an action the app does not
+        // perform, which is the failure this guard exists to prevent.
+        using var temp = new TempLedgerDir();
+        var ledger = temp.NewLedger();   // deliberately empty
+
+        var scanned = new List<ServiceEntry>
+        {
+            new() { Name = "WSearch", DisplayName = "Windows Search", Status = "Stopped", StartType = "Disabled" },
+        };
+        using var vm = await CreateWithLedgerAsync(scanned, ledger);
+        using var dialog = new DialogAnswer(confirm: false);
+
+        await vm.EnableServiceCommand.ExecuteAsync(scanned[0]);
+
+        if (dialog.Calls == 0) return;   // not elevated: returned at the gate, before any prompt
+
+        DialogService.Instance.Received(1).Confirm(
+            Arg.Is<string>(m => m.Contains("Manual") && !m.Contains("set back to")),
+            Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task EnableService_WithARememberedType_NamesThatTypeInThePrompt()
+    {
+        using var temp = new TempLedgerDir();
+        var ledger = temp.NewLedger();
+        ledger.Remember("Spooler", "Automatic", DateTimeOffset.UnixEpoch);
+
+        var scanned = new List<ServiceEntry>
+        {
+            new() { Name = "Spooler", DisplayName = "Print Spooler", Status = "Stopped", StartType = "Disabled" },
+        };
+        using var vm = await CreateWithLedgerAsync(scanned, ledger);
+        using var dialog = new DialogAnswer(confirm: false);
+
+        await vm.EnableServiceCommand.ExecuteAsync(scanned[0]);
+
+        if (dialog.Calls == 0) return;   // not elevated
+
+        DialogService.Instance.Received(1).Confirm(
+            Arg.Is<string>(m => m.Contains("set back to Automatic")),
+            Arg.Any<string>());
+    }
+
+    [Fact]
+    public void EveryMutatingServiceCommand_GoesThroughAConfirm()
+    {
+        // A source-level guard, because the runtime tests above cannot cover the elevated branch on a
+        // non-elevated CI runner. Enable was missing its confirm precisely because three siblings had
+        // one and nothing checked that the fourth did — so the count is asserted rather than assumed.
+        var source = File.ReadAllText(Path.Combine(
+            FindProjectDir(), "..", "SysManager", "ViewModels", "ServicesViewModel.cs"));
+
+        var confirms = source.Split("DialogService.Instance.Confirm(").Length - 1;
+
+        Assert.True(confirms >= 4,
+            $"Expected a confirmation on all four mutating commands (Start, Stop, Disable, Enable) " +
+            $"but found {confirms} calls to DialogService.Instance.Confirm.");
+    }
+
+    private static string FindProjectDir()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "SysManager.Tests.csproj"))) return dir.FullName;
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException("Could not locate the test project directory.");
     }
 
     /// <summary>A throwaway ledger directory, so the developer's real %LOCALAPPDATA% file is untouched.</summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.61.4</Version>
-    <FileVersion>1.61.4.0</FileVersion>
-    <AssemblyVersion>1.61.4.0</AssemblyVersion>
+    <Version>1.61.6</Version>
+    <FileVersion>1.61.6.0</FileVersion>
+    <AssemblyVersion>1.61.6.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -235,6 +235,27 @@ public sealed partial class ServicesViewModel : ViewModelBase
         var previous = _ledger.PreviousStartTypeFor(entry.Name) ?? entry.PreviousStartType;
         var targetToken = ServiceManagerService.StartTypeToScToken(previous);
 
+        // Confirm, like Start / Stop / Disable already do. This is a persistent, machine-scope change
+        // to a Windows service, and it was the ONE mutating command on this tab with no prompt —
+        // reachable in a single click, because the Enable button renders on every row with no
+        // Visibility or CanExecute guard.
+        //
+        // The wording branches on whether the original type is known, because when it is not this
+        // command does NOT restore anything: `previous` is null and StartTypeToScToken's `_ =>
+        // "demand"` fallback sets the service to Manual. That is the likely case for a service the
+        // user disabled outside SysManager, so the prompt must say "set to Manual" rather than
+        // "restored" — otherwise it describes an action the app is not performing.
+        var message = string.IsNullOrWhiteSpace(previous)
+            ? $"Enable service \"{entry.DisplayName}\"?\n\n" +
+              "SysManager has no record of how this service was set before, so it will be set to " +
+              "Manual — Windows starts it when something needs it, rather than at every boot. If it " +
+              "used to start automatically, you can change that yourself afterwards."
+            : $"Enable service \"{entry.DisplayName}\"?\n\n" +
+              $"Its startup type will be set back to {previous}, which is what it was before " +
+              "SysManager disabled it.";
+
+        if (!DialogService.Instance.Confirm(message, "Enable Service — Confirm")) return;
+
         try
         {
             await ServiceManagerService.SetStartupTypeAsync(entry.Name, targetToken, _ps);


### PR DESCRIPTION
Found by an adversarial audit of every SignPath Foundation Code of Conduct condition against real source. It was the **only** finding that survived refutation out of the whole Code of Conduct — the other candidate blockers were argued down against the code, not waved through.

## The defect

`ServicesViewModel` has four mutating commands. Three confirm; one did not.

| Command | Confirms? |
|---|---|
| Start | yes — `:131` |
| Stop | yes — `:167` |
| Disable | yes — `:202` |
| **Enable** | **no** |

`EnableServiceAsync` checked elevation and then called `SetStartupTypeAsync` directly — `sc.exe config` on a persistent, machine-scope setting with no prompt. `Views/ServicesView.xaml:197-201` renders the Enable button on every row with no `Visibility`, `IsEnabled` or `CanExecute` guard, so it was reachable in one click.

## And it was not always a restore

`_ledger.PreviousStartTypeFor(name) ?? entry.PreviousStartType` is `null` for a service the user disabled **outside** SysManager. `StartTypeToScToken`'s `_ => "demand"` fallback (`ServiceManagerService.cs:183`) then sets it to **Manual**.

So a service that used to start automatically could be silently converted to Manual — no prompt, no statement of what changed, no undo offer. The status line reports `✓ … set to {StartType}` afterwards, which is accurate but too late to be a decision.

## The prompt branches, deliberately

Known previous type → names it. Unknown → says the service will be set to Manual and why.

Wording the unknown case as *"restored"* would describe an action the app is not performing. That is the specific failure a confirmation exists to prevent, so the branch is not cosmetic — it is the whole point. Captured from the green run:

```
Enable service "Harness Test Service"?

Its startup type will be set back to Automatic, which is what it was before
SysManager disabled it.
```

## Guards

- **Declining leaves both the startup type and the ledger entry untouched** — so a later accepted Enable can still restore the real value instead of dropping to the Manual fallback. Asserting only the startup type would have missed that.
- **Two wording tests** for the known and unknown branches. They **skip explicitly** when the run is not elevated rather than asserting something they cannot observe — `EnableServiceAsync` returns at its own elevation gate first, and a test that only passed under admin would be quarantined in CI.
- **`EveryMutatingServiceCommand_GoesThroughAConfirm`** counts the confirms at source level. Enable was missing one precisely *because* three siblings had one and nothing checked the fourth; a count is the mechanical form of that check.
- The class now joins `[Collection("DialogService")]`, as the guard added in #1771 requires.

## Verification

**Red control** (`origin/main`, detached worktree):
```
confirm calls in ServicesViewModel: 3
  [FAIL] all four mutating commands confirm (Start/Stop/Disable/Enable) — only 3
  [FAIL] the confirm is inside EnableServiceAsync itself
  [FAIL] the unknown-type prompt says Manual rather than "restored"
  [FAIL] a prompt was actually shown — prompts=0
=== 4 FAILED ===
```

**Green** (this branch): **8/8 PASS**, with the prompt text captured above.

- All four projects: **0 errors, 0 warnings**.
- Leak scan: **0 hits** across all 32 terms.

## Disclosure about the harness itself

Its first run used `"Spooler"` as the target service, and this machine is elevated. The red tree by definition has **no confirmation to decline**, so it really did issue `sc.exe config Spooler start= auto` against the live machine. Print Spooler's default startup type is Automatic and it was already Running, so the effect was nil — verified afterwards as `Automatic` / `Running`, registry `Start=2`.

The harness now targets a service name that cannot exist, with a comment stating why: **a red control executes whatever it is handed.** That is the same class of mistake as #1772 — a test reaching real system state through a path the author did not model — and it is recorded here rather than quietly corrected, because the pattern is what matters.

## Why this was in scope

The Code of Conduct requires: *"Software must not modify the user's system configuration without proper warnings."* Every other system-mutating path in the app is gated; this was the exception, and it sits on a tab whose whole purpose is changing Windows services.

Closes #1779