### PR TITLE
fix: two versions were written into the CHANGELOG but never released

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Tags are needed by "Check the version is the one the merge will tag" below, which
+          # compares the PR's version against a bump from the newest tag. A shallow clone carries no
+          # tags, so that check would silently pass against nothing.
+          fetch-depth: 0
 
       - name: Setup .NET 10 SDK
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
@@ -89,6 +94,55 @@ jobs:
                     "version the merge will actually tag."
           }
           Write-Host "Version $csproj is consistent across csproj and CHANGELOG."
+
+      # The check above proves csproj and CHANGELOG agree with EACH OTHER. It does not prove they agree
+      # with the version the merge will actually tag — a different number, computed by auto-release as a
+      # bump from the newest TAG, not from whatever the files say.
+      #
+      # That gap stranded two versions on 2026-08-11. Several fix: PRs were open at once; each resolved
+      # its CHANGELOG conflict by taking the next free number, so main ended up carrying entries for
+      # 1.61.4 and 1.61.6 while the newest tag was still v1.61.2. Auto-release computed 1.61.3, found no
+      # entry for it, and refused — twice. Its own guard worked (no tag was created, so nothing was left
+      # half-published), but the cost landed AFTER the merge and the remedy was another PR.
+      #
+      # Checking it here turns that into one edit on the PR. Mirrors auto-release's arithmetic
+      # deliberately — same tag selection, same bump rules — so the two cannot drift apart on what
+      # "next" means.
+      - name: Check the version is the one the merge will tag
+        shell: bash
+        run: |
+          set -o pipefail
+
+          MATCHES=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)
+          TAG=${MATCHES%%$'\n'*}
+          if [ -z "$TAG" ]; then
+            echo "No release tag found — nothing to compute a bump from, skipping."
+            exit 0
+          fi
+
+          CSPROJ=$(grep -oPm1 '(?<=<Version>)[^<]+' SysManager/SysManager/SysManager.csproj)
+          IFS='.' read -r MAJOR MINOR PATCH <<< "${TAG#v}"
+
+          # A PR's commit type is not reliably available here, so accept ANY of the three legal bumps
+          # rather than guessing. That still catches the real failure: a version that is not a single
+          # bump from the newest tag, which is exactly what "1.61.6 while the tag is v1.61.2" was.
+          PATCH_NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          MINOR_NEXT="${MAJOR}.$((MINOR + 1)).0"
+          MAJOR_NEXT="$((MAJOR + 1)).0.0"
+
+          if [ "$CSPROJ" = "$PATCH_NEXT" ] || [ "$CSPROJ" = "$MINOR_NEXT" ] || [ "$CSPROJ" = "$MAJOR_NEXT" ]; then
+            echo "Version $CSPROJ is a valid bump from $TAG."
+            exit 0
+          fi
+
+          # Unchanged is fine: docs:/test:/ci:/chore: PRs do not release, so they never touch it.
+          if [ "$CSPROJ" = "${TAG#v}" ]; then
+            echo "Version $CSPROJ equals the newest tag — no release expected from this PR."
+            exit 0
+          fi
+
+          echo "::error::Version $CSPROJ is not what this merge will tag. The newest tag is $TAG, so auto-release will compute $PATCH_NEXT (fix:), $MINOR_NEXT (feat:) or $MAJOR_NEXT (breaking). Set csproj Version AND the newest CHANGELOG header to whichever applies. If another PR merged first and took your number, re-resolve against main rather than picking the next free one — a gap makes auto-release fail after the merge instead of before it."
+          exit 1
 
       # The release workflow copies the matching CHANGELOG block VERBATIM into the release body and the
       # auto-posted announcement, so whatever that entry starts with is the first thing a prospective

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,21 +10,17 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
-## [1.61.6] - 2026-08-11
+## [1.61.3] - 2026-08-11
 
-Turning a Windows service back on now asks first — like starting, stopping and disabling one
-already did — and it tells you what it is about to set.
-
-### Fixed
-- **"Enable" changed a Windows service without asking.** On the Services tab, Start, Stop and Disable each ask before doing anything. Enable did not: one click and the service's startup type changed. It also was not always putting things back the way they were — if SysManager had no record of how the service was set before, which is the case for anything you disabled yourself outside the app, it quietly set it to **Manual** instead. It now asks first and says exactly what it will do: either the original setting by name, or plainly that it will use Manual because the original is not known, so you can decide rather than find out afterwards.
-
-## [1.61.4] - 2026-08-11
-
-Quick Tune-Up said "2 recommendations" on a perfectly healthy PC. It now says "All good"
-when everything is actually fine.
+Quick Tune-Up says "All good" when your PC actually is, and turning a Windows service back
+on now asks first and tells you what it is about to set.
 
 ### Fixed
 - **Quick Tune-Up counted every healthy disk as a problem.** If you have two drives and nothing wrong with your PC — no broken shortcuts, plenty of free memory, recently restarted — the Tune-Up result still opened with **"2 recommendations"** in amber, showed the "what to look at" section, and then listed those same two drives with their own verdict reading *"Healthy — 38 °C"*. The headline contradicted the detail directly underneath it. The check was comparing the disk's verdict against the word "Healthy" on its own, but the app never writes that exact wording — it always adds the temperature and wear, or a full stop. So every healthy drive matched "not healthy". It now decides from the same green/amber/red signal the disk row itself uses, so a healthy PC reads "All good" and a drive that genuinely needs attention still counts.
+- **"Enable" changed a Windows service without asking.** On the Services tab, Start, Stop and Disable each ask before doing anything. Enable did not: one click and the service's startup type changed. It also was not always putting things back the way they were — if SysManager had no record of how the service was set before, which is the case for anything you disabled yourself outside the app, it quietly set it to **Manual** instead. It now asks first and says exactly what it will do: either the original setting by name, or plainly that it will use Manual because the original is not known, so you can decide rather than find out afterwards.
+
+### Changed
+- **The build now refuses a version number that does not match what the release will be tagged.** Internal only — it does not change anything you see in the app. Two versions had ended up written into the changelog without ever being published, because several fixes were in flight at once and each picked the next free number; the release step then looked for a version that was not there and stopped. The check that catches this now runs while the change is still being reviewed, so it costs one correction instead of a stalled release.
 
 ## [1.61.2] - 2026-08-11
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.61.6</Version>
-    <FileVersion>1.61.6.0</FileVersion>
-    <AssemblyVersion>1.61.6.0</AssemblyVersion>
+    <Version>1.61.3</Version>
+    <FileVersion>1.61.3.0</FileVersion>
+    <AssemblyVersion>1.61.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Auto-release **failed twice today** and shipped no release for two versions that were already sitting in the CHANGELOG. `v1.61.4` and `v1.61.6` exist as changelog entries; neither exists as a tag or a release.

## Root cause, not the symptom

CI verified that csproj and CHANGELOG agree with **each other**. It never verified that either agrees with the version the merge will actually **tag** — a different number, computed by auto-release as a bump from the newest **tag**:

```
MATCHES=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$')
TAG=${MATCHES%%$'\n'*}          # v1.61.2
PATCH=$((PATCH + 1))            # -> 1.61.3
```

Several `fix:` PRs were open at once. Each resolved its CHANGELOG conflict by taking the next free number, so main ended up carrying `1.61.4` and `1.61.6` while the newest tag was still `v1.61.2`. Auto-release computed `1.61.3`, found no entry, and refused:

```
##[error]No CHANGELOG.md entry for 1.61.3 (a patch bump from v1.61.2).
         Add a '## [1.61.3] - <date>' section, then re-run. No tag was created.
```

**That guard did its job** — no tag was created, so nothing was left half-published, which is exactly the stranded-version failure it was written to prevent. The gap is upstream of it: nothing checked the number while it could still be corrected for the price of one edit.

## The fix

A new CI step that mirrors auto-release's own arithmetic — same tag selection, same bump rules — so the two cannot drift on what "next" means. It accepts **any** of the three legal bumps rather than guessing the commit type from a PR title, which is not reliably available in that context, and an unchanged version passes because `docs:`/`test:`/`ci:`/`chore:` PRs do not release.

The first job's checkout needed `fetch-depth: 0`. A shallow clone carries **no tags**, so the check would have silently passed against nothing — a guard that looks green while measuring an empty set is worse than no guard, so the comment says so explicitly.

## Verified against the actual failures

Driven with the real tag/version pairs rather than invented ones:

| newest tag | version | verdict |
|---|---|---|
| `v1.61.2` | `1.61.4` | **rejected** ← today's first failure |
| `v1.61.2` | `1.61.6` | **rejected** ← today's second failure |
| `v1.61.2` | `1.61.5` | **rejected** ← would have been the third |
| `v1.61.2` | `1.61.3` | accepted (fix bump) |
| `v1.61.2` | `1.62.0` | accepted (feat bump) |
| `v1.61.2` | `2.0.0` | accepted (breaking) |
| `v1.61.2` | `1.61.2` | accepted (docs-only, no release) |

All three real failures caught; all four legitimate shapes still pass. **This PR's own version passes its own gate** (`1.61.3` against `v1.61.2`).

## Also: unstranding the two versions

The two unreleased entries are compacted into a single `1.61.3`, so the sequence is contiguous from `v1.61.2` again and the next merge tags something that exists.

Checked before renumbering — neither was published, so nothing user-facing moves:

```
v1.61.3 (no release)   v1.61.4 (no release)
v1.61.5 (no release)   v1.61.6 (no release)
git tag | grep '1\.61\.[3-9]'  ->  (none)
```

The two fixes they described (Tune-Up's false "2 recommendations", and the Services Enable confirmation) are both preserved verbatim under `1.61.3`, plus a `### Changed` line for this guard itself.

- All four workflows parse as YAML — checked, because a previous edit in this area produced an unparseable workflow.
- All four projects: **0 errors, 0 warnings**.
- Existing CI version-consistency check and the CHANGELOG lead gate both pass on `1.61.3`.
- Leak scan: **0 hits** across all 32 terms.