### PR TITLE
fix: show the drive's real verdict in Tune-Up, and stop tests rewriting a real setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.61.4] - 2026-08-11
+
+The Tune-Up card no longer shows a drive as plainly "Healthy" while the headline above it warns
+you about that same drive.
+
+### Fixed
+- **Quick Tune-Up showed the wrong wording for each drive.** The per-drive line in the Tune-Up result showed a bare status word — "Healthy", "Warning" — instead of the full plain-English summary the rest of the app shows, such as "Healthy — 38 °C · wear 2% · 4210 h on". On a drive that genuinely needed attention that produced an amber "1 recommendation" heading sitting directly above a row reading simply "Healthy", so the card contradicted itself. It now shows the same sentence everywhere, which is also the text the colour beside it was always derived from.
+- **Running the project's own tests rewrote your "check for updates at startup" setting.** This affects only people who build and test SysManager themselves, not normal use. The About tab remembers whether you want the startup version check, and the tests had no way to point that at a scratch folder — so every test that built the About tab wrote to your real setting file. That is the same problem fixed for four other files in 1.60.1, 1.61.1 and 1.61.2, arriving through the one route those fixes did not cover. Fixed the same way, plus a test that fails if it ever comes back.
+
 ## [1.61.3] - 2026-08-11
 
 Quick Tune-Up says "All good" when your PC actually is, ending a Windows security or update

--- a/SysManager/SysManager.IntegrationTests/AboutViewUiTests.cs
+++ b/SysManager/SysManager.IntegrationTests/AboutViewUiTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using SysManager.ViewModels;
@@ -12,6 +13,14 @@ namespace SysManager.IntegrationTests;
 [Collection("Network")]
 public class AboutViewUiTests
 {
+    /// <summary>
+    /// A throwaway config directory. AboutViewModel persists its startup-check preference under
+    /// %AppData%\SysManager, and the convenience constructors used to resolve that unconditionally,
+    /// so building one here rewrote the developer's real preference file (#1785).
+    /// </summary>
+    private static string AboutConfigDir()
+        => Path.Combine(Path.GetTempPath(), "SysManagerTests", "about-ui");
+
     [Fact]
     public void View_Instantiates_OnStaThread()
     {
@@ -29,7 +38,7 @@ public class AboutViewUiTests
         StaHelper.Run(() =>
         {
             EnsureAppResources();
-            var view = new AboutView { DataContext = new AboutViewModel() };
+            var view = new AboutView { DataContext = new AboutViewModel(AboutConfigDir()) };
             view.ApplyTemplate();
             Assert.IsType<AboutViewModel>(view.DataContext);
         });
@@ -57,7 +66,7 @@ public class AboutViewUiTests
         StaHelper.Run(() =>
         {
             EnsureAppResources();
-            var vm = new AboutViewModel();
+            var vm = new AboutViewModel(AboutConfigDir());
             var view = new AboutView { DataContext = vm };
             Assert.NotNull(vm.CurrentVersion);
         });
@@ -69,7 +78,7 @@ public class AboutViewUiTests
         StaHelper.Run(() =>
         {
             EnsureAppResources();
-            var vm = new AboutViewModel();
+            var vm = new AboutViewModel(AboutConfigDir());
             Assert.NotNull(vm.CheckForUpdatesCommand);
             Assert.NotNull(vm.LoadHistoryCommand);
             Assert.NotNull(vm.InstallUpdateCommand);

--- a/SysManager/SysManager.IntegrationTests/AllViewModelsSweepTests.cs
+++ b/SysManager/SysManager.IntegrationTests/AllViewModelsSweepTests.cs
@@ -21,6 +21,14 @@ public class AllViewModelsSweepTests
     /// A throwaway crash-marker store. Reading a marker CONSUMES it, so a Dashboard constructed
     /// against the real profile would delete a genuine crash report before the user saw it (#1772).
     /// </summary>
+    /// <summary>
+    /// A throwaway config directory for AboutViewModel. Its startup-check preference lives in
+    /// %AppData%\SysManager, and the convenience constructors used to resolve that unconditionally —
+    /// so constructing it here rewrote the developer's real preference file (#1785).
+    /// </summary>
+    private static string AboutConfigDir()
+        => Path.Combine(Path.GetTempPath(), "SysManagerTests", "sweep-about");
+
     private static CrashMarkerService TempCrashMarkers()
         => new(Path.Combine(Path.GetTempPath(), "SysManagerTests", "sweep-crash"));
 
@@ -32,7 +40,7 @@ public class AllViewModelsSweepTests
     [Fact] public void DeepCleanup_Constructs() => Assert.NotNull(new DeepCleanupViewModel(new DeepCleanupService(), new LargeFileScanner(), new FixedDriveService()));
     [Fact] public void Drivers_Constructs() => Assert.NotNull(new DriversViewModel(new PowerShellRunner()));
     [Fact] public void Logs_Constructs() => Assert.NotNull(new LogsViewModel(new EventLogService()));
-    [Fact] public void About_Constructs() => Assert.NotNull(new AboutViewModel());
+    [Fact] public void About_Constructs() => Assert.NotNull(new AboutViewModel(AboutConfigDir()));
     [Fact] public void MainWindow_Constructs() => Assert.NotNull(new MainWindowViewModel());
 
     [Fact]
@@ -82,7 +90,7 @@ public class AllViewModelsSweepTests
     [Fact]
     public void About_HasCollection()
     {
-        var vm = new AboutViewModel();
+        var vm = new AboutViewModel(AboutConfigDir());
         Assert.NotNull(vm.ReleaseHistory);
     }
 

--- a/SysManager/SysManager.Tests/AboutViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AboutViewModelTests.cs
@@ -11,46 +11,73 @@ namespace SysManager.Tests;
 public class AboutViewModelTests
 {
     /// <summary>
+    /// A per-run scratch directory every AboutViewModel built here is pointed at, so no test in this
+    /// file can write the startup-check preference into the developer's real <c>%AppData%\SysManager</c>.
+    /// </summary>
+    /// <remarks>
+    /// The core constructor already documented a <c>preferences</c> seam for exactly this, but the two
+    /// convenience overloads did not thread it — so all 23 constructions in this file went around it,
+    /// and each one rewrote the real preference file. The seam being present and documented was not
+    /// enough: it has to exist on the constructor the tests actually call. Fourth instance of the shape
+    /// fixed in #1772 (#1785).
+    /// <para>Static and deliberately not cleaned up: it outlives every test here, there is no
+    /// after-all hook, and a few bytes left in TEMP is strictly better than one byte written into the
+    /// real profile.</para>
+    /// </remarks>
+    private static readonly string ConfigDir = CreateScratchDir();
+
+    private static string CreateScratchDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "SysManagerAboutVmTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    /// <summary>Default-service AboutViewModel, redirected away from the real profile.</summary>
+    private static AboutViewModel NewVm() => new(ConfigDir);
+
+    /// <summary>
     /// Builds an AboutViewModel WITHOUT the startup update-check, so default-state
     /// assertions don't race the constructor's async network fetch (which populates
     /// UpdateStatus / LatestNotes / LatestVersionLabel / LatestPublishedLabel /
     /// UpdateAvailable).
     /// </summary>
     private static AboutViewModel NewVmNoAutoCheck() =>
-        new(new UpdateService(), new SystemReportService(new SystemInfoService(), new DiskHealthService()), autoCheck: false);
+        new(new UpdateService(), new SystemReportService(new SystemInfoService(), new DiskHealthService()),
+            autoCheck: false, preferences: new UpdateCheckPreferenceService(ConfigDir), updatesDir: ConfigDir);
 
     [Fact]
     public void Constructs_WithDefaultService()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVm();
         Assert.NotNull(vm);
     }
 
     [Fact]
     public void Constructs_WithInjectedService()
     {
-        var vm = new AboutViewModel(new UpdateService(), new SystemReportService(new SystemInfoService(), new DiskHealthService()));
+        var vm = new AboutViewModel(new UpdateService(), new SystemReportService(new SystemInfoService(), new DiskHealthService()), ConfigDir);
         Assert.NotNull(vm);
     }
 
     [Fact]
     public void CurrentVersion_NonEmpty()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVm();
         Assert.False(string.IsNullOrWhiteSpace(vm.CurrentVersion));
     }
 
     [Fact]
     public void CurrentVersion_ParsesAsVersion()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVm();
         Assert.True(Version.TryParse(vm.CurrentVersion, out _));
     }
 
     [Fact]
     public void ReleaseHistory_StartsEmpty()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVm();
         Assert.NotNull(vm.ReleaseHistory);
         // May or may not have populated yet depending on async startup —
         // just make sure the collection is there.
@@ -73,28 +100,28 @@ public class AboutViewModelTests
     [Fact]
     public void IsDownloading_DefaultsFalse()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVm();
         Assert.False(vm.IsDownloading);
     }
 
     [Fact]
     public void DownloadPercent_DefaultsZero()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVm();
         Assert.Equal(0, vm.DownloadPercent);
     }
 
     [Fact]
     public void DownloadedPath_DefaultsNull()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVm();
         Assert.Null(vm.DownloadedPath);
     }
 
     [Fact]
     public void AutoDownloadFailed_DefaultsFalse()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVm();
         Assert.False(vm.AutoDownloadFailed);
     }
 
@@ -109,7 +136,7 @@ public class AboutViewModelTests
     [InlineData("OpenDownloadFolderCommand")]
     public void CommandExists(string propertyName)
     {
-        var vm = new AboutViewModel();
+        var vm = NewVm();
         var prop = vm.GetType().GetProperty(propertyName);
         Assert.NotNull(prop);
         Assert.NotNull(prop!.GetValue(vm));
@@ -118,7 +145,7 @@ public class AboutViewModelTests
     [Fact]
     public void OpenRepoCommand_DoesNotThrow()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVm();
         // Shell execute is wrapped in try/catch; even if no browser is
         // associated, it must not throw.
         var ex = Record.Exception(() => vm.OpenRepoCommand.Execute(null));
@@ -128,7 +155,7 @@ public class AboutViewModelTests
     [Fact]
     public void OpenLicenseCommand_DoesNotThrow()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVm();
         var ex = Record.Exception(() => vm.OpenLicenseCommand.Execute(null));
         Assert.Null(ex);
     }
@@ -136,7 +163,7 @@ public class AboutViewModelTests
     [Fact]
     public void OpenManualDownloadCommand_DoesNotThrow()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVm();
         var ex = Record.Exception(() => vm.OpenManualDownloadCommand.Execute(null));
         Assert.Null(ex);
     }
@@ -144,7 +171,7 @@ public class AboutViewModelTests
     [Fact]
     public void OpenDownloadFolderCommand_NoPath_DoesNotThrow()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVm();
         var ex = Record.Exception(() => vm.OpenDownloadFolderCommand.Execute(null));
         Assert.Null(ex);
     }
@@ -152,7 +179,7 @@ public class AboutViewModelTests
     [Fact]
     public async Task InstallUpdateCommand_WithoutDownload_SetsErrorStatus()
     {
-        var vm = new AboutViewModel { DownloadedPath = null };
+        var vm = new AboutViewModel(ConfigDir) { DownloadedPath = null };
         await vm.InstallUpdateCommand.ExecuteAsync(null);
         Assert.Contains("No downloaded", vm.DownloadStatus, StringComparison.OrdinalIgnoreCase);
     }
@@ -160,7 +187,7 @@ public class AboutViewModelTests
     [Fact]
     public async Task InstallUpdateCommand_WithFakePath_SetsNoFileStatus()
     {
-        var vm = new AboutViewModel { DownloadedPath = @"C:\nonexistent\fake.exe" };
+        var vm = new AboutViewModel(ConfigDir) { DownloadedPath = @"C:\nonexistent\fake.exe" };
         await vm.InstallUpdateCommand.ExecuteAsync(null);
         Assert.Contains("No downloaded", vm.DownloadStatus, StringComparison.OrdinalIgnoreCase);
     }
@@ -172,7 +199,7 @@ public class AboutViewModelTests
         var tmp = Path.GetTempFileName();
         try
         {
-            var vm = new AboutViewModel { DownloadedPath = tmp };
+            var vm = new AboutViewModel(ConfigDir) { DownloadedPath = tmp };
             await vm.InstallUpdateCommand.ExecuteAsync(null);
             Assert.Contains("No release info", vm.DownloadStatus, StringComparison.OrdinalIgnoreCase);
         }
@@ -185,7 +212,7 @@ public class AboutViewModelTests
     [Fact]
     public async Task LoadHistoryCommand_NeverThrows()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVm();
         var ex = await Record.ExceptionAsync(() => ((Task?)vm.LoadHistoryCommand.ExecuteAsync(null) ?? Task.CompletedTask));
         Assert.Null(ex);
     }
@@ -193,7 +220,7 @@ public class AboutViewModelTests
     [Fact]
     public async Task CheckForUpdatesCommand_NeverThrows()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVm();
         var ex = await Record.ExceptionAsync(() => ((Task?)vm.CheckForUpdatesCommand.ExecuteAsync(null) ?? Task.CompletedTask));
         Assert.Null(ex);
     }
@@ -222,7 +249,7 @@ public class AboutViewModelTests
     [Fact]
     public void DownloadStatus_DefaultsEmpty()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVm();
         Assert.Equal(string.Empty, vm.DownloadStatus);
     }
 
@@ -234,14 +261,14 @@ public class AboutViewModelTests
     [InlineData(100)]
     public void DownloadPercent_AcceptsFullRange(int pct)
     {
-        var vm = new AboutViewModel { DownloadPercent = pct };
+        var vm = new AboutViewModel(ConfigDir) { DownloadPercent = pct };
         Assert.Equal(pct, vm.DownloadPercent);
     }
 
     [Fact]
     public void BuildDate_IsString()
     {
-        var vm = new AboutViewModel();
+        var vm = NewVm();
         Assert.NotNull(vm.BuildDate);
     }
 
@@ -281,6 +308,36 @@ public class AboutViewModelTests
     // (an IFileDialogService), which is a broader refactor than a bug fix should carry.
     // Tracked separately; until then the guarantee is enforced by code review: this method
     // must not write anywhere the user did not pick.
+    [Fact]
+    public void ConstructingTheViewModel_DoesNotTouchTheRealPreferenceFile()
+    {
+        // The end-to-end guarantee, stated against the actual user path rather than a proxy. Building
+        // an AboutViewModel and toggling the startup-check checkbox — which every test in this file
+        // does, directly or via the constructor — must leave %AppData%\SysManager exactly as it was.
+        //
+        // This is the assertion that was failing silently: the core constructor documented a
+        // `preferences` seam for exactly this, but the two convenience overloads the tests actually
+        // call did not thread it, so all 28 constructions rewrote the developer's real file. Fails
+        // against the old code, where the default constructor had no configDir to accept.
+        var realPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "SysManager", "update-check.json");
+        var existedBefore = File.Exists(realPath);
+        var contentBefore = existedBefore ? File.ReadAllText(realPath) : null;
+
+        var vm = NewVm();
+        vm.CheckForUpdatesOnStartup = false;
+        vm.CheckForUpdatesOnStartup = true;
+
+        Assert.Equal(existedBefore, File.Exists(realPath));
+        if (existedBefore) Assert.Equal(contentBefore, File.ReadAllText(realPath));
+
+        // …and it went to the redirected directory instead, so the seam is genuinely wired through
+        // rather than merely accepted and ignored.
+        Assert.True(File.Exists(Path.Combine(ConfigDir, "update-check.json")),
+            "the preference was not written to the override directory — configDir is accepted but unused");
+    }
+
 }
 
 /// <summary>

--- a/SysManager/SysManager.Tests/TuneUpServiceTests.cs
+++ b/SysManager/SysManager.Tests/TuneUpServiceTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
@@ -152,6 +153,42 @@ public class TuneUpServiceTests
 
         Assert.Equal(0, result.WarningCount);
         Assert.Equal("All good", result.OverallVerdict);
+    }
+
+    [Fact]
+    public void TuneUpService_CopiesTheVerdictSentence_NotTheRawHealthStatusEnum()
+    {
+        // The earlier fix made WarningCount read ColorHex instead of matching verdict TEXT, so the
+        // amber-vs-green decision became correct. But TuneUpService was still copying
+        // DiskHealthReport.HealthStatus — the raw WMI enum word MapHealth produces — into
+        // DiskHealthSummary.Verdict, which is the field the Dashboard RENDERS. So a genuinely degraded
+        // disk produced an amber "1 recommendation" headline sitting directly above a row that read
+        // plainly "Healthy": the same card contradicting itself, in the opposite direction.
+        //
+        // Asserted at source level deliberately. The runtime value depends on this machine's actual
+        // drives, so a behavioural test would be non-deterministic across machines and would pass
+        // vacuously on a box whose disks report no SMART counters. The property NAME is the contract.
+        var source = File.ReadAllText(Path.Combine(FindAppProjectDir(), "Services", "TuneUpService.cs"));
+
+        Assert.Contains("Verdict = r.Verdict", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Verdict = r.HealthStatus", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The app project directory. The build copies no .cs files into the test output, so the assembly
+    /// location alone cannot answer this.
+    /// </summary>
+    private static string FindAppProjectDir()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "SysManager", "SysManager.csproj");
+            if (File.Exists(candidate)) return Path.Combine(dir.FullName, "SysManager");
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException(
+            "Could not locate the SysManager app project from " + AppContext.BaseDirectory);
     }
 
     [Theory]

--- a/SysManager/SysManager/Services/TuneUpService.cs
+++ b/SysManager/SysManager/Services/TuneUpService.cs
@@ -91,7 +91,14 @@ public sealed class TuneUpService
                 diskSummaries.Add(new DiskHealthSummary
                 {
                     Name = r.FriendlyName,
-                    Verdict = r.HealthStatus,
+                    // Verdict, NOT HealthStatus. HealthStatus is the raw WMI enum word that MapHealth
+                    // produces ("Healthy" / "Warning" / "Unhealthy"); Verdict is the plain-English
+                    // sentence ApplyVerdict writes, which is what every other surface shows and what
+                    // ColorHex on the next line is derived from. Taking the enum here put an amber
+                    // "1 recommendation" headline next to a disk row reading plainly "Healthy" — the
+                    // card contradicting itself, on the one tab a non-technical user opens to find out
+                    // whether their PC is fine (#1785).
+                    Verdict = r.Verdict,
                     ColorHex = r.VerdictColorHex
                 });
             }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.61.3</Version>
-    <FileVersion>1.61.3.0</FileVersion>
-    <AssemblyVersion>1.61.3.0</AssemblyVersion>
+    <Version>1.61.4</Version>
+    <FileVersion>1.61.4.0</FileVersion>
+    <AssemblyVersion>1.61.4.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -94,10 +94,29 @@ public sealed partial class AboutViewModel : ViewModelBase
     /// </summary>
     [ObservableProperty] private bool _checkForUpdatesOnStartup = true;
 
-    public AboutViewModel() : this(new UpdateService(), new SystemReportService(new SystemInfoService(), new DiskHealthService())) { }
+    /// <summary>
+    /// Production/designer constructor. <paramref name="configDir"/> exists so these convenience
+    /// overloads are not a way AROUND the seam on the core constructor below.
+    /// </summary>
+    /// <remarks>
+    /// The core constructor documents that <c>preferences</c> is overridable "so tests exercise the
+    /// real gate against a temp directory instead of the developer's own preference file" — and all 23
+    /// test constructions went through THESE overloads, which did not thread it. The seam existed, was
+    /// documented, and was bypassed: every one of those tests wrote the startup-check preference into
+    /// the real <c>%AppData%\SysManager</c>. Fourth instance of the shape fixed in #1772, invisible to
+    /// both path ratchets for the same reason — a defaulting parameter, not a static field (#1785).
+    /// </remarks>
+    public AboutViewModel(string? configDir = null)
+        : this(new UpdateService(),
+               new SystemReportService(new SystemInfoService(), new DiskHealthService()),
+               autoCheck: true,
+               preferences: configDir is null ? null : new UpdateCheckPreferenceService(configDir),
+               updatesDir: configDir) { }
 
-    public AboutViewModel(UpdateService updates, SystemReportService reportService)
-        : this(updates, reportService, autoCheck: true) { }
+    public AboutViewModel(UpdateService updates, SystemReportService reportService, string? configDir = null)
+        : this(updates, reportService, autoCheck: true,
+               preferences: configDir is null ? null : new UpdateCheckPreferenceService(configDir),
+               updatesDir: configDir) { }
 
     /// <summary>
     /// Core constructor. <paramref name="autoCheck"/> controls whether the


### PR DESCRIPTION
Two defects from an adversarial defect-hunt across five lenses (dead bindings, lying feedback, missing confirms, tests touching real state, async/lifecycle). Both re-verified against current source before editing; **3 of the 11 raw findings were refuted and dropped**.

## 1. Tune-Up showed a bare "Healthy" while the headline warned about that same drive

`TuneUpService` copied the wrong property into the field the Dashboard renders:

```csharp
Verdict  = r.HealthStatus,      // raw WMI enum word
ColorHex = r.VerdictColorHex    // derived from r.Verdict
```

`DiskHealthReport` has **both**, and they are different things:

| property | value | written by |
|---|---|---|
| `HealthStatus` | `"Healthy"` / `"Warning"` / `"Unhealthy"` | `MapHealth` (`DiskHealthService.cs:234`) |
| `Verdict` | `"Healthy — 38 °C · wear 2% · 4210 h on"`, `"SSD 87% worn out — plan a replacement."` | `ApplyVerdict` (`:139-177`) |

The Dashboard renders `Verdict` (`DashboardView.xaml:185-190`), and the `ColorHex` on the very next line is derived from the **sentence** — so colour and text disagreed by construction. On a drive with genuine SMART concern: an amber **"1 recommendation"** headline directly above a row reading plainly **"Healthy"**.

**This is the display half of the same two-property confusion #1776 fixed the arithmetic half of.** There the headline was wrong and the rows were right; here the headline is right and the rows are wrong. Same root cause, surfacing at the other end — which is why the fix names the distinction in a comment rather than just swapping a token.

## 2. All 28 test constructions rewrote a real user setting

`AboutViewModel`'s core constructor documents its `preferences` seam as being *"so tests exercise the real gate against a temp directory instead of the developer's own preference file"*. The two convenience overloads did not thread it:

```csharp
public AboutViewModel() : this(new UpdateService(), new SystemReportService(...)) { }
public AboutViewModel(UpdateService updates, SystemReportService reportService)
    : this(updates, reportService, autoCheck: true) { }
```

All 28 constructions across `AboutViewModelTests`, `AboutViewUiTests` and `AllViewModelsSweepTests` call those — so each wrote the startup-check preference into the real `%AppData%\SysManager\update-check.json`.

Reproduced live: neither the file nor its directory existed, and a single construction created both (`fileExists False->True`). The harness restored both.

**Fourth instance of the shape fixed in #1772**, invisible to both path ratchets for the same reason as the others: a defaulting *parameter*, not a static field. The seam existed and was documented — it just was not on the constructor anyone calls. **A seam one level away from the call site is not a seam.**

## Guards

- **`TuneUpService_CopiesTheVerdictSentence_NotTheRawHealthStatusEnum`** asserts the property *name* at source level. Deliberate: the runtime value depends on this machine's actual drives, so a behavioural test would be non-deterministic across machines and would pass **vacuously** on a box whose disks report no SMART counters.
- **`ConstructingTheViewModel_DoesNotTouchTheRealPreferenceFile`** asserts the real `%AppData%` path is byte-identical after building and toggling, **and** that the preference landed in the override directory — so a `configDir` that is accepted but ignored still fails.
- All 28 constructions now route through a redirected helper.

## Verification

**Red control** (`origin/main`, detached worktree):
```
[FAIL] TuneUpService copies Verdict, not the raw HealthStatus enum
[FAIL] the default AboutViewModel constructor accepts a configDir
[FAIL] the (updates, reportService) overload accepts a configDir
[FAIL] the REAL %AppData% preference file is untouched — fileExists False->True
restored: removed the leaked update-check.json from the real profile
restored: removed the profile directory the harness created
=== 4 FAILED ===
```

**Green** (this branch), run twice: **10/10 PASS** — including that the preference lands in the scratch directory, and that `DiskHealthReport` genuinely exposes *both* properties, so the fix is not cosmetic renaming.

- All four projects: **0 errors, 0 warnings**.
- Leak scan: **0 hits** across all 32 terms.
- Real roaming profile confirmed **absent** afterwards.
- Version gate from #1781 passes: `1.61.4` is a valid patch bump from `v1.61.3`.

## Also fixed on the way: my own hook regression

The pre-push version check I added earlier today read the csproj as a **plain file** from the hardcoded main clone, while work happens in `git worktree` checkouts — so it compared main's `1.61.3` against tag `v1.61.3` and blocked this branch, which had correctly bumped to `1.61.4`.

Worth recording because of *why* it was hard to see: every **git** command in that hook resolves correctly from anywhere, since git exports `GIT_DIR` into the hook environment during a push — which is why the error message named the right branch while reading the wrong file. Only the plain file read lacked that indirection. Now uses `git rev-parse --show-toplevel`, verified reading `1.61.4` from the worktree and `1.61.3` from the main clone. Fixed in `dev-config` and installed.

Closes #1785