### PR TITLE
fix: stop warning about healthy drives, and report a refused Recycle Bin empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.61.5] - 2026-08-11
+
+Two places where SysManager told you something that was not true: the tray warning that a
+perfectly healthy drive might be failing, and Cleanup reporting that it emptied a Recycle Bin
+Windows had refused to empty.
+
+### Fixed
+- **The tray could warn that a healthy drive was failing.** SysManager reads disk health from two different places in Windows depending on what the machine offers, and the second one describes a good drive as "OK" rather than "Healthy". The background check only accepted the exact word "Healthy", so on those machines it treated every drive as a problem and showed "Disk Health Warning — reports status: OK. Consider backing up important data." every four hours: a warning that contradicts itself in its own sentence, over nothing. It now recognises what each source actually says, warns for the values that genuinely mean trouble, and stays quiet when it cannot read the status at all — inventing urgency from a value it could not read would be worse than saying nothing. Drives that really are failing still warn, including the abbreviated wording ("Pred Fail", "NonRecover") that Windows uses in the second source.
+- **Emptying the Recycle Bin reported success even when Windows refused.** Windows reports a refused empty by returning a failure code rather than by raising an error, and Cleanup ignored that code — so if the Recycle Bin was open in Explorer or a file inside it was still in use, the status read "Done" and a "Operation finished successfully" notification appeared while the bin was still full. It now says plainly that Windows would not empty it, suggests why, and records it in the log. Deep Cleanup and the One-Click Tune-Up already handled this correctly; Cleanup was the one place that did not.
+
+---
+
 ## [1.61.4] - 2026-08-11
 
 The Tune-Up card no longer shows a drive as plainly "Healthy" while the headline above it warns

--- a/SysManager/SysManager.Tests/CleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/CleanupViewModelTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using System.Reflection;
 using SysManager.Helpers;
 using SysManager.Models;
@@ -487,6 +488,61 @@ public class CleanupViewModelTests
 
         Assert.False(vm.IsBusy);
         Assert.False(vm.IsProgressIndeterminate);
+    }
+
+    // ---------- the Recycle Bin must not claim a success it did not get ----------
+
+    [Fact]
+    public void EmptyRecycleBin_UsesTheShellResult_RatherThanAssumingSuccess()
+    {
+        // RecycleBinHelper.EmptyAllDrives wraps SHEmptyRecycleBin, a LibraryImport that returns an
+        // HRESULT: a refusal (bin open in Explorer, a file still locked) comes back as `false`, never as
+        // an exception. The VM discarded that bool, so the try block always fell through to
+        // StatusMessage = "Done" and a "Operation finished successfully" toast — the app told the user
+        // it had emptied a bin that was still full. For a cleanup tool that is the worst possible lie,
+        // and it is invisible: nothing throws, nothing logs, the label just reads Done.
+        //
+        // Asserted at source level on purpose, and this is the one place where that is not a compromise
+        // but the only safe option: driving the command would empty THIS machine's real Recycle Bin.
+        // There is no seam to fake — the helper is a static shell P/Invoke — and inventing one to make a
+        // three-line status branch mockable would be a larger change than the fix. The check is precise
+        // regardless: it looks at the call statement's shape, so it can only pass if the result is bound
+        // to something, and only fail if the call stands alone as a discarded statement.
+        var source = File.ReadAllText(
+            Path.Combine(FindAppProjectDir(), "ViewModels", "CleanupViewModel.cs"));
+
+        var callSites = source
+            .Split('\n')
+            .Select(l => l.Trim())
+            .Where(l => l.Contains("RecycleBinHelper.EmptyAllDrives", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.NotEmpty(callSites); // guards the test itself: a rename must fail loudly, not vacuously
+        Assert.All(callSites, line =>
+            Assert.False(line.StartsWith("await Task.Run", StringComparison.Ordinal),
+                "The Recycle Bin result is discarded — a refused empty would still report success: " + line));
+        Assert.Contains(callSites, l => l.Contains("= await Task.Run", StringComparison.Ordinal));
+
+        // …and the failure path has to actually SAY something different. Capturing the bool but
+        // printing "Done" either way would satisfy the check above and fix nothing.
+        Assert.Contains("Could not empty the Recycle Bin", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The app project directory. No .cs files are copied into the test output, so the assembly
+    /// location cannot answer this on its own.
+    /// </summary>
+    private static string FindAppProjectDir()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "SysManager", "SysManager.csproj");
+            if (File.Exists(candidate)) return Path.Combine(dir.FullName, "SysManager");
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException(
+            "Could not locate the SysManager app project from " + AppContext.BaseDirectory);
     }
 }
 

--- a/SysManager/SysManager.Tests/TrayIconServiceTests.cs
+++ b/SysManager/SysManager.Tests/TrayIconServiceTests.cs
@@ -132,4 +132,112 @@ public class TrayIconServiceTests
             new List<DiskInfo>(),
             DateTime.Now);
     }
+
+    // ── Disk-health notification: which statuses are actually a problem ──────────────────────────
+    //
+    // The check was `d.HealthStatus != "Healthy"`, and SystemInfoService.QueryDisks has TWO producer
+    // arms. The MSFT_PhysicalDisk arm maps to "Healthy"/"Warning"/"Unhealthy"/"Unknown", but the
+    // Win32_DiskDrive FALLBACK passes Win32_DiskDrive.Status straight through — and that reports "OK"
+    // for a perfectly good disk. So on any machine that took the fallback the tray fired on every
+    // drive and popped "Disk Health Warning — reports status: OK": a toast that contradicts itself and
+    // tells a non-technical user to back up over nothing.
+
+    [Theory]
+    [InlineData("Healthy")]      // MSFT_PhysicalDisk, healthy
+    [InlineData("OK")]           // Win32_DiskDrive fallback, healthy — the false alarm
+    [InlineData("Unknown")]      // unreadable: not knowing is not a failure
+    [InlineData("")]             // absent value
+    [InlineData(null)]
+    public void IsDiskProblem_HealthyOrUnknownStatus_DoesNotWarn(string? status)
+    {
+        Assert.False(TrayIconService.IsDiskProblem(status));
+    }
+
+    [Theory]
+    [InlineData("Warning")]              // MSFT_PhysicalDisk mapping
+    [InlineData("Unhealthy")]
+    public void IsDiskProblem_PhysicalDiskProblemStatus_Warns(string status)
+    {
+        // The other half: keying on problem values rather than "not Healthy" must not stop the tray
+        // warning about a drive that genuinely is failing.
+        Assert.True(TrayIconService.IsDiskProblem(status));
+    }
+
+    [Theory]
+    [InlineData("Degraded")]
+    [InlineData("Stressed")]
+    [InlineData("Pred Fail")]
+    [InlineData("Error")]
+    [InlineData("NonRecover")]
+    [InlineData("Lost Comm")]
+    [InlineData("No Contact")]
+    public void IsDiskProblem_Win32FallbackProblemStatus_Warns(string status)
+    {
+        // These are the values the FALLBACK arm can actually produce, and they matter more than they
+        // look. Win32_DiskDrive.Status uses CIM's ABBREVIATED vocabulary — capped at 10 characters, so
+        // "Pred Fail" and "NonRecover", never "Predictive Failure" or "Non-Recoverable Error". Those
+        // long forms belong to OperationalStatus, a different DiskInfo property the tray never reads.
+        //
+        // Worth stating because the first version of this fix keyed on the long names only: it read as
+        // full coverage of failing drives while in fact matching nothing the fallback emits, so a disk
+        // reporting "Pred Fail" — a drive announcing its own imminent death — would have fallen through
+        // to "unrecognised, therefore fine" and warned nobody. Trading a false alarm for a missed real
+        // failure would have been a strictly worse bug than the one being fixed.
+        Assert.True(TrayIconService.IsDiskProblem(status));
+    }
+
+    [Theory]
+    [InlineData("Predictive Failure")]
+    [InlineData("Non-Recoverable Error")]
+    public void IsDiskProblem_LongFormOperationalStatus_AlsoWarns(string status)
+    {
+        // No current caller passes OperationalStatus here, but accepting its wording costs nothing and
+        // keeps the predicate honest if one ever does.
+        Assert.True(TrayIconService.IsDiskProblem(status));
+    }
+
+    [Fact]
+    public void IsDiskProblem_ToleratesSurroundingWhitespace()
+    {
+        // WMI string values arrive as-is from the provider; a padded value must not silently become
+        // "unrecognised, therefore fine".
+        Assert.True(TrayIconService.IsDiskProblem("  Unhealthy  "));
+        Assert.False(TrayIconService.IsDiskProblem("  OK  "));
+    }
+
+    [Fact]
+    public void IsDiskProblem_AgreesWithEveryStatusTheProducerCanEmit()
+    {
+        // The guard the first attempt at this fix needed and did not have. A predicate keyed on literal
+        // strings is only correct while those strings match what the PRODUCER writes, and nothing in the
+        // compiler connects the two: SystemInfoService.QueryDisks builds DiskInfo.HealthStatus from two
+        // unrelated vocabularies, and getting one wrong fails OPEN — an unmatched value reads as "no
+        // problem", so a failing drive warns nobody and no test notices.
+        //
+        // Enumerating the producer's full value set here closes that. The Win32 half is not a guess: it
+        // is the complete ValueMap the CIM schema declares for Win32_DiskDrive.Status, read off this
+        // machine with Get-CimClass — all twelve values, partitioned into the two verdicts.
+        var win32Ok = new[] { "OK", "Unknown", "Starting", "Stopping", "Service" };
+        var win32Problem = new[] { "Error", "Degraded", "Pred Fail", "Stressed", "NonRecover", "No Contact", "Lost Comm" };
+
+        // MSFT_PhysicalDisk's HealthStatus map, the primary arm's three outcomes plus its unknown.
+        var physicalOk = new[] { "Healthy", "Unknown" };
+        var physicalProblem = new[] { "Warning", "Unhealthy" };
+
+        Assert.All([.. win32Ok, .. physicalOk], (string s) =>
+            Assert.False(TrayIconService.IsDiskProblem(s),
+                $"\"{s}\" is not a failure, but it would raise a back-up-your-data toast."));
+        Assert.All([.. win32Problem, .. physicalProblem], (string s) =>
+            Assert.True(TrayIconService.IsDiskProblem(s),
+                $"\"{s}\" IS a failure the producer can emit, and it would warn nobody."));
+
+        // The two Win32 groups must together be the WHOLE ValueMap — an unclassified value is precisely
+        // the fail-open hole described above, so leaving one out has to break this test rather than pass
+        // quietly. Twelve is the schema's count, not a number chosen to match the arrays.
+        Assert.Equal(12, win32Ok.Length + win32Problem.Length);
+
+        // "Service"/"Starting"/"Stopping" are transient states, not failures — a disk being serviced is
+        // not a disk dying, and an unprompted "back up important data" toast over one would be exactly
+        // the false alarm this fix removes.
+    }
 }

--- a/SysManager/SysManager/Services/TrayIconService.cs
+++ b/SysManager/SysManager/Services/TrayIconService.cs
@@ -259,8 +259,17 @@ public sealed class TrayIconService : IDisposable
                 $"Your PC has been running for {(int)snapshot.Os.Uptime.TotalDays} days. A restart can improve performance.");
         }
 
-        // Disk health warning
-        var unhealthyDisk = snapshot.Disks.FirstOrDefault(d => d.HealthStatus != "Healthy");
+        // Disk health warning.
+        //
+        // Matched against the values that MEAN a problem, rather than "anything that is not the word
+        // Healthy". SystemInfoService.QueryDisks has two producer arms: the MSFT_PhysicalDisk arm maps
+        // to "Healthy"/"Warning"/"Unhealthy"/"Unknown", but the Win32_DiskDrive FALLBACK passes
+        // Win32_DiskDrive.Status straight through — and that reports "OK" for a perfectly good disk.
+        // So on any machine that took the fallback, `!= "Healthy"` fired on every drive and the tray
+        // popped "Disk Health Warning — reports status: OK", a toast that contradicts itself and tells
+        // a non-technical user to back up over nothing. "Unknown" is excluded deliberately: not
+        // knowing is not a failure, and it is what both arms emit when the value is unreadable.
+        var unhealthyDisk = snapshot.Disks.FirstOrDefault(d => IsDiskProblem(d.HealthStatus));
         if (unhealthyDisk is not null && now - _lastDiskNotification > NotificationCooldown)
         {
             _lastDiskNotification = now;
@@ -268,6 +277,39 @@ public sealed class TrayIconService : IDisposable
                 $"{unhealthyDisk.FriendlyName} reports status: {unhealthyDisk.HealthStatus}. Consider backing up important data.");
         }
     }
+
+    /// <summary>
+    /// True when a disk's reported status actually indicates trouble, across BOTH shapes
+    /// <see cref="SystemInfoService"/> can produce for <c>DiskInfo.HealthStatus</c>: the
+    /// MSFT_PhysicalDisk mapping ("Warning" / "Unhealthy") and the Win32_DiskDrive fallback, which
+    /// passes <c>Win32_DiskDrive.Status</c> through raw ("OK", "Degraded", "Pred Fail", …).
+    /// </summary>
+    /// <remarks>
+    /// <para>Keyed on the problem values rather than on "not Healthy" so a healthy disk described with
+    /// any other wording — most importantly the fallback's "OK" — cannot raise a false alarm. Anything
+    /// unrecognised, including "Unknown" and an empty value, is treated as NOT a problem: this drives
+    /// an unprompted toast telling the user to back up, and inventing urgency from a value the app
+    /// could not read is worse than staying quiet. The Disk Health tab still shows the raw status.</para>
+    /// <para>The fallback's vocabulary is CIM's <c>Status</c> string set, which is ABBREVIATED to fit a
+    /// 10-character field — "Pred Fail", "NonRecover", "Lost Comm" — and is NOT the long-form
+    /// <c>OperationalStatus</c> wording ("Predictive Failure", "Non-Recoverable Error") that
+    /// SystemInfoService's own <c>OpStatusName</c> map produces. Those long names only ever reach
+    /// <c>DiskInfo.OperationalStatus</c>, a different property this method never sees, so matching them
+    /// here would be dead code hiding the very failures it looks like it covers. Both vocabularies are
+    /// accepted anyway: it costs nothing, and it keeps the predicate correct if a caller ever passes the
+    /// operational status instead.</para>
+    /// </remarks>
+    internal static bool IsDiskProblem(string? status) => status?.Trim() switch
+    {
+        // MSFT_PhysicalDisk mapping (SystemInfoService's primary arm).
+        "Warning" or "Unhealthy" => true,
+        // Win32_DiskDrive.Status — CIM's abbreviated vocabulary, the fallback arm's actual values.
+        "Degraded" or "Stressed" or "Pred Fail" or "Error" => true,
+        "NonRecover" or "Lost Comm" or "No Contact" => true,
+        // Long-form OperationalStatus wording, accepted for free in case a caller passes that instead.
+        "Predictive Failure" or "Non-Recoverable Error" => true,
+        _ => false,
+    };
 
     private void ShowNotification(string title, string message)
     {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.61.4</Version>
-    <FileVersion>1.61.4.0</FileVersion>
-    <AssemblyVersion>1.61.4.0</AssemblyVersion>
+    <Version>1.61.5</Version>
+    <FileVersion>1.61.5.0</FileVersion>
+    <AssemblyVersion>1.61.5.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -323,11 +323,27 @@ public sealed partial class CleanupViewModel : ViewModelBase
             // Clear-RecycleBin can leave behind, and keeps this in step with Deep Cleanup
             // and the One-Click Tune-Up. Run off the UI thread.
             var ct = _binCts.Token;
-            await Task.Run(RecycleBinHelper.EmptyAllDrives, ct);
-            StatusMessage = "Done";
-            ToastService.Instance.Show("Cleanup complete", "Operation finished successfully");
+            // EmptyAllDrives reports failure through its RETURN VALUE, not an exception:
+            // SHEmptyRecycleBin is a LibraryImport returning an HRESULT, so there is nothing to catch.
+            // The result used to be discarded, which meant "Done — Operation finished successfully"
+            // appeared even when the shell refused and the bin was still full. A cleanup tool claiming
+            // it cleaned when it did not is the one thing it must never do.
+            var emptied = await Task.Run(RecycleBinHelper.EmptyAllDrives, ct);
+            if (emptied)
+            {
+                StatusMessage = "Done";
+                ToastService.Instance.Show("Cleanup complete", "Operation finished successfully");
+            }
+            else
+            {
+                StatusMessage = "Could not empty the Recycle Bin — Windows refused the request.";
+                ToastService.Instance.Show("Recycle Bin not emptied",
+                    "Windows would not empty it. It may be open in Explorer, or a file may be in use.");
+                Log.Warning("Empty Recycle Bin: the shell API reported failure");
+            }
             // The operation's own flag still holds the bar (it clears in finally), so this
-            // refresh must not take it over.
+            // refresh must not take it over. Runs either way, so the size shown matches reality
+            // whether the empty succeeded or not.
             await PreScanAsync(reportProgress: false);
         }
         catch (OperationCanceledException) { StatusMessage = "Recycle Bin cleanup cancelled."; }


### PR DESCRIPTION
Closes #1788

Two places where the app told the user something that was not true. Both silent — nothing throws, nothing logs, only the wording is wrong.

## 1. The tray warned that healthy drives were failing

`TrayIconService.CheckAndNotify` used `d.HealthStatus != "Healthy"`. `SystemInfoService.QueryDisks` fills that field from **two** producers:

| Arm | When | Healthy value |
|---|---|---|
| `MSFT_PhysicalDisk` (primary) | Storage WMI namespace available | `"Healthy"` |
| `Win32_DiskDrive` (fallback) | `scope.Connect()` throws — older/headless Windows | **`"OK"`** |

`"OK" != "Healthy"`, so on any machine taking the fallback the tray fired on every drive and popped *"Disk Health Warning — Model X reports status: OK. Consider backing up important data."* every four hours: a warning that contradicts itself in its own sentence, aimed at a non-technical user.

Replaced with `IsDiskProblem()`, keyed on the values that mean trouble in **both** vocabularies.

**The part worth reviewing.** My first version of this predicate keyed on `"Predictive Failure"` / `"Non-Recoverable Error"` — the long-form `OperationalStatus` wording. That was wrong, and wrong in the dangerous direction. `Win32_DiskDrive.Status` is capped at `MaxLen=10` by the CIM schema, so its vocabulary is **abbreviated**: `"Pred Fail"`, `"NonRecover"`, `"Lost Comm"`. The long names only ever reach `DiskInfo.OperationalStatus`, a different property the tray never reads. So those arms would have been dead code that *looked* like coverage of failing drives, while a disk reporting `"Pred Fail"` — a drive announcing its own imminent death — fell through to "unrecognised, therefore fine" and warned nobody. Trading a false alarm for a missed real failure is strictly worse than the bug being fixed. Caught by checking the actual schema:

```
(Get-CimClass Win32_DiskDrive).CimClassProperties['Status'].Qualifiers['ValueMap'].Value
OK, Error, Degraded, Unknown, Pred Fail, Starting, Stopping, Service, Stressed, NonRecover, No Contact, Lost Comm
```

All twelve are now classified. An unrecognised or unreadable value stays quiet — this drives an unprompted "back up your data" toast, and inventing urgency from a value the app could not read is worse than staying silent. The Disk Health tab still shows the raw status either way.

## 2. Emptying the Recycle Bin reported a success it did not get

```csharp
await Task.Run(RecycleBinHelper.EmptyAllDrives, ct);   // bool discarded
StatusMessage = "Done";
```

`SHEmptyRecycleBin` is a `LibraryImport` returning an **HRESULT** — a refusal (bin open in Explorer, file locked) comes back as `false`, never as an exception. So the code fell through to "Done — Operation finished successfully" over a bin that was still full. For a cleanup tool that is the worst thing it can claim.

Now uses the result, with a distinct message, its own toast, and `Log.Warning`.

**Propagate check.** Grepped all three `EmptyAllDrives` call sites: `DeepCleanupService.cs:342` guards with `if (…)`, `TuneUpService.cs:299` returns `Task<bool>` into `binEmptied` which the Dashboard renders. `CleanupViewModel` was the only defective one. Also swept every discarded `await Task.Run(…)` in the app — the rest target `void` methods, so nothing else in this class.

## Tests

**Red before, green after** — proven with a throwaway console harness against two worktrees (`origin/main` vs this branch), since the xUnit suite cannot run on this workstation:

```
RED  (origin/main):  4 FAILED  — no predicate; "OK" raises a warning; bool discarded; no failure branch
GREEN (this branch): 20 checks, ALL PASS
```

Added:
- `IsDiskProblem_HealthyOrUnknownStatus_DoesNotWarn` — 5 cases incl. `"OK"` and `null`
- `IsDiskProblem_PhysicalDiskProblemStatus_Warns` / `_Win32FallbackProblemStatus_Warns` — the abbreviated set, 7 cases
- `IsDiskProblem_LongFormOperationalStatus_AlsoWarns` — accepted for free
- `IsDiskProblem_ToleratesSurroundingWhitespace`
- `IsDiskProblem_AgreesWithEveryStatusTheProducerCanEmit` — the **guard my first attempt needed and lacked**. A predicate keyed on literal strings is only correct while those strings match what the producer writes, and nothing in the compiler connects them; getting one wrong fails *open*. It enumerates the CIM ValueMap's full 12 values and asserts the count, so an unclassified value breaks the test instead of passing quietly.
- `EmptyRecycleBin_UsesTheShellResult_RatherThanAssumingSuccess` — source-level, deliberately: driving the command would empty the developer's real Recycle Bin, and the helper is a static shell P/Invoke with no seam. It inspects the call statement's *shape*, so it can only pass if the result is bound, and it also asserts the failure branch says something different (capturing the bool but printing "Done" anyway would satisfy a weaker check and fix nothing).

## Verification

- All four projects build **0 errors, 0 warnings**
- Author headers present on all four touched `.cs` files
- Leak scan over the full diff against `leak-terms.txt` — clean
- Regression: `TrayIconService` is the only consumer that makes a *decision* from `DiskInfo.HealthStatus`; the three `DiskHealthReport` status maps (`HealthScoreService`, `DiskHealthReport.HealthPercent`, `DiskHealthService.ApplyVerdict`) are fed only by `MapHealth`, which cannot emit `"OK"`, so they are unaffected
- CHANGELOG entry + version bump to 1.61.5 in this PR
