### PR TITLE
fix: make the Settings Watchdog show what it is actually watching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.61.7] - 2026-08-11
+
+The Settings Watchdog now shows what it is watching, instead of only telling you once something
+has already changed.
+
+### Fixed
+- **Settings Watchdog never showed what it watches.** The tab monitors eight Windows settings that feature updates tend to reset — telemetry, the advertising ID, activity history, web search in Start, Widgets, Start-menu suggestions and two more — and it loaded that list every time you opened it, but nothing on screen ever displayed it. Until something actually drifted, all you saw was the intro sentence naming four of them as examples, then an empty panel. Being asked to trust a monitor without being told what it monitors is a fair thing to hesitate over, so the list is now on the page: every watched setting with its category, its value right now in the same plain English the change list uses ("Off", "Full", "Not set"), and the reason it is watched. Hovering a row also shows the exact registry location, so anyone who wants to check the claim can. The values refresh with the rest of the tab rather than being read once at startup, and a setting that has drifted is tinted here too — so this list and the changed-settings list above it can never appear to disagree about the same setting.
+
+---
+
 ## [1.61.6] - 2026-08-11
 
 Five buttons that were missing: the "row highlight" for System Logs and Services announced back in

--- a/README.md
+++ b/README.md
@@ -495,6 +495,9 @@ a confirmation before it runs:
 - **Catch the settings Windows Update silently resets** — feature and quality
   updates often flip telemetry back to Full, re-enable web search, the Widgets
   board, lock-screen ads, and Start-menu suggestions
+- **See exactly what is being watched** — the full list of monitored settings, each
+  with its value right now in plain language and the reason it is watched, visible
+  from the moment you open the tab rather than only after something has changed
 - **Save a baseline** of your current preferences with one click; the watchdog
   remembers exactly what each watched setting was
 - **Check now** re-reads the live values and lists any drift in plain language —

--- a/SysManager/SysManager.Tests/SettingsWatchdogViewBindingTests.cs
+++ b/SysManager/SysManager.Tests/SettingsWatchdogViewBindingTests.cs
@@ -1,0 +1,100 @@
+// SysManager · SettingsWatchdogViewBindingTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Xml.Linq;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Asserts that Settings Watchdog actually SHOWS what it watches.
+/// </summary>
+/// <remarks>
+/// <para>`SettingsWatchdogViewModel.Watched` was populated in the constructor and bound by nothing, so
+/// the tab rendered only settings that had already drifted. Before a drift the page held the heading,
+/// the intro sentence — which names four of the eight watched settings as examples — and an empty
+/// state. A user could not find out what the watchdog covers without reading the source.</para>
+/// <para>A view-model test cannot catch that: `Watched` was correctly populated the whole time, and
+/// every test of it would have passed. The absence existed only in the markup, which is why this
+/// asserts against the shipped XAML — the same approach as
+/// <c>AboutViewModelTests.AboutView_RendersTheRollbackButtonAndItsStatus</c> and the reachability
+/// ratchet in <c>ArchitectureTests</c>, neither of which covers a collection.</para>
+/// </remarks>
+public class SettingsWatchdogViewBindingTests
+{
+    private static readonly XNamespace Presentation = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+
+    [Fact]
+    public void TheViewBindsTheWatchedList()
+    {
+        var doc = XDocument.Load(ViewPath());
+
+        var grids = doc.Descendants(Presentation + "DataGrid").ToList();
+        Assert.NotEmpty(grids);   // else the assertions below would pass by finding nothing
+
+        var watchedGrid = grids.FirstOrDefault(g =>
+            (g.Attribute("ItemsSource")?.Value ?? "").Contains("Watched", StringComparison.Ordinal));
+        Assert.NotNull(watchedGrid);
+
+        // Unlike the drift grid, this one must NOT be gated on HasDrift — its entire purpose is to be
+        // present BEFORE anything drifts, which is exactly the state that used to render nothing.
+        var visibility = watchedGrid!.Attribute("Visibility")?.Value ?? "";
+        Assert.DoesNotContain("HasDrift", visibility, StringComparison.Ordinal);
+
+        // Every column the row type offers has to be rendered, or the list is a name-only list that
+        // still cannot answer "what is set right now, and why is it watched".
+        var columnBindings = watchedGrid
+            .Descendants(Presentation + "DataGridTextColumn")
+            .Select(c => c.Attribute("Binding")?.Value ?? "")
+            .ToList();
+
+        Assert.Contains(columnBindings, b => b.Contains("Name", StringComparison.Ordinal));
+        Assert.Contains(columnBindings, b => b.Contains("Category", StringComparison.Ordinal));
+        Assert.Contains(columnBindings, b => b.Contains("CurrentLabel", StringComparison.Ordinal));
+        Assert.Contains(columnBindings, b => b.Contains("Description", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ADriftedRowIsTintedInTheWatchedList()
+    {
+        // Both lists describe the same settings, so a setting must not read as settled in one while the
+        // other flags it. The tint is what makes them agree on screen.
+        var doc = XDocument.Load(ViewPath());
+
+        var watchedGrid = doc.Descendants(Presentation + "DataGrid").First(g =>
+            (g.Attribute("ItemsSource")?.Value ?? "").Contains("Watched", StringComparison.Ordinal));
+
+        var rowStyles = watchedGrid
+            .Descendants(Presentation + "DataGrid.RowStyle")
+            .Elements(Presentation + "Style")
+            .ToList();
+        Assert.NotEmpty(rowStyles);
+
+        Assert.All(rowStyles, style =>
+        {
+            // BasedOn, or the local style replaces the App.xaml DataGridRow style wholesale and the
+            // app-wide row hover disappears — the defect this exact pattern already caused in LogsView.
+            var basedOn = style.Attribute("BasedOn")?.Value ?? "";
+            Assert.Contains("DataGridRow", basedOn, StringComparison.Ordinal);
+        });
+
+        var triggerBindings = rowStyles
+            .Descendants(Presentation + "DataTrigger")
+            .Select(t => t.Attribute("Binding")?.Value ?? "");
+        Assert.Contains(triggerBindings, b => b.Contains("HasDrifted", StringComparison.Ordinal));
+    }
+
+    // Walks up from the test binaries to the app project — .xaml is not copied to the output.
+    private static string ViewPath()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "SysManager", "Views")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);
+        var path = Path.Combine(dir!.FullName, "SysManager", "Views", "SettingsWatchdogView.xaml");
+        Assert.True(File.Exists(path), $"SettingsWatchdogView.xaml not found at {path}");
+        return path;
+    }
+}

--- a/SysManager/SysManager.Tests/SettingsWatchdogViewModelTests.cs
+++ b/SysManager/SysManager.Tests/SettingsWatchdogViewModelTests.cs
@@ -152,4 +152,107 @@ public class SettingsWatchdogViewModelTests
         Assert.False(vm.HasBaseline);
         Assert.False(vm.HasDrift);
     }
+
+    // ── "What is being watched" ──────────────────────────────────────────────────────────────────
+    //
+    // `Watched` was populated in the constructor and bound by nothing, so the tab showed only settings
+    // that had ALREADY drifted; before a drift the page held the intro sentence and an empty state.
+    // A watchdog that will not say what it watches is asking for trust it has not earned.
+    // RowMarkBindingTests' sibling in this batch asserts the binding half; these cover the data.
+
+    private static ISettingsWatchdogService WithCatalog(
+        IReadOnlyDictionary<string, int?> current, params SettingDrift[] drifts)
+    {
+        var svc = Substitute.For<ISettingsWatchdogService>();
+        svc.Catalog.Returns([Setting("telemetry"), Setting("widgets"), Setting("web-search")]);
+        svc.LoadBaseline().Returns(new BaselineSnapshot(new DateTime(2026, 1, 1), []));
+        svc.HasBaseline.Returns(true);
+        svc.DetectDrift().Returns(drifts);
+        svc.ReadCurrent().Returns(current);
+        return svc;
+    }
+
+    [Fact]
+    public void TheWatchedList_ShowsEveryCatalogEntry_EvenWithNoDrift()
+    {
+        // The case that was invisible: nothing has drifted, so the drift list is empty — and that is
+        // precisely when the user most needs to see what is covered.
+        var vm = new SettingsWatchdogViewModel(
+            WithCatalog(new Dictionary<string, int?> { ["telemetry"] = 0, ["widgets"] = 1, ["web-search"] = null }));
+
+        Assert.False(vm.HasDrift);
+        Assert.Empty(vm.Drifts);
+        Assert.Equal(3, vm.Watched.Count);
+        Assert.Equal(["Name telemetry", "Name widgets", "Name web-search"], vm.Watched.Select(w => w.Name));
+    }
+
+    [Fact]
+    public void TheWatchedList_RendersEachValueInPlainLanguage()
+    {
+        // Same wording as the drift list, via WatchedSetting.Describe — a bare number would tell the
+        // target user nothing, and "0" beside "telemetry" is actively misleading (it means Off, not
+        // absent).
+        var vm = new SettingsWatchdogViewModel(
+            WithCatalog(new Dictionary<string, int?> { ["telemetry"] = 0, ["widgets"] = 1, ["web-search"] = null }));
+
+        Assert.Equal("Off", vm.Watched.Single(w => w.Setting.Key == "telemetry").CurrentLabel);
+        Assert.Equal("On", vm.Watched.Single(w => w.Setting.Key == "widgets").CurrentLabel);
+        // Absent from the registry reads as "Not set", not as a blank cell or a zero.
+        Assert.Equal("Not set", vm.Watched.Single(w => w.Setting.Key == "web-search").CurrentLabel);
+    }
+
+    [Fact]
+    public void ASettingMissingFromTheCurrentRead_ReadsAsNotSet()
+    {
+        // ReadCurrent returns one entry per catalog key, but a key it could not read must degrade to
+        // "Not set" rather than throwing — the list has to render on a machine where a policy key is
+        // simply absent, which is the common case for several of these.
+        var vm = new SettingsWatchdogViewModel(WithCatalog(new Dictionary<string, int?>()));
+
+        Assert.Equal(3, vm.Watched.Count);
+        Assert.All(vm.Watched, w => Assert.Equal("Not set", w.CurrentLabel));
+    }
+
+    [Fact]
+    public void ADriftedSetting_IsMarkedInTheWatchedList_SoTheTwoListsCannotDisagree()
+    {
+        // Both lists describe the same settings. If one said a setting was settled while the other
+        // flagged it as changed, the page would contradict itself — the defect class already fixed in
+        // Tune-Up, where a "1 recommendation" headline sat directly above a row reading "Healthy".
+        var vm = new SettingsWatchdogViewModel(
+            WithCatalog(new Dictionary<string, int?> { ["telemetry"] = 1, ["widgets"] = 1, ["web-search"] = 1 },
+                        Drift("widgets")));
+
+        Assert.True(vm.HasDrift);
+        Assert.True(vm.Watched.Single(w => w.Setting.Key == "widgets").HasDrifted);
+        Assert.False(vm.Watched.Single(w => w.Setting.Key == "telemetry").HasDrifted);
+        Assert.False(vm.Watched.Single(w => w.Setting.Key == "web-search").HasDrifted);
+    }
+
+    [Fact]
+    public void TheWatchedList_IsRebuiltOnRefresh_SoItsValuesAreNeverStale()
+    {
+        // Rebuilt per refresh rather than once in the constructor. Showing a watched list carrying the
+        // values from app start would be its own quiet lie — the user presses Refresh precisely to find
+        // out what the machine looks like NOW.
+        var svc = WithCatalog(new Dictionary<string, int?> { ["telemetry"] = 0, ["widgets"] = 0, ["web-search"] = 0 });
+        var vm = new SettingsWatchdogViewModel(svc);
+        Assert.Equal("Off", vm.Watched.Single(w => w.Setting.Key == "telemetry").CurrentLabel);
+
+        svc.ReadCurrent().Returns(new Dictionary<string, int?> { ["telemetry"] = 1, ["widgets"] = 0, ["web-search"] = 0 });
+        vm.RefreshCommand.Execute(null);
+
+        Assert.Equal("On", vm.Watched.Single(w => w.Setting.Key == "telemetry").CurrentLabel);
+    }
+
+    [Fact]
+    public void TheWatchedList_ExposesTheRegistryLocation()
+    {
+        // Shown as a tooltip, not a column: the target user does not read registry paths, but anyone who
+        // wants to verify what the app claims to watch should not have to read the source to do it.
+        var vm = new SettingsWatchdogViewModel(WithCatalog(new Dictionary<string, int?>()));
+
+        Assert.Equal(@"HKLM\SOFTWARE\Test\telemetry\Val",
+            vm.Watched.Single(w => w.Setting.Key == "telemetry").Location);
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.61.6</Version>
-    <FileVersion>1.61.6.0</FileVersion>
-    <AssemblyVersion>1.61.6.0</AssemblyVersion>
+    <Version>1.61.7</Version>
+    <FileVersion>1.61.7.0</FileVersion>
+    <AssemblyVersion>1.61.7.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/SettingsWatchdogViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SettingsWatchdogViewModel.cs
@@ -22,7 +22,20 @@ public sealed partial class SettingsWatchdogViewModel : ViewModelBase
     private readonly ISettingsWatchdogService _service;
 
     public BulkObservableCollection<DriftRow> Drifts { get; } = new();
-    public BulkObservableCollection<WatchedSetting> Watched { get; } = new();
+
+    /// <summary>
+    /// Everything the watchdog monitors, with each setting's live value — the answer to the first
+    /// question anyone asks of a monitor: what exactly are you watching?
+    /// </summary>
+    /// <remarks>
+    /// This used to hold bare <see cref="WatchedSetting"/> records and be bound by nothing: it was
+    /// filled in the constructor and never read, so the tab showed only settings that had ALREADY
+    /// drifted. Before a drift there was nothing on screen but the intro sentence, which names four of
+    /// the eight as examples. Asking a non-technical user to trust a watchdog over an unseen list is
+    /// worse than showing them the list, especially when every entry already carries a human-readable
+    /// name, a category and a plain-English reason written for exactly this purpose.
+    /// </remarks>
+    public BulkObservableCollection<WatchedRow> Watched { get; } = new();
 
     [ObservableProperty] private bool _hasBaseline;
     [ObservableProperty] private string _baselineTaken = "";
@@ -33,7 +46,6 @@ public sealed partial class SettingsWatchdogViewModel : ViewModelBase
     {
         _service = service;
         IsElevated = AdminHelper.IsElevated();
-        Watched.ReplaceWith(_service.Catalog);
         InitializeAsync(() => { Refresh(); return System.Threading.Tasks.Task.CompletedTask; });
     }
 
@@ -44,7 +56,7 @@ public sealed partial class SettingsWatchdogViewModel : ViewModelBase
             System.Windows.Application.Current?.Shutdown();
     }
 
-    /// <summary>Re-reads the baseline and live state and rebuilds the drift list.</summary>
+    /// <summary>Re-reads the baseline and live state and rebuilds both the watched list and the drifts.</summary>
     [RelayCommand]
     private void Refresh()
     {
@@ -56,6 +68,15 @@ public sealed partial class SettingsWatchdogViewModel : ViewModelBase
         Drifts.ReplaceWith(drifts.Select(d => new DriftRow(d)));
         HasDrift = Drifts.Count > 0;
         RestoreSelectedCommand.NotifyCanExecuteChanged();
+
+        // Rebuilt on every refresh rather than once in the constructor, so the values shown are the
+        // LIVE ones — a list of watched settings with stale values would be its own quiet lie, and this
+        // is the same read DetectDrift performs. Drifted settings are marked so the two lists agree:
+        // the same setting cannot read as settled here while the drift list flags it below.
+        var current = _service.ReadCurrent();
+        var drifted = drifts.Select(d => d.Setting.Key).ToHashSet(StringComparer.Ordinal);
+        Watched.ReplaceWith(_service.Catalog.Select(s =>
+            new WatchedRow(s, current.TryGetValue(s.Key, out var v) ? v : null, drifted.Contains(s.Key))));
 
         StatusMessage = !HasBaseline
             ? "No baseline yet — save your current settings to start watching for changes."
@@ -121,5 +142,34 @@ public sealed partial class SettingsWatchdogViewModel : ViewModelBase
         public string BaselineLabel => Drift.BaselineLabel;
         public string CurrentLabel => Drift.CurrentLabel;
         public bool CanRestore => Drift.CanRestore;
+    }
+
+    /// <summary>
+    /// One watched setting with its live value, for the "what is being watched" list.
+    /// </summary>
+    /// <remarks>
+    /// A row type rather than binding <see cref="WatchedSetting"/> directly, because the record carries
+    /// only the DEFINITION — it has no current value, and a list of names with no values would not tell
+    /// the user whether anything is actually set. <see cref="WatchedSetting.Describe"/> renders the raw
+    /// number in the same plain language the drift list uses ("Off", "Full", "Not set"), so one setting
+    /// reads identically in both places.
+    /// </remarks>
+    public sealed partial class WatchedRow(WatchedSetting setting, int? currentValue, bool hasDrifted)
+        : ObservableObject
+    {
+        public WatchedSetting Setting { get; } = setting;
+        public string Name => Setting.Name;
+        public string Category => Setting.Category;
+        public string Description => Setting.Description;
+        public string CurrentLabel => Setting.Describe(currentValue);
+
+        /// <summary>True when this setting is also in the drift list, so the two views cannot disagree.</summary>
+        public bool HasDrifted { get; } = hasDrifted;
+
+        /// <summary>
+        /// The registry location, shown as a tooltip. Deliberately not a column: the target user does not
+        /// read registry paths, but anyone who wants to verify a claim should not have to read the source.
+        /// </summary>
+        public string Location => $@"{Setting.RegistryPath}\{Setting.ValueName}";
     }
 }

--- a/SysManager/SysManager/Views/SettingsWatchdogView.xaml
+++ b/SysManager/SysManager/Views/SettingsWatchdogView.xaml
@@ -18,6 +18,10 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <!-- Row 6: the watched-settings list. Auto rather than star so the drift list above keeps
+                 the flexible space — drift is the actionable content, and this list is bounded by its
+                 own MaxHeight (the catalog is a fixed eight entries). -->
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
@@ -124,8 +128,65 @@
             </Grid>
         </Border>
 
+        <!-- What is being watched.
+             The list the tab always had in memory and never showed: `Watched` was filled in the
+             constructor and bound by nothing, so before a drift the page held only the intro sentence,
+             which names four of the eight settings as examples. A watchdog that will not say what it
+             watches is asking for trust it has not earned — and every entry already carries a
+             human-readable name, a category and a plain-English reason.
+             Always visible, unlike the drift list: its whole purpose is to be there BEFORE anything
+             drifts. Same DataGrid settings as the drift grid above. -->
+        <Border Grid.Row="6" Style="{StaticResource Card}" Margin="28,16,28,0">
+            <StackPanel>
+                <TextBlock Text="What SysManager is watching" Style="{StaticResource SectionTitle}" Margin="0,0,0,4"/>
+                <TextBlock Text="These are the settings checked against your baseline, with their values right now. Nothing here is changed unless you press Restore."
+                           Style="{StaticResource Subtle}" TextWrapping="Wrap" Margin="0,0,0,10"/>
+                <DataGrid ItemsSource="{Binding Watched}" AutoGenerateColumns="False" IsReadOnly="True"
+                          HeadersVisibility="Column" GridLinesVisibility="None" Background="Transparent"
+                          BorderThickness="0" CanUserAddRows="False"
+                          VirtualizingPanel.IsVirtualizing="True"
+                          MaxHeight="260"
+                          AutomationProperties.Name="Settings being watched">
+                    <DataGrid.RowStyle>
+                        <!-- BasedOn so the app-wide hover and selection are inherited, not replaced. -->
+                        <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                            <Style.Triggers>
+                                <!-- A setting that has drifted is tinted here too, so this list and the
+                                     drift list above can never appear to disagree about the same row. -->
+                                <DataTrigger Binding="{Binding HasDrifted}" Value="True">
+                                    <Setter Property="Background" Value="{DynamicResource WarningBgSubtle}"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </DataGrid.RowStyle>
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Setting" Binding="{Binding Name}" Width="2*"/>
+                        <DataGridTextColumn Header="Category" Binding="{Binding Category}" Width="*"/>
+                        <DataGridTextColumn Header="Now" Binding="{Binding CurrentLabel}" Width="*"/>
+                        <DataGridTextColumn Header="Why it is watched" Binding="{Binding Description}" Width="3*">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+                                    <!-- Full reason plus the exact registry location, for anyone who
+                                         wants to verify the claim without reading the source. -->
+                                    <Setter Property="ToolTip">
+                                        <Setter.Value>
+                                            <MultiBinding StringFormat="{}{0}&#x0a;{1}">
+                                                <Binding Path="Description"/>
+                                                <Binding Path="Location"/>
+                                            </MultiBinding>
+                                        </Setter.Value>
+                                    </Setter>
+                                </Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </StackPanel>
+        </Border>
+
         <!-- Status -->
-        <TextBlock Grid.Row="6" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+        <TextBlock Grid.Row="7" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
                    Margin="28,12,28,24" TextWrapping="Wrap"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
Closes #1793

## The defect

`SettingsWatchdogViewModel` exposed the full catalog of what the tab monitors, populated it on construction, and nothing ever read it:

```csharp
public BulkObservableCollection<WatchedSetting> Watched { get; } = new();
…
Watched.ReplaceWith(_service.Catalog);     // constructor
```

```
$ grep -rn "\.Watched\b" --include=*.cs --include=*.xaml .
(no matches)
```

The view bound `Drifts`, `HasBaseline`, `HasDrift`, `BaselineTaken`, `IsElevated`, `StatusMessage` and the four commands — never `Watched`. So until a setting actually drifted, the page showed the heading, the elevation banner, the Save-baseline button, and the intro sentence:

> Save a baseline of the Windows settings that feature updates tend to reset — telemetry, web search, widgets, lock-screen ads — and the watchdog will flag anything that drifts, with one-click restore.

…which names **four** of the **eight** watched settings as examples, and then an empty state. The tab could not answer the first question anyone asks of a monitor: *what exactly are you watching?* For the target user, being asked to trust a watchdog over an unseen list is worse than being shown the list — especially when every entry already carries a human-readable name, a category and a plain-English reason written for exactly this purpose.

A view-model test could never have caught it. `Watched` was correctly populated the whole time; the absence existed only in the markup.

## The fix

`Watched` now holds a `WatchedRow` per setting rather than the bare `WatchedSetting` record. The record carries only the *definition* — it has no current value — and a list of names would not tell the user whether anything is actually set.

- **Values in plain language**, through the existing `WatchedSetting.Describe`, so one setting reads identically here and in the drift list: `"Off"`, `"Full"`, `"Not set"` — never a bare number. `0` beside "telemetry" is actively misleading; it means Off, not absent.
- **Rebuilt on every Refresh**, not once at construction. Showing values from app start would be its own quiet lie, since Refresh is pressed precisely to learn what the machine looks like *now*.
- **A drifted setting is tinted here too**, so the two lists cannot appear to disagree about the same row — the contradiction class already fixed in Tune-Up, where an amber "1 recommendation" headline sat directly above a row reading "Healthy".
- **Registry location as a tooltip**, not a column: the target user does not read registry paths, but anyone who wants to verify what the app claims to watch should not have to read the source.
- **`RowStyle` is `BasedOn` the implicit `DataGridRow` style.** Declaring one without `BasedOn` replaces the App.xaml style wholesale and silently drops the app-wide row hover — exactly how LogsView lost its hover (fixed in #1792). All three views with a local `RowStyle` now inherit; verified by grep.

Layout follows the drift grid directly above it: same `DataGrid` settings, same Card wrapper, Strategy-2 per-section `28` gutters. `Auto` row height rather than star so the drift list keeps the flexible space — drift is the actionable content — with `MaxHeight="260"` since the catalog is a fixed eight entries.

## Propagate: is this pattern anywhere else?

The reachability ratchet added in #1792 covers `ICommand` properties, not collections, so I swept for the collection-level version. Six candidates, **five refuted**:

| Collection | Verdict |
|---|---|
| `UninstallerViewModel.AllApps` | Backs `FilteredApps`, which the view binds (`:351,362`) |
| `WindowsFeaturesViewModel.AllFeatures` | Same shape — backs the filtered collection and the enabled count |
| `PrivacyViewModel.Toggles` | Backs `FilteredToggles`, which the view binds |
| `MainWindowViewModel.NavGroups` | Bound in `MainWindow.xaml:126` — the first pass missed it by only looking in `Views/` |
| `MainWindowViewModel.NavItems` | Read from C# (`DashboardViewModel.cs:754`) to drive tab navigation |
| **`SettingsWatchdogViewModel.Watched`** | **Confirmed** — no projection, no binding, no C# reader |

Worth stating plainly: this was the only genuinely dead collection in the app, so the pattern is not spreading.

## Verification

**Red before, green after** — throwaway console harness against two worktrees, since the xUnit suite cannot run on this workstation:

```
RED  (origin/main):  2 FAILED
     · nothing binds Watched — the catalog is loaded into memory and never shown
     · rows are bare WatchedSetting definitions with no current value
GREEN (this branch): 14 checks, ALL PASS
```

The harness drives the ViewModel through the real `ISettingsWatchdogService` seam with a stub, so it touches no registry key and no baseline file on this machine.

Tests added:
- `SettingsWatchdogViewBindingTests` — asserts against the shipped XAML (parsed as XML): a grid binds `Watched`, it is **not** gated on `HasDrift` (its whole purpose is to be present *before* anything drifts), all four columns render, the row style is `BasedOn`, and a `HasDrifted` trigger exists
- 6 view-model tests: every catalog entry listed with no drift, values in plain language, a missing read degrades to "Not set" rather than throwing, a drifted setting is marked, the list is rebuilt on Refresh, the location is exposed

Checks:
- All four projects build **0 errors, 0 warnings**
- Author headers on all four touched files
- Leak scan over the full diff incl. the new untracked file — clean
- No new `btn-*` AutomationIds, so the UI-automation contract set-equality is unaffected
- Gate-DOCS: README's Settings Watchdog section updated; CHANGELOG entry + version bump to 1.61.7 in this PR

Visual confirmation is deferred to the secondary workstation, per the project's rule that this machine never launches the app.
