### PR TITLE
fix: ask before six irreversible actions, and stop asking a question we ignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.61.8] - 2026-08-11
+
+Six places where SysManager either did not ask before doing something irreversible, or asked a
+question it did not mean.
+
+### Fixed
+- **Deep Cleanup's confirmation said the Recycle Bin was not involved while it was about to empty it.** The prompt ended with "These files are removed directly, not sent to the Recycle Bin." That was meant to say the deletion is permanent, but it reads as a promise that your Recycle Bin is left alone — and "Recycle Bin (all drives)" is one of the categories, ticked automatically whenever the bin has anything in it. So the single dialog standing between you and an emptied Recycle Bin implied the opposite of what the Clean button would do. It now says plainly that the Recycle Bin will be emptied when that category is selected, and keeps the "cannot be recovered" warning when it is not.
+- **"Upgrade selected" upgraded every ticked app without asking.** The same action on the Dashboard has always asked first. Now both do, and the App Updates prompt names the apps when there are five or fewer, since "3 apps" tells you less than which three. One prompt covers the whole batch, not one per app.
+- **"Restore default" wiped your Windows Update settings without asking.** Of the three buttons in the update-timing panel, the two that *apply* a setting both asked for confirmation; the one that *discards* everything you had configured did not. It now asks, and the prompt shows the current deferral or pause so you can see what you are giving up.
+- **"Create restore point" silently turned System Protection back on.** Windows cannot create a restore point while System Protection is off for the Windows drive, so SysManager quietly switched it on first. That is the right thing to do — but it is a lasting change that starts reserving disk space, and it happened with no mention anywhere. Both places that create a restore point (Restore Points and Performance Mode) now say so before doing it.
+- **Saving a volume preset silently replaced an existing one.** Deleting a preset asked for confirmation because the change is written to disk immediately with no undo; saving over one destroys exactly the same data and did not ask. Now it does — matching names case-insensitively, since "gaming" and "Gaming" are the same preset — while saving under a new name is never interrupted.
+- **A "cannot end this process" message was shown as a Yes/No question.** Trying to end a critical system process from the File Lock Detector opened a dialog with two buttons that did the same thing, and the answer was thrown away. It is now a plain notice with a single button. Dialogs that ask nothing should not look like questions; that habit is what teaches people to dismiss the ones that matter.
+
+---
+
 ## [1.61.7] - 2026-08-11
 
 The Settings Watchdog now shows what it is watching, instead of only telling you once something

--- a/SysManager/SysManager.Tests/AppUpdatesViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppUpdatesViewModelTests.cs
@@ -10,6 +10,9 @@ using SysManager.ViewModels;
 
 namespace SysManager.Tests;
 
+// Serialized: the confirmation-gate tests swap the static DialogService.Instance, which is
+// process-wide shared state. Required by ArchitectureTests.DialogServiceSwappers_AreInTheSerializedCollection.
+[Collection("DialogService")]
 public class AppUpdatesViewModelTests
 {
     private static readonly PowerShellRunner _sharedRunner = new();
@@ -234,9 +237,69 @@ public class AppUpdatesViewModelTests
         var vm = new AppUpdatesViewModel(winget);
         vm.Packages.Add(new AppPackage { Name = "A", Id = "a", CurrentVersion = "1", AvailableVersion = "2", IsSelected = true });
 
+        // Upgrading now confirms first, so this test has to answer the prompt to reach the code it is
+        // actually about.
+        using var _ = new DialogAnswer(confirm: true);
         var ex = await Record.ExceptionAsync(() => vm.UpgradeSelectedCommand.ExecuteAsync(null));
 
         Assert.Null(ex);
         Assert.Equal(AppUpdatesViewModel.WingetUnavailableMessage, vm.StatusMessage);
+    }
+
+    // ── Upgrading confirms, like the same action on the Dashboard already did ──────────────────────
+    //
+    // DashboardViewModel.QuickUpdateApps has always confirmed ("Confirm Update All Apps") before
+    // UpgradeAllAsync. This tab ran the identical operation — restarting apps, no undo — without asking,
+    // so the app prompted in one place and not the other for the same consequences.
+
+    [Fact]
+    public async Task UpgradeSelected_WhenUserDeclines_UpgradesNothing()
+    {
+        var winget = Substitute.For<IWingetService>();
+        var vm = new AppUpdatesViewModel(winget);
+        vm.Packages.Add(new AppPackage { Name = "A", Id = "a", CurrentVersion = "1", AvailableVersion = "2", IsSelected = true });
+
+        using var dialog = new DialogAnswer(confirm: false);
+        await vm.UpgradeSelectedCommand.ExecuteAsync(null);
+
+        Assert.Equal(1, dialog.Calls);   // the gate ran…
+        await winget.DidNotReceiveWithAnyArgs().UpgradeAsync(default!, default);   // …and it blocked
+        Assert.False(vm.IsBusy);
+    }
+
+    [Fact]
+    public async Task UpgradeSelected_WhenConfirmed_StillUpgrades()
+    {
+        // The other half: the gate must not have turned the button into a no-op.
+        var winget = Substitute.For<IWingetService>();
+        winget.UpgradeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new WingetResult(0, true, ""));
+        var vm = new AppUpdatesViewModel(winget);
+        vm.Packages.Add(new AppPackage { Name = "A", Id = "a", CurrentVersion = "1", AvailableVersion = "2", IsSelected = true });
+
+        using var dialog = new DialogAnswer(confirm: true);
+        await vm.UpgradeSelectedCommand.ExecuteAsync(null);
+
+        Assert.Equal(1, dialog.Calls);
+        await winget.Received(1).UpgradeAsync("a", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpgradeSelected_AsksOnce_ForTheWholeBatch()
+    {
+        // One prompt for the batch, not one per app. Three dialogs in a row for a three-app upgrade is
+        // how people learn to click through prompts without reading them.
+        var winget = Substitute.For<IWingetService>();
+        winget.UpgradeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new WingetResult(0, true, ""));
+        var vm = new AppUpdatesViewModel(winget);
+        for (var i = 0; i < 3; i++)
+            vm.Packages.Add(new AppPackage { Name = $"App{i}", Id = $"id{i}", CurrentVersion = "1", AvailableVersion = "2", IsSelected = true });
+
+        using var dialog = new DialogAnswer(confirm: true);
+        await vm.UpgradeSelectedCommand.ExecuteAsync(null);
+
+        Assert.Equal(1, dialog.Calls);
+        await winget.Received(3).UpgradeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 }

--- a/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
@@ -45,6 +45,15 @@ public class AudioMixerViewModelTests
         float peak = 0f) =>
         new(id, pid, name, ExePath: "", volume, muted, state, systemSounds, peak);
 
+    // A session WITH an executable path. SavePreset derives each preset entry's key from the exe
+    // name and drops entries whose name is empty, so the ExePath-less Session() helper above
+    // produces an empty preset and SavePreset returns "No apps to save" before any confirm.
+    private static AudioSessionInfo SessionWithExe(
+        string id = "s1", uint pid = 10, string name = "Chrome", float volume = 0.5f,
+        string exePath = @"C:\Program Files\Test\chrome.exe") =>
+        new(id, pid, name, exePath, volume, IsMuted: false, AudioSessionState.Active,
+            IsSystemSounds: false, PeakLevel: 0f);
+
     // A substitute service that returns a fixed session list from GetSessions.
     private static IAudioMixerService ServiceWith(params AudioSessionInfo[] sessions)
     {
@@ -565,7 +574,7 @@ public class AudioMixerViewModelTests
     {
         // A new name is not destructive, so it must NOT prompt — otherwise the confirmation becomes
         // noise that people learn to dismiss without reading.
-        var vm = NewVm(ServiceWith(Session("s1", pid: 10, name: "Chrome", volume: 0.8f)));
+        var vm = NewVm(ServiceWith(SessionWithExe(volume: 0.8f)));
         vm.NewPresetName = "Gaming";
 
         using var dialog = new DialogAnswer(confirm: false);
@@ -578,7 +587,7 @@ public class AudioMixerViewModelTests
     [Fact]
     public void SavePreset_OverAnExistingName_WhenDeclined_KeepsTheOldPreset()
     {
-        var vm = NewVm(ServiceWith(Session("s1", pid: 10, name: "Chrome", volume: 0.8f)));
+        var vm = NewVm(ServiceWith(SessionWithExe(volume: 0.8f)));
         vm.NewPresetName = "Gaming";
         using (new DialogAnswer(confirm: false)) vm.SavePresetCommand.Execute(null);
         var originalVolume = Assert.Single(vm.Presets, p => p.Name == "Gaming").Entries[0].Volume;
@@ -599,7 +608,7 @@ public class AudioMixerViewModelTests
     public void SavePreset_OverAnExistingName_WhenConfirmed_Overwrites()
     {
         // The other half: the gate must not have turned saving into a no-op.
-        var vm = NewVm(ServiceWith(Session("s1", pid: 10, name: "Chrome", volume: 0.8f)));
+        var vm = NewVm(ServiceWith(SessionWithExe(volume: 0.8f)));
         vm.NewPresetName = "Gaming";
         using (new DialogAnswer(confirm: false)) vm.SavePresetCommand.Execute(null);
 
@@ -619,7 +628,7 @@ public class AudioMixerViewModelTests
     {
         // Windows users do not distinguish "Gaming" from "gaming", and the presets file does not either —
         // saving as "gaming" replaces "Gaming", so it has to prompt like any other overwrite.
-        var vm = NewVm(ServiceWith(Session("s1", pid: 10, name: "Chrome", volume: 0.8f)));
+        var vm = NewVm(ServiceWith(SessionWithExe(volume: 0.8f)));
         vm.NewPresetName = "Gaming";
         using (new DialogAnswer(confirm: false)) vm.SavePresetCommand.Execute(null);
 

--- a/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
@@ -552,4 +552,82 @@ public class AudioMixerViewModelTests
         Assert.Empty(seen);
         Assert.False(vm.IsBusy);
     }
+
+    // ── Saving over an existing preset confirms, like deleting one already did ─────────────────────
+    //
+    // Save() rewrites the presets file on disk immediately, so overwriting destroys exactly the same data
+    // as deleting, with the same absence of undo — and DeletePreset confirmed for precisely that reason
+    // while SavePreset did not. Its own doc comment stated the behaviour plainly ("Overwrites a
+    // same-named preset") without the UI ever telling the user.
+
+    [Fact]
+    public void SavePreset_WithANewName_DoesNotInterrupt()
+    {
+        // A new name is not destructive, so it must NOT prompt — otherwise the confirmation becomes
+        // noise that people learn to dismiss without reading.
+        var vm = NewVm(ServiceWith(Session("s1", pid: 10, name: "Chrome", volume: 0.8f)));
+        vm.NewPresetName = "Gaming";
+
+        using var dialog = new DialogAnswer(confirm: false);
+        vm.SavePresetCommand.Execute(null);
+
+        Assert.Equal(0, dialog.Calls);
+        Assert.Contains(vm.Presets, p => p.Name == "Gaming");
+    }
+
+    [Fact]
+    public void SavePreset_OverAnExistingName_WhenDeclined_KeepsTheOldPreset()
+    {
+        var vm = NewVm(ServiceWith(Session("s1", pid: 10, name: "Chrome", volume: 0.8f)));
+        vm.NewPresetName = "Gaming";
+        using (new DialogAnswer(confirm: false)) vm.SavePresetCommand.Execute(null);
+        var originalVolume = Assert.Single(vm.Presets, p => p.Name == "Gaming").Entries[0].Volume;
+
+        // Change the live volume, then try to save over the same name and decline.
+        vm.Sessions[0].Volume = 0.2f;
+        vm.NewPresetName = "Gaming";
+
+        using var dialog = new DialogAnswer(confirm: false);
+        vm.SavePresetCommand.Execute(null);
+
+        Assert.Equal(1, dialog.Calls);   // the gate ran…
+        var after = Assert.Single(vm.Presets, p => p.Name == "Gaming");
+        Assert.Equal(originalVolume, after.Entries[0].Volume);   // …and the old values survived
+    }
+
+    [Fact]
+    public void SavePreset_OverAnExistingName_WhenConfirmed_Overwrites()
+    {
+        // The other half: the gate must not have turned saving into a no-op.
+        var vm = NewVm(ServiceWith(Session("s1", pid: 10, name: "Chrome", volume: 0.8f)));
+        vm.NewPresetName = "Gaming";
+        using (new DialogAnswer(confirm: false)) vm.SavePresetCommand.Execute(null);
+
+        vm.Sessions[0].Volume = 0.2f;
+        vm.NewPresetName = "Gaming";
+
+        using var dialog = new DialogAnswer(confirm: true);
+        vm.SavePresetCommand.Execute(null);
+
+        Assert.Equal(1, dialog.Calls);
+        var after = Assert.Single(vm.Presets, p => p.Name == "Gaming");
+        Assert.Equal(0.2f, after.Entries[0].Volume, precision: 3);
+    }
+
+    [Fact]
+    public void SavePreset_OverAnExistingName_MatchesCaseInsensitively()
+    {
+        // Windows users do not distinguish "Gaming" from "gaming", and the presets file does not either —
+        // saving as "gaming" replaces "Gaming", so it has to prompt like any other overwrite.
+        var vm = NewVm(ServiceWith(Session("s1", pid: 10, name: "Chrome", volume: 0.8f)));
+        vm.NewPresetName = "Gaming";
+        using (new DialogAnswer(confirm: false)) vm.SavePresetCommand.Execute(null);
+
+        vm.NewPresetName = "gaming";
+
+        using var dialog = new DialogAnswer(confirm: false);
+        vm.SavePresetCommand.Execute(null);
+
+        Assert.Equal(1, dialog.Calls);
+    }
 }

--- a/SysManager/SysManager.Tests/DeepCleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupViewModelTests.cs
@@ -620,4 +620,66 @@ public class DeepCleanupViewModelTests
             try { Directory.Delete(dir, recursive: true); } catch { }
         }
     }
+
+    // ── The confirmation must describe what will actually happen ──────────────────────────────────
+    //
+    // The wording was "These files are removed directly, not sent to the Recycle Bin." Intended as
+    // "this is permanent", it reads as "your Recycle Bin is not touched" — while the
+    // "Recycle Bin (all drives)" category is pre-ticked whenever the bin is non-empty
+    // (DeepCleanupService selects everything with size and no destructive hint). So the one dialog
+    // between the user and an emptied Recycle Bin implied the opposite of what Clean would do.
+    //
+    // Neither test creates a file or cleans anything: the user declines, so the assertion is purely on
+    // the message text captured from the dialog.
+
+    private static string CapturedCleanPrompt(bool includeRecycleBin)
+    {
+        string? shown = null;
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Do<string>(m => shown = m), Arg.Any<string>()).Returns(false);
+        DialogService.Instance = dialog;
+        try
+        {
+            var vm = NewVm();
+            vm.Categories.Add(new CleanupCategory
+            {
+                Name = includeRecycleBin ? "Recycle Bin (all drives)" : "Temp",
+                Description = "test",
+                Paths = [],
+                TotalSizeBytes = 1,
+                FileCount = 1,
+                IsRecycleBin = includeRecycleBin,
+                IsSelected = true
+            });
+
+            vm.CleanCommand.Execute(null);
+        }
+        finally { DialogService.Instance = prevDialog; }
+
+        Assert.NotNull(shown);
+        return shown!;
+    }
+
+    [Fact]
+    public void Clean_WhenTheRecycleBinIsSelected_TheConfirmationSaysSo()
+    {
+        var prompt = CapturedCleanPrompt(includeRecycleBin: true);
+
+        Assert.Contains("Recycle Bin", prompt, StringComparison.Ordinal);
+        Assert.Contains("emptying", prompt, StringComparison.OrdinalIgnoreCase);
+        // And it must NOT still carry the old phrasing, which reads as a promise the bin is untouched.
+        Assert.DoesNotContain("not sent to the Recycle Bin", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Clean_WhenTheRecycleBinIsNotSelected_StillWarnsThatDeletionIsPermanent()
+    {
+        // The other half: dropping the misleading sentence must not lose the "this is permanent"
+        // warning, which is the reason that sentence existed at all.
+        var prompt = CapturedCleanPrompt(includeRecycleBin: false);
+
+        Assert.Contains("cannot be recovered", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("emptying the Recycle Bin", prompt, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/SysManager/SysManager.Tests/FileLockViewModelTests.cs
+++ b/SysManager/SysManager.Tests/FileLockViewModelTests.cs
@@ -110,14 +110,18 @@ public class FileLockViewModelTests
     }
 
     [Fact]
-    public void KillSelected_OnCriticalProcess_ShowsBlockDialog_AndDoesNotKill()
+    public void KillSelected_OnCriticalProcess_InformsWithoutAsking_AndDoesNotKill()
     {
-        // A critical (RmCritical) locker must be blocked: the VM shows a single informational
-        // confirm and returns without ever attempting to terminate it. No kill is issued, so
-        // this exercises the guard branch safely without touching a real process.
+        // A critical (RmCritical) locker must be blocked: the VM states that it cannot be ended and
+        // returns without attempting to terminate it. No kill is issued, so this exercises the guard
+        // branch safely without touching a real process.
+        //
+        // Inform, not Confirm. This used to be a Yes/No dialog whose answer was discarded — the user
+        // chose between two buttons that did the same thing — which is how people learn to click through
+        // prompts without reading them, weakening the confirmations that DO gate something destructive.
+        // The assertion is deliberately two-sided: the notice appears AND no question is asked.
         var prevDialog = DialogService.Instance;
         var dialog = Substitute.For<IDialogService>();
-        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
         DialogService.Instance = dialog;
         try
         {
@@ -126,8 +130,8 @@ public class FileLockViewModelTests
 
             vm.KillSelectedCommand.Execute(null);
 
-            // Exactly one (informational) confirm for the "cannot end" message; nothing else.
-            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            dialog.Received(1).Inform(Arg.Any<string>(), Arg.Any<string>());
+            dialog.DidNotReceive().Confirm(Arg.Any<string>(), Arg.Any<string>());
         }
         finally
         {

--- a/SysManager/SysManager.Tests/RestorePointsViewModelTests.cs
+++ b/SysManager/SysManager.Tests/RestorePointsViewModelTests.cs
@@ -29,6 +29,11 @@ public class RestorePointsViewModelTests
     private static RestorePointsViewModel NewVm(out IPowerShellRunner runner)
     {
         runner = Substitute.For<IPowerShellRunner>();
+        // Stubbed, not left to NSubstitute's default: an unstubbed Task-returning member yields a Task
+        // whose Result is null, and RestorePointService calls .Any() on it — the test would then fail
+        // with an ArgumentNullException from inside LINQ instead of telling us anything about the gate.
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+            .Returns(new System.Collections.ObjectModel.Collection<System.Management.Automation.PSObject>());
         return new RestorePointsViewModel(new RestorePointService(runner));
     }
 
@@ -36,7 +41,8 @@ public class RestorePointsViewModelTests
     public async Task Create_WhenUserDeclines_RunsNothing()
     {
         var vm = NewVm(out var runner);
-        runner.ClearReceivedCalls();   // the constructor's initial list is not what this test is about
+        await vm.InitializationComplete;   // the constructor's initial list is not what this test is about
+        runner.ClearReceivedCalls();
 
         using var dialog = new DialogAnswer(confirm: false);
         await vm.CreateCommand.ExecuteAsync(null);
@@ -75,6 +81,7 @@ public class RestorePointsViewModelTests
     {
         // The other half: the gate must not have turned the button into a no-op.
         var vm = NewVm(out var runner);
+        await vm.InitializationComplete;   // the constructor's initial list is not what this asserts
         runner.ClearReceivedCalls();
 
         using var dialog = new DialogAnswer(confirm: true);

--- a/SysManager/SysManager.Tests/RestorePointsViewModelTests.cs
+++ b/SysManager/SysManager.Tests/RestorePointsViewModelTests.cs
@@ -1,0 +1,86 @@
+// SysManager · RestorePointsViewModelTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using NSubstitute;
+using SysManager.Services;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="RestorePointsViewModel"/>'s confirmation gate.
+/// </summary>
+/// <remarks>
+/// Creating a checkpoint runs <c>Enable-ComputerRestore -Drive $env:SystemDrive</c> before
+/// <c>Checkpoint-Computer</c>, because Windows refuses to create a restore point while System Protection
+/// is off. That is a real, persistent change to system configuration — someone who deliberately turned
+/// protection off (a common step on a small SSD, since it then reserves disk space indefinitely) got it
+/// switched back on by a button that only advertised "create a restore point". Enabling it is the right
+/// behaviour; doing it without saying so is not.
+/// <para>The whole VM runs on a substituted <see cref="IPowerShellRunner"/>, so no PowerShell is
+/// started and nothing on this machine's System Protection settings is touched.</para>
+/// </remarks>
+// Serialized: these swap the static DialogService.Instance, which is process-wide shared state.
+// Required by ArchitectureTests.DialogServiceSwappers_AreInTheSerializedCollection.
+[Collection("DialogService")]
+public class RestorePointsViewModelTests
+{
+    private static RestorePointsViewModel NewVm(out IPowerShellRunner runner)
+    {
+        runner = Substitute.For<IPowerShellRunner>();
+        return new RestorePointsViewModel(new RestorePointService(runner));
+    }
+
+    [Fact]
+    public async Task Create_WhenUserDeclines_RunsNothing()
+    {
+        var vm = NewVm(out var runner);
+        runner.ClearReceivedCalls();   // the constructor's initial list is not what this test is about
+
+        using var dialog = new DialogAnswer(confirm: false);
+        await vm.CreateCommand.ExecuteAsync(null);
+
+        Assert.Equal(1, dialog.Calls);                      // the gate ran…
+        await runner.DidNotReceiveWithAnyArgs().RunAsync(default!, default, default);   // …and it blocked
+        Assert.False(vm.IsBusy);
+    }
+
+    [Fact]
+    public async Task Create_TellsTheUserItMayTurnSystemProtectionBackOn()
+    {
+        // The disclosure IS the fix. A prompt that says only "create a restore point?" leaves the side
+        // effect invisible, which is the state this test exists to prevent returning to.
+        var vm = NewVm(out _);
+
+        string? shown = null;
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Do<string>(m => shown = m), Arg.Any<string>()).Returns(false);
+        DialogService.Instance = dialog;
+        try
+        {
+            await vm.CreateCommand.ExecuteAsync(null);
+        }
+        finally { DialogService.Instance = prevDialog; }
+
+        Assert.NotNull(shown);
+        Assert.Contains("System Protection", shown!, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("turn it", shown!, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("disk space", shown!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Create_WhenConfirmed_StillCreates()
+    {
+        // The other half: the gate must not have turned the button into a no-op.
+        var vm = NewVm(out var runner);
+        runner.ClearReceivedCalls();
+
+        using var dialog = new DialogAnswer(confirm: true);
+        await vm.CreateCommand.ExecuteAsync(null);
+
+        Assert.Equal(1, dialog.Calls);
+        await runner.ReceivedWithAnyArgs().RunAsync(default!, default, default);
+    }
+}

--- a/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
+++ b/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
@@ -621,6 +621,81 @@ public class WindowsUpdateViewModelTests
         }
     }
 
+    // ── "Restore default" is the destructive one of the three policy buttons ──────────────────────
+    //
+    // DeferFeatureUpdates and PauseUpdates confirmed from the start; Restore — which DISCARDS whatever
+    // deferral or pause those two produced — was the one that did not ask. All three are pinned here so
+    // the asymmetry cannot come back.
+    //
+    // Driven with isElevated: true and a DECLINED confirm, deliberately. WindowsUpdatePolicyService is
+    // sealed with no interface, so it cannot be substituted; on an elevated machine a confirmed Restore
+    // would really delete six values under HKLM\…\WindowsUpdate — the developer's own update policy.
+    // Declining is the assertion that matters anyway (the gate exists and it blocks), and it reaches the
+    // Confirm without ever reaching the registry.
+
+    [Theory]
+    [InlineData("RestoreUpdatePolicyCommand")]
+    [InlineData("DeferFeatureUpdatesCommand")]
+    [InlineData("PauseUpdatesCommand")]
+    public void EveryPolicyButton_AsksBeforeItChangesAnything(string commandName)
+    {
+        var vm = new WindowsUpdateViewModel(
+            Substitute.For<IPowerShellRunner>(),
+            new WindowsUpdateService(),
+            new WindowsUpdatePolicyService(),
+            static () => true);
+
+        var before = vm.PolicySummary;
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false); // user clicks "No"
+        DialogService.Instance = dialog;
+        try
+        {
+            var command = (System.Windows.Input.ICommand)vm.GetType().GetProperty(commandName)!.GetValue(vm)!;
+            command.Execute(null);
+
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            // Declining returns before the policy write, so the summary is untouched.
+            Assert.Equal(before, vm.PolicySummary);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public void RestoreUpdatePolicy_TellsTheUserWhatStateIsBeingDiscarded()
+    {
+        // A confirmation that says only "are you sure?" leaves the user guessing what they are giving
+        // up. The prompt quotes the current policy summary — the very thing Restore erases.
+        var vm = new WindowsUpdateViewModel(
+            Substitute.For<IPowerShellRunner>(),
+            new WindowsUpdateService(),
+            new WindowsUpdatePolicyService(),
+            static () => true);
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        string? shown = null;
+        dialog.Confirm(Arg.Do<string>(m => shown = m), Arg.Any<string>()).Returns(false);
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.RestoreUpdatePolicyCommand.Execute(null);
+
+            Assert.NotNull(shown);
+            Assert.Contains("default", shown!, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(vm.PolicySummary, shown!, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
     // ---------- progress reporting ----------
 
     [Fact]

--- a/SysManager/SysManager/Services/DialogService.cs
+++ b/SysManager/SysManager/Services/DialogService.cs
@@ -47,4 +47,14 @@ public sealed class DialogService : IDialogService
             _ => CloseChoice.Cancel
         };
     }
+
+    /// <inheritdoc/>
+    public void Inform(string message, string title)
+    {
+        // One OK button and an information glyph, not the Question glyph a Yes/No prompt gets: nothing
+        // here is being asked. Same no-UI guard as the others (unit tests, shutdown) — there is nothing
+        // to return, so it simply does not show.
+        if (Application.Current == null) return;
+        MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Information);
+    }
 }

--- a/SysManager/SysManager/Services/IDialogService.cs
+++ b/SysManager/SysManager/Services/IDialogService.cs
@@ -37,4 +37,17 @@ public interface IDialogService
     /// without making one of them the ambiguous default.
     /// </summary>
     CloseChoice AskCloseOrMinimize(string message, string title);
+
+    /// <summary>
+    /// Show a message with nothing to decide — one dismiss button, no return value.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="Confirm"/> for the same reason <see cref="AskCloseOrMinimize"/> is: the
+    /// shape of the dialog should match the shape of the decision. Using Confirm for a pure notice
+    /// presented "this process cannot be safely ended" as a Yes/No question and then discarded the
+    /// answer, so the user chose between two buttons that did the same thing. That is how people learn
+    /// to click through dialogs without reading them, which quietly erodes the confirmations that DO
+    /// gate something destructive.
+    /// </remarks>
+    void Inform(string message, string title);
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.61.7</Version>
-    <FileVersion>1.61.7.0</FileVersion>
-    <AssemblyVersion>1.61.7.0</AssemblyVersion>
+    <Version>1.61.8</Version>
+    <FileVersion>1.61.8.0</FileVersion>
+    <AssemblyVersion>1.61.8.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
@@ -122,6 +122,21 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
         var toUpgrade = Packages.Where(p => p.IsSelected).ToList();
         if (toUpgrade.Count == 0) { StatusMessage = "No packages selected"; return; }
 
+        // Confirm, because upgrading restarts apps and cannot be undone — and because the SAME action on
+        // the Dashboard already asks ("Confirm Update All Apps"), so without this the app asked in one
+        // place and not the other for identical consequences. Names the apps when there are few enough to
+        // read, since "3 apps" tells the user less than which three.
+        var names = toUpgrade.Count <= 5
+            ? "\n\n" + string.Join("\n", toUpgrade.Select(p => "• " + p.Name))
+            : "";
+        if (!DialogService.Instance.Confirm(
+                $"Upgrade {toUpgrade.Count} app{(toUpgrade.Count == 1 ? "" : "s")} via winget?{names}\n\n" +
+                "Apps may restart during the upgrade, and an upgrade cannot be undone.",
+                "Confirm App Upgrade"))
+        {
+            return;
+        }
+
         IsBusy = true;
         _cts?.Dispose();
         _cts = new CancellationTokenSource();

--- a/SysManager/SysManager/ViewModels/AudioMixerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AudioMixerViewModel.cs
@@ -193,7 +193,7 @@ public sealed partial class AudioMixerViewModel : ViewModelBase
 
     /// <summary>
     /// Save the current per-app volume/mute as a named preset (keyed by exe name so it re-applies
-    /// across restarts). Overwrites a same-named preset. No-ops on a blank name.
+    /// across restarts). Confirms before overwriting a same-named preset. No-ops on a blank name.
     /// </summary>
     [RelayCommand]
     private void SavePreset()
@@ -209,6 +209,20 @@ public sealed partial class AudioMixerViewModel : ViewModelBase
             .ToList();
 
         if (entries.Count == 0) { StatusMessage = "No apps to save into a preset right now."; return; }
+
+        // Overwriting destroys exactly the same data as deleting, with the same absence of undo —
+        // Save() rewrites the presets file on disk immediately — and DeletePreset below already confirms
+        // for that reason. So saving over an existing name asks too. A NEW name is not destructive and
+        // is not interrupted; only the overwrite is.
+        var existing = Presets.FirstOrDefault(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase));
+        if (existing is not null && !DialogService.Instance.Confirm(
+                $"Replace the existing preset \"{existing.Name}\"?\n\n" +
+                $"Its saved levels for {existing.Entries.Count} app{(existing.Entries.Count == 1 ? "" : "s")} " +
+                "will be overwritten with the current ones, and the old values are gone for good.",
+                "Replace Preset — Confirm"))
+        {
+            return;
+        }
 
         Presets.ReplaceWith(_presets.Save(new VolumePreset(name, entries)));
         NewPresetName = "";

--- a/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
@@ -223,15 +223,26 @@ public sealed partial class DeepCleanupViewModel : ViewModelBase
     {
         if (IsCleaning || !Categories.Any(c => c.IsSelected)) return;
 
-        // Deletion is permanent (files are not sent to the Recycle Bin). Confirm
-        // first, showing how much will be removed so the choice is informed.
+        // Deletion is permanent. Confirm first, showing how much will be removed so the choice is
+        // informed — and naming the Recycle Bin explicitly whenever it is one of the selected categories.
+        //
+        // The previous wording was only "These files are removed directly, not sent to the Recycle Bin."
+        // That was meant as "this is permanent", but it reads as "your Recycle Bin is not touched" — and
+        // the "Recycle Bin (all drives)" category is SELECTED BY DEFAULT whenever the bin is non-empty
+        // (DeepCleanupService pre-ticks every category that has size and no destructive hint). So the one
+        // dialog standing between the user and an emptied Recycle Bin appeared to promise the opposite of
+        // what pressing Clean would actually do.
         var selected = Categories.Where(c => c.IsSelected).ToList();
         var totalBytes = selected.Sum(c => c.TotalSizeBytes);
         var fileCount = selected.Sum(c => c.FileCount);
         if (!DialogService.Instance.Confirm(
                 $"Permanently delete {fileCount:N0} files (~{FormatHelper.FormatSize(totalBytes)}) " +
                 $"across {selected.Count} categor{(selected.Count == 1 ? "y" : "ies")}?\n\n" +
-                "These files are removed directly, not sent to the Recycle Bin.",
+                (selected.Any(c => c.IsRecycleBin)
+                    ? "This includes emptying the Recycle Bin on every drive, so whatever is in it now " +
+                      "goes too. Nothing deleted here can be recovered afterwards."
+                    : "These files are deleted outright — they do not go to the Recycle Bin, so they " +
+                      "cannot be recovered afterwards."),
                 "Confirm Deep Cleanup"))
         {
             return;

--- a/SysManager/SysManager/ViewModels/FileLockViewModel.cs
+++ b/SysManager/SysManager/ViewModels/FileLockViewModel.cs
@@ -107,7 +107,10 @@ public sealed partial class FileLockViewModel : ViewModelBase
 
         if (locker.IsCritical)
         {
-            DialogService.Instance.Confirm(
+            // Inform, not Confirm. Nothing is being decided — the process will not be ended either way —
+            // but this was a Yes/No dialog whose answer was discarded, so the user chose between two
+            // buttons that did the same thing.
+            DialogService.Instance.Inform(
                 $"\"{locker.ProcessName}\" is a critical system process and cannot be safely ended from here.",
                 "Cannot End Process");
             return;

--- a/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
@@ -493,7 +493,20 @@ public sealed partial class PerformanceViewModel : ViewModelBase
             return;
         }
 
-        if (!DialogService.Instance.Confirm("Create a System Restore point?\n\nThis saves the current system state so you can roll back later if something goes wrong.", "Restore Point — Confirm")) return;
+        // Same disclosure as the Restore Points tab: creating a checkpoint enables System Protection for
+        // the Windows drive first, because Checkpoint-Computer fails when it is off. Both entry points
+        // reach the same service call, so both have to say so — a prompt that is honest in one tab and
+        // silent in the other still leaves the user surprised.
+        if (!DialogService.Instance.Confirm(
+                "Create a System Restore point?\n\n" +
+                "This saves the current system state so you can roll back later if something goes wrong.\n\n" +
+                "If System Protection is currently off for the Windows drive, SysManager will turn it " +
+                "back on — Windows cannot create a restore point otherwise. Protection then reserves " +
+                "some disk space for restore points until you turn it off again in System Properties.",
+                "Restore Point — Confirm"))
+        {
+            return;
+        }
 
         // Serialize with the app-wide system-modification lock (see ApplyPowerPlanAsync).
         using var opLock = OperationLockService.Instance.TryAcquire(OperationCategory.SystemModification, "Create restore point");

--- a/SysManager/SysManager/ViewModels/RestorePointsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/RestorePointsViewModel.cs
@@ -89,6 +89,24 @@ public sealed partial class RestorePointsViewModel : ViewModelBase
             ? $"SysManager — {DateTime.Now:yyyy-MM-dd HH:mm}"
             : NewDescription.Trim();
 
+        // Disclose the side effect BEFORE doing it. Creating a checkpoint runs
+        // `Enable-ComputerRestore -Drive $env:SystemDrive` first (RestorePointService), because
+        // Checkpoint-Computer fails outright when protection is off. That is a real, persistent change to
+        // system configuration: someone who deliberately turned System Protection off — a common step on a
+        // small SSD, since it then reserves disk space indefinitely — got it switched back on by pressing
+        // a button that only advertised "create a restore point", with no prompt and no mention anywhere
+        // in the UI. Enabling it is the right behaviour (a restore point is useless otherwise); doing it
+        // without saying so is not.
+        if (!DialogService.Instance.Confirm(
+                $"Create a restore point named \"{description}\"?\n\n" +
+                "If System Protection is currently off for the Windows drive, SysManager will turn it " +
+                "back on — Windows cannot create a restore point otherwise. Protection then reserves " +
+                "some disk space for restore points until you turn it off again in System Properties.",
+                "Create Restore Point"))
+        {
+            return;
+        }
+
         IsBusy = true;
         IsProgressIndeterminate = true;
         StatusMessage = "Creating restore point…";

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -164,6 +164,15 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
     private void RestoreUpdatePolicy()
     {
         if (!RequireAdminForPolicy()) return;
+        // Confirmed like its two siblings above. This is the one button on the panel that DISCARDS
+        // configuration — it clears whatever deferral and pause window the user set — and it was the
+        // only one of the three that did not ask. The summary line describes the state being thrown
+        // away, so the user can see what they are giving up before agreeing to it.
+        if (!DialogService.Instance.Confirm(
+                "Restore Windows Update to its default settings?\n\n" +
+                $"This clears any deferral or pause you have configured. Current state: {PolicySummary}",
+                "Restore update defaults"))
+            return;
         PolicySummary = _policy.RestoreDefault()
             ? _policy.Read(DateTime.Now).Summary
             : "Couldn't restore the policy — administrator rights are required.";


### PR DESCRIPTION
Closes #1795

Six confirmation defects. Each is an **inconsistency with the app's own behaviour elsewhere** — the same action confirms in one tab and not in another — which is what makes them defects rather than preferences. Each was verified individually against current `main` before being touched.

## 1. Deep Cleanup's confirmation said the Recycle Bin was not involved while it was about to empty it

The prompt ended with:

> These files are removed directly, **not sent to the Recycle Bin**.

Meant as "this is permanent". It reads as "your Recycle Bin is left alone" — and `DeepCleanupService.cs:116` defines a **"Recycle Bin (all drives)"** category which the pre-tick rule at `:239` (`IsSelected = size > 0 && !d.IsDestructiveHint`) **selects by default** whenever the bin is non-empty. Pressing Clean then empties it at `:342`. So the one dialog between the user and an emptied Recycle Bin implied the opposite of what the button does.

Now names the Recycle Bin explicitly when that category is selected, and keeps the permanence warning when it is not.

## 2. "Upgrade selected" upgraded every ticked app with no prompt

`AppUpdatesViewModel.cs:120` went straight from the empty-selection guard into the upgrade loop. Meanwhile `DashboardViewModel.QuickUpdateApps` has always confirmed (*"Confirm Update All Apps"*) for the **identical** operation. Upgrading restarts apps and cannot be undone.

Both ask now. The App Updates prompt names the apps at five or fewer — "3 apps" tells the user less than *which* three — and asks **once for the batch**, not once per app (a pinned test).

## 3. "Restore default" wiped six Windows Update policy values with no prompt

Of the three buttons on that panel, `DeferFeatureUpdates` (`:132`) and `PauseUpdates` (`:147`) both confirmed from the start. `RestoreUpdatePolicy` (`:164`) — the one that **discards** whatever the other two configured — did not. Its prompt now quotes the current policy summary, so the user can see what they are giving up rather than being asked a bare "are you sure?".

## 4. "Create restore point" silently turned System Protection back on

`RestorePointService.cs:104` runs:

```powershell
Enable-ComputerRestore -Drive $env:SystemDrive -ErrorAction SilentlyContinue;
Checkpoint-Computer -Description '…' -RestorePointType 'MODIFY_SETTINGS'
```

Enabling it is correct — Windows refuses to create a checkpoint otherwise — but it is a **lasting change to system configuration** that then reserves disk space indefinitely, and it happened with no prompt and no mention anywhere in the UI. Someone who deliberately turned System Protection off (common on a small SSD) got it switched back on by a button advertising only "create a restore point".

**Both** entry points now disclose it: the Restore Points tab and Performance Mode, which reach the same service call and were both silent.

## 5. Saving a volume preset silently replaced an existing one

`AudioMixerViewModel.cs:198` — its own doc comment said *"Overwrites a same-named preset."* `DeletePreset` (`:246`) confirmed, with the reason spelled out in a comment: *"Delete() rewrites the presets file on disk straight away, so there is no undo."* Overwriting destroys the same data with the same absence of undo.

Now confirms, matching names **case-insensitively** (the presets file does not distinguish "gaming" from "Gaming", so saving as one replaces the other). Saving under a **new** name is not destructive and is never interrupted — a pinned test, since a prompt on every save would be noise people learn to dismiss.

## 6. A "cannot end this process" message was shown as a Yes/No question

`FileLockViewModel.cs:110` used `Confirm` for a pure notice and discarded the result, so the user chose between two buttons that did the same thing.

Added **`IDialogService.Inform`** — one dismiss button, no return value, the information glyph rather than the question glyph. Separate from `Confirm` for the same reason `AskCloseOrMinimize` is: the shape of the dialog should match the shape of the decision. Training people to click through dialogs is precisely what erodes the confirmations that *do* gate something destructive.

## Propagate

Swept every ViewModel and Service for other statement-position `Confirm` calls (a discarded result) — **none remain**.

## Verification

- All four projects build **0 errors, 0 warnings**
- Author headers on all 15 touched files
- Leak scan over the full diff incl. the new untracked file — clean
- **14 tests added** across five files, each pinning **both halves**: declining blocks the action *and* confirming still performs it, so the gate cannot silently become a no-op. Where the wording **is** the fix, the message content is asserted from the captured dialog text: Deep Cleanup's Recycle Bin disclosure (both branches), Restore's policy quote, Create's System Protection warning.
- `RestorePointsViewModelTests` is new and drives the whole VM on a substituted `IPowerShellRunner`, so no PowerShell starts and this machine's System Protection settings are never touched. The WindowsUpdate policy tests decline deliberately — `WindowsUpdatePolicyService` is `sealed` with no interface, so on an elevated machine a *confirmed* Restore would really delete six values under `HKLM\…\WindowsUpdate`, i.e. the developer's own update policy. Declining is the assertion that matters and it never reaches the registry.
- Two existing tests needed the new gate answered to keep reaching the code they were actually about (`Upgrade_WhenWingetMissing…`, and the FileLock critical-process test now asserts `Inform` **and** that no `Confirm` was shown). `AppUpdatesViewModelTests` gained `[Collection("DialogService")]`, which `ArchitectureTests.DialogServiceSwappers_AreInTheSerializedCollection` requires of any file swapping the static instance.
- CHANGELOG entry + version bump to 1.61.8 in this PR

No UI-layout change, so nothing here needs the secondary workstation beyond the usual visual sanity pass.
