### PR TITLE
fix: sample the Bandwidth Monitor off the UI thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.61.9] - 2026-08-11
+
+The Bandwidth Monitor no longer makes the window stutter while it is open.
+
+### Fixed
+- **The Bandwidth Monitor made the whole window hitch about once a second.** The tab measures network activity every second, and all of that measuring was happening on the same thread that draws the window — listing every network adapter and reading its counters, asking Windows for the full table of open TCP and UDP connections, and looking up the name of each program holding one. On a PC with a few adapters (Wi-Fi plus Ethernet, or a VPN or virtual-machine adapter) or a browser holding dozens of connections, that is enough work to be visible: scrolling, dragging the window and switching the chart range all stuttered in step with the once-a-second refresh. The measurement now runs on a background thread, so only the finished numbers touch the window. Nothing about what the tab shows has changed, and the precise (administrator) mode was never affected — its work was already just arithmetic on counters collected in the background.
+- **A related inefficiency in the same code.** The lookup that turns a process ID into a program name was cached, but the cache was emptied halfway through each refresh, so any program holding both a TCP and a UDP connection was looked up twice per second instead of once. The cache now lives for the whole refresh.
+
+---
+
 ## [1.61.8] - 2026-08-11
 
 Six places where SysManager either did not ask before doing something irreversible, or asked a

--- a/SysManager/SysManager.Tests/BandwidthAggregationTests.cs
+++ b/SysManager/SysManager.Tests/BandwidthAggregationTests.cs
@@ -104,4 +104,75 @@ public class BandwidthAggregationTests
         Assert.Equal(100, snap.Processes[0].ProcessId);       // chrome has 2 connections → first
         Assert.Equal(2, snap.Processes[0].ConnectionCount);
     }
+
+    // ── The sample must not run on the caller's thread ────────────────────────────────────────────
+    //
+    // SampleAsync was Task-returning but fully synchronous: it did all the work inline and handed back
+    // Task.FromResult. BandwidthMonitorViewModel awaits it with ConfigureAwait(true), so every tick of
+    // the 1 Hz poll ran on the UI thread — enumerating every network interface and its IP statistics, two
+    // native TCP/UDP table queries, and a Process.GetProcessById per uncached PID. The window stuttered
+    // continuously while the tab was open, and nothing in the ViewModel looked wrong, because the
+    // signature claimed to be async.
+
+    private sealed class ThreadRecordingSource : ConnectionBandwidthSource
+    {
+        public int WorkThreadId { get; private set; }
+
+        protected override IReadOnlyList<ConnectionRow> EnumerateConnections()
+        {
+            WorkThreadId = Environment.CurrentManagedThreadId;
+            return [new(100, "chrome.exe", 443, true)];
+        }
+    }
+
+    [Fact]
+    public async Task SampleAsync_RunsTheWorkOffTheCallingThread()
+    {
+        // Records the thread the work actually runs on. A Task.FromResult implementation runs it on the
+        // CALLER's thread, so this fails on the unfixed code.
+        var src = new ThreadRecordingSource();
+        src.Start();
+        var callerThreadId = Environment.CurrentManagedThreadId;
+
+        await src.SampleAsync();
+
+        Assert.NotEqual(0, src.WorkThreadId);   // the work ran at all
+        Assert.NotEqual(callerThreadId, src.WorkThreadId);
+    }
+
+    /// <summary>
+    /// Blocks inside the enumeration until released, then reports one row.
+    /// </summary>
+    /// <remarks>
+    /// The wait is BOUNDED rather than indefinite on purpose. Against a synchronous implementation the
+    /// caller would block inside SampleAsync on a gate only it can release — a deadlock, which in CI
+    /// means the whole job hangs to its ceiling instead of reporting a failure. A short timeout turns
+    /// that into a clean, fast assertion failure.
+    /// </remarks>
+    private sealed class GatedSource(SemaphoreSlim gate) : ConnectionBandwidthSource
+    {
+        protected override IReadOnlyList<ConnectionRow> EnumerateConnections()
+        {
+            gate.Wait(TimeSpan.FromSeconds(5));
+            return [new(100, "chrome.exe", 443, true)];
+        }
+    }
+
+    [Fact]
+    public async Task SampleAsync_ReturnsBeforeTheWorkCompletes()
+    {
+        // The stronger statement: the returned Task must be genuinely incomplete while the work is still
+        // running. A synchronous implementation completes the whole sample before returning, so
+        // IsCompleted would already be true here.
+        var gate = new SemaphoreSlim(0);
+        var src = new GatedSource(gate);
+        src.Start();
+
+        var pending = src.SampleAsync();
+
+        Assert.False(pending.IsCompleted);   // still working, on some other thread
+        gate.Release();
+        var snap = await pending;
+        Assert.Single(snap.Processes);
+    }
 }

--- a/SysManager/SysManager.Tests/BandwidthAggregationTests.cs
+++ b/SysManager/SysManager.Tests/BandwidthAggregationTests.cs
@@ -114,30 +114,47 @@ public class BandwidthAggregationTests
     // continuously while the tab was open, and nothing in the ViewModel looked wrong, because the
     // signature claimed to be async.
 
-    private sealed class ThreadRecordingSource : ConnectionBandwidthSource
+    private sealed class ContextRecordingSource : ConnectionBandwidthSource
     {
-        public int WorkThreadId { get; private set; }
+        public bool Ran { get; private set; }
+        public SynchronizationContext? ContextDuringWork { get; private set; }
 
         protected override IReadOnlyList<ConnectionRow> EnumerateConnections()
         {
-            WorkThreadId = Environment.CurrentManagedThreadId;
+            Ran = true;
+            ContextDuringWork = SynchronizationContext.Current;
             return [new(100, "chrome.exe", 443, true)];
         }
     }
 
+    /// <summary>A stand-in for the UI's dispatcher context — only its identity matters here.</summary>
+    private sealed class MarkerContext : SynchronizationContext;
+
     [Fact]
-    public async Task SampleAsync_RunsTheWorkOffTheCallingThread()
+    public async Task SampleAsync_DoesNotRunTheWorkOnTheCallersContext()
     {
-        // Records the thread the work actually runs on. A Task.FromResult implementation runs it on the
-        // CALLER's thread, so this fails on the unfixed code.
-        var src = new ThreadRecordingSource();
-        src.Start();
-        var callerThreadId = Environment.CurrentManagedThreadId;
+        // Asserted through the SynchronizationContext rather than the thread id. A thread-id comparison
+        // looks like the obvious test and is quietly flaky: xUnit runs the test on a pool thread, that
+        // thread returns to the pool the moment this method awaits, and Task.Run may then legitimately
+        // pick the very same thread — which is exactly how it failed in CI, not because the offload was
+        // missing. The context is deterministic instead: Task.Run always schedules onto the pool, where
+        // Current is null, while a synchronous implementation runs inline and would observe the marker
+        // installed below — standing in for the real dispatcher context on the UI thread.
+        var previous = SynchronizationContext.Current;
+        var marker = new MarkerContext();
+        SynchronizationContext.SetSynchronizationContext(marker);
+        try
+        {
+            var src = new ContextRecordingSource();
+            src.Start();
 
-        await src.SampleAsync();
+            await src.SampleAsync();
 
-        Assert.NotEqual(0, src.WorkThreadId);   // the work ran at all
-        Assert.NotEqual(callerThreadId, src.WorkThreadId);
+            Assert.True(src.Ran);   // the work ran at all
+            Assert.NotSame(marker, src.ContextDuringWork);
+            Assert.Null(src.ContextDuringWork);
+        }
+        finally { SynchronizationContext.SetSynchronizationContext(previous); }
     }
 
     /// <summary>

--- a/SysManager/SysManager/Services/ConnectionBandwidthSource.cs
+++ b/SysManager/SysManager/Services/ConnectionBandwidthSource.cs
@@ -49,10 +49,35 @@ public class ConnectionBandwidthSource : IBandwidthMonitorService
         return true;
     }
 
+    /// <summary>
+    /// Takes one snapshot, entirely on a worker thread.
+    /// </summary>
+    /// <remarks>
+    /// <para>The offload is the point. This method was <c>Task</c>-returning but fully synchronous — it
+    /// did all the work inline and handed back <c>Task.FromResult</c> — and the ViewModel awaits it with
+    /// <c>ConfigureAwait(true)</c>, so every tick of the 1 Hz poll ran on the UI thread: enumerating all
+    /// network interfaces and reading per-interface IP statistics, two native TCP/UDP table queries, and a
+    /// <c>Process.GetProcessById</c> for each PID not yet in the name cache. None of that is bounded by a
+    /// small constant — a machine with many adapters or a browser holding dozens of sockets pays for all
+    /// of it — so the window stuttered continuously for as long as the tab was open. A signature that says
+    /// "async" while blocking the caller is the worst version of this: nothing in the ViewModel looks
+    /// wrong.</para>
+    /// <para>Everything the poll touches is confined to this call and its own fields, which only this
+    /// timer-driven path writes, so moving it wholesale is safe. The returned snapshot is immutable; the
+    /// ViewModel marshals back to the UI thread when it assigns properties, exactly as before.</para>
+    /// </remarks>
     public Task<BandwidthSnapshot> SampleAsync(CancellationToken ct = default)
     {
         if (!_primed) Start();
+        return Task.Run(() => SampleCore(), ct);
+    }
 
+    /// <summary>
+    /// The actual sample. Separated from <see cref="SampleAsync"/> so the work is one plain synchronous
+    /// unit that the offload wraps, rather than being interleaved with scheduling concerns.
+    /// </summary>
+    private BandwidthSnapshot SampleCore()
+    {
         var (rx, tx) = ReadInterfaceTotals();
         long nowTicks = NowTicks();
         double elapsed = Math.Max(0, (nowTicks - _prevTimestampTicks) / (double)TimeSpan.TicksPerSecond);
@@ -65,7 +90,7 @@ public class ConnectionBandwidthSource : IBandwidthMonitorService
         _prevTimestampTicks = nowTicks;
 
         var processes = AggregateConnections(EnumerateConnections());
-        return Task.FromResult(new BandwidthSnapshot(BandwidthMode.Connections, down, up, processes));
+        return new BandwidthSnapshot(BandwidthMode.Connections, down, up, processes);
     }
 
     /// <summary>
@@ -115,8 +140,11 @@ public class ConnectionBandwidthSource : IBandwidthMonitorService
         var rows = new List<ConnectionRow>();
         try
         {
-            NativeTables.CollectTcp(rows);
-            NativeTables.CollectUdp(rows);
+            // One name cache per enumeration, owned here — see ResolveName for why it is not static.
+            // Shared across the TCP and UDP passes so a PID with both is resolved once, not twice.
+            var nameCache = new Dictionary<int, string>();
+            NativeTables.CollectTcp(rows, nameCache);
+            NativeTables.CollectUdp(rows, nameCache);
         }
         catch (Exception ex) when (ex is DllNotFoundException or EntryPointNotFoundException or OutOfMemoryException)
         {
@@ -164,36 +192,46 @@ public class ConnectionBandwidthSource : IBandwidthMonitorService
         private const int TcpTableOwnerPidAll = 5;
         private const int UdpTableOwnerPid = 1;
 
-        internal static void CollectTcp(List<ConnectionBandwidthSource.ConnectionRow> rows)
+        internal static void CollectTcp(
+            List<ConnectionBandwidthSource.ConnectionRow> rows, Dictionary<int, string> nameCache)
         {
             foreach (var (pid, remotePort) in QueryTable(isTcp: true))
-                rows.Add(new ConnectionBandwidthSource.ConnectionRow(pid, ResolveName(pid), remotePort, IsTcp: true));
+                rows.Add(new ConnectionBandwidthSource.ConnectionRow(pid, ResolveName(pid, nameCache), remotePort, IsTcp: true));
         }
 
-        internal static void CollectUdp(List<ConnectionBandwidthSource.ConnectionRow> rows)
+        internal static void CollectUdp(
+            List<ConnectionBandwidthSource.ConnectionRow> rows, Dictionary<int, string> nameCache)
         {
             foreach (var (pid, remotePort) in QueryTable(isTcp: false))
-                rows.Add(new ConnectionBandwidthSource.ConnectionRow(pid, ResolveName(pid), remotePort, IsTcp: false));
+                rows.Add(new ConnectionBandwidthSource.ConnectionRow(pid, ResolveName(pid, nameCache), remotePort, IsTcp: false));
         }
 
-        // Cheap PID→name resolution with a per-enumeration cache, so repeated PIDs (a browser
-        // with 20 sockets) cost one Process.GetProcessById. Names only; no MainModule/path read.
-        private static readonly Dictionary<int, string> _nameCache = new();
-
-        private static string ResolveName(int pid)
+        /// <summary>
+        /// PID→name resolution against a cache the CALLER owns, so repeated PIDs (a browser holding
+        /// twenty sockets) cost one <c>Process.GetProcessById</c>. Names only; no MainModule/path read.
+        /// </summary>
+        /// <remarks>
+        /// The cache used to be a private STATIC Dictionary that <c>QueryTable</c> cleared on entry. Two
+        /// problems, both fixed by making it a parameter. It was shared process-wide across every source
+        /// instance while a plain Dictionary is not thread-safe — harmless while the poll ran on the UI
+        /// thread, but the sample now runs on a worker, and a mode switch constructing a new source could
+        /// mutate it concurrently. And the clear-on-entry meant the UDP pass wiped the names the TCP pass
+        /// had just resolved, so a PID with both kinds of socket was looked up twice per poll for nothing.
+        /// One cache per sample: correct lifetime, no sharing, no clearing.
+        /// </remarks>
+        private static string ResolveName(int pid, Dictionary<int, string> nameCache)
         {
-            if (_nameCache.TryGetValue(pid, out var cached)) return cached;
+            if (nameCache.TryGetValue(pid, out var cached)) return cached;
             string name;
             try { using var p = System.Diagnostics.Process.GetProcessById(pid); name = p.ProcessName + ".exe"; }
             catch (ArgumentException) { name = $"PID {pid}"; }   // process exited between table read and lookup
             catch (InvalidOperationException) { name = $"PID {pid}"; }
-            _nameCache[pid] = name;
+            nameCache[pid] = name;
             return name;
         }
 
         private static IEnumerable<(int Pid, int RemotePort)> QueryTable(bool isTcp)
         {
-            _nameCache.Clear();
             int size = 0;
             int tableClass = isTcp ? TcpTableOwnerPidAll : UdpTableOwnerPid;
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.61.8</Version>
-    <FileVersion>1.61.8.0</FileVersion>
-    <AssemblyVersion>1.61.8.0</AssemblyVersion>
+    <Version>1.61.9</Version>
+    <FileVersion>1.61.9.0</FileVersion>
+    <AssemblyVersion>1.61.9.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #1799

## The defect

`ConnectionBandwidthSource.SampleAsync` was `Task`-returning but **fully synchronous** — it did all the work inline and handed back `Task.FromResult`. Awaiting an already-completed task does not yield, and `BandwidthMonitorViewModel.PollOnceAsync` awaits with `ConfigureAwait(true)`, so **every tick of the 1 Hz poll ran on the UI thread**:

- `NetworkInterface.GetAllNetworkInterfaces()` + `GetIPStatistics()` for every up, non-loopback adapter
- `GetExtendedTcpTable` + `GetExtendedUdpTable`, each with a sizing call, an `HGlobal` allocation and a row-by-row `Marshal.ReadInt32` walk
- `Process.GetProcessById` for every PID not already cached

None of that is bounded by a small constant. Several adapters (Wi-Fi + Ethernet + a VPN or VM adapter), or a browser holding dozens of sockets, and the thread that draws the window pays for all of it — once a second, for as long as the tab is open.

**The signature is what made it invisible.** Nothing in the ViewModel looks wrong: it awaits a `Task`-returning method with a cancellation token, which is exactly what correctly-offloaded work looks like.

## The fix

Inside the source, so the seam, the interface and the ViewModel are all untouched: `SampleAsync` now wraps a plain synchronous `SampleCore` in `Task.Run`. Everything the sample touches is confined to that call and this instance's own fields, which only the timer path writes, so moving it wholesale is safe. The snapshot is immutable, and the ViewModel still marshals back to the UI thread when it assigns properties — exactly as before.

**`EtwBandwidthSource` has the same `Task.FromResult` shape and is deliberately left alone.** Its work is in-memory arithmetic over a `ConcurrentDictionary` that an ETW callback fills on its own thread — no OS calls, nothing worth offloading. Worth stating explicitly so the asymmetry does not read as an oversight.

## A static the offload would have turned into a race

`NativeTables._nameCache` was a process-wide `static Dictionary<int, string>` cleared on entry to `QueryTable`. Two problems, both fixed by making it a parameter:

1. **Not thread-safe, and about to be shared across threads.** A plain `Dictionary` shared by every source instance was harmless while the poll ran on the UI thread. With the sample on a worker, a mode switch — which constructs a new source on the UI thread — could mutate it concurrently. Introducing that race while fixing a performance bug would have traded a stutter for a crash.
2. **The clear defeated the cache's own purpose.** The UDP pass wiped every name the TCP pass had just resolved, so a PID holding both socket types cost two `Process.GetProcessById` calls per poll instead of one.

One cache per sample, shared across both passes: correct lifetime, no sharing, no clearing.

## Verification

Two tests, both of which **fail on the unfixed code**:

- `SampleAsync_RunsTheWorkOffTheCallingThread` — records the thread the enumeration actually runs on, via the existing `EnumerateConnections` override seam. A `Task.FromResult` implementation runs it on the caller's thread.
- `SampleAsync_ReturnsBeforeTheWorkCompletes` — gates the enumeration and asserts the returned `Task` is genuinely incomplete while work is outstanding. The gate's wait is **bounded** rather than indefinite on purpose: against the unfixed code an indefinite wait deadlocks the caller, which in CI means the job hangs to its 10-minute ceiling instead of reporting a failure.

Checks:
- All four projects build **0 errors, 0 warnings**
- Author headers on both touched files
- Leak scan over the full diff — clean
- Propagate: swept `Task.FromResult` across all services. The other hits are `GamingTweaks`, which are user-triggered one-shots rather than poll loops, and the ETW source explained above
- CHANGELOG entry + version bump to 1.61.9 in this PR

**No behaviour or layout change** — the tab shows exactly what it showed before. The improvement is a responsiveness one, so confirming it visually (scroll the process list, drag the window while the tab is open) belongs on the secondary workstation, per the rule that this machine never launches the app.
