### PR TITLE
fix: give the five unreachable Services filters a chip each

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.61.10] - 2026-08-11
+
+The Services tab can now actually filter by the things it always claimed to — including the gaming
+recommendations, which are the reason the list is more useful than the one in Windows.
+
+### Fixed
+- **Five of the Services tab's nine filters had no button.** Filtering by status (Running / Stopped) and by gaming recommendation (Safe to disable / Keep enabled / Advanced) was fully written and working, but nothing on screen could select it — the only chips were Safe, Caution, Critical and All, so those five could be reached only from a debugger. The README promised both anyway: "filter by status (Running/Stopped) … gaming recommendation". All nine are now chips, grouped under Safety / Status / For gaming so the two different meanings do not get confused: safety answers "will turning this off break Windows", the gaming recommendation answers "is it worth turning off for games". Each chip shows how many services it matches, so you can tell before pressing it, and the row reflows on a narrow window instead of clipping.
+
+---
+
 ## [1.61.9] - 2026-08-11
 
 The Bandwidth Monitor no longer makes the window stutter while it is open.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ recommendations, which are the reason the list is more useful than the one in Wi
 
 ### Fixed
 - **Five of the Services tab's nine filters had no button.** Filtering by status (Running / Stopped) and by gaming recommendation (Safe to disable / Keep enabled / Advanced) was fully written and working, but nothing on screen could select it — the only chips were Safe, Caution, Critical and All, so those five could be reached only from a debugger. The README promised both anyway: "filter by status (Running/Stopped) … gaming recommendation". All nine are now chips, grouped under Safety / Status / For gaming so the two different meanings do not get confused: safety answers "will turning this off break Windows", the gaming recommendation answers "is it worth turning off for games". Each chip shows how many services it matches, so you can tell before pressing it, and the row reflows on a narrow window instead of clipping.
+- **The "N services (M running)" line could disagree with the list under it.** Those two numbers were recalculated only by a full refresh, while everything else on the tab recalculated on every search keystroke and every filter press. So after typing in the search box, the header still described the previous scan. Every count on the tab is now worked out in one place, at the same moment.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -787,7 +787,8 @@ offers, "rate us" prompts:
   or "keep enabled" — hover a row's description to read why, in plain language
   instead of Microsoft's own wording
 - Filter by status (Running/Stopped), safety level (Safe/Caution/Critical),
-  gaming recommendation, or free-text search
+  gaming recommendation (Safe to disable / Keep enabled / Advanced), or free-text
+  search — each chip shows how many services it matches, so you know before pressing it
 - Mark any row with the flag button to keep it findable while you keep filtering or
   searching. "Clear marks" removes them all, including any a filter is hiding
 - Start, stop, disable, or enable services with confirmation dialogs

--- a/SysManager/SysManager.Tests/ServicesViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ServicesViewModelTests.cs
@@ -187,6 +187,109 @@ public class ServicesViewModelTests
         Assert.Contains(vm.Services, s => s.SafetyLevel == Models.SafetyLevel.Caution);
     }
 
+    // ── Every filter must be SELECTABLE, not merely implemented ───────────────────────────────────
+    //
+    // The tests above prove all nine filters WORK. They passed the whole time five of them had no control
+    // in the view: Running, Stopped and the three gaming recommendations could only be reached by
+    // assigning SelectedFilter from code, exactly as these tests do. Meanwhile the README promised
+    // filtering "by status (Running/Stopped)" and "gaming recommendation".
+    //
+    // That gap can only be closed against the markup — a view-model test cannot see a missing chip. Same
+    // class as the ICommand reachability ratchet in ArchitectureTests, which does not cover filter values.
+
+    [Fact]
+    public void EveryFilterOption_HasAChipInTheView()
+    {
+        var xaml = System.Xml.Linq.XDocument.Load(ViewPath("ServicesView.xaml"));
+
+        // The parameter each chip feeds the IsEqual converter IS the filter value it selects.
+        var chipValues = xaml.Descendants()
+            .Select(e => (string?)e.Attribute("IsChecked") ?? "")
+            .Where(v => v.Contains("SelectedFilter", StringComparison.Ordinal)
+                     && v.Contains("ConverterParameter=", StringComparison.Ordinal))
+            .Select(v => v.Split("ConverterParameter=")[1].TrimEnd('}').Trim().Trim('\''))
+            .ToList();
+
+        Assert.NotEmpty(chipValues);   // else this would pass by finding nothing
+
+        var vm = new ServicesViewModel(new Services.PowerShellRunner());
+        var missing = vm.FilterOptions.Except(chipValues, StringComparer.Ordinal).ToList();
+
+        Assert.True(missing.Count == 0,
+            "These filters are implemented in ApplyFilter but no control in ServicesView selects them, " +
+            "so a user cannot reach them: " + string.Join(", ", missing));
+
+        // And the reverse: a chip for a value ApplyFilter does not handle would silently show everything.
+        var unknown = chipValues.Except(vm.FilterOptions, StringComparer.Ordinal).ToList();
+        Assert.True(unknown.Count == 0,
+            "These chips select a value ApplyFilter does not handle, so they fall through to the " +
+            "unfiltered default: " + string.Join(", ", unknown));
+    }
+
+    [Fact]
+    public async Task EveryChipCount_ReportsWhatItsFilterWouldMatch()
+    {
+        // Each chip shows its own count, so the count has to agree with the filter beside it — a chip
+        // reading "(0)" next to a filter that would return rows is its own small lie. Counted over the
+        // whole list rather than the filtered view, so selecting one chip does not zero the others.
+        var vm = await CreateWithDataAsync();
+
+        // Fixture: Running = wuauserv, Spooler, WSearch (3); Stopped = XboxGipSvc, BITS (2);
+        // safe-to-disable = Spooler, XboxGipSvc (2); keep-enabled = wuauserv, BITS (2); advanced = WSearch (1).
+        Assert.Equal(3, vm.RunningCount);
+        Assert.Equal(2, vm.StoppedCount);
+        Assert.Equal(2, vm.SafeToDisableCount);
+        Assert.Equal(2, vm.KeepEnabledCount);
+        Assert.Equal(1, vm.AdvancedCount);
+
+        // Each count equals what its filter actually returns.
+        foreach (var (option, expected) in new[]
+                 {
+                     ("Running", vm.RunningCount), ("Stopped", vm.StoppedCount),
+                     ("Safe to disable", vm.SafeToDisableCount),
+                     ("Keep enabled", vm.KeepEnabledCount), ("Advanced", vm.AdvancedCount),
+                 })
+        {
+            vm.SelectedFilter = option;
+            Assert.Equal(expected, vm.Services.Count);
+        }
+    }
+
+    [Fact]
+    public async Task StoppedCount_IsNotTotalMinusRunning()
+    {
+        // Windows also reports StartPending / StopPending / Paused, so Running and Stopped are NOT
+        // complements. Deriving Stopped by subtraction would over-count the moment a service is
+        // mid-transition — the chip would promise more rows than the filter returns.
+        var entries = new List<ServiceEntry>
+        {
+            new() { Name = "a", DisplayName = "A", Description = "", Status = "Running", StartType = "Automatic", Recommendation = "", SafetyLevel = Models.SafetyLevel.Safe },
+            new() { Name = "b", DisplayName = "B", Description = "", Status = "Stopped", StartType = "Manual", Recommendation = "", SafetyLevel = Models.SafetyLevel.Safe },
+            new() { Name = "c", DisplayName = "C", Description = "", Status = "StartPending", StartType = "Automatic", Recommendation = "", SafetyLevel = Models.SafetyLevel.Safe },
+        };
+        var vm = await CreateWithDataAsync(entries);
+
+        Assert.Equal(1, vm.RunningCount);
+        Assert.Equal(1, vm.StoppedCount);          // not 2 — StartPending is neither
+        Assert.NotEqual(vm.TotalCount - vm.RunningCount, vm.StoppedCount);
+
+        vm.SelectedFilter = "Stopped";
+        Assert.Single(vm.Services);                // and the filter agrees with the count
+    }
+
+    /// <summary>The app's Views folder — .xaml is not copied to the test output.</summary>
+    private static string ViewPath(string fileName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "SysManager", "Views")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);
+        var path = Path.Combine(dir!.FullName, "SysManager", "Views", fileName);
+        Assert.True(File.Exists(path), $"{fileName} not found at {path}");
+        return path;
+    }
+
     [Fact]
     public void FilterOptions_CoverEveryRecommendationTheGuideProduces()
     {

--- a/SysManager/SysManager.Tests/ServicesViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ServicesViewModelTests.cs
@@ -236,6 +236,12 @@ public class ServicesViewModelTests
 
         // Fixture: Running = wuauserv, Spooler, WSearch (3); Stopped = XboxGipSvc, BITS (2);
         // safe-to-disable = Spooler, XboxGipSvc (2); keep-enabled = wuauserv, BITS (2); advanced = WSearch (1).
+        //
+        // Total and Running are asserted alongside the rest because they are computed alongside the rest.
+        // They used to be assigned in ApplyFilterCore, one caller up, so every other path into ApplyFilter
+        // refreshed seven counts and left these two behind — visible here as the machine's real service
+        // count sitting next to a five-entry fixture.
+        Assert.Equal(5, vm.TotalCount);
         Assert.Equal(3, vm.RunningCount);
         Assert.Equal(2, vm.StoppedCount);
         Assert.Equal(2, vm.SafeToDisableCount);
@@ -269,6 +275,7 @@ public class ServicesViewModelTests
         };
         var vm = await CreateWithDataAsync(entries);
 
+        Assert.Equal(3, vm.TotalCount);
         Assert.Equal(1, vm.RunningCount);
         Assert.Equal(1, vm.StoppedCount);          // not 2 — StartPending is neither
         Assert.NotEqual(vm.TotalCount - vm.RunningCount, vm.StoppedCount);

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.61.9</Version>
-    <FileVersion>1.61.9.0</FileVersion>
-    <AssemblyVersion>1.61.9.0</AssemblyVersion>
+    <Version>1.61.10</Version>
+    <FileVersion>1.61.10.0</FileVersion>
+    <AssemblyVersion>1.61.10.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -35,6 +35,14 @@ public sealed partial class ServicesViewModel : ViewModelBase
     [ObservableProperty] private int _cautionCount;
     [ObservableProperty] private int _criticalCount;
 
+    // Counts for the filters that had no chip. Each chip shows its own count for the same reason the
+    // safety chips do: "Safe to disable (12)" tells the user whether the filter is worth pressing before
+    // they press it, and a count of 0 explains an empty list without them having to wonder.
+    [ObservableProperty] private int _stoppedCount;
+    [ObservableProperty] private int _safeToDisableCount;
+    [ObservableProperty] private int _keepEnabledCount;
+    [ObservableProperty] private int _advancedCount;
+
     /// <summary>
     /// How many rows the user has marked. Drives the visibility of the "Clear marks" button — with no
     /// marks there is nothing to clear, and a permanently visible dead button is the kind of control
@@ -42,11 +50,20 @@ public sealed partial class ServicesViewModel : ViewModelBase
     /// </summary>
     [ObservableProperty] private int _highlightedCount;
 
-    // "Safe to disable" / "Advanced" filter on the GAMING RECOMMENDATION, which is a different
-    // dataset from the Safe/Caution/Critical SAFETY level above it: safety says "will this break
-    // Windows", the recommendation says "is this worth turning off for games, and why". Both were
-    // computed; only the safety level was filterable, so README's "filter by recommendation level"
-    // claim was untrue.
+    /// <summary>
+    /// Every value <see cref="ApplyFilter"/> understands, in the order the chips appear.
+    /// </summary>
+    /// <remarks>
+    /// <para>"Safe to disable" / "Keep enabled" / "Advanced" filter on the GAMING RECOMMENDATION, which
+    /// is a different dataset from the Safe/Caution/Critical SAFETY level: safety answers "will this
+    /// break Windows", the recommendation answers "is this worth turning off for games, and why".</para>
+    /// <para>This array previously existed with nothing bound to it, and its comment claimed the
+    /// README's "filter by recommendation level" promise had been made true — while five of the nine
+    /// values (Running, Stopped, and all three recommendations) had no control at all, so they could
+    /// only be reached from a debugger. The chips now cover all nine. The array is still not bound to a
+    /// ComboBox: it is the single list the filter tests enumerate, so a value added here without a chip
+    /// fails <c>EveryFilterOption_HasAChipInTheView</c> rather than going unnoticed again.</para>
+    /// </remarks>
     public string[] FilterOptions { get; } =
         { "All", "Running", "Stopped", "Safe", "Caution", "Critical",
           "Safe to disable", "Keep enabled", "Advanced" };
@@ -306,7 +323,11 @@ public sealed partial class ServicesViewModel : ViewModelBase
 
         Services.ReplaceWith(filtered.OrderBy(s => s.DisplayName, StringComparer.OrdinalIgnoreCase));
 
+        // One pass for every chip's count. Counted over _allServices rather than the filtered result, so
+        // each chip shows how many it WOULD match — a count that shrank to reflect the active filter
+        // would make the other chips look empty and unpressable.
         int safe = 0, caution = 0, critical = 0;
+        int stopped = 0, safeToDisable = 0, keepEnabled = 0, advanced = 0;
         foreach (var s in _allServices)
         {
             switch (s.SafetyLevel)
@@ -315,10 +336,26 @@ public sealed partial class ServicesViewModel : ViewModelBase
                 case SafetyLevel.Caution: caution++; break;
                 case SafetyLevel.Critical: critical++; break;
             }
+
+            // "Stopped" counted explicitly rather than as Total - Running: Windows also reports
+            // StartPending / StopPending / Paused, so the two are not complements and subtracting would
+            // over-count whenever a service is mid-transition.
+            if (s.Status == "Stopped") stopped++;
+
+            switch (s.Recommendation)
+            {
+                case "safe-to-disable": safeToDisable++; break;
+                case "keep-enabled": keepEnabled++; break;
+                case "advanced": advanced++; break;
+            }
         }
         SafeCount = safe;
         CautionCount = caution;
         CriticalCount = critical;
+        StoppedCount = stopped;
+        SafeToDisableCount = safeToDisable;
+        KeepEnabledCount = keepEnabled;
+        AdvancedCount = advanced;
     }
 
     /// <summary>

--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -139,11 +139,13 @@ public sealed partial class ServicesViewModel : ViewModelBase
 
     private void ApplyFilterCore()
     {
-        TotalCount = _allServices.Count;
-        RunningCount = _allServices.Count(s => s.Status == "Running");
         // A refresh replaces every ServiceEntry, so the marks are gone with them — recount rather than
         // leaving a stale non-zero count that would keep offering to clear marks that no longer exist.
         UpdateHighlightCount();
+        // ApplyFilter owns every count, TotalCount and RunningCount included, so the status line below
+        // reads what it just computed. Those two used to be assigned here instead, which split one job
+        // across two methods: every other path into ApplyFilter — a search keystroke, a filter chip —
+        // refreshed the other seven counts and left these two showing a previous scan's numbers.
         ApplyFilter();
         StatusMessage = $"Loaded {TotalCount} services ({RunningCount} running).";
         ToastService.Instance.Show("Services refreshed", $"{TotalCount} services ({RunningCount} running)");
@@ -323,24 +325,26 @@ public sealed partial class ServicesViewModel : ViewModelBase
 
         Services.ReplaceWith(filtered.OrderBy(s => s.DisplayName, StringComparer.OrdinalIgnoreCase));
 
-        // One pass for every chip's count. Counted over _allServices rather than the filtered result, so
-        // each chip shows how many it WOULD match — a count that shrank to reflect the active filter
+        // One pass for every count on the tab. Counted over _allServices rather than the filtered result,
+        // so each chip shows how many it WOULD match — a count that shrank to reflect the active filter
         // would make the other chips look empty and unpressable.
+        int running = 0, stopped = 0;
         int safe = 0, caution = 0, critical = 0;
-        int stopped = 0, safeToDisable = 0, keepEnabled = 0, advanced = 0;
+        int safeToDisable = 0, keepEnabled = 0, advanced = 0;
         foreach (var s in _allServices)
         {
+            // Running and Stopped are both counted explicitly rather than one being derived as
+            // Total - the other: Windows also reports StartPending / StopPending / Paused, so the two are
+            // not complements and subtracting would over-count whenever a service is mid-transition.
+            if (s.Status == "Running") running++;
+            else if (s.Status == "Stopped") stopped++;
+
             switch (s.SafetyLevel)
             {
                 case SafetyLevel.Safe: safe++; break;
                 case SafetyLevel.Caution: caution++; break;
                 case SafetyLevel.Critical: critical++; break;
             }
-
-            // "Stopped" counted explicitly rather than as Total - Running: Windows also reports
-            // StartPending / StopPending / Paused, so the two are not complements and subtracting would
-            // over-count whenever a service is mid-transition.
-            if (s.Status == "Stopped") stopped++;
 
             switch (s.Recommendation)
             {
@@ -349,10 +353,12 @@ public sealed partial class ServicesViewModel : ViewModelBase
                 case "advanced": advanced++; break;
             }
         }
+        TotalCount = _allServices.Count;
+        RunningCount = running;
+        StoppedCount = stopped;
         SafeCount = safe;
         CautionCount = caution;
         CriticalCount = critical;
-        StoppedCount = stopped;
         SafeToDisableCount = safeToDisable;
         KeepEnabledCount = keepEnabled;
         AdvancedCount = advanced;

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -86,29 +86,75 @@
                         </TextBlock>
                     </StackPanel>
                 </DockPanel>
-                <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-                    <TextBlock Text="Filter:" Foreground="{DynamicResource TextMuted}" FontSize="11"
-                               VerticalAlignment="Center" Margin="0,0,8,0"/>
+                <!-- Filter chips. All nine share one GroupName because SelectedFilter holds a single
+                     value, so they are mutually exclusive by construction.
+                     Five of these are new: ApplyFilter has always implemented Running, Stopped and the
+                     three gaming recommendations, but no control ever selected them, so they could only
+                     be reached from a debugger — while the README promised filtering "by status
+                     (Running/Stopped)" and "gaming recommendation". A WrapPanel rather than the previous
+                     StackPanel so nine chips reflow instead of clipping on a narrow window. -->
+                <WrapPanel Orientation="Horizontal" Margin="0,10,0,0">
+                    <TextBlock Text="Safety:" Foreground="{DynamicResource TextMuted}" FontSize="11"
+                               VerticalAlignment="Center" Margin="0,0,8,4"/>
                     <RadioButton Content="{Binding SafeCount, StringFormat='Safe ({0})'}"
-                                 GroupName="SafetyFilter" Margin="0,0,6,0"
+                                 GroupName="SafetyFilter" Margin="0,0,6,4"
                                  IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=Safe}"
                                  Style="{StaticResource FilterChip}"
                                  AutomationProperties.Name="Filter safe services"/>
                     <RadioButton Content="{Binding CautionCount, StringFormat='Caution ({0})'}"
-                                 GroupName="SafetyFilter" Margin="0,0,6,0"
+                                 GroupName="SafetyFilter" Margin="0,0,6,4"
                                  IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=Caution}"
                                  Style="{StaticResource FilterChipCaution}"
                                  AutomationProperties.Name="Filter caution services"/>
                     <RadioButton Content="{Binding CriticalCount, StringFormat='Critical ({0})'}"
-                                 GroupName="SafetyFilter" Margin="0,0,6,0"
+                                 GroupName="SafetyFilter" Margin="0,0,6,4"
                                  IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=Critical}"
                                  Style="{StaticResource FilterChipCritical}"
                                  AutomationProperties.Name="Filter critical services"/>
-                    <RadioButton Content="All" GroupName="SafetyFilter" Margin="0,0,6,0"
+
+                    <TextBlock Text="Status:" Foreground="{DynamicResource TextMuted}" FontSize="11"
+                               VerticalAlignment="Center" Margin="10,0,8,4"/>
+                    <RadioButton Content="{Binding RunningCount, StringFormat='Running ({0})'}"
+                                 GroupName="SafetyFilter" Margin="0,0,6,4"
+                                 IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=Running}"
+                                 Style="{StaticResource FilterChip}"
+                                 AutomationProperties.Name="Filter running services"/>
+                    <RadioButton Content="{Binding StoppedCount, StringFormat='Stopped ({0})'}"
+                                 GroupName="SafetyFilter" Margin="0,0,6,4"
+                                 IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=Stopped}"
+                                 Style="{StaticResource FilterChip}"
+                                 AutomationProperties.Name="Filter stopped services"/>
+
+                    <!-- Gaming recommendation: a different dataset from the safety level on the left.
+                         Safety answers "will this break Windows"; the recommendation answers "is this
+                         worth turning off for games". It is the tab's headline capability and was the
+                         least reachable part of it. -->
+                    <TextBlock Text="For gaming:" Foreground="{DynamicResource TextMuted}" FontSize="11"
+                               VerticalAlignment="Center" Margin="10,0,8,4"/>
+                    <RadioButton Content="{Binding SafeToDisableCount, StringFormat='Safe to disable ({0})'}"
+                                 GroupName="SafetyFilter" Margin="0,0,6,4"
+                                 IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter='Safe to disable'}"
+                                 Style="{StaticResource FilterChip}"
+                                 ToolTip="Services SysManager considers safe to turn off for gaming"
+                                 AutomationProperties.Name="Filter services safe to disable for gaming"/>
+                    <RadioButton Content="{Binding KeepEnabledCount, StringFormat='Keep enabled ({0})'}"
+                                 GroupName="SafetyFilter" Margin="0,0,6,4"
+                                 IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter='Keep enabled'}"
+                                 Style="{StaticResource FilterChip}"
+                                 ToolTip="Services to leave alone — turning these off causes problems"
+                                 AutomationProperties.Name="Filter services to keep enabled"/>
+                    <RadioButton Content="{Binding AdvancedCount, StringFormat='Advanced ({0})'}"
+                                 GroupName="SafetyFilter" Margin="0,0,6,4"
+                                 IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=Advanced}"
+                                 Style="{StaticResource FilterChip}"
+                                 ToolTip="Only worth changing if you know what the service does"
+                                 AutomationProperties.Name="Filter advanced services"/>
+
+                    <RadioButton Content="All" GroupName="SafetyFilter" Margin="10,0,6,4"
                                  IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=All}"
                                  Style="{StaticResource FilterChip}"
                                  AutomationProperties.Name="Show all services"/>
-                </StackPanel>
+                </WrapPanel>
             </StackPanel>
         </Border>
 


### PR DESCRIPTION
Closes #1802

## The defect

`ApplyFilter` implements **nine** filters. The view exposed **four**.

| Filter | Implemented | Had a chip |
|---|:---:|:---:|
| All, Safe, Caution, Critical | ✅ | ✅ |
| Running, Stopped | ✅ | ❌ |
| Safe to disable, Keep enabled, Advanced | ✅ | ❌ |

The five missing ones could only be reached by assigning `SelectedFilter` from a debugger — which is exactly what the existing view-model tests do, so **every filter test passed the whole time**. And the README promised two of them outright:

> Filter by status (**Running/Stopped**), safety level (Safe/Caution/Critical), **gaming recommendation**, or free-text search

The gaming recommendation is the tab's headline capability — the reason this list beats `services.msc` — and its data is real: `GamingGuide` classifies 25 services (12 safe-to-disable, 9 keep-enabled, 4 advanced). A user could see each row's tag and had no way to filter by it.

## The fix

All nine are chips now, grouped **Safety / Status / For gaming** so the two datasets cannot be confused: safety answers *"will turning this off break Windows"*, the recommendation answers *"is it worth turning off for games"*. Same `RadioButton` + `FilterChip` + `IsEqual` pattern as the existing four, one shared `GroupName` because `SelectedFilter` holds a single value. `WrapPanel` rather than `StackPanel` so nine chips reflow instead of clipping on a narrow window.

Each chip carries its own count, as the safety chips already did — it answers "is this worth pressing" *before* it is pressed, and a `(0)` explains an empty list. Counted over `_allServices` rather than the filtered view, so selecting one chip does not zero the others.

**`StoppedCount` is counted explicitly, not derived as `Total - Running`.** `ServiceEntry.Status` is `ServiceControllerStatus.ToString()`, which also yields `StartPending` / `StopPending` / `Paused` (plus `"Unknown"` on an SCM error), so Running and Stopped are **not** complements — subtraction would promise more rows than the filter returns the moment a service is mid-transition. A test pins that with a `StartPending` fixture.

## The comment that was wrong

`FilterOptions` existed with nothing bound to it, and its comment claimed the README promise had already been made true:

```csharp
// … only the safety level was filterable, so README's "filter by recommendation level"
// claim was untrue.        ← written as though fixed; the array was added, the chips were not
```

Corrected, and the array is now the single list `EveryFilterOption_HasAChipInTheView` enumerates, so a value added without a chip fails rather than going unnoticed again. That test asserts **both** directions: no implemented filter without a chip, and no chip selecting a value `ApplyFilter` ignores (which would silently fall through to unfiltered).

## Propagate

Swept every ViewModel exposing an option array against its view. Two apparent hits, **both refuted**: `LogsViewModel.AvailableLogs` and `SpeedTestViewModel.OoklaServerOptions` are each bound via `ItemsSource` to a `ComboBox`, so all their values are selectable — my literal-string grep was simply the wrong test for that pattern. Services was the only genuine case.

## Verification

**Red before, green after** — throwaway harness against two worktrees, since the xUnit suite cannot run on this workstation:

```
RED  (origin/main):  5 FAILED
     chips found: Safe, Caution, Critical, All
     unreachable: Running, Stopped, Safe to disable, Keep enabled, Advanced
     StoppedCount / SafeToDisableCount / KeepEnabledCount / AdvancedCount — property does not exist
GREEN (this branch): ALL PASS
     chips found: Safe, Caution, Critical, Running, Stopped, Safe to disable, Keep enabled, Advanced, All
     every count matches what its filter returns; StoppedCount(1) != Total-Running(2)
```

I also verified the nine chip parameters parse out of the shipped XAML exactly matching `FilterOptions` — including the quoted multi-word `'Safe to disable'` and `'Keep enabled'`, which the `IsEqual` converter compares ordinally.

Tests added: `EveryFilterOption_HasAChipInTheView` (the ratchet, both directions), `EveryChipCount_ReportsWhatItsFilterWouldMatch`, `StoppedCount_IsNotTotalMinusRunning`. The behaviour of all nine filters was already covered — the gap was only reachability.

Checks:
- All four projects build **0 errors, 0 warnings**
- Author headers on all three touched files
- Leak scan over the full diff — clean
- No new `btn-*` AutomationIds, so the UI-automation contract set-equality is unaffected
- Version gate: `1.61.10` is the patch bump from tag `v1.61.9` — verified against the gate's own arithmetic
- Gate-DOCS: README's Services section now names the recommendation values and the per-chip counts; CHANGELOG entry + version bump in this PR

The chip row is the only visual change; confirming the reflow at a narrow width belongs on the secondary workstation, per the rule that this machine never launches the app.
