### PR TITLE
fix: stop the Uninstaller's admin banner from contradicting itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.61.11] - 2026-08-12
+
+The Uninstaller tab no longer looks broken when you open it after granting administrator access
+somewhere else — it now explains, in the neutral colour it should always have used, why uninstalling
+waits for a normal window.
+
+### Fixed
+- **The Uninstaller told administrators to "reopen SysManager normally" with no way to do it, in the colour that everywhere else means "you can now do more".** Uninstalling is deliberately turned off while SysManager runs as administrator, so each app can raise its own permission prompt rather than inheriting ours. But this tab announced that in the same gold banner the other 30 tabs use to say "Running as administrator — you can now …", and the message was "Uninstall is disabled in administrator sessions. Reopen SysManager normally to continue." So after pressing the gold "Run as administrator" button on Quick Cleanup, you arrived here to a reassuring gold bar, a greyed-out Uninstall button, no explanation of why, and an instruction the app offers no button for. The banner is now the same neutral grey as the one directly above it, and says what is happening and why: uninstalling is off while running as administrator so each app can show you its own permission prompt, then close and reopen normally to uninstall. The restriction itself is unchanged — it is a safety property, not a bug.
+
+---
+
 ## [1.61.10] - 2026-08-11
 
 The Services tab can now actually filter by the things it always claimed to — including the gaming

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -351,12 +351,93 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// The gold elevation banner means one thing and only one thing: you are running as administrator,
+    /// so MORE is available. Every tab that shows it must say so.
+    /// </summary>
+    /// <remarks>
+    /// <para>The project's UI contract reserves the golden/amber treatment for elevation-unlocks-more,
+    /// with purple for primary actions and neutral for everything else. 30 views render this banner, and
+    /// they are hand-written copies of each other, so the convention is held together by nothing but
+    /// whoever wrote the last one.</para>
+    /// <para>It had already broken once. The Uninstaller tab — the one place where elevation DISABLES a
+    /// feature, because each app's own uninstaller wants to raise its own UAC prompt — used the identical
+    /// gold treatment to say "Uninstall is disabled in administrator sessions. Reopen SysManager normally
+    /// to continue." So the colour that had taught the user "press this, get more" on 29 other tabs was,
+    /// on that one, the colour of a dead end, attached to an instruction the app offers no control for
+    /// (there is no de-elevation path — <c>AdminHelper.RelaunchAsAdmin</c> goes one way only). That tab
+    /// now uses the neutral treatment; this test is why it cannot quietly go back.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryGoldElevationBanner_PromisesMoreAccess()
+    {
+        var viewsDir = Path.Combine(FindAppProjectDir(), "Views");
+        var offenders = new List<string>();
+        var banners = 0;
+
+        foreach (var file in Directory.GetFiles(viewsDir, "*.xaml"))
+        {
+            foreach (var message in GoldElevatedBannerMessages(File.ReadAllText(file)))
+            {
+                banners++;
+                if (!message.StartsWith("Running as administrator", StringComparison.Ordinal))
+                    offenders.Add($"{Path.GetFileName(file)}: \"{message}\"");
+            }
+        }
+
+        // Guards the guard: if the parse stops finding banners, every assertion below passes vacuously.
+        Assert.True(banners >= 25,
+            $"Only {banners} gold elevation banners parsed — the check is not reading the markup it thinks it is.");
+
+        Assert.True(offenders.Count == 0,
+            "These tabs use the gold elevation banner — which everywhere else in the app means \"you are " +
+            "elevated, so you can now do more\" — to say something else. Rewrite the message to start " +
+            "\"Running as administrator — …\", or, if elevation genuinely does not unlock more on that tab, " +
+            "use the neutral Surface2/Border1 treatment instead, so the colour does not contradict the " +
+            "words:\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// Messages inside a Border that is (a) shown WHEN elevated and (b) painted with the gold
+    /// WarningBgSubtle. Parsed rather than grepped: the not-elevated banner sits in the same
+    /// <c>Grid.Row</c> in every one of these views, so a file-wide text search would read the wrong one.
+    /// </summary>
+    private static List<string> GoldElevatedBannerMessages(string xamlText)
+    {
+        var found = new List<string>();
+        System.Xml.Linq.XDocument doc;
+        try { doc = System.Xml.Linq.XDocument.Parse(xamlText); }
+        catch (System.Xml.XmlException) { return found; }
+
+        foreach (var border in doc.Descendants().Where(e => e.Name.LocalName == "Border"))
+        {
+            var visibility = (string?)border.Attribute("Visibility") ?? "";
+            if (!visibility.Contains("IsElevated", StringComparison.Ordinal)) continue;
+            // Inverse == shown when NOT elevated, which is the other banner in the same slot.
+            if (visibility.Contains("Inverse", StringComparison.Ordinal)) continue;
+            if (!((string?)border.Attribute("Background") ?? "").Contains("WarningBgSubtle", StringComparison.Ordinal)) continue;
+
+            foreach (var block in border.Descendants().Where(e => e.Name.LocalName == "TextBlock"))
+            {
+                var text = (string?)block.Attribute("Text") ?? "";
+                // Skip the icon glyph (one private-use codepoint) and bound values.
+                if (text.Length < 20 || text.StartsWith('{')) continue;
+                found.Add(WhitespaceRun().Replace(text, " ").Trim());
+            }
+        }
+        return found;
+    }
+
+    /// <summary>
     /// A method DECLARATION rather than a call — `private void Foo()`, `private async Task FooAsync(`,
     /// `internal Task Foo(`. Used to drop declaration lines before searching for call sites, so a
     /// method is never counted as its own caller.
     /// </summary>
     [GeneratedRegex(@"^\s*(private|internal|public|protected)\b.*\b\w+\s*\(", RegexOptions.Compiled)]
     private static partial Regex DeclarationLine();
+
+    /// <summary>Collapses the line breaks XAML allows inside an attribute value.</summary>
+    [GeneratedRegex(@"\s+", RegexOptions.Compiled)]
+    private static partial Regex WhitespaceRun();
 
     /// <summary>The app project directory — .xaml is not copied to the test output.</summary>
     private static string FindAppProjectDir()

--- a/SysManager/SysManager.Tests/UninstallerElevationBannerTests.cs
+++ b/SysManager/SysManager.Tests/UninstallerElevationBannerTests.cs
@@ -1,0 +1,132 @@
+// SysManager · UninstallerElevationBannerTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Xml.Linq;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Pins the Uninstaller's elevated-state banner: the one place in the app where being an administrator
+/// takes a feature AWAY.
+/// </summary>
+/// <remarks>
+/// <para>The gate itself is deliberate and stays — <c>CanUninstall</c> requires an unelevated process so
+/// each app's own uninstaller can raise its own UAC prompt. What was wrong was how the tab said so. It
+/// used the identical gold <c>WarningBgSubtle</c> banner that the other 30 tabs use to mean "you are
+/// elevated, so you can now do more", and filled it with "Uninstall is disabled in administrator
+/// sessions. Reopen SysManager normally to continue." Two problems in one control: the colour promised
+/// more access while the words removed it, and the instruction asked for something the app cannot help
+/// with — there is no de-elevation path anywhere in the codebase, only
+/// <c>AdminHelper.RelaunchAsAdmin</c>, which goes one way.</para>
+/// <para>Asserted against the shipped markup because that is the only place the defect existed: every
+/// view-model test passed throughout, since <c>CanUninstall</c> was behaving exactly as written.
+/// <c>ArchitectureTests.EveryGoldElevationBanner_PromisesMoreAccess</c> guards the colour convention
+/// across all views; this file pins THIS banner's copy, which that check cannot see once the banner is
+/// no longer gold.</para>
+/// </remarks>
+public class UninstallerElevationBannerTests
+{
+    private static readonly XNamespace Presentation = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+
+    /// <summary>
+    /// The banner shown WHEN elevated. Both banners live in the same <c>Grid.Row="1"</c> slot and are
+    /// switched by <c>IsElevated</c>, so they are told apart by the converter's Inverse parameter — a
+    /// file-wide text search would read whichever came first.
+    /// </summary>
+    private static XElement ElevatedBanner()
+    {
+        var doc = XDocument.Load(ViewPath());
+        var banners = doc.Descendants(Presentation + "Border")
+            .Where(b =>
+            {
+                var visibility = b.Attribute("Visibility")?.Value ?? "";
+                return visibility.Contains("IsElevated", StringComparison.Ordinal)
+                    && !visibility.Contains("Inverse", StringComparison.Ordinal);
+            })
+            .ToList();
+
+        Assert.Single(banners);
+        return banners[0];
+    }
+
+    private static string BannerMessage(XElement banner) =>
+        banner.Descendants(Presentation + "TextBlock")
+            .Select(t => t.Attribute("Text")?.Value ?? "")
+            // Drop the icon glyph (a single private-use codepoint) and any bound value.
+            .Where(t => t.Length >= 20 && !t.StartsWith('{'))
+            .Select(t => string.Join(" ", t.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)))
+            .Single();
+
+    [Fact]
+    public void TheElevatedBannerIsNeutral_NotTheGoldMoreUnlockedTreatment()
+    {
+        var banner = ElevatedBanner();
+
+        var background = banner.Attribute("Background")?.Value ?? "";
+        Assert.DoesNotContain("Warning", background, StringComparison.Ordinal);
+        // Specifically the neutral treatment of the not-elevated banner directly above it, so the slot
+        // does not visibly change shape or colour at the moment the user elevates on another tab.
+        Assert.Contains("Surface2", background, StringComparison.Ordinal);
+
+        // The gold accent stripe is part of the same "unlocked" vocabulary and must go with it.
+        Assert.DoesNotContain(
+            banner.Descendants(Presentation + "Border"),
+            inner => (inner.Attribute("Background")?.Value ?? "").Contains("Warning", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TheElevatedBannerGivesTheReason_NotJustTheRestriction()
+    {
+        var message = BannerMessage(ElevatedBanner());
+
+        // "so each app can show you its own permission prompt" is the load-bearing half: without a reason
+        // the restriction reads as a bug on the app's most consequential tab. Asserted on the substance
+        // rather than the exact sentence, so the copy can be improved without a test edit.
+        Assert.Contains("own", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("prompt", message, StringComparison.OrdinalIgnoreCase);
+
+        // And it must not reintroduce the jargon the persona cannot parse.
+        Assert.DoesNotContain("administrator sessions", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TheGateItselfIsUnchanged_ElevationAloneBlocksUninstall()
+    {
+        // Guards against "fixing" the banner by deleting the restriction it describes. The banner is only
+        // honest while the gate is real, and the gate exists so each uninstaller raises its own UAC prompt
+        // rather than silently inheriting ours.
+        //
+        // The list is populated first, and both states are asserted. CanUninstall is
+        // `NotBusy && HasApps && !IsElevated`, so on an unscanned list HasApps is false and CanExecute
+        // returns false no matter what elevation says — asserting only the elevated case would pass with
+        // the elevation term deleted, which is precisely the change this test exists to catch.
+        var vm = new SysManager.ViewModels.UninstallerViewModel(
+            new SysManager.Services.UninstallerService(new SysManager.Services.PowerShellRunner()));
+        vm.IsElevated = false;
+        vm.AllApps.Add(new SysManager.Models.InstalledApp { Name = "app", Id = "id" });
+        vm.FilterText = "app";   // triggers ApplyFilter, which refreshes AppCount
+        vm.FilterText = "";
+
+        Assert.True(vm.UninstallSelectedCommand.CanExecute(null),
+            "With a populated list and no elevation, uninstall must be available — otherwise the elevated " +
+            "assertion below proves nothing.");
+
+        vm.IsElevated = true;
+        Assert.False(vm.UninstallSelectedCommand.CanExecute(null));
+    }
+
+    // Walks up from the test binaries to the app project — .xaml is not copied to the output.
+    private static string ViewPath()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "SysManager", "Views")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);
+        var path = Path.Combine(dir!.FullName, "SysManager", "Views", "UninstallerView.xaml");
+        Assert.True(File.Exists(path), $"UninstallerView.xaml not found at {path}");
+        return path;
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.61.10</Version>
-    <FileVersion>1.61.10.0</FileVersion>
-    <AssemblyVersion>1.61.10.0</AssemblyVersion>
+    <Version>1.61.11</Version>
+    <FileVersion>1.61.11.0</FileVersion>
+    <AssemblyVersion>1.61.11.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -41,19 +41,29 @@
             </DockPanel>
         </Border>
 
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
+        <!-- Elevation banner: elevated.
+             Deliberately NOT the gold WarningBgSubtle treatment the other 30 tabs use here. Everywhere
+             else in the app, gold in this slot means "you are elevated, so you can now do more" — this
+             is the one tab where elevation does the opposite, and dressing a restriction in the colour
+             of a reward is what made the tab read as broken rather than deliberately gated. It shares
+             the neutral Surface2/Border1 geometry of the not-elevated banner directly above instead, so
+             the slot does not change appearance when the user elevates on another tab and arrives here. -->
+        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
+                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center" Foreground="{DynamicResource WarningText}"/>
-                    <TextBlock Text="Uninstall is disabled in administrator sessions. Reopen SysManager normally to continue."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
+            <!-- DockPanel, not the sibling banners' horizontal StackPanel: this message is the longest in
+                 the app, and a StackPanel hands its children infinite width along its orientation, so
+                 TextWrapping there is inert and the tail is simply clipped. Docking the glyph left leaves
+                 the message as LastChildFill, which gives it a real width to wrap inside — it needs about
+                 two lines at the 960px minimum window. -->
+            <DockPanel>
+                <TextBlock DockPanel.Dock="Left" Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                           FontSize="16" Margin="0,0,10,0" VerticalAlignment="Top"
+                           Foreground="{DynamicResource TextSecondary}"/>
+                <TextBlock Text="Uninstalling is turned off while SysManager runs as administrator, so each app can show you its own permission prompt. Close SysManager and open it normally to uninstall."
+                           Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"
+                           TextWrapping="Wrap"/>
+            </DockPanel>
         </Border>
 
         <!-- Toolbar -->


### PR DESCRIPTION
Closes #1649.

## The defect

Uninstalling is deliberately turned off while SysManager runs elevated
(`UninstallerViewModel.cs:67`, `CanUninstall => NotBusy && HasApps && !IsElevated`)
so each package raises its own UAC prompt rather than silently inheriting ours.
**That gate is correct and unchanged.** What was wrong was how the tab said so.

The elevated banner used the identical gold `WarningBgSubtle` treatment that the
other 30 tabs use, and filled it with:

> Uninstall is disabled in administrator sessions. Reopen SysManager normally to continue.

Two problems in one control:

1. **The colour contradicted the words.** I tallied the elevated-banner copy across
   every view: 29 of 30 begin "Running as administrator — you can …". This tab alone
   used that treatment for a restriction. So a user who pressed the gold
   Run-as-administrator button on Quick Cleanup arrived here to a reassuring gold bar
   over a greyed-out Uninstall button, with no explanation of why.
2. **The instruction had no button behind it.** Grepping
   `RelaunchNormal|RelaunchUnelevated|RestartNonElevated` across the whole app returns
   nothing — only `AdminHelper.RelaunchAsAdmin` (`AdminHelper.cs:37`), which goes one
   way. "Reopen SysManager normally" is a chore the app cannot help with, on its most
   consequential tab.

## The change

The banner now uses the neutral `Surface2`/`Border1` treatment of the not-elevated
banner **directly above it in the same `Grid.Row`** — same background, border, radius
and padding — so the slot does not visibly change when the user elevates elsewhere and
navigates here. The gold accent stripe goes with it. New copy:

> Uninstalling is turned off while SysManager runs as administrator, so each app can
> show you its own permission prompt. Close SysManager and open it normally to
> uninstall.

Built as a `DockPanel`, not the sibling banners' horizontal `StackPanel`. That is not
a style preference: a StackPanel measures its children with infinite width along its
orientation, so `TextWrapping="Wrap"` inside one is inert and the overflow is clipped.
At 170 characters this is the longest message in the app — roughly 1120px on one line
at 13px, against about 630px of content width at the `MinWidth="960"` floor. It needs
to wrap, so it needed a parent that imposes a width.

## Guards

The compiler cannot see a colour that means the wrong thing, and no view-model test
could have caught this — `CanUninstall` behaved exactly as written the entire time.
Both guards therefore assert against the shipped markup.

- **`ArchitectureTests.EveryGoldElevationBanner_PromisesMoreAccess`** parses all views,
  finds every Border that is shown when elevated AND painted `WarningBgSubtle`, and
  fails if its message does not start "Running as administrator". This makes the colour
  convention mechanical across all 30 tabs rather than a thing each hand-written copy
  remembers. It carries a floor (`banners >= 25`) so a parse that stops finding
  banners fails loudly instead of passing vacuously.
- **`UninstallerElevationBannerTests`** pins this banner specifically — that it is
  neutral, that no gold stripe survives inside it, and that the copy carries the
  reason and not the old jargon. Plus `TheGateItselfIsUnchanged_ElevationAloneBlocksUninstall`,
  which guards against "fixing" the message by deleting the restriction it describes.
  That test populates the list and asserts **both** states, because `CanUninstall` also
  requires `HasApps`: on an unscanned list `CanExecute` is false regardless of
  elevation, so asserting only the elevated case would still pass with the `!IsElevated`
  term removed — exactly the regression it exists to catch.

## Verification

- Red/green harness: **8 checks failing before the change, 0 after.** The red run
  confirmed each failure was for the documented reason (gold background, gold stripe,
  jargon copy, missing reason, missing guards), and that the cross-view sweep found
  31 gold banners with exactly one offender.
- All four projects build **0 warnings, 0 errors**.
- No `AutomationId` added or removed, so `UiAutomationContractTests` set-equality is
  unaffected.
- `Surface2`, `Border1` and `TextSecondary` are all theme-driven through
  `ThemeService` (`:163/:167/:177`), so contrast in custom and light themes is
  identical to the not-elevated banner that already ships.
- README `:695` already documents this behaviour correctly ("Runs uninstall actions
  only from an unelevated SysManager session; each package requests its own UAC
  elevation when required") and matches the new copy's reason, so no docs change is
  needed.

## Filed separately, not swept in

**#1807** — the inert-`TextWrapping` trap I hit here exists in **16** other
TextBlocks, three of which clip even at the default 1280px window (the File Shredder
SSD warning at 175 characters, and both Context Menu explanations). Those are safety
and explanatory copy, so a truncation drops the caveat and keeps the setup. It wants
its own PR plus a mechanical check, not a drive-by in a diff about one banner.
