### PR TITLE
feat: tell the user whether their speed test result is any good

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -169,6 +169,11 @@ Key services:
   log needs elevation, and swallowing that made the UI report "0 events". Reset at
   the start of every query so a past refusal cannot outlive it.
 - `HealthAnalyzer` — raw SMART / ping data into verdict pills.
+- `SpeedVerdictAnalyzer` — a speed-test result into a plain-English verdict
+  ("Fast connection", what that allows) plus a comparison against the previous
+  run on the same engine. Pure and static like `HealthAnalyzer`, so the
+  judgement is unit-testable without a network; deliberately never emits the
+  failure colour, because a slow plan is not a fault.
 - `SystemInfoService` — OS / CPU / RAM / uptime snapshot.
 - `BiosService` — read-only BIOS/firmware + motherboard info (Win32_BIOS,
   Win32_BaseBoard, UEFI/Secure-Boot registry) plus a pure manufacturer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.62.0] - 2026-08-12
+
+The Speed Test tab now tells you whether your speed is any good, instead of leaving you to work it
+out from a number in Mbps.
+
+### Added
+- **A plain-English verdict on every speed test.** The tab measured your connection and then showed you "43.2 Mbps", which answers "what is my speed" and not the question most people open the tab with — "is that actually good?". Each result now comes with a short verdict saying what that speed is enough for in terms you can check against your own household: whether video calls and HD video will struggle, whether 4K on several devices at once is comfortable. The Ping tab next door has explained itself in plain English for a long time; this brings Speed Test in line with it, using the same layout so the two read as one app.
+- **A comparison with your last test.** When there is an earlier result for the same test engine, the verdict adds one line putting the two side by side — "About the same as your last test (45 Mbps)" or "Noticeably slower than your last test (was 92 Mbps)". That is the difference between a number and evidence: it is what you can point at when calling your provider. Results have always been stored, so nothing new is saved to do this, and small run-to-run differences are treated as noise rather than reported as news — a speed test varies on an unchanged line.
+- A slow result is never coloured as a fault. If you are on a modest plan, the app says the speed will limit some things; it does not tell you something is broken when nothing is.
+
+---
+
 ## [1.61.11] - 2026-08-12
 
 The Uninstaller tab no longer looks broken when you open it after granting administrator access

--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ Edit Windows environment variables without the cramped built-in dialog:
 - Speed tests: HTTP (Cloudflare) and the official Ookla CLI (auto-downloaded)
   with persistent history (last 20 results per engine) for tracking service
   degradation over time
+- Every speed result comes with a plain-English verdict — what that speed is
+  actually enough for (video calls, HD, 4K, several devices at once) rather than
+  just a number — plus one line comparing it with your previous test on the same
+  engine
 - Jitter, loss %, and average ping per target rolled up into health pills
 - **Network repair tools**: DNS flush, Winsock reset, TCP/IP reset with
   confirmation dialogs and admin checks

--- a/SysManager/SysManager.Tests/SpeedVerdictAnalyzerTests.cs
+++ b/SysManager/SysManager.Tests/SpeedVerdictAnalyzerTests.cs
@@ -1,0 +1,195 @@
+// SysManager · SpeedVerdictAnalyzerTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="SpeedVerdictAnalyzer"/> — the plain-English reading of a speed-test result.
+/// </summary>
+/// <remarks>
+/// The analyzer is pure and static for the same reason <c>HealthAnalyzer</c> is: the judgement is the
+/// part worth testing, and it must be reachable without a network, a timer or a view model. Every case
+/// below runs on a constructed <see cref="SpeedTestResult"/>, so nothing here touches the connection.
+/// </remarks>
+public class SpeedVerdictAnalyzerTests
+{
+    private static SpeedTestResult Result(double downMbps, string engine = "Ookla") =>
+        new(engine, downMbps, UploadMbps: 10, PingMs: 20, Server: "test", CompletedAt: new DateTime(2026, 1, 1));
+
+    // ── The four bands ──────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0.5)]
+    [InlineData(4.9)]
+    public void BelowFiveMbps_IsSlow(double down)
+    {
+        var verdict = SpeedVerdictAnalyzer.Analyze(Result(down));
+
+        Assert.Equal("Slow connection", verdict.Headline);
+        // The detail has to name what will actually struggle, or it is a label without information.
+        Assert.Contains("video call", verdict.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(5)]
+    [InlineData(24.9)]
+    public void FiveToTwentyFive_IsDecent(double down)
+        => Assert.Equal("Decent connection", SpeedVerdictAnalyzer.Analyze(Result(down)).Headline);
+
+    [Theory]
+    [InlineData(25)]
+    [InlineData(99.9)]
+    public void TwentyFiveToOneHundred_IsFast(double down)
+        => Assert.Equal("Fast connection", SpeedVerdictAnalyzer.Analyze(Result(down)).Headline);
+
+    [Theory]
+    [InlineData(100)]
+    [InlineData(940)]
+    public void OneHundredAndAbove_IsVeryFast(double down)
+        => Assert.Equal("Very fast connection", SpeedVerdictAnalyzer.Analyze(Result(down)).Headline);
+
+    [Fact]
+    public void TheBandsAreContiguous_EveryPositiveSpeedGetsAVerdict()
+    {
+        // Walks the whole range rather than sampling the arms above, so an off-by-one in a threshold
+        // (`<` vs `<=`) cannot leave a speed with an empty headline — the boundary values are exactly
+        // where a hand-written switch goes wrong.
+        for (var down = 0.1; down < 200; down += 0.1)
+        {
+            var verdict = SpeedVerdictAnalyzer.Analyze(Result(down));
+            Assert.False(string.IsNullOrWhiteSpace(verdict.Headline), $"No headline at {down:F1} Mbps");
+            Assert.False(string.IsNullOrWhiteSpace(verdict.Detail), $"No detail at {down:F1} Mbps");
+        }
+    }
+
+    // ── Colour: a slow plan is not a fault ──────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0.5)]
+    [InlineData(4.9)]
+    [InlineData(5)]
+    [InlineData(50)]
+    [InlineData(940)]
+    public void NoSpeedIsEverColouredAsAFailure(double down)
+    {
+        // The app's failure colour would tell someone on a cheap rural plan that SysManager found a
+        // fault on a working connection. Slow is amber at worst: "this will limit you", never "broken".
+        Assert.NotEqual("Danger", SpeedVerdictAnalyzer.Analyze(Result(down)).ColorKey);
+    }
+
+    [Fact]
+    public void SlowIsAmber_AndFastIsGreen()
+    {
+        Assert.Equal("Warning", SpeedVerdictAnalyzer.Analyze(Result(2)).ColorKey);
+        Assert.Equal("Info", SpeedVerdictAnalyzer.Analyze(Result(10)).ColorKey);
+        Assert.Equal("Success", SpeedVerdictAnalyzer.Analyze(Result(50)).ColorKey);
+        Assert.Equal("Success", SpeedVerdictAnalyzer.Analyze(Result(500)).ColorKey);
+    }
+
+    [Fact]
+    public void EveryColourKeyIsOneTheThemeCanResolve()
+    {
+        // The keys name theme brushes that ThemeService recomputes per preset. A hex literal here would
+        // silently reintroduce the dark-calibrated-colour-on-light-theme contrast bug that StatusColors
+        // exists to prevent, and HexToBrushConverter would fall back to grey for a typo'd key.
+        string[] known = ["Success", "Warning", "Info", "Danger", "TextMuted"];
+        foreach (var down in new[] { 0d, 1, 5, 25, 100, 1000 })
+            Assert.Contains(SpeedVerdictAnalyzer.Analyze(Result(down)).ColorKey, known);
+    }
+
+    // ── States that are not a measurement ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void NoResult_SaysSoRatherThanJudging()
+    {
+        var verdict = SpeedVerdictAnalyzer.Analyze(null);
+
+        Assert.Equal("No test yet", verdict.Headline);
+        Assert.Equal("TextMuted", verdict.ColorKey);
+        Assert.Empty(verdict.Comparison);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void ZeroOrNegativeDownload_IsNotCalledSlow(double down)
+    {
+        // A cancelled or failed run can leave a zero. Calling that "Slow connection" would be a false
+        // accusation about the user's connection based on a measurement that never happened.
+        var verdict = SpeedVerdictAnalyzer.Analyze(Result(down));
+
+        Assert.Equal("No speed measured", verdict.Headline);
+        Assert.DoesNotContain("Slow", verdict.Headline, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("TextMuted", verdict.ColorKey);
+    }
+
+    // ── Comparison against the previous run ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void WithNoHistory_ThereIsNoComparisonLine()
+        => Assert.Empty(SpeedVerdictAnalyzer.Analyze(Result(50)).Comparison);
+
+    [Theory]
+    [InlineData(50, 50)]      // identical
+    [InlineData(50, 45)]      // -10%
+    [InlineData(50, 60)]      // +20%
+    [InlineData(50, 40)]      // exactly -20%
+    public void AChangeWithinTheNoiseBand_ReadsAsAboutTheSame(double before, double now)
+    {
+        var verdict = SpeedVerdictAnalyzer.Analyze(Result(now), Result(before));
+
+        Assert.Contains("About the same", verdict.Comparison, StringComparison.Ordinal);
+        // The previous figure is included either way: "about the same as what" is the useful part.
+        Assert.Contains($"{before:F0}", verdict.Comparison, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AMeaningfulDrop_ReadsAsSlowerAndNamesTheOldFigure()
+    {
+        var verdict = SpeedVerdictAnalyzer.Analyze(Result(30), Result(92));
+
+        Assert.Contains("slower", verdict.Comparison, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("92", verdict.Comparison, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AMeaningfulRise_ReadsAsFaster()
+    {
+        var verdict = SpeedVerdictAnalyzer.Analyze(Result(90), Result(30));
+
+        Assert.Contains("faster", verdict.Comparison, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("30", verdict.Comparison, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AZeroPreviousRun_IsNotComparedAgainst()
+    {
+        // Dividing by a zero baseline would yield Infinity and report every run as "noticeably faster"
+        // than a test that failed.
+        Assert.Empty(SpeedVerdictAnalyzer.Analyze(Result(50), Result(0)).Comparison);
+    }
+
+    [Fact]
+    public void TheComparisonNeverClaimsToMeasureTheUsersPlan()
+    {
+        // A single test over Wi-Fi says little about the line someone pays for, so the wording must not
+        // imply SysManager verified their subscription — that is a complaint to an ISP built on a number
+        // the app cannot stand behind.
+        string[] forbidden = ["plan", "subscription", "paying", "advertised", "promised"];
+        foreach (var verdict in new[]
+                 {
+                     SpeedVerdictAnalyzer.Analyze(Result(2)),
+                     SpeedVerdictAnalyzer.Analyze(Result(50), Result(90)),
+                     SpeedVerdictAnalyzer.Analyze(Result(900), Result(10)),
+                 })
+        {
+            var text = $"{verdict.Headline} {verdict.Detail} {verdict.Comparison}";
+            foreach (var word in forbidden)
+                Assert.DoesNotContain(word, text, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/SysManager/SysManager/Models/SpeedVerdict.cs
+++ b/SysManager/SysManager/Models/SpeedVerdict.cs
@@ -1,0 +1,31 @@
+// SysManager · SpeedVerdict
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// The plain-English reading of a speed-test result — what the numbers on the Speed Test tab mean for
+/// the things someone actually does with their connection.
+/// </summary>
+/// <param name="Headline">Short answer to "is that good", e.g. "Fast connection".</param>
+/// <param name="Detail">What that allows, in recognisable terms rather than in Mbps.</param>
+/// <param name="ColorKey">
+/// A semantic key from <see cref="Helpers.StatusColors"/>, resolved against the live theme by
+/// HexToBrushConverter — never a hex literal, or the light presets would render it below the AA
+/// contrast floor.
+/// </param>
+/// <param name="Comparison">
+/// One sentence against the previous run on the same engine, or empty when there is no history.
+/// </param>
+/// <remarks>
+/// An immutable record rather than an <c>ObservableObject</c> like <see cref="HealthDiagnostic"/>: a
+/// speed test produces one verdict per completed run, so the view model swaps the whole value through
+/// an <c>[ObservableProperty]</c>. HealthDiagnostic is mutable because ping updates it in place
+/// several times a second and a single binding has to follow it.
+/// </remarks>
+public sealed record SpeedVerdict(
+    string Headline,
+    string Detail,
+    string ColorKey,
+    string Comparison);

--- a/SysManager/SysManager/Services/SpeedVerdictAnalyzer.cs
+++ b/SysManager/SysManager/Services/SpeedVerdictAnalyzer.cs
@@ -1,0 +1,107 @@
+// SysManager · SpeedVerdictAnalyzer
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Helpers;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Turns a speed-test result into a plain-English answer to the question the user actually opened the
+/// tab with: not "what is my speed" but "is that any good".
+/// </summary>
+/// <remarks>
+/// <para>Pure and static, like <see cref="HealthAnalyzer"/> — same reason: the judgement is the part
+/// worth testing, so it must be reachable without a network, a timer, or a view model.</para>
+/// <para>The thresholds are deliberately broad and described in things a person recognises (a video
+/// call, HD video, 4K, several devices) rather than in numbers, because a number is what the tab
+/// already showed and what the user could not interpret. They are rough guidance about the connection
+/// as measured right now, and the wording never claims to have measured the plan someone pays for —
+/// a single test over Wi-Fi says little about the line itself.</para>
+/// </remarks>
+public static class SpeedVerdictAnalyzer
+{
+    /// <summary>Below this, a video call is a coin flip. Roughly what one HD stream needs.</summary>
+    private const double SlowMbps = 5;
+
+    /// <summary>Comfortable for HD on a couple of devices, short of 4K plus a household.</summary>
+    private const double OkMbps = 25;
+
+    /// <summary>4K and several devices at once.</summary>
+    private const double FastMbps = 100;
+
+    /// <summary>
+    /// A run has to differ from the previous one by more than this fraction before it is called out as
+    /// a change. Speed tests vary between runs on identical lines — Wi-Fi, the chosen server, whatever
+    /// else is using the connection — so a tighter band would report noise as news, every time.
+    /// </summary>
+    private const double MeaningfulChange = 0.25;
+
+    /// <summary>
+    /// The verdict for <paramref name="result"/>, optionally compared against the previous run on the
+    /// same engine.
+    /// </summary>
+    /// <param name="result">The run just completed. Null yields the waiting state.</param>
+    /// <param name="previous">
+    /// The most recent earlier run on the same engine, or null when there is no history. Comparing
+    /// across engines would be meaningless — the HTTP and Ookla tests measure differently — so the
+    /// caller is responsible for passing a same-engine run.
+    /// </param>
+    public static SpeedVerdict Analyze(SpeedTestResult? result, SpeedTestResult? previous = null)
+    {
+        if (result is null)
+            return new SpeedVerdict("No test yet", "Press Start to measure your connection.", StatusColors.Neutral, "");
+
+        var down = result.DownloadMbps;
+
+        // A failed or aborted run can leave a zero. Saying "slow" about a measurement that did not
+        // happen would be a false accusation about the user's connection.
+        if (down <= 0)
+            return new SpeedVerdict(
+                "No speed measured",
+                "The test did not return a download speed. Try again, or use the other test engine.",
+                StatusColors.Neutral, "");
+
+        // Note what is NOT here: StatusColors.Bad. A slow result is not an error. Someone on a cheap
+        // rural plan would see the app's failure colour on a working connection and reasonably conclude
+        // it had found a fault. Amber at worst, meaning "this will limit you", never "something is broken".
+        var (headline, detail, colour) = down switch
+        {
+            < SlowMbps => ("Slow connection",
+                "Fine for email and browsing, but video calls and HD video will struggle — especially with " +
+                "someone else using the connection at the same time.",
+                StatusColors.Warning),
+            < OkMbps => ("Decent connection",
+                "Comfortable for HD streaming on one or two devices, and for video calls.",
+                StatusColors.Info),
+            < FastMbps => ("Fast connection",
+                "Handles 4K streaming and several devices at once.",
+                StatusColors.Good),
+            _ => ("Very fast connection",
+                "More than enough for anything a home connection is normally asked to do.",
+                StatusColors.Good),
+        };
+
+        return new SpeedVerdict(headline, detail, colour, CompareWithPrevious(down, previous));
+    }
+
+    /// <summary>
+    /// One sentence putting this run next to the last one, or empty when there is nothing to compare.
+    /// This is the part that turns a single number into evidence someone can take to their provider.
+    /// </summary>
+    private static string CompareWithPrevious(double down, SpeedTestResult? previous)
+    {
+        if (previous is null || previous.DownloadMbps <= 0) return "";
+
+        var before = previous.DownloadMbps;
+        var change = (down - before) / before;
+
+        if (Math.Abs(change) <= MeaningfulChange)
+            return $"About the same as your last test ({before:F0} Mbps).";
+
+        return change < 0
+            ? $"Noticeably slower than your last test (was {before:F0} Mbps)."
+            : $"Noticeably faster than your last test (was {before:F0} Mbps).";
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.61.11</Version>
-    <FileVersion>1.61.11.0</FileVersion>
-    <AssemblyVersion>1.61.11.0</AssemblyVersion>
+    <Version>1.62.0</Version>
+    <FileVersion>1.62.0.0</FileVersion>
+    <AssemblyVersion>1.62.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
@@ -23,6 +23,12 @@ public sealed partial class SpeedTestViewModel : ViewModelBase
 
     [ObservableProperty] private SpeedTestResult? _httpResult;
     [ObservableProperty] private SpeedTestResult? _ooklaResult;
+
+    // The plain-English reading of each engine's latest result. The tab used to show only the raw Mbps,
+    // which answers "what is my speed" and not the question people actually open it with — "is that
+    // good". One per engine, because each has its own result card and its own history to compare against.
+    [ObservableProperty] private SpeedVerdict? _httpVerdict;
+    [ObservableProperty] private SpeedVerdict? _ooklaVerdict;
     [ObservableProperty] private string _selectedOoklaServer = "Auto (nearest)";
 
     public string[] OoklaServerOptions { get; } = {
@@ -99,6 +105,11 @@ public sealed partial class SpeedTestViewModel : ViewModelBase
             Log.Information("HTTP speed test: {Down:F1} Mbps down, {Up:F1} Mbps up",
                 HttpResult.DownloadMbps, HttpResult.UploadMbps);
 
+            // Read the verdict BEFORE the history insert below: HttpHistory[0] is the previous run only
+            // until this one is prepended. Same-engine history, so the comparison never puts an HTTP
+            // result next to an Ookla one — the two engines measure differently.
+            HttpVerdict = SpeedVerdictAnalyzer.Analyze(HttpResult, HttpHistory.FirstOrDefault());
+
             // Persist result to history.
             await _history.SaveAsync(HttpResult);
             HttpHistory.Insert(0, HttpResult);
@@ -139,6 +150,9 @@ public sealed partial class SpeedTestViewModel : ViewModelBase
             OoklaStatus = "Ookla done";
             Log.Information("Ookla speed test: {Down:F1} Mbps down, {Up:F1} Mbps up",
                 OoklaResult.DownloadMbps, OoklaResult.UploadMbps);
+
+            // Before the insert, for the same reason as the HTTP path above.
+            OoklaVerdict = SpeedVerdictAnalyzer.Analyze(OoklaResult, OoklaHistory.FirstOrDefault());
 
             // Persist result to history.
             await _history.SaveAsync(OoklaResult);

--- a/SysManager/SysManager/Views/SpeedTestView.xaml
+++ b/SysManager/SysManager/Views/SpeedTestView.xaml
@@ -3,6 +3,39 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
+    <UserControl.Resources>
+        <!-- The verdict callout, defined once and used by both engine cards. Two hand-written copies of
+             one thing is how the elevation banner ended up saying the opposite on one tab out of thirty;
+             the ContentControls below bind a SpeedVerdict and this template renders it.
+             Styling follows the Ping tab's health verdict (PingView.xaml:48-65) — colour dot, SemiBold
+             headline in the verdict's own colour, secondary detail line — because that tab answers the
+             same kind of question and the two should not look like unrelated features. -->
+        <DataTemplate x:Key="SpeedVerdictTemplate">
+            <Border Style="{StaticResource CardInner}" Margin="0,12,0,0" Padding="12,10"
+                    BorderBrush="{Binding ColorKey, Converter={StaticResource HexBrush}}"
+                    BorderThickness="1">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <Ellipse Width="10" Height="10" Margin="0,0,8,0" VerticalAlignment="Center"
+                                 Fill="{Binding ColorKey, Converter={StaticResource HexBrush}}"/>
+                        <TextBlock Text="{Binding Headline}" FontSize="14" FontWeight="SemiBold"
+                                   VerticalAlignment="Center"
+                                   Foreground="{Binding ColorKey, Converter={StaticResource HexBrush}}"/>
+                    </StackPanel>
+                    <!-- Stacked vertically rather than beside the dot: a horizontal StackPanel measures
+                         children with infinite width, so TextWrapping inside one is inert and long copy is
+                         clipped instead of wrapped (#1807). These two lines are the whole point of the
+                         callout, so they must not be the ones that get cut. -->
+                    <TextBlock Text="{Binding Detail}" Foreground="{DynamicResource TextSecondary}"
+                               FontSize="12" TextWrapping="Wrap" Margin="18,6,0,0"/>
+                    <TextBlock Text="{Binding Comparison}" Style="{StaticResource Caption}"
+                               TextWrapping="Wrap" Margin="18,4,0,0"
+                               Visibility="{Binding Comparison, Converter={StaticResource FlexVis}}"/>
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+    </UserControl.Resources>
+
     <Grid Background="{DynamicResource Surface0}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -51,6 +84,11 @@
                             <Border Grid.Column="1" Style="{StaticResource CardInner}" Margin="6,0"><StackPanel><TextBlock Text="UPLOAD" Style="{StaticResource SectionLabel}"/><TextBlock Text="{Binding OoklaResult.UploadMbps, StringFormat={}{0:F1} Mbps}" Style="{StaticResource Metric}" Foreground="{DynamicResource Success}"/></StackPanel></Border>
                             <Border Grid.Column="2" Style="{StaticResource CardInner}" Margin="6,0,0,0"><StackPanel><TextBlock Text="PING" Style="{StaticResource SectionLabel}"/><TextBlock Text="{Binding OoklaResult.PingMs, StringFormat={}{0:F0} ms}" Style="{StaticResource Metric}" Foreground="{DynamicResource Warning}"/></StackPanel></Border>
                         </Grid>
+                        <!-- What the numbers above mean. Placed right under them, because the verdict is
+                             the answer and the Mbps are the working. -->
+                        <ContentControl Content="{Binding OoklaVerdict}"
+                                        ContentTemplate="{StaticResource SpeedVerdictTemplate}"
+                                        Visibility="{Binding OoklaVerdict, Converter={StaticResource FlexVis}}"/>
                         <TextBlock Text="{Binding OoklaResult.Server}" Style="{StaticResource Caption}" Margin="0,10,0,0" Visibility="{Binding OoklaResult, Converter={StaticResource FlexVis}}"/>
                         <ProgressBar AutomationProperties.Name="Progress" Value="{Binding SpeedProgress}" Maximum="100" Height="4" Margin="0,14,0,0" Visibility="{Binding IsOoklaTesting, Converter={StaticResource FlexVis}}"/>
                         <TextBlock Text="{Binding OoklaStatus}" Style="{StaticResource Subtle}" Margin="0,6,0,0"/>
@@ -83,6 +121,10 @@
                             <Border Grid.Column="1" Style="{StaticResource CardInner}" Margin="6,0"><StackPanel><TextBlock Text="UPLOAD" Style="{StaticResource SectionLabel}"/><TextBlock Text="{Binding HttpResult.UploadMbps, StringFormat={}{0:F1} Mbps}" Style="{StaticResource Metric}" Foreground="{DynamicResource Success}"/></StackPanel></Border>
                             <Border Grid.Column="2" Style="{StaticResource CardInner}" Margin="6,0,0,0"><StackPanel><TextBlock Text="PING" Style="{StaticResource SectionLabel}"/><TextBlock Text="{Binding HttpResult.PingMs, StringFormat={}{0:F0} ms}" Style="{StaticResource Metric}" Foreground="{DynamicResource Warning}"/></StackPanel></Border>
                         </Grid>
+                        <!-- Same template as the Ookla card — see UserControl.Resources. -->
+                        <ContentControl Content="{Binding HttpVerdict}"
+                                        ContentTemplate="{StaticResource SpeedVerdictTemplate}"
+                                        Visibility="{Binding HttpVerdict, Converter={StaticResource FlexVis}}"/>
                         <ProgressBar AutomationProperties.Name="Progress" Value="{Binding SpeedProgress}" Maximum="100" Height="4" Margin="0,14,0,0" Visibility="{Binding IsHttpTesting, Converter={StaticResource FlexVis}}"/>
                         <TextBlock Text="{Binding HttpStatus}" Style="{StaticResource Subtle}" Margin="0,6,0,0"/>
                         <!-- Shares the single EstimatedTime property with the Ookla card above; only one


### PR DESCRIPTION
Closes #1655.

## The gap

Speed Test measured the connection and rendered `43.2 Mbps` in the large `Metric`
style. That answers "what is my speed" and not the question people open the tab with:
**is that good?**

I re-verified the report's central claim before starting: grepping
`ViewModels/SpeedTestViewModel.cs` for `verdict|headline|streaming|4K|enough` returns
**zero hits**. Meanwhile the app already owns this exact capability one tab over —
`Services/HealthAnalyzer.cs` turns ping, jitter and loss into a plain-English headline
and detail ("Problem on your local network" · "Check Wi-Fi signal, restart the router,
or try cable"), rendered prominently at `PingView.xaml:55/58`. `DiskHealthService`
does the same for SMART data. Speed Test was the outlier.

## What was added

`Services/SpeedVerdictAnalyzer.cs` — pure and static, for the same reason
`HealthAnalyzer` is: the judgement is the part worth testing, so it has to be
reachable without a network, a timer or a view model. It returns a headline, a detail
line, a theme colour key, and a comparison line.

Four bands, described in things someone can check against their own household rather
than in Mbps: under 5 ("video calls and HD video will struggle"), 5–25 ("HD streaming
on one or two devices"), 25–100 ("4K and several devices at once"), 100+.

**Three decisions worth calling out, all of them things the issue flagged as risks:**

1. **It never emits the failure colour.** Someone on a modest rural plan would
   otherwise see the app's error colour on a working connection and reasonably
   conclude SysManager had found a fault. Amber at worst, meaning "this will limit
   you" — never "something is broken". A test asserts no speed in the range maps to
   `Danger`.
2. **A zero download is "No speed measured", not "Slow".** A cancelled or failed run
   leaves a zero, and calling that slow accuses the user's connection of something the
   test never measured.
3. **The comparison treats ±25% as noise.** A speed test varies between runs on an
   unchanged line — Wi-Fi, the chosen server, whatever else is using the connection —
   so a tighter band would report noise as news every single time. And a zero baseline
   is not compared against at all, or the division would report every subsequent run
   as "noticeably faster" than a test that failed.

The issue's "must not imply SysManager measured the plan the user pays for" constraint
is enforced, not just respected: a test scans the produced copy for
`plan|subscription|paying|advertised|promised` and fails on any of them.

## Ordering, which is load-bearing

The verdict is computed **before** the history insert in both engine paths. The history
list is prepended with the new result, so reading it afterwards would compare a run
against itself and always report "about the same". The harness pins that ordering by
index rather than trusting the comment next to it.

Same-engine history only — the HTTP and Ookla tests measure differently, so comparing
across them would be meaningless.

## Rendering

One shared `DataTemplate` in `UserControl.Resources`, used by both engine cards via
`ContentControl`. Two hand-written copies of one callout is exactly how the elevation
banner ended up contradicting itself on one tab out of thirty (#1649, shipped in
v1.61.11).

Styling follows the Ping tab's health verdict — colour dot, SemiBold headline in the
verdict's own colour, secondary detail — so the two tabs read as one app. The colour
goes through `HexBrush`, which resolves a `StatusColors` KEY against the live theme, so
it stays AA-legible on the light presets; a `DynamicResource` or hex literal could not
follow the verdict.

The detail lines stack vertically rather than sitting beside the dot, because
`TextWrapping` is inert inside a horizontal `StackPanel` (#1807) and these lines are the
whole point of the callout.

## Verification

- Red/green harness: **13 checks failing before, 0 after.** The green run prints the
  actual produced strings, so the judgement is exercised rather than merely present —
  e.g. `"Noticeably slower than your last test (was 92 Mbps)."`
- **20 unit tests** on the analyzer. Beyond the per-band cases:
  `TheBandsAreContiguous_EveryPositiveSpeedGetsAVerdict` walks 0.1→200 Mbps in 0.1
  steps, so a `<` vs `<=` slip cannot leave a speed with an empty headline;
  `EveryColourKeyIsOneTheThemeCanResolve` catches a typo'd key that
  `HexToBrushConverter` would silently render grey.
- All four projects build **0 warnings, 0 errors**.
- No `AutomationId` added, so `UiAutomationContractTests` set-equality is unaffected.
  `SpeedVerdict` is a plain record rather than an `ObservableObject`, and the command
  reachability ratchet only inspects `*Command` properties, so no ratchet changes.
- Gate-DOCS: README network bullets gained the verdict + comparison;
  `ARCHITECTURE.md` lists `SpeedVerdictAnalyzer` beside `HealthAnalyzer` with the
  no-failure-colour rationale.

`feat:` → minor bump, 1.62.0 from tag v1.61.11.
