### PR TITLE
fix: wrap 14 warning messages that were clipped inside horizontal StackPanels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.62.1] - 2026-08-12
+
+Several on-screen warnings and admin notices that were being cut off mid-sentence on a narrow window now
+wrap and show in full.
+
+### Fixed
+- **14 warning and information messages could be truncated instead of wrapping.** Across 13 tabs, notices like the File Shredder's "SSD users: overwrite-based shredding is unreliable…" caveat, Windows Defender's Tamper Protection notice, and the "requires administrator" banners were laid out in a way that told them to wrap but never gave them a width to wrap into — so on a narrow or default-width window the text was cut off at the right edge rather than continuing on a second line. The three longest were clipped even at the default window size. They now wrap and show in full. This is a layout fix only; no wording changed.
+
+---
+
 ## [1.62.0] - 2026-08-12
 
 The Speed Test tab now tells you whether your speed is any good, instead of leaving you to work it

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -397,6 +397,86 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// <c>TextWrapping="Wrap"</c> must not sit inside a horizontal <c>StackPanel</c>, where it does
+    /// nothing.
+    /// </summary>
+    /// <remarks>
+    /// <para>A StackPanel measures its children with infinite width along its orientation, so a TextBlock
+    /// inside a horizontal one never learns a width to wrap against: the attribute is inert and the text
+    /// is laid out on a single line, with whatever exceeds the panel silently clipped. It reads as
+    /// protection and provides none.</para>
+    /// <para>14 TextBlocks across 13 views did this, every one of them a warning or an explanation — an
+    /// SSD-shredding caveat, a Tamper-Protection notice, admin-requirement banners — so the truncation
+    /// dropped the caveat and kept the setup. The correct parent is a <c>DockPanel</c> (glyph docked
+    /// left, message filling) or a <c>Grid</c>, both of which give the text a real width. This test keeps
+    /// the next hand-written banner from reintroducing the class.</para>
+    /// </remarks>
+    [Fact]
+    public void NoTextWrapping_IsInertInsideAHorizontalStackPanel()
+    {
+        var viewsDir = Path.Combine(FindAppProjectDir(), "Views");
+        var offenders = new List<string>();
+        var scanned = 0;
+
+        foreach (var file in Directory.GetFiles(viewsDir, "*.xaml"))
+        {
+            System.Xml.Linq.XDocument doc;
+            try { doc = System.Xml.Linq.XDocument.Load(file); }
+            catch (System.Xml.XmlException) { continue; }
+
+            foreach (var tb in doc.Descendants().Where(e => e.Name.LocalName == "TextBlock"))
+            {
+                scanned++;
+                if (((string?)tb.Attribute("TextWrapping") ?? "") != "Wrap") continue;
+                if (!InsideHorizontalStackPanel(tb)) continue;
+
+                var text = WhitespaceRun().Replace((string?)tb.Attribute("Text") ?? "", " ").Trim();
+                // Bound values and short glyphs cannot meaningfully clip; only real prose does.
+                if (text.Length < 40 || text.StartsWith('{')) continue;
+
+                offenders.Add($"{Path.GetFileName(file)}: \"{(text.Length > 60 ? text[..60] + "…" : text)}\"");
+            }
+        }
+
+        Assert.True(scanned > 100, $"Only {scanned} TextBlocks parsed — the check is not reading the views.");
+
+        Assert.True(offenders.Count == 0,
+            "These TextBlocks set TextWrapping=\"Wrap\" but their nearest layout ancestor is a horizontal " +
+            "StackPanel, which hands children infinite width — so wrapping does nothing and the text is " +
+            "clipped instead. Put the message in a DockPanel (glyph docked left) or a Grid so it has a " +
+            "real width to wrap in:\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// True if the nearest ancestor that constrains width along an axis is a horizontal StackPanel.
+    /// A Grid, DockPanel, Border, ScrollViewer or vertical StackPanel between the TextBlock and any
+    /// horizontal StackPanel gives the text a real width, so the decision is made on the FIRST layout
+    /// container encountered walking outward — only an unbroken path into a horizontal StackPanel is inert.
+    /// </summary>
+    private static bool InsideHorizontalStackPanel(System.Xml.Linq.XElement textBlock)
+    {
+        for (var e = textBlock.Parent; e is not null; e = e.Parent)
+        {
+            switch (e.Name.LocalName)
+            {
+                case "StackPanel":
+                    // No Orientation attribute defaults to Vertical, which constrains width — not a problem.
+                    return (((string?)e.Attribute("Orientation")) ?? "Vertical") == "Horizontal";
+                case "Grid":
+                case "DockPanel":
+                case "Border":
+                case "ScrollViewer":
+                case "WrapPanel":
+                case "UserControl":
+                case "GroupBox":
+                case "ToolTip":
+                    return false;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
     /// Messages inside a Border that is (a) shown WHEN elevated and (b) painted with the gold
     /// WarningBgSubtle. Parsed rather than grepped: the not-elevated banner sits in the same
     /// <c>Grid.Row</c> in every one of these views, so a file-wide text search would read the wrong one.

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.62.0</Version>
-    <FileVersion>1.62.0.0</FileVersion>
-    <AssemblyVersion>1.62.0.0</AssemblyVersion>
+    <Version>1.62.1</Version>
+    <FileVersion>1.62.1.0</FileVersion>
+    <AssemblyVersion>1.62.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/BandwidthMonitorView.xaml
+++ b/SysManager/SysManager/Views/BandwidthMonitorView.xaml
@@ -36,12 +36,14 @@
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
                         AutomationProperties.Name="Run as administrator"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Total speed and per-app activity are shown below. Run as administrator to unlock exact per-app upload/download speeds."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
-                </StackPanel>
+                <!-- Glyph docked left of the message, not a nested horizontal StackPanel: a StackPanel
+                     gives its children infinite width along its orientation, so the message's
+                     TextWrapping was inert and clipped at a narrow width (#1807). As the DockPanel's fill
+                     child the message now has a real width to wrap in. -->
+                <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" DockPanel.Dock="Left"
+                           FontSize="16" Margin="0,0,10,0" VerticalAlignment="Top" Foreground="{DynamicResource TextSecondary}"/>
+                <TextBlock Text="Total speed and per-app activity are shown below. Run as administrator to unlock exact per-app upload/download speeds."
+                           Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
             </DockPanel>
         </Border>
 
@@ -123,12 +125,15 @@
         <Border Grid.Row="3" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
                 BorderThickness="1" CornerRadius="12" Padding="12,10" Margin="28,12,28,0"
                 Visibility="{Binding HasAlert, Converter={StaticResource FlexVis}}">
-            <StackPanel Orientation="Horizontal">
-                <TextBlock Text="&#xE7BA;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                           FontSize="14" Foreground="{DynamicResource WarningText}" VerticalAlignment="Center" Margin="0,0,10,0"/>
+            <!-- DockPanel, not a horizontal StackPanel: a StackPanel gives children infinite width along
+                 its orientation, so TextWrapping was inert and a long alert clipped (#1807). AlertMessage
+                 is bound, so its length is not fixed — wrapping matters more here, not less. -->
+            <DockPanel>
+                <TextBlock Text="&#xE7BA;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" DockPanel.Dock="Left"
+                           FontSize="14" Foreground="{DynamicResource WarningText}" VerticalAlignment="Top" Margin="0,0,10,0"/>
                 <TextBlock Text="{Binding AlertMessage}" Foreground="{DynamicResource WarningText}"
                            FontSize="12.5" VerticalAlignment="Center" TextWrapping="Wrap"/>
-            </StackPanel>
+            </DockPanel>
         </Border>
 
         <!-- Chart + top consumers -->

--- a/SysManager/SysManager/Views/BootAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/BootAnalyzerView.xaml
@@ -34,12 +34,14 @@
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
                         AutomationProperties.Name="Restart SysManager as administrator"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Reading the Windows boot-performance log requires administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
-                </StackPanel>
+                <!-- Glyph docked left of the message, not a nested horizontal StackPanel: a StackPanel
+                     gives its children infinite width along its orientation, so the message's
+                     TextWrapping was inert and clipped at a narrow width (#1807). As the DockPanel's fill
+                     child the message now has a real width to wrap in. -->
+                <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" DockPanel.Dock="Left"
+                           FontSize="16" Margin="0,0,10,0" VerticalAlignment="Top" Foreground="{DynamicResource TextSecondary}"/>
+                <TextBlock Text="Reading the Windows boot-performance log requires administrator privileges."
+                           Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
             </DockPanel>
         </Border>
 

--- a/SysManager/SysManager/Views/DefenderView.xaml
+++ b/SysManager/SysManager/Views/DefenderView.xaml
@@ -66,12 +66,14 @@
         <Border Grid.Row="3" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
                 BorderThickness="1" CornerRadius="12" Padding="12,10" Margin="0,0,0,12"
                 Visibility="{Binding IsTamperProtected, Converter={StaticResource FlexVis}}">
-            <StackPanel Orientation="Horizontal">
-                <TextBlock Text="&#xE730;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                           FontSize="14" Foreground="{DynamicResource WarningText}" VerticalAlignment="Center" Margin="0,0,10,0"/>
+            <!-- DockPanel, not a horizontal StackPanel: a StackPanel gives children infinite width along
+                 its orientation, so TextWrapping was inert and this warning clipped (#1807). -->
+            <DockPanel>
+                <TextBlock Text="&#xE730;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" DockPanel.Dock="Left"
+                           FontSize="14" Foreground="{DynamicResource WarningText}" VerticalAlignment="Top" Margin="0,0,10,0"/>
                 <TextBlock Text="Tamper Protection is ON. Windows may silently ignore changes here until you turn it off in Windows Security."
                            Foreground="{DynamicResource WarningText}" FontSize="12.5" VerticalAlignment="Center" TextWrapping="Wrap"/>
-            </StackPanel>
+            </DockPanel>
         </Border>
 
         <!-- Status cards -->

--- a/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
+++ b/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
@@ -33,12 +33,14 @@
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
                         AutomationProperties.Name="Restart SysManager as administrator"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Editing System variables writes to machine-wide registry keys and requires administrator privileges. User variables can be edited without it."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
-                </StackPanel>
+                <!-- Glyph docked left of the message, not a nested horizontal StackPanel: a StackPanel
+                     gives its children infinite width along its orientation, so the message's
+                     TextWrapping was inert and the second sentence clipped at a narrow width (#1807).
+                     As the DockPanel's fill child the message now has a real width to wrap in. -->
+                <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" DockPanel.Dock="Left"
+                           FontSize="16" Margin="0,0,10,0" VerticalAlignment="Top" Foreground="{DynamicResource TextSecondary}"/>
+                <TextBlock Text="Editing System variables writes to machine-wide registry keys and requires administrator privileges. User variables can be edited without it."
+                           Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
             </DockPanel>
         </Border>
 

--- a/SysManager/SysManager/Views/FileShredderView.xaml
+++ b/SysManager/SysManager/Views/FileShredderView.xaml
@@ -33,12 +33,15 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
             <Border Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1" CornerRadius="8"
                     Margin="0,10,0,0" Padding="10,8">
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock Text="&#xE7BA;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="14" Foreground="{DynamicResource WarningText}" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                <!-- DockPanel, not a horizontal StackPanel: a StackPanel measures children with infinite
+                     width along its orientation, so TextWrapping is inert there and this warning clips
+                     instead of wrapping (#1807). Glyph docked left, message fills the rest. -->
+                <DockPanel>
+                    <TextBlock Text="&#xE7BA;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" DockPanel.Dock="Left"
+                               FontSize="14" Foreground="{DynamicResource WarningText}" VerticalAlignment="Top" Margin="0,0,8,0"/>
                     <TextBlock Foreground="{DynamicResource WarningText}" FontSize="12" TextWrapping="Wrap" VerticalAlignment="Center"
                                Text="SSD users: overwrite-based shredding is unreliable on solid-state drives due to wear-leveling. Use full-disk encryption (BitLocker/VeraCrypt) for secure data disposal on SSDs."/>
-                </StackPanel>
+                </DockPanel>
             </Border>
         </StackPanel>
 

--- a/SysManager/SysManager/Views/GamingProfileView.xaml
+++ b/SysManager/SysManager/Views/GamingProfileView.xaml
@@ -38,12 +38,14 @@
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
                         AutomationProperties.Name="Run as administrator"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE7EF;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Most optimizations apply as-is. Freeing standby memory and pausing search indexing need administrator."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
-                </StackPanel>
+                <!-- Glyph docked left of the message, not a nested horizontal StackPanel: a StackPanel
+                     gives its children infinite width along its orientation, so the message's
+                     TextWrapping was inert and clipped at a narrow width (#1807). As the DockPanel's fill
+                     child the message now has a real width to wrap in. -->
+                <TextBlock Text="&#xE7EF;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" DockPanel.Dock="Left"
+                           FontSize="16" Margin="0,0,10,0" VerticalAlignment="Top" Foreground="{DynamicResource TextSecondary}"/>
+                <TextBlock Text="Most optimizations apply as-is. Freeing standby memory and pausing search indexing need administrator."
+                           Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
             </DockPanel>
         </Border>
 
@@ -54,11 +56,14 @@
             <Grid>
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                <!-- DockPanel, not a horizontal StackPanel: a StackPanel gives children infinite width
+                     along its orientation, so this banner's TextWrapping was inert and clipped on a
+                     narrow window (#1807). The stripe Border above is untouched. -->
+                <DockPanel Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Top" DockPanel.Dock="Left"/>
                     <TextBlock Text="Running as administrator — every optimization, including freeing standby memory and pausing search indexing, can be applied."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center" TextWrapping="Wrap"/>
-                </StackPanel>
+                </DockPanel>
             </Grid>
         </Border>
 

--- a/SysManager/SysManager/Views/RestorePointsView.xaml
+++ b/SysManager/SysManager/Views/RestorePointsView.xaml
@@ -34,12 +34,14 @@
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
                         AutomationProperties.Name="Restart SysManager as administrator"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Creating and restoring restore points require administrator privileges. You can still view existing points without elevation."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
-                </StackPanel>
+                <!-- Glyph docked left of the message, not a nested horizontal StackPanel: a StackPanel
+                     gives its children infinite width along its orientation, so the message's
+                     TextWrapping was inert and clipped at a narrow width (#1807). As the DockPanel's fill
+                     child the message now has a real width to wrap in. -->
+                <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" DockPanel.Dock="Left"
+                           FontSize="16" Margin="0,0,10,0" VerticalAlignment="Top" Foreground="{DynamicResource TextSecondary}"/>
+                <TextBlock Text="Creating and restoring restore points require administrator privileges. You can still view existing points without elevation."
+                           Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
             </DockPanel>
         </Border>
 

--- a/SysManager/SysManager/Views/SettingsWatchdogView.xaml
+++ b/SysManager/SysManager/Views/SettingsWatchdogView.xaml
@@ -73,11 +73,14 @@
             <Grid>
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                <!-- DockPanel, not a horizontal StackPanel: a StackPanel gives children infinite width
+                     along its orientation, so this banner's TextWrapping was inert and clipped on a
+                     narrow window (#1807). The stripe Border above is untouched. -->
+                <DockPanel Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Top" DockPanel.Dock="Left"/>
                     <TextBlock Text="Running as administrator — machine-wide watched settings can be restored, not just per-user ones."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center" TextWrapping="Wrap"/>
-                </StackPanel>
+                </DockPanel>
             </Grid>
         </Border>
 
@@ -96,13 +99,15 @@
         <Border Grid.Row="4" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
                 BorderThickness="1" CornerRadius="12" Padding="12,10" Margin="28,12,28,0"
                 Visibility="{Binding HasDrift, Converter={StaticResource FlexVis}}">
-            <StackPanel Orientation="Horizontal">
-                <TextBlock Text="&#xE7BA;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                           FontSize="14" Foreground="{DynamicResource WarningText}" VerticalAlignment="Center" Margin="0,0,10,0"/>
+            <!-- DockPanel, not a horizontal StackPanel: a StackPanel gives children infinite width along
+                 its orientation, so TextWrapping was inert and this drift notice clipped (#1807). -->
+            <DockPanel>
+                <TextBlock Text="&#xE7BA;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" DockPanel.Dock="Left"
+                           FontSize="14" Foreground="{DynamicResource WarningText}" VerticalAlignment="Top" Margin="0,0,10,0"/>
                 <TextBlock Text="Some settings have changed since your baseline. Review them below and restore if they weren't your doing."
                            Foreground="{DynamicResource WarningText}" FontSize="12.5"
                            VerticalAlignment="Center" TextWrapping="Wrap"/>
-            </StackPanel>
+            </DockPanel>
         </Border>
 
         <!-- Drift list -->

--- a/SysManager/SysManager/Views/SystemFixesView.xaml
+++ b/SysManager/SysManager/Views/SystemFixesView.xaml
@@ -34,12 +34,14 @@
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
                         AutomationProperties.Name="Restart SysManager as administrator"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="These repairs modify system services and settings, so they require administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
-                </StackPanel>
+                <!-- Glyph docked left of the message, not a nested horizontal StackPanel: a StackPanel
+                     gives its children infinite width along its orientation, so the message's
+                     TextWrapping was inert and clipped at a narrow width (#1807). As the DockPanel's fill
+                     child the message now has a real width to wrap in. -->
+                <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" DockPanel.Dock="Left"
+                           FontSize="16" Margin="0,0,10,0" VerticalAlignment="Top" Foreground="{DynamicResource TextSecondary}"/>
+                <TextBlock Text="These repairs modify system services and settings, so they require administrator privileges."
+                           Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
             </DockPanel>
         </Border>
 

--- a/SysManager/SysManager/Views/TimerResolutionView.xaml
+++ b/SysManager/SysManager/Views/TimerResolutionView.xaml
@@ -69,14 +69,16 @@
         <!-- Power warning -->
         <Border Grid.Row="3" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
                 BorderThickness="1" CornerRadius="12" Padding="12,10" Margin="0,0,0,16">
-            <StackPanel Orientation="Horizontal">
-                <TextBlock Text="&#xE9CE;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+            <!-- DockPanel, not a horizontal StackPanel: a StackPanel gives children infinite width along
+                 its orientation, so TextWrapping was inert and this warning clipped (#1807). -->
+            <DockPanel>
+                <TextBlock Text="&#xE9CE;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" DockPanel.Dock="Left"
                            FontSize="14" Foreground="{DynamicResource WarningText}"
-                           VerticalAlignment="Center" Margin="0,0,10,0"/>
+                           VerticalAlignment="Top" Margin="0,0,10,0"/>
                 <TextBlock Text="A finer timer wakes the CPU more often, which can increase power draw, heat and battery drain — most noticeable on laptops."
                            Foreground="{DynamicResource WarningText}" FontSize="12.5"
                            VerticalAlignment="Center" TextWrapping="Wrap"/>
-            </StackPanel>
+            </DockPanel>
         </Border>
 
         <!-- Actions -->

--- a/SysManager/SysManager/Views/TweaksHubView.xaml
+++ b/SysManager/SysManager/Views/TweaksHubView.xaml
@@ -93,11 +93,14 @@
             <Grid>
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                <!-- DockPanel, not a horizontal StackPanel: a StackPanel gives children infinite width
+                     along its orientation, so this banner's TextWrapping was inert and clipped on a
+                     narrow window (#1807). The stripe Border above is untouched. -->
+                <DockPanel Margin="6,0,0,0">
+                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Top" DockPanel.Dock="Left"/>
                     <TextBlock Text="Running as administrator — both Essential and Advanced (machine-wide) tweaks can be applied."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center" TextWrapping="Wrap"/>
-                </StackPanel>
+                </DockPanel>
             </Grid>
         </Border>
 


### PR DESCRIPTION
Closes #1807.

## The defect

`TextWrapping="Wrap"` does nothing inside a horizontal `StackPanel`. A StackPanel
measures its children with infinite width along its orientation, so a TextBlock inside
one never learns a width to wrap against — the text is laid out on one line and
whatever exceeds the panel is clipped, silently. The attribute reads as protection and
provides none.

I found the sites by parsing each view and tracking horizontal-StackPanel ancestry
rather than a text grep, because the attribute is harmless in the many places whose
parent is a Grid or DockPanel. **14 TextBlocks across 13 views** had it inside a
horizontal StackPanel. (The issue estimated 16; the real count is 14 — two of the
original hits sit in a *vertical* StackPanel inside a `ToolTip MaxWidth="520"`, which
constrains width, so they were never broken. The parse in the guard test decides on
the first width-imposing ancestor, so it does not make that mistake.)

At 13px the usable content width is ~630px at the `MinWidth="960"` floor and ~950px at
the default `Width="1280"`. The three longest — the File Shredder SSD caveat (175
chars) and both Context Menu... actually the two longest survivors are the File
Shredder caveat and the Environment Variables / Bandwidth admin notices — clip even at
the default size; the rest clip at the minimum. Every one is a warning or an
explanation, so the truncation dropped the caveat and kept the setup.

## The change

Each message now lives in a `DockPanel` with the glyph docked left and the message as
the fill child — the pattern already used correctly elsewhere in these same files — so
it inherits a real width and wraps. **Layout only: no wording changed**, and the gold
accent stripe on the elevated banners is untouched.

Views touched: BandwidthMonitor (×2), BootAnalyzer, Defender, EnvironmentVariables,
FileShredder, GamingProfile (×2), RestorePoints, SettingsWatchdog (×2), SystemFixes,
TimerResolution, TweaksHub.

## The guard

`ArchitectureTests.NoTextWrapping_IsInertInsideAHorizontalStackPanel` parses every view
and fails on any `TextWrapping="Wrap"` whose nearest layout ancestor is a horizontal
StackPanel. It walks outward and decides on the **first** layout container it meets, so
a Grid, DockPanel or Border between the TextBlock and any horizontal StackPanel counts
as safe — only an unbroken chain into a horizontal StackPanel is inert. It carries a
floor on the number of TextBlocks scanned, so a parse that silently stops matching
fails loudly rather than passing vacuously. This is what keeps the next hand-written
banner from reintroducing the class.

## Verification

- Red/green harness: **14 offenders before across 13 views, 0 after.** The harness uses
  the identical ancestor-walk logic as the guard test, so the test is proven red→green
  by construction.
- All four projects build **0 warnings, 0 errors**.
- The diff is layout-only — filtering the added XAML lines for anything other than
  StackPanel→DockPanel restructuring and the existing text/style attributes returns
  nothing.
- No `AutomationId` change, so `UiAutomationContractTests` is unaffected. Author headers
  intact on all 13 views.

`fix:` → patch bump, 1.62.1 from tag v1.62.0.
