### PR TITLE
feat: show what each Startup Manager entry is and whether it is safe

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -203,7 +203,9 @@ Key services:
 - `UpdateApplier` — runs on relaunch to swap the freshly-downloaded exe over the
   old one and restart, before any DI/UI is built (see the Updates flow below).
 - `StartupService` — enumerate and toggle startup programs via registry
-  Run / RunOnce keys.
+  Run / RunOnce keys. Enriches each entry from `ProcessDescriptionService`
+  (plain-language description + `ProcessSafety`) keyed on the executable's base
+  name; unrecognised programs are left blank so the UI never guesses a safety.
 - `DuplicateFileService` — three-pass duplicate finder (size grouping →
   partial hash pre-filter → full SHA-256). Read-only, never deletes.
 - `DiskAnalyzerService` — folder-level space breakdown with progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.63.0] - 2026-08-12
+
+The Startup Manager now tells you what each program is and whether it is safe to turn off, instead of
+showing a raw file path you would have to decode.
+
+### Added
+- **Plain-language descriptions and a safety label in the Startup Manager.** The tab listed each startup program by name and its raw command line — a full file path with switches, like `"C:\Program Files\NVIDIA Corporation\NvContainer\nvcontainer.exe"` — and left you to work out whether turning it off was safe. It now shows a short description of what the program actually is (drawn from the same built-in database the Process Manager already uses) and a Safety chip: **Windows** for parts of the operating system, **Known app** for recognised software, or **Not recognised** for everything else. So you can tell "nvcontainer" (part of your graphics driver, leave it) from "Spotify" (safe to turn off) at a glance. Programs the database does not recognise keep showing their file path and get no safety label — the app never guesses that something is safe to disable. The full path is always available on hover.
+
+---
+
 ## [1.62.1] - 2026-08-12
 
 Several on-screen warnings and admin notices that were being cut off mid-sentence on a narrow window now

--- a/README.md
+++ b/README.md
@@ -380,8 +380,11 @@ a confirmation before it runs:
 ### Startup Manager
 - Lists every program that runs at Windows boot (Registry Run / RunOnce keys)
 - Toggle on/off without deleting the original entry (same mechanism as Task Manager)
-- Sort by name, publisher, or status via clickable column headers
-- Shows name, publisher, command, and enabled/disabled status
+- Sort by name, publisher, safety, or status via clickable column headers
+- Plain-language description for recognised programs (from the built-in database) instead
+  of a raw command line, plus a Safety chip — Windows / Known app / Not recognised — so you
+  can tell what an entry is before deciding whether to turn it off
+- Shows name, publisher, and enabled/disabled status; the full command path is on hover
 - Open file location in Explorer
 
 ### Windows Features

--- a/SysManager/SysManager.Tests/StartupServiceTests.cs
+++ b/SysManager/SysManager.Tests/StartupServiceTests.cs
@@ -176,4 +176,82 @@ public class StartupServiceTests
 
         Assert.Equal(StartupSource.StartupFolder, entry.Source);
     }
+
+    // ── ExecutableNameFromCommand (pure — the exe-name parser feeding the description lookup) ──
+
+    [Theory]
+    // Quoted path with arguments — the common Run-key shape.
+    [InlineData("\"C:\\Program Files\\OneDrive\\OneDrive.exe\" /background", "OneDrive")]
+    // Unquoted path with a switch.
+    [InlineData(@"C:\Windows\system32\SecurityHealthSystray.exe /run", "SecurityHealthSystray")]
+    // Bare path, no arguments.
+    [InlineData(@"C:\Program Files\Spotify\Spotify.exe", "Spotify")]
+    // A resolved shortcut target with spaces in the folder but no arguments.
+    [InlineData(@"C:\Program Files (x86)\Steam\steam.exe", "steam")]
+    // Quoted path, no arguments.
+    [InlineData("\"C:\\Program Files\\NVIDIA Corporation\\NvContainer\\nvcontainer.exe\"", "nvcontainer")]
+    // Already just a name.
+    [InlineData("Discord.exe", "Discord")]
+    public void ExecutableNameFromCommand_ExtractsTheBareExeName(string command, string expected)
+        => Assert.Equal(expected, StartupService.ExecutableNameFromCommand(command));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ExecutableNameFromCommand_BlankCommand_ReturnsEmpty(string command)
+        => Assert.Equal("", StartupService.ExecutableNameFromCommand(command));
+
+    [Fact]
+    public void ExecutableNameFromCommand_IllegalPathChars_ReturnsEmptyRatherThanThrow()
+    {
+        // A rundll32 entry-point spec or similar can carry characters that are not a valid path. The
+        // parser must degrade to "no match" (empty), never throw into the scan.
+        var result = StartupService.ExecutableNameFromCommand("rundll32.exe shell32.dll,Control_RunDLL \"x\"|<>");
+        // Whatever it returns, it must not have thrown; rundll32 is the leading token here.
+        Assert.Equal("rundll32", result);
+    }
+
+    // ── EnrichWithDescriptions (pure over the finished list — the actual feature) ──
+
+    [Fact]
+    public void EnrichWithDescriptions_KnownProgram_GetsDescriptionAndSafety()
+    {
+        // OneDrive is in the shipped database; a real Run-key command shape drives the lookup.
+        var entry = new StartupEntry { Name = "OneDrive", Command = "\"C:\\Program Files\\Microsoft OneDrive\\OneDrive.exe\" /background" };
+
+        StartupService.EnrichWithDescriptions([entry]);
+
+        Assert.NotEqual("", entry.Description);
+        // The safety is a ProcessSafety name, so it binds to the ProcessSafety* chip converters.
+        Assert.Contains(entry.Safety, new[] { "System", "Trusted", "Unknown" });
+    }
+
+    [Fact]
+    public void EnrichWithDescriptions_UnknownProgram_LeavesBothEmpty()
+    {
+        // The stated risk: never assert a safety on a guess. An executable the database does not know
+        // must come back with both fields empty, so the view shows no chip and falls back to publisher.
+        var entry = new StartupEntry
+        {
+            Name = "TotallyMadeUpVendorWidget",
+            Command = @"C:\Vendor\TotallyMadeUpVendorWidget9000.exe",
+            Publisher = "Made Up Vendor Inc.",
+        };
+
+        StartupService.EnrichWithDescriptions([entry]);
+
+        Assert.Equal("", entry.Description);
+        Assert.Equal("", entry.Safety);
+    }
+
+    [Fact]
+    public void EnrichWithDescriptions_BlankCommand_DoesNotThrowOrPopulate()
+    {
+        var entry = new StartupEntry { Name = "Weird", Command = "" };
+
+        StartupService.EnrichWithDescriptions([entry]);
+
+        Assert.Equal("", entry.Description);
+        Assert.Equal("", entry.Safety);
+    }
 }

--- a/SysManager/SysManager.Tests/StartupServiceTests.cs
+++ b/SysManager/SysManager.Tests/StartupServiceTests.cs
@@ -188,6 +188,11 @@ public class StartupServiceTests
     [InlineData(@"C:\Program Files\Spotify\Spotify.exe", "Spotify")]
     // A resolved shortcut target with spaces in the folder but no arguments.
     [InlineData(@"C:\Program Files (x86)\Steam\steam.exe", "steam")]
+    // Unquoted path with spaces in the folder AND arguments — the extension, not the first space,
+    // ends the path.
+    [InlineData(@"C:\Program Files\App\app.exe --background /silent", "app")]
+    // A folder name containing ".com" must not be mistaken for the executable extension.
+    [InlineData(@"C:\Company Tools\updater.exe /run", "updater")]
     // Quoted path, no arguments.
     [InlineData("\"C:\\Program Files\\NVIDIA Corporation\\NvContainer\\nvcontainer.exe\"", "nvcontainer")]
     // Already just a name.

--- a/SysManager/SysManager/Models/StartupEntry.cs
+++ b/SysManager/SysManager/Models/StartupEntry.cs
@@ -23,6 +23,22 @@ public sealed partial class StartupEntry : ObservableObject
     [ObservableProperty] private string _statusText = "";
     [ObservableProperty] private ImageSource? _icon;
 
+    /// <summary>
+    /// Plain-language description of the program from the built-in database
+    /// (<see cref="Services.ProcessDescriptionService"/>), or empty when the program is not recognised.
+    /// The tab used to show only the raw command line, which tells the target persona nothing about
+    /// whether an entry is safe to turn off.
+    /// </summary>
+    [ObservableProperty] private string _description = "";
+
+    /// <summary>
+    /// Provenance from the built-in database as a <see cref="Services.ProcessSafety"/> name
+    /// ("System" / "Trusted" / "Unknown"), or empty when the program is not recognised. A string, not
+    /// the enum, so it binds to the same ProcessSafety* chip converters the Process Manager tab uses —
+    /// and so an unrecognised entry renders NOTHING rather than defaulting to a colour it has not earned.
+    /// </summary>
+    [ObservableProperty] private string _safety = "";
+
     /// <summary>Registry key path (for registry-based entries).</summary>
     public string RegistryKey { get; init; } = "";
 

--- a/SysManager/SysManager/Services/StartupService.cs
+++ b/SysManager/SysManager/Services/StartupService.cs
@@ -132,11 +132,11 @@ public sealed class StartupService
         }
         else
         {
-            // Unquoted: the path is the run up to the first space. A space inside an unquoted path is
-            // ambiguous and rare for autostart entries; taking the first token matches how Windows itself
-            // resolves an unquoted command, and a wrong split just means no database hit.
-            var space = text.IndexOf(' ');
-            path = space > 0 ? text[..space] : text;
+            // Unquoted: the executable ends at its extension, NOT at the first space — an unquoted path
+            // like "C:\Program Files\Spotify\Spotify.exe" contains spaces and is entirely the path.
+            // Find the first known executable extension that is followed by end-of-string or a space;
+            // everything up to and including it is the path, and the rest are arguments.
+            path = SplitUnquotedExecutable(text);
         }
 
         try
@@ -149,6 +149,40 @@ public sealed class StartupService
             // keys on anyway.
             return "";
         }
+    }
+
+    // Executable extensions that can appear at the end of the path portion of an unquoted command.
+    // .exe covers all but a handful; the others are the launchers Windows actually invokes at logon.
+    private static readonly string[] ExecutableExtensions = [".exe", ".com", ".bat", ".cmd", ".scr"];
+
+    /// <summary>
+    /// Splits an UNQUOTED command line into its executable path, treating a space as an argument
+    /// separator ONLY after the executable's extension. "C:\Program Files\App\app.exe --flag" returns
+    /// "C:\Program Files\App\app.exe" (the spaces before .exe are part of the path); "app.exe /run"
+    /// returns "app.exe". Falls back to the first space-delimited token when no known extension is
+    /// present, which still handles the common "app.exe" bare case via the whole string.
+    /// </summary>
+    private static string SplitUnquotedExecutable(string text)
+    {
+        foreach (var ext in ExecutableExtensions)
+        {
+            var idx = text.IndexOf(ext, StringComparison.OrdinalIgnoreCase);
+            while (idx >= 0)
+            {
+                var after = idx + ext.Length;
+                // The extension ends the path only if the executable token ends here — i.e. end of
+                // string or a space begins the arguments. Guards against matching ".com" inside a folder
+                // like "C:\Company\...": require the next char to be a separator or nothing.
+                if (after == text.Length || text[after] == ' ')
+                    return text[..after];
+                idx = text.IndexOf(ext, after, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        // No recognised extension (e.g. a bare token, or a path to something unusual). Fall back to the
+        // first token; a wrong split just means no database hit, never a wrong description.
+        var space = text.IndexOf(' ');
+        return space > 0 ? text[..space] : text;
     }
 
     private static void ReadStartupFolder(string folderPath, string locationLabel, bool isCommon, List<StartupEntry> results)

--- a/SysManager/SysManager/Services/StartupService.cs
+++ b/SysManager/SysManager/Services/StartupService.cs
@@ -75,7 +75,80 @@ public sealed class StartupService
         // Check StartupApproved to determine enabled/disabled state
         ApplyApprovedState(results);
 
+        // Attach the plain-language description + provenance the app already ships in
+        // ProcessDescriptions.json. Done once, over the finished list, rather than at each of the three
+        // construction sites, so every source (registry, startup folder, scheduled task) is enriched the
+        // same way and there is one place to test.
+        EnrichWithDescriptions(results);
+
         return results;
+    }
+
+    /// <summary>
+    /// Fills <see cref="StartupEntry.Description"/> and <see cref="StartupEntry.Safety"/> from the
+    /// built-in process database, keyed on the executable's base name. An entry the database does not
+    /// know is left with both empty — the view falls back to the publisher, and NO safety chip renders,
+    /// so the tab never asserts "safe" on a guess (the report's stated risk).
+    /// </summary>
+    internal static void EnrichWithDescriptions(IReadOnlyList<StartupEntry> entries)
+    {
+        foreach (var entry in entries)
+        {
+            var exe = ExecutableNameFromCommand(entry.Command);
+            if (exe.Length == 0) continue;
+
+            var info = ProcessDescriptionService.Instance.Lookup(exe);
+            if (info is null) continue;
+
+            entry.Description = info.Description;
+            entry.Safety = info.Safety.ToString();
+        }
+    }
+
+    /// <summary>
+    /// The bare executable name (no path, no ".exe", no arguments) from a startup command line, or an
+    /// empty string when none can be read. Handles the three shapes the scanners produce: a quoted path
+    /// with arguments (<c>"C:\Program Files\App\app.exe" --flag</c>), an unquoted path with arguments
+    /// (<c>C:\Windows\system32\app.exe /run</c>), and a bare name already resolved from a shortcut.
+    /// </summary>
+    /// <remarks>
+    /// Pure and static so the parsing — which is the fiddly part — is unit-testable without touching the
+    /// registry. Kept conservative: it returns the token the database is keyed on, and
+    /// <see cref="ProcessDescriptionService.Lookup"/> handles the case-insensitive match and the ".exe"
+    /// strip, so a miss here costs only the enrichment, never a wrong description.
+    /// </remarks>
+    internal static string ExecutableNameFromCommand(string command)
+    {
+        if (string.IsNullOrWhiteSpace(command)) return "";
+
+        var text = command.Trim();
+        string path;
+
+        if (text.StartsWith('"'))
+        {
+            // Quoted executable: everything up to the closing quote is the path, args follow.
+            var end = text.IndexOf('"', 1);
+            path = end > 1 ? text[1..end] : text.Trim('"');
+        }
+        else
+        {
+            // Unquoted: the path is the run up to the first space. A space inside an unquoted path is
+            // ambiguous and rare for autostart entries; taking the first token matches how Windows itself
+            // resolves an unquoted command, and a wrong split just means no database hit.
+            var space = text.IndexOf(' ');
+            path = space > 0 ? text[..space] : text;
+        }
+
+        try
+        {
+            return System.IO.Path.GetFileNameWithoutExtension(path.Trim());
+        }
+        catch (ArgumentException)
+        {
+            // Illegal path characters (e.g. a rundll32 entry point spec) — not something the database
+            // keys on anyway.
+            return "";
+        }
     }
 
     private static void ReadStartupFolder(string folderPath, string locationLabel, bool isCommon, List<StartupEntry> results)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.62.1</Version>
-    <FileVersion>1.62.1.0</FileVersion>
-    <AssemblyVersion>1.62.1.0</AssemblyVersion>
+    <Version>1.63.0</Version>
+    <FileVersion>1.63.0.0</FileVersion>
+    <AssemblyVersion>1.63.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -112,9 +112,27 @@
                                            RenderOptions.BitmapScalingMode="HighQuality"/>
                                     <StackPanel VerticalAlignment="Center">
                                         <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13"/>
-                                        <TextBlock Text="{Binding Command}" FontSize="11"
-                                                   Foreground="{DynamicResource TextMuted}"
-                                                   TextTrimming="CharacterEllipsis" MaxWidth="500"/>
+                                        <!-- Prefer the plain-language description from the built-in
+                                             database; it says what the program IS, which is what the
+                                             persona needs to judge whether to turn it off. Fall back to
+                                             the raw command line only when the program is unrecognised —
+                                             a path still helps a power user place an unknown entry, and
+                                             is better than a blank second line. The full path is on the
+                                             tooltip either way. -->
+                                        <TextBlock FontSize="11" Foreground="{DynamicResource TextMuted}"
+                                                   TextTrimming="CharacterEllipsis" MaxWidth="500"
+                                                   ToolTip="{Binding Command}">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Text" Value="{Binding Description}"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding Description}" Value="">
+                                                            <Setter Property="Text" Value="{Binding Command}"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
                                     </StackPanel>
                                 </StackPanel>
                             </DataTemplate>
@@ -134,6 +152,33 @@
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
+
+                    <!-- Safety/provenance from the built-in database. Chip structure matches the Process
+                         Manager tab's Safety column (ProcessManagerView.xaml) and uses the same
+                         ProcessSafety* converters, so "is this Windows, or something I installed?" is
+                         answered the same way across the Startup/Process/Services trio. The whole chip
+                         collapses when Safety is empty — an entry the database does not recognise gets no
+                         chip rather than a colour it has not earned. -->
+                    <DataGridTemplateColumn Header="Safety" Width="120" MinWidth="100" SortMemberPath="Safety">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Border CornerRadius="8" Padding="6,3"
+                                        Background="{Binding Safety, Converter={StaticResource ProcSafetyBg}}"
+                                        BorderBrush="{Binding Safety, Converter={StaticResource ProcSafetyBg}}"
+                                        BorderThickness="1" HorizontalAlignment="Left"
+                                        ToolTip="{Binding Safety, Converter={StaticResource ProcSafetyTip}}"
+                                        Visibility="{Binding Safety, Converter={StaticResource FlexVis}}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <Ellipse Width="6" Height="6" VerticalAlignment="Center" Margin="0,0,4,0"
+                                                 Fill="{Binding Safety, Converter={StaticResource ProcSafetyBrush}}"/>
+                                        <TextBlock Text="{Binding Safety, Converter={StaticResource ProcSafetyText}}"
+                                                   FontSize="11" FontWeight="SemiBold" VerticalAlignment="Center"
+                                                   Foreground="{Binding Safety, Converter={StaticResource ProcSafetyBrush}}"/>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
 
                     <DataGridTemplateColumn Header="Status" Width="100" MinWidth="90" SortMemberPath="StatusText">
                         <DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
Closes #1637.

## The gap

Startup Manager showed each program by name plus its **raw command line** — a full exe
path with switches — and a Publisher column. So the persona saw a row like
`nvcontainer` with `"C:\Program Files\NVIDIA Corporation\NvContainer\nvcontainer.exe"`
and had to decide, from a path, whether turning it off was safe.

The knowledge to answer that already shipped and was verified present:
`Data/ProcessDescriptions.json` (108 entries of `{name, description, category,
safety}`) and `ProcessDescriptionService.Instance.Lookup` returning a
`ProcessDescriptionEntry`. A solution-wide grep found it consumed in exactly **one**
place — `ProcessManagerViewModel:103`. Startup Manager was never wired to it.

## The change

`StartupEntry` gains `Description` and `Safety`. `StartupService` enriches every entry
from the database in a single pass over the finished list — one place, so the three
sources (registry Run keys, startup folders, scheduled tasks) are all treated
identically — keyed on the executable's base name.

The view now shows:
- **The plain-language description** as the second line under the name (what the
  program *is*), falling back to the raw command path only when the program is
  unrecognised — a path still helps a power user place an unknown entry, and beats a
  blank line. The full path is on the row tooltip either way.
- **A Safety chip** — Windows / Known app / Not recognised — matching the Process
  Manager column exactly, using the same `ProcessSafety*` converters, so the
  Startup / Process / Services trio finally explain themselves consistently.

## Two safety properties

1. **Never guesses.** An entry the database does not recognise comes back with **both
   fields empty**. The chip collapses (`FlexVis` on an empty string) so no colour is
   shown, and the second line falls back to the command path. The tab never asserts
   "safe to disable" on a name it does not know — the exact risk the report flagged. A
   test (`EnrichWithDescriptions_UnknownProgram_LeavesBothEmpty`) pins this.
2. **Loses nothing.** The raw command path, previously the second line, is preserved on
   the tooltip, so its diagnostic value survives.

## On the report's proposal

The issue suggested reusing the **Services** `SafetyLevel` converters. I used the
**ProcessSafety** ones instead, because the database returns `ProcessSafety`
(System/Trusted/Unknown), which is a different scale from the Services
Safe/Caution/Critical enum — and Process Manager already established the correct
converter set for exactly this data. `Safety` is stored as the `ProcessSafety` name
string, matching how `ProcessManagerViewModel` does it.

## Verification

- The fiddly part — parsing an exe name out of a quoted/unquoted command with args — is
  a pure static `ExecutableNameFromCommand`, unit-tested in isolation (6 command shapes
  + blank + illegal-char cases).
- Red/green harness: **7 checks failing before, 0 after.** The green run includes a
  live `ScanAsync` on the CI/dev box that enriched **6 of 82** real startup entries
  end-to-end — OneDrive resolved to "Microsoft OneDrive — cloud file sync and backup" /
  Trusted — proving the model→service→DB path works, not just the isolated method.
- **11 new unit tests** across the parser and the enrichment pass.
- All four projects build **0 warnings, 0 errors**.
- Gate-UX: the chip is an informational Border+TextBlock with a tooltip, no new focus
  target and no `AutomationId` — matching the Process Manager precedent. No interactive
  control added.
- No test asserts the exact `StartupEntry` shape or column count, and the command
  reachability ratchet only inspects `*Command` properties, so the two new
  `[ObservableProperty]` fields do not perturb it.

`feat:` → minor bump, 1.63.0 from tag v1.62.1.
