### PR TITLE
fix: guard the Bandwidth poll against dispose during its off-thread await

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.63.1] - 2026-08-12
+
+A rare crash that could happen if you closed the window at the exact moment the Bandwidth Monitor was
+taking a reading.
+
+### Fixed
+- **Closing the window while the Bandwidth Monitor was mid-measurement could crash the app.** In 1.61.9 the network measurement moved onto a background thread so the window stops stuttering. That introduced a small window: if you closed SysManager (or it minimised to tray during shutdown) in the fraction of a second while a measurement was in flight, the finished measurement tried to update a tab that had already been torn down — including its chart, whose drawing resources were already released — which could throw. The measurement now checks whether the tab is still alive before touching anything, and quietly stops if it is not. Only the Bandwidth Monitor tab was affected, and only at the moment of closing.
+
+---
+
 ## [1.63.0] - 2026-08-12
 
 The Startup Manager now tells you what each program is and whether it is safe to turn off, instead of

--- a/SysManager/SysManager.Tests/BandwidthMonitorViewModelTests.cs
+++ b/SysManager/SysManager.Tests/BandwidthMonitorViewModelTests.cs
@@ -572,4 +572,63 @@ public class BandwidthMonitorViewModelTests : IDisposable
         MainWindowViewModel.ApplyPollGate(ItemFor(new object()), windowVisible: false);
         MainWindowViewModel.ApplyPollGate(ItemFor(new object()), windowVisible: true);
     }
+
+    // ── Dispose during an in-flight poll ────────────────────────────────────
+    // SampleAsync now genuinely yields (its work runs on a worker thread), so the window can close —
+    // disposing the view model, its source, and every SkiaSharp paint — while a sample is still in
+    // flight. The cancellation token only stops a sample from STARTING; one already running completes
+    // and its continuation would resume on the torn-down view model, mutating the LiveCharts buffers
+    // and repainting through disposed native paint handles. PollOnceAsync re-checks disposal after the
+    // await to bail before touching any of that.
+
+    // A source whose SampleAsync blocks until released, so a Dispose() can be interleaved deterministically
+    // between the await starting and its continuation running — no sleeps, no wall-clock.
+    private sealed class GatedSource : IBandwidthMonitorService
+    {
+        private readonly ManualResetEventSlim _release = new(false);
+        private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public Task Entered => _entered.Task;
+        public BandwidthMode Mode => BandwidthMode.Connections;
+        public bool IsAvailable => true;
+        public bool Start() => true;
+
+        public Task<BandwidthSnapshot> SampleAsync(CancellationToken ct = default) => Task.Run(() =>
+        {
+            _entered.TrySetResult();                       // signal we are inside the sample
+            _release.Wait(TimeSpan.FromSeconds(5));        // bounded, so a broken test fails instead of hanging CI
+            return new BandwidthSnapshot(BandwidthMode.Connections, 123, 456,
+                [new ProcessNetworkUsage { ProcessId = 1, ProcessName = "app.exe", DownBytesPerSec = 1 }]);
+        }, ct);
+
+        public void ReleaseSample() => _release.Set();
+        public void Dispose() => _release.Set();   // Dispose must not deadlock a waiting sample
+    }
+
+    [Fact]
+    public async Task DisposeDuringAnInFlightPoll_DoesNotTouchTheTornDownViewModel()
+    {
+        var gated = new GatedSource();
+        var vm = NewVm(connFactory: () => gated);
+
+        // Invoke the poll directly so the in-flight moment is controllable. PollOnceAsync is private —
+        // it is the seam the crash lives on, and there is no public trigger that pauses mid-sample.
+        var poll = typeof(BandwidthMonitorViewModel)
+            .GetMethod("PollOnceAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var pollTask = (Task)poll.Invoke(vm, [CancellationToken.None])!;
+
+        // Wait until the sample is genuinely running, THEN dispose — this is the interleave the fix guards.
+        await gated.Entered;
+        vm.Dispose();
+        gated.ReleaseSample();
+
+        // The continuation must complete without throwing (no repaint through disposed SkiaSharp handles)
+        // and must NOT have applied the snapshot to the disposed view model.
+        var completed = await Task.WhenAny(pollTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(pollTask, completed);
+        await pollTask;   // re-throws anything the continuation threw
+
+        Assert.Equal(0, vm.TotalDownBytesPerSec);   // snapshot's 123 was never applied
+        Assert.Equal(0, vm.TotalUpBytesPerSec);     // snapshot's 456 was never applied
+        Assert.Empty(vm.Processes);                 // MergeInto never ran
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.63.0</Version>
-    <FileVersion>1.63.0.0</FileVersion>
-    <AssemblyVersion>1.63.0.0</AssemblyVersion>
+    <Version>1.63.1</Version>
+    <FileVersion>1.63.1.0</FileVersion>
+    <AssemblyVersion>1.63.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
@@ -253,6 +253,16 @@ public sealed partial class BandwidthMonitorViewModel : ViewModelBase
         if (_source is null) return;
         var snap = await _source.SampleAsync(ct).ConfigureAwait(true);
 
+        // Re-check AFTER the await, not just before it. SampleAsync now genuinely yields (its work runs
+        // on a worker thread), so Dispose() — which cancels _pollCts and disposes _source plus every
+        // SkiaSharp paint — can run while a sample is in flight. The cancellation token only prevents a
+        // sample from STARTING; one already running completes and would resume here, writing bound
+        // state, mutating the LiveCharts buffers and repainting through disposed native paint handles on
+        // a torn-down view model (the window can close mid-poll — ShutdownMode is OnExplicitShutdown, so
+        // the dispatcher keeps pumping this queued continuation). Same guard the init path already uses
+        // after its awaits (see InitAsync). _source is nulled in Dispose, so this covers it directly.
+        if (_source is null || _pollCts is null || ct.IsCancellationRequested) return;
+
         TotalDownBytesPerSec = snap.TotalDownBytesPerSec;
         TotalUpBytesPerSec = snap.TotalUpBytesPerSec;
 


### PR DESCRIPTION
Fixes a use-after-dispose crash introduced by #1800 (shipped v1.61.9). Found by an
adversarial code-review of that PR.

## The crash

`PollOnceAsync` guards `_source is null` at line 253 — but **before** the await on
line 254. #1800 made `SampleAsync` genuinely yield (its work runs on a worker thread
via `Task.Run`), so the continuation at 256-286 now resumes asynchronously, and it
re-checks nothing.

`Dispose()` (589-593) cancels `_pollCts`, disposes `_source`, and disposes every
LiveCharts series + SkiaSharp paint. But `Task.Run(…, ct)`'s token only prevents a
sample from **starting** — one already in flight completes successfully after
`_pollCts.Cancel()`, and its continuation then runs `AppendToLiveChart` / `MergeInto`
and repaints through **disposed native SKPaint handles** on a torn-down view model.
`App.xaml.cs` sets `ShutdownMode.OnExplicitShutdown`, so the dispatcher keeps pumping
the queued continuation after the window closes — which is exactly when a user closes
the app (or it minimises to tray during shutdown) with the Bandwidth tab open.

## The fix

The guard the init path already uses after its own awaits (`InitAsync`:199,
`if (_pollCts is null || ct.IsCancellationRequested) return; // disposed during init`),
applied after `SampleAsync` returns and before the first bound-state write:

```csharp
if (_source is null || _pollCts is null || ct.IsCancellationRequested) return;
```

`_source` is nulled in `Dispose`, so this covers the disposed case directly. One line
plus its comment; no behaviour change on the normal path.

## Regression test

`DisposeDuringAnInFlightPoll_DoesNotTouchTheTornDownViewModel` drives a `GatedSource`
whose `SampleAsync` blocks on a bounded `ManualResetEventSlim` until released, so the
interleave is deterministic — no sleeps, no wall-clock:

1. Invoke the private `PollOnceAsync` (the seam the crash lives on; there is no public
   trigger that pauses mid-sample).
2. `await gated.Entered` — wait until the sample is genuinely running.
3. `vm.Dispose()` while it is blocked, then release the gate.
4. Assert the continuation completes without throwing, and never applied the snapshot
   (totals stay 0, `Processes` stays empty).

The background poll loop cannot interfere: it only samples when `IsActive` is true
(BandwidthMonitorViewModel:242), and the test leaves it false, so only the explicit
reflection call hits the gate.

## Scope

Deliberately a **minimal crash fix** — one guard, one test. The code-review also found
that precise (ETW) mode still samples on the UI thread and its per-tick cost grows
unbounded, contradicting #1800's CHANGELOG. That is a real but separate perf issue,
filed as **#1816** rather than bundled into a crash fix (no refactoring during a fix).

## Verification

- Red/green harness: 3 checks failing before (no post-await guard, no regression test,
  no gated source), 0 after. The harness isolates `PollOnceAsync`'s brace-balanced body
  so a guard elsewhere in the file cannot make it pass falsely.
- All four projects build **0 warnings, 0 errors**.
- No `AutomationId` change; no public surface change.

`fix:` → patch bump, 1.63.1 from tag v1.63.0.
