### PR TITLE
feat: add an in-app way to report a problem (#1643)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.0] - 2026-08-12
+
+There is now a way to report a problem from inside the app, instead of being told to "report it on
+GitHub" with no link to get there.
+
+### Added
+- **"Report a problem" and "Ask a question" in the About tab.** Preview-feature banners asked you to report anything unexpected on GitHub, but nothing in the app took you there — so a problem usually went unreported. The About tab now has a "Report a problem" button that opens the bug-report form on GitHub with your SysManager version and whether you were running as administrator already filled in (the two details reports most often leave out), and an "Ask a question" button that opens Discussions for anything that is not a bug. The Preview banner now points at that button instead of a dead end. A browser tab opens only when you press one of the buttons — nothing is sent automatically.
+
+---
+
 ## [1.63.1] - 2026-08-12
 
 A rare crash that could happen if you closed the window at the exact moment the Bandwidth Monitor was

--- a/README.md
+++ b/README.md
@@ -859,6 +859,10 @@ offers, "rate us" prompts:
   confirmation, and notes that whatever the newer version fixed will come back too.
   One generation is kept, so it never accumulates copies of the app.
 - Full release-note history pulled live from GitHub.
+- **"Report a problem"** opens the GitHub bug-report form with your SysManager
+  version and administrator state already filled in — the two fields reports most
+  often miss — and **"Ask a question"** opens Discussions for anything that is not
+  a bug. Both are in the About tab; a browser tab opens only when you press them.
 
 ### Profile Export / Import
 - Export your SysManager settings — theme/appearance and speed-test history — to

--- a/SysManager/SysManager.Tests/AboutViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AboutViewModelTests.cs
@@ -338,6 +338,49 @@ public class AboutViewModelTests
             "the preference was not written to the override directory — configDir is accepted but unused");
     }
 
+    // ── BuildBugReportUrl (pure — the "Report a problem" pre-fill) ──
+    // The Preview banner asks users to report on GitHub; these pin that the in-app link lands on the
+    // right form with the two required fields pre-filled. Pre-fill is query-param based and GitHub
+    // silently drops an unknown field id, so a template drift degrades to a blank field — hence a test.
+
+    [Fact]
+    public void BuildBugReportUrl_TargetsTheBugTemplateOnTheRealRepo()
+    {
+        var url = AboutViewModel.BuildBugReportUrl("1.63.1", isElevated: false);
+
+        Assert.StartsWith($"https://github.com/{UpdateService.Owner}/{UpdateService.Repo}/issues/new", url);
+        // The field id must match .github/ISSUE_TEMPLATE/bug_report.yml, or GitHub opens a blank chooser.
+        Assert.Contains("template=bug_report.yml", url);
+    }
+
+    [Fact]
+    public void BuildBugReportUrl_PrefillsTheVersionField()
+    {
+        var url = AboutViewModel.BuildBugReportUrl("1.63.1", isElevated: false);
+        Assert.Contains("version=1.63.1", url);
+    }
+
+    [Theory]
+    // The dropdown option strings must match bug_report.yml exactly (spaces + parentheses, URL-encoded).
+    [InlineData(true, "Yes%20%28elevated%29")]
+    [InlineData(false, "No%20%28standard%20user%29")]
+    public void BuildBugReportUrl_PrefillsElevationWithTheExactDropdownOption(bool elevated, string encoded)
+    {
+        var url = AboutViewModel.BuildBugReportUrl("1.63.1", elevated);
+        Assert.Contains($"elevation={encoded}", url);
+    }
+
+    [Fact]
+    public void BuildBugReportUrl_EncodesTheValues_NoRawSpacesOrParens()
+    {
+        // A raw space or bracket in a URL is invalid and some launchers truncate at it, dropping the
+        // pre-fill silently. The query must be fully encoded.
+        var url = AboutViewModel.BuildBugReportUrl("1.63.1", isElevated: true);
+        var query = url[(url.IndexOf('?') + 1)..];
+        Assert.DoesNotContain(' ', query);
+        Assert.DoesNotContain('(', query);
+        Assert.DoesNotContain(')', query);
+    }
 }
 
 /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.63.1</Version>
-    <FileVersion>1.63.1.0</FileVersion>
-    <AssemblyVersion>1.63.1.0</AssemblyVersion>
+    <Version>1.64.0</Version>
+    <FileVersion>1.64.0.0</FileVersion>
+    <AssemblyVersion>1.64.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -370,6 +370,40 @@ public sealed partial class AboutViewModel : ViewModelBase
     private void OpenLicense() => OpenUrl($"https://github.com/{UpdateService.Owner}/{UpdateService.Repo}/blob/main/LICENSE");
 
     /// <summary>
+    /// Opens the repository's bug-report form with the version and elevation fields pre-filled. The
+    /// Preview banner tells users to "report anything unexpected on GitHub" but nothing in the app
+    /// gave them a way there — so a bug simply never got reported. Version and elevation are the two
+    /// fields the template marks required and that users most often leave blank or get wrong, and the
+    /// app already knows both.
+    /// </summary>
+    [RelayCommand]
+    private void ReportProblem() => OpenUrl(BuildBugReportUrl(UpdateService.CurrentVersion.ToString(3), AdminHelper.IsElevated()));
+
+    /// <summary>Opens Discussions for questions, mirroring SUPPORT.md's bug-vs-question split.</summary>
+    [RelayCommand]
+    private void OpenDiscussions() => OpenUrl($"https://github.com/{UpdateService.Owner}/{UpdateService.Repo}/discussions");
+
+    /// <summary>
+    /// The GitHub issue-form URL with the <c>version</c> and <c>elevation</c> fields pre-filled through
+    /// query parameters. Pure and static so the pre-fill — which silently breaks if a template field id
+    /// or a dropdown option string drifts — is unit-testable without opening a browser.
+    /// </summary>
+    /// <remarks>
+    /// The field ids (<c>version</c>, <c>elevation</c>) and the elevation option strings
+    /// ("Yes (elevated)" / "No (standard user)") must match <c>.github/ISSUE_TEMPLATE/bug_report.yml</c>
+    /// exactly; GitHub silently ignores an unknown id, so a drift degrades to an empty field rather than
+    /// an error. Values are URL-encoded because the option strings contain spaces and parentheses.
+    /// </remarks>
+    internal static string BuildBugReportUrl(string version, bool isElevated)
+    {
+        var elevation = isElevated ? "Yes (elevated)" : "No (standard user)";
+        return $"https://github.com/{UpdateService.Owner}/{UpdateService.Repo}/issues/new"
+             + "?template=bug_report.yml"
+             + $"&version={Uri.EscapeDataString(version)}"
+             + $"&elevation={Uri.EscapeDataString(elevation)}";
+    }
+
+    /// <summary>
     /// Copy a bug-report-ready block with SysManager version, Windows version,
     /// architecture, .NET runtime, elevation state, and hardware diagnostics
     /// (CPU, RAM, GPU, storage, display) to the clipboard.

--- a/SysManager/SysManager/Views/AboutView.xaml
+++ b/SysManager/SysManager/Views/AboutView.xaml
@@ -76,6 +76,17 @@
                                     Visibility="{Binding CanRollBack, Converter={StaticResource BoolToVis}}"
                                     AutomationProperties.Name="Go back to the previous version of SysManager"
                                     ToolTip="Reinstall the version you had before the last update. SysManager will close and reopen; your settings are not affected."/>
+                            <!-- The Preview banner asks users to "report anything unexpected on GitHub"
+                                 but nothing in the app took them there. This opens the bug form with the
+                                 version and elevation fields already filled in (see ReportProblem). -->
+                            <Button Content="Report a problem" Command="{Binding ReportProblemCommand}"
+                                    Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"
+                                    AutomationProperties.Name="Report a problem on GitHub"
+                                    ToolTip="Open the bug-report form on GitHub, with your version and elevation state already filled in."/>
+                            <Button Content="Ask a question" Command="{Binding OpenDiscussionsCommand}"
+                                    Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"
+                                    AutomationProperties.Name="Open GitHub Discussions"
+                                    ToolTip="Open GitHub Discussions for questions and ideas — for anything that is not a bug."/>
                             <Button Content="View license" Command="{Binding OpenLicenseCommand}"
                                     Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"/>
                             <!-- OpenChangelogCommand existed alongside OpenRepo and OpenLicense from the

--- a/SysManager/SysManager/Views/DevelopmentBanner.xaml
+++ b/SysManager/SysManager/Views/DevelopmentBanner.xaml
@@ -20,7 +20,11 @@
                 <StackPanel VerticalAlignment="Center">
                     <TextBlock Text="Preview feature" FontSize="13" FontWeight="SemiBold"
                                Foreground="{DynamicResource Info}"/>
-                    <TextBlock Text="This feature is newly added and still being verified. Please report anything unexpected on GitHub."
+                    <!-- Names the About tab rather than a bare "on GitHub": that is where "Report a
+                         problem" now lives (it opens the bug form pre-filled), so the instruction points
+                         at something the user can actually reach. The banner is a plain UserControl with
+                         no DataContext, so it names the route rather than binding the command itself. -->
+                    <TextBlock Text="This feature is newly added and still being verified. If something looks wrong, use “Report a problem” on the About tab."
                                FontSize="11.5" Foreground="{DynamicResource TextSecondary}"
                                Margin="0,2,0,0" TextWrapping="Wrap"/>
                 </StackPanel>


### PR DESCRIPTION
Closes #1643.

## The gap

The shared `DevelopmentBanner` (on 7 preview tabs) says "Please report anything
unexpected on GitHub" — an instruction with no way to follow it. An app-wide grep for
any reporting path (`issues/new`, `/issues`, `discussions`, `report a bug`, `feedback`)
returns nothing; the About tab links to the repo root, changelog, license and releases,
but never to issues or Discussions. So the persona's bug simply never gets reported.

## The change

Two buttons in the About action row:
- **"Report a problem"** opens `bug_report.yml` with the **version** and **elevation**
  fields pre-filled via query parameters — the two fields the template marks `required`
  and that users most often leave blank or get wrong, and the app already computes both.
- **"Ask a question"** opens Discussions, mirroring SUPPORT.md's bug-vs-question split.

The Preview banner now points at that button ("use *Report a problem* on the About
tab") instead of the dead-end "on GitHub". The banner is a plain `UserControl` with no
DataContext, so it names the route rather than binding the command itself.

## The pre-fill, and why it is a pure function

`BuildBugReportUrl(version, isElevated)` is `internal static`. GitHub issue-form pre-fill
is query-parameter based and **silently drops an unknown field id**, so a drift between
the code and `bug_report.yml` degrades to a blank field with no error — exactly the kind
of thing that rots unnoticed. So it is unit-tested:

- field ids (`version`, `elevation`) match the template;
- the elevation values are the template's **exact** dropdown option strings
  (`Yes (elevated)` / `No (standard user)`), URL-encoded to `Yes%20%28elevated%29` /
  `No%20%28standard%20user%29`;
- the whole query is encoded (a raw space or paren truncates the pre-fill in some
  launchers).

I verified the encoding independently (`Uri.EscapeDataString`) before asserting it.

## Verification

- Red/green harness: **6 checks failing before, 0 after.** The green run prints the
  actual URL: `…/issues/new?template=bug_report.yml&version=1.63.1&elevation=Yes%20%28elevated%29`.
- **5 unit tests** on `BuildBugReportUrl` (template target, repo target, version pre-fill,
  both elevation options with exact encoding, full-encoding check).
- All four projects build **0 warnings, 0 errors**.
- Gate-UX: both buttons carry `AutomationProperties.Name` + a `ToolTip`, matching the
  sibling link buttons. A browser tab opens only on a button press — nothing automatic,
  matching the app's existing outbound links.
- The banner reword propagates to all 7 preview tabs (one shared control); no test
  pinned the old wording.

`feat:` → minor bump, 1.64.0 from tag v1.63.1.
