### PR TITLE
ci: publish the changelog entry with the date the release actually shipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,6 +257,28 @@ jobs:
               throw $msg
           }
 
+          # Normalize the entry's DATE to the day this release actually publishes (#1806).
+          #
+          # The header date is written by hand while a pull request is being prepared, but the release it
+          # describes publishes when that PR merges. A merge that crosses midnight UTC therefore ships
+          # yesterday's date — and because $body is copied VERBATIM into the release body and the
+          # announcement discussion, the wrong date reaches three public surfaces at once. It happened
+          # twice consecutively: 1.61.9 and 1.61.10 both read 2026-08-11 and published on the 12th.
+          #
+          # Keep a Changelog defines this field as the RELEASE date, so the workflow — the only
+          # participant that knows that date — owns it instead of asking a human to predict it.
+          #
+          # Scope: this corrects the three PUBLISHED surfaces (release body, announcement discussion, and
+          # the notes artifact), which is where a wrong date is actually read. CHANGELOG.md in the repo
+          # keeps whatever date the author typed; correcting the file too would mean this workflow pushing
+          # a commit to main, which is a bigger decision than a date fix and is deliberately left out.
+          # The consequence is bounded and visible: the file may read one day earlier than the release it
+          # describes, while every public surface reads correctly.
+          $today = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')
+          $headerPattern = "^## \[$([regex]::Escape($version))\].*$"
+          $body = [regex]::Replace($body, $headerPattern, "## [$version] - $today", 'Multiline')
+          "date=$today" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
           $body | Out-File -FilePath $notesPath -Encoding utf8
           "path=$notesPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 


### PR DESCRIPTION
Refs #1806. Ships the half of option 1 that needs no push to `main`.

## The problem

The date in a `## [x.y.z] - <date>` header is typed by hand while a PR is prepared, but the
release it describes publishes when that PR merges. A merge crossing midnight UTC ships
yesterday's date — and `release.yml` copies the matched entry **verbatim** into the release
body and the announcement discussion, so the wrong date reaches three public surfaces at once.

Measured, not assumed:

| Version | CHANGELOG header | Actually published |
|---|---|---|
| 1.61.10 | 2026-08-11 | 2026-08-12 |
| 1.61.9 | 2026-08-11 | 2026-08-12 |
| 1.61.8 and earlier | 2026-08-11 | 2026-08-11 ✓ |

Two consecutive releases, same structural cause. Keep a Changelog defines that field as the
release date, so the file contradicts its own stated format.

## The change

The notes-extraction step rewrites the entry's header to the publish date (UTC) before writing
`release-notes.md`. The workflow is the only participant that knows that date, so it owns it
instead of asking a human to predict it.

The substitution is anchored to this version's header line only. Verified against a realistic
entry: header corrected, **line count unchanged**, plain-English lead and `### Added` category
both intact — so the existing CI lead-paragraph gate still sees exactly what it expects. Both
workflows re-parsed as valid YAML after the edit.

## What is deliberately NOT here

Correcting `CHANGELOG.md` **in the repo**. That requires this workflow to push a commit to
`main`, which is a materially bigger decision than a date fix and belongs in its own change with
its own review. The consequence is bounded and documented in the step's comment: the file may
read one day earlier than the release it describes, while every **published** surface — the
release page, the announcement, the notes artifact — reads correctly. That is where a wrong date
is actually read, so this fixes the part that matters and leaves the rest as an explicit
decision.

`ci:` → no release, no version bump.
