### PR TITLE
fix: guard Resource History reload against teardown mid-reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.1] - 2026-08-12
+
+A rare crash that could happen if you closed the window while the Resource History tab was loading
+its charts.
+
+### Fixed
+- **Closing the window while Resource History was loading could crash the app.** The tab reads your recorded history from disk in the background and then redraws five chart lines. If you closed SysManager during that read — which is easy to hit, because the read starts on its own when you open the tab, when you change the time range, and when you press Refresh — the finished read tried to redraw charts whose drawing resources had already been released during shutdown. There were three separate ways it could fail, including one that turned a clean shutdown into an error. The loading path now checks whether the tab is still there before touching anything and stops quietly if it is not. Same kind of problem as the Bandwidth Monitor crash fixed in 1.63.1: after that fix every other tab was checked for the same pattern, and this was the one that had it. Only the Resource History tab was affected, and only at the moment of closing.
+
+---
+
 ## [1.64.0] - 2026-08-12
 
 There is now a way to report a problem from inside the app, instead of being told to "report it on

--- a/SysManager/SysManager.Tests/ResourceHistoryViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ResourceHistoryViewModelTests.cs
@@ -156,4 +156,62 @@ public class ResourceHistoryViewModelReloadTests : IDisposable
         Assert.Equal(0, vm.SampleCount);
         Assert.Contains("No history yet", vm.StatusMessage);
     }
+
+    // ── Dispose during an in-flight reload ──────────────────────────────────
+    // ReloadAsync awaits twice (the reload gate, then the history load) and then calls ReplaceWith on
+    // five buffers LiveCharts observes — while Dispose releases every chart series, axis paint, the
+    // SkiaSharp typeface AND the gate itself. Closing the window mid-reload therefore had three ways to
+    // fail: a wait on a disposed semaphore, a Release on a disposed semaphore out of a finally block,
+    // and a repaint through disposed native handles. Reachable from all three entry points (the tab's
+    // own init, a range switch, the Refresh button). Same class as the crash fixed in
+    // BandwidthMonitorViewModel (v1.63.1).
+
+    [Fact]
+    public async Task DisposeDuringAnInFlightReload_DoesNotThrow()
+    {
+        var now = DateTime.Now;
+        using var service = SeededService(
+            new ResourceSample(now.AddMinutes(-20), 10, 20, 30, 40, 50),
+            new ResourceSample(now.AddMinutes(-10), 15, 25, 35, 45, 55));
+        var vm = new ResourceHistoryViewModel(service);
+        await vm.InitializationComplete;
+
+        // Start a reload and dispose while it is still in flight. Not awaited first, deliberately: the
+        // point is for teardown to land between the awaits.
+        var reload = vm.ReloadCommand.ExecuteAsync(null);
+        vm.Dispose();
+
+        // Must complete without throwing — an ObjectDisposedException out of the finally, or a repaint
+        // through a disposed paint, is exactly what the guards prevent.
+        await reload;
+    }
+
+    [Fact]
+    public async Task ReloadAfterDispose_IsANoOpRatherThanAThrow()
+    {
+        // The range ComboBox and the Refresh command can both fire during teardown, so a reload STARTED
+        // after Dispose must bail rather than enter the disposed gate.
+        var now = DateTime.Now;
+        using var service = SeededService(new ResourceSample(now.AddMinutes(-5), 10, 20, 30, 40, 50));
+        var vm = new ResourceHistoryViewModel(service);
+        await vm.InitializationComplete;
+
+        vm.Dispose();
+
+        await vm.ReloadCommand.ExecuteAsync(null);   // must not throw
+        Assert.False(vm.IsBusy);                     // and must not leave the progress bar stuck on
+    }
+
+    [Fact]
+    public async Task DoubleDispose_IsHarmless()
+    {
+        // MainWindowViewModel disposes tabs on shutdown, and a tab can also be disposed by its own
+        // teardown path — the second call must not throw on the already-disposed gate or paints.
+        using var service = SeededService();
+        var vm = new ResourceHistoryViewModel(service);
+        await vm.InitializationComplete;
+
+        vm.Dispose();
+        vm.Dispose();
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.64.0</Version>
-    <FileVersion>1.64.0.0</FileVersion>
-    <AssemblyVersion>1.64.0.0</AssemblyVersion>
+    <Version>1.64.1</Version>
+    <FileVersion>1.64.1.0</FileVersion>
+    <AssemblyVersion>1.64.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
@@ -82,6 +82,16 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
     // access", which is how CI caught the identical race on the bandwidth chart.
     private readonly SemaphoreSlim _reloadGate = new(1, 1);
 
+    // Set by Dispose so the async reload can tell that the tab was torn down while it was awaiting.
+    // ReloadAsync awaits twice (the gate, then the history load) and afterwards calls ReplaceWith on
+    // buffers LiveCharts observes — while Dispose releases every chart series, axis paint, SkiaSharp
+    // typeface AND this gate. Without this flag the continuation repaints through disposed native
+    // handles, or the gate wait itself throws ObjectDisposedException. Same guard as
+    // BandwidthMonitorViewModel's post-await check; that view model uses its poll CTS for this, and
+    // this one has no CTS, so the state is explicit. Only ever written on the UI thread (Dispose),
+    // only ever read on the UI thread (after ConfigureAwait(true)), so no interlocking is needed.
+    private bool _disposed;
+
     public ResourceHistoryViewModel(ResourceHistoryService service)
     {
         _service = service;
@@ -119,14 +129,36 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
     [RelayCommand]
     private async Task ReloadAsync()
     {
+        // Nothing to reload into once the tab is gone — and the gate below is disposed by Dispose,
+        // so entering it after teardown throws ObjectDisposedException instead of doing work.
+        if (_disposed) return;
+
         // A gate rather than a lock: this is an async path so it must not block the UI thread, and
         // dropping nothing is important here — unlike a range switch, each caller may be asking for
         // a different range, so every request runs, just strictly one at a time.
-        await _reloadGate.WaitAsync().ConfigureAwait(true);
+        try
+        {
+            await _reloadGate.WaitAsync().ConfigureAwait(true);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Disposed between the check above and the wait: the window closed mid-reload. Nothing to
+            // release, because the wait never succeeded.
+            return;
+        }
+
         IsBusy = true;
         try
         {
             _loaded = await _service.LoadAsync(SelectedRange.Range);
+
+            // Re-check AFTER the load. Dispose releases every chart series, axis paint and SkiaSharp
+            // typeface, so the ReplaceWith calls below would repaint through disposed native handles on
+            // a torn-down view model. Reachable in normal use: this method runs from the tab's own init,
+            // from a range switch on the ComboBox, and from the Refresh button — closing the window
+            // during any of them lands here. Same post-await guard as BandwidthMonitorViewModel's.
+            if (_disposed) return;
+
             var points = ResourceHistoryService.Downsample(_loaded, MaxChartPoints);
 
             _cpuBuffer.ReplaceWith(points.Select(p => new DateTimePoint(p.Timestamp, p.CpuPercent)));
@@ -148,7 +180,14 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
         finally
         {
             IsBusy = false;
-            _reloadGate.Release();
+            // Release only if the gate is still alive: Dispose can land while the load is in flight, and
+            // releasing a disposed SemaphoreSlim throws — out of a finally block, which would replace a
+            // clean teardown with an unhandled exception.
+            if (!_disposed)
+            {
+                try { _reloadGate.Release(); }
+                catch (ObjectDisposedException) { /* disposed mid-reload; nothing left to release */ }
+            }
         }
     }
 
@@ -257,6 +296,10 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
     {
         if (disposing)
         {
+            // FIRST, before anything is released: an in-flight ReloadAsync re-reads this after each of
+            // its awaits and bails, so it cannot touch a series or paint that the lines below dispose.
+            _disposed = true;
+
             ThemeService.Instance.ThemeChanged -= ApplyChartTheme;
             foreach (var s in UsageSeries) DisposeSeries(s);
             foreach (var s in TemperatureSeries) DisposeSeries(s);


### PR DESCRIPTION
## Problem

`ResourceHistoryViewModel.ReloadAsync` awaits twice — the reload gate, then `_service.LoadAsync(...)` — and afterwards calls `ReplaceWith` on the five `BulkObservableCollection<DateTimePoint>` buffers LiveCharts observes.

`Dispose(bool)` releases every chart series stroke/fill, all four axis paint sets, `LegendTextPaint.SKTypeface`, the four Skia paints **and `_reloadGate` itself**. Closing the window mid-reload therefore had three distinct failure paths:

1. `WaitAsync()` on an already-disposed `SemaphoreSlim` throws `ObjectDisposedException`.
2. `Release()` in the `finally` throws on a disposed gate — **out of a finally block**, which turns a clean teardown into an unhandled exception.
3. The five `ReplaceWith` calls repaint through disposed native SkiaSharp handles.

Reachable from all three entry points, not a synthetic path: the tab's own `InitializeAsync(() => ReloadAsync())`, the fire-and-forget in `OnSelectedRangeChanged` (the range ComboBox), and the Refresh button bound to `ReloadCommand`.

## Fix

An explicit `_disposed` flag, set **first** in `Dispose(bool)` before anything is released, re-read after each await:

- before entering the gate (plus a `catch (ObjectDisposedException)` for the disposal that lands between the check and the wait);
- after the load await, before the first `ReplaceWith`;
- in the `finally`, so `Release()` is only called on a live gate.

`BandwidthMonitorViewModel` (fixed in v1.63.1) uses its poll CTS as the liveness signal; this view model has no CTS, so the state is explicit. Written only on the UI thread (`Dispose`), read only after `ConfigureAwait(true)` — no interlocking needed.

## How it was found

Not from a report — after v1.63.1 I checked every other view model for the same post-await-mutation-after-dispose shape. `AudioMixerViewModel.ReconcileAsync` has the shape but disposes no native resource, so it is benign; this one was the real second instance, and worse than Bandwidth's because `Dispose` also disposes the semaphore the method is holding.

## Regression proof (red → green)

`dotnet test` is not run on this workstation, so the guard shape was proven with a source-level harness driven against two worktrees:

```
===== RED =====
  [PASS] found ReloadAsync
  [PASS] the two awaits and the first chart write are all present
  [FAIL] a disposal check guards the gate wait
  [FAIL] a disposal check sits between the load await and the first chart write
  [FAIL] the finally guards the gate release
  [PASS] found Dispose
  [FAIL] Dispose sets _disposed before releasing anything — _disposed is never set
  [FAIL] regression test DisposeDuringAnInFlightReload exists
  [FAIL] regression test ReloadAfterDispose exists
  [FAIL] regression test DoubleDispose exists
=== 7 FAILED ===

===== GREEN =====
=== ALL PASS ===
```

Three xUnit tests pin the behaviour in `ResourceHistoryViewModelReloadTests`:

- `DisposeDuringAnInFlightReload_DoesNotThrow` — starts a reload, disposes mid-flight, awaits it.
- `ReloadAfterDispose_IsANoOpRatherThanAThrow` — also asserts `IsBusy` is not left stuck on.
- `DoubleDispose_IsHarmless` — `MainWindowViewModel` disposes tabs on shutdown and a tab can dispose itself.

## Verification

- All four projects build Release: **0 warnings, 0 errors**.
- Leak scan over the full diff against `leak-terms.txt`: 0 hits.
- Author headers present; git identity `laurentiu021`.
- Version 1.64.1 across `Version`/`FileVersion`/`AssemblyVersion`; CHANGELOG entry with the plain-English lead in this same PR.