### PR TITLE
fix: refuse an update target that is not this application's own executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.2] - 2026-08-12
+
+Two ways the built-in updater could be tricked into damaging your PC are now closed off. Nothing about
+normal updating changes.
+
+### Security
+- **SysManager could be told to overwrite the wrong file.** When SysManager installs an update, it starts the newly downloaded copy with a hidden instruction naming the file to replace. That instruction was only checked for the right shape, not for what it actually pointed at — so anyone who could start SysManager with a crafted command line (a shortcut, a scheduled task, a script someone talked you into running) could name any file on your PC and have SysManager write over it. If you were running SysManager as administrator at the time, that meant almost any file, including ones Windows needs. SysManager now refuses unless the file it is told to replace really is an existing copy of SysManager itself, outside protected system folders, and writes a note in its log saying why it refused. Normal updates are unaffected; they always pointed at the right file.
+- **"Go back to the previous version" now checks the saved copy before starting it.** SysManager keeps one copy of your previous version so you can go back after a bad update, and that copy sits in your own user folder where other programs can also write. Starting it was previously based only on the file being there — so anything running on your PC could have swapped that copy for something else and had SysManager launch it, with administrator rights if SysManager was elevated. SysManager now records a checksum when it saves the copy and verifies it right before starting it, keeping the file locked in between so it cannot be swapped in the meantime. If the copy has changed, or was saved by a version before this one and has no checksum, the button is not offered and you are told why instead of it happening silently. Installing an update already worked this way; going back now does too.
+
+---
+
 ## [1.64.1] - 2026-08-12
 
 A rare crash that could happen if you closed the window while the Resource History tab was loading

--- a/SysManager/SysManager.Tests/AboutViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AboutViewModelTests.cs
@@ -523,6 +523,19 @@ public sealed class AboutViewModelRollbackTests : IDisposable
 
     private string PreviousBuild => Path.Combine(_dir, UpdateApplier.PreviousBuildFileName);
 
+    /// <summary>
+    /// Writes a retained build the way the applier does — the binary AND its checksum. A rollback is
+    /// only offered when both exist, because SysManager will not start a saved build it cannot verify,
+    /// so writing the binary alone sets up the legacy/tampered state rather than the healthy one.
+    /// </summary>
+    private void RetainBuild(string content = "OLD-BUILD")
+    {
+        File.WriteAllText(PreviousBuild, content);
+        File.WriteAllText(
+            UpdateApplier.PreviousBuildHashPath(_dir),
+            UpdateApplier.ComputeFileHash(PreviousBuild));
+    }
+
     [Fact]
     public void CanRollBack_IsFalse_WhenNoPreviousBuildWasRetained()
     {
@@ -538,11 +551,25 @@ public sealed class AboutViewModelRollbackTests : IDisposable
     [Fact]
     public void CanRollBack_IsTrue_WhenAPreviousBuildExists()
     {
-        File.WriteAllText(PreviousBuild, "OLD-BUILD");
+        RetainBuild();
 
         using var vm = NewVm();
 
         Assert.True(vm.CanRollBack);
+    }
+
+    [Fact]
+    public void CanRollBack_IsFalse_WhenTheRetainedBuildHasNoChecksum()
+    {
+        // A build retained by a version that predates the checksum, or one an attacker dropped in.
+        // SysManager will not start a saved build it cannot verify, so the offer must not appear at all
+        // — being offered a button that then refuses is worse than not seeing it.
+        File.WriteAllText(PreviousBuild, "OLD-BUILD");   // binary only, deliberately no checksum
+        Assert.False(File.Exists(UpdateApplier.PreviousBuildHashPath(_dir)));
+
+        using var vm = NewVm();
+
+        Assert.False(vm.CanRollBack);
     }
 
     [Fact]
@@ -558,7 +585,7 @@ public sealed class AboutViewModelRollbackTests : IDisposable
         // The file can disappear between the button appearing and being pressed (manual cleanup, disk
         // tools, another instance). That must produce an explanation and a corrected UI rather than a
         // silent no-op or a crash.
-        File.WriteAllText(PreviousBuild, "OLD-BUILD");
+        RetainBuild();
         using var vm = NewVm();
         Assert.True(vm.CanRollBack);
 
@@ -567,6 +594,23 @@ public sealed class AboutViewModelRollbackTests : IDisposable
 
         Assert.False(vm.CanRollBack);
         Assert.Contains("no longer available", vm.RollBackStatus);
+    }
+
+    [Fact]
+    public async Task RollBack_WhenTheRetainedBuildWasSwapped_RefusesAndExplains()
+    {
+        // The binary is still there and its checksum is still there, but the bytes no longer match —
+        // exactly what a same-user attacker replacing the saved copy looks like. Starting it would run
+        // their payload with SysManager's token, so this must refuse and say so rather than launch.
+        RetainBuild();
+        using var vm = NewVm();
+        Assert.True(vm.CanRollBack);
+
+        File.WriteAllText(PreviousBuild, "ATTACKER-PAYLOAD");
+        await vm.RollBackCommand.ExecuteAsync(null);
+
+        Assert.Contains("Cannot go back safely", vm.RollBackStatus);
+        Assert.Contains("changed", vm.RollBackStatus);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/UpdateApplierTests.cs
+++ b/SysManager/SysManager.Tests/UpdateApplierTests.cs
@@ -353,4 +353,256 @@ public class UpdateApplierTests
         }
         finally { dir.Delete(recursive: true); }
     }
+
+    // ── The --apply-update target is attacker-supplied ──────────────────────────────────────────────
+    // App.OnStartup takes the applier branch before the mutex, DI and the CLI guard, so targetExe comes
+    // straight from argv. TryParseArgs only ever checked SHAPE (sentinel, non-blank, numeric pid), which
+    // made `SysManager.exe --apply-update "<any writable path>" <pid>` copy this executable over that
+    // path and launch it — with whatever token started the process, and the app's documented workflow is
+    // "Run as administrator". These tests assert the hostile input is REFUSED, per the rule that a
+    // validation which is the sole defense must be explicitly tested.
+
+    /// <summary>
+    /// The name the applier will accept, derived the same way production does. In the test host this is
+    /// the runner's own executable, which is the point: the rule is "my own name", not a literal.
+    /// </summary>
+    private static string OwnExeName() => Path.GetFileName(Environment.ProcessPath)!;
+
+    [Fact]
+    public void ApplyTarget_AcceptsAnExistingCopyOfThisExecutable()
+    {
+        // The legitimate case, so the negative tests below cannot pass by refusing everything.
+        var dir = Directory.CreateTempSubdirectory("ApplierTarget_");
+        try
+        {
+            var target = Path.Combine(dir.FullName, OwnExeName());
+            File.WriteAllText(target, "the installed build");
+
+            Assert.True(UpdateApplier.IsValidApplyTarget(target, out var reason), reason);
+            Assert.Equal("", reason);
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Theory]
+    [InlineData("hosts")]                 // the file an attacker would aim at first
+    [InlineData("evil.exe")]
+    [InlineData("SysManager.dll")]        // right stem, wrong extension
+    [InlineData("notepad.exe")]
+    public void ApplyTarget_RefusesAFileThatIsNotThisExecutable(string fileName)
+    {
+        var dir = Directory.CreateTempSubdirectory("ApplierTarget_");
+        try
+        {
+            // Existing and writable — the ONLY thing wrong with it is that it is not our own binary.
+            var target = Path.Combine(dir.FullName, fileName);
+            File.WriteAllText(target, "someone else's file");
+
+            Assert.False(UpdateApplier.IsValidApplyTarget(target, out var reason));
+            Assert.Contains("not named", reason);
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public void ApplyTarget_RefusesAPathThatDoesNotExistYet()
+    {
+        // An update REPLACES an install; it never creates one. Without this the applier could be used to
+        // plant a new 85 MB executable at a path of the attacker's choosing — a startup folder, a
+        // scheduled-task target — even with the name check in place.
+        var dir = Directory.CreateTempSubdirectory("ApplierTarget_");
+        try
+        {
+            var target = Path.Combine(dir.FullName, OwnExeName());   // correct name, never created
+
+            Assert.False(UpdateApplier.IsValidApplyTarget(target, out var reason));
+            Assert.Contains("does not exist", reason);
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public void ApplyTarget_RefusesAPathInsideTheWindowsDirectory()
+    {
+        // Belt-and-braces for a file legitimately named like ours inside a system root: an elevated
+        // SysManager must not be steerable into writing there, whatever the file is called.
+        var windows = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+        var target = Path.Combine(windows, "System32", OwnExeName());
+
+        Assert.False(UpdateApplier.IsValidApplyTarget(target, out var reason));
+        // Specifically for BEING in a system root — the location check runs before the existence check,
+        // so this cannot pass merely because no file happens to sit at that path.
+        Assert.Contains("system directory", reason);
+    }
+
+    [Fact]
+    public void ApplyTarget_RefusesARealExistingSystemBinary()
+    {
+        // A file that genuinely exists, so this cannot pass via the existence check — the only thing
+        // that can refuse it is the name rule. Together with the test above (a system-root path bearing
+        // OUR name, refused for its location) this pins both branches as reachable rather than dead.
+        var existing = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.System), "notepad.exe");
+        Assert.True(File.Exists(existing), "probe file missing — this test needs a real System32 file");
+
+        Assert.False(UpdateApplier.IsValidApplyTarget(existing, out var reason));
+        Assert.Contains("not named", reason);
+    }
+
+    [Fact]
+    public void ApplyTarget_ResolvesDotSegmentsBeforeDeciding()
+    {
+        // Validate and act on the SAME string. A target of "<temp>\sub\..\hosts" has the file name
+        // "hosts" only after canonicalisation; comparing the raw string would see "..".
+        var dir = Directory.CreateTempSubdirectory("ApplierTarget_");
+        try
+        {
+            var sub = Directory.CreateDirectory(Path.Combine(dir.FullName, "sub"));
+            var real = Path.Combine(dir.FullName, "hosts");
+            File.WriteAllText(real, "someone else's file");
+
+            var traversal = Path.Combine(sub.FullName, "..", "hosts");
+
+            Assert.False(UpdateApplier.IsValidApplyTarget(traversal, out var reason));
+            Assert.Contains("not named", reason);
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public void Run_WithAHostileTarget_LeavesThatFileUntouched()
+    {
+        // The end-to-end proof: Run is what writes, so Run is what must refuse. Drives the real entry
+        // point the startup branch calls, and asserts the would-be victim file is byte-identical after.
+        var dir = Directory.CreateTempSubdirectory("ApplierRun_");
+        try
+        {
+            var victim = Path.Combine(dir.FullName, "hosts");
+            File.WriteAllText(victim, "127.0.0.1 localhost");
+            var before = Sha256(victim);
+
+            // A pid that cannot exist, so Run does not wait: this is exactly what an attacker supplies.
+            UpdateApplier.Run(victim, 999999);
+
+            Assert.True(File.Exists(victim));
+            Assert.Equal(before, Sha256(victim));
+            Assert.False(File.Exists(victim + ".new"));   // not even a staging file was written
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    // ── The retained rollback build lives in a user-writable folder ─────────────────────────────────
+    // RollBackAsync launched %LOCALAPPDATA%\SysManager\updates\SysManager-previous.exe on File.Exists
+    // alone, with UseShellExecute — so anything running as the user could replace it and have it start
+    // with SysManager's token. The install path hardens this exact shape (hash from a held handle, then
+    // launch without reopening); these tests pin that rollback now does the same.
+
+    [Fact]
+    public void PreserveCurrentBuild_RecordsTheChecksumOfWhatItWrote()
+    {
+        var dir = Directory.CreateTempSubdirectory("ApplierPreserve_");
+        try
+        {
+            var updates = Updates(dir);
+            var current = Path.Combine(dir.FullName, "SysManager.exe");
+            File.WriteAllText(current, "the outgoing build");
+
+            UpdateApplier.PreserveCurrentBuild(current, updates);
+
+            var previous = UpdateApplier.PreviousBuildPath(updates);
+            var hashFile = UpdateApplier.PreviousBuildHashPath(updates);
+            Assert.True(File.Exists(previous));
+            Assert.True(File.Exists(hashFile), "a retained build without its checksum can never be verified");
+            // The recorded hash must describe the RETAINED bytes, not the source's.
+            Assert.Equal(Sha256(previous), File.ReadAllText(hashFile).Trim());
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public void VerifiedPreviousBuild_AcceptsAnUntouchedRetainedBuild()
+    {
+        var dir = Directory.CreateTempSubdirectory("ApplierVerify_");
+        try
+        {
+            var updates = Updates(dir);
+            var current = Path.Combine(dir.FullName, "SysManager.exe");
+            File.WriteAllText(current, "the outgoing build");
+            UpdateApplier.PreserveCurrentBuild(current, updates);
+
+            Assert.True(
+                UpdateApplier.TryOpenVerifiedPreviousBuild(updates, out var stream, out var reason),
+                reason);
+            using (stream)
+            {
+                Assert.NotNull(stream);
+                // The handle is returned so the caller launches the very bytes that were verified,
+                // instead of reopening the path and reintroducing the swap window.
+                Assert.Throws<IOException>(() => new FileStream(
+                    UpdateApplier.PreviousBuildPath(updates),
+                    FileMode.Open, FileAccess.Write, FileShare.None));
+            }
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public void VerifiedPreviousBuild_RefusesABuildSwappedAfterItWasSaved()
+    {
+        // THE attack: the retained copy is replaced between the update and the click on "Go back".
+        var dir = Directory.CreateTempSubdirectory("ApplierVerify_");
+        try
+        {
+            var updates = Updates(dir);
+            var current = Path.Combine(dir.FullName, "SysManager.exe");
+            File.WriteAllText(current, "the outgoing build");
+            UpdateApplier.PreserveCurrentBuild(current, updates);
+
+            File.WriteAllText(UpdateApplier.PreviousBuildPath(updates), "attacker payload");
+
+            Assert.False(UpdateApplier.TryOpenVerifiedPreviousBuild(updates, out var stream, out var reason));
+            Assert.Null(stream);   // nothing left open on a refusal
+            Assert.Contains("changed", reason);
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Theory]
+    [InlineData(null)]                                   // no checksum recorded at all
+    [InlineData("")]                                     // present but empty
+    [InlineData("not-a-hash")]                           // present but unusable
+    [InlineData("DEADBEEF")]                             // right alphabet, wrong length
+    public void VerifiedPreviousBuild_FailsClosedWithoutAUsableChecksum(string? hashContent)
+    {
+        // "Cannot prove this" is a refusal, not a skip — the same call UpdateService makes for a missing
+        // published .sha256. A permissive branch here would undo the whole check.
+        var dir = Directory.CreateTempSubdirectory("ApplierVerify_");
+        try
+        {
+            var updates = Directory.CreateDirectory(Updates(dir)).FullName;
+            File.WriteAllText(UpdateApplier.PreviousBuildPath(updates), "some build");
+            if (hashContent is not null)
+                File.WriteAllText(UpdateApplier.PreviousBuildHashPath(updates), hashContent);
+
+            Assert.False(UpdateApplier.TryOpenVerifiedPreviousBuild(updates, out var stream, out var reason));
+            Assert.Null(stream);
+            Assert.NotEqual("", reason);   // and it says why, so the UI never refuses silently
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public void VerifiedPreviousBuild_RefusesWhenThereIsNoRetainedBuild()
+    {
+        var dir = Directory.CreateTempSubdirectory("ApplierVerify_");
+        try
+        {
+            var updates = Directory.CreateDirectory(Updates(dir)).FullName;
+
+            Assert.False(UpdateApplier.TryOpenVerifiedPreviousBuild(updates, out var stream, out var reason));
+            Assert.Null(stream);
+            Assert.NotEqual("", reason);
+        }
+        finally { dir.Delete(recursive: true); }
+    }
 }

--- a/SysManager/SysManager/Services/UpdateApplier.cs
+++ b/SysManager/SysManager/Services/UpdateApplier.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
 using Serilog;
 
 [assembly: InternalsVisibleTo("SysManager.Tests")]
@@ -35,6 +36,13 @@ internal static class UpdateApplier
     internal const string PreviousBuildFileName = "SysManager-previous.exe";
 
     /// <summary>
+    /// The one file name the applier is allowed to write. Derived from the running assembly rather
+    /// than hardcoded, so a rename of the produced executable cannot silently disable the check.
+    /// </summary>
+    private static string OwnExecutableName =>
+        Path.GetFileName(Environment.ProcessPath) is { Length: > 0 } name ? name : "SysManager.exe";
+
+    /// <summary>
     /// Where the outgoing executable is kept so a bad update can be undone.
     /// </summary>
     /// <remarks>
@@ -47,6 +55,25 @@ internal static class UpdateApplier
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "SysManager", "updates"),
         PreviousBuildFileName);
+
+    /// <summary>
+    /// Where the SHA-256 of the retained previous build is recorded, so rollback can prove the binary
+    /// it is about to launch is the one this app wrote.
+    /// </summary>
+    /// <remarks>
+    /// SEC: the retained build lives in a user-writable directory and persists indefinitely between
+    /// being written and the user clicking "Go back". Provenance is not integrity — any process running
+    /// as the user can replace it, and rollback launches it with <c>UseShellExecute</c>, inheriting
+    /// SysManager's token. The install path solves this with a hash check against the published
+    /// <c>.sha256</c>; rollback has no published hash to compare with, so the applier records one at
+    /// the moment it makes the copy.
+    /// <para>The sidecar is no more tamper-proof than the binary — an attacker who can write one can
+    /// write both. It is not meant to stop a determined local attacker; it removes the SILENT case,
+    /// where a binary swapped by anything else (a half-finished copy, an unrelated tool, malware that
+    /// does not know SysManager) is executed with no check at all.</para>
+    /// </remarks>
+    internal static string PreviousBuildHashPath(string? updatesDir = null) =>
+        PreviousBuildPath(updatesDir) + ".sha256";
 
     /// <summary>
     /// Builds the command-line arguments handed to the downloaded executable so
@@ -78,6 +105,112 @@ internal static class UpdateApplier
         if (!int.TryParse(args[2], out pid) || pid <= 0) return false;
         targetExe = args[1];
         return true;
+    }
+
+    /// <summary>
+    /// Decides whether <paramref name="targetExe"/> is a path the applier may overwrite.
+    /// </summary>
+    /// <remarks>
+    /// SEC: this is the ONLY thing standing between <c>--apply-update</c> and an arbitrary-file
+    /// overwrite. The applier branch in <c>App.OnStartup</c> runs before the single-instance mutex, DI
+    /// and the CLI guard, so its target path arrives straight from <c>argv</c> — from whoever started
+    /// the process, not necessarily from <see cref="BuildArguments"/>. The quote check in
+    /// BuildArguments constrains only the string this app EMITS; an attacker types the command line
+    /// directly, so the inbound side has to re-establish trust on its own.
+    /// <para>Without this, <c>SysManager.exe --apply-update "&lt;any writable path&gt;" &lt;pid&gt;</c> copies this
+    /// 85 MB executable over that path and then launches it — and because the app's documented
+    /// workflow is "Run as administrator", the writable set can be every file on the machine.</para>
+    /// <para>The rule is deliberately narrow: an update replaces SysManager with SysManager, so the
+    /// target must be an EXISTING file (never a creation) whose name is this executable's own name.
+    /// Requiring existence matters as much as the name: a first install has nothing to update, and it
+    /// stops the applier being used to plant a new file where none was. Rejecting a target under a
+    /// system root is belt-and-braces for the case where someone has legitimately named a file
+    /// SysManager.exe inside Windows.</para>
+    /// <para>Returns a reason rather than a bare bool so the refusal can be logged specifically —
+    /// a silent no-op here would look identical to a successful update.</para>
+    /// </remarks>
+    internal static bool IsValidApplyTarget(string targetExe, out string reason)
+    {
+        reason = "";
+
+        if (string.IsNullOrWhiteSpace(targetExe))
+        {
+            reason = "the target path is empty";
+            return false;
+        }
+
+        string full;
+        try
+        {
+            // Canonicalise first: validate and act on the SAME string, so ".." segments or a relative
+            // path resolved against the current directory cannot mean one thing here and another at
+            // File.Move. Mirrors how UninstallerService validates fullPath then launches fullPath.
+            full = Path.GetFullPath(targetExe);
+        }
+        catch (ArgumentException)
+        {
+            reason = "the target path is not a valid path";
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            reason = "the target path is not a valid path";
+            return false;
+        }
+        catch (PathTooLongException)
+        {
+            reason = "the target path is too long";
+            return false;
+        }
+
+        if (!Path.GetFileName(full).Equals(OwnExecutableName, StringComparison.OrdinalIgnoreCase))
+        {
+            reason = $"the target is not named {OwnExecutableName}";
+            return false;
+        }
+
+        // Location before existence: whether a path is protected is a property of the path, not of
+        // whether a file happens to be sitting there. Checking it first also keeps this branch
+        // deterministically reachable instead of being shadowed by the existence check below.
+        if (IsUnderSystemRoot(full))
+        {
+            reason = "the target is inside a protected system directory";
+            return false;
+        }
+
+        if (!File.Exists(full))
+        {
+            // An update REPLACES an install; it never creates one. This is what stops the applier
+            // being aimed at a path that does not exist yet.
+            reason = "the target does not exist, and an update only ever replaces an existing build";
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// True when <paramref name="fullPath"/> sits under the Windows or Program Files roots. Compared
+    /// on a directory boundary so a sibling like <c>C:\WindowsApps</c> is not mistaken for
+    /// <c>C:\Windows</c> — the same boundary rule FileShredderService and UninstallerService use.
+    /// </summary>
+    private static bool IsUnderSystemRoot(string fullPath)
+    {
+        foreach (var folder in (Environment.SpecialFolder[])
+                 [
+                     Environment.SpecialFolder.Windows,
+                     Environment.SpecialFolder.System,
+                     Environment.SpecialFolder.ProgramFiles,
+                     Environment.SpecialFolder.ProgramFilesX86,
+                 ])
+        {
+            var root = Environment.GetFolderPath(folder);
+            if (string.IsNullOrEmpty(root)) continue;
+
+            var prefix = root.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            if (fullPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+        return false;
     }
 
     /// <summary>
@@ -162,6 +295,13 @@ internal static class UpdateApplier
             if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
 
             File.Copy(targetExe, previous, overwrite: true);
+
+            // Record the hash of what we just wrote, so RollBackAsync can prove the binary it launches
+            // is still that copy. Hashed from the RETAINED file rather than the source, so the recorded
+            // value describes the bytes that actually landed on disk. Written after the copy: a hash
+            // present without its binary is harmless (rollback checks the binary exists first), whereas
+            // a binary present without its hash is what we must never leave behind.
+            File.WriteAllText(previous + ".sha256", ComputeFileHash(previous));
             Log.Information("Update apply: retained the outgoing build for rollback");
         }
         catch (IOException ex)
@@ -174,6 +314,88 @@ internal static class UpdateApplier
         }
     }
 
+    /// <summary>SHA-256 of a file as an uppercase hex string, matching the published .sha256 format.</summary>
+    internal static string ComputeFileHash(string path)
+    {
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        return Convert.ToHexString(SHA256.HashData(stream));
+    }
+
+    /// <summary>
+    /// Verifies the retained previous build against the hash recorded when it was written, returning
+    /// the open read handle on success so the caller can launch the very bytes that were verified.
+    /// </summary>
+    /// <remarks>
+    /// SEC: returns the HANDLE, not a bool. Verifying by path and then launching by path is two
+    /// independent opens of a mutable file in a user-writable directory — the exact TOCTOU the install
+    /// path closes by holding a <c>FileShare.Read</c> handle across <c>Process.Start</c>
+    /// (see the comment in <c>AboutViewModel.InstallUpdateAsync</c>). Handing the handle back makes the
+    /// caller inherit that property instead of re-opening.
+    /// <para>Fails CLOSED: a missing or unreadable hash sidecar means "cannot prove this", which is a
+    /// refusal, not a skip — the same decision <c>UpdateService</c> makes for a missing published
+    /// <c>.sha256</c>.</para>
+    /// </remarks>
+    internal static bool TryOpenVerifiedPreviousBuild(
+        string? updatesDir, out FileStream? verifiedStream, out string reason)
+    {
+        verifiedStream = null;
+        reason = "";
+
+        var previous = PreviousBuildPath(updatesDir);
+        var hashFile = PreviousBuildHashPath(updatesDir);
+
+        FileStream? stream = null;
+        try
+        {
+            // Open with deny-write BEFORE hashing, and keep it open on the way out: from this point the
+            // bytes cannot change under us.
+            stream = new FileStream(previous, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+            if (!File.Exists(hashFile))
+            {
+                reason = "there is no recorded checksum for the saved version";
+                stream.Dispose();
+                return false;
+            }
+
+            var expected = File.ReadAllText(hashFile).Trim();
+            if (expected.Length != 64)
+            {
+                reason = "the recorded checksum for the saved version is not readable";
+                stream.Dispose();
+                return false;
+            }
+
+            var actual = Convert.ToHexString(SHA256.HashData(stream));
+            if (!actual.Equals(expected, StringComparison.OrdinalIgnoreCase))
+            {
+                Log.Warning(
+                    "Rollback: retained build hash mismatch — expected {Expected}, got {Actual}",
+                    expected, actual);
+                reason = "the saved version has changed since it was saved";
+                stream.Dispose();
+                return false;
+            }
+
+            verifiedStream = stream;
+            return true;
+        }
+        catch (IOException ex)
+        {
+            Log.Warning(ex, "Rollback: could not read the retained build to verify it");
+            reason = "the saved version could not be read";
+            stream?.Dispose();
+            return false;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Log.Warning(ex, "Rollback: access denied reading the retained build to verify it");
+            reason = "the saved version could not be read";
+            stream?.Dispose();
+            return false;
+        }
+    }
+
     /// <summary>
     /// Runs the full applier sequence on the current (downloaded) process: wait
     /// for the old process to exit, swap this executable over the old one, then
@@ -182,6 +404,17 @@ internal static class UpdateApplier
     /// </summary>
     public static void Run(string targetExe, int oldPid)
     {
+        // SEC: the gate sits here rather than in TryParseArgs so it cannot be bypassed by a future
+        // second caller — Run is the only thing that writes, so Run is what must refuse.
+        if (!IsValidApplyTarget(targetExe, out var reason))
+        {
+            Log.Error(
+                "Update apply: refusing to write {Target} — {Reason}. An update may only replace this " +
+                "application's own executable.",
+                LogService.SanitizePath(targetExe), reason);
+            return;
+        }
+
         var sourceExe = Environment.ProcessPath;
         if (string.IsNullOrWhiteSpace(sourceExe))
         {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.64.1</Version>
-    <FileVersion>1.64.1.0</FileVersion>
-    <AssemblyVersion>1.64.1.0</AssemblyVersion>
+    <Version>1.64.2</Version>
+    <FileVersion>1.64.2.0</FileVersion>
+    <AssemblyVersion>1.64.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -809,19 +809,15 @@ public sealed partial class AboutViewModel : ViewModelBase
             return;
         }
 
-        if (!DialogService.Instance.Confirm(
-                $"Go back to the version you had before the last update?\n\n" +
-                "SysManager will close and reopen on the older version. Anything the newer version " +
-                "fixed will come back, and your settings are not affected.",
-                "Go back to the previous version"))
-        {
-            return;
-        }
-
         // SEC: verify the retained build against the checksum recorded when it was written, and hold the
-        // verified handle across Process.Start. The retained copy sits in a user-writable folder and can
-        // have been replaced at any point since the update was applied; rollback previously ran on
-        // File.Exists alone, while the install path directly above closes this same window this same way.
+        // verified handle from here until after the launch. The retained copy sits in a user-writable
+        // folder and can have been replaced at any point since the update was applied; rollback
+        // previously ran on File.Exists alone, while the install path directly above closes this same
+        // window this same way.
+        //
+        // Before the confirmation, deliberately: never ask the user to approve something that is then
+        // refused. It also means the deny-write handle is already held while the dialog is open, so the
+        // file cannot be swapped during the seconds the prompt sits on screen.
         if (!UpdateApplier.TryOpenVerifiedPreviousBuild(_updatesDir, out var verifiedStream, out var why))
         {
             RollBackStatus = $"Cannot go back safely — {why}.";
@@ -831,6 +827,15 @@ public sealed partial class AboutViewModel : ViewModelBase
 
         try
         {
+            if (!DialogService.Instance.Confirm(
+                    $"Go back to the version you had before the last update?\n\n" +
+                    "SysManager will close and reopen on the older version. Anything the newer version " +
+                    "fixed will come back, and your settings are not affected.",
+                    "Go back to the previous version"))
+            {
+                return;
+            }
+
             var args = UpdateApplier.BuildArguments(currentExe, Environment.ProcessId);
             RollBackStatus = "Going back — SysManager will restart…";
 

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -157,11 +157,18 @@ public sealed partial class AboutViewModel : ViewModelBase
     /// Re-reads whether a retained previous build exists. Called on construction and after a
     /// rollback, so the button disappears once the copy has been consumed.
     /// </summary>
+    /// <remarks>
+    /// Requires the recorded checksum as well as the binary: we can only offer a rollback we are able
+    /// to verify, so a copy with no checksum is not offered rather than offered-then-refused. This also
+    /// means a build retained by a version that predates the checksum is not offered — that is the
+    /// intended outcome, since its integrity was never recorded, and the next update writes both files.
+    /// </remarks>
     private void RefreshRollbackAvailability()
     {
         try
         {
-            CanRollBack = File.Exists(UpdateApplier.PreviousBuildPath(_updatesDir));
+            CanRollBack = File.Exists(UpdateApplier.PreviousBuildPath(_updatesDir))
+                       && File.Exists(UpdateApplier.PreviousBuildHashPath(_updatesDir));
         }
         catch (IOException)
         {
@@ -811,6 +818,17 @@ public sealed partial class AboutViewModel : ViewModelBase
             return;
         }
 
+        // SEC: verify the retained build against the checksum recorded when it was written, and hold the
+        // verified handle across Process.Start. The retained copy sits in a user-writable folder and can
+        // have been replaced at any point since the update was applied; rollback previously ran on
+        // File.Exists alone, while the install path directly above closes this same window this same way.
+        if (!UpdateApplier.TryOpenVerifiedPreviousBuild(_updatesDir, out var verifiedStream, out var why))
+        {
+            RollBackStatus = $"Cannot go back safely — {why}.";
+            RefreshRollbackAvailability();
+            return;
+        }
+
         try
         {
             var args = UpdateApplier.BuildArguments(currentExe, Environment.ProcessId);
@@ -836,6 +854,12 @@ public sealed partial class AboutViewModel : ViewModelBase
         catch (System.ComponentModel.Win32Exception ex)
         {
             RollBackStatus = $"Could not go back: {ex.Message}";
+        }
+        finally
+        {
+            // Released only after the launch: Windows holds the image section open for the new process's
+            // lifetime, so the binary stays immutable once it has loaded.
+            verifiedStream?.Dispose();
         }
     }
 


### PR DESCRIPTION
Closes #1823

## Problem

Two paths reach the update **applier** while dropping the verification the normal install path performs. Both verified against `main`.

### 1. `--apply-update` validated the target's shape, not its identity

`App.xaml.cs:65` takes the applier branch **before** the single-instance mutex, DI and the CLI guard, so `targetExe` arrives straight from `argv`. `TryParseArgs` checked only: sentinel matches, `args[1]` non-blank, `args[2]` a positive int. Nothing compared the target against the running executable. `Run` then calls `ApplyCopy(Environment.ProcessPath, targetExe)`, ending in `File.Move(staging, targetExe, overwrite: true)`, and launches the result with `UseShellExecute = true` — which its own comment notes deliberately inherits elevation.

**Reproduced end-to-end against unfixed code:** a temp file containing `127.0.0.1 localhost` came back **162,304 bytes** after `UpdateApplier.Run(victim, 999999)`. `WaitForProcessExit` catches `ArgumentException` for a non-existent pid and returns immediately, so no wait is needed to reach the write.

`BuildArguments` rejecting `"` constrains only the string this app *emits*; an attacker supplies the command line directly, so the inbound side must re-establish trust itself.

### 2. Rollback launched a user-writable binary on `File.Exists` alone

`RollBackAsync` started `%LOCALAPPDATA%\SysManager\updates\SysManager-previous.exe` after one existence check, with `UseShellExecute = true`. That directory is user-writable and the file persists indefinitely between being written and the click, so anything running as the user could replace it and have it start with SysManager's token.

`InstallUpdateAsync` directly above hardens this exact shape — `FileShare.Read` handle opened **before** verifying, SHA-256 from the held stream, then launch without reopening. Rollback (#1765) reused `BuildArguments` and the applier, documented as "the SAME applier path", but inherited none of the verification.

## Fix

**`IsValidApplyTarget`** — the gate lives in `Run`, the only method that writes, so a future second caller cannot bypass it. Requires:
- a canonicalised path, so validation and the write act on the same string (`sub\..\hosts` is judged as `hosts`);
- this executable's own name, derived from `Environment.ProcessPath` rather than hardcoded;
- a location outside the Windows / System / Program Files roots, compared on a directory boundary;
- an **existing** file — an update replaces an install, it never creates one, which is what stops the applier planting a new binary at a chosen path.

It returns a *reason*, so a refusal is logged specifically instead of looking identical to a successful update.

**Rollback** — `PreserveCurrentBuild` records the SHA-256 of the bytes it wrote. `TryOpenVerifiedPreviousBuild` opens with deny-write **before** hashing and **returns the handle**, so the caller launches the bytes it verified rather than reopening the path. Fails closed: a missing or unusable checksum is a refusal, matching what `UpdateService` does for a missing published `.sha256`. `CanRollBack` now requires the checksum too, so a build retained by an earlier version is not offered rather than offered-then-refused.

## Regression proof (red → green)

`dotnet test` is not run on this workstation, so a harness drove the **real methods** via `InternalsVisibleTo` — behaviour, not source shape.

```
===== RED =====
  [FAIL] the victim file was NOT overwritten by the application binary — 162304 bytes
  [FAIL] UpdateApplier.IsValidApplyTarget exists
  [FAIL] UpdateApplier.TryOpenVerifiedPreviousBuild exists
  ... (11 total)
=== 11 FAILED ===

===== GREEN =====
  [PASS] the victim file was NOT overwritten by the application binary — 19 bytes
  [PASS] an existing copy of this executable is accepted
  [PASS] a path inside the Windows directory is refused FOR ITS LOCATION — the target is inside a protected system directory
  [PASS] a real existing system binary is refused on its name — the target is not named …
  [PASS] a retained build swapped after saving is REFUSED — the saved version has changed since it was saved
  [PASS] a retained build with no checksum is refused — there is no recorded checksum for the saved version
=== ALL PASS ===
```

19 bytes = the original `hosts` content, untouched.

15 unit tests in `UpdateApplierTests`, each asserting the hostile input is **refused**, with positive controls so "refuse everything" cannot score full marks:

- `ApplyTarget_AcceptsAnExistingCopyOfThisExecutable` (the control)
- `ApplyTarget_RefusesAFileThatIsNotThisExecutable` — `hosts`, `evil.exe`, `SysManager.dll`, `notepad.exe`
- `ApplyTarget_RefusesAPathThatDoesNotExistYet`
- `ApplyTarget_RefusesAPathInsideTheWindowsDirectory` — asserts specifically the *location* reason
- `ApplyTarget_RefusesARealExistingSystemBinary` — a file that genuinely exists, so it cannot pass via the existence check
- `ApplyTarget_ResolvesDotSegmentsBeforeDeciding`
- `Run_WithAHostileTarget_LeavesThatFileUntouched` — end-to-end, hash-compared, and asserts not even a `.new` staging file appeared
- `PreserveCurrentBuild_RecordsTheChecksumOfWhatItWrote`
- `VerifiedPreviousBuild_AcceptsAnUntouchedRetainedBuild` — also proves the returned handle denies writes
- `VerifiedPreviousBuild_RefusesABuildSwappedAfterItWasSaved`
- `VerifiedPreviousBuild_FailsClosedWithoutAUsableChecksum` — absent / empty / garbage / wrong-length
- `VerifiedPreviousBuild_RefusesWhenThereIsNoRetainedBuild`

The name and system-root branches are each pinned as **independently reachable**: the location check runs before the existence check, so it cannot be shadowed, and a test proves each fires for its own reason.

## Verification

- All four projects build Release: **0 warnings, 0 errors** (rebuilt after rebasing onto 1.64.1).
- Leak scan over the full diff against `leak-terms.txt`: 0 hits.
- Version 1.64.2 across the triple; CHANGELOG entry with the plain-English lead in this same PR.
- No behaviour change to a normal update: it always pointed at the running executable, which is exactly what the new rule accepts.