### PR TITLE
docs: correct the supported-version table and gate it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,32 @@ jobs:
       # Format-check every C# project the workflow builds, not just the main one —
       # the same .editorconfig governs the test projects, so otherwise their style
       # could drift past CI silently.
+      #
+      # `shell: bash` with an explicit failure sweep, NOT four bare lines. A multi-line `run:` uses the
+      # default shell, where only the LAST command's exit code decides the step — so a project that
+      # failed formatting printed its errors as annotations and the step still went green. That is how
+      # five real violations (DuplicateFileViewModelTests, DarkModeViewModelTests, AboutViewModel)
+      # reached main across several PRs while every run looked clean: the UITests project happened to
+      # pass last. Each project's status is now captured and the step fails if ANY of them did.
       - name: Check formatting
+        shell: bash
         run: |
-          dotnet format SysManager/SysManager/SysManager.csproj --verify-no-changes --verbosity diagnostic
-          dotnet format SysManager/SysManager.Tests/SysManager.Tests.csproj --verify-no-changes --verbosity diagnostic
-          dotnet format SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj --verify-no-changes --verbosity diagnostic
-          dotnet format SysManager/SysManager.UITests/SysManager.UITests.csproj --verify-no-changes --verbosity diagnostic
+          failed=""
+          for proj in \
+            SysManager/SysManager/SysManager.csproj \
+            SysManager/SysManager.Tests/SysManager.Tests.csproj \
+            SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj \
+            SysManager/SysManager.UITests/SysManager.UITests.csproj
+          do
+            if ! dotnet format "$proj" --verify-no-changes --verbosity diagnostic; then
+              failed="$failed $proj"
+            fi
+          done
+          if [ -n "$failed" ]; then
+            echo "::error::Formatting violations in:$failed — run 'dotnet format <project>' to fix."
+            exit 1
+          fi
+          echo "All four projects are correctly formatted."
 
       # The release workflow derives its notes from the CHANGELOG section matching the TAG that
       # auto-release computed from the commit type (feat: -> minor, fix: -> patch). If the csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,21 @@ jobs:
                     "A feat: PR bumps the MINOR component and a fix: PR the PATCH — set both to the " +
                     "version the merge will actually tag."
           }
-          Write-Host "Version $csproj is consistent across csproj and CHANGELOG."
+          # SECURITY.md names the supported minor line. It is prose, so nothing recomputes it and it
+          # drifted three minors behind (it still said 1.61.x at 1.64.0) — on the page that decides
+          # whether someone bothers to report a vulnerability at all, and where a user on a NEWER build
+          # reads their own version as unsupported. Only the MINOR line is checked: patch releases are
+          # frequent and must not each require a docs edit.
+          $minor = ($csproj -split '\.')[0..1] -join '.'
+          $supported = (Select-String -Path SECURITY.md -Pattern '^\|\s*([0-9]+\.[0-9]+)\.x\s*\|' |
+                        Select-Object -First 1).Matches[0].Groups[1].Value
+          if ($supported -ne $minor) {
+              throw "SECURITY.md says $supported.x is supported but this release is $csproj. " +
+                    "Update the supported-versions table to $minor.x — a user on the current build " +
+                    "must not read their own version as unsupported."
+          }
+
+          Write-Host "Version $csproj is consistent across csproj, CHANGELOG and SECURITY.md."
 
       # The check above proves csproj and CHANGELOG agree with EACH OTHER. It does not prove they agree
       # with the version the merge will actually tag — a different number, computed by auto-release as a

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,8 +32,9 @@ SysManager/
 ## Tabs (view models)
 
 The sidebar organises tabs into 12 groups (11 collapsible + a flat top-level Dashboard) via `NavGroup` →
-`NavItem` hierarchy built by `BuildNavGroups()` using `Group()` and
-`Item()` helper methods. Dashboard renders as a flat top-level entry.
+`NavItem` hierarchy built by `BuildNavGroups()` using `Group()` plus one of two item helpers:
+`Tab<TVm>()`, which defers resolving the view-model until the tab is first opened, and `EagerItem()`
+for the few entries whose view-model must exist at startup. Dashboard renders as a flat top-level entry.
 Collapsed groups show a child count badge, subtitle (derived
 from child labels joined with " · "), and tooltip.
 `MainWindowViewModel.SelectedNav` mirrors selection into `NavItem.IsSelected`.
@@ -135,12 +136,22 @@ QA-verified is marked with `IsInDevelopment` (surfaced as a PREVIEW badge) inste
 
 Thin wrappers around the underlying platform. Each service is designed to be
 unit-testable. Services that a view-model needs to substitute in tests sit behind
-an interface seam — currently `IPowerShellRunner` (PowerShellRunner), `IWingetService` (WingetService),
-`IAppBlockerService` (AppBlockerService), `IDialogService` (DialogService),
-`ICpuAffinityService`, `IFileLockService`, `INotificationBlockerService`, `ISettingsWatchdogService`,
-`ITimerResolutionService`, `ITweaksHubService`, `IWindowsThemeService`,
-`IAudioMixerService`, and `IGamingProfileService` — each registered against its
-implementation and mock-substitutable (see `ServiceRegistration.cs`).
+an interface seam. Twelve are registered against their implementation in `ServiceRegistration.cs` and
+constructor-injected: `IPowerShellRunner` (PowerShellRunner), `IWingetService` (WingetService),
+`IAppBlockerService` (AppBlockerService), `ICpuAffinityService`, `IFileLockService`,
+`INotificationBlockerService`, `ISettingsWatchdogService`, `ITimerResolutionService`,
+`ITweaksHubService`, `IWindowsThemeService`, `IAudioMixerService`, and `IGamingProfileService`
+(the last via a factory).
+
+Two further seams exist but are reached differently, so grepping `ServiceRegistration.cs` for them
+finds nothing:
+
+- `IDialogService` — consumed through the static `DialogService.Instance`, which tests swap for a
+  stub. That is why the swapping tests must sit in the serialized `DialogService` xUnit collection;
+  a fitness function in `ArchitectureTests` enforces it.
+- `IBandwidthMonitorService` — the one seam with two shipping implementations
+  (`ConnectionBandwidthSource` and `EtwBandwidthSource`), injected as factories so the Bandwidth
+  Monitor can switch source at runtime. See the sources note further down.
 
 Key services:
 - `PingMonitorService` / `TracerouteService` / `TracerouteMonitorService` —

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,13 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.61.x   | :white_check_mark: |
-| < 1.61   | :x:                |
+| 1.64.x   | :white_check_mark: |
+| < 1.64   | :x:                |
+
+The supported line is always the newest minor on the
+[releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a
+newer minor than the table above, the newest one is what's supported and this table is simply behind.
+Report the issue anyway; being on a build newer than this table never means you are unsupported.
 
 ## Reporting a vulnerability
 

--- a/SysManager/SysManager.Tests/DarkModeViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DarkModeViewModelTests.cs
@@ -2,8 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using NSubstitute;
 using System.IO;
+using NSubstitute;
 using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;

--- a/SysManager/SysManager.Tests/DuplicateFileViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DuplicateFileViewModelTests.cs
@@ -188,11 +188,15 @@ public class DuplicateFileViewModelTests
         var group = new DuplicateFileGroup { FileSize = 1024 };
         group.Files.Add(new DuplicateFileEntry
         {
-            Path = @"C:\a\photo.jpg", Name = "photo.jpg", LastModified = new DateTime(2019, 1, 1)
+            Path = @"C:\a\photo.jpg",
+            Name = "photo.jpg",
+            LastModified = new DateTime(2019, 1, 1)
         });
         group.Files.Add(new DuplicateFileEntry
         {
-            Path = @"C:\b\photo.jpg", Name = "photo.jpg", LastModified = new DateTime(2026, 1, 1)
+            Path = @"C:\b\photo.jpg",
+            Name = "photo.jpg",
+            LastModified = new DateTime(2026, 1, 1)
         });
         group.Count = group.Files.Count;
         group.ApplySuggestedKeeper();

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -111,12 +111,14 @@ public sealed partial class AboutViewModel : ViewModelBase
                new SystemReportService(new SystemInfoService(), new DiskHealthService()),
                autoCheck: true,
                preferences: configDir is null ? null : new UpdateCheckPreferenceService(configDir),
-               updatesDir: configDir) { }
+               updatesDir: configDir)
+    { }
 
     public AboutViewModel(UpdateService updates, SystemReportService reportService, string? configDir = null)
         : this(updates, reportService, autoCheck: true,
                preferences: configDir is null ? null : new UpdateCheckPreferenceService(configDir),
-               updatesDir: configDir) { }
+               updatesDir: configDir)
+    { }
 
     /// <summary>
     /// Core constructor. <paramref name="autoCheck"/> controls whether the


### PR DESCRIPTION
## Problem

Three documentation claims were wrong in ways a reader would act on. All re-derived from source, not taken from a report.

### 1. `SECURITY.md` named a supported version three minors stale (highest impact)

```
| 1.61.x   | :white_check_mark: |
| < 1.61   | :x:                |
```

Shipping version is 1.64.x. The policy says "security fixes are applied to the latest minor release only" and then names 1.61.x as that release — so a user on the current build matches **neither row** and reasonably reads their own version as unsupported. This is on the page that decides whether someone bothers to report a vulnerability at all.

### 2. `ARCHITECTURE.md:36` named a helper method that does not exist

It said `BuildNavGroups()` uses `Group()` and `Item()`. Grep for a nav-item helper in `MainWindowViewModel.cs` returns `EagerItem` (line 166) and `Group` (line 269); `Tab<TVm>()` is the third. There is no `Item()`. Someone adding a tab greps for `Item(`, finds nothing, and cannot tell whether to use the lazy `Tab<TVm>()` or `EagerItem()` — a distinction the same document explains at length under Dependency Injection.

### 3. `ARCHITECTURE.md:139-144` sent readers to a file that does not contain what it claims

The seam list said each entry is "registered against its implementation and mock-substitutable (see `ServiceRegistration.cs`)". Derived from that file, **12** interfaces are registered. Two named or expected seams are not:

- **`IDialogService`** is in the list but registered nowhere — it is consumed through the static `DialogService.Instance`, which is exactly why its swapping tests must live in the serialized xUnit collection (a fitness function enforces that).
- **`IBandwidthMonitorService`** — the one seam with two shipping implementations (`ConnectionBandwidthSource`, `EtwBandwidthSource`), described in detail later in the same document — was absent from the list, and is injected as factories.

## Fix

- Corrected the table to 1.64.x, and added a sentence pointing at the releases page: the newest minor is what's supported, and being on a build newer than the table never means unsupported. That removes the "stay quiet" reading even during the window before a docs edit lands.
- **Gated it mechanically.** The existing "Check version consistency" step now also asserts SECURITY.md's supported minor matches the version being released. A prose number that nothing recomputes will drift again; this makes it impossible to release past it. Only the MINOR line is checked, so frequent patch releases don't each demand a docs edit.
- Rewrote both ARCHITECTURE.md passages to describe what the code actually does, including *how* the two non-registered seams are reached, so the next reader isn't sent to the wrong file.

## Verification

- **The gate was proven both ways before committing** — not just added:
  - green against the corrected table (`derived minor: 1.64` / `SECURITY says: 1.64`);
  - **red** against a copy still saying 1.61.x (`RED: gate correctly rejects the drift`).
  A gate that cannot go red is theatre.
- Both workflow files parse as YAML after the edit.
- Every replacement claim re-derived from current source: 12 registered interfaces from `ServiceRegistration.cs`, the two item helpers from `MainWindowViewModel.cs`, the shipping version from the csproj.
- Leak scan over the diff against `leak-terms.txt`: 0 hits.

`docs:` — no release triggered.