### PR TITLE
fix: stop the Standby List Cleaner polling when nobody is watching it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.3] - 2026-08-12
+
+The Standby List Cleaner used to keep checking your memory every two seconds for as long as SysManager
+stayed open, even after you left the tab. It now stops when you are not looking at it.
+
+### Fixed
+- **The Standby List Cleaner kept working in the background after you left it.** Opening that tab once started a check every two seconds — and it never stopped: not when you switched to another tab, not when you minimised the window, and not when you closed SysManager to the notification area. On a laptop that is wasted battery for a tab nobody is looking at, and if you had turned on automatic purging, that could run unattended from a hidden tab. The check now runs while the tab is open, and stops when it is not. **Automatic purging still works exactly as before** — if you have turned it on, SysManager keeps watching your free memory in the background, because that is the whole point of the setting; the check only stops when there is nothing it could act on. Every other tab that watches something live already worked this way; this one had been left out, and a new automatic check now makes sure a future tab cannot be missed the same way.
+
+---
+
 ## [1.64.2] - 2026-08-12
 
 Two ways the built-in updater could be tricked into damaging your PC are now closed off. Nothing about

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -519,6 +519,70 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"\s+", RegexOptions.Compiled)]
     private static partial Regex WhitespaceRun();
 
+    /// <summary>
+    /// Every view model that declares an <c>IsActive</c> flag must be handled by
+    /// <c>MainWindowViewModel.SetActive</c>, or its poll is never gated by visibility.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>SetActive</c> is a hand-maintained switch, so a new polling tab is opted OUT of the gate by
+    /// default and nothing about the omission looks wrong — no compiler error, no failing test, and the
+    /// tab still works. That is exactly how the Standby List Cleaner ended up running a 2-second
+    /// dispatcher tick for the whole session after being opened once: behind another tab, minimised, and
+    /// closed to the tray, with an unsupervised privileged purge reachable from it.
+    /// </para>
+    /// <para>
+    /// Reflection rather than a source scan: declaring <c>IsActive</c> is a compile-time fact about the
+    /// type, so the assembly is the more reliable source. The switch arms are read from source, because
+    /// a <c>switch</c> pattern arm is not visible through reflection.
+    /// </para>
+    /// <para>
+    /// Deliberately keyed on <c>IsActive</c> and not on "owns a timer": <c>IsActive</c> IS the gate
+    /// contract. A view model that polls without declaring it would slip past this — which is why the
+    /// floor below asserts the check found the flags it expects, so a rename cannot make it vacuous.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void EveryViewModelWithAnIsActiveFlag_IsHandledBySetActive()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindAppProjectDir(), "ViewModels", "MainWindowViewModel.cs"));
+
+        // Only the SetActive body counts. Searching the whole file would let an unrelated mention of a
+        // view model's name pass the check — the same cross-type pooling trap the command-reachability
+        // guard has to work around.
+        var start = source.IndexOf("internal static void SetActive(", StringComparison.Ordinal);
+        Assert.True(start >= 0, "SetActive not found — this check is not reading what it thinks it is.");
+        var end = source.IndexOf("\n    }", start, StringComparison.Ordinal);
+        Assert.True(end > start, "Could not delimit the SetActive body.");
+        var body = source[start..end];
+
+        var gated = typeof(SysManager.ViewModels.MainWindowViewModel).Assembly
+            .GetTypes()
+            .Where(t => t.Namespace == "SysManager.ViewModels"
+                     && t.Name.EndsWith("ViewModel", StringComparison.Ordinal)
+                     && t.GetProperty("IsActive") is not null)
+            // Row-level view models are not tabs, so the shell never navigates to them.
+            .Where(t => t.Name != "AudioSessionRowViewModel")
+            .ToList();
+
+        // Vacuity floor: if a rename made the reflection find nothing, every assertion below would pass
+        // while checking nothing at all.
+        Assert.True(gated.Count >= 5,
+            $"Expected at least 5 view models with an IsActive flag, found {gated.Count} — " +
+            "the reflection filter is probably no longer matching.");
+
+        var missing = gated
+            .Where(t => !body.Contains(t.Name, StringComparison.Ordinal))
+            .Select(t => t.Name)
+            .ToList();
+
+        Assert.True(missing.Count == 0,
+            "These view models declare an IsActive flag but MainWindowViewModel.SetActive never sets " +
+            "it, so their poll keeps running while the tab is hidden. Add a case arm:\n  " +
+            string.Join("\n  ", missing));
+    }
+
     /// <summary>The app project directory — .xaml is not copied to the test output.</summary>
     private static string FindAppProjectDir()
     {

--- a/SysManager/SysManager.Tests/StandbyMemoryTests.cs
+++ b/SysManager/SysManager.Tests/StandbyMemoryTests.cs
@@ -25,6 +25,46 @@ public class StandbyMemoryTests
         Assert.False(StandbyMemoryViewModel.ShouldAutoPurge(-1, 1024));
     }
 
+    // ── When the 2-second poll may run ──────────────────────────────────────────────────────────────
+    // The poll used to start in the constructor and never stop, so opening this tab ONCE left a
+    // dispatcher tick firing every 2 seconds for the rest of the session — including while minimised or
+    // closed to the tray, with an unsupervised privileged purge reachable from it. Visibility alone is
+    // the wrong gate though: auto-purge is set-and-forget, so gating purely on IsActive would silently
+    // stop watching free memory the moment the user navigated away.
+
+    [Fact]
+    public void ShouldPoll_WhileTheTabIsVisible()
+        => Assert.True(StandbyMemoryViewModel.ShouldPoll(isActive: true, autoPurgeEnabled: false, isElevated: false));
+
+    [Fact]
+    public void ShouldNotPoll_WhenHiddenAndAutoPurgeIsOff()
+        => Assert.False(StandbyMemoryViewModel.ShouldPoll(isActive: false, autoPurgeEnabled: false, isElevated: true));
+
+    [Fact]
+    public void ShouldPoll_WhenHiddenButAutoPurgeIsArmed()
+    {
+        // The whole point of auto-purge: the user arms it, navigates away, and it keeps watching free
+        // memory. Gating this on visibility would turn the feature off without telling anyone — a worse
+        // bug than the one being fixed.
+        Assert.True(StandbyMemoryViewModel.ShouldPoll(isActive: false, autoPurgeEnabled: true, isElevated: true));
+    }
+
+    [Fact]
+    public void ShouldNotPoll_WhenAutoPurgeIsArmedButPurgingIsImpossible()
+    {
+        // Armed without administrator: a purge can never happen, so a hidden tick could only re-read
+        // memory into a tab nobody is looking at — the exact waste this gate removes.
+        Assert.False(StandbyMemoryViewModel.ShouldPoll(isActive: false, autoPurgeEnabled: true, isElevated: false));
+    }
+
+    [Fact]
+    public void ShouldPoll_WhenVisible_EvenWithoutElevation()
+    {
+        // The tab shows live memory figures to every user, so visibility is sufficient on its own — the
+        // elevation condition must not leak into the visible case.
+        Assert.True(StandbyMemoryViewModel.ShouldPoll(isActive: true, autoPurgeEnabled: true, isElevated: false));
+    }
+
     [Fact]
     public void MemoryStatus_FormatsAndComputesMb()
     {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.64.2</Version>
-    <FileVersion>1.64.2.0</FileVersion>
-    <AssemblyVersion>1.64.2.0</AssemblyVersion>
+    <Version>1.64.3</Version>
+    <FileVersion>1.64.3.0</FileVersion>
+    <AssemblyVersion>1.64.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -312,10 +312,15 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         if (newValue is not null) newValue.IsSelected = true;
     }
 
-    // The three tabs with a visibility-gated poll expose an IsActive flag. Toggle it generically
-    // so this doesn't depend on eager VM properties that no longer exist for lazy tabs.
+    // Every tab with a visibility-gated poll exposes an IsActive flag. Toggle it generically so this
+    // doesn't depend on eager VM properties that no longer exist for lazy tabs.
     // internal (not private) so a test can pin the gate without constructing the whole shell,
     // exactly as UpdateSelectionState above is tested.
+    //
+    // This list is hand-maintained, which means a NEW polling tab is opted OUT of the gate by default
+    // and nothing about the omission looks wrong — that is how Standby List Cleaner ended up polling
+    // every 2 seconds for the whole session after being opened once. ArchitectureTests now asserts
+    // every view model declaring IsActive appears here, so the next one cannot be forgotten silently.
     internal static void SetActive(object content, bool active)
     {
         switch (content)
@@ -324,6 +329,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             case DashboardViewModel db: db.IsActive = active; break;
             case AudioMixerViewModel am: am.IsActive = active; break;
             case BandwidthMonitorViewModel bw: bw.IsActive = active; break;
+            case StandbyMemoryViewModel sm: sm.IsActive = active; break;
         }
     }
 

--- a/SysManager/SysManager/ViewModels/StandbyMemoryViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StandbyMemoryViewModel.cs
@@ -34,6 +34,18 @@ public sealed partial class StandbyMemoryViewModel : ViewModelBase
     [ObservableProperty] private bool _autoPurgeEnabled;
     [ObservableProperty] private double _thresholdMb = StandbyPreferenceService.DefaultThresholdMb;
 
+    /// <summary>
+    /// True while this tab is the visible one. Set by <c>MainWindowViewModel.SetActive</c>, like the
+    /// other polling tabs.
+    /// </summary>
+    /// <remarks>
+    /// The poll used to start in the constructor and never stop, so opening this tab ONCE left a
+    /// 2-second dispatcher tick running for the rest of the session — behind another tab, minimised,
+    /// and closed to the tray. See <see cref="ShouldPoll"/> for why visibility alone is not the
+    /// condition.
+    /// </remarks>
+    [ObservableProperty] private bool _isActive;
+
     public StandbyMemoryViewModel(StandbyMemoryService service, StandbyPreferenceService? preferences = null)
     {
         _service = service;
@@ -61,7 +73,10 @@ public sealed partial class StandbyMemoryViewModel : ViewModelBase
                 Interval = TimeSpan.FromSeconds(2),
             };
             _timer.Tick += (_, _) => Tick();
-            _timer.Start();
+            // NOT started here. The tab is constructed on first open, and MainWindowViewModel sets
+            // IsActive immediately after, which starts it — so the visible case is unaffected while a
+            // hidden tab no longer polls forever.
+            SyncTimer();
         }
     }
 
@@ -69,9 +84,48 @@ public sealed partial class StandbyMemoryViewModel : ViewModelBase
     public static bool ShouldAutoPurge(double availableMb, double thresholdMb)
         => thresholdMb > 0 && availableMb > 0 && availableMb < thresholdMb;
 
+    /// <summary>
+    /// Pure: should the 2-second poll be running? True while the tab is visible, OR while auto-purge is
+    /// armed and could actually act.
+    /// </summary>
+    /// <remarks>
+    /// Visibility alone is the WRONG condition here, unlike the other polling tabs. Auto-purge is
+    /// deliberately set-and-forget — the user arms it, navigates away, and expects it to keep watching
+    /// free memory — so gating purely on IsActive would silently turn the feature off the moment the tab
+    /// lost focus, which is a worse bug than the one being fixed.
+    /// <para>Elevation is part of the condition because a purge needs administrator: without it the tick
+    /// could never do anything but re-read memory into a hidden tab, which is exactly the waste this
+    /// change removes.</para>
+    /// </remarks>
+    internal static bool ShouldPoll(bool isActive, bool autoPurgeEnabled, bool isElevated)
+        => isActive || (autoPurgeEnabled && isElevated);
+
+    /// <summary>Starts or stops the poll to match <see cref="ShouldPoll"/>.</summary>
+    private void SyncTimer()
+    {
+        if (_timer is null) return;
+
+        if (ShouldPoll(IsActive, AutoPurgeEnabled, IsElevated))
+        {
+            if (!_timer.IsEnabled) _timer.Start();
+        }
+        else if (_timer.IsEnabled)
+        {
+            _timer.Stop();
+        }
+    }
+
+    partial void OnIsActiveChanged(bool value) => SyncTimer();
+
     // Persist on change rather than on close: the app can be closed to the tray or killed, and a
     // setting the user visibly toggled should survive either.
-    partial void OnAutoPurgeEnabledChanged(bool value) => SavePreferences();
+    partial void OnAutoPurgeEnabledChanged(bool value)
+    {
+        SavePreferences();
+        // Arming auto-purge has to be able to START the poll, and disarming it while the tab is hidden
+        // has to STOP it — otherwise the "set and forget" path would either never watch or never stop.
+        SyncTimer();
+    }
 
     partial void OnThresholdMbChanged(double value) => SavePreferences();
 


### PR DESCRIPTION
Closes #1830

## Problem

`StandbyMemoryViewModel`'s constructor started a `DispatcherTimer` at 2 seconds (`:59-64`) and nothing ever stopped it. Opening the tab **once** left a dispatcher tick firing every 2 seconds for the rest of the session — behind another tab, minimised, and closed to the tray.

The app already has the gate. `MainWindowViewModel.SetActive` (`:319-328`) toggles `IsActive` on the polling tabs:

```csharp
case ProcessManagerViewModel pm: pm.IsActive = active; break;
case DashboardViewModel db: db.IsActive = active; break;
case AudioMixerViewModel am: am.IsActive = active; break;
case BandwidthMonitorViewModel bw: bw.IsActive = active; break;
```

Standby was never added, and exposed no `IsActive` at all. Beyond the wasted battery, with auto-purge armed the tick could reach `NtSetSystemInformation(MemoryPurgeStandbyList)` (`:113`) unattended, from a tab nobody was looking at.

## Why the obvious fix would have been wrong

Gating purely on `IsActive` — what the other four do — would have **broken auto-purge**. It is deliberately set-and-forget: the user arms it, navigates away, and expects SysManager to keep watching free memory. Turning that off silently the moment the tab lost focus is a worse bug than the one being fixed.

So the condition is `visible OR (armed AND elevated)`:

```csharp
internal static bool ShouldPoll(bool isActive, bool autoPurgeEnabled, bool isElevated)
    => isActive || (autoPurgeEnabled && isElevated);
```

Elevation is part of it because a purge needs administrator — without it a hidden tick could only re-read memory into a tab nobody can see, which is exactly the waste being removed. `OnAutoPurgeEnabledChanged` also re-syncs, so arming can *start* the poll and disarming while hidden can *stop* it.

## Fixing the class, not the instance

`SetActive` is a hand-maintained switch, so a new polling tab is opted **out** of the gate by default and nothing about the omission looks wrong — no compiler error, no failing test, the tab still works. That is precisely how this shipped.

`ArchitectureTests.EveryViewModelWithAnIsActiveFlag_IsHandledBySetActive` now asserts every view model declaring `IsActive` appears in the `SetActive` body. Details that make it real rather than decorative:

- **Scoped to the `SetActive` body**, not the whole file — otherwise an unrelated mention of a view model's name would satisfy it.
- **Vacuity floor** (`gated.Count >= 5`): if a rename stopped the reflection matching, every assertion would otherwise pass while checking nothing.
- Reflection for the flag (a compile-time fact), source for the switch arms (a `switch` pattern arm is invisible to reflection).

Also corrected the switch's comment, which said "three tabs" while listing four.

## Regression proof (red → green)

```
===== RED =====
  [FAIL] StandbyMemoryViewModel declares an IsActive flag
  [FAIL] ShouldPoll exists
  [FAIL] SetActive handles StandbyMemoryViewModel
  [FAIL] a fitness function pins every IsActive view model to SetActive
  ... (7 total)
=== 7 FAILED ===

===== GREEN =====
  [PASS] polls while the tab is visible
  [PASS] does NOT poll when hidden with auto-purge off
  [PASS] still polls when hidden if auto-purge is armed
  [PASS] does NOT poll when armed but not elevated (a purge could never happen)
  [PASS] visibility alone is enough, without elevation
  [PASS] SetActive still handles ProcessManagerViewModel / Dashboard / AudioMixer / BandwidthMonitor
=== ALL PASS ===
```

The four "still handles" lines are controls: a rewrite must not trade one tab's gate for another's.

5 unit tests in `StandbyMemoryTests` cover both directions, including the two cases that encode the judgement call — armed-and-hidden **polls**, armed-without-admin **does not**.

## Verification

- All four projects build Release: **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes` clean on all four (now that the gate from #1826 actually enforces it).
- Leak scan over the diff against `leak-terms.txt`: 0 hits.
- Version 1.64.3 across the triple; CHANGELOG entry with the plain-English lead, stating explicitly that auto-purge still works as before.