### PR TITLE
fix: make "close SysManager" actually end the process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.4] - 2026-08-12
+
+Choosing "close SysManager" now actually closes it. It used to leave SysManager running invisibly, with
+no window and no icon next to the clock to get it back.
+
+### Fixed
+- **"Close SysManager" left it running with no way to see it or stop it.** When you press X, SysManager asks once whether to keep running next to the clock or close completely — and remembers your answer. Choosing to close completely made the window disappear, but the program kept running: no window, and no icon next to the clock either, so there was nothing to click. Worse, it then blocked itself from starting again — launching SysManager would hand over to the invisible copy and quit immediately, so it looked like the app simply would not open. Because your answer is remembered, this happened every time, and the only way out was Task Manager. Closing completely now really does end the program. Keeping it next to the clock, and pressing Cancel to go back, both work exactly as before.
+
+---
+
 ## [1.64.3] - 2026-08-12
 
 The Standby List Cleaner used to keep checking your memory every two seconds for as long as SysManager

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -583,6 +583,39 @@ public partial class ArchitectureTests
             string.Join("\n  ", missing));
     }
 
+    /// <summary>
+    /// <c>MainWindow.OnClosing</c> must request an application shutdown, not merely close the window.
+    /// </summary>
+    /// <remarks>
+    /// <c>App</c> sets <c>ShutdownMode.OnExplicitShutdown</c> so SysManager can live in the notification
+    /// area, which means closing the last window does NOT end the process. The Exit branch used to fall
+    /// through to <c>base.OnClosing</c> with no <c>Shutdown</c> call, leaving the app running with no
+    /// window and no tray icon (the icon is disposed in <c>App.OnExit</c>, which nothing had triggered),
+    /// still holding the single-instance mutex — so the next launch handed itself over to an invisible
+    /// instance and quit, and because the answer is remembered that repeated on every launch (#1827).
+    /// <para>
+    /// The decision itself is unit-tested through <c>CloseDecision</c>; this pins the one part that
+    /// cannot be: that the window's own code actually performs the shutdown. Source-level because
+    /// <c>OnClosing</c> is protected WPF code-behind a headless test cannot invoke.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void ClosingTheWindowToExit_RequestsAnApplicationShutdown()
+    {
+        var source = File.ReadAllText(Path.Combine(FindAppProjectDir(), "MainWindow.xaml.cs"));
+
+        var start = source.IndexOf("protected override void OnClosing(", StringComparison.Ordinal);
+        Assert.True(start >= 0, "OnClosing not found — this check is not reading what it thinks it is.");
+        var end = source.IndexOf("protected override void OnClosed(", start, StringComparison.Ordinal);
+        Assert.True(end > start, "Could not delimit the OnClosing body.");
+        var body = source[start..end];
+
+        // Vacuity floor: the body must still contain the branch this is about, otherwise the assertion
+        // below could pass against an OnClosing that no longer decides anything.
+        Assert.Contains("CloseAction", body);
+        Assert.Contains("Shutdown()", body);
+    }
+
     /// <summary>The app project directory — .xaml is not copied to the test output.</summary>
     private static string FindAppProjectDir()
     {

--- a/SysManager/SysManager.Tests/ClosePreferenceServiceTests.cs
+++ b/SysManager/SysManager.Tests/ClosePreferenceServiceTests.cs
@@ -144,3 +144,88 @@ public class ClosePreferenceServiceTests : IDisposable
         Assert.Equal(CloseBehavior.Exit, new ClosePreferenceService(nested).Load());
     }
 }
+
+/// <summary>
+/// What closing the window resolves to. This lives outside <c>MainWindow.OnClosing</c> precisely so it
+/// can be asserted: the Exit branch used to fall through to <c>base.OnClosing</c> without calling
+/// <c>Shutdown</c>, and because <c>App</c> sets <c>ShutdownMode.OnExplicitShutdown</c> the process kept
+/// running with no window and no tray icon — the icon is disposed in <c>App.OnExit</c>, which nothing had
+/// triggered. The single-instance mutex stayed held, so the next launch handed itself to an invisible
+/// instance and quit, and the remembered answer made it recur on every launch (#1827).
+/// </summary>
+public class CloseDecisionTests
+{
+    [Fact]
+    public void RememberedExit_EndsTheProcess()
+    {
+        // The defect. Nothing else in the app exits on the user's behalf, so this must resolve to a
+        // shutdown and not merely to "close the window".
+        Assert.Equal(
+            CloseAction.ExitApplication,
+            CloseDecision.Resolve(CloseBehavior.Exit, answer: null));
+    }
+
+    [Fact]
+    public void RememberedTray_HidesInsteadOfExiting()
+        => Assert.Equal(
+            CloseAction.HideToTray,
+            CloseDecision.Resolve(CloseBehavior.MinimizeToTray, answer: null));
+
+    [Theory]
+    [InlineData(CloseChoice.Exit, CloseAction.ExitApplication)]
+    [InlineData(CloseChoice.MinimizeToTray, CloseAction.HideToTray)]
+    [InlineData(CloseChoice.Cancel, CloseAction.KeepOpen)]
+    public void WithNothingRemembered_TheAnswerDecides(CloseChoice answer, CloseAction expected)
+        => Assert.Equal(expected, CloseDecision.Resolve(CloseBehavior.Ask, answer));
+
+    [Fact]
+    public void ARememberedAnswerIsNotOverriddenByAStaleChoice()
+    {
+        // A remembered preference must win outright. If the stored value were ever ignored in favour of
+        // an answer, a user who chose "keep running" would be exited by a leftover value.
+        Assert.Equal(
+            CloseAction.HideToTray,
+            CloseDecision.Resolve(CloseBehavior.MinimizeToTray, CloseChoice.Exit));
+        Assert.Equal(
+            CloseAction.ExitApplication,
+            CloseDecision.Resolve(CloseBehavior.Exit, CloseChoice.MinimizeToTray));
+    }
+
+    [Fact]
+    public void UnansweredPrompt_LeavesTheWindowOpenRatherThanExiting()
+    {
+        // "We could not ask" is not consent to quit. Losing a window is recoverable; exiting unasked
+        // during an operation is not — so the unknown case must be the harmless one.
+        Assert.Equal(
+            CloseAction.KeepOpen,
+            CloseDecision.Resolve(CloseBehavior.Ask, answer: null));
+    }
+
+    [Theory]
+    [InlineData(CloseChoice.Exit, CloseBehavior.Exit)]
+    [InlineData(CloseChoice.MinimizeToTray, CloseBehavior.MinimizeToTray)]
+    public void AnAnsweredPromptIsRemembered(CloseChoice answer, CloseBehavior expected)
+        => Assert.Equal(expected, CloseDecision.PreferenceToSave(answer));
+
+    [Fact]
+    public void CancellingRemembersNothing()
+    {
+        // Cancel means "not now", not a preference. Saving anything here would silently answer the
+        // question for the user and they would never be asked again.
+        Assert.Null(CloseDecision.PreferenceToSave(CloseChoice.Cancel));
+    }
+
+    [Fact]
+    public void EveryChoiceAndBehaviourIsResolved()
+    {
+        // Total by construction: no combination may fall through to an unintended arm. The old switch
+        // relied on a `default:` meaning Exit, which is safe only as long as every other member is
+        // listed above it — a new CloseChoice member would silently have become "exit the app".
+        foreach (var behavior in Enum.GetValues<CloseBehavior>())
+        {
+            Assert.Contains(CloseDecision.Resolve(behavior, null), Enum.GetValues<CloseAction>());
+            foreach (var choice in Enum.GetValues<CloseChoice>())
+                Assert.Contains(CloseDecision.Resolve(behavior, choice), Enum.GetValues<CloseAction>());
+        }
+    }
+}

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -187,9 +187,10 @@ public partial class MainWindow : Window
         }
 
         var behavior = _closePreference.Load();
+        CloseChoice? answer = null;
         if (behavior == CloseBehavior.Ask)
         {
-            var choice = DialogService.Instance.AskCloseOrMinimize(
+            answer = DialogService.Instance.AskCloseOrMinimize(
                 "SysManager can keep running in the notification area (the icons next to the "
                 + "clock) so it continues watching your system, or it can close completely.\n\n"
                 + "Yes — keep it running in the notification area\n"
@@ -199,39 +200,47 @@ public partial class MainWindow : Window
                 + "to reopen the window or exit at any time.",
                 "Close SysManager?");
 
-            switch (choice)
-            {
-                case CloseChoice.Cancel:
-                    e.Cancel = true;
-                    return;
-                case CloseChoice.MinimizeToTray:
-                    behavior = CloseBehavior.MinimizeToTray;
-                    break;
-                default:
-                    behavior = CloseBehavior.Exit;
-                    break;
-            }
-
-            _closePreference.Save(behavior);
+            // Cancel saves nothing — the user has not chosen a behaviour, so they must be asked again.
+            // Expressed as a nullable rather than an early return so the save rule sits next to the
+            // resolve rule and both are unit-testable.
+            if (CloseDecision.PreferenceToSave(answer.Value) is { } chosen)
+                _closePreference.Save(chosen);
         }
 
-        if (behavior == CloseBehavior.MinimizeToTray)
+        switch (CloseDecision.Resolve(behavior, answer))
         {
-            e.Cancel = true;
-            TrayIconService.HideWindow(this);
-            // Say where the window went the first time it happens. Without this the window
-            // simply vanishes, which reads as a crash rather than as running in the tray.
-            if (!_trayHintShown)
-            {
-                _trayHintShown = true;
-                ToastService.Instance.Show(
-                    "SysManager is still running",
-                    "Find it next to the clock. Right-click the icon to reopen or exit.");
-            }
-            return;
-        }
+            case CloseAction.KeepOpen:
+                e.Cancel = true;
+                return;
 
-        base.OnClosing(e);
+            case CloseAction.HideToTray:
+                e.Cancel = true;
+                TrayIconService.HideWindow(this);
+                // Say where the window went the first time it happens. Without this the window
+                // simply vanishes, which reads as a crash rather than as running in the tray.
+                if (!_trayHintShown)
+                {
+                    _trayHintShown = true;
+                    ToastService.Instance.Show(
+                        "SysManager is still running",
+                        "Find it next to the clock. Right-click the icon to reopen or exit.");
+                }
+                return;
+
+            default:
+                // Closing the window is NOT enough to end the process: App sets
+                // ShutdownMode.OnExplicitShutdown so SysManager can live in the notification area,
+                // which means WPF never exits on its own when the last window closes. Every other exit
+                // path calls Shutdown (the tray's Exit item, every RelaunchAsAdmin handler) — this one
+                // fell through to base.OnClosing and left the process running with no window AND no
+                // tray icon, because the icon is disposed in App.OnExit, which nothing had triggered.
+                // The single-instance mutex stayed held too, so the next launch handed itself over to
+                // an invisible instance and quit; and because the answer above is REMEMBERED, that
+                // repeated on every launch until the user found it in Task Manager.
+                Application.Current?.Shutdown();
+                base.OnClosing(e);
+                return;
+        }
     }
 
     protected override void OnClosed(EventArgs e)

--- a/SysManager/SysManager/Services/ClosePreferenceService.cs
+++ b/SysManager/SysManager/Services/ClosePreferenceService.cs
@@ -24,6 +24,69 @@ public enum CloseBehavior
 }
 
 /// <summary>
+/// What closing the window must actually do, resolved from the remembered preference and the user's
+/// answer to the prompt.
+/// </summary>
+public enum CloseAction
+{
+    /// <summary>Leave the window open — the user cancelled.</summary>
+    KeepOpen,
+
+    /// <summary>Hide the window and keep running in the notification area.</summary>
+    HideToTray,
+
+    /// <summary>
+    /// End the process. This is a SHUTDOWN, not just a window close: <c>App</c> sets
+    /// <c>ShutdownMode.OnExplicitShutdown</c> so SysManager can live in the tray, which means closing
+    /// the last window does not exit on its own.
+    /// </summary>
+    ExitApplication
+}
+
+/// <summary>
+/// Resolves what the close button does. Pure and separate from the window so the decision is
+/// assertable — the defect this exists to prevent was a MISSING shutdown on the Exit branch, which no
+/// test could see while the logic lived inside <c>MainWindow.OnClosing</c>.
+/// </summary>
+public static class CloseDecision
+{
+    /// <summary>
+    /// Resolves the remembered <paramref name="behavior"/> — consulting <paramref name="answer"/> only
+    /// when nothing has been remembered yet — into the action the window must take.
+    /// </summary>
+    /// <param name="behavior">The stored preference.</param>
+    /// <param name="answer">
+    /// The user's answer to the prompt, or <c>null</c> when no prompt was shown because the preference
+    /// was already known.
+    /// </param>
+    public static CloseAction Resolve(CloseBehavior behavior, CloseChoice? answer) => behavior switch
+    {
+        CloseBehavior.MinimizeToTray => CloseAction.HideToTray,
+        CloseBehavior.Exit => CloseAction.ExitApplication,
+        // Ask: the answer decides. A null answer here means the prompt could not be shown, and the safe
+        // reading of "we do not know what the user wants" is to leave the window open rather than to
+        // exit — losing a window is recoverable, exiting unasked is not.
+        _ => answer switch
+        {
+            CloseChoice.MinimizeToTray => CloseAction.HideToTray,
+            CloseChoice.Exit => CloseAction.ExitApplication,
+            _ => CloseAction.KeepOpen,
+        },
+    };
+
+    /// <summary>
+    /// The preference to persist for an answered prompt, or <c>null</c> when nothing should be saved
+    /// (the user cancelled, so they have not chosen anything yet and must be asked again).
+    /// </summary>
+    public static CloseBehavior? PreferenceToSave(CloseChoice answer) => answer switch
+    {
+        CloseChoice.MinimizeToTray => CloseBehavior.MinimizeToTray,
+        CloseChoice.Exit => CloseBehavior.Exit,
+        _ => null,
+    };
+}
+
+/// <summary>
 /// Persists the user's answer to the close prompt so it is asked once rather than on
 /// every close. Stored next to the other per-user state in
 /// <c>%LOCALAPPDATA%\SysManager</c>, following the same load/persist shape as

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.64.3</Version>
-    <FileVersion>1.64.3.0</FileVersion>
-    <AssemblyVersion>1.64.3.0</AssemblyVersion>
+    <Version>1.64.4</Version>
+    <FileVersion>1.64.4.0</FileVersion>
+    <AssemblyVersion>1.64.4.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #1827

## Problem

`App` sets `ShutdownMode.OnExplicitShutdown` (`App.xaml.cs:121`) so SysManager can live in the notification area — which means WPF **never exits when the last window closes**. Only an explicit `Shutdown()` ends the process.

Every other exit path calls it: the tray's Exit item (`TrayIconService.cs:163`) and ~30 `RelaunchAsAdmin` handlers. `OnClosing`'s Exit branch did not — it fell through to `base.OnClosing(e)` and returned.

The consequence is worse than a leaked process:

- **No window and no tray icon.** `_trayService` is disposed in `App.OnExit` (`App.xaml.cs:214`), which nothing had triggered — so there was nothing left to click.
- **The app stopped opening.** The `Global\SysManager_SingleInstance` mutex stayed held, so the next launch took `ActivateExistingInstance()` (`App.xaml.cs:100`) and shut *itself* down, with no window to activate.
- **It recurred every launch**, because `_closePreference.Save(CloseBehavior.Exit)` remembers the answer.
- **Recovery was Task Manager.**

## Why this needed a seam, not a one-liner

The bug was a *missing call* inside protected WPF code-behind that no headless test can invoke. `ClosePreferenceService` is well covered — but nothing could observe what `OnClosing` **did** with the value it loaded, which is precisely why this survived.

So the rules moved out into pure functions (`Services/ClosePreferenceService.cs`):

```csharp
public static CloseAction Resolve(CloseBehavior behavior, CloseChoice? answer)
public static CloseBehavior? PreferenceToSave(CloseChoice answer)
```

`CloseAction.ExitApplication` is named for what it means — *end the process*, not "close the window" — so the distinction the bug turned on is now in the type. `OnClosing` switches on the result.

This follows the codebase's existing idiom for exactly this problem: `StandbyMemoryViewModel.ShouldPoll` and `ShouldAutoPurge` are pure, testable decisions extracted from untestable surroundings.

## Tests

**9 unit tests** in `CloseDecisionTests`, the load-bearing ones being:

- `RememberedExit_EndsTheProcess` — the defect itself.
- `ARememberedAnswerIsNotOverriddenByAStaleChoice` — a stored preference must win outright, or a leftover answer could exit a user who chose to keep running.
- `UnansweredPrompt_LeavesTheWindowOpenRatherThanExiting` — "we could not ask" is not consent to quit. Losing a window is recoverable; exiting unasked during an operation is not.
- `CancellingRemembersNothing` — Cancel means "not now", so nothing is saved and the user is asked again.
- `EveryChoiceAndBehaviourIsResolved` — total by construction. The old `switch` relied on `default:` meaning Exit, which is only safe while every other member is listed above it; a new `CloseChoice` member would silently have become "exit the app".

**`ArchitectureTests.ClosingTheWindowToExit_RequestsAnApplicationShutdown`** pins the part unit tests cannot reach — that `OnClosing`'s body actually calls `Shutdown()` — with a vacuity floor (`Assert.Contains("CloseAction", body)`) so it cannot pass against an `OnClosing` that no longer decides anything.

## Regression proof (red → green)

```
===== RED =====
  [FAIL] CloseDecision exists
  [FAIL] OnClosing requests an application shutdown     ← the defect
  [FAIL] OnClosing routes through the testable decision
  [PASS] the hide-to-tray path is still there            ← control
  ... (8 total)
=== 8 FAILED ===

===== GREEN =====
  [PASS] a remembered Exit resolves to ExitApplication — ExitApplication
  [PASS] answering Cancel keeps the window open — KeepOpen
  [PASS] an unanswered prompt keeps the window open rather than exiting — KeepOpen
  [PASS] a remembered preference is not overridden by an answer
  [PASS] cancelling remembers nothing, so the user is asked again
  [PASS] OnClosing requests an application shutdown
  [PASS] the hide-to-tray path is still there
=== ALL PASS ===
```

The tray-path assertion is a deliberate control: a fix that exited on **every** close would be worse than the bug, since the whole point of tray mode is that closing can mean "keep running".

## Behaviour unchanged

Hide-to-tray and Cancel work exactly as before. I checked the original `switch` before writing the notes: `case CloseChoice.Cancel` already returned early and saved nothing, so Cancel was never mis-saved — the CHANGELOG says only what actually changed.

## Verification

- All four projects build Release: **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes` clean on all four.
- Leak scan over the diff against `leak-terms.txt`: 0 hits.
- Author headers present; no `MessageBox`, no generic catch, no debug code in the diff.
- Version 1.64.4 across the triple; CHANGELOG entry with the plain-English lead in this same PR.