### PR TITLE
fix: refuse a context-menu registry path that cannot be passed safely to reg.exe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.5] - 2026-08-12
+
+A right-click menu entry with an unusual name can no longer make SysManager write a file where it should
+not. Nothing about using the Context Menu tab changes.
+
+### Security
+- **A crafted right-click menu entry could redirect SysManager's backup file.** Before turning a right-click menu entry on or off, SysManager saves a copy of the relevant registry key so the change can be undone. It built the command for that backup using the entry's own name — and a program running on your PC can create an entry whose name contains a quotation mark, which broke the command apart and let the rest of the name decide where the backup was written. Since SysManager is often started as administrator, that file could have landed somewhere it had no business being. SysManager now checks the name first and skips the backup with a note in its log if the name cannot be used safely, instead of running the command anyway. Ordinary entry names — spaces, dashes, brackets, symbols — are unaffected, and the same check was already being applied elsewhere in SysManager for the same reason; this was the one place it had been missed.
+
+---
+
 ## [1.64.4] - 2026-08-12
 
 Choosing "close SysManager" now actually closes it. It used to leave SysManager running invisibly, with

--- a/SysManager/SysManager.Tests/ContextMenuServiceTests.cs
+++ b/SysManager/SysManager.Tests/ContextMenuServiceTests.cs
@@ -50,4 +50,47 @@ public class ContextMenuServiceTests
             CultureInfo.CurrentCulture = prev;
         }
     }
+
+    // ── Registry paths reach a reg.exe command line ─────────────────────────────────────────────────
+    // BackupRegistry interpolates the path into `reg export "{path}" "{file}" /y`. The path is built
+    // from a subkey NAME enumerated out of HKEY_CLASSES_ROOT, and HKCR\*\shell merges
+    // HKCU\Software\Classes — which an unprivileged user can write. A key name may legally contain a
+    // double quote, which closed the intended argument early and let further reg.exe arguments through,
+    // controlling the export destination. This validation is the ONLY defense, so it is tested
+    // explicitly, negative cases first.
+
+    [Theory]
+    [InlineData(@"HKCR\*\shell\evil"" ""C:\Windows\System32\out.reg"" /y")]  // the attack: destination hijack
+    [InlineData(@"HKCR\*\shell\has""quote")]                                 // a bare embedded quote
+    [InlineData("\"")]                                                       // nothing but a quote
+    [InlineData("HKCR\\*\\shell\\trailing\0dropped")]                        // NUL truncates the command line
+    [InlineData("")]                                                         // no path at all
+    [InlineData("   ")]                                                      // whitespace only
+    public void IsSafeRegistryPath_RejectsWhatCannotBePassedSafely(string path)
+        => Assert.False(ContextMenuService.IsSafeRegistryPath(path));
+
+    [Theory]
+    [InlineData(@"HKCR\*\shell\Open with Notepad")]     // spaces are fine — the argument stays quoted
+    [InlineData(@"HKCR\Directory\shell\cmd")]
+    [InlineData(@"HKCR\*\shell\7-Zip")]
+    [InlineData(@"HKCR\*\shell\Scan with Defender (2)")]  // parentheses are not shell metacharacters here
+    [InlineData(@"HKCR\*\shell\C# project")]              // # is legal in a key name
+    public void IsSafeRegistryPath_AcceptsRealWorldKeyNames(string path)
+        => Assert.True(ContextMenuService.IsSafeRegistryPath(path),
+            $"a legitimate key name must not be refused: {path}");
+
+    [Fact]
+    public void BackupRegistry_WithAHostilePath_ReturnsWithoutRunningRegExe()
+    {
+        // End-to-end on the real method: refusing must not become an exception either, because the
+        // backup is best-effort and a throw here would block the enable/disable the user asked for.
+        //
+        // Asserts only that the call returns. It deliberately does NOT count files in the real
+        // %LOCALAPPDATA%\SysManager\Backups: BackupRegistry has no injectable directory, so reading that
+        // folder would make the test depend on the developer's own data — the failure mode this repo has
+        // already had to fix twice (#1758, #1772). The refusal itself is proven by the IsSafeRegistryPath
+        // theories above; what this adds is that the guard short-circuits instead of throwing.
+        Assert.Null(Record.Exception(() =>
+            ContextMenuService.BackupRegistry(@"HKCR\*\shell\evil"" ""C:\Windows\System32\pwned.reg"" /y")));
+    }
 }

--- a/SysManager/SysManager/Services/ContextMenuService.cs
+++ b/SysManager/SysManager/Services/ContextMenuService.cs
@@ -246,11 +246,51 @@ public sealed partial class ContextMenuService
     }
 
     /// <summary>
+    /// True when <paramref name="registryPath"/> is safe to interpolate into a <c>reg.exe</c> command
+    /// line.
+    /// </summary>
+    /// <remarks>
+    /// SEC: the path is built from a subkey NAME enumerated out of HKEY_CLASSES_ROOT
+    /// (<c>GetSubKeyNames</c>), and <c>HKCR\*\shell</c> merges <c>HKCU\Software\Classes</c>, which an
+    /// unprivileged user can write. Registry key names may legally contain a double quote, so a key
+    /// named <c>evil" "C:\somewhere\out.reg" /y</c> closed the intended <c>"{fullPath}"</c> argument
+    /// early and appended further arguments to <c>reg.exe</c> — controlling the export DESTINATION.
+    /// With <c>UseShellExecute = false</c> that is argument injection rather than command chaining, so
+    /// the impact is bounded at writing a .reg export to a chosen path; but SysManager is commonly run
+    /// as administrator, and then that write lands with administrator rights outside the intended
+    /// backup root.
+    /// <para>The sanitisation that already existed applied only to the backup FILE NAME
+    /// (<c>Path.GetInvalidFileNameChars</c>); the value interpolated into the arguments was raw. The
+    /// identical guard is already applied to the analogous <c>schtasks</c> call in
+    /// <c>StartupService.SetTaskEnabled</c> — this is a missed instance of a pattern the project had
+    /// already decided on, which is why the check is that same shape rather than a new invention.</para>
+    /// <para>NUL is rejected for the reason it is in the sibling guard: it terminates the native command
+    /// line, so everything after it silently disappears.</para>
+    /// </remarks>
+    internal static bool IsSafeRegistryPath(string registryPath) =>
+        !string.IsNullOrWhiteSpace(registryPath)
+        && !registryPath.Contains('"')
+        && !registryPath.Contains('\0');
+
+    /// <summary>
     /// Exports the registry key to a .reg file before modification.
     /// Uses <c>reg export</c> which is available on all Windows versions.
     /// </summary>
     public static void BackupRegistry(string registryPath)
     {
+        // Refuse before anything is built: a path that cannot be passed safely cannot be backed up
+        // safely either, and the backup is best-effort — skipping one is strictly better than handing
+        // attacker-controlled arguments to a possibly-elevated reg.exe. Logged at Warning, unlike the
+        // ordinary "reg export returned non-zero" case below, because this means the enumerated key name
+        // itself is hostile.
+        if (!IsSafeRegistryPath(registryPath))
+        {
+            Log.Warning(
+                "Registry backup refused — the key name contains a character that cannot be passed "
+                + "safely to reg.exe: {Path}", registryPath);
+            return;
+        }
+
         try
         {
             var backupDir = Path.Combine(

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.64.4</Version>
-    <FileVersion>1.64.4.0</FileVersion>
-    <AssemblyVersion>1.64.4.0</AssemblyVersion>
+    <Version>1.64.5</Version>
+    <FileVersion>1.64.5.0</FileVersion>
+    <AssemblyVersion>1.64.5.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #1828

## Problem

`ContextMenuService.BackupRegistry` interpolated the registry path straight into a `reg.exe` command line:

```csharp
Arguments = $"export \"{fullPath}\" \"{backupFile}\" /y",
```

`fullPath` derives from `entry.RegistryPath`, built as `$@"HKCR\{subKey}\{entryName}"` where `entryName` is a **subkey name enumerated from HKEY_CLASSES_ROOT** (`GetSubKeyNames`). `HKCR\*\shell` merges `HKCU\Software\Classes`, which an **unprivileged user can write**, and registry key names may legally contain a double quote.

So a key named `evil" "C:\somewhere\out.reg" /y` closes the intended `"{fullPath}"` argument early and appends further arguments to `reg.exe` — controlling the export **destination**. `BackupRegistry` runs on every enable and disable, so nothing unusual is needed to reach it.

`UseShellExecute = false`, so this is argument injection rather than command chaining: the impact is bounded at writing a `.reg` export to a chosen path. But SysManager is commonly run as administrator, and then that write lands with administrator rights outside the intended `%LOCALAPPDATA%\SysManager\Backups\ContextMenu` root.

## Why the existing sanitisation did not cover it

`safeName` strips `Path.GetInvalidFileNameChars()` — but that value is used **only for the backup file name**. The value interpolated into the arguments was raw.

The correct guard already exists in this codebase for the analogous `schtasks` call, `StartupService.cs:538`:

```csharp
if (taskPath.Contains('"') || taskPath.Contains('\0'))
```

This is a **missed instance of a pattern the project had already decided on**, so the fix is deliberately that same shape rather than a new invention.

## Fix

`IsSafeRegistryPath` rejects a quote, a NUL (it terminates the native command line, so everything after it silently disappears) and a blank path. Two details that matter:

- **The refusal happens before any argument is built.** A path that cannot be passed safely cannot be backed up safely either.
- **It logs at Warning, not Debug.** The neighbouring "reg export returned non-zero" case is ordinary and logs at Debug; this one means the enumerated key name itself is hostile, which is worth seeing.

Skipping a best-effort backup is strictly better than handing attacker-controlled arguments to a possibly-elevated `reg.exe`, and the caller is unaffected — the backup never blocked the operation.

**Scope checked, not assumed:** `TrySetLegacyDisable` also receives this path, but passes it to `Registry.OpenSubKey`/`CreateSubKey`, which does no shell parsing. No guard is needed there, and adding one would only imply a risk that does not exist.

## Regression proof (red → green)

```
===== RED =====
  [FAIL] IsSafeRegistryPath exists
  [FAIL] BackupRegistry checks the path
  [FAIL] the check runs BEFORE the reg.exe arguments are built — one of them is missing
  ... (6 total)
=== 6 FAILED ===

===== GREEN =====
  [PASS] the destination-hijack key name is refused
  [PASS] a bare embedded quote is refused
  [PASS] a NUL is refused (it truncates the native command line)
  [PASS] a legitimate key name is accepted: HKCR\*\shell\Open with Notepad
  [PASS] a legitimate key name is accepted: HKCR\*\shell\Scan with Defender (2)
  [PASS] a legitimate key name is accepted: HKCR\*\shell\C# project
  [PASS] the check runs BEFORE the reg.exe arguments are built — guard@12575 args@13713
=== ALL PASS ===
```

The harness asserts the guard's **position by index** relative to the argument construction, not just its presence — a check placed after the interpolation would be useless.

**11 tests**, 6 negative (including the exact destination-hijack string) and **5 positive controls** with spaces, digits, dashes, parentheses and `#`. The positives are the important half: refusing legitimate key names would silently stop backups from happening at all, which is a quieter failure than the bug.

One test-hygiene note: `BackupRegistry_WithAHostilePath_ReturnsWithoutRunningRegExe` deliberately does **not** count files in the real `%LOCALAPPDATA%\SysManager\Backups`. `BackupRegistry` has no injectable directory, so reading that folder would make the test depend on the developer's own data — the failure mode this repo already had to fix in #1758 and #1772. It asserts only that the guard short-circuits instead of throwing; the refusal itself is proven by the theories.

## Verification

- All four projects build Release: **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes` clean on all four.
- Leak scan over the diff against `leak-terms.txt`: 0 hits.
- Version 1.64.5 across the triple; CHANGELOG entry with the plain-English lead in this same PR.