### PR TITLE
fix: cancel work in flight when a tab or the app is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.6] - 2026-08-12
+
+Closing a tab, or closing SysManager, now actually stops what that tab was doing. Scans, cleanups and
+file shredding used to keep running in the background after you closed them.
+
+### Fixed
+- **Work carried on after you closed the tab or the app.** Every tab that runs something you can wait on — a scan, a cleanup, a speed test, shredding files, the one-click Tune-Up — is supposed to stop when you close it. Behind the scenes, SysManager was releasing the "stop" signal without ever giving it, so 28 of those operations across 23 tabs simply carried on: file shredding kept overwriting files after you closed the window, Deep Cleanup and the browser cleaner kept deleting, a speed test kept using your connection, and the Tune-Up kept changing settings. Nothing was corrupted by this — the work was real work you had started — but it continued when you had every reason to think it had stopped, and it kept your PC busy after SysManager appeared to be gone. All of them now stop when you close the tab or quit, exactly as the Cancel button already did. A new automatic check makes sure a future tab cannot be added with the same mistake.
+
+---
+
 ## [1.64.5] - 2026-08-12
 
 A right-click menu entry with an unusual name can no longer make SysManager write a file where it should

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -616,6 +616,88 @@ public partial class ArchitectureTests
         Assert.Contains("Shutdown()", body);
     }
 
+    /// <summary>
+    /// A <c>Dispose</c> that disposes a <see cref="CancellationTokenSource"/> must cancel it first.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>CancellationTokenSource.Dispose()</c> does NOT cancel — that is documented behaviour, and it
+    /// is easy to read a lone <c>_cts?.Dispose()</c> as "stop the work" when it means the opposite. 28
+    /// sources across 23 view models had that shape, so closing a tab (or the whole app) left whatever
+    /// they started running: <c>FileShredderViewModel</c> kept overwriting files after teardown,
+    /// <c>DeepCleanupViewModel</c> and <c>BrowserCleanerViewModel</c> kept deleting, and
+    /// <c>DashboardViewModel</c>'s one-click Tune-Up kept mutating system state. Every one is reachable
+    /// at exit, because <c>MainWindowViewModel.Dispose</c> disposes each nav item.
+    /// </para>
+    /// <para>
+    /// Keyed on the FIELD DECLARATION, not on what the Dispose body mentions. Scanning the body alone
+    /// gets the answer wrong in both directions — it misses a class whose field is declared elsewhere and
+    /// it flags one that cancels through a differently-shaped call. I made both mistakes by hand while
+    /// triaging this, which is the argument for the check existing at all.
+    /// </para>
+    /// <para>
+    /// Accepts any cancel on the field (<c>_cts.Cancel()</c>, <c>_cts?.Cancel()</c>, or a
+    /// try/catch-wrapped one as <c>DnsHostsViewModel</c> uses), because the requirement is that
+    /// cancellation happens, not that it is spelled a particular way.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void EveryDisposedCancellationSource_IsCancelledFirst()
+    {
+        var vmDir = Path.Combine(FindAppProjectDir(), "ViewModels");
+        var offenders = new List<string>();
+        var checkedFields = 0;
+
+        foreach (var file in Directory.GetFiles(vmDir, "*.cs"))
+        {
+            var source = File.ReadAllText(file);
+
+            var start = source.IndexOf("protected override void Dispose(bool", StringComparison.Ordinal);
+            if (start < 0) continue;
+            var end = source.IndexOf("\n    }", start, StringComparison.Ordinal);
+            if (end < 0) continue;
+            var body = source[start..end];
+
+            // Fields this type declares as a cancellation source, however they are initialised.
+            var fields = new HashSet<string>(StringComparer.Ordinal);
+            foreach (Match m in CancellationFieldDeclaration().Matches(source))
+                fields.Add(m.Groups[1].Value);
+            foreach (Match m in CancellationFieldAssignment().Matches(source))
+                fields.Add(m.Groups[1].Value);
+
+            foreach (var field in fields)
+            {
+                if (!body.Contains($"{field}?.Dispose()", StringComparison.Ordinal)
+                    && !body.Contains($"{field}.Dispose()", StringComparison.Ordinal))
+                    continue;   // not disposed here — nothing to require
+
+                checkedFields++;
+                if (!body.Contains($"{field}?.Cancel()", StringComparison.Ordinal)
+                    && !body.Contains($"{field}.Cancel()", StringComparison.Ordinal))
+                    offenders.Add($"{Path.GetFileName(file)} · {field}");
+            }
+        }
+
+        // Vacuity floor: if the field-detection regexes stopped matching, every assertion here would
+        // pass while inspecting nothing.
+        Assert.True(checkedFields >= 25,
+            $"Expected at least 25 disposed cancellation sources, found {checkedFields} — " +
+            "the detection is probably no longer matching the field declarations.");
+
+        Assert.True(offenders.Count == 0,
+            "These cancellation sources are disposed without being cancelled, so work already in "
+            + "flight keeps running after teardown — Dispose() does not cancel. Add a Cancel() before "
+            + "the Dispose():\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>A field declared as a cancellation source, e.g. <c>private CancellationTokenSource? _cts;</c>.</summary>
+    [GeneratedRegex(@"CancellationTokenSource\??\s+(_[A-Za-z]\w*)", RegexOptions.Compiled)]
+    private static partial Regex CancellationFieldDeclaration();
+
+    /// <summary>A field assigned a new cancellation source, for types that declare it via <c>var</c>-like shapes.</summary>
+    [GeneratedRegex(@"(_[A-Za-z]\w*)\s*=\s*new CancellationTokenSource", RegexOptions.Compiled)]
+    private static partial Regex CancellationFieldAssignment();
+
     /// <summary>The app project directory — .xaml is not copied to the test output.</summary>
     private static string FindAppProjectDir()
     {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.64.5</Version>
-    <FileVersion>1.64.5.0</FileVersion>
-    <AssemblyVersion>1.64.5.0</AssemblyVersion>
+    <Version>1.64.6</Version>
+    <FileVersion>1.64.6.0</FileVersion>
+    <AssemblyVersion>1.64.6.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
@@ -203,6 +203,7 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
         {
             _winget.LineReceived -= _lineHandler;
             PropertyChanged -= OnVmPropertyChanged;
+            _cts?.Cancel();
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/BootAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BootAnalyzerViewModel.cs
@@ -111,6 +111,7 @@ public sealed partial class BootAnalyzerViewModel : ViewModelBase
         if (disposing)
         {
             PropertyChanged -= OnVmPropertyChanged;
+            _cts?.Cancel();
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/BrowserCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BrowserCleanerViewModel.cs
@@ -146,6 +146,7 @@ public sealed partial class BrowserCleanerViewModel : ViewModelBase
         {
             PropertyChanged -= OnVmPropertyChanged;
             foreach (var i in Items) i.PropertyChanged -= OnItemSelectionChanged;
+            _cts?.Cancel();
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
@@ -517,6 +517,7 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
         if (disposing)
         {
             PropertyChanged -= OnVmPropertyChanged;
+            _cts?.Cancel();
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -104,9 +104,13 @@ public sealed partial class CleanupViewModel : ViewModelBase
         {
             _runner.LineReceived -= OnRunnerLineReceived;
             _runner.ProgressChanged -= OnRunnerProgressChanged;
+            _tempCts?.Cancel();
             _tempCts?.Dispose();
+            _binCts?.Cancel();
             _binCts?.Dispose();
+            _sfcCts?.Cancel();
             _sfcCts?.Dispose();
+            _dismCts?.Cancel();
             _dismCts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -911,6 +911,7 @@ public sealed partial class DashboardViewModel : ViewModelBase
         {
             _pollingCts?.Cancel();
             _pollingCts?.Dispose();
+            _tuneUpCts?.Cancel();
             _tuneUpCts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/DebloaterViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DebloaterViewModel.cs
@@ -233,6 +233,7 @@ public sealed partial class DebloaterViewModel : ViewModelBase
         if (disposing)
         {
             PropertyChanged -= OnVmPropertyChanged;
+            _cts?.Cancel();
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
@@ -143,8 +143,11 @@ public sealed partial class DeepCleanupViewModel : ViewModelBase
         {
             foreach (var c in Categories)
                 c.PropertyChanged -= OnCategoryPropertyChanged;
+            _scanCts?.Cancel();
             _scanCts?.Dispose();
+            _cleanCts?.Cancel();
             _cleanCts?.Dispose();
+            _largeCts?.Cancel();
             _largeCts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
@@ -194,6 +194,7 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
     {
         if (disposing)
         {
+            _cts?.Cancel();
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/DriversViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DriversViewModel.cs
@@ -109,6 +109,7 @@ public sealed partial class DriversViewModel : ViewModelBase
         if (disposing)
         {
             PropertyChanged -= OnVmPropertyChanged;
+            _cts?.Cancel();
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
@@ -183,6 +183,7 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
     {
         if (disposing)
         {
+            _cts?.Cancel();
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/FileShredderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/FileShredderViewModel.cs
@@ -251,6 +251,7 @@ public sealed partial class FileShredderViewModel : ViewModelBase
     {
         if (disposing)
         {
+            _cts?.Cancel();
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -236,6 +236,7 @@ public sealed partial class LogsViewModel : ViewModelBase
         if (disposing)
         {
             PropertyChanged -= OnVmPropertyChanged;
+            _cts?.Cancel();
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/PrivacyMonitorViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PrivacyMonitorViewModel.cs
@@ -93,6 +93,7 @@ public sealed partial class PrivacyMonitorViewModel : ViewModelBase
         if (disposing)
         {
             PropertyChanged -= OnVmPropertyChanged;
+            _cts?.Cancel();
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/RestorePointsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/RestorePointsViewModel.cs
@@ -202,6 +202,7 @@ public sealed partial class RestorePointsViewModel : ViewModelBase
         if (disposing)
         {
             PropertyChanged -= OnVmPropertyChanged;
+            _cts?.Cancel();
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
@@ -173,6 +173,7 @@ public sealed partial class ShortcutCleanerViewModel : ViewModelBase
         {
             foreach (var s in BrokenShortcuts)
                 s.PropertyChanged -= OnShortcutPropertyChanged;
+            _cts?.Cancel();
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
@@ -209,6 +209,7 @@ public sealed partial class SpeedTestViewModel : ViewModelBase
     {
         if (disposing)
         {
+            _speedCts?.Cancel();
             _speedCts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/SystemFixesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemFixesViewModel.cs
@@ -139,6 +139,7 @@ public sealed partial class SystemFixesViewModel : ViewModelBase
         {
             _service.LineReceived -= OnLine;
             PropertyChanged -= OnVmPropertyChanged;
+            _cts?.Cancel();
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
@@ -78,6 +78,7 @@ public sealed partial class SystemHealthViewModel : ViewModelBase
         if (disposing)
         {
             _runner.LineReceived -= OnRunnerLineReceived;
+            _cts?.Cancel();
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/SystemReportViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemReportViewModel.cs
@@ -132,6 +132,7 @@ public sealed partial class SystemReportViewModel : ViewModelBase
         if (disposing)
         {
             PropertyChanged -= OnVmPropertyChanged;
+            _cts?.Cancel();
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/TracerouteViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TracerouteViewModel.cs
@@ -131,6 +131,7 @@ public sealed partial class TracerouteViewModel : ViewModelBase
             // NetworkSharedState is a DI singleton that outlives this VM, so a live handler here
             // would keep the VM alive for the rest of the session.
             Shared.PropertyChanged -= OnSharedPropertyChanged;
+            _traceCts?.Cancel();
             _traceCts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
@@ -320,6 +320,7 @@ public sealed partial class UninstallerViewModel : ViewModelBase
         {
             _service.LineReceived -= _lineHandler;
             PropertyChanged -= OnVmPropertyChanged;
+            _cts?.Cancel();
             _cts?.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -232,6 +232,7 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
             _runner.ProgressChanged -= OnRunnerProgressChanged;
             _wu.Log -= OnWuLog;
             PropertyChanged -= OnVmPropertyChanged;
+            _cts?.Cancel();
             _cts?.Dispose();
         }
         base.Dispose(disposing);


### PR DESCRIPTION
Closes #1836

## Problem

`CancellationTokenSource.Dispose()` does **not** cancel — that is documented behaviour, and a lone `_cts?.Dispose()` in a teardown path reads like "stop the work" while meaning the opposite. **28 sources across 23 view models** had that shape, so closing a tab (or the whole app) released the stop signal without ever giving it.

Concrete consequences, verified against source:

| View model | What kept running |
|---|---|
| `FileShredderViewModel` | a multi-pass overwrite — **still writing to disk** after teardown |
| `DeepCleanupViewModel` (3 sources) | deletion |
| `BrowserCleanerViewModel` | deletion |
| `DashboardViewModel._tuneUpCts` | the one-click Tune-Up, **mutating system state** |
| `SpeedTestViewModel` | a ~30 s transfer, then wrote results + `Progress<T>` callbacks into a disposed VM |
| `CleanupViewModel` (4 sources) | SFC / DISM / temp / recycle-bin operations |

`FileShredderViewModel` is the sharpest case: its own Cancel command *does* call `_cts?.Cancel()` (`:234`), so cancellation worked when the user asked for it and not when they quit.

`MainWindowViewModel.Dispose` disposes every nav item at shutdown, so all 28 are reachable at exit — not only on tab teardown.

## The convention already existed

Three view models get it right — `ProcessManagerViewModel`, `BandwidthMonitorViewModel` and `ResourceHistoryViewModel` (the latter two from the crash fixes in 1.63.1 and 1.64.1). This was a **half-applied convention**, not an open design question, so the sweep matches them rather than inventing anything.

**The diff in `ViewModels/` adds 28 `Cancel()` lines and nothing else** — verified by diffing for any added line that is not a `.Cancel();`.

## The ratchet is the real deliverable

I miscounted this **twice by hand, in opposite directions**, because I keyed on text inside the `Dispose` body:

- first too low — missed the multi-source classes (`CleanupViewModel` has 4, `DeepCleanupViewModel` 3) and `DashboardViewModel._tuneUpCts`;
- then with a false positive — `DnsHostsViewModel`, which *is* correct: it cancels inside a `try/catch (ObjectDisposedException)` without the `?.` my pattern required.

That is the argument for a mechanical check rather than 28 careful edits. `EveryDisposedCancellationSource_IsCancelledFirst`:

- keys on the **field declaration** (`CancellationTokenSource? _foo` or `_foo = new CancellationTokenSource`), not on what the body happens to mention;
- accepts **any** cancel spelling, because the requirement is that cancellation happens, not how it is written;
- carries a **vacuity floor of 25** so a regex that stops matching cannot read as success.

## Regression proof (red → green)

```
===== RED =====
       disposed sources: 35, not cancelled: 28
  [PASS] the scan actually inspected the view models — 35 found
  [FAIL] every disposed cancellation source is cancelled first — AppUpdatesViewModel·_cts, … +22 more
  [FAIL] FileShredderViewModel._cts is cancelled on teardown
  [FAIL] DeepCleanupViewModel._cleanCts is cancelled on teardown
  [FAIL] DashboardViewModel._tuneUpCts is cancelled on teardown
  [PASS] DnsHostsViewModel's existing try/catch cancel survived
=== 5 FAILED ===

===== GREEN =====
       disposed sources: 35, not cancelled: 0
=== ALL PASS ===
```

The red run independently reproduced the corrected count (28 of 35), which is what convinced me the third scan was right where two earlier ones were wrong. The three riskiest cases are asserted individually so a partial sweep cannot pass, and the `DnsHostsViewModel` line is a control: the sweep must not have removed a cancel that was already correct.

## Verification

- All four projects build Release: **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes` clean on all four.
- Leak scan over the diff against `leak-terms.txt`: 0 hits.
- Version 1.64.6 across the triple; CHANGELOG entry with the plain-English lead, stating plainly that nothing was corrupted — the work was real work the user started, it just continued past the point they stopped it.