### PR TITLE
test: serialize every test that touches a process-wide singleton

### DIFF
--- a/SysManager/SysManager.Tests/AppAlertsViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppAlertsViewModelTests.cs
@@ -11,7 +11,7 @@ namespace SysManager.Tests;
 // ClearHistory's confirmation gate swaps the global DialogService.Instance, so this class must
 // run in the serialized collection — otherwise a parallel class's substitute steals the Confirm
 // call and the gate assertions go flaky.
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class AppAlertsViewModelTests
 {
     [Fact]

--- a/SysManager/SysManager.Tests/AppBlockerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppBlockerViewModelTests.cs
@@ -12,7 +12,7 @@ namespace SysManager.Tests;
 
 // Serialized: the confirm-gate tests swap the static DialogService.Instance, which is
 // process-wide shared state (see the DialogService test-collection used elsewhere).
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class AppBlockerViewModelTests
 {
     // A blocker that reports nothing blocked — keeps the VM ctor's RefreshList()

--- a/SysManager/SysManager.Tests/AppUpdatesViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppUpdatesViewModelTests.cs
@@ -12,7 +12,7 @@ namespace SysManager.Tests;
 
 // Serialized: the confirmation-gate tests swap the static DialogService.Instance, which is
 // process-wide shared state. Required by ArchitectureTests.DialogServiceSwappers_AreInTheSerializedCollection.
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class AppUpdatesViewModelTests
 {
     private static readonly PowerShellRunner _sharedRunner = new();

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -148,50 +148,75 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
-    /// Any test class that swaps <c>DialogService.Instance</c> must be in the serialized collection.
+    /// Any test class that touches a process-wide mutable singleton must be in the serialized collection.
+    /// </summary>
+    /// <remarks>
     /// <para>
-    /// The collection exists and 24 classes use it correctly, but the attribute is easy to forget and
+    /// The collection exists and most classes use it correctly, but the attribute is easy to forget and
     /// nothing enforced it: <c>DebloaterViewModelTests</c> and <c>DialogServiceTests</c> both touched
-    /// the static while running in PARALLEL with the serialized group, because
+    /// <c>DialogService.Instance</c> while running in PARALLEL with the serialized group, because
     /// <c>parallelizeTestCollections</c> is true. The failure mode is not a clean crash — one class
     /// restores the singleton to a value another class is still using, so a confirmation gate answers
     /// with a foreign canned answer and a destructive-op test passes for the wrong reason.
     /// </para>
     /// <para>
-    /// Source-level, deliberately. The attribute is a compile-time fact about a test class, so a
-    /// reflection scan over the test assembly would work too — but reading the source also catches a
-    /// class that swaps the static inside a helper, and the same source-scan approach is already used
-    /// for the destructive-op logging guard in ActivityLogServiceTests.
+    /// This originally scanned for <c>DialogService.Instance</c> ONLY, and that gap let exactly the same
+    /// defect through for a second singleton: <c>CleanupViewModelTests</c> acquired the process-wide
+    /// <c>OperationLockService.Instance</c> and asserted which operation held it, with no collection
+    /// attribute at all. The list of watched statics is therefore data, not a hardcoded string — adding
+    /// the next one is one row.
     /// </para>
-    /// </summary>
+    /// <para>
+    /// Source-level, deliberately. The attribute is a compile-time fact so reflection would work too, but
+    /// reading the source also catches a class that touches the static inside a helper, and the same
+    /// approach is already used for the destructive-op logging guard in ActivityLogServiceTests.
+    /// </para>
+    /// </remarks>
     [Fact]
-    public void DialogServiceSwappers_AreInTheSerializedCollection()
+    public void ProcessWideStaticUsers_AreInTheSerializedCollection()
     {
+        // marker → what it is, for the failure message. Both shapes of the dialog swap count: assigning
+        // the static directly, or using the scoped DialogAnswer helper.
+        (string Marker, string What)[] watched =
+        [
+            ("DialogService.Instance =", "DialogService.Instance"),
+            ("new DialogAnswer(", "DialogService.Instance (via the DialogAnswer helper)"),
+            ("OperationLockService.Instance", "OperationLockService.Instance"),
+        ];
+
         var testDir = FindTestSourceDirectory();
         var offenders = new List<string>();
+        var inspected = 0;
 
         foreach (var file in Directory.GetFiles(testDir, "*.cs"))
         {
             var name = Path.GetFileName(file);
-            if (name is "DialogAnswer.cs" or "ArchitectureTests.cs") continue;   // the helper and this test
+            // The helper itself, this test, and the collection definitions are not test classes.
+            if (name is "DialogAnswer.cs" or "ArchitectureTests.cs" or "TestCollections.cs") continue;
 
             var source = File.ReadAllText(file);
 
-            // Either shape counts: assigning the static directly, or using the scoped helper — both
-            // install a substitute into process-wide state for the duration of the test.
-            var swaps = source.Contains("DialogService.Instance =", StringComparison.Ordinal)
-                     || source.Contains("new DialogAnswer(", StringComparison.Ordinal);
-            if (!swaps) continue;
+            var touched = watched.Where(w => source.Contains(w.Marker, StringComparison.Ordinal))
+                                 .Select(w => w.What)
+                                 .Distinct()
+                                 .ToList();
+            if (touched.Count == 0) continue;
 
-            if (!source.Contains("[Collection(\"DialogService\")]", StringComparison.Ordinal))
-                offenders.Add(name);
+            inspected++;
+            if (!source.Contains("[Collection(\"ProcessWideStatics\")]", StringComparison.Ordinal))
+                offenders.Add($"{name} — touches {string.Join(", ", touched)}");
         }
 
+        // Vacuity floor: if the markers stopped matching, this would pass while inspecting nothing.
+        Assert.True(inspected >= 25,
+            $"Expected at least 25 classes touching a process-wide singleton, found {inspected} — " +
+            "the markers are probably out of date.");
+
         Assert.True(offenders.Count == 0,
-            "These test classes swap the process-wide DialogService.Instance but are not in the " +
-            "serialized \"DialogService\" collection, so they race the classes that are — a test can " +
-            "restore a substitute another test is still using. Add [Collection(\"DialogService\")]:\n  " +
-            string.Join("\n  ", offenders));
+            "These test classes touch a process-wide mutable singleton but are not in the serialized "
+            + "\"ProcessWideStatics\" collection, so they race the classes that are — a test can observe "
+            + "state another test owns, and pass or fail for a foreign reason. Add "
+            + "[Collection(\"ProcessWideStatics\")]:\n  " + string.Join("\n  ", offenders));
     }
 
     /// <summary>

--- a/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
@@ -31,7 +31,7 @@ namespace SysManager.Tests;
 // DeletePreset's confirmation gate swaps the global DialogService.Instance, so this class must
 // run in the serialized collection — otherwise a parallel class's substitute steals the Confirm
 // call and the gate assertions go flaky.
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class AudioMixerViewModelTests
 {
     private static AudioSessionInfo Session(

--- a/SysManager/SysManager.Tests/CleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/CleanupViewModelTests.cs
@@ -15,7 +15,12 @@ namespace SysManager.Tests;
 /// Pure unit tests for <see cref="CleanupViewModel"/> that don't touch the
 /// real PowerShell runner, the WPF dispatcher, or spawn any processes.
 /// Heavier end-to-end scenarios live in SysManager.IntegrationTests.
+/// <para>Serialized because <c>SystemModificationLock_IsMutuallyExclusive</c> acquires the process-wide
+/// <see cref="OperationLockService"/> and asserts which operation holds it. Without the attribute this
+/// class ran fully in parallel with the other classes that take the same lock, so it could observe a
+/// foreign operation's name — or be observed holding one.</para>
 /// </summary>
+[Collection("ProcessWideStatics")]
 public class CleanupViewModelTests
 {
     private static CleanupViewModel NewVm() => new(new PowerShellRunner());

--- a/SysManager/SysManager.Tests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DashboardViewModelTests.cs
@@ -16,7 +16,7 @@ namespace SysManager.Tests;
 /// </summary>
 // Serialized: the confirm-gate tests swap the static DialogService.Instance,
 // which is process-wide shared state.
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class DashboardViewModelTests
 {
     private static DashboardViewModel NewVm(IWingetService? winget = null)

--- a/SysManager/SysManager.Tests/DebloaterViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DebloaterViewModelTests.cs
@@ -22,7 +22,7 @@ namespace SysManager.Tests;
 // that ARE in the collection (parallelizeTestCollections is true), so two tests could interleave
 // their save/restore and leave a foreign substitute installed in the singleton for the rest of the
 // run — a confirmation gate answering with another test's canned answer.
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class DebloaterViewModelTests
 {
     private static DebloaterViewModel NewVm() =>

--- a/SysManager/SysManager.Tests/DeepCleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupViewModelTests.cs
@@ -15,7 +15,7 @@ namespace SysManager.Tests;
 /// Pure unit tests for <see cref="DeepCleanupViewModel"/>.
 /// Heavier scan/clean tests that hit the real filesystem live in IntegrationTests.
 /// </summary>
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class DeepCleanupViewModelTests
 {
     private static DeepCleanupViewModel NewVm() => new(new Services.DeepCleanupService(), new Services.LargeFileScanner(), new Services.FixedDriveService());

--- a/SysManager/SysManager.Tests/DefenderViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DefenderViewModelTests.cs
@@ -17,7 +17,7 @@ namespace SysManager.Tests;
 /// (NotBusy) that serialises the mutating Defender commands so two overlapping
 /// Set-MpPreference operations can't race the read-back verification.
 /// </summary>
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class DefenderViewModelTests
 {
     private static DefenderViewModel NewVm()

--- a/SysManager/SysManager.Tests/DialogServiceTests.cs
+++ b/SysManager/SysManager.Tests/DialogServiceTests.cs
@@ -15,7 +15,7 @@ namespace SysManager.Tests;
 // Serialized: Instance_RejectsNull touches the static DialogService.Instance. The assignment is
 // rejected, so nothing is actually swapped — but the read-then-restore still races a parallel class
 // that IS mid-swap, which would restore that class's substitute after it had finished with it.
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class DialogServiceTests
 {
     [Fact]

--- a/SysManager/SysManager.Tests/DisplayProfileViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DisplayProfileViewModelTests.cs
@@ -15,7 +15,7 @@ namespace SysManager.Tests;
 /// ChangeDisplaySettingsEx) runs off the UI thread and the auto-revert DispatcherTimer
 /// keeps ticking during a mode switch.
 /// </summary>
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class DisplayProfileViewModelTests
 {
     private static DisplayProfileViewModel NewVm()

--- a/SysManager/SysManager.Tests/DnsHostsViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DnsHostsViewModelTests.cs
@@ -103,7 +103,7 @@ public class DnsHostsViewModelTests
 /// (never touches System32). <c>IsElevated</c> is set true in-test to pass the admin guard
 /// that sits before each gate.
 /// </summary>
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class DnsHostsViewModelGateTests
 {
     private const string TestInterfaceGuid = "11111111-2222-3333-4444-555555555555";

--- a/SysManager/SysManager.Tests/EdgeOneDriveViewModelTests.cs
+++ b/SysManager/SysManager.Tests/EdgeOneDriveViewModelTests.cs
@@ -19,7 +19,7 @@ namespace SysManager.Tests;
 /// binds to. The service is constructed over redirected HKCU roots and a substituted runner, so
 /// no process, scheduled task, or real machine key is touched.
 /// </summary>
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public sealed class EdgeOneDriveViewModelTests : IDisposable
 {
     private readonly string _rootName = @"Software\SysManagerTests\EdgeOneDriveVm_" + Guid.NewGuid().ToString("N");

--- a/SysManager/SysManager.Tests/FileLockViewModelTests.cs
+++ b/SysManager/SysManager.Tests/FileLockViewModelTests.cs
@@ -21,7 +21,7 @@ namespace SysManager.Tests;
 ///
 /// Serialized because several tests swap the global <see cref="DialogService.Instance"/> static.
 /// </summary>
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class FileLockViewModelTests
 {
     private static FileLockViewModel NewVm() => new(new FileLockService());

--- a/SysManager/SysManager.Tests/FileShredderViewModelTests.cs
+++ b/SysManager/SysManager.Tests/FileShredderViewModelTests.cs
@@ -17,7 +17,7 @@ namespace SysManager.Tests;
 /// ShredAll command routes through <see cref="DialogService.Instance"/>.Confirm
 /// (audit finding tests #2 — the "every destructive op needs Confirm" contract).
 /// </summary>
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class FileShredderViewModelTests
 {
     private static FileShredderViewModel NewVm() =>

--- a/SysManager/SysManager.Tests/GamingProfileViewModelTests.cs
+++ b/SysManager/SysManager.Tests/GamingProfileViewModelTests.cs
@@ -21,7 +21,7 @@ namespace SysManager.Tests;
 /// <para>Serialized on the DialogService collection: the Start/Stop confirm-gate tests swap
 /// the process-wide <see cref="DialogService.Instance"/>, matching the established pattern.</para>
 /// </summary>
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class GamingProfileViewModelTests
 {
     // Swap DialogService.Instance with a substitute that returns <paramref name="confirm"/>,

--- a/SysManager/SysManager.Tests/NetworkRepairViewModelTests.cs
+++ b/SysManager/SysManager.Tests/NetworkRepairViewModelTests.cs
@@ -9,7 +9,7 @@ using SysManager.ViewModels;
 namespace SysManager.Tests;
 
 // Serialized: the flush-DNS gate test swaps the static DialogService.Instance.
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class NetworkRepairViewModelTests
 {
     private static NetworkSharedState NewShared() =>

--- a/SysManager/SysManager.Tests/NotificationBlockerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/NotificationBlockerViewModelTests.cs
@@ -14,7 +14,7 @@ namespace SysManager.Tests;
 /// pending-change tracking (per-app and master), the confirm gate, partial-failure baseline
 /// handling, and discard — all against a substituted service (no registry).
 /// </summary>
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class NotificationBlockerViewModelTests
 {
     private static NotificationApp App(string aumid, bool enabled = true, string? name = null) =>

--- a/SysManager/SysManager.Tests/OperationLockServiceEdgeCaseTests.cs
+++ b/SysManager/SysManager.Tests/OperationLockServiceEdgeCaseTests.cs
@@ -5,7 +5,7 @@ using SysManager.Services;
 
 namespace SysManager.Tests;
 
-[Collection("OperationLock")]
+[Collection("ProcessWideStatics")]
 public class OperationLockServiceEdgeCaseTests
 {
     private static OperationLockService Service => OperationLockService.Instance;

--- a/SysManager/SysManager.Tests/OperationLockServiceTests.cs
+++ b/SysManager/SysManager.Tests/OperationLockServiceTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace SysManager.Tests;
 
-[Collection("OperationLock")]
+[Collection("ProcessWideStatics")]
 public class OperationLockServiceTests
 {
     private OperationLockService Sut => OperationLockService.Instance;

--- a/SysManager/SysManager.Tests/PerformanceSnapshotRestartTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceSnapshotRestartTests.cs
@@ -13,7 +13,7 @@ namespace SysManager.Tests;
 /// Regression coverage for the persisted Performance Mode recovery point.
 /// Every test uses an isolated directory and never touches the real app profile.
 /// </summary>
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public sealed class PerformanceSnapshotRestartTests
 {
     private static IPowerShellRunner NewRunner()

--- a/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
@@ -19,7 +19,7 @@ namespace SysManager.Tests;
 /// tests below swap the global <see cref="DialogService.Instance"/> and take the
 /// shared <see cref="OperationLockService"/>, both process-wide singletons.
 /// </remarks>
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class PerformanceViewModelTests
 {
     private static PerformanceViewModel NewVm(bool completeInitialization = false)

--- a/SysManager/SysManager.Tests/PrivacyViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PrivacyViewModelTests.cs
@@ -13,7 +13,7 @@ namespace SysManager.Tests;
 /// category filtering, pending-change tracking, and discard behavior
 /// without writing to the registry.
 /// </summary>
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class PrivacyViewModelTests
 {
     // The VM loads its toggles asynchronously off the UI thread (so startup isn't blocked);

--- a/SysManager/SysManager.Tests/ProcessManagerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ProcessManagerViewModelTests.cs
@@ -16,7 +16,7 @@ namespace SysManager.Tests;
 /// </summary>
 // Serialized: the kill-guard tests swap the static DialogService.Instance, which is
 // process-wide shared state.
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class ProcessManagerViewModelTests
 {
     [Fact]

--- a/SysManager/SysManager.Tests/RestorePointsViewModelTests.cs
+++ b/SysManager/SysManager.Tests/RestorePointsViewModelTests.cs
@@ -23,7 +23,7 @@ namespace SysManager.Tests;
 /// </remarks>
 // Serialized: these swap the static DialogService.Instance, which is process-wide shared state.
 // Required by ArchitectureTests.DialogServiceSwappers_AreInTheSerializedCollection.
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class RestorePointsViewModelTests
 {
     private static RestorePointsViewModel NewVm(out IPowerShellRunner runner)

--- a/SysManager/SysManager.Tests/ServicesViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ServicesViewModelTests.cs
@@ -22,7 +22,7 @@ namespace SysManager.Tests;
 /// </summary>
 // Serialized: the Enable-confirm tests swap the static DialogService.Instance, which is
 // process-wide shared state. Required by ArchitectureTests.DialogServiceSwappers_AreInTheSerializedCollection.
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class ServicesViewModelTests
 {
     private static readonly List<ServiceEntry> TestServices = new()

--- a/SysManager/SysManager.Tests/SettingsWatchdogViewModelTests.cs
+++ b/SysManager/SysManager.Tests/SettingsWatchdogViewModelTests.cs
@@ -10,7 +10,7 @@ using SysManager.ViewModels;
 namespace SysManager.Tests;
 
 // Serialized: the confirm-gate tests swap the static DialogService.Instance.
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class SettingsWatchdogViewModelTests
 {
     private static WatchedSetting Setting(string key) => new(

--- a/SysManager/SysManager.Tests/ShortcutCleanerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ShortcutCleanerViewModelTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 namespace SysManager.Tests;
 
 // Serialized: the DeleteSelected gate tests swap the static DialogService.Instance.
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class ShortcutCleanerViewModelTests
 {
     [Fact]

--- a/SysManager/SysManager.Tests/StartupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/StartupViewModelTests.cs
@@ -15,7 +15,7 @@ namespace SysManager.Tests;
 /// Serialized under the DialogService collection: the confirm-gate test swaps the
 /// process-wide static <see cref="DialogService.Instance"/>.
 /// </summary>
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class StartupViewModelTests
 {
     [Fact]

--- a/SysManager/SysManager.Tests/TestCollections.cs
+++ b/SysManager/SysManager.Tests/TestCollections.cs
@@ -12,26 +12,37 @@ namespace SysManager.Tests;
 public class NetworkCollection { }
 
 /// <summary>
-/// Groups tests that use the shared OperationLockService singleton so they
-/// run sequentially and avoid cross-test lock contention.
-/// </summary>
-[CollectionDefinition("OperationLock", DisableParallelization = true)]
-public class OperationLockCollection { }
-
-/// <summary>
 /// Groups tests that use the shared IconExtractorService static cache.
 /// </summary>
 [CollectionDefinition("IconCache", DisableParallelization = true)]
 public class IconCacheCollection { }
 
 /// <summary>
-/// Groups tests that swap the global <c>DialogService.Instance</c> static so they
-/// run sequentially. Without this, two collections setting the shared static in
-/// parallel race each other — one test's substitute receives (or misses) another's
-/// Confirm call, making the confirmation-gate tests flaky.
+/// Groups every test class that touches a process-wide mutable singleton — <c>DialogService.Instance</c>
+/// or <c>OperationLockService.Instance</c> — so they run sequentially.
 /// </summary>
-[CollectionDefinition("DialogService", DisableParallelization = true)]
-public class DialogServiceCollection { }
+/// <remarks>
+/// <para>
+/// Without serialization, two classes setting <c>DialogService.Instance</c> in parallel race each other:
+/// one test's substitute receives (or misses) another's Confirm call, so a confirmation gate answers with
+/// a foreign canned answer and a destructive-op test passes for the wrong reason.
+/// </para>
+/// <para>
+/// This replaces two separate collections, "DialogService" and "OperationLock", and the split was itself
+/// the defect rather than untidiness. <c>parallelizeTestCollections</c> is true, so two DIFFERENT
+/// serialized collections still run in parallel with EACH OTHER — and <c>PerformanceViewModelTests</c>
+/// and <c>ShortcutCleanerViewModelTests</c> touch both singletons. xUnit allows a class only one
+/// collection, so with two names those classes were serialized against the dialog group while racing the
+/// lock group, whichever name they picked. No correct answer was available.
+/// </para>
+/// <para>
+/// One collection spanning both statics is the only shape that can express "serialize against everything
+/// sharing this state". The cost is roughly 500 tests running sequentially instead of 460; the benefit is
+/// that a test asserting which operation holds the lock can no longer observe a foreign one.
+/// </para>
+/// </remarks>
+[CollectionDefinition("ProcessWideStatics", DisableParallelization = true)]
+public class ProcessWideStaticsCollection { }
 
 /// <summary>
 /// Groups tests that temporarily replace process environment variables.

--- a/SysManager/SysManager.Tests/TweaksHubViewModelTests.cs
+++ b/SysManager/SysManager.Tests/TweaksHubViewModelTests.cs
@@ -10,7 +10,7 @@ using SysManager.ViewModels;
 namespace SysManager.Tests;
 
 // Serialized: the confirm-gate tests swap the static DialogService.Instance.
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class TweaksHubViewModelTests
 {
     private static TweakItem Tweak(string name, string hive, bool applied)

--- a/SysManager/SysManager.Tests/UninstallerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/UninstallerViewModelTests.cs
@@ -106,7 +106,7 @@ public class UninstallerViewModelTests
 /// serialized "DialogService" collection. Process execution is substituted through
 /// <see cref="IPowerShellRunner"/> so success, failure, and cancellation stay deterministic.
 /// </summary>
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class UninstallerViewModelGateTests
 {
     private static UninstallerViewModel NewVm(IPowerShellRunner? runner = null)

--- a/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
+++ b/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
@@ -15,7 +15,7 @@ namespace SysManager.Tests;
 /// Tests that require PSWindowsUpdate module are in IntegrationTests.
 /// </summary>
 // Serialized: the confirm-gate test swaps the static DialogService.Instance.
-[Collection("DialogService")]
+[Collection("ProcessWideStatics")]
 public class WindowsUpdateViewModelTests
 {
     private static WindowsUpdateViewModel NewVm() => new(new PowerShellRunner(), new WindowsUpdateService(), new WindowsUpdatePolicyService());


### PR DESCRIPTION
## Problem

Two serialized xUnit collections do **not** serialize against each other. `parallelizeTestCollections` is `true`, so `"DialogService"` and `"OperationLock"` ran in parallel *with one another* — the split itself was the defect:

| Class | Collection | Touches |
|---|---|---|
| `CleanupViewModelTests` | **NONE** | `OperationLockService.Instance` |
| `OperationLockServiceTests` / `…EdgeCaseTests` | `OperationLock` | the lock |
| `PerformanceViewModelTests` | `DialogService` | **both** |
| `ShortcutCleanerViewModelTests` | `DialogService` | **both** |

- **`CleanupViewModelTests` had no collection at all.** `SystemModificationLock_IsMutuallyExclusive` acquires the process-wide lock and asserts *which operation holds it* (`Assert.Equal("SFC scan", …GetActiveOperationName(…))`), so it could observe a foreign operation's name — or be observed holding one by the classes that do serialize.
- **`PerformanceViewModelTests` and `ShortcutCleanerViewModelTests` touch both singletons.** xUnit allows one collection per class, so whichever name they picked they were serialized against one group while racing the other. **There was no correct answer available** — that is why this could not be fixed by adding an attribute.

This is the exact failure the `DialogService` ratchet was written to prevent, reaching a second singleton because the ratchet only watched the first.

## Fix

One `"ProcessWideStatics"` collection covering both statics — the only shape that can express "serialize against everything sharing this state". 31 classes now sit in it.

**Cost stated plainly:** ~500 tests run sequentially instead of ~460. The 40 extra are `CleanupViewModelTests` (48) and the two lock classes (24), minus overlap. That is the price of the assertions being meaningful.

**The ratchet had the same blind spot as the code.** `DialogServiceSwappers_AreInTheSerializedCollection` scanned for `DialogService.Instance` only — which is precisely how the identical defect reached `OperationLockService` unnoticed. It is now `ProcessWideStaticUsers_AreInTheSerializedCollection`, with the watched statics as a **data table** (adding the next one is a row) and a **vacuity floor of 25** so markers that stop matching cannot read as success.

## Regression proof (red → green)

```
===== RED =====
  [PASS] collections run in parallel (so a split into two groups is not serialisation)
       classes touching a process-wide singleton: 31
         DialogService: 28
         OperationLock: 2
         NONE: 1
  [FAIL] no class touches a process-wide singleton without a collection — CleanupViewModelTests.cs
  [FAIL] they are all in ONE serialized collection — DialogService + NONE + OperationLock
  [FAIL] a fitness function pins collection membership
  [FAIL] the fitness function watches OperationLockService, not only DialogService
=== 4 FAILED ===

===== GREEN =====
       classes touching a process-wide singleton: 31
         ProcessWideStatics: 31
=== ALL PASS ===
```

The harness asserts the **premise** it rests on — that `parallelizeTestCollections` is `true`, so a split into two groups really is not serialisation — and that the collection actually sets `DisableParallelization`. If either were false the whole finding would be moot, so neither is assumed.

`dotnet test` is banned on this workstation, so this is source-level analysis of the *configuration* that decides whether those classes can race, not an attempt to observe a flake. The race is a scheduling property; asserting the configuration is the deterministic version of the check.

## One thing bundled deliberately

Running `dotnet format` on this project also reflowed a multi-line LINQ chain I introduced in the Standby gate ratchet (#1832). That reflow is included here rather than deferred: it was only invisible because #1832 predates the format-gate fix in #1826, and leaving `main` red on formatting would block the next PR. It is whitespace only.

## Verification

- `SysManager.Tests` builds Release: **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes` on the test project: **exit 0** (the pre-existing `CA2255` on `TestAssemblyInit` is an analyzer suppression decision, unrelated and untouched).
- No dangling references to the old collection names anywhere in the solution.
- Leak scan over the diff against `leak-terms.txt`: 0 hits.
- `test:` — no version bump, no release.