### PR TITLE
fix: release the rollback verification handle on every exit path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.7] - 2026-08-12
+
+Internal hardening in the "go back to the previous version" check. Nothing you do with SysManager changes.
+
+### Fixed
+- **The rollback check could keep a saved version locked if reading it failed unexpectedly.** Before starting your previous version, SysManager opens the saved copy, locks it so nothing can swap it, and checks it against a recorded checksum. Every ordinary outcome — checksum missing, unreadable, or not matching — released that lock correctly. But if reading the file failed in an unusual way, the lock could be left in place until SysManager closed, and while it was held, no future update could refresh your saved copy — so you could quietly end up with an out-of-date version to go back to. The lock is now released the same way on every possible outcome, including ones that have not happened. Found by the project's own automated security scan flagging code added in 1.64.2; nobody reported it, and no user is known to have hit it.
+
+---
+
 ## [1.64.6] - 2026-08-12
 
 Closing a tab, or closing SysManager, now actually stops what that tab was doing. Scans, cleanups and

--- a/SysManager/SysManager.Tests/UpdateApplierTests.cs
+++ b/SysManager/SysManager.Tests/UpdateApplierTests.cs
@@ -605,4 +605,60 @@ public class UpdateApplierTests
         }
         finally { dir.Delete(recursive: true); }
     }
+
+    [Theory]
+    [InlineData(null)]           // no checksum file
+    [InlineData("")]             // present but empty
+    [InlineData("not-a-hash")]   // unusable
+    [InlineData("00000000000000000000000000000000000000000000000000000000000000FF")]  // valid shape, wrong value
+    public void VerifiedPreviousBuild_ReleasesTheHandleOnEveryRefusal(string? hashContent)
+    {
+        // The verification opens the retained build with FileShare.Read (deny-write) BEFORE hashing it.
+        // Every refusal path must close that handle, and a leak here is worse than an ordinary handle
+        // leak: while it is held, nothing can replace SysManager-previous.exe, so the next legitimate
+        // update silently fails to refresh the rollback copy and leaves the user with a stale one.
+        // Proven by DELETING the file afterwards — Windows refuses that while a handle is open, so a
+        // successful delete IS the evidence the handle was released.
+        var dir = Directory.CreateTempSubdirectory("ApplierHandle_");
+        try
+        {
+            var updates = Directory.CreateDirectory(Updates(dir)).FullName;
+            var previous = UpdateApplier.PreviousBuildPath(updates);
+            File.WriteAllText(previous, "some build");
+            if (hashContent is not null)
+                File.WriteAllText(UpdateApplier.PreviousBuildHashPath(updates), hashContent);
+
+            Assert.False(UpdateApplier.TryOpenVerifiedPreviousBuild(updates, out var stream, out _));
+            Assert.Null(stream);
+
+            File.Delete(previous);   // throws IOException if the handle is still open
+            Assert.False(File.Exists(previous));
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public void VerifiedPreviousBuild_OnSuccess_KeepsTheHandleOpenForTheCaller()
+    {
+        // The control for the test above: the success path must NOT release the handle, because holding it
+        // across Process.Start is the whole point — it is what stops the verified bytes being swapped
+        // between the check and the launch. A finally that disposed unconditionally would pass the
+        // refusal tests and silently destroy this guarantee.
+        var dir = Directory.CreateTempSubdirectory("ApplierHandle_");
+        try
+        {
+            var updates = Updates(dir);
+            var current = Path.Combine(dir.FullName, "SysManager.exe");
+            File.WriteAllText(current, "the outgoing build");
+            UpdateApplier.PreserveCurrentBuild(current, updates);
+
+            Assert.True(UpdateApplier.TryOpenVerifiedPreviousBuild(updates, out var stream, out var why), why);
+            using (stream)
+            {
+                Assert.NotNull(stream);
+                Assert.Throws<IOException>(() => File.Delete(UpdateApplier.PreviousBuildPath(updates)));
+            }
+        }
+        finally { dir.Delete(recursive: true); }
+    }
 }

--- a/SysManager/SysManager/Services/UpdateApplier.cs
+++ b/SysManager/SysManager/Services/UpdateApplier.cs
@@ -345,6 +345,15 @@ internal static class UpdateApplier
         var hashFile = PreviousBuildHashPath(updatesDir);
 
         FileStream? stream = null;
+        // Ownership transfers to the caller ONLY on the success path. Every other exit — an early return
+        // OR an exception of any type — must close the handle here, and a per-branch stream.Dispose()
+        // could not promise that: File.ReadAllText and SHA256.HashData can throw types outside the two
+        // catches below, and that path leaked the handle (CodeQL cs/dispose-not-called-on-throw).
+        //
+        // A leaked deny-write handle here is worse than an ordinary handle leak: nothing could replace
+        // SysManager-previous.exe until the process exited, so the NEXT legitimate update would fail to
+        // refresh the rollback copy and quietly leave the user with a stale one. A single finally keyed on
+        // whether ownership moved covers every exit, including ones not yet imagined.
         try
         {
             // Open with deny-write BEFORE hashing, and keep it open on the way out: from this point the
@@ -354,7 +363,6 @@ internal static class UpdateApplier
             if (!File.Exists(hashFile))
             {
                 reason = "there is no recorded checksum for the saved version";
-                stream.Dispose();
                 return false;
             }
 
@@ -362,7 +370,6 @@ internal static class UpdateApplier
             if (expected.Length != 64)
             {
                 reason = "the recorded checksum for the saved version is not readable";
-                stream.Dispose();
                 return false;
             }
 
@@ -373,7 +380,6 @@ internal static class UpdateApplier
                     "Rollback: retained build hash mismatch — expected {Expected}, got {Actual}",
                     expected, actual);
                 reason = "the saved version has changed since it was saved";
-                stream.Dispose();
                 return false;
             }
 
@@ -384,15 +390,19 @@ internal static class UpdateApplier
         {
             Log.Warning(ex, "Rollback: could not read the retained build to verify it");
             reason = "the saved version could not be read";
-            stream?.Dispose();
             return false;
         }
         catch (UnauthorizedAccessException ex)
         {
             Log.Warning(ex, "Rollback: access denied reading the retained build to verify it");
             reason = "the saved version could not be read";
-            stream?.Dispose();
             return false;
+        }
+        finally
+        {
+            // verifiedStream is non-null only where the caller took ownership; anywhere else the handle
+            // is still ours to close.
+            if (verifiedStream is null) stream?.Dispose();
         }
     }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.64.6</Version>
-    <FileVersion>1.64.6.0</FileVersion>
-    <AssemblyVersion>1.64.6.0</AssemblyVersion>
+    <Version>1.64.7</Version>
+    <FileVersion>1.64.7.0</FileVersion>
+    <AssemblyVersion>1.64.7.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem

CodeQL raised three `cs/dispose-not-called-on-throw` alerts against `TryOpenVerifiedPreviousBuild` — code that **v1.64.2 added earlier today**. The alerts are correct.

The method opens the retained build with `FileShare.Read` (deny-write) *before* hashing it, and transfers ownership to the caller only on success. Disposal was written **per branch**: each of the three early returns and both catches called `stream.Dispose()`. That covers every outcome I thought of and misses the ones I did not — `File.ReadAllText` and `SHA256.HashData` can throw types outside `IOException` / `UnauthorizedAccessException`, and that path leaked the handle.

**Consequence had it fired:** a leaked deny-write handle on `SysManager-previous.exe` means nothing can replace that file until the process exits — so the next legitimate update silently fails to refresh the rollback copy and leaves the user with a stale version to go back to. Worse than an ordinary handle leak, because the failure is invisible.

## Fix

Ownership expressed **once**, in a `finally` keyed on whether it moved:

```csharp
finally
{
    if (verifiedStream is null) stream?.Dispose();
}
```

That covers every exit including ones not yet imagined — the property the per-branch version could not have.

## Honest scope

**I could not construct a reachable throw for the uncovered path using real fixtures.** So this is *defensive hardening*, not a demonstrable user-facing bug, and I would rather say that than dress it up as a crash fix. The harness header states it too.

Concretely: the four behavioural checks **pass on the unfixed code as well**, because the pre-fix version did dispose correctly on all five paths it handled. They are regression protection; only the structural check distinguishes fixed from unfixed. That is the whole truth of the red/green here.

## What the tests actually prove

Ownership is proven **behaviourally**, not by reading code — Windows refuses to delete a file while a handle is open:

- `VerifiedPreviousBuild_ReleasesTheHandleOnEveryRefusal` (4 cases) — after each refusal, `File.Delete` **succeeds**. That success *is* the evidence the handle was released.
- `VerifiedPreviousBuild_OnSuccess_KeepsTheHandleOpenForTheCaller` — the control, and the important one: on success `File.Delete` must **throw**, because holding the handle across `Process.Start` is the entire point (it is what stops the verified bytes being swapped between check and launch). A naive `finally` that disposed unconditionally would pass all four refusal tests while silently destroying that guarantee. The harness additionally asserts the file becomes deletable again *after* the caller disposes it.

## Not fixed here, deliberately

CodeQL also raised three `cs/constant-condition` alerts on today's batches, at `ResourceHistoryViewModel.cs:160`, `:186` and `BandwidthMonitorViewModel.cs:264`. Those flag the post-await `if (_disposed)` and `if (_source is null)` guards — **which are the v1.63.1 and v1.64.1 crash fixes themselves**. CodeQL cannot see that `Dispose` mutates those fields from another path, so it reads the condition as constant. Removing them would reintroduce the crashes. Leaving them as open `note`-level alerts is the correct outcome; I am not suppressing them either, since a suppression comment would be a claim about CodeQL rather than about the code.

## Verification

- All four projects build Release: **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes` clean on all four.
- Leak scan over the diff against `leak-terms.txt`: 0 hits.
- Version 1.64.7 across the triple; CHANGELOG entry with the plain-English lead, stating plainly that nobody reported this and no user is known to have hit it.