### PR TITLE
ci: stop publishing a code-signing sponsor that has not accepted us

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,29 @@ jobs:
           if ($file -ne "$csproj.0") { throw "FileVersion ($file) does not match Version ($csproj)." }
           if ($asm -ne "$csproj.0") { throw "AssemblyVersion ($asm) does not match Version ($csproj)." }
 
+          # A code-signing attribution must never be published before a certificate exists. The README
+          # and the release-notes template both carried "Free code signing provided by SignPath.io,
+          # certificate by SignPath Foundation" in the present tense while no certificate had been
+          # issued — the Foundation had in fact declined the application. It reached 22 published
+          # release pages before anyone noticed, because the release template reproduces it every time.
+          # Claiming a sponsor that has not accepted you is a credibility problem, not a typo, so the
+          # claim is now blocked mechanically rather than trusted to review.
+          #
+          # When a certificate IS issued: delete this gate in the same PR that adds the attribution.
+          # That is the intended way out, and it makes the gate self-documenting rather than an
+          # obstacle someone works around.
+          $signingClaim = 'code signing provided by|certificate by \[?SignPath'
+          foreach ($file in @('README.md', '.github/workflows/release.yml')) {
+              $hit = Select-String -Path $file -Pattern $signingClaim
+              if ($hit) {
+                  throw "$file line $($hit[0].LineNumber) states a code-signing provider as fact: " +
+                        "'$($hit[0].Line.Trim())'. No certificate is in place, so this must not be " +
+                        "published. Remove the claim, or delete this gate in the same PR that adds a " +
+                        "real certificate."
+              }
+          }
+          Write-Host "No premature code-signing attribution found."
+
           # The newest CHANGELOG entry must be for that same version, or the release step that reads
           # release notes out of the CHANGELOG finds nothing.
           $head = (Select-String -Path CHANGELOG.md -Pattern '^## \[([0-9]+\.[0-9]+\.[0-9]+)\]' |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,10 +315,13 @@ jobs:
 
           ### Code signing policy
 
-          Free code signing provided by [SignPath.io](https://signpath.io/), certificate by
-          [SignPath Foundation](https://signpath.org/). Team roles, the release-approval process
-          and the privacy policy are documented under [Code signing
-          policy](https://github.com/laurentiu021/SystemManager#code-signing-policy).
+          This release is **not** code-signed. The team roles, release-approval process and
+          privacy policy required by the [SignPath Foundation](https://signpath.org/) programme
+          are documented in advance under [Code signing
+          policy](https://github.com/laurentiu021/SystemManager#code-signing-policy) — that
+          documentation is a prerequisite for applying, not evidence of a certificate. The
+          attribution line naming SignPath as the signing provider will appear here once a
+          certificate is actually issued.
 
           This program will not transfer any information to other networked systems unless
           specifically requested by the user or the person installing or operating it. Full

--- a/README.md
+++ b/README.md
@@ -1132,11 +1132,14 @@ first-launch prompt does not appear.
 
 ### Code signing
 
-Releases are currently **unsigned**, which is why the warning above appears. Code signing
-for this project is planned through the [SignPath Foundation](https://signpath.org/) — a
-programme that provides free code-signing certificates to open-source projects, with the
-signing itself performed by [SignPath.io](https://signpath.io/). Certificates issued under
-that programme are held in SignPath Foundation's name rather than an individual's.
+Releases are currently **unsigned**, which is why the warning above appears. The intention is
+to sign them through the [SignPath Foundation](https://signpath.org/) — a programme that
+provides free code-signing certificates to open-source projects, with the signing performed
+by [SignPath.io](https://signpath.io/) — and an application there is the plan for this
+project. It has not happened yet: the Foundation asks for a level of public visibility
+(stars, external write-ups, independent references) that a three-month-old project does not
+have, which is a fair bar for a certificate issued in their name. Until a certificate is
+actually in place, this section says so plainly rather than implying one exists.
 
 Until a certificate is in place, the two checks above — the published SHA-256 and the
 GitHub build-provenance attestation — are what establish that a download is the genuine,
@@ -1152,8 +1155,13 @@ quietly become a formality on the day signing is switched on. See
 
 ### Code signing policy
 
-*Free code signing provided by [SignPath.io](https://signpath.io/), certificate by
-[SignPath Foundation](https://signpath.org/).*
+> **Not yet in effect.** This policy is written in advance of any certificate, because the
+> [SignPath Foundation](https://signpath.org/) programme the project hopes to sign through
+> requires the roles and approval process below to be documented and public before an
+> application is considered. Nothing here describes a signing arrangement that exists today —
+> releases are unsigned, and the SHA-256 plus build attestation above are what verify a
+> download. The provider attribution that belongs in this section will be added on the day a
+> certificate is actually issued, and not a day earlier.
 
 **Team roles.** SysManager is maintained by a single developer, so all three roles below are
 held by the same person. That is stated plainly rather than dressed up as a team, because it


### PR DESCRIPTION
## Problem

The repo advertised SignPath as the signing provider **in the present tense** while no certificate existed — and the SignPath Foundation had **declined the application earlier the same day**, on the grounds that the project lacks public visibility.

Verified on three surfaces:

| Surface | Evidence |
|---|---|
| `README.md` | under `### Code signing policy` — the attribution stated as present fact |
| `.github/workflows/release.yml` | the same sentence baked into the release-notes template — so **every future release republished it automatically** |
| **22 published release pages** | v1.61.2 through v1.64.7, each confirmed to contain the string. It landed in `0e42740` (2026-08-11); v1.61.1 and older are clean |

Claiming a sponsor who has not accepted you is a credibility problem, not a typo. That is why this jumped ahead of feature work.

## What changed — and what deliberately did not

**Changed.** The `### Code signing` section now says plainly that releases are unsigned, that SignPath is still the **intended** route, and why it has not happened yet. The intent stays because it is true; only the false present tense is gone.

**Deliberately kept:**
- **The `### Code signing policy` heading**, with a note explaining it is written *in advance* because documenting these roles is a prerequisite for applying — not evidence of a certificate. Two inbound anchors depend on that heading (`SECURITY.md:261` and the release template), and the roles/approval block is exactly the evidence a future application needs. Deleting it would cost the re-application and break two links.
- **The whole Authors/Reviewers/Approvers and privacy block.** Accurate as-is.

**The release template** now states the release is not signed and that the policy is a prerequisite, so no future release can reproduce the claim.

## Fixed mechanically, not by intention

A CI gate rejects the attribution string in `README.md` and `release.yml`. Two design choices:

- **It documents its own removal.** The comment says to delete the gate *in the same PR that adds a real certificate* — an intended exit rather than something a future author works around.
- **Verified both ways before committing** — green on the corrected files, **red** against a copy with the old line restored (rejected at line 1157).

The gate also caught **my own first draft**, which quoted the forbidden sentence inside the explanation of why it was removed. The quote is gone. A gate that catches its author on day one is doing its job.

## Not done here

**The 22 published release bodies are not edited.** Each needs its own `gh release edit --notes` against a body containing code fences and SHA-256 values — a loose substitution would corrupt a published hash, which is worse than the wording. That is its own careful batch.

## Also checked, and NOT a defect

The 7 "Preview feature" markers in the README were suspected stale. **They are accurate** — `MainWindowViewModel.cs` has exactly 7 `inDevelopment: true` flags (lines 197, 200, 208, 212, 219, 245, 265: Tweaks Hub, Gaming Profile, Resource History, Settings Watchdog, Scheduled Maintenance, Notification Blocker, CLI Interface) and the README marks exactly those 7. All seven are genuinely implemented (61–343 lines each, real commands, 5 of 7 with test files), so whether to *drop* the flag is a product decision — not something to change silently in a correctness PR.

## Verification

- Both workflow files parse as YAML after the edit.
- No remaining present-tense signing claim anywhere in the tree.
- The two inbound anchors to `#code-signing-policy` still resolve.
- Leak scan over the diff: 0 hits.
- `ci:` — no version bump, no release.