### PR TITLE
fix: send every "ask a question" link to Q&A, not the announcements wall

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,11 @@
 blank_issues_enabled: false
 contact_links:
+  # Deep-links the Q&A category rather than the Discussions root. The root is dominated by
+  # auto-posted release announcements, so someone arriving with a question landed in a wall of
+  # changelogs and had to work out where to post. blank_issues_enabled is false, which makes this
+  # chooser the highest-traffic route of the four that pointed at the root.
   - name: Ask a question / general discussion
-    url: https://github.com/laurentiu021/SystemManager/discussions
+    url: https://github.com/laurentiu021/SystemManager/discussions/categories/q-a
     about: For how-to questions, help setting things up, or open-ended discussion.
   - name: Report a security vulnerability
     url: https://github.com/laurentiu021/SystemManager/security/advisories/new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.8] - 2026-08-12
+
+"Ask a question" now takes you to the questions area instead of the release-announcements wall.
+
+### Fixed
+- **Every "ask a question" link dropped you into a page of release notes.** The Ask a question button on the About tab, the link in the README, the one in SUPPORT.md, and the "Ask a question / general discussion" entry you see when you click New issue on GitHub all opened the top of Discussions. SysManager posts an announcement there for every release, and there have been hundreds — so the page you arrived at was a wall of changelogs, with the actual Q&A area a separate category you had to spot for yourself. All four links now open Q&A directly, so you land on the box where you type your question. The GitHub one mattered most: SysManager deliberately has no blank-issue option, so that chooser is what everyone sees first.
+
+---
+
 ## [1.64.7] - 2026-08-12
 
 Internal hardening in the "go back to the previous version" check. Nothing you do with SysManager changes.

--- a/README.md
+++ b/README.md
@@ -1267,8 +1267,8 @@ Found something broken? Missing a feature you'd love to have?
 - 💡 **Features** — [open an issue](https://github.com/laurentiu021/SystemManager/issues/new?template=feature_request.yml)
   using the feature request template.
 - 💬 **Questions and how-to's** — use
-  [Discussions](https://github.com/laurentiu021/SystemManager/discussions) instead
-  of issues for anything open-ended.
+  [Discussions › Q&A](https://github.com/laurentiu021/SystemManager/discussions/categories/q-a)
+  instead of issues for anything open-ended.
 - 🔒 **Security vulnerabilities** — please report privately via the
   [Security tab](https://github.com/laurentiu021/SystemManager/security/advisories/new).
   See [SECURITY.md](SECURITY.md) for the full policy.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -7,7 +7,7 @@ useful. Here's where to go depending on what you need.
 
 | Kind of question                                    | Go here                                                               |
 | --------------------------------------------------- | --------------------------------------------------------------------- |
-| "How do I...?" / "Is this possible?"                | [Discussions › Q&A](https://github.com/laurentiu021/SystemManager/discussions) |
+| "How do I...?" / "Is this possible?"                | [Discussions › Q&A](https://github.com/laurentiu021/SystemManager/discussions/categories/q-a) — nobody has asked anything there yet, so yours will be the first rather than buried |
 | "This feature would be useful"                      | [Feature request issue](https://github.com/laurentiu021/SystemManager/issues/new?template=feature_request.yml) |
 | "Something is broken"                               | [Bug report issue](https://github.com/laurentiu021/SystemManager/issues/new?template=bug_report.yml) |
 | "I found a security problem"                        | [Security Advisory](https://github.com/laurentiu021/SystemManager/security/advisories/new) (private) · see [SECURITY.md](SECURITY.md) |

--- a/SysManager/SysManager.Tests/AboutViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AboutViewModelTests.cs
@@ -381,6 +381,24 @@ public class AboutViewModelTests
         Assert.DoesNotContain('(', query);
         Assert.DoesNotContain(')', query);
     }
+
+    // ── QuestionsUrl (the "Ask a question" button) ──
+    // The button used to open the Discussions root, which every release fills with an auto-posted
+    // announcement — so a user looking for the question box landed in a wall of changelogs.
+
+    [Fact]
+    public void QuestionsUrl_DeepLinksTheQAndACategory_NotTheDiscussionsRoot()
+    {
+        var url = AboutViewModel.QuestionsUrl;
+
+        Assert.Equal(
+            $"https://github.com/{UpdateService.Owner}/{UpdateService.Repo}/discussions/categories/q-a",
+            url);
+        // The regression, stated as its own assertion: the root is not an acceptable answer.
+        Assert.NotEqual(
+            $"https://github.com/{UpdateService.Owner}/{UpdateService.Repo}/discussions",
+            url);
+    }
 }
 
 /// <summary>

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -723,6 +723,72 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"(_[A-Za-z]\w*)\s*=\s*new CancellationTokenSource", RegexOptions.Compiled)]
     private static partial Regex CancellationFieldAssignment();
 
+    /// <summary>
+    /// Every place that sends a user somewhere to ask a question must deep-link the Q&amp;A category,
+    /// never the Discussions root. Each release auto-posts an announcement, so the root is a wall of
+    /// changelogs; four separate surfaces (the in-app button, SUPPORT.md, README.md and the issue
+    /// chooser) all pointed there, and each was written independently — exactly the drift a fitness
+    /// function catches better than review does.
+    /// </summary>
+    [Fact]
+    public void EverySupportRoute_DeepLinksTheQuestionCategory_NotTheDiscussionsRoot()
+    {
+        var root = FindRepoRoot();
+        string[] surfaces = ["SUPPORT.md", "README.md", Path.Combine(".github", "ISSUE_TEMPLATE", "config.yml")];
+
+        var offenders = new List<string>();
+        var deepLinks = 0;
+
+        foreach (var relative in surfaces)
+        {
+            var path = Path.Combine(root, relative);
+            Assert.True(File.Exists(path), $"{relative} not found at {path} — the guard would pass vacuously");
+
+            var lines = File.ReadAllLines(path);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                foreach (var hit in DiscussionsRootLink().Matches(lines[i]).Cast<Match>())
+                    offenders.Add($"{relative}:{i + 1}  {hit.Value}");
+
+                deepLinks += QuestionCategoryLink().Matches(lines[i]).Count;
+            }
+        }
+
+        // Vacuity floor: the three doc surfaces plus the view-model must actually carry the deep link,
+        // so an accidental find-and-delete can't turn this into a test that asserts nothing.
+        Assert.True(deepLinks >= 3,
+            $"expected the Q&A deep link on all three doc surfaces, found {deepLinks} — the guard has gone vacuous");
+        Assert.Equal($"https://github.com/{UpdateService.Owner}/{UpdateService.Repo}/discussions/categories/q-a",
+            SysManager.ViewModels.AboutViewModel.QuestionsUrl);
+
+        Assert.True(offenders.Count == 0,
+            "these support routes still point at the Discussions root instead of /discussions/categories/q-a:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>A link to the Discussions root — <c>/discussions</c> not followed by a category path.</summary>
+    [GeneratedRegex(@"/discussions(?![/\w-])", RegexOptions.Compiled)]
+    private static partial Regex DiscussionsRootLink();
+
+    /// <summary>A link that correctly deep-links the Q&amp;A category.</summary>
+    [GeneratedRegex(@"/discussions/categories/q-a", RegexOptions.Compiled)]
+    private static partial Regex QuestionCategoryLink();
+
+    /// <summary>The repository root — the docs the guards read are not copied to the test output.</summary>
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "SUPPORT.md"))
+                && File.Exists(Path.Combine(dir.FullName, "README.md")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException(
+            "Could not locate the repository root from " + AppContext.BaseDirectory);
+    }
+
     /// <summary>The app project directory — .xaml is not copied to the test output.</summary>
     private static string FindAppProjectDir()
     {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.64.7</Version>
-    <FileVersion>1.64.7.0</FileVersion>
-    <AssemblyVersion>1.64.7.0</AssemblyVersion>
+    <Version>1.64.8</Version>
+    <FileVersion>1.64.8.0</FileVersion>
+    <AssemblyVersion>1.64.8.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -390,7 +390,21 @@ public sealed partial class AboutViewModel : ViewModelBase
 
     /// <summary>Opens Discussions for questions, mirroring SUPPORT.md's bug-vs-question split.</summary>
     [RelayCommand]
-    private void OpenDiscussions() => OpenUrl($"https://github.com/{UpdateService.Owner}/{UpdateService.Repo}/discussions");
+    private void OpenDiscussions() => OpenUrl(QuestionsUrl);
+
+    /// <summary>
+    /// The Q&amp;A category, not the Discussions root. Every release auto-posts an announcement, so the
+    /// root is a wall of changelogs — a user who pressed "Ask a question" landed there and had to work
+    /// out that Q&amp;A was a separate category further down the page. Deep-linking opens the right
+    /// category directly.
+    /// </summary>
+    /// <remarks>
+    /// <c>q-a</c> is GitHub's slug for the "Q&amp;A" category. The four support routes (this button,
+    /// SUPPORT.md, README.md and the issue-template chooser) must all point at the same place, so the
+    /// URL lives in one testable member rather than being interpolated at each call site.
+    /// </remarks>
+    internal static string QuestionsUrl =>
+        $"https://github.com/{UpdateService.Owner}/{UpdateService.Repo}/discussions/categories/q-a";
 
     /// <summary>
     /// The GitHub issue-form URL with the <c>version</c> and <c>elevation</c> fields pre-filled through


### PR DESCRIPTION
## Problem

Four separate places invite the user to ask a question, and all four opened the
**Discussions root**:

| Surface | Where |
|---|---|
| The in-app **"Ask a question"** button | `AboutViewModel.OpenDiscussions()`, bound in `AboutView.xaml` |
| `SUPPORT.md` | the "How do I…?" row — link *text* already said "Discussions › Q&A", the href did not |
| `README.md` | "Questions and how-to's" |
| `.github/ISSUE_TEMPLATE/config.yml` | the "Ask a question / general discussion" chooser entry |

Every release auto-posts an announcement discussion, and there are hundreds of
them. So the page a user landed on was a wall of changelogs, with Q&A a separate
category they had to notice for themselves.

The chooser entry is the highest-traffic of the four: `blank_issues_enabled: false`,
so *everyone* who presses **New issue** sees it.

Verified against the live repo before fixing: the Q&A category exists, and every
one of the discussions currently posted sits in Announcements — so the root
really is nothing but release notes.

## Fix

All four routes now deep-link `/discussions/categories/q-a`.

The URL moved into one place — `AboutViewModel.QuestionsUrl` — instead of being
interpolated at each call site. The four copies were written independently, which
is precisely how they came to differ from the link text next to them.

`SUPPORT.md` also says plainly that nobody has asked anything in Q&A yet, so a
first question reads as welcome rather than as arriving somewhere abandoned.

## Guard against recurrence

`ArchitectureTests.EverySupportRoute_DeepLinksTheQuestionCategory_NotTheDiscussionsRoot`
reads the three doc surfaces and fails on any `/discussions` not followed by a
category path, and asserts `QuestionsUrl` matches. Vacuity floor: at least three
deep links must be present, so deleting the links rather than fixing them cannot
make the guard pass.

`AboutViewModelTests.QuestionsUrl_DeepLinksTheQAndACategory_NotTheDiscussionsRoot`
pins the button's target, including an explicit `NotEqual` against the old root URL.

## Red → green proof

Throwaway harness against two worktrees (`origin/main` vs this branch). It reads
the doc surfaces from the target repo and reflects over the view-model; it does
not launch a browser.

**Red (unfixed `main` @ 66db1f6) — 5 failures, all for the intended reason:**

```
[FAIL] SUPPORT.md sends questions to the Q&A category, not the root — line 10: …/discussions
[FAIL] README.md sends questions to the Q&A category, not the root — line 1270: …/discussions
[FAIL] .github\ISSUE_TEMPLATE\config.yml sends questions to the Q&A category, not the root — line 4: …/discussions
[FAIL] all three surfaces actually carry the Q&A deep link — found 0
[FAIL] the button's target is defined in one testable place — AboutViewModel.QuestionsUrl does not exist
       OpenDiscussions source: private void OpenDiscussions() => OpenUrl($"https://github.com/{UpdateService.Owner}/{UpdateService.Repo}/discussions");
5 FAILED
```

**Green (this branch):**

```
[PASS] SUPPORT.md sends questions to the Q&A category, not the root
[PASS] README.md sends questions to the Q&A category, not the root
[PASS] .github\ISSUE_TEMPLATE\config.yml sends questions to the Q&A category, not the root
[PASS] all three surfaces actually carry the Q&A deep link — found 3
[PASS] the button opens the Q&A category — https://github.com/laurentiu021/SystemManager/discussions/categories/q-a
[PASS] OpenDiscussions command is still present
[PASS] the button is bound in AboutView.xaml
ALL PASS
```

The last two checks are regression protection: the button must stay bound in XAML,
so this cannot decay into a command nothing reaches.

## Verification

- `dotnet build` Release, app + tests: **0 errors, 0 warnings** (one xUnit2000 analyzer
  error on the first attempt — argument order in `Assert.Equal` — fixed before commit).
- `dotnet format --verify-no-changes` on both projects: exit 0.
- Propagate check: `grep -rn "/discussions"` across `*.md`, `*.yml`, `*.cs`, `*.xaml` —
  no bare-root link remains. `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` never linked
  Discussions. The remaining hits in `release.yml` are permission scopes and the
  announcement-posting step, not user-facing routes.
- Version bumped to 1.64.8; CHANGELOG entry added with its plain-English lead.
- `SECURITY.md` still reads `1.64.x`, so the supported-minor gate stays satisfied.
