### PR TITLE
ci: check the release-notes footer is ASCII on the PR, not at release time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,42 @@ jobs:
           }
           Write-Host "No premature code-signing attribution found."
 
+          # The release-notes footer that release.yml appends must be ASCII-only, and release.yml
+          # enforces that AT RELEASE TIME — which is too late: the check runs after the merge, so a
+          # single em dash in that template failed the v1.64.8 release and shipped no binary at all.
+          # The rule is now also checked here, on the pull request, where a violation is a red check
+          # instead of a missing release. Only the appended footer is constrained; the CHANGELOG body
+          # the notes are built from keeps its punctuation.
+          $releaseYml = Get-Content '.github/workflows/release.yml'
+          $start = ($releaseYml | Select-String -Pattern '^\s*\$template = @''' | Select-Object -First 1)
+          if (-not $start) {
+              throw "Could not find the release-notes template in .github/workflows/release.yml. " +
+                    "If it was renamed, update this gate in the same PR."
+          }
+          $end = $releaseYml |
+              Select-String -Pattern "^\s*'@\s*$" |
+              Where-Object { $_.LineNumber -gt $start.LineNumber } |
+              Select-Object -First 1
+          if (-not $end) { throw "The release-notes template is not terminated; check release.yml." }
+
+          $footer = $releaseYml[$start.LineNumber..($end.LineNumber - 2)]
+          $offenders = @()
+          for ($i = 0; $i -lt $footer.Count; $i++) {
+              foreach ($m in [regex]::Matches($footer[$i], '[^\x00-\x7F]')) {
+                  $offenders += "release.yml line $($start.LineNumber + $i + 1): '$($m.Value)'"
+              }
+          }
+          if ($offenders.Count -gt 0) {
+              throw "The appended release-notes footer must be ASCII-only (release.yml enforces this " +
+                    "at release time, which fails the release instead of the PR). Found: " +
+                    ($offenders -join '; ')
+          }
+          if ($footer.Count -lt 20) {
+              throw "Only $($footer.Count) template lines were scanned; the gate is not reading the " +
+                    "real footer. Fix the gate rather than trusting the pass."
+          }
+          Write-Host "Release-notes footer is ASCII-only ($($footer.Count) lines scanned)."
+
           # The newest CHANGELOG entry must be for that same version, or the release step that reads
           # release notes out of the CHANGELOG finds nothing.
           $head = (Select-String -Path CHANGELOG.md -Pattern '^## \[([0-9]+\.[0-9]+\.[0-9]+)\]' |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,7 +318,7 @@ jobs:
           This release is **not** code-signed. The team roles, release-approval process and
           privacy policy required by the [SignPath Foundation](https://signpath.org/) programme
           are documented in advance under [Code signing
-          policy](https://github.com/laurentiu021/SystemManager#code-signing-policy) — that
+          policy](https://github.com/laurentiu021/SystemManager#code-signing-policy). That
           documentation is a prerequisite for applying, not evidence of a certificate. The
           attribution line naming SignPath as the signing provider will appear here once a
           certificate is actually issued.


### PR DESCRIPTION
## What broke

The **v1.64.8 release failed and published nothing.** `d11245c` merged, the
release workflow ran, the exe built — and then this:

```
Exception: The appended verification notes must be ASCII-only;
found 1 non-ASCII character(s): —
```

`release.yml:321`, inside the appended release-notes footer:

```
policy](…#code-signing-policy) — that documentation is a prerequisite …
```

That em dash came from my own signing-attribution rewrite in #1844.

## Why the guard was right

The footer is deliberately ASCII-only: a non-ASCII character there is decoded
according to how the host reads the script file, so identical text can render as
mojibake under a different PowerShell host than CI's. It is published twice — the
release page and the Discussions announcement — so garbled output is visible to
every user. Failing the release is the correct response.

## Why it still needs fixing

The rule only ran **at release time**, i.e. after the merge. So one character cost
a version that built successfully and then shipped nothing, with no signal until
the release job died. CI was fully green on #1844.

Two changes, both needed — either alone leaves the failure mode reachable:

1. `release.yml:321` — em dash replaced with a full stop. Same meaning, ASCII.
2. `ci.yml` — the same ASCII rule now runs on the pull request, against
   `release.yml`'s template block, so a violation is a red check instead of a
   missing release.

The CI gate locates the template by its here-string delimiters and throws if it
cannot find them, or if it scanned fewer than 20 lines — a gate that silently
reads nothing is worse than no gate.

## Verification

Extracted the exact gate logic into a script and ran it against both trees:

```
=== RED (main, em dash present) ===
RED: release.yml line 321: '—'
exit=1

=== GREEN (this branch) ===
GREEN: footer ASCII-only, 47 lines scanned
exit=0
```

(Run locally under PowerShell 5.1, which reads the UTF-8 em dash as multiple ANSI
bytes and so reports it more than once; CI's pwsh 7 reports the single character.
Either way the gate blocks, and the gate uses no version-specific syntax.)

- Both workflow files re-parsed as YAML after the edit.
- `grep -P "[^\x00-\x7F]"` over the footer block: 0 hits.

## After merge

v1.64.8 is not published. This branch is `ci:`, so it does not release on its own —
the next `fix:`/`feat:` merge carries 1.64.8 out, or the tag can be pushed to
trigger `release.yml` directly.
