### PR TITLE
docs: give the README a table of contents and route rough ideas to Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,24 @@ winget install laurentiu021.SysManager
 
 ---
 
+## Table of contents
+
+- [What it is](#what-it-is)
+- [Why SysManager?](#why-sysmanager)
+- [Features](#features) — all 58 tabs, grouped
+- [Screenshots](#screenshots)
+- [Install](#install)
+- [Uninstalling](#uninstalling)
+- [Build from source](#build-from-source)
+- [First-time flow](#first-time-flow)
+- [Documentation](#documentation)
+- [Reporting bugs and requesting features](#reporting-bugs-and-requesting-features)
+- [Tech stack](#tech-stack)
+- [Privacy](#privacy)
+- [Contributing](#contributing)
+- [Support](#support)
+- [License](#license)
+
 ## What it is
 
 SysManager is a local-first desktop tool for keeping an eye on a Windows PC.
@@ -1273,7 +1291,9 @@ Found something broken? Missing a feature you'd love to have?
 - 🐛 **Bugs** — [open an issue](https://github.com/laurentiu021/SystemManager/issues/new?template=bug_report.yml)
   using the bug report template.
 - 💡 **Features** — [open an issue](https://github.com/laurentiu021/SystemManager/issues/new?template=feature_request.yml)
-  using the feature request template.
+  using the feature request template, or post in
+  [Discussions › Ideas](https://github.com/laurentiu021/SystemManager/discussions/categories/ideas)
+  if it's still a rough idea rather than a concrete request.
 - 💬 **Questions and how-to's** — use
   [Discussions › Q&A](https://github.com/laurentiu021/SystemManager/discussions/categories/q-a)
   instead of issues for anything open-ended.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -8,7 +8,7 @@ useful. Here's where to go depending on what you need.
 | Kind of question                                    | Go here                                                               |
 | --------------------------------------------------- | --------------------------------------------------------------------- |
 | "How do I...?" / "Is this possible?"                | [Discussions › Q&A](https://github.com/laurentiu021/SystemManager/discussions/categories/q-a) — nobody has asked anything there yet, so yours will be the first rather than buried |
-| "This feature would be useful"                      | [Feature request issue](https://github.com/laurentiu021/SystemManager/issues/new?template=feature_request.yml) |
+| "This feature would be useful"                      | [Feature request issue](https://github.com/laurentiu021/SystemManager/issues/new?template=feature_request.yml) — or [Discussions › Ideas](https://github.com/laurentiu021/SystemManager/discussions/categories/ideas) if it's still a half-formed thought |
 | "Something is broken"                               | [Bug report issue](https://github.com/laurentiu021/SystemManager/issues/new?template=bug_report.yml) |
 | "I found a security problem"                        | [Security Advisory](https://github.com/laurentiu021/SystemManager/security/advisories/new) (private) · see [SECURITY.md](SECURITY.md) |
 | "I want to contribute code or docs"                 | [CONTRIBUTING.md](CONTRIBUTING.md) |

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -774,6 +774,98 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"/discussions/categories/q-a", RegexOptions.Compiled)]
     private static partial Regex QuestionCategoryLink();
 
+    /// <summary>
+    /// Every discussion-category deep link must name a category that exists. GitHub answers an unknown
+    /// slug with a 404, and the docs are the one place a typo would go unnoticed — nothing compiles them.
+    /// The list mirrors the repository's configured categories.
+    /// </summary>
+    [Fact]
+    public void EveryDiscussionCategoryLink_NamesACategoryThatExists()
+    {
+        string[] slugs = ["announcements", "general", "ideas", "polls", "q-a", "show-and-tell"];
+        var root = FindRepoRoot();
+
+        var offenders = new List<string>();
+        var links = 0;
+
+        foreach (var path in Directory.EnumerateFiles(root, "*.md", SearchOption.TopDirectoryOnly)
+                     .Concat(Directory.EnumerateFiles(Path.Combine(root, ".github", "ISSUE_TEMPLATE"), "*.yml")))
+        {
+            var lines = File.ReadAllLines(path);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                foreach (var hit in CategoryLink().Matches(lines[i]).Cast<Match>())
+                {
+                    links++;
+                    var slug = hit.Groups[1].Value;
+                    if (!slugs.Contains(slug))
+                        offenders.Add($"{Path.GetFileName(path)}:{i + 1}  unknown category '{slug}'");
+                }
+            }
+        }
+
+        Assert.True(links >= 4, $"expected the category deep links to be present, found {links}");
+        Assert.True(offenders.Count == 0,
+            "these links name a discussion category that does not exist (GitHub answers 404):\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>A discussion-category deep link, capturing the slug.</summary>
+    [GeneratedRegex(@"/discussions/categories/([a-z0-9-]+)", RegexOptions.Compiled)]
+    private static partial Regex CategoryLink();
+
+    /// <summary>
+    /// The README's table of contents must resolve. It is 1300+ lines long, so the contents list is the
+    /// only practical way to navigate it — and a heading rename silently breaks an anchor, which renders
+    /// as a link that quietly does nothing rather than as an error.
+    /// </summary>
+    [Fact]
+    public void TheReadmeTableOfContents_HasNoDeadAnchors()
+    {
+        var lines = File.ReadAllLines(Path.Combine(FindRepoRoot(), "README.md"));
+
+        // GitHub's anchor rule: lower-case, drop everything but word characters, spaces and hyphens,
+        // then replace runs of whitespace with a single hyphen.
+        var anchors = lines
+            .Select(l => HeadingLine().Match(l))
+            .Where(m => m.Success)
+            .Select(m => Slug(m.Groups[1].Value))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var start = Array.FindIndex(lines, l => l.Trim() == "## Table of contents");
+        Assert.True(start >= 0, "README.md has no '## Table of contents' section — the guard is vacuous");
+
+        var dead = new List<string>();
+        var entries = 0;
+        for (var i = start + 1; i < lines.Length && !lines[i].StartsWith("## ", StringComparison.Ordinal); i++)
+        {
+            var m = InPageLink().Match(lines[i]);
+            if (!m.Success) continue;
+            entries++;
+            if (!anchors.Contains(m.Groups[1].Value))
+                dead.Add($"README.md:{i + 1}  #{m.Groups[1].Value}");
+        }
+
+        Assert.True(entries >= 10, $"expected the full contents list, found {entries} entries");
+        Assert.True(dead.Count == 0,
+            "these table-of-contents links point at headings that do not exist:\n  " + string.Join("\n  ", dead));
+    }
+
+    private static string Slug(string heading) =>
+        WhitespaceRun().Replace(NonAnchorCharacter().Replace(heading.Trim().ToLowerInvariant(), string.Empty).Trim(), "-");
+
+    /// <summary>A markdown heading of level 2 or deeper, capturing its text.</summary>
+    [GeneratedRegex(@"^#{2,}\s+(.*)$", RegexOptions.Compiled)]
+    private static partial Regex HeadingLine();
+
+    /// <summary>An in-page markdown link, capturing the anchor.</summary>
+    [GeneratedRegex(@"\]\(#([^)]+)\)", RegexOptions.Compiled)]
+    private static partial Regex InPageLink();
+
+    /// <summary>Characters GitHub strips when building an anchor.</summary>
+    [GeneratedRegex(@"[^\w\s-]", RegexOptions.Compiled)]
+    private static partial Regex NonAnchorCharacter();
+
     /// <summary>The repository root — the docs the guards read are not copied to the test output.</summary>
     private static string FindRepoRoot()
     {


### PR DESCRIPTION
## Two navigation gaps

Both from the reach audit, both re-verified against the current files before fixing.

### 1. A 1349-line README with no contents list

15 top-level sections, no table of contents. `CONTRIBUTING.md` — 237 lines, a fifth
the length — has one. So the longer document was the one you had to scroll.

Added a contents list covering all 15 sections, in the same style
`CONTRIBUTING.md` already uses. Part of #1668.

### 2. Nowhere to put a rough idea

The feature rows in `README.md` and `SUPPORT.md` offered only the issue template.
A half-formed thought therefore had to be filed as a formal feature request or not
raised at all. Discussions has an **Ideas** category — verified live, slug `ideas`,
currently empty — and nothing linked it.

Both surfaces now offer Ideas alongside the template, for when a request is not yet
concrete. Part of #1665 (whose Q&A half shipped in v1.64.8).

## Guards

Nothing compiles a markdown link, so both classes of breakage are silent:

- `EveryDiscussionCategoryLink_NamesACategoryThatExists` — scans every root `.md`
  and every issue-template `.yml` for `/discussions/categories/<slug>` and fails on
  a slug the repository does not have. GitHub answers an unknown slug with a 404.
- `TheReadmeTableOfContents_HasNoDeadAnchors` — recomputes each heading's anchor with
  GitHub's own rule (lower-case, strip all but word characters/space/hyphen, spaces to
  hyphens) and fails on a contents link that resolves to nothing. A heading rename
  breaks an anchor with no error anywhere.

Both have vacuity floors (≥4 category links, ≥10 contents entries), so deleting the
content cannot turn either into a test that asserts nothing.

## Red → green proof

Harness against two worktrees, reading the docs from the target repo:

**Red (`d11245c`):**

```
       README is 1329 lines with 15 listable sections
[FAIL] README has a table of contents — no '## Table of contents' heading
[FAIL] README.md offers Ideas alongside the feature-request template — the issue template is the only route offered
[FAIL] SUPPORT.md offers Ideas alongside the feature-request template — the issue template is the only route offered
[PASS] every category deep link names a category that exists — 3 links checked
3 FAILED
```

**Green (this branch):**

```
       README is 1349 lines with 15 listable sections
[PASS] README has a table of contents — line 38
[PASS] the contents list covers every top-level section — 15 entries for 15 sections
[PASS] every contents link resolves to a real heading — 15 anchors checked
[PASS] README.md offers Ideas alongside the feature-request template
[PASS] SUPPORT.md offers Ideas alongside the feature-request template
[PASS] every category deep link names a category that exists — 5 links checked
ALL PASS
```

The "covers every section" check found a real off-by-one in my first draft (the
contents heading counting itself), which is why the count is asserted rather than
just the presence of a list.

## Verification

- `dotnet build` Release on the tests project: 0 errors, 0 warnings. (First attempt
  failed with CS0756 — `WhitespaceRun()` already existed in the file; reused the
  existing one rather than adding a second.)
- `dotnet format --verify-no-changes`: exit 0.
- Category slugs confirmed live via GraphQL: `announcements, general, ideas, polls,
  q-a, show-and-tell`.
- Leak scan over the added lines against `leak-terms.txt`: 0 hits.
- No app code touched, so no version bump — `docs:` does not release, and v1.64.8 is
  already tagged and pending.
