### PR TITLE
docs: make the templates, badges and storage table match the app

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,8 +19,10 @@ body:
     id: version
     attributes:
       label: SysManager version
-      description: Visible in the **About** tab. Example: `0.12.1`.
-      placeholder: "0.12.1"
+      description: >-
+        Shown at the top of the **About** tab, and in the title bar. The "Copy environment info"
+        button there puts it on your clipboard along with your Windows version.
+      placeholder: e.g. the version shown on the About tab
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -44,22 +44,64 @@ body:
       multiple: true
       options:
         - Dashboard
-        - App updates
+        - System Health
         - Windows Update
-        - System health
-        - Cleanup
-        - Deep cleanup
-        - Startup
-        - Duplicates
+        - Performance Mode
+        - Services
+        - Startup Manager
+        - Windows Features
+        - Restore Points
+        - Task Scheduler
+        - Boot Analyzer
+        - System Fixes
+        - Tweaks Hub
+        - Gaming Profile
+        - Standby List Cleaner
+        - Timer Resolution
+        - CPU Core Affinity
+        - Display Profiles
+        - Process Manager
+        - Resource History
+        - Camera/Mic/Location
+        - App Alerts
+        - File Lock Detector
+        - Settings Watchdog
+        - Bandwidth Monitor
+        - Quick Cleanup
+        - Deep Cleanup
+        - Shortcut Cleaner
+        - Scheduled Maintenance
         - Disk Analyzer
-        - Processes
-        - Battery
+        - Duplicate Finder
+        - Ping
+        - Traceroute
+        - Speed Test
+        - Network Repair
+        - DNS & Hosts
+        - App Updates
+        - Bulk Installer
         - Uninstaller
-        - Performance
-        - Network
+        - Privacy & Telemetry
+        - File Shredder
+        - App Blocker
+        - Debloater & Ads
+        - Browser Cleaner
+        - Edge/OneDrive Remover
+        - Defender Tweaks
+        - Notification Blocker
+        - Context Menu
+        - Dark Mode Scheduler
+        - Volume Control
         - Drivers
-        - Logs
-        - About / updates
+        - Battery Health
+        - System Logs
+        - System Report
+        - Legacy Panels
+        - About
+        - Profile Export/Import
+        - CLI Interface
+        - Environment Variables
+        - Multiple / general UI
         - New tab / cross-cutting
 
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/general_issue.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue.yml
@@ -30,8 +30,8 @@ body:
     id: version
     attributes:
       label: SysManager version
-      description: Visible in the **About** tab.
-      placeholder: "0.12.5"
+      description: Shown at the top of the **About** tab, and in the title bar.
+      placeholder: e.g. the version shown on the About tab
     validations:
       required: true
 
@@ -42,22 +42,63 @@ body:
       multiple: true
       options:
         - Dashboard
-        - App updates
+        - System Health
         - Windows Update
-        - System health
-        - Cleanup
-        - Deep cleanup
-        - Startup
-        - Duplicates
+        - Performance Mode
+        - Services
+        - Startup Manager
+        - Windows Features
+        - Restore Points
+        - Task Scheduler
+        - Boot Analyzer
+        - System Fixes
+        - Tweaks Hub
+        - Gaming Profile
+        - Standby List Cleaner
+        - Timer Resolution
+        - CPU Core Affinity
+        - Display Profiles
+        - Process Manager
+        - Resource History
+        - Camera/Mic/Location
+        - App Alerts
+        - File Lock Detector
+        - Settings Watchdog
+        - Bandwidth Monitor
+        - Quick Cleanup
+        - Deep Cleanup
+        - Shortcut Cleaner
+        - Scheduled Maintenance
         - Disk Analyzer
-        - Processes
-        - Battery
+        - Duplicate Finder
+        - Ping
+        - Traceroute
+        - Speed Test
+        - Network Repair
+        - DNS & Hosts
+        - App Updates
+        - Bulk Installer
         - Uninstaller
-        - Performance
-        - Network
+        - Privacy & Telemetry
+        - File Shredder
+        - App Blocker
+        - Debloater & Ads
+        - Browser Cleaner
+        - Edge/OneDrive Remover
+        - Defender Tweaks
+        - Notification Blocker
+        - Context Menu
+        - Dark Mode Scheduler
+        - Volume Control
         - Drivers
-        - Logs
-        - About / updates
+        - Battery Health
+        - System Logs
+        - System Report
+        - Legacy Panels
+        - About
+        - Profile Export/Import
+        - CLI Interface
+        - Environment Variables
         - Multiple / general UI
         - Not sure
     validations:

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ toggle, and a friendly Event Log viewer — all in one WPF desktop app.
 [![CodeQL](https://github.com/laurentiu021/SystemManager/actions/workflows/codeql.yml/badge.svg)](https://github.com/laurentiu021/SystemManager/actions/workflows/codeql.yml)
 [![codecov](https://codecov.io/gh/laurentiu021/SystemManager/branch/main/graph/badge.svg)](https://codecov.io/gh/laurentiu021/SystemManager)
 [![Release](https://img.shields.io/github/v/release/laurentiu021/SystemManager?display_name=tag&sort=semver)](https://github.com/laurentiu021/SystemManager/releases/latest)
-[![Downloads](https://img.shields.io/github/downloads/laurentiu021/SystemManager/total)](https://github.com/laurentiu021/SystemManager/releases)
+[![Asset downloads](https://img.shields.io/github/downloads/laurentiu021/SystemManager/total?label=asset%20downloads)](https://github.com/laurentiu021/SystemManager/releases)
 [![Issues](https://img.shields.io/github/issues/laurentiu021/SystemManager)](https://github.com/laurentiu021/SystemManager/issues)
 ![Platform](https://img.shields.io/badge/platform-Windows%2010%2B-blue)
 ![.NET](https://img.shields.io/badge/.NET-10.0-512BD4)
-[![winget](https://img.shields.io/badge/winget-laurentiu021.SysManager-0078D4?logo=windows)](https://github.com/laurentiu021/SystemManager/releases/latest)
+[![winget](https://img.shields.io/badge/winget-laurentiu021.SysManager-0078D4?logo=windows)](https://github.com/microsoft/winget-pkgs/tree/master/manifests/l/laurentiu021/SysManager)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/laurentiu021/SystemManager?style=social)](https://github.com/laurentiu021/SystemManager/stargazers)
 
@@ -1086,6 +1086,13 @@ Grab `SysManager-v<version>.exe` (the `<version>` shown on the latest release) f
 [latest release](https://github.com/laurentiu021/SystemManager/releases/latest)
 and double-click it. The executable is self-contained — no installer, no .NET
 runtime required.
+
+> **About the download counter.** The badge above counts release-asset downloads, not
+> people. Most of that number is machinery: SysManager's own in-app updater fetches the
+> exe, winget installs fetch it, and Microsoft's manifest validation fetches it for every
+> submitted version. Across all releases the exe has been fetched roughly 88 times for
+> every checksum file — and a human verifying a download takes both. Treat the badge as
+> traffic, not as an install base.
 
 ### Verifying the download
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -172,7 +172,7 @@ app.
 
 | What | Where | Why it exists |
 |---|---|---|
-| Appearance and theme choice | `%LocalAppData%\SysManager` | So the app looks the same next launch |
+| Appearance and theme choice | `%AppData%\SysManager` | So the app looks the same next launch |
 | Dark-mode schedule | `%AppData%\SysManager` | Your chosen on/off times |
 | Speed-test history | `%LocalAppData%\SysManager` | So you can compare results over time |
 | Recent-activity list | `%LocalAppData%\SysManager` | Counts and sizes of actions you performed — never file names |
@@ -180,6 +180,13 @@ app.
 | Resource history | `%LocalAppData%\SysManager` | CPU / RAM / temperature samples, for the history graphs |
 | Diagnostic log | `%LocalAppData%\SysManager\logs` | 14 days of rolling files, so a problem can be diagnosed |
 | Downloaded updates | `%LocalAppData%\SysManager\updates` | The build you downloaded, plus one previous version for rollback |
+| Startup version-check on/off | `%AppData%\SysManager` | The About-tab checkbox that controls the once-a-day version check |
+| Your saved sets and choices | `%LocalAppData%\SysManager` | Gaming profiles, volume presets, what closing the window does, the standby-cleaner choice, saved environment variables |
+| State the app keeps to undo its own changes | `%LocalAppData%\SysManager` | A performance snapshot to restore from, a ledger of the service startup types it changed, whether the last session crashed, cached app-icon lookups |
+
+Every one of these sits inside your own user profile, opens in a text editor, and can be
+deleted without breaking the app. Two folders are involved only because Windows separates
+roaming settings from machine-local data; nothing is hidden in either.
 
 Your Windows user name is replaced with `[user]` in every log line — including
 inside error messages — so a log you choose to share does not carry your account

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -815,6 +815,132 @@ public partial class ArchitectureTests
     private static partial Regex CategoryLink();
 
     /// <summary>
+    /// Every issue template that asks which tab is affected must offer the real tabs. Two of the three
+    /// templates were still offering an 18-entry list from when the app had roughly that many tabs, with
+    /// names that no longer matched the sidebar ("Cleanup" for "Quick Cleanup") and one entry — "Network"
+    /// — that is a nav group, not a tab. A reporter could not name 41 of the 58 tabs, so reports arrived
+    /// mis-labelled or unlabelled. Nothing compiles a YAML dropdown, so only a test catches the drift.
+    /// </summary>
+    [Theory]
+    [InlineData("bug_report.yml", "tab")]
+    [InlineData("feature_request.yml", "scope")]
+    [InlineData("general_issue.yml", "tab")]
+    public void EveryIssueTemplateTabList_OffersTheRealTabs(string template, string dropdownId)
+    {
+        var labels = SidebarTabLabels();
+        Assert.True(labels.Count >= 50,
+            $"only {labels.Count} tab labels were parsed from MainWindowViewModel — the guard is vacuous");
+
+        var options = DropdownOptions(
+            Path.Combine(FindRepoRoot(), ".github", "ISSUE_TEMPLATE", template), dropdownId);
+        Assert.NotEmpty(options);
+
+        // Every real tab must be offerable. Extra options are fine: each template ends with its own
+        // catch-alls ("Not sure", "New tab / cross-cutting"), which are deliberate, not tab names.
+        var missing = labels.Where(l => !options.Contains(l)).ToList();
+        Assert.True(missing.Count == 0,
+            $"{template} ({dropdownId}) cannot describe {missing.Count} of the {labels.Count} tabs:\n  "
+            + string.Join("\n  ", missing));
+
+        // And no option may name a tab that does not exist — a stale name is as misleading as a gap.
+        string[] catchAlls = ["Multiple / general UI", "Not sure", "New tab / cross-cutting"];
+        var unknown = options.Where(o => !labels.Contains(o) && !catchAlls.Contains(o)).ToList();
+        Assert.True(unknown.Count == 0,
+            $"{template} ({dropdownId}) offers options that are not tabs (nor known catch-alls):\n  "
+            + string.Join("\n  ", unknown));
+    }
+
+    /// <summary>
+    /// The version field of an issue template must not pin an example release. Both templates showed
+    /// <c>0.12.x</c> — roughly 130 releases stale — so a reporter copying the placeholder filed against
+    /// a version that never shipped, in the field used for triage. Writing today's number in only resets
+    /// the clock, so the rule is that no version literal belongs there at all.
+    /// </summary>
+    [Theory]
+    [InlineData("bug_report.yml")]
+    [InlineData("general_issue.yml")]
+    public void TheIssueTemplateVersionField_PinsNoExampleRelease(string template)
+    {
+        var path = Path.Combine(FindRepoRoot(), ".github", "ISSUE_TEMPLATE", template);
+        Assert.True(File.Exists(path), $"{template} not found — the guard would pass vacuously");
+
+        var lines = File.ReadAllLines(path);
+        var field = Array.FindIndex(lines, l => l.Trim() == "id: version");
+        Assert.True(field >= 0, $"{template} has no version field — the guard is vacuous");
+
+        var pinned = new List<string>();
+        for (var i = field; i < lines.Length; i++)
+        {
+            if (i > field && lines[i].TrimStart().StartsWith("- type:", StringComparison.Ordinal)) break;
+
+            var m = SemanticVersion().Match(lines[i]);
+            if (m.Success) pinned.Add($"{template}:{i + 1}  {m.Groups[1].Value}");
+        }
+
+        Assert.True(pinned.Count == 0,
+            "the version field pins an example release, which goes stale on the next release:\n  "
+            + string.Join("\n  ", pinned));
+    }
+
+    /// <summary>A three-part version number.</summary>
+    [GeneratedRegex(@"\b(\d+\.\d+\.\d+)\b", RegexOptions.Compiled)]
+    private static partial Regex SemanticVersion();
+
+    /// <summary>The tab labels exactly as the sidebar registers them.</summary>
+    private static HashSet<string> SidebarTabLabels()
+    {
+        var source = File.ReadAllText(
+            Path.Combine(FindAppProjectDir(), "ViewModels", "MainWindowViewModel.cs"));
+
+        // Both registration helpers take (id, label, …); the label is the second string argument.
+        return NavRegistration().Matches(source)
+            .Select(m => m.Groups[1].Value)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    /// <summary>A nav registration, capturing the user-visible label.</summary>
+    [GeneratedRegex(@"(?:Tab<\w+>|EagerItem)\(\s*""[\w-]+""\s*,\s*""([^""]+)""", RegexOptions.Compiled)]
+    private static partial Regex NavRegistration();
+
+    /// <summary>
+    /// The options of one dropdown in an issue-form template, read line-wise. A full YAML parse is
+    /// avoided deliberately: these files contain unquoted colons inside descriptions, which several
+    /// parsers reject, and a guard that cannot read the file is worse than no guard.
+    /// </summary>
+    private static List<string> DropdownOptions(string path, string dropdownId)
+    {
+        Assert.True(File.Exists(path), $"{path} not found — the guard would pass vacuously");
+
+        var lines = File.ReadAllLines(path);
+        var options = new List<string>();
+        var inDropdown = false;
+        var inOptions = false;
+
+        foreach (var line in lines)
+        {
+            if (line.TrimStart().StartsWith("- type:", StringComparison.Ordinal))
+            {
+                inDropdown = false;
+                inOptions = false;
+            }
+
+            if (line.Trim() == $"id: {dropdownId}") inDropdown = true;
+            if (!inDropdown) continue;
+
+            if (line.Trim() == "options:") { inOptions = true; continue; }
+            if (!inOptions) continue;
+
+            var trimmed = line.Trim();
+            if (trimmed.StartsWith("- ", StringComparison.Ordinal))
+                options.Add(trimmed[2..].Trim().Trim('"'));
+            else if (trimmed.Length > 0)
+                break;      // the dropdown's option list ended
+        }
+
+        return options;
+    }
+
+    /// <summary>
     /// The README's table of contents must resolve. It is 1300+ lines long, so the contents list is the
     /// only practical way to navigate it — and a heading rename silently breaks an anchor, which renders
     /// as a link that quietly does nothing rather than as an error.

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ SysManager has three test projects, each with a distinct scope and runner.
 
 | Project | What it tests | Runs on CI |
 |---|---|---|
-| `SysManager.Tests` | Unit tests — mostly pure logic, but some tests touch lightweight OS APIs (registry reads, process enumeration, Task Scheduler queries) and a few exercise STA/UI-thread code via `Xunit.StaFact` (`[StaFact]` / `[UIFact]`). No WMI, no network I/O, no admin required. | ✅ Every push / PR |
+| `SysManager.Tests` | Unit tests — mostly pure logic, but some tests touch lightweight OS APIs (registry reads, process enumeration, Task Scheduler queries) and a few exercise STA/UI-thread code via `Xunit.StaFact` (`[StaFact]`). No WMI, no network I/O, no admin required. | ✅ Every push / PR |
 | `SysManager.IntegrationTests` | Integration tests — real Windows APIs (Event Log, WMI, PowerShell, ICMP, WPF dispatcher) | ❌ Local only |
 | `SysManager.UITests` | End-to-end UI automation via FlaUI — needs an interactive desktop session; runs in CI on a desktop-enabled runner, non-blocking (`continue-on-error`) and skipped on fork PRs | ⚠️ CI (non-blocking) |
 
@@ -76,9 +76,14 @@ Coverage is collected automatically on CI via `coverlet` and uploaded to
 | Package | Purpose |
 |---|---|
 | xUnit 2.9 | Test framework |
-| NSubstitute 5.3 | Mocking/substitution for interface-based testing |
+| NSubstitute 6.1 | Mocking/substitution for interface-based testing |
+| NetArchTest.Rules 1.3 | Architecture fitness functions — MVVM dependency direction, and guards that pin recurring defect classes |
 | coverlet | Code coverage collection |
 | Xunit.StaFact | STA thread support for WPF-dependent tests |
+
+Package versions are managed centrally in `SysManager/Directory.Packages.props`
+(`ManagePackageVersionsCentrally`), so a `PackageReference` in a `.csproj` carries no
+`Version` attribute — adding one fails the restore.
 
 ### Parallelism
 
@@ -87,10 +92,16 @@ Tests that share state or touch OS resources are isolated via xUnit
 collection definitions (all defined in `TestCollections.cs`, each with
 `DisableParallelization = true`):
 
-- `[Collection("Network")]` — tests using ICMP sockets.
-- `[Collection("OperationLock")]` — tests that acquire the shared `OperationLockService`.
+- `[Collection("ProcessWideStatics")]` — tests that touch **any** process-wide static: swapping
+  `DialogService.Instance`, or acquiring `OperationLockService.Instance`. This was once two
+  collections, `"DialogService"` and `"OperationLock"`, and the split was itself the defect: two
+  *different* serialized collections still run in parallel **with each other**, so a test swapping
+  the dialog could race a test holding the lock. xUnit allows one collection per class, so the fix
+  was to merge them. This is the collection most of the suite uses.
+- `[Collection("ProcessEnvironment")]` — tests that mutate the process's environment variables.
 - `[Collection("IconCache")]` — tests touching the shared icon cache.
-- `[Collection("DialogService")]` — tests that swap the static `DialogService.Instance`.
+- `[Collection("Network")]` — tests using ICMP sockets. Defined here, but currently used only by
+  `SysManager.IntegrationTests`.
 
 ### Shared helpers
 
@@ -98,7 +109,8 @@ collection definitions (all defined in `TestCollections.cs`, each with
   the previous instance on dispose, so a confirmation gate can be driven without a UI:
   `using var _ = new DialogAnswer(false);`. Its `Calls` counter lets a test assert a dialog was
   *not* shown — asserting the side effect alone cannot distinguish "the user said yes" from
-  "no gate ran at all". Requires `[Collection("DialogService")]` on the test class.
+  "no gate ran at all". Requires `[Collection("ProcessWideStatics")]` on the test class — a fitness
+  function in `ArchitectureTests` fails the build if a class swaps a process-wide static without it.
 - `SyncProgress<T>` — a synchronous `IProgress<T>` that records reports on the calling thread, so
   progress assertions need no `Task.Delay`.
 - `StaHelper` — runs a delegate on an STA thread for WPF-dependent types.


### PR DESCRIPTION
## Six factual drifts, each verified against current source

Two read-only audits swept the doc set; every finding below I then re-derived myself
before touching anything. Several other reported findings were dropped or corrected on
that second pass — see the last section.

### 1. Two issue templates could not name 53 of the 58 tabs

`feature_request.yml` (`scope`) and `general_issue.yml` (`tab`) still carried an
18-entry list from when the app had roughly that many tabs.

- 53 of 58 real tabs unnameable — no Tweaks Hub, Gaming Profile, Bandwidth Monitor,
  DNS & Hosts, File Shredder, Debloater, Context Menu, CLI Interface, …
- Nine offered names no longer match the sidebar: `Cleanup` (really *Quick Cleanup*),
  `System health`, `App updates`, `Startup`, `Duplicates`, `Processes`, `Battery`,
  `Performance`, `Logs`.
- `Network` is not a tab at all — it is a nav **group** holding five tabs.

`bug_report.yml` was migrated to the full list at some point and the other two were
not, so both now use that same list. `feature_request.yml` keeps
"New tab / cross-cutting" (a feature request may be for something that doesn't exist);
`general_issue.yml` keeps "Not sure".

### 2. Both templates pinned a version from ~130 releases ago

The version field showed `0.12.1` / `0.12.5` as the example, in the field used for
triage. Setting today's number would only reset the clock, so the field now says where
to find the version rather than naming one.

### 3. TESTING.md told contributors to use collections that don't exist

Lines 91/93/101 instructed `[Collection("OperationLock")]` and
`[Collection("DialogService")]`. Neither exists — they were merged into
`ProcessWideStatics` *because* two separate serialized collections still run in parallel
with each other, which was the actual race. Following the doc as written produces an
xUnit error. The section now documents the real four and says why the merge happened.

Same file: NSubstitute is **6.1.0**, not 5.3. `NetArchTest.Rules` is referenced by the
suite but was absent from the frameworks table. `[UIFact]` was documented and appears
**0** times in the repo.

### 4. SECURITY.md sent users to the wrong folder for their theme file

`| Appearance and theme choice | %LocalAppData%\SysManager |` — but
`ThemeService.cs:20` uses `SpecialFolder.ApplicationData`, which is Roaming
(`%AppData%`). `ProfileService` states the same thing explicitly. Corrected, and the
table now accounts for the other per-user files it implied were covered.

I checked each of those service-by-service rather than trusting the audit's grouping:
my first draft filed close-preference, gaming profiles and volume presets as Roaming.
They are all **Local**. Only the update-check preference is Roaming. Fixed before commit.

### 5. The Downloads badge reads as an install base

Re-derived from the API just now: **19,138** `.exe` downloads against **218**
`.sha256` — a ratio of **88:1**. A human verifying a download takes both files, so the
figure is dominated by the in-app updater, winget, and Microsoft's manifest validation.
Badge relabelled "asset downloads", with a note in Install explaining what it counts.

### 6. The winget badge pointed at the wrong place

It linked to the releases page. It now links the published manifest at
`microsoft/winget-pkgs/manifests/l/laurentiu021/SysManager` (verified 200; 327 versions
present upstream).

## Guards

Nothing compiles a YAML dropdown or a documentation claim, so all three of these were
invisible to CI:

- `EveryIssueTemplateTabList_OffersTheRealTabs` — derives the tab labels from the nav
  registrations in `MainWindowViewModel` and asserts each template can name every one,
  and offers nothing that isn't a tab (bar the known catch-alls). The count is never
  hardcoded.
- `TheIssueTemplateVersionField_PinsNoExampleRelease` — fails on **any** version literal
  in that field, including a freshly-correct one.
- Both carry vacuity floors (≥50 parsed labels, version field must exist).

## Red → green proof

Harness against two worktrees, reading the shipped bytes and resolving each claim
against the app source:

**Red (`13d08b5`) — 11 failures:**

```
       58 tabs registered in the sidebar
[PASS] bug_report.yml (tab) can name every tab — 60 options
[FAIL] feature_request.yml (scope) can name every tab — 53 of 58 tabs unnameable, e.g. System Health, Performance Mode, Services, Startup Manager
[FAIL] feature_request.yml (scope) offers no option that is not a tab — App updates, System health, Cleanup, Deep cleanup, Startup, Duplicates, Processes, Battery, Performance, Network, Logs, About / updates
[FAIL] general_issue.yml (tab) can name every tab — 53 of 58 tabs unnameable
[FAIL] general_issue.yml (tab) offers no option that is not a tab — …
[FAIL] bug_report.yml version field pins no example release — line 22: 0.12.1; line 23: 0.12.1 (app is 1.64.8; any pin goes stale)
[FAIL] general_issue.yml version field pins no example release — line 34: 0.12.5
       collections that exist: IconCache, Network, ProcessEnvironment, ProcessWideStatics
[FAIL] every collection TESTING.md names actually exists — line 91: "OperationLock"; line 93: "DialogService"; line 101: "DialogService"
[FAIL] TESTING.md states the real NSubstitute version — doc says 5.3, package is 6.1
[FAIL] TESTING.md lists NetArchTest, which the suite actually references
[FAIL] TESTING.md does not document an attribute the suite never uses — [UIFact] is documented but used 0 times
       ThemeService writes to %AppData% (Roaming)
[FAIL] SECURITY.md points at the folder the theme file is really in — line 175 says %LocalAppData%, ThemeService uses Roaming
11 FAILED
```

**Green (this branch):** all 15 checks pass, `58 tabs` → `60 options` on all three
templates.

## Verification

- `dotnet build` Release, tests project: 0 errors, 0 warnings.
- `dotnet format --verify-no-changes`: exit 0.
- All four issue templates now parse under a strict YAML parser — `bug_report.yml`
  previously did not, because of an unquoted colon in the version description; the
  rewrite to a block scalar fixed that incidentally.
- Leak scan over added lines against `leak-terms.txt`: 0 hits.
- No app code touched → no version bump. `docs:` does not release.

## Audit findings I did NOT act on, and why

- **"ARCHITECTURE.md line 553 says ~50 tab VMs"** — real but harmless: 51 are lazy, 58
  total. Left for an ARCHITECTURE pass rather than mixed into this one.
- **"ActivityLogService logs 23 labels, not the documented six"** — confirmed real
  (28 call sites), but it is a substantive rewrite of a SECURITY/ARCHITECTURE claim about
  what gets recorded, and deserves its own PR with its own reading of each call site.
- **"README says 58 tabs fully implemented but 7 carry `inDevelopment: true`"** — the
  README already explains the flask marker means "fully implemented and usable, marked
  in-app while it settles in". Not a contradiction.
- **"README says a three-month-old project, it is 3 months 23 days"** — self-rotting
  prose, but not wrong today.
