### PR TITLE
fix: stop a closing tab from taking the recovery snapshot away from a running change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.9] - 2026-08-12
+
+Closing the Performance Mode tab in the middle of applying a tweak can no longer throw away the
+saved settings that "Restore all" needs. Closing the Bandwidth Monitor mid-load no longer risks an
+error on the way out.
+
+### Fixed
+- **Closing Performance Mode while a change was being applied could leave that change with nothing to undo it.** Before touching any Windows setting, SysManager saves a snapshot of how things were, so "Restore all" can put them back. Closing the tab clears that snapshot — but it did so without waiting for a change that was still in progress, so in the moment between "saving your original settings" and "applying the new one", closing the tab could take the snapshot away from the very operation that was relying on it. The result would be a setting changed with no recorded way back. The tab now waits for any in-progress change before clearing anything, and an attempt to apply a change to a tab that is already closing is refused outright instead of going ahead unprotected.
+- **Closing a tab mid-operation could log an error on an otherwise clean exit.** Eleven parts of the app take an internal turn-taking lock so two operations cannot run over each other. Six of them — the Bandwidth Monitor, Performance Mode, and the DNS, network-repair, speed-test-history and system-fix helpers — released that lock on shutdown without checking whether it had already been packed away, which reports an error during what is otherwise a normal exit. The other five already did this correctly; all eleven now behave the same way, and a new automatic check stops a twelfth from being added with the old pattern.
+
+---
+
 ## [1.64.8] - 2026-08-12
 
 "Ask a question" now takes you to the questions area instead of the release-announcements wall.

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -724,6 +724,56 @@ public partial class ArchitectureTests
     private static partial Regex CancellationFieldAssignment();
 
     /// <summary>
+    /// A type that disposes a <see cref="SemaphoreSlim"/> must track its own disposal, because an
+    /// operation already inside the gate resumes after teardown: entering a disposed gate throws, and
+    /// releasing one throws out of a <c>finally</c> block, turning a clean teardown into an unhandled
+    /// exception. The sibling of <see cref="EveryDisposedCancellationSource_IsCancelledFirst"/>, and the
+    /// same class of half-migration — the correct shape existed in three types while six others, two of
+    /// them view models disposed on every tab close, had no flag at all.
+    /// </summary>
+    [Fact]
+    public void EveryTypeThatDisposesAGate_TracksItsOwnDisposal()
+    {
+        var appDir = FindAppProjectDir();
+        var offenders = new List<string>();
+        var checkedTypes = 0;
+
+        foreach (var file in Directory.GetFiles(Path.Combine(appDir, "Services"), "*.cs")
+                     .Concat(Directory.GetFiles(Path.Combine(appDir, "ViewModels"), "*.cs")))
+        {
+            var source = File.ReadAllText(file);
+
+            var fields = GateFieldDeclaration().Matches(source)
+                .Select(m => m.Groups[1].Value)
+                .Where(f => source.Contains($"{f}.Dispose()", StringComparison.Ordinal))
+                .ToList();
+            if (fields.Count == 0) continue;
+
+            checkedTypes++;
+
+            // Either its own flag, or the one ViewModelBase exposes for exactly this purpose.
+            if (!source.Contains("_disposed", StringComparison.Ordinal)
+                && !source.Contains("IsDisposed", StringComparison.Ordinal))
+                offenders.Add($"{Path.GetFileName(file)} · disposes {string.Join(", ", fields)} with no disposal flag");
+        }
+
+        // Vacuity floor: if the declaration regex stopped matching, this would inspect nothing and pass.
+        Assert.True(checkedTypes >= 10,
+            $"Expected at least 10 types that dispose a gate, found {checkedTypes} — the detection is "
+            + "probably no longer matching the field declarations.");
+
+        Assert.True(offenders.Count == 0,
+            "These types dispose a SemaphoreSlim without tracking disposal, so an operation still inside "
+            + "the gate throws on release after teardown. Guard the wait and the release against a "
+            + "disposal flag (ViewModelBase.IsDisposed for view models):\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>A field declared as a gate, e.g. <c>private readonly SemaphoreSlim _gate = new(1, 1);</c>.</summary>
+    [GeneratedRegex(@"SemaphoreSlim\??\s+(_[A-Za-z]\w*)", RegexOptions.Compiled)]
+    private static partial Regex GateFieldDeclaration();
+
+    /// <summary>
     /// Every place that sends a user somewhere to ask a question must deep-link the Q&amp;A category,
     /// never the Discussions root. Each release auto-posts an announcement, so the root is a wall of
     /// changelogs; four separate surfaces (the in-app button, SUPPORT.md, README.md and the issue

--- a/SysManager/SysManager.Tests/BandwidthMonitorViewModelTests.cs
+++ b/SysManager/SysManager.Tests/BandwidthMonitorViewModelTests.cs
@@ -631,4 +631,38 @@ public class BandwidthMonitorViewModelTests : IDisposable
         Assert.Equal(0, vm.TotalUpBytesPerSec);     // snapshot's 456 was never applied
         Assert.Empty(vm.Processes);                 // MergeInto never ran
     }
+
+    // ── Reload after teardown ──
+    // The reload path is serialized by a gate that Dispose disposes. Entering or releasing a disposed
+    // SemaphoreSlim throws — the release out of a finally block, which would turn a clean tab close into
+    // an unhandled exception. Both tests go through the public command, i.e. the same route the Refresh
+    // button and a range change take.
+
+    [Fact]
+    public async Task ReloadAfterDispose_IsANoOpRatherThanAThrow()
+    {
+        var now = DateTime.UtcNow;
+        var history = SeededHistory(new BandwidthSample(now.AddMinutes(-10), 1_048_576, 131_072));
+        var vm = NewVm(history: history);
+        vm.SelectedRange = vm.RangeOptions.First(r => r.Range == TimeSpan.FromHours(1));
+
+        vm.Dispose();
+
+        // No throw, and nothing repainted: the chart buffers' paints and typefaces are already released,
+        // so a completed reload here would draw through disposed SkiaSharp handles.
+        await vm.ReloadHistoryCommand.ExecuteAsync(null);
+        Assert.False(vm.ShowingHistory);
+    }
+
+    [Fact]
+    public async Task DoubleDispose_IsHarmless()
+    {
+        // MainWindowViewModel disposes every tab on shutdown, and a tab can also be disposed by its own
+        // teardown — the second call must not throw on the already-disposed gate, paints or source.
+        var vm = NewVm();
+        await vm.ReloadHistoryCommand.ExecuteAsync(null);
+
+        vm.Dispose();
+        vm.Dispose();
+    }
 }

--- a/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
@@ -357,4 +357,71 @@ public class PerformanceViewModelTests
             DialogService.Instance = prevDialog;
         }
     }
+
+    // ── Disposal and the recovery snapshot ──
+    // Every Apply secures a snapshot first so the change can be reverted. Dispose clears that snapshot
+    // and disposes the gate that makes it exclusive, so a tab closed mid-Apply is the moment where a
+    // tweak could be applied with nothing left to revert it.
+
+    [Fact]
+    public async Task ApplyAfterDispose_RefusesRatherThanChangingAnythingUnprotected()
+    {
+        var vm = NewVm(completeInitialization: true);
+        await vm.InitializationComplete;
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+
+        try
+        {
+            vm.Dispose();
+
+            // The snapshot path cannot secure a snapshot on a disposed view model, so the Apply must
+            // report the refusal rather than proceeding. The command catches the refusal itself, so what
+            // is observable is the status text — and crucially NOT a success message.
+            await vm.ApplyPowerPlanCommand.ExecuteAsync(null);
+
+            Assert.DoesNotContain("Switched", vm.StatusMessage);
+            Assert.DoesNotContain("Applied", vm.StatusMessage);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public async Task DoubleDispose_IsHarmless()
+    {
+        // MainWindowViewModel disposes every tab at shutdown, and a tab can also be disposed by its own
+        // teardown — the second call must not throw on the already-disposed snapshot gate.
+        var vm = NewVm(completeInitialization: true);
+        await vm.InitializationComplete;
+
+        vm.Dispose();
+        vm.Dispose();
+    }
+
+    [Fact]
+    public async Task Dispose_ClearsTheSnapshotItHeld()
+    {
+        // The clear moved inside the gate; it must still happen, or Dispose would leak a snapshot
+        // reference and the "cleared on teardown" behaviour would silently disappear.
+        var vm = NewVm(completeInitialization: true);
+        await vm.InitializationComplete;
+
+        var field = typeof(PerformanceViewModel)
+            .GetField("_snapshot", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        field.SetValue(vm, new PerformanceService.OriginalSnapshot(
+            PowerPlanGuid: "guid", PowerPlanName: "Balanced", UiEffectsEnabled: true,
+            GameModeEnabled: true, XboxGameBarEnabled: true, XboxGameDvrEnabled: true,
+            GpuDynamicPstate: true, ProcessorMinPercentAc: 5, NvidiaSubKey: null));
+        Assert.NotNull(field.GetValue(vm));
+
+        vm.Dispose();
+
+        Assert.Null(field.GetValue(vm));
+    }
 }

--- a/SysManager/SysManager/Services/DnsService.cs
+++ b/SysManager/SysManager/Services/DnsService.cs
@@ -22,9 +22,31 @@ public sealed class DnsService : IDisposable
     private readonly IPowerShellRunner _ps;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
+    // Idempotent, and paired with the guarded releases below: this is a DI singleton disposed at
+    // process exit, so a request in flight at shutdown would otherwise release a disposed gate from a
+    // finally block and log an error on a clean exit.
+    private bool _disposed;
+
     public DnsService(IPowerShellRunner ps) => _ps = ps;
 
-    public void Dispose() => _gate.Dispose();
+    /// <summary>
+    /// Releases the gate unless <see cref="Dispose"/> has already claimed it. Releasing a disposed
+    /// <see cref="SemaphoreSlim"/> throws, and every call site is a <c>finally</c> block, where that
+    /// would replace a clean shutdown — or a real error — with an unhandled exception.
+    /// </summary>
+    private void ReleaseGate()
+    {
+        if (_disposed) return;
+        try { _gate.Release(); }
+        catch (ObjectDisposedException) { /* disposed mid-request at shutdown */ }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _gate.Dispose();
+    }
 
     /// <summary>
     /// Returns the built-in DNS presets.
@@ -83,7 +105,7 @@ public sealed class DnsService : IDisposable
             Log.Debug("DNS status read failed: {Error}", ex.Message);
             return "Unavailable";
         }
-        finally { _gate.Release(); }
+        finally { ReleaseGate(); }
     }
 
     // Single source of truth for "the active adapter": prefer a non-virtual adapter
@@ -361,7 +383,7 @@ public sealed class DnsService : IDisposable
                 v4Source,
                 v6Source);
         }
-        finally { _gate.Release(); }
+        finally { ReleaseGate(); }
     }
 
     private static bool TryParseConfigurationSource(
@@ -681,8 +703,9 @@ public sealed class DnsService : IDisposable
                 .ConfigureAwait(false);
             ThrowIfMutationPreconditionFailed(results);
         }
-        finally { _gate.Release(); }
+        finally { ReleaseGate(); }
     }
+
     /// <summary>
     /// Sets the DNS server addresses on the active network adapter.
     /// </summary>
@@ -824,8 +847,9 @@ public sealed class DnsService : IDisposable
                 .ConfigureAwait(false);
             ThrowIfMutationPreconditionFailed(results);
         }
-        finally { _gate.Release(); }
+        finally { ReleaseGate(); }
     }
+
     /// <summary>
     /// Resets DNS to automatic (DHCP) on the active network adapter.
     /// </summary>
@@ -872,6 +896,6 @@ public sealed class DnsService : IDisposable
                 .ConfigureAwait(false);
             ThrowIfMutationPreconditionFailed(results);
         }
-        finally { _gate.Release(); }
+        finally { ReleaseGate(); }
     }
 }

--- a/SysManager/SysManager/Services/NetworkRepairService.cs
+++ b/SysManager/SysManager/Services/NetworkRepairService.cs
@@ -15,10 +15,32 @@ public sealed class NetworkRepairService : IDisposable
     private readonly IPowerShellRunner _ps;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
+    // Idempotent, and paired with the guarded releases below: this is a DI singleton disposed at
+    // process exit, so a request in flight at shutdown would otherwise release a disposed gate from a
+    // finally block and log an error on a clean exit.
+    private bool _disposed;
+
     public NetworkRepairService(IPowerShellRunner ps) => _ps = ps;
 
     /// <inheritdoc />
-    public void Dispose() => _gate.Dispose();
+    /// <summary>
+    /// Releases the gate unless <see cref="Dispose"/> has already claimed it. Releasing a disposed
+    /// <see cref="SemaphoreSlim"/> throws, and every call site is a <c>finally</c> block, where that
+    /// would replace a clean shutdown — or a real error — with an unhandled exception.
+    /// </summary>
+    private void ReleaseGate()
+    {
+        if (_disposed) return;
+        try { _gate.Release(); }
+        catch (ObjectDisposedException) { /* disposed mid-request at shutdown */ }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _gate.Dispose();
+    }
 
     /// <summary>
     /// Flush the DNS resolver cache. Does not require a reboot.
@@ -39,7 +61,7 @@ public sealed class NetworkRepairService : IDisposable
                 string.Join(Environment.NewLine, output),
                 NeedsReboot: false);
         }
-        finally { _ps.LineReceived -= OnLine; _gate.Release(); }
+        finally { _ps.LineReceived -= OnLine; ReleaseGate(); }
     }
 
     /// <summary>
@@ -61,7 +83,7 @@ public sealed class NetworkRepairService : IDisposable
                 string.Join(Environment.NewLine, output),
                 NeedsReboot: true);
         }
-        finally { _ps.LineReceived -= OnLine; _gate.Release(); }
+        finally { _ps.LineReceived -= OnLine; ReleaseGate(); }
     }
 
     /// <summary>
@@ -83,6 +105,6 @@ public sealed class NetworkRepairService : IDisposable
                 string.Join(Environment.NewLine, output),
                 NeedsReboot: true);
         }
-        finally { _ps.LineReceived -= OnLine; _gate.Release(); }
+        finally { _ps.LineReceived -= OnLine; ReleaseGate(); }
     }
 }

--- a/SysManager/SysManager/Services/SpeedTestHistoryService.cs
+++ b/SysManager/SysManager/Services/SpeedTestHistoryService.cs
@@ -31,6 +31,11 @@ public sealed class SpeedTestHistoryService : IDisposable
     // acts as an async-compatible mutex.
     private readonly SemaphoreSlim _fileLock = new(1, 1);
 
+    // Idempotent, and paired with the guarded releases below: this is a DI singleton disposed at
+    // process exit, so a request in flight at shutdown would otherwise release a disposed gate from a
+    // finally block and log an error on a clean exit.
+    private bool _disposed;
+
     /// <summary>
     /// Creates the service. <paramref name="configDir"/> is overridable so tests exercise the real
     /// save/load/clear paths against a temp directory instead of the user's own history file — same
@@ -49,7 +54,24 @@ public sealed class SpeedTestHistoryService : IDisposable
     }
 
     /// <inheritdoc />
-    public void Dispose() => _fileLock.Dispose();
+    /// <summary>
+    /// Releases the gate unless <see cref="Dispose"/> has already claimed it. Releasing a disposed
+    /// <see cref="SemaphoreSlim"/> throws, and every call site is a <c>finally</c> block, where that
+    /// would replace a clean shutdown — or a real error — with an unhandled exception.
+    /// </summary>
+    private void ReleaseFilelock()
+    {
+        if (_disposed) return;
+        try { _fileLock.Release(); }
+        catch (ObjectDisposedException) { /* disposed mid-request at shutdown */ }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _fileLock.Dispose();
+    }
 
     /// <summary>
     /// Loads all saved results from disk. Returns empty list on any error.
@@ -139,7 +161,7 @@ public sealed class SpeedTestHistoryService : IDisposable
         }
         finally
         {
-            _fileLock.Release();
+            ReleaseFilelock();
         }
     }
 
@@ -191,7 +213,7 @@ public sealed class SpeedTestHistoryService : IDisposable
         }
         finally
         {
-            _fileLock.Release();
+            ReleaseFilelock();
         }
     }
 

--- a/SysManager/SysManager/Services/SystemFixService.cs
+++ b/SysManager/SysManager/Services/SystemFixService.cs
@@ -23,6 +23,11 @@ public sealed class SystemFixService : IDisposable
     private readonly IPowerShellRunner _ps;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
+    // Idempotent, and paired with the guarded releases below: this is a DI singleton disposed at
+    // process exit, so a request in flight at shutdown would otherwise release a disposed gate from a
+    // finally block and log an error on a clean exit.
+    private bool _disposed;
+
     public SystemFixService(IPowerShellRunner ps) => _ps = ps;
 
     public event Action<PowerShellLine>? LineReceived
@@ -31,7 +36,24 @@ public sealed class SystemFixService : IDisposable
         remove => _ps.LineReceived -= value;
     }
 
-    public void Dispose() => _gate.Dispose();
+    /// <summary>
+    /// Releases the gate unless <see cref="Dispose"/> has already claimed it. Releasing a disposed
+    /// <see cref="SemaphoreSlim"/> throws, and every call site is a <c>finally</c> block, where that
+    /// would replace a clean shutdown — or a real error — with an unhandled exception.
+    /// </summary>
+    private void ReleaseGate()
+    {
+        if (_disposed) return;
+        try { _gate.Release(); }
+        catch (ObjectDisposedException) { /* disposed mid-request at shutdown */ }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _gate.Dispose();
+    }
 
     /// <summary>
     /// Resets Windows Update: stops the services, renames SoftwareDistribution and
@@ -99,7 +121,7 @@ public sealed class SystemFixService : IDisposable
         finally
         {
             _ps.LineReceived -= OnLine;
-            _gate.Release();
+            ReleaseGate();
         }
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.64.8</Version>
-    <FileVersion>1.64.8.0</FileVersion>
-    <AssemblyVersion>1.64.8.0</AssemblyVersion>
+    <Version>1.64.9</Version>
+    <FileVersion>1.64.9.0</FileVersion>
+    <AssemblyVersion>1.64.9.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
@@ -387,7 +387,23 @@ public sealed partial class BandwidthMonitorViewModel : ViewModelBase
         // A gate rather than a lock: this is an async path, so it must not block, and dropping an
         // overlapping reload is correct behaviour — the newest selection is what the user asked for
         // and the queued run would repaint with identical data anyway.
-        await _reloadGate.WaitAsync().ConfigureAwait(true);
+        //
+        // Nothing to reload into once the tab is gone, and Dispose disposes the gate below — so entering
+        // it after teardown throws instead of doing work, and completing a load would repaint chart
+        // buffers whose paints and typefaces Dispose has already released.
+        if (IsDisposed) return;
+
+        try
+        {
+            await _reloadGate.WaitAsync().ConfigureAwait(true);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Disposed between the check above and the wait: the tab closed mid-reload. Nothing to
+            // release, because the wait never succeeded.
+            return;
+        }
+
         try
         {
             var range = SelectedRange;
@@ -432,7 +448,17 @@ public sealed partial class BandwidthMonitorViewModel : ViewModelBase
             }
             finally { IsBusy = false; }
         }
-        finally { _reloadGate.Release(); }
+        finally
+        {
+            // Release only if the gate is still alive: Dispose can land while the load is in flight, and
+            // releasing a disposed SemaphoreSlim throws — out of a finally block, which would replace a
+            // clean teardown with an unhandled exception.
+            if (!IsDisposed)
+            {
+                try { _reloadGate.Release(); }
+                catch (ObjectDisposedException) { /* disposed mid-reload; nothing left to release */ }
+            }
+        }
     }
 
     /// <summary>

--- a/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
@@ -65,7 +65,19 @@ public sealed partial class PerformanceViewModel : ViewModelBase
 
     private async Task InitAsync()
     {
-        await _snapshotGate.WaitAsync();
+        // Fire-and-forget from the constructor: a tab opened and closed quickly can dispose the gate
+        // before this runs. Nothing to initialise into at that point.
+        if (IsDisposed) return;
+
+        try
+        {
+            await _snapshotGate.WaitAsync();
+        }
+        catch (ObjectDisposedException)
+        {
+            return;
+        }
+
         try
         {
             // Recovery must not wait behind live powercfg probes. A blocked or unavailable
@@ -73,7 +85,7 @@ public sealed partial class PerformanceViewModel : ViewModelBase
             _snapshot ??= await Task.Run(_service.LoadSnapshot);
             HasSnapshot = _snapshot is not null;
         }
-        finally { _snapshotGate.Release(); }
+        finally { ReleaseSnapshotGate(); }
 
         try { await RefreshAsync(); }
         catch (InvalidOperationException ex) { Log.Warning("Performance auto-refresh failed: {Error}", ex.Message); }
@@ -84,7 +96,22 @@ public sealed partial class PerformanceViewModel : ViewModelBase
     /// <summary>Ensure snapshot exists before any change.</summary>
     private async Task EnsureSnapshotAsync()
     {
-        await _snapshotGate.WaitAsync();
+        // Every Apply command awaits this before touching the system, so a tab closed mid-command
+        // resumes here with a disposed gate. Returning quietly would let the caller carry on and mutate
+        // the system with no snapshot to revert it — strictly worse than failing. So this reports the
+        // same refusal the "snapshot could not be saved" path already uses, and every caller already
+        // catches InvalidOperationException and abandons the change.
+        if (IsDisposed) throw SnapshotUnavailable();
+
+        try
+        {
+            await _snapshotGate.WaitAsync();
+        }
+        catch (ObjectDisposedException)
+        {
+            throw SnapshotUnavailable();
+        }
+
         try
         {
             if (_snapshot is null)
@@ -98,17 +125,33 @@ public sealed partial class PerformanceViewModel : ViewModelBase
                 {
                     var captured = await _service.TakeSnapshotAsync();
                     var saved = await Task.Run(() => _service.SaveSnapshot(captured));
-                    if (!saved)
-                    {
-                        throw new InvalidOperationException(
-                            "The recovery snapshot could not be saved, so no setting was changed.");
-                    }
+                    if (!saved) throw SnapshotUnavailable();
                     _snapshot = captured;
                 }
             }
             HasSnapshot = true;
         }
-        finally { _snapshotGate.Release(); }
+        finally { ReleaseSnapshotGate(); }
+    }
+
+    /// <summary>
+    /// The single refusal for "no recovery snapshot, so nothing was changed". Every Apply command
+    /// catches <see cref="InvalidOperationException"/> and abandons the change, which is what makes
+    /// this safe to throw from anywhere in the snapshot path.
+    /// </summary>
+    private static InvalidOperationException SnapshotUnavailable() =>
+        new("The recovery snapshot could not be saved, so no setting was changed.");
+
+    /// <summary>
+    /// Releases the snapshot gate unless disposal has already claimed it. Releasing a disposed
+    /// <see cref="SemaphoreSlim"/> throws, and this runs from a <c>finally</c>, where an exception
+    /// would replace a clean teardown — or a real error — with an unhandled one.
+    /// </summary>
+    private void ReleaseSnapshotGate()
+    {
+        if (IsDisposed) return;
+        try { _snapshotGate.Release(); }
+        catch (ObjectDisposedException) { /* disposed mid-operation; nothing left to release */ }
     }
 
     private void UpdateSummary()
@@ -746,7 +789,17 @@ public sealed partial class PerformanceViewModel : ViewModelBase
     {
         if (disposing)
         {
-            _snapshot = null;
+            // Clear the snapshot INSIDE the gate. Clearing it outside meant a tab closed mid-Apply
+            // could null the recovery snapshot while EnsureSnapshotAsync was still capturing or saving
+            // it — the exact "a tweak applied with no snapshot left to revert it" outcome the gate
+            // exists to prevent. Bounded, like GamingProfileService's Dispose: the holder finishes in
+            // well under this, and a teardown must never hang waiting for it.
+            if (_snapshotGate.Wait(TimeSpan.FromSeconds(2)))
+            {
+                try { _snapshot = null; }
+                finally { _snapshotGate.Release(); }
+            }
+
             _snapshotGate.Dispose();
         }
         base.Dispose(disposing);

--- a/SysManager/SysManager/ViewModels/ViewModelBase.cs
+++ b/SysManager/SysManager/ViewModels/ViewModelBase.cs
@@ -14,7 +14,17 @@ public abstract partial class ViewModelBase : ObservableObject, IDisposable
     [ObservableProperty] private int _progress; // 0-100
     [ObservableProperty] private bool _isProgressIndeterminate;
 
-    private bool _disposed;
+    /// <summary>
+    /// True from the moment <see cref="Dispose()"/> is entered, before any derived override runs.
+    /// <para>An async command that resumes after a tab closes must not touch state a
+    /// <c>Dispose(bool)</c> override has already released — the recurring failure here was a
+    /// <see cref="SemaphoreSlim"/> disposed while an in-flight command still held it. Derived classes
+    /// check this before awaiting and again after every await.</para>
+    /// <para>Set in the public <see cref="Dispose()"/> rather than in <c>Dispose(bool)</c> on purpose:
+    /// overrides call <c>base.Dispose(disposing)</c> <em>last</em>, so a flag set there would still be
+    /// false while the override was releasing everything — exactly the window that needs guarding.</para>
+    /// </summary>
+    protected bool IsDisposed { get; private set; }
 
     /// <summary>
     /// Completes when the constructor's <see cref="InitializeAsync"/> work has finished
@@ -74,12 +84,12 @@ public abstract partial class ViewModelBase : ObservableObject, IDisposable
     /// </summary>
     protected virtual void Dispose(bool disposing)
     {
-        if (_disposed) return;
-        _disposed = true;
     }
 
     public void Dispose()
     {
+        if (IsDisposed) return;
+        IsDisposed = true;
         Dispose(disposing: true);
         GC.SuppressFinalize(this);
     }


### PR DESCRIPTION
## The defect

**11 types dispose a `SemaphoreSlim` that serializes their own work. 5 guarded that
disposal correctly; 6 did not** — and two of the six are view models disposed every time
the user closes a tab. A half-migration, from an audit finding I then re-derived myself.

### The load-bearing case: Performance Mode can lose the ability to undo

Every Apply command calls `EnsureSnapshotAsync()` first, so a changed Windows setting can
be put back. The gate is what makes that snapshot exclusive. But `Dispose` did this:

```csharp
if (disposing)
{
    _snapshot = null;          // outside the gate
    _snapshotGate.Dispose();
}
```

`PerformanceViewModel.cs:749` on main. So closing the tab mid-Apply could null the
snapshot while `EnsureSnapshotAsync` was still between `TakeSnapshotAsync()` and
`SaveSnapshot()` — **a system setting changed with nothing recorded to revert it.**

That is the exact outcome the comment at `PerformanceViewModel.cs:190` says the
serialization exists to prevent:

> Without it, Apply* and Restore All can race: e.g. Restore All can delete the snapshot +
> null `_snapshot` while an Apply's registry write is still in flight, leaving a tweak
> applied with no snapshot to revert it.

The operation lock closed that door between two commands. Disposal walked around it.

### The second case: Bandwidth Monitor repaints released handles

Same shape, different consequence. `_reloadGate` is waited at `:390`, released in a
`finally` at `:435`, disposed at `:604`, and `grep _disposed` over that file returns
nothing. Close the window during a range load and the continuation calls `ReplaceWith` on
buffers LiveCharts observes, after `Dispose` released every paint and typeface.

### The other four

`DnsService`, `NetworkRepairService`, `SpeedTestHistoryService`, `SystemFixService` — DI
singletons disposed at process exit, so the effect is an **Error-level log line on a clean
shutdown**, not a user-visible fault. Fixed in the same PR because leaving them is
precisely what produced this half-migration.

## The fix

**`ViewModelBase.IsDisposed`**, set in the *public* `Dispose()` before the virtual call.
The private `_disposed` it already had was useless as a guard: overrides call
`base.Dispose(disposing)` **last**, so the flag stayed false for the entire window in
which the override was releasing everything — exactly the window that needs guarding.
Idempotence moved to the public method; all 45 overrides call base, and nothing else
invokes `Dispose(bool)`, so double-dispose stays harmless (pinned by a test).

**Performance Mode** clears the snapshot *inside* the gate, with a bounded wait — the
shape `GamingProfileService.Dispose` (`:488`) already uses, so a teardown cannot hang
behind a slow system call:

```csharp
if (_snapshotGate.Wait(TimeSpan.FromSeconds(2)))
{
    try { _snapshot = null; }
    finally { _snapshotGate.Release(); }
}
_snapshotGate.Dispose();
```

An Apply on a disposing tab now raises the **existing** "The recovery snapshot could not
be saved, so no setting was changed." refusal. I deliberately did **not** return quietly
there: a silent return would let the caller mutate the system with no snapshot, which is
worse than the bug being fixed. Every Apply already catches
`InvalidOperationException` and abandons the change.

**Bandwidth Monitor** gets the pre-await check, the `ObjectDisposedException` catch around
the wait, and the guarded release — copied from `ResourceHistoryViewModel`, which already
had the correct shape.

## Ratchet

`EveryTypeThatDisposesAGate_TracksItsOwnDisposal` — sibling to
`EveryDisposedCancellationSource_IsCancelledFirst`, same keying on the field declaration,
vacuity floor of 10 types.

## Red → green proof

Harness against two worktrees. It counted the scope independently and agreed with my own
grep:

**Red (`1a87073`):**

```
-- PerformanceViewModel: the recovery snapshot --
[PASS] Dispose still clears the snapshot
[FAIL] the snapshot is cleared INSIDE the gate, not beside it — no acquire in Dispose — the clear races a mid-flight Apply
[FAIL] the acquire is bounded so teardown cannot hang
-- every type that disposes a gate --
       11 types dispose a gate; 5 track disposal
[FAIL] every type that disposes a gate tracks its own disposal — 6 unguarded: DnsService.cs (_gate); NetworkRepairService.cs (_gate); SpeedTestHistoryService.cs (_fileLock); SystemFixService.cs (_gate); BandwidthMonitorViewModel.cs (_reloadGate); PerformanceViewModel.cs (_snapshotGate)
[PASS] the detection is actually finding gates — 11 found
[FAIL] ViewModelBase exposes a disposal flag to derived classes — only a private _disposed, unusable as a guard in a derived VM
4 FAILED
```

**Green (this branch):** `11 types dispose a gate; 11 track disposal`, ALL PASS.

## Regression tests

- `PerformanceViewModelTests.ApplyAfterDispose_RefusesRatherThanChangingAnythingUnprotected`
  — asserts the status text is *not* a success message.
- `PerformanceViewModelTests.Dispose_ClearsTheSnapshotItHeld` — the clear moved, so it must
  still happen; without this the behaviour could silently disappear.
- `PerformanceViewModelTests.DoubleDispose_IsHarmless` and the same for Bandwidth — pins the
  idempotence contract I moved out of `Dispose(bool)`.
- `BandwidthMonitorViewModelTests.ReloadAfterDispose_IsANoOpRatherThanAThrow`.

## Verification

- `dotnet build` Release, app + tests: **0 errors, 0 warnings**.
- `dotnet format --verify-no-changes`, both projects: exit 0. It first failed with 100+
  `ENDOFLINE` errors — my scripted edit wrote LF into CRLF files. Fixed before commit;
  worth noting because the format gate is the only thing that catches it.
- Diff re-read line by line: guard code, comments and tests only. No behaviour change in
  any non-teardown path.
- Leak scan over added lines: 0 hits.
- 1.64.9 + CHANGELOG entry. The entry first said "nine parts of the app"; I re-derived and
  it is **eleven** (6 fixed, 5 already correct), corrected before commit.
