### PR TITLE
fix: show the process description the app already looked up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.10] - 2026-08-13
+
+Process Manager now tells you in plain English what each process is, using the description database
+it already shipped with but never showed you.
+
+### Fixed
+- **The Process Manager knew what each process was and didn't tell you.** SysManager ships a database of 108 common Windows processes and popular applications, each with a plain-English one-liner ("Windows service host — runs background services grouped by function") and a category. It was being looked up for every process, and the search box even matched against it — you could type "browser" and get results — but the list never displayed any of it. What you saw under each process name was the technical description the program file carries, which is the same wording Task Manager already gives you. Worse, Windows refuses to hand over that technical description for its own system processes unless SysManager is running as administrator, so for exactly the processes people are most unsure about — `svchost`, `csrss`, `lsass` — the line was simply blank, while the plain-English explanation sat unused. The description now appears under each process name, falling back to the technical one for anything the database doesn't know, and the category has its own sortable column. A new automatic check makes sure a field the search can match can never again be invisible.
+
+---
+
 ## [1.64.9] - 2026-08-12
 
 Closing the Performance Mode tab in the middle of applying a tweak can no longer throw away the

--- a/README.md
+++ b/README.md
@@ -444,10 +444,13 @@ a confirmation before it runs:
 ### Process Manager
 - Lists running Windows processes with PID, memory, threads, and status
 - Real-time filter by name, description, category, or PID
-- Sort by memory, CPU usage, name, or PID via clickable column headers
+- Sort by memory, CPU usage, name, category, or PID via clickable column headers
 - **Built-in description database** — 108 common Windows processes and popular
   applications with plain-language descriptions and categories (System, Browser,
-  Development, Communication, Media, Gaming, etc.)
+  Development, Communication, Media, Gaming, etc.). The description sits under each
+  process name and the category has its own sortable column, so a process you don't
+  recognise explains itself without a web search — including the Windows system
+  processes whose own description Windows withholds unless SysManager is elevated
 - **Safety column** — every process is labelled **Windows**, **Known app** or
   **Not recognised**, with a hover explanation of what that means for ending it.
   Sortable, so everything unrecognised can be grouped together at a glance

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -865,6 +865,47 @@ public partial class ArchitectureTests
     private static partial Regex CategoryLink();
 
     /// <summary>
+    /// A field a search box matches against must be visible somewhere in that tab's view. Otherwise the
+    /// user is invited to filter by text the app never shows them — and it hides a whole unreachable
+    /// field: the Process Manager loaded a plain-English description and a category from its 108-entry
+    /// database, matched both in the search, and rendered neither, showing the raw exe FileDescription
+    /// instead. The searchable-but-invisible field is the quiet signature of that defect class.
+    /// </summary>
+    [Fact]
+    public void EverySearchableField_IsVisibleInItsView()
+    {
+        var appDir = FindAppProjectDir();
+        var source = File.ReadAllText(Path.Combine(appDir, "ViewModels", "ProcessManagerViewModel.cs"));
+        var xaml = File.ReadAllText(Path.Combine(appDir, "Views", "ProcessManagerView.xaml"));
+
+        // The filter enumerates its fields in one span; read them from there rather than restating them,
+        // so adding a fourth searchable field is covered automatically.
+        var span = SearchableFieldSpan().Match(source);
+        Assert.True(span.Success,
+            "could not find the Process Manager's searchable-field list — if the filter was rewritten, "
+            + "update this guard rather than deleting it");
+
+        var fields = span.Groups[1].Value
+            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .Select(f => f.Replace("p.", "", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.True(fields.Count >= 3, $"expected the filter's field list, parsed {fields.Count}");
+
+        var invisible = fields
+            .Where(f => !xaml.Contains($"Binding {f}", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.True(invisible.Count == 0,
+            "the Process Manager search matches these fields but its view renders none of them, so a "
+            + "user can filter by text they were never shown:\n  " + string.Join("\n  ", invisible));
+    }
+
+    /// <summary>The Process Manager's searchable-field span, capturing the field list.</summary>
+    [GeneratedRegex(@"ReadOnlySpan<string\?>\s+fields\s*=\s*\[([^\]]+)\]", RegexOptions.Compiled)]
+    private static partial Regex SearchableFieldSpan();
+
+    /// <summary>
     /// Every issue template that asks which tab is affected must offer the real tabs. Two of the three
     /// templates were still offering an 18-entry list from when the app had roughly that many tabs, with
     /// names that no longer matched the sidebar ("Cleanup" for "Quick Cleanup") and one entry — "Network"

--- a/SysManager/SysManager.Tests/ConverterTests.cs
+++ b/SysManager/SysManager.Tests/ConverterTests.cs
@@ -442,6 +442,34 @@ public class ConverterTests
     }
 
     [Fact]
+    public void ProcessManagerView_ShowsTheDatabaseDescription_NotTheRawFileDescription()
+    {
+        // Same defect class as the Safety column above, one field over: the database's plain-English
+        // description was loaded into ProcessEntry.PlainDescription, used to widen the search filter, and
+        // bound by no XAML — the Name column showed the raw exe FileDescription instead. That is jargon
+        // at best, and blank for most Windows system processes, because MainModule throws access-denied
+        // when unelevated — precisely the processes the database covers best.
+        var xaml = File.ReadAllText(ViewPath("ProcessManagerView.xaml"));
+
+        Assert.Contains("Binding PlainDescription", xaml);
+
+        // The raw value stays as the fallback, so a process the database does not know still shows
+        // whatever Windows reported rather than an empty line.
+        Assert.Contains("Value=\"{Binding Description}\"", xaml);
+    }
+
+    [Fact]
+    public void ProcessManagerView_ShowsTheDatabaseCategory()
+    {
+        // The search box already matched against Category, so a user could filter by a word the app
+        // never showed them. README advertises the categories alongside the descriptions.
+        var xaml = File.ReadAllText(ViewPath("ProcessManagerView.xaml"));
+
+        Assert.Contains("Header=\"Category\"", xaml);
+        Assert.Contains("SortMemberPath=\"Category\"", xaml);
+    }
+
+    [Fact]
     public void App_RegistersTheProcessSafetyConverters()
     {
         // A binding to an unregistered StaticResource key is a runtime XAML failure, and the view test

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.64.9</Version>
-    <FileVersion>1.64.9.0</FileVersion>
-    <AssemblyVersion>1.64.9.0</AssemblyVersion>
+    <Version>1.64.10</Version>
+    <FileVersion>1.64.10.0</FileVersion>
+    <AssemblyVersion>1.64.10.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -120,9 +120,30 @@
                                            RenderOptions.BitmapScalingMode="HighQuality"/>
                                     <StackPanel VerticalAlignment="Center">
                                         <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13"/>
-                                        <TextBlock Text="{Binding Description}" FontSize="11"
+
+                                        <!-- The 108-entry database (Data/ProcessDescriptions.json) supplies a
+                                             plain-English line for each known process, and this column bound the raw
+                                             exe FileDescription instead — so the tab answered "what is this?" with the
+                                             same jargon Task Manager gives, or with nothing at all: MainModule throws
+                                             access-denied for most Windows system processes when not elevated, which
+                                             is exactly what the database covers best. PlainDescription already falls
+                                             back to the raw text, so the trigger below only fires when neither exists.
+                                             Same shape as StartupView's Description/Command fallback. -->
+                                        <TextBlock FontSize="11"
                                                    Foreground="{DynamicResource TextMuted}"
-                                                   TextTrimming="CharacterEllipsis" MaxWidth="400"/>
+                                                   TextTrimming="CharacterEllipsis" MaxWidth="400"
+                                                   ToolTip="{Binding PlainDescription}">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Text" Value="{Binding PlainDescription}"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding PlainDescription}" Value="">
+                                                            <Setter Property="Text" Value="{Binding Description}"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
                                     </StackPanel>
                                 </StackPanel>
                             </DataTemplate>
@@ -223,6 +244,21 @@
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
+
+                    <!-- The same database supplies a category (System, Browser, Gaming, …) that the search box
+                         already matched against but nothing displayed, so a user could filter by a word they
+                         were never shown. Plain text rather than a chip: Safety is the column that carries the
+                         judgement, and two chips side by side would compete for the same attention. -->
+                    <DataGridTextColumn Header="Category" Binding="{Binding Category}"
+                                        Width="110" MinWidth="90" SortMemberPath="Category">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
+                                <Setter Property="FontSize" Value="12"/>
+                                <Setter Property="VerticalAlignment" Value="Center"/>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
 
                     <DataGridTemplateColumn Header="Actions" Width="120" MinWidth="120" CanUserSort="False" CanUserResize="False">
                         <DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
## The defect

SysManager ships `Data/ProcessDescriptions.json` — **108 entries**, each with a plain-English
one-liner and a category. Process Manager looks it up for every newly-seen PID
(`ProcessManagerViewModel.cs:103-106`), stores it on `ProcessEntry.PlainDescription`,
and **matches it in the search box** (`:396`).

**No XAML binds it.** A case-insensitive grep for `plaindescription` across all 64 `.xaml`
files returns zero hits. The Name column bound the raw exe `FileDescription` instead
(`ProcessManagerView.xaml:123`), which is the same wording Task Manager already gives.

So: the search invited you to filter by text the app never showed you.

### For the processes people are least sure about, it showed nothing

`ProcessManagerService.cs:83-89` reads `Process.MainModule` inside a `try` that swallows
`InvalidOperationException` and `Win32Exception` — i.e. access denied. Windows denies that
access for its own system processes unless SysManager is elevated, and the app is
unelevated by default (the tab even shows a "Run as administrator" banner).

`svchost`, `csrss`, `lsass`, `dwm`, `winlogon` are the **first entries** of the database.
For exactly those rows the second line was **blank**, while "Windows service host — runs
background services grouped by function" sat in memory unrendered.

### One field over from a fix we already shipped

`ProcessManagerView.xaml:203-206` carries this comment:

> The app carries a 108-entry process database whose provenance flag was loaded, assigned to
> `ProcessEntry.SafetyLevel` and never rendered — so "is this Windows, or something I
> installed?", the question this tab exists to answer, was invisible.

That fix surfaced `SafetyLevel` from the same database and stopped one field short of the
description beside it. Meanwhile `StartupView.xaml:127-131` **does** prefer the database
description over the raw command line — so a sibling tab renders it while the owning tab
does not.

## The fix

The Name column binds `PlainDescription`, with the raw value as a `DataTrigger` fallback —
the same shape `StartupView` already uses, not a new pattern:

```xml
<Setter Property="Text" Value="{Binding PlainDescription}"/>
<Style.Triggers>
    <DataTrigger Binding="{Binding PlainDescription}" Value="">
        <Setter Property="Text" Value="{Binding Description}"/>
    </DataTrigger>
</Style.Triggers>
```

`Category` gets its own sortable column, `ElementStyle` copied from the existing muted
text columns. Plain text rather than a chip: Safety is the column that carries the
judgement, and two chips side by side would compete for the same attention.

## Guard

`EverySearchableField_IsVisibleInItsView` parses the filter's **own** `ReadOnlySpan<string?>
fields = [...]` span and requires each field to be bound in the view — so a fourth
searchable field is covered without editing the test. A searchable-but-invisible field is
the quiet signature of this defect class.

Plus two markup assertions in `ConverterTests`, alongside the existing
`ProcessManagerView_RendersTheSafetyColumn`.

## Red → green proof

The harness resolves each claim against the real database and the shipped XAML, and
counted the scope independently:

**Red (`1a8f926`):**

```
       108 entries in ProcessDescriptions.json
[PASS] the database covers the processes whose raw description is unavailable when unelevated — 5/5: svchost, csrss, lsass, dwm, winlogon
[PASS] every entry carries both a description and a category — 108 checked
[FAIL] the Name column shows the database description — binds the raw exe FileDescription instead
[FAIL] the raw description remains the fallback
[FAIL] the category is shown as its own column
[FAIL] the category column is sortable, like every other column here
       search matches: Description, PlainDescription, Category
[FAIL] every field the search matches is rendered somewhere in the view — not rendered: PlainDescription, Category
5 FAILED
```

**Green (this branch):** ALL PASS.

One harness check is a self-guard: it fails on any `StaticResource *Muted*` reference,
because a missing style is a runtime `XamlParseException`, not a build error — the app
would crash on opening the tab. My first draft referenced an invented
`DataGridCellMuted`; I caught it before building and replaced it with the inline style the
neighbouring columns use.

## Verification

- `dotnet build` Release, app + tests: **0 errors, 0 warnings**.
- `dotnet format --verify-no-changes`, both projects: exit 0.
- README: the Process Manager section already advertised "plain-language descriptions and
  categories" — this makes that true rather than needing new prose. Added `category` to the
  sortable-columns line, which was genuinely incomplete, and a sentence about the elevation
  case.
- Leak scan over added lines: 0 hits.
- 1.64.10 + CHANGELOG entry.

## Note on scope

The audit finding this came from also listed `StartTime` and `UserName` as grep-0 fields.
I dropped both: `StartTime` is legitimately consumed in C# as the PID-reuse identity guard
(`ProcessManagerViewModel.cs:165`), and `UserName` is a separate never-assigned field —
unrelated, and worth its own look rather than being folded in here.
