### PR TITLE
fix: show which file a duplicate scan is reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.11] - 2026-08-13
+
+A duplicate scan now shows which file it is reading, so a long scan no longer looks like it might
+have frozen.
+
+### Fixed
+- **The Duplicate Finder never showed which file it was working on.** During a scan the status line counted files found and hashed, but never named the file being read — even though the scan reported it on every single update and SysManager stored it. On a big folder that made a slow scan indistinguishable from a stuck one: the numbers would crawl while one enormous file, or one file on a slow network drive, was being hashed, and there was no way to tell which. The file name now appears at the end of the status line, and hovering over it shows the full folder path.
+
+---
+
 ## [1.64.10] - 2026-08-13
 
 Process Manager now tells you in plain English what each process is, using the description database

--- a/SysManager/SysManager.Tests/DuplicateFileViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DuplicateFileViewModelTests.cs
@@ -267,6 +267,66 @@ public class DuplicateFileViewModelTests
         Assert.Contains("LastModified", xaml);               // so "oldest" is checkable by eye
     }
 
+    // ── Scan progress ──
+    // The service reported the file it was reading on every tick and the view model stored it, but no XAML
+    // bound it: a scan of a large folder showed rising counts with no sign of which file it was on, or
+    // whether it had stalled on one.
+
+    [Fact]
+    public void ScanStatus_NamesTheFileBeingRead()
+    {
+        var status = DuplicateFileViewModel.BuildScanStatus(new Services.DuplicateFileService.ScanProgress(
+            FilesDiscovered: 1_234, FilesHashed: 567, BytesProcessed: 0,
+            CurrentFile: @"C:\Users\someone\Pictures\holiday-2019\DSC_0042.jpg",
+            Phase: "Hashing"));
+
+        Assert.Contains("Hashing", status);
+        Assert.Contains("1,234 found", status);
+        Assert.Contains("567 hashed", status);
+        Assert.Contains("DSC_0042.jpg", status);
+
+        // Only the name: a deep path would dominate a single-line status row. The full path is the tooltip.
+        Assert.DoesNotContain("Pictures", status);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ScanStatus_OmitsTheFileWhenThereIsNone(string current)
+    {
+        // The discovery phase reports ticks before it has a file in hand; the line must not end in a
+        // dangling separator.
+        var status = DuplicateFileViewModel.BuildScanStatus(new Services.DuplicateFileService.ScanProgress(
+            FilesDiscovered: 10, FilesHashed: 0, BytesProcessed: 0, CurrentFile: current, Phase: "Scanning"));
+
+        Assert.Equal("Scanning — 10 found, 0 hashed", status);
+    }
+
+    [Fact]
+    public void ScanStatus_HandlesAFolderPathWithATrailingSeparator()
+    {
+        // Path.GetFileName returns "" for a path ending in a separator, which would have shown nothing at
+        // all after the separator. Discovery reports folders too.
+        var status = DuplicateFileViewModel.BuildScanStatus(new Services.DuplicateFileService.ScanProgress(
+            FilesDiscovered: 5, FilesHashed: 0, BytesProcessed: 0,
+            CurrentFile: @"C:\Users\someone\Downloads\", Phase: "Scanning"));
+
+        Assert.Contains("Downloads", status);
+        Assert.DoesNotContain("· ·", status);
+    }
+
+    [Fact]
+    public void DuplicateFileView_ShowsTheScanStatusWithTheFullPathOnHover()
+    {
+        // The pure formatter above would pass on the unfixed code, because the view model always built a
+        // status string — what was missing was the file name in it, and the path anywhere at all. Only the
+        // shipped markup can show the tooltip is wired.
+        var xaml = File.ReadAllText(ViewPath("DuplicateFileView.xaml"));
+
+        Assert.Contains("ToolTip=\"{Binding CurrentFile}\"", xaml);
+        Assert.Contains("TextTrimming=\"CharacterEllipsis\"", xaml);
+    }
+
     // Walks up from the test binaries to the app project — .xaml is not copied to the output.
     private static string ViewPath(string fileName)
     {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.64.10</Version>
-    <FileVersion>1.64.10.0</FileVersion>
-    <AssemblyVersion>1.64.10.0</AssemblyVersion>
+    <Version>1.64.11</Version>
+    <FileVersion>1.64.11.0</FileVersion>
+    <AssemblyVersion>1.64.11.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
@@ -128,7 +128,7 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
             var progress = new Progress<DuplicateFileService.ScanProgress>(p =>
             {
                 CurrentFile = p.CurrentFile;
-                StatusMessage = $"{p.Phase} — {p.FilesDiscovered:N0} found, {p.FilesHashed:N0} hashed";
+                StatusMessage = BuildScanStatus(p);
             });
 
             var results = await _service.ScanAsync(SelectedFolder, minBytes, progress, ct);
@@ -171,6 +171,26 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
             IsProgressIndeterminate = false;
             CurrentFile = "";
         }
+    }
+
+    /// <summary>
+    /// The scan's status line: phase, running counts, and the file currently being read.
+    /// <para>The file name was reported by the service and assigned to <see cref="CurrentFile"/> on every
+    /// progress tick, but nothing displayed it — so a scan of a large folder showed only rising numbers,
+    /// with no sign of which file it was on or whether it had stalled on one. Only the name is shown; the
+    /// full path goes in the row's tooltip, because a deep path would otherwise dominate the line.</para>
+    /// <para>Pure and static so the formatting is testable without running a scan.</para>
+    /// </summary>
+    internal static string BuildScanStatus(DuplicateFileService.ScanProgress p)
+    {
+        var counts = $"{p.Phase} — {p.FilesDiscovered:N0} found, {p.FilesHashed:N0} hashed";
+
+        // Path.GetFileName returns "" for a directory path ending in a separator, and the discovery phase
+        // reports folders as well as files; fall back to the raw value rather than showing nothing.
+        if (string.IsNullOrWhiteSpace(p.CurrentFile)) return counts;
+        var name = Path.GetFileName(p.CurrentFile.TrimEnd(Path.DirectorySeparatorChar,
+                                                          Path.AltDirectorySeparatorChar));
+        return string.IsNullOrEmpty(name) ? counts : $"{counts} · {name}";
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/Views/DuplicateFileView.xaml
+++ b/SysManager/SysManager/Views/DuplicateFileView.xaml
@@ -183,7 +183,24 @@
             <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <!-- The status text now carries the file being read, so it can be long; trim it rather than
+                 letting a deep path stretch the row. The full path is on hover — the scan reported it on
+                 every tick and nothing ever showed it. -->
+            <TextBlock Text="{Binding StatusMessage}"
+                       TextTrimming="CharacterEllipsis"
+                       ToolTip="{Binding CurrentFile}">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock" BasedOn="{StaticResource Caption}">
+                        <!-- No tooltip outside a scan: an empty one renders as a stray blank box. -->
+                        <Setter Property="ToolTipService.IsEnabled" Value="False"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsBusy}" Value="True">
+                                <Setter Property="ToolTipService.IsEnabled" Value="True"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
         </DockPanel>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## The defect

`DuplicateFileService` reports the file it is reading on every progress tick, and
`DuplicateFileViewModel` stores it:

```csharp
CurrentFile = p.CurrentFile;                                    // :130
StatusMessage = $"{p.Phase} — {p.FilesDiscovered:N0} found, {p.FilesHashed:N0} hashed";
```

`grep -c CurrentFile DuplicateFileView.xaml` → **0**. The field is written on every
tick, cleared in the `finally`, and displayed nowhere.

### What that costs the user

The status row *does* show phase and rising counts, so this is milder than "no
feedback" — I checked before writing it up. What's missing is **which file**, and that
is exactly what distinguishes a slow scan from a stuck one: the counters crawl while one
enormous file, or one file on a slow network drive, is being hashed, and nothing says
which. Hashing is the phase where a scan actually stalls.

## The fix

The file name closes the status line; the full path is on hover.

```
Hashing — 1,234 found, 567 hashed · DSC_0042.jpg
```

Name only inline — a deep path would dominate a single-line row — and the row now trims
instead of stretching. The tooltip is disabled while no scan is running, or an empty one
renders as a stray blank box on hover.

Formatting moved into a pure `BuildScanStatus`, because two edge cases are real and worth
pinning without running a scan:

- the discovery phase ticks **before** it has a file in hand → would leave a dangling `·`
- it reports **folders** too, and `Path.GetFileName` returns `""` for a trailing separator
  → would show nothing after the separator

## Red → green proof

The harness drives the real formatter by reflection, so the same binary works against
both trees — on the unfixed tree the method does not exist, which is itself the signal.

**Red (`ba14453`):**

```
-- the premise --
[PASS] the service's progress record carries a CurrentFile
[PASS] the view model stores it on every tick
-- the status line --
[FAIL] the scan status is built by a testable formatter — DuplicateFileViewModel.BuildScanStatus does not exist — the status is inlined, counts only
-- the view --
[FAIL] the full path is reachable on hover — CurrentFile appears nowhere in the view
[FAIL] the status row trims instead of stretching on a long path
[PASS] the status text is still bound
3 FAILED
```

**Green (this branch):**

```
       status: Hashing — 1,234 found, 567 hashed · DSC_0042.jpg
[PASS] the status names the file being read
[PASS] the counts are still there
[PASS] only the name, not the whole path
[PASS] no dangling separator when there is no file yet — 'Scanning — 1,234 found, 567 hashed'
[PASS] a folder path still shows something — 'Scanning — 1,234 found, 567 hashed · Downloads'
[PASS] the full path is reachable on hover
[PASS] the status row trims instead of stretching on a long path
[PASS] the status text is still bound
ALL PASS
```

The trimming check initially passed on red — `TextTrimming` already appears once elsewhere
in that view, so a whole-file grep proved nothing. Scoped it to the status row, and it
then failed on red correctly. Worth stating because a check that passes before the fix is
worse than no check.

The harness also asserts the **premise** (the service reports a path, the VM stores it), so
if either stopped being true the rest would be shown to be testing a non-problem rather
than quietly passing.

## Tests

Four in `DuplicateFileViewModelTests`: the name appears with counts intact and the path
does not; the two edge cases above; and one markup assertion, because the pure formatter
would pass on the unfixed code — the view model always built *a* status string.

## Verification

- `dotnet build` Release, app + tests: **0 errors, 0 warnings**.
- `dotnet format --verify-no-changes`, both projects: exit 0.
- Leak scan over added lines: 0 hits.
- 1.64.11 + CHANGELOG entry.
- No README change: the Duplicate Finder section describes what the scan finds, not its
  progress reporting, so there was nothing stale to correct.
