### PR TITLE
fix: drop three model fields that could never report the truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.12] - 2026-08-13
+
+Internal tidy-up: removed three pieces of information the app tracked but could never truthfully
+report. Nothing you see or do changes.
+
+### Fixed
+- **Removed a "blocked on" date that recorded when you opened the tab.** The App Blocker kept a timestamp for each blocked app, and it was set at the moment the list was read rather than when the block was applied — so it would have shown "just now" for a block made last month. Windows records no date for these blocks, so there is nothing to read; rather than display a number that looks meaningful and isn't, the field is gone. It was never shown on screen, so nothing is missing from the tab.
+- **Removed two fields that could only ever have been blank.** The App Blocker tracked a full file path for each blocked app, but blocks work by program name — Windows never records where the file was, which is also why a block keeps working if you move the file. The Process Manager tracked a process owner that nothing ever filled in. Both had a passing test asserting they were empty, which is how they survived. Neither reached the screen.
+
+---
+
 ## [1.64.11] - 2026-08-13
 
 A duplicate scan now shows which file it is reading, so a long scan no longer looks like it might

--- a/SysManager/SysManager.Tests/AppBlockerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppBlockerViewModelTests.cs
@@ -71,8 +71,25 @@ public class AppBlockerViewModelTests
     {
         var app = new BlockedApp();
         Assert.Equal("", app.ExecutableName);
-        Assert.Equal("", app.FullPath);
         Assert.False(app.IsSelected);
+    }
+
+    [Fact]
+    public void BlockedApp_CarriesNoFieldItCannotFill()
+    {
+        // FullPath and BlockedAt were declared and could never hold a truthful value: an IFEO key records
+        // the executable NAME and nothing else, so there is no path to report and no creation time to
+        // read. BlockedAt was worse than empty — it was assigned DateTime.Now when the list was READ, so
+        // it reported when the tab was opened, not when anything was blocked. The default-values test
+        // above previously asserted FullPath's default, which made a permanently-empty field look
+        // exercised.
+        var names = typeof(BlockedApp).GetProperties().Select(p => p.Name).ToList();
+
+        Assert.DoesNotContain("FullPath", names);
+        Assert.DoesNotContain("BlockedAt", names);
+
+        // Vacuity floor: the reflection must actually be seeing the model.
+        Assert.Contains("ExecutableName", names);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -906,6 +906,77 @@ public partial class ArchitectureTests
     private static partial Regex SearchableFieldSpan();
 
     /// <summary>
+    /// Every model property must be reachable: written by something, or shown by something. A property
+    /// that is neither is a promise the app cannot keep — <c>BlockedApp.FullPath</c> was permanently empty
+    /// because an IFEO key records only the executable name, and <c>ProcessEntry.UserName</c> was never
+    /// assigned at all. Both had a passing unit test asserting their default value, which is what let them
+    /// look exercised while displaying nothing.
+    /// <para>Setter-only is fine (a value the app consumes in C#), and display-only is fine (a computed
+    /// property). Neither, with no XAML binding either, is dead.</para>
+    /// </summary>
+    [Fact]
+    public void EveryModelProperty_IsEitherWrittenOrShown()
+    {
+        var appDir = FindAppProjectDir();
+        var modelsDir = Path.Combine(appDir, "Models");
+
+        var xaml = string.Join('\n', Directory
+            .EnumerateFiles(appDir, "*.xaml", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Select(File.ReadAllText));
+
+        var sources = Directory
+            .EnumerateFiles(appDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .ToDictionary(f => f, File.ReadAllText);
+
+        var dead = new List<string>();
+        var checkedProperties = 0;
+
+        foreach (var (path, source) in sources.Where(kv => kv.Key.StartsWith(modelsDir, StringComparison.Ordinal)))
+        {
+            var typeName = TypeDeclaration().Match(source).Groups[1].Value;
+            if (typeName.Length == 0) continue;
+
+            foreach (var m in ObservablePropertyField().Matches(source).Cast<Match>())
+            {
+                var field = m.Groups[1].Value;
+                var property = char.ToUpperInvariant(field[0]) + field[1..];
+                checkedProperties++;
+
+                if (xaml.Contains(property, StringComparison.Ordinal)) continue;
+                if (Regex.IsMatch(source, $@"\b{Regex.Escape(property)}\b")) continue;
+
+                // Require the declaring type's name in the same file, so a same-named property on another
+                // model (FriendlyEventEntry also has a UserName) cannot make this one look alive.
+                var referenced = sources.Any(kv => kv.Key != path
+                    && kv.Value.Contains(typeName, StringComparison.Ordinal)
+                    && Regex.IsMatch(kv.Value, $@"\b{Regex.Escape(property)}\b"));
+                if (referenced) continue;
+
+                dead.Add($"{typeName}.{property} ({Path.GetFileName(path)})");
+            }
+        }
+
+        Assert.True(checkedProperties >= 40,
+            $"only {checkedProperties} model properties were inspected — the detection is probably no "
+            + "longer matching the [ObservableProperty] declarations.");
+
+        Assert.True(dead.Count == 0,
+            "these model properties are never written and never shown, so they can only ever present an "
+            + "empty value to the user. Populate them or remove them:\n  " + string.Join("\n  ", dead));
+    }
+
+    /// <summary>A class or record declaration, capturing the type name.</summary>
+    [GeneratedRegex(@"(?:class|record)\s+(\w+)", RegexOptions.Compiled)]
+    private static partial Regex TypeDeclaration();
+
+    /// <summary>An <c>[ObservableProperty]</c> backing field, capturing the field name without its underscore.</summary>
+    [GeneratedRegex(@"\[ObservableProperty\][^\n]*\n?\s*(?:private|internal)\s+[\w\?<>,\[\]\. ]+?\s+_(\w+)\s*[;=]",
+        RegexOptions.Compiled)]
+    private static partial Regex ObservablePropertyField();
+
+    /// <summary>
     /// Every issue template that asks which tab is affected must offer the real tabs. Two of the three
     /// templates were still offering an 18-entry list from when the app had roughly that many tabs, with
     /// names that no longer matched the sidebar ("Cleanup" for "Quick Cleanup") and one entry — "Network"

--- a/SysManager/SysManager/Models/BlockedApp.cs
+++ b/SysManager/SysManager/Models/BlockedApp.cs
@@ -12,13 +12,16 @@ namespace SysManager.Models;
 public sealed partial class BlockedApp : ObservableObject
 {
     /// <summary>Executable file name (e.g., "notepad.exe").</summary>
+    /// <remarks>
+    /// A name, not a path, and deliberately so: an IFEO key is per executable NAME, which is why a block
+    /// keeps working wherever the user moves or copies the file. A <c>FullPath</c> property used to sit
+    /// beside this one and nothing could ever fill it — the registry does not record where the executable
+    /// lived — so it was permanently empty and has been removed rather than left to imply the app knows.
+    /// A <c>BlockedAt</c> timestamp was removed for a sharper reason: it was set to <c>DateTime.Now</c>
+    /// when the list was READ, so it recorded when you opened the tab, not when you blocked anything.
+    /// IFEO stores no creation time, so the honest answer is not to claim one.
+    /// </remarks>
     [ObservableProperty] private string _executableName = "";
-
-    /// <summary>Full path to the executable (if known).</summary>
-    [ObservableProperty] private string _fullPath = "";
-
-    /// <summary>When the block was applied.</summary>
-    [ObservableProperty] private DateTime _blockedAt;
 
     /// <summary>Whether this entry is selected in the UI.</summary>
     [ObservableProperty] private bool _isSelected;

--- a/SysManager/SysManager/Models/ProcessEntry.cs
+++ b/SysManager/SysManager/Models/ProcessEntry.cs
@@ -21,7 +21,11 @@ public sealed partial class ProcessEntry : ObservableObject
     [NotifyPropertyChangedFor(nameof(MemoryDisplay))]
     private long _memoryBytes;
     [ObservableProperty] private string _status = "";
-    [ObservableProperty] private string _userName = "";
+    // No UserName: one was declared here and nothing ever assigned it, so it could only ever have shown
+    // an empty owner. Reading a process's owner needs OpenProcessToken per process, which Windows denies
+    // for other users' and most system processes unless elevated — so the choices were to implement it
+    // properly or not to imply it exists. Dropped; the Safety column already answers the question this
+    // tab is for ("is this Windows, or something I installed?").
     [ObservableProperty] private DateTime _startTime;
     [ObservableProperty] private int _threadCount;
     [ObservableProperty] private string _filePath = "";

--- a/SysManager/SysManager/Services/AppBlockerService.cs
+++ b/SysManager/SysManager/Services/AppBlockerService.cs
@@ -315,11 +315,7 @@ public sealed partial class AppBlockerService : IAppBlockerService
                     var debugger = appKey.GetValue("Debugger") as string;
                     if (debugger is not null && debugger.Equals(BlockerDebugger, StringComparison.OrdinalIgnoreCase))
                     {
-                        blocked.Add(new BlockedApp
-                        {
-                            ExecutableName = subKeyName,
-                            BlockedAt = DateTime.Now
-                        });
+                        blocked.Add(new BlockedApp { ExecutableName = subKeyName });
                     }
                 }
                 catch (IOException) { /* skip */ }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.64.11</Version>
-    <FileVersion>1.64.11.0</FileVersion>
-    <AssemblyVersion>1.64.11.0</AssemblyVersion>
+    <Version>1.64.12</Version>
+    <FileVersion>1.64.12.0</FileVersion>
+    <AssemblyVersion>1.64.12.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Three fields the app could never truthfully fill

### `BlockedApp.BlockedAt` — the one that was actively wrong

```csharp
blocked.Add(new BlockedApp
{
    ExecutableName = subKeyName,
    BlockedAt = DateTime.Now        // inside GetBlockedApps()
});
```

That is set while **reading** the list, so it recorded when the tab was opened — a block
made last month would report "just now". IFEO stores no creation time, so there is nothing
to read. A value that looks meaningful and is wrong is worse than an empty one.

### `BlockedApp.FullPath` — permanently empty by construction

Declared, never assigned, and it *cannot* be: an IFEO key is keyed on the executable
**name**. The registry never records where the file was — which is also precisely why a
block keeps working when the user moves or copies it.

### `ProcessEntry.UserName` — declared, assigned by nothing, bound by nothing

Reading a process owner needs `OpenProcessToken` per process, which Windows denies for
other users' and most system processes unless elevated. The Safety column already answers
the question that tab exists for.

**None of the three ever reached the screen**, so nothing is missing from either tab.

## How they survived

Each had a **passing unit test asserting its default value**:

```csharp
Assert.Equal("", app.FullPath);
```

That is what let a permanently-empty field look exercised. The test now asserts the fields
are absent and states why — the inverse assertion, which is the only one that stays true.

## Ratchet

`EveryModelProperty_IsEitherWrittenOrShown`. Setter-only is fine (consumed in C#) and
display-only is fine (computed); **neither**, with no XAML binding, is dead.

The subtle part: it requires the declaring type's name to appear in a file before counting
a reference there. `FriendlyEventEntry` also has a `UserName` — and that collision is
exactly what hid `ProcessEntry`'s. My own first sweep returned **0 dead properties** for
that reason; the type-aware version found both.

Vacuity floor of 40. It currently inspects **164**.

## Red → green proof

The harness re-derives the sweep independently, so the ratchet's answer is corroborated
rather than trusted — and it checks the ratchet is honest in *both* directions: it must
flag these, and must not flag the 160-odd properties that are legitimately write-only or
display-only.

**Red (`58c39a5`):**

```
[FAIL] BlockedApp has no FullPath it could never fill
[FAIL] BlockedApp has no BlockedAt it could only misreport
[FAIL] ProcessEntry has no UserName nothing assigns
[PASS] the models are otherwise intact
[FAIL] the list reader stamps no time of its own — GetBlockedApps still assigns DateTime.Now, i.e. when the tab was opened
[PASS] it still reports the blocked executables
       167 model properties inspected
[PASS] the detection sees the model surface — 167 found
[FAIL] no model property is both unwritten and unshown — BlockedApp.FullPath, ProcessEntry.UserName
5 FAILED
```

**Green (this branch):** ALL PASS, `164 model properties inspected` — exactly the three
removed, and the independent sweep reports zero dead.

Note the red run's sweep found **2**, not 3: `BlockedAt` *was* assigned, so it is not
"unwritten" — which is why it gets its own source-level check against reintroducing a
read-time timestamp. A single-shaped guard would have missed the worst of the three.

## Verification

- `dotnet build` Release, app + tests: **0 errors, 0 warnings**. The test project initially
  failed with CS1061 on `FullPath` — that was the vanity test, now rewritten.
- `dotnet format --verify-no-changes`, both projects: exit 0. It passed by luck at first;
  my scripted edit had written LF into a CRLF file. Fixed before commit.
- Leak scan over added lines: 0 hits.
- 1.64.12 + CHANGELOG entry. No README change: none of the three was ever documented,
  because none was ever visible.
