### PR TITLE
fix: point every confirmation prompt at its safe answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.13] - 2026-08-13
+
+Pressing Enter on a confirmation prompt no longer approves it. Every "are you sure?" now starts on
+the safe answer, so an accidental keypress cancels instead of going ahead.
+
+### Fixed
+- **A stray Enter could approve a confirmation you hadn't read.** Every prompt that asks you to confirm something — shredding files, ending a process, removing built-in apps, uninstalling, applying a preset — opened with **Yes** already selected. So pressing Enter, or pressing it a second time after the key that opened the prompt, went straight ahead with the action. All 76 of those prompts now open with **No** selected: Enter cancels, and choosing Yes still takes a single click or keypress. The same applies to the prompt you get when closing the window, which now starts on Cancel — its behaviour finally matches what it already promised, since Esc and the window's X have always meant "leave things alone".
+
+---
+
 ## [1.64.12] - 2026-08-13
 
 Internal tidy-up: removed three pieces of information the app tracked but could never truthfully

--- a/SysManager/SysManager.Tests/DialogServiceTests.cs
+++ b/SysManager/SysManager.Tests/DialogServiceTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using SysManager.Services;
 
 namespace SysManager.Tests;
@@ -62,5 +63,42 @@ public class DialogServiceTests
         {
             DialogService.Instance = previous;
         }
+    }
+
+    // ── The focused button ──
+    // Which button WPF focuses cannot be observed without a live Application, and the dialogs are
+    // deliberately out of scope for unit tests (see the class summary). But the safe default is a
+    // one-argument difference that compiles either way and stays invisible until someone presses Enter
+    // over a file-shredder prompt — so the shipped source is what gets pinned, the same way the
+    // XAML-binding guards work. All 76 confirmation call sites in the app go through Confirm.
+
+    [Theory]
+    [InlineData("public bool Confirm(", "MessageBoxResult.No")]
+    [InlineData("public CloseChoice AskCloseOrMinimize(", "MessageBoxResult.Cancel")]
+    public void EveryPromptFocusesItsSafeAnswer(string methodSignature, string expectedDefault)
+    {
+        var source = File.ReadAllText(ServiceSourcePath("DialogService.cs"));
+
+        var start = source.IndexOf(methodSignature, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"{methodSignature} not found — update this guard rather than deleting it");
+        var body = source[start..source.IndexOf("\n    }", start, StringComparison.Ordinal)];
+
+        Assert.Contains("MessageBox.Show", body);
+
+        // MessageBox.Show without a defaultResult focuses the FIRST button, which is Yes.
+        Assert.Contains(expectedDefault, body);
+    }
+
+    // Walks up from the test binaries to the app project — source is not copied to the output.
+    private static string ServiceSourcePath(string fileName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "SysManager", "Services")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);   // else the assertions above would silently test nothing
+        var path = Path.Combine(dir!.FullName, "SysManager", "Services", fileName);
+        Assert.True(File.Exists(path), $"{fileName} not found at {path}");
+        return path;
     }
 }

--- a/SysManager/SysManager/Services/DialogService.cs
+++ b/SysManager/SysManager/Services/DialogService.cs
@@ -24,7 +24,14 @@ public sealed class DialogService : IDialogService
     public bool Confirm(string message, string title)
     {
         if (Application.Current == null) return false;
-        var result = MessageBox.Show(message, title, MessageBoxButton.YesNo, MessageBoxImage.Question);
+
+        // MessageBoxResult.No is the DEFAULT, i.e. the focused button. Without it WPF focuses Yes, so a
+        // stray Enter — or a second Enter after the keypress that opened the dialog — approves whatever
+        // is being confirmed. Every destructive operation in the app funnels through here (file
+        // shredding, ending a process, debloat, uninstall), so the safe default belongs in this one
+        // place rather than at each of the call sites. A user who means Yes still only presses one key.
+        var result = MessageBox.Show(message, title, MessageBoxButton.YesNo, MessageBoxImage.Question,
+                                     MessageBoxResult.No);
         return result == MessageBoxResult.Yes;
     }
 
@@ -38,8 +45,12 @@ public sealed class DialogService : IDialogService
         // Yes = keep running in the notification area, No = exit, Cancel = stay open.
         // The caller's message states which option is which, so the mapping is explicit
         // on screen. Cancel is also what Esc and the dialog's own close button produce,
-        // which is the right default for an accidental click.
-        var result = MessageBox.Show(message, title, MessageBoxButton.YesNoCancel, MessageBoxImage.Question);
+        // which is the right default for an accidental click — and passing it as the
+        // defaultResult is what actually makes that true of the Enter key too. Without it
+        // WPF focuses Yes, so Enter would silently choose "hide to the notification area"
+        // when the user meant to dismiss the question.
+        var result = MessageBox.Show(message, title, MessageBoxButton.YesNoCancel, MessageBoxImage.Question,
+                                     MessageBoxResult.Cancel);
         return result switch
         {
             MessageBoxResult.Yes => CloseChoice.MinimizeToTray,

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.64.12</Version>
-    <FileVersion>1.64.12.0</FileVersion>
-    <AssemblyVersion>1.64.12.0</AssemblyVersion>
+    <Version>1.64.13</Version>
+    <FileVersion>1.64.13.0</FileVersion>
+    <AssemblyVersion>1.64.13.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## The defect

```csharp
var result = MessageBox.Show(message, title, MessageBoxButton.YesNo, MessageBoxImage.Question);
```

`MessageBox.Show` without a `defaultResult` focuses the **first** button — Yes. So every
confirmation prompt in the app opened with Yes focused, and a stray Enter approved it. So
did a second Enter after the keypress that opened the prompt.

**76 call sites** funnel through `DialogService.Confirm`, including:

| Where | What Enter would have done |
|---|---|
| `FileShredderViewModel.cs:127` | started an unrecoverable multi-pass overwrite |
| `ProcessManagerViewModel.cs:268` | ended the selected process |
| `DebloaterViewModel.cs:148` | removed built-in apps |
| `UninstallerViewModel.cs:146` | uninstalled the selected app |
| `ContextMenuViewModel.cs:195` | applied a registry preset |

`Confirm` now passes `MessageBoxResult.No`. Saying yes still costs one click or one
keypress; saying it by accident no longer does.

### The close prompt was already documenting the fix it didn't have

`AskCloseOrMinimize` carried this comment:

> Cancel is also what Esc and the dialog's own close button produce, **which is the right
> default for an accidental click.**

True of Esc and the X — not of Enter, which chose "hide to the notification area". It now
passes `MessageBoxResult.Cancel`, so the code does what the comment claimed.

Both fixes are in the single place the dialogs are created, not at the call sites, so a
77th confirmation inherits the safe default.

## Guard

`EveryPromptFocusesItsSafeAnswer` reads the shipped source. Which button WPF focuses needs
a live `Application`, and these dialogs are deliberately outside the unit-test scope (the
test class says so) — but this is a **one-argument difference that compiles either way** and
stays invisible until someone presses Enter over a shredder prompt. That is exactly the
profile the XAML-binding guards exist for.

## Red → green proof

Same logic the xUnit `Theory` runs, applied by hand to both trees:

```
--- RED (main, ced3c36) ---
  [FAIL] Confirm focuses No
  [FAIL] AskCloseOrMinimize focuses Cancel
--- GREEN (this branch) ---
  [PASS] Confirm focuses No
  [PASS] AskCloseOrMinimize focuses Cancel
```

## Verification

- `dotnet build` Release, app + tests: **0 errors, 0 warnings**. (First test build failed
  CS0103 — missing `using System.IO`; fixed before commit.)
- `dotnet format --verify-no-changes`, both projects: exit 0.
- `grep MessageBox.Show`: 4 call sites total. The two above now pass a default; `Inform` is
  OK-only so there is nothing to choose; `App.xaml.cs:347` is the crash reporter, also
  OK-only.
- Leak scan over added lines: 0 hits.
- 1.64.13 + CHANGELOG entry.

## Provenance

Found by a single-file review pass over `DialogService.cs` — one file, no other context.
Two other suggestions from the same pass were **dropped**: an owner-window overload (the
`Application.Current == null` guard already handles the headless case, and modality is a
separate UX question), and modernising `?? throw new ArgumentNullException` to
`ArgumentNullException.ThrowIfNull` — both forms throw the identical exception with the
identical parameter name, so it is churn, not a fix.
