### PR TITLE
fix: announce the elevation button with the words printed on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.14] - 2026-08-13
+
+The "Run as administrator" button now tells screen readers and voice control exactly what it says on
+screen, on all 30 pages that offer it.
+
+### Fixed
+- **The "Run as administrator" button announced a different name than the one printed on it.** Thirty pages offer that button, and only fifteen of them announced it as "Run as administrator". Five said "Restart SysManager as administrator", four said "Relaunch as administrator", one said "Restart as administrator", and five said nothing at all. Anyone using a screen reader heard a verb that was not on the screen, and anyone using Windows Speech Recognition or Voice Access could say the words they could read and have nothing happen — on the one button that unlocks everything else. All thirty now say "Run as administrator", and a test fails the build if a new page drifts again.
+
+---
+
 ## [1.64.13] - 2026-08-13
 
 Pressing Enter on a confirmation prompt no longer approves it. Every "are you sure?" now starts on

--- a/SysManager/SysManager.Tests/UiAutomationContractTests.cs
+++ b/SysManager/SysManager.Tests/UiAutomationContractTests.cs
@@ -148,6 +148,52 @@ public partial class UiAutomationContractTests
     private static partial Regex FindButtonByIdCall();
 
     /// <summary>
+    /// The elevation button is the same control on every page that needs administrator rights, so it must
+    /// be announced with the same words everywhere — and with the words that are printed on it.
+    /// <para>Across the 30 buttons labelled "Run as administrator" only 15 were announced that way: 5 said
+    /// "Restart SysManager as administrator", 4 "Relaunch as administrator", 1 "Restart as administrator",
+    /// and 5 carried no accessible name at all. A screen-reader user heard a different verb than the one on
+    /// screen, and a voice-control user saying what they could read could not activate the app's most
+    /// consequential control. WCAG 2.5.3 (Label in Name) is the rule; 30 copies of one control is the
+    /// reason it has to be mechanical rather than remembered.</para>
+    /// </summary>
+    [Fact]
+    public void EveryElevationButton_IsAnnouncedWithTheWordsPrintedOnIt()
+    {
+        const string label = "Run as administrator";
+        var views = Path.Combine(FindSolutionDirectory().FullName, "SysManager", "Views");
+
+        var offenders = new List<string>();
+        var checkedButtons = 0;
+
+        foreach (var view in Directory.EnumerateFiles(views, "*.xaml", SearchOption.TopDirectoryOnly))
+        {
+            foreach (var button in XDocument.Load(view)
+                         .Descendants(Presentation + "Button")
+                         .Where(b => (string?)b.Attribute("Content") == label))
+            {
+                checkedButtons++;
+                var spoken = (string?)button.Attribute("AutomationProperties.Name");
+
+                // No name at all is also a failure: WPF would fall back to the label, which happens to be
+                // right, but the contract is stated explicitly on every other elevation button.
+                if (spoken != label)
+                    offenders.Add($"{Path.GetFileName(view)}: announced as \"{spoken ?? "(no name)"}\"");
+            }
+        }
+
+        // Vacuity floor: if the elevation button were renamed, this would inspect nothing and pass.
+        Assert.True(checkedButtons >= 20,
+            $"only {checkedButtons} elevation buttons were found — if the label changed, update this guard "
+            + "rather than letting it inspect nothing.");
+
+        Assert.True(offenders.Count == 0,
+            $"these elevation buttons are labelled \"{label}\" but announced differently, so a screen "
+            + "reader says one thing while the screen says another and voice control cannot activate "
+            + $"them:\n  {string.Join("\n  ", offenders)}");
+    }
+
+    /// <summary>
     /// The event-log severity column must not convey severity by colour alone. It previously held
     /// a bare coloured Ellipse under an empty header — no text, no tooltip, no accessible name —
     /// so severity was unavailable to anyone with a colour-vision deficiency and to a screen

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.64.13</Version>
-    <FileVersion>1.64.13.0</FileVersion>
-    <AssemblyVersion>1.64.13.0</AssemblyVersion>
+    <Version>1.64.14</Version>
+    <FileVersion>1.64.14.0</FileVersion>
+    <AssemblyVersion>1.64.14.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AppBlockerView.xaml
+++ b/SysManager/SysManager/Views/AppBlockerView.xaml
@@ -32,7 +32,8 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
+                        AutomationProperties.Name="Run as administrator"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml
@@ -26,7 +26,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        AutomationProperties.Name="Relaunch as administrator"
+                        AutomationProperties.Name="Run as administrator"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"

--- a/SysManager/SysManager/Views/BootAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/BootAnalyzerView.xaml
@@ -32,7 +32,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        AutomationProperties.Name="Restart SysManager as administrator"
+                        AutomationProperties.Name="Run as administrator"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <!-- Glyph docked left of the message, not a nested horizontal StackPanel: a StackPanel
                      gives its children infinite width along its orientation, so the message's

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -32,7 +32,8 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
+                        AutomationProperties.Name="Run as administrator"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -25,7 +25,8 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
+                        AutomationProperties.Name="Run as administrator"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -61,7 +61,8 @@
                     Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
                 <DockPanel>
                     <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                            Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                            Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
+                            AutomationProperties.Name="Run as administrator"/>
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                    FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>

--- a/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
+++ b/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
@@ -31,7 +31,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        AutomationProperties.Name="Restart SysManager as administrator"
+                        AutomationProperties.Name="Run as administrator"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <!-- Glyph docked left of the message, not a nested horizontal StackPanel: a StackPanel
                      gives its children infinite width along its orientation, so the message's

--- a/SysManager/SysManager/Views/NetworkRepairView.xaml
+++ b/SysManager/SysManager/Views/NetworkRepairView.xaml
@@ -20,7 +20,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        AutomationProperties.Name="Relaunch as administrator"
+                        AutomationProperties.Name="Run as administrator"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -31,7 +31,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        AutomationProperties.Name="Restart SysManager as administrator"
+                        AutomationProperties.Name="Run as administrator"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"

--- a/SysManager/SysManager/Views/RestorePointsView.xaml
+++ b/SysManager/SysManager/Views/RestorePointsView.xaml
@@ -32,7 +32,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        AutomationProperties.Name="Restart SysManager as administrator"
+                        AutomationProperties.Name="Run as administrator"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <!-- Glyph docked left of the message, not a nested horizontal StackPanel: a StackPanel
                      gives its children infinite width along its orientation, so the message's

--- a/SysManager/SysManager/Views/StandbyMemoryView.xaml
+++ b/SysManager/SysManager/Views/StandbyMemoryView.xaml
@@ -37,7 +37,7 @@
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Restart as administrator"/>
+                        AutomationProperties.Name="Run as administrator"/>
                 <TextBlock Text="Purging the standby list requires administrator privileges."
                            Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center" TextWrapping="Wrap"/>
             </DockPanel>

--- a/SysManager/SysManager/Views/SystemFixesView.xaml
+++ b/SysManager/SysManager/Views/SystemFixesView.xaml
@@ -32,7 +32,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        AutomationProperties.Name="Restart SysManager as administrator"
+                        AutomationProperties.Name="Run as administrator"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <!-- Glyph docked left of the message, not a nested horizontal StackPanel: a StackPanel
                      gives its children infinite width along its orientation, so the message's

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -27,7 +27,7 @@
                         Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
                     <DockPanel>
                         <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                                AutomationProperties.Name="Relaunch as administrator"
+                                AutomationProperties.Name="Run as administrator"
                                 Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                             <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -57,7 +57,7 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        AutomationProperties.Name="Relaunch as administrator"
+                        AutomationProperties.Name="Run as administrator"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -34,7 +34,8 @@
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
+                        AutomationProperties.Name="Run as administrator"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>


### PR DESCRIPTION
## Problem

Thirty pages offer a button labelled **Run as administrator**. Only fifteen of them announced it that way.

| Announced as | Count |
|---|---|
| `Run as administrator` (correct) | 15 |
| `Restart SysManager as administrator` | 5 |
| `Relaunch as administrator` | 4 |
| `Restart as administrator` | 1 |
| *(no accessible name at all)* | 5 |

Two concrete user consequences:

- **Screen reader** — the user hears a verb that is not on the screen. "Relaunch" when the button says "Run".
- **Voice control** (Windows Speech Recognition, Voice Access) — the user says the words they can read and *nothing happens*. Voice control matches on the accessible name, so on 15 of 30 pages the app's most consequential control is unreachable by voice.

This is WCAG 2.5.3 *Label in Name*: the accessible name must contain the visible label.

The canonical wording is not a judgement call — the project's admin-control contract already names this control "Run as administrator", which is also what is printed on all thirty buttons.

## Fix

All thirty now announce `Run as administrator`. Ten had a mismatched name realigned; five had no name and gained one.

Views touched: AppBlocker, AppUpdates, BootAnalyzer, BulkInstaller, Cleanup, Dashboard, EnvironmentVariables, NetworkRepair, Privacy, RestorePoints, StandbyMemory, SystemFixes, SystemHealth, WindowsFeatures, WindowsUpdate.

No visual change: `Content` was already correct everywhere. Only what assistive technology reads changes.

## Guard

`UiAutomationContractTests.EveryElevationButton_IsAnnouncedWithTheWordsPrintedOnIt` parses every view's XAML, finds each `Button` whose `Content` is the label, and fails if the announced name differs — **including when it is absent**, so a new page cannot silently opt out by omitting the attribute.

It carries a vacuity floor (`>= 20` buttons inspected). Without it, renaming the label would make the guard inspect nothing and pass.

## Regression proof

Independently re-derived by XML parsing on both trees:

```
RED  (main f1e7951): 30 elevation buttons, 15 mismatched -> FAIL
GREEN (this branch): 30 elevation buttons,  0 mismatched -> PASS
```

The red run names all 15 offenders, so the guard fails for the stated reason and not by accident.

## Verification

- `dotnet build` app project, Release — 0 errors, 0 warnings
- `dotnet build` tests project, Release — 0 errors, 0 warnings
- `dotnet format --verify-no-changes` — clean on both projects
- Identity/AI leak scan over all 18 changed files — 0 hits, with a control term proving the scan is not vacuous
- CHANGELOG entry added in this PR; version bumped to 1.64.14

## Scope note

Sweeping the views turned up 89 of 248 controls whose accessible name does not contain its visible label. Most are cases where the name *extends* the label (a longer, more descriptive phrase) — arguably intentional and lower severity. This PR fixes only the class where the name **contradicts** the label, on one control repeated thirty times. The remainder is left for separate triage rather than bundled here.