### PR TITLE
fix: say when a file could not be added to the shred queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.15] - 2026-08-13
+
+The File Shredder now tells you when a file you picked could not be added to the list, instead of
+quietly leaving it out.
+
+### Fixed
+- **A file you picked could disappear from the shred list with nothing said.** If a file or folder could not be read — locked by another program, on a disconnected drive, or protected by permissions — it was written to a log file you never see and then left out of the list. Pick ten files, see eight, and nothing on screen explained the other two: it looked like the app had simply finished. The footer now names what could not be added and says plainly that it is **not** in the list, so you can retry or remove it rather than assuming it is queued for destruction.
+- **A long message in the File Shredder footer was cut off instead of wrapping.** The footer laid its text out on a single unbounded line, so anything longer than the window ran off the right edge invisibly. It now wraps, which is what makes the message above readable when it names several files.
+
+---
+
 ## [1.64.14] - 2026-08-13
 
 The "Run as administrator" button now tells screen readers and voice control exactly what it says on

--- a/SysManager/SysManager.Tests/FileShredderViewModelTests.cs
+++ b/SysManager/SysManager.Tests/FileShredderViewModelTests.cs
@@ -183,4 +183,84 @@ public class FileShredderViewModelTests
             DialogService.Instance = prevDialog;
         }
     }
+
+    // ---------- items the user picked but that could not be queued ----------
+    // The queue is the user's record of what is about to be destroyed. A file that cannot be read
+    // was logged to a file the user never opens and then omitted, so picking ten files and seeing
+    // eight looked like the app had simply finished. The message has to name what is missing, and
+    // it has to say the item is NOT queued — otherwise "couldn't read it" reads as a warning about
+    // something that will still be shredded.
+
+    [Fact]
+    public void SkippedMessage_WhenNothingWasSkipped_IsEmptySoNoStaleWarningRemains()
+    {
+        Assert.Equal(string.Empty, FileShredderViewModel.DescribeSkipped([]));
+    }
+
+    [Fact]
+    public void SkippedMessage_ForOneItem_NamesItAndSaysItIsNotQueued()
+    {
+        var message = FileShredderViewModel.DescribeSkipped(["locked.dat"]);
+
+        Assert.Contains("locked.dat", message, StringComparison.Ordinal);
+        Assert.Contains("NOT", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SkippedMessage_ForSeveralItems_ReportsTheCountAndEveryName()
+    {
+        var message = FileShredderViewModel.DescribeSkipped(["a.dat", "b.dat", "c.dat"]);
+
+        Assert.Contains("3", message, StringComparison.Ordinal);
+        Assert.Contains("a.dat", message, StringComparison.Ordinal);
+        Assert.Contains("b.dat", message, StringComparison.Ordinal);
+        Assert.Contains("c.dat", message, StringComparison.Ordinal);
+        Assert.Contains("NOT", message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The message is only useful if it reaches the screen, and the defect was precisely that a
+    /// failure never did. Both add paths must therefore assign StatusMessage on the failure branch —
+    /// asserted against the source because the failure needs an unreadable file picked through a
+    /// file dialog, which a unit test cannot drive.
+    /// </summary>
+    [Fact]
+    public void BothAddPaths_ReportSkippedItemsOnScreen_NotOnlyToTheLog()
+    {
+        var source = File.ReadAllText(ViewModelSourcePath());
+
+        var offenders = new List<string>();
+        foreach (var command in new[] { "private void AddFiles()", "private void AddFolder()" })
+        {
+            var start = source.IndexOf(command, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"{command} not found — update this guard.");
+            var body = source[start..source.IndexOf("\n    }", start, StringComparison.Ordinal)];
+
+            // Every catch that logs a skipped item must also surface it.
+            var logs = body.Split("Log.Warning", StringSplitOptions.None).Length - 1;
+            var surfaced = body.Split("StatusMessage", StringSplitOptions.None).Length - 1;
+            if (logs == 0)
+                offenders.Add($"{command}: no failure logging found — guard is inspecting nothing");
+            else if (surfaced == 0)
+                offenders.Add($"{command}: {logs} logged failure(s), none reported on screen");
+        }
+
+        Assert.True(offenders.Count == 0,
+            "an item the user picked can vanish from the shred queue with nothing said on screen:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    private static string ViewModelSourcePath()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory is not null;
+             directory = directory.Parent)
+        {
+            var candidate = Path.Combine(
+                directory.FullName, "SysManager", "ViewModels", "FileShredderViewModel.cs");
+            if (File.Exists(candidate)) return candidate;
+        }
+
+        throw new FileNotFoundException("Could not locate FileShredderViewModel.cs from the test output.");
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.64.14</Version>
-    <FileVersion>1.64.14.0</FileVersion>
-    <AssemblyVersion>1.64.14.0</AssemblyVersion>
+    <Version>1.64.15</Version>
+    <FileVersion>1.64.15.0</FileVersion>
+    <AssemblyVersion>1.64.15.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/FileShredderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/FileShredderViewModel.cs
@@ -44,6 +44,8 @@ public sealed partial class FileShredderViewModel : ViewModelBase
 
         if (dialog.ShowDialog() != true) return;
 
+        var skipped = new List<string>();
+
         foreach (var filePath in dialog.FileNames)
         {
             if (Items.Any(i => i.Path.Equals(filePath, StringComparison.OrdinalIgnoreCase)))
@@ -63,6 +65,7 @@ public sealed partial class FileShredderViewModel : ViewModelBase
             catch (IOException ex)
             {
                 Log.Warning(ex, "Could not read file info: {Path}", filePath);
+                skipped.Add(Path.GetFileName(filePath));
             }
             catch (UnauthorizedAccessException ex)
             {
@@ -70,9 +73,26 @@ public sealed partial class FileShredderViewModel : ViewModelBase
                 // whole drop. UnauthorizedAccessException is a sibling of IOException, not a
                 // subclass, so the catch above never covered it.
                 Log.Warning(ex, "Access denied reading file info: {Path}", filePath);
+                skipped.Add(Path.GetFileName(filePath));
             }
         }
+
+        StatusMessage = DescribeSkipped(skipped);
     }
+
+    /// <summary>
+    /// Builds the message shown when items the user picked could not be queued. Returning an empty
+    /// string clears any previous warning, so a successful second attempt does not leave a stale one
+    /// on screen.
+    /// <para>Named separately so the wording is assertable without a file dialog.</para>
+    /// </summary>
+    internal static string DescribeSkipped(IReadOnlyList<string> skipped) => skipped.Count switch
+    {
+        0 => string.Empty,
+        1 => $"Could not add \"{skipped[0]}\" — it could not be read, so it is NOT in the list below.",
+        _ => $"Could not add {skipped.Count} of the items you picked ({string.Join(", ", skipped)}) — "
+             + "they could not be read, so they are NOT in the list below."
+    };
 
     [RelayCommand(CanExecute = nameof(CanEditQueue))]
     private void AddFolder()
@@ -101,14 +121,19 @@ public sealed partial class FileShredderViewModel : ViewModelBase
                 SizeBytes = size,
                 IsFolder = true
             });
+            StatusMessage = string.Empty;
         }
         catch (UnauthorizedAccessException ex)
         {
             Log.Warning(ex, "Access denied while reading folder: {Path}", folderPath);
+            StatusMessage = DescribeSkipped([Path.GetFileName(folderPath.TrimEnd(
+                Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))]);
         }
         catch (IOException ex)
         {
             Log.Warning(ex, "Could not read folder info: {Path}", folderPath);
+            StatusMessage = DescribeSkipped([Path.GetFileName(folderPath.TrimEnd(
+                Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))]);
         }
     }
 

--- a/SysManager/SysManager/Views/FileShredderView.xaml
+++ b/SysManager/SysManager/Views/FileShredderView.xaml
@@ -117,14 +117,19 @@
 
         <!-- Footer -->
         <Border Grid.Row="3" Margin="28,8,28,16" Padding="8">
-            <StackPanel Orientation="Horizontal">
-                <TextBlock Style="{StaticResource Subtle}">
+            <!-- DockPanel, not a horizontal StackPanel: a StackPanel gives its children infinite
+                 width, so TextWrapping never engages and a long message — such as one naming
+                 several files that could not be queued — is clipped off the right edge. -->
+            <DockPanel>
+                <TextBlock DockPanel.Dock="Left" Style="{StaticResource Subtle}"
+                           VerticalAlignment="Center">
                     <Run Text="{Binding Items.Count, Mode=OneWay}"/>
                     <Run Text=" item(s) queued"/>
                 </TextBlock>
                 <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
-                           Margin="16,0,0,0" Opacity="0.8"/>
-            </StackPanel>
+                           Margin="16,0,0,0" Opacity="0.8" TextWrapping="Wrap"
+                           VerticalAlignment="Center"/>
+            </DockPanel>
         </Border>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Problem

Both File Shredder add paths — `AddFiles` and `AddFolder` — caught a per-item read failure, logged it, and continued:

```csharp
catch (IOException ex)
{
    Log.Warning(ex, "Could not read file info: {Path}", filePath);
}
```

The log file is one the user never opens. The item was simply absent from the queue, with nothing on screen.

**Why this one matters more than a typical missing-feedback bug:** the queue is the user's record of what is about to be *irreversibly destroyed*. Pick ten files, see eight, and the app looks like it finished normally. A locked file, a disconnected network drive and a permissions denial all produce the same silence. And the failure mode cuts the dangerous way too — a user can reasonably conclude the missing item **was** queued and is about to be shredded.

Four catch sites, two commands.

## Fix

The footer now names what could not be added and states plainly that it is **not** in the list.

`DescribeSkipped` is a separate `internal static` formatter so the wording is assertable without driving a file dialog. It returns an empty string when nothing was skipped, so a successful retry clears the previous warning rather than leaving a stale one on screen.

### The footer could not have shown that message

It was a horizontal `StackPanel`, which measures children with infinite width along its orientation — so a long line is laid out on one row and clipped off the right edge instead of wrapping. It is now a `DockPanel` with the count docked left and the message as the fill child, matching `CpuAffinityView`, `DisplayProfileView` and `FileLockView`.

This is the same class PR #1812 fixed in 14 places. That PR's guard deliberately skips *bound* values (`text.StartsWith('{')`) since it cannot know a bound string's length, which is exactly why this one survived: the text here is `{Binding StatusMessage}`.

## Guard

Four tests in `FileShredderViewModelTests`:

- `SkippedMessage_WhenNothingWasSkipped_IsEmptySoNoStaleWarningRemains`
- `SkippedMessage_ForOneItem_NamesItAndSaysItIsNotQueued`
- `SkippedMessage_ForSeveralItems_ReportsTheCountAndEveryName`
- `BothAddPaths_ReportSkippedItemsOnScreen_NotOnlyToTheLog` — asserts against the source that every logged failure in both commands is also surfaced. Reproducing the real failure needs an unreadable file chosen through a file dialog, which a unit test cannot drive. It throws if it finds no logging at all, so it cannot pass by inspecting nothing.

## Regression proof

Re-derived independently of the xUnit run:

```
RED  (main bc4482c): 5 checks FAIL
    AddFiles()  - 2 logged, 0 surfaced
    AddFolder() - 2 logged, 0 surfaced
    no testable formatter exists
    footer is a horizontal StackPanel (clips instead of wrapping)
    status TextBlock does not wrap
GREEN (this branch): ALL PASS
```

## Verification

- `dotnet build` app + tests, Release — 0 errors, 0 warnings each
- `dotnet format --verify-no-changes` — clean on both projects
- Identity leak scan over all 5 changed files against the full term list — the only hit is a pre-existing line in a 2026 CHANGELOG entry describing one of the Privacy tab's toggles, confirmed **not** among this branch's additions. The scan includes a vacuity control, so "0 hits" is evidence rather than a silently broken scan.
- CHANGELOG entry added in this PR; version bumped to 1.64.15

## Scope note

I swept every view for both variants of this layout defect. The 5 remaining `TextWrapping`-in-a-horizontal-`StackPanel` cases are all bound values the existing guard intentionally exempts, and the other 9 unwrapped bound TextBlocks are short badges and counts (`Status`, `ErrorCount`, a dashboard chip) that cannot meaningfully clip. The File Shredder footer was the only one carrying variable-length prose, so scope stays here rather than churning nine views.