### PR TITLE
fix: show one decimal separator for sizes and speeds on every locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.16] - 2026-08-13
+
+File sizes now use the same decimal point as network speeds, everywhere in the app, whatever
+language your Windows is set to.
+
+### Fixed
+- **Sizes and speeds disagreed about the decimal separator outside English.** File sizes were formatted using your Windows language settings while network speeds always used a dot, so on a Romanian, German, French or most other European system the same screen showed "1,5 GB" next to "12.4 Mbps". All 32 places that show a size now use a dot, matching the speeds. On an English system nothing changes.
+
+### Changed
+- **Internal: removed notification-suppression code that never did anything.** The shared list used by every refreshing table carried a flag meant to silence change notifications during a bulk refresh. It could never have fired — the refresh writes to the underlying list, which raises no notifications in the first place — so it read as protection while providing none. The list now also refuses, instead of quietly rewriting itself, if something tries to replace its contents from inside a change handler. No visible change; the refresh behaviour is identical.
+
+---
+
 ## [1.64.15] - 2026-08-13
 
 The File Shredder now tells you when a file you picked could not be added to the list, instead of

--- a/SysManager/SysManager.Tests/AdminHelperTests.cs
+++ b/SysManager/SysManager.Tests/AdminHelperTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using SysManager.Helpers;
 
 namespace SysManager.Tests;
@@ -57,4 +58,47 @@ public class AdminHelperTests
     // bool-returning method (always true, tested nothing) while needlessly invoking the
     // side-effecting relaunch a third time. RelaunchAsAdmin_DoesNotThrow already covers
     // the call.
+
+    /// <summary>
+    /// The hint must reach the elevated child through <c>ArgumentList</c>, never concatenated into the
+    /// <c>Arguments</c> string. Concatenation lets a hint containing a space split into several
+    /// arguments — silently breaking the "return to the right tab" contract, and appending switches to
+    /// a process that is about to run with administrator rights.
+    /// <para>Asserted against the source, because observing the real command line would mean starting
+    /// an elevated process and therefore a UAC prompt. No caller passes a hint today, so this guards
+    /// the first one that does.</para>
+    /// </summary>
+    [Fact]
+    public void RelaunchAsAdmin_PassesTheHintAsAnArgument_NotAsConcatenatedText()
+    {
+        var source = File.ReadAllText(HelperSourcePath());
+        var start = source.IndexOf("public static bool RelaunchAsAdmin", StringComparison.Ordinal);
+        Assert.True(start >= 0, "RelaunchAsAdmin not found — update this guard.");
+        var body = source[start..source.IndexOf("\n    }", start, StringComparison.Ordinal)];
+
+        Assert.Contains("ArgumentList.Add", body, StringComparison.Ordinal);
+
+        // The specific defect: the hint interpolated beside the sentinel in a single string, and the
+        // Arguments property being set at all.
+        Assert.DoesNotContain("{RelaunchedElevatedArg} {", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("Arguments =", body, StringComparison.Ordinal);
+
+        // The sentinel must still be passed, or the elevated child is treated as a duplicate and the
+        // user is left looking at the non-elevated window.
+        Assert.Contains("ArgumentList.Add(RelaunchedElevatedArg)", body, StringComparison.Ordinal);
+    }
+
+    private static string HelperSourcePath()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory is not null;
+             directory = directory.Parent)
+        {
+            var candidate = Path.Combine(
+                directory.FullName, "SysManager", "Helpers", "AdminHelper.cs");
+            if (File.Exists(candidate)) return candidate;
+        }
+
+        throw new FileNotFoundException("Could not locate AdminHelper.cs from the test output.");
+    }
 }

--- a/SysManager/SysManager.Tests/BulkObservableCollectionTests.cs
+++ b/SysManager/SysManager.Tests/BulkObservableCollectionTests.cs
@@ -124,4 +124,50 @@ public class BulkObservableCollectionTests
         Assert.Throws<InvalidOperationException>(() => collection.ReplaceWith(Failing()));
         Assert.Equal([1, 2, 3], collection);
     }
+
+    // ── Rewriting the collection from inside a change handler ──
+    // ReplaceWith mutates Items (the backing list) directly. That is deliberate — it is how one Reset
+    // replaces N+1 events — but it also skips the CheckReentrancy call every ObservableCollection
+    // mutator makes first. Without an explicit check, a handler that re-enters ReplaceWith rewrites the
+    // collection in the middle of event dispatch and a bound ItemsControl's container generator can
+    // desync from its source. Failing fast is the documented contract.
+
+    [Fact]
+    public void ReplaceWith_ReenteredFromAChangeHandler_ThrowsInsteadOfRewritingMidDispatch()
+    {
+        var collection = new BulkObservableCollection<int>();
+        collection.ReplaceWith([1, 2, 3]);
+
+        Exception? reentrant = null;
+
+        // Two subscribers, because ObservableCollection only treats reentrancy as an error when more
+        // than one handler is attached — which is the real situation: WPF's ListCollectionView is
+        // subscribed alongside application code.
+        collection.CollectionChanged += (_, _) =>
+            reentrant ??= Record.Exception(() => collection.ReplaceWith([7, 8, 9]));
+        collection.CollectionChanged += (_, _) => { };
+
+        collection.ReplaceWith([4, 5, 6]);
+
+        Assert.IsType<InvalidOperationException>(reentrant);
+        Assert.Equal([4, 5, 6], collection); // the reentrant rewrite did not take effect
+    }
+
+    [Fact]
+    public void ReplaceWith_WithOneSubscriber_StillRefreshesNormally()
+    {
+        // Guard against over-correcting: the ordinary single-subscriber refresh must keep working.
+        var collection = new BulkObservableCollection<int>();
+        var resets = 0;
+        collection.CollectionChanged += (_, e) =>
+        {
+            if (e.Action == NotifyCollectionChangedAction.Reset) resets++;
+        };
+
+        collection.ReplaceWith([1, 2, 3]);
+        collection.ReplaceWith([4, 5]);
+
+        Assert.Equal([4, 5], collection);
+        Assert.Equal(2, resets);
+    }
 }

--- a/SysManager/SysManager.Tests/FormatHelperTests.cs
+++ b/SysManager/SysManager.Tests/FormatHelperTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using SysManager.Helpers;
 using Xunit;
 
@@ -64,5 +65,67 @@ public class FormatHelperTests
     public void FormatSize_ExactBoundary_1GB()
     {
         Assert.Equal("1.0 GB", FormatHelper.FormatSize(1L << 30));
+    }
+
+    // ---------- one decimal separator, whatever the machine's locale ----------
+    // FormatSize used a bare interpolated ":F1", which formats with CurrentCulture, while FormatRate
+    // was already explicitly invariant. On a comma-decimal locale — ro-RO, de-DE, fr-FR, most of
+    // Europe — the same screen showed "1,5 GB" next to "12.4 Mbps". Every assertion above expects a
+    // dot, so they were quietly asserting "this test host happens to be en-US".
+
+    [Theory]
+    [InlineData("ro-RO")]
+    [InlineData("de-DE")]
+    [InlineData("fr-FR")]
+    [InlineData("en-US")]
+    [InlineData("")] // invariant
+    public void FormatSize_UsesADot_OnEveryLocale(string culture)
+    {
+        WithCulture(culture, () =>
+        {
+            Assert.Equal("1.5 GB", FormatHelper.FormatSize(1610612736));
+            Assert.Equal("1.0 KB", FormatHelper.FormatSize(1L << 10));
+            Assert.Equal("512 B", FormatHelper.FormatSize(512));
+        });
+    }
+
+    [Theory]
+    [InlineData("ro-RO")]
+    [InlineData("de-DE")]
+    [InlineData("en-US")]
+    public void SizeAndRate_AgreeOnTheSeparator_OnEveryLocale(string culture)
+    {
+        WithCulture(culture, () =>
+        {
+            // The defect was the MISMATCH, so assert the two helpers agree rather than testing them
+            // apart: a size and a rate sitting on one screen must not use different separators.
+            var size = FormatHelper.FormatSize(1610612736);   // "1.5 GB"
+            var rate = FormatHelper.FormatRate(1_550_000);    // "12.4 Mbps"
+
+            Assert.Contains('.', size);
+            Assert.Contains('.', rate);
+            Assert.DoesNotContain(',', size);
+            Assert.DoesNotContain(',', rate);
+        });
+    }
+
+    /// <summary>
+    /// Runs <paramref name="assert"/> with the thread's culture switched, restoring it in a finally so
+    /// one test cannot leak a locale into the rest of the run. Deterministic: no ambient state is read.
+    /// </summary>
+    private static void WithCulture(string culture, Action assert)
+    {
+        var previous = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = culture.Length == 0
+                ? CultureInfo.InvariantCulture
+                : new CultureInfo(culture);
+            assert();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
     }
 }

--- a/SysManager/SysManager/Helpers/AdminHelper.cs
+++ b/SysManager/SysManager/Helpers/AdminHelper.cs
@@ -31,9 +31,23 @@ public static class AdminHelper
     public const string RelaunchedElevatedArg = "--relaunched-elevated";
 
     /// <summary>
-    /// Relaunch the current process with UAC elevation and exit the current instance.
-    /// Pass an optional argument hint so the new instance can jump back to the right tab.
+    /// Start an elevated copy of the current process. Returns true when the elevated copy was
+    /// started, false when it could not be (no <c>Application.Current</c>, unknown process path,
+    /// or the user dismissed the UAC prompt).
+    /// <para><b>On true the CALLER must shut this instance down</b> —
+    /// <c>Application.Current?.Shutdown()</c> — because this method deliberately does not. The
+    /// elevated copy waits on the single-instance mutex (see
+    /// <see cref="RelaunchedElevatedArg"/>), so an instance that stays alive leaves the user on
+    /// the non-elevated window: exactly the failure the sentinel exists to prevent. All current
+    /// callers do this; the earlier summary claimed the method exited the instance itself, which
+    /// it never did.</para>
     /// </summary>
+    /// <param name="argumentHint">
+    /// Optional extra argument for the elevated copy, so it can return to the right tab. Passed
+    /// through <see cref="ProcessStartInfo.ArgumentList"/>, which applies Windows quoting — a hint
+    /// containing a space would otherwise split into several arguments, or add switches to a
+    /// process about to run elevated. No caller passes one today.
+    /// </param>
     public static bool RelaunchAsAdmin(string? argumentHint = null)
     {
         if (System.Windows.Application.Current == null) return false;
@@ -43,19 +57,21 @@ public static class AdminHelper
             var exePath = Environment.ProcessPath ?? currentProc.MainModule?.FileName;
             if (string.IsNullOrWhiteSpace(exePath)) return false;
 
-            // Always tag the elevated child so its single-instance guard waits for this
-            // instance to release the mutex rather than bailing as a "duplicate".
-            var arguments = string.IsNullOrWhiteSpace(argumentHint)
-                ? RelaunchedElevatedArg
-                : $"{RelaunchedElevatedArg} {argumentHint}";
-
             var psi = new ProcessStartInfo
             {
                 FileName = exePath,
                 UseShellExecute = true,
-                Verb = "runas",
-                Arguments = arguments
+                Verb = "runas"
             };
+
+            // Always tag the elevated child so its single-instance guard waits for this
+            // instance to release the mutex rather than bailing as a "duplicate".
+            // ArgumentList, not a concatenated Arguments string: it applies Windows quoting, so a
+            // hint containing a space cannot split into extra arguments to a process about to run
+            // elevated. No caller passes a hint today — this keeps the first one that does safe.
+            psi.ArgumentList.Add(RelaunchedElevatedArg);
+            if (!string.IsNullOrWhiteSpace(argumentHint))
+                psi.ArgumentList.Add(argumentHint);
             // Dispose the returned Process handle — we don't track the elevated instance.
             Process.Start(psi)?.Dispose();
             return true;

--- a/SysManager/SysManager/Helpers/FormatHelper.cs
+++ b/SysManager/SysManager/Helpers/FormatHelper.cs
@@ -1,3 +1,7 @@
+// SysManager · FormatHelper
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
 using System.Globalization;
 
 namespace SysManager.Helpers;
@@ -10,16 +14,23 @@ public static class FormatHelper
 {
     /// <summary>
     /// Formats a byte count into a human-readable string (B, KB, MB, GB, TB).
+    /// <para>Invariant culture, deliberately. A bare interpolated <c>:F1</c> formats with the
+    /// user's locale, so on a comma-decimal locale (ro-RO, de-DE) a size printed "1,5 GB" while
+    /// <see cref="FormatRate"/> — already invariant — printed "12.4 Mbps" on the same screen.
+    /// One decimal separator across the whole app.</para>
     /// </summary>
     public static string FormatSize(long bytes) => bytes switch
     {
         <= 0 => "0 B",
-        < 1L << 10 => $"{bytes} B",
-        < 1L << 20 => $"{bytes / (double)(1L << 10):F1} KB",
-        < 1L << 30 => $"{bytes / (double)(1L << 20):F1} MB",
-        < 1L << 40 => $"{bytes / (double)(1L << 30):F1} GB",
-        _ => $"{bytes / (double)(1L << 40):F1} TB"
+        < 1L << 10 => bytes.ToString(CultureInfo.InvariantCulture) + " B",
+        < 1L << 20 => OneDecimal(bytes, 1L << 10) + " KB",
+        < 1L << 30 => OneDecimal(bytes, 1L << 20) + " MB",
+        < 1L << 40 => OneDecimal(bytes, 1L << 30) + " GB",
+        _ => OneDecimal(bytes, 1L << 40) + " TB"
     };
+
+    private static string OneDecimal(long bytes, long divisor) =>
+        (bytes / (double)divisor).ToString("F1", CultureInfo.InvariantCulture);
 
     /// <summary>
     /// Formats a byte-per-second rate as a human-readable "12.4 Mbps"-style string. Network speeds

--- a/SysManager/SysManager/Helpers/ObservableCollectionExtensions.cs
+++ b/SysManager/SysManager/Helpers/ObservableCollectionExtensions.cs
@@ -14,7 +14,13 @@ namespace SysManager.Helpers;
 /// </summary>
 public sealed class BulkObservableCollection<T> : ObservableCollection<T>
 {
-    private bool _suppressNotifications;
+    // Immutable and identical on every call. ReplaceWith is the standard bulk-refresh path for
+    // poll-driven lists, so it runs on the UI thread on every refresh tick; the BCL caches exactly
+    // these three instances internally for the same reason.
+    private static readonly PropertyChangedEventArgs CountChanged = new("Count");
+    private static readonly PropertyChangedEventArgs IndexerChanged = new("Item[]");
+    private static readonly NotifyCollectionChangedEventArgs CollectionReset =
+        new(NotifyCollectionChangedAction.Reset);
 
     /// <summary>
     /// Replaces all items with a single Reset notification instead of
@@ -39,32 +45,22 @@ public sealed class BulkObservableCollection<T> : ObservableCollection<T>
         // collection, which Items.Clear() below would empty before a single item was carried over.
         var snapshot = items.ToList();
 
-        _suppressNotifications = true;
-        try
-        {
-            Items.Clear();
-            for (int i = 0; i < snapshot.Count; i++)
-                Items.Add(snapshot[i]);
-        }
-        finally
-        {
-            _suppressNotifications = false;
-        }
+        // Refuse to rewrite the collection from inside a change handler. Items.Clear()/Items.Add()
+        // below bypass the base class's own CheckReentrancy calls, so without this a handler that
+        // re-enters ReplaceWith would silently rewrite the collection mid-dispatch and desync an
+        // ItemsControl from its source; failing fast is the documented ObservableCollection contract.
+        CheckReentrancy();
 
-        OnPropertyChanged(new PropertyChangedEventArgs("Count"));
-        OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
-        OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
-    }
+        // Mutating Items (the backing list) directly rather than via Clear()/Add() is the whole point:
+        // those route through ClearItems/InsertItem and would raise N+1 notifications. Items does not,
+        // which is why the three explicit raises below are needed — and why no suppression flag is:
+        // nothing here can raise an event that would need suppressing.
+        Items.Clear();
+        for (int i = 0; i < snapshot.Count; i++)
+            Items.Add(snapshot[i]);
 
-    protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
-    {
-        if (!_suppressNotifications)
-            base.OnCollectionChanged(e);
-    }
-
-    protected override void OnPropertyChanged(PropertyChangedEventArgs e)
-    {
-        if (!_suppressNotifications)
-            base.OnPropertyChanged(e);
+        OnPropertyChanged(CountChanged);
+        OnPropertyChanged(IndexerChanged);
+        OnCollectionChanged(CollectionReset);
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.64.15</Version>
-    <FileVersion>1.64.15.0</FileVersion>
-    <AssemblyVersion>1.64.15.0</AssemblyVersion>
+    <Version>1.64.16</Version>
+    <FileVersion>1.64.16.0</FileVersion>
+    <AssemblyVersion>1.64.16.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Three findings in `Helpers/`, all verified against the real source. One is user-visible on any non-English Windows; two are latent traps.

## 1. Sizes and speeds disagreed about the decimal separator

`FormatSize` used a bare interpolated `:F1`, which formats with `CurrentCulture`. `FormatRate`, in the same file, was already explicitly `InvariantCulture`.

On any comma-decimal locale — ro-RO, de-DE, fr-FR, most of Europe — the same screen showed:

```
1,5 GB          <- FormatSize, user's locale
12.4 Mbps       <- FormatRate, invariant
```

**32 call sites** render a size, so this was app-wide, not one tab.

Both are now invariant. `FormatHelper.cs` also gained the author header it was missing.

**The existing tests were the tell.** Every size assertion expected a dot (`"1.0 KB"`), so they were quietly asserting "this test host happens to be en-US" and would have failed on the user's own machine. New theories run the assertions under ro-RO, de-DE, fr-FR, en-US and invariant, restoring the culture in a `finally` so no test leaks a locale. One asserts the two helpers **agree with each other** rather than testing them apart — the defect was the mismatch, not either value alone.

## 2. Notification suppression that could never fire

`BulkObservableCollection.ReplaceWith` carried a `_suppressNotifications` flag, a try/finally, and two `On*Changed` overrides that checked it.

None of it could ever do anything. `ReplaceWith` mutates `Items` — the backing `List<T>` — directly. That is deliberate and is the entire point of the class: it is how one `Reset` replaces N+1 events. But `Items` never routes through the virtual `ClearItems`/`InsertItem`, so **no notification is raised for the flag to suppress**. The flag was never `true` at any moment one could fire.

Code that reads as protection and provides none is worse than no code, so it is gone.

Removing it exposed the real gap it was obscuring: bypassing the base mutators also bypasses their `CheckReentrancy` call. A change handler that re-enters `ReplaceWith` would silently rewrite the collection **in the middle of event dispatch**, and a bound `ItemsControl`'s container generator can desync from its source. `ReplaceWith` now calls `CheckReentrancy()` explicitly — failing fast is the documented `ObservableCollection` contract.

The three immutable event-args instances are hoisted to statics rather than allocated on every call; this is the standard bulk-refresh path for poll-driven lists, so it ran on the UI thread on every refresh tick. The BCL caches exactly these three internally for the same reason.

Two new tests: one proves reentrancy throws (with two subscribers, since that is when `ObservableCollection` treats it as an error — and mirrors reality, where WPF's `ListCollectionView` is subscribed alongside app code), one proves the ordinary single-subscriber refresh still works, guarding against over-correcting.

## 3. Elevated relaunch concatenated its argument

`RelaunchAsAdmin` built `$"{RelaunchedElevatedArg} {argumentHint}"` and assigned it to `Arguments`. A hint containing a space would split into several arguments — to a process about to run **elevated**.

**Not exploitable today: I checked all 33 call sites and none passes a hint** — the parameter is always `null`. So this is a latent trap, not a live vulnerability, and I am not treating it as one. It now uses `ProcessStartInfo.ArgumentList`, which applies Windows quoting. Verified that `ArgumentList` + `UseShellExecute = true` is accepted on .NET 10 (it historically threw) with a throwaway probe that set both without starting a process.

Its doc also claimed the method "exits the current instance". It never did — and all 33 callers call `Shutdown()` themselves, 33 of 33. The behaviour was right everywhere; only the contract was wrong, which would have bitten caller 34. The doc now states the caller's obligation and why (the elevated copy waits on the single-instance mutex).

## Regression proof

Re-derived from source, independently of the tests:

```
RED  (main a4c767f): 13 checks FAIL
    4 interpolated :F1 arms use CurrentCulture; no explicit culture; no author header
    no CheckReentrancy; suppression flag present; both no-op overrides present;
    4 property + 3 collection raises; args allocated per call
    hint concatenated into Arguments; doc claims a shutdown it never performs
GREEN (this branch): ALL PASS
```

## Verification

- `dotnet build` app + tests, Release — 0 errors, 0 warnings each
- `dotnet format --verify-no-changes` — clean on both projects
- Identity leak scan over all 8 changed files — the only hit is a pre-existing line in a 2026 CHANGELOG entry describing a Privacy tab toggle, confirmed absent from this branch's additions (0 occurrences in the diff's `+` lines). Scan carries a vacuity control.
- CHANGELOG entry in this PR; version bumped to 1.64.16

## Refuted while triaging

Two claims from the same batch of findings did **not** survive checking, and are deliberately not in this PR:

- *"`FormatRate` can print `Infinity Tbps` via division by zero elapsed time"* — `BandwidthFormat.RatePerSecond` already guards `elapsedSeconds <= 0` and returns 0. The path does not exist. `double.IsFinite` would be defence-in-depth, not a fix.
- *"`AdminHelper.IsElevated` should cache"* — correct that elevation is fixed per process, but it is not a defect, and caching a security-relevant check is a change I would want discussed rather than slipped into a fix PR.