### PR TITLE
fix: write user data atomically so an interrupted save cannot erase it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.17] - 2026-08-13
+
+If the PC loses power or crashes while SysManager is saving, your settings and history survive
+instead of coming back empty.
+
+### Fixed
+- **A crash or power cut while saving could silently wipe your history and presets.** Seventeen places wrote your data by emptying the file first and then filling it back in. Interrupt that — a power cut, a crash, a full disk — and the file on disk is neither the old version nor the new one. Worse, the app treated a file it could not read as "no data", quietly starting from scratch: you would open the app and find your activity history, speed-test history, volume presets, gaming profiles or saved settings simply gone, with nothing explaining why. Saves now write to a second file and swap it in as one step, so an interrupted save leaves the previous version completely intact. Affects the Activity log, Speed Test history, Volume presets, Gaming profiles, theme and appearance settings, the close-behaviour preference, the standby and update preferences, the Settings Watchdog baseline, the service-startup ledger, the performance snapshot used to undo tweaks, restored configuration backups, and the app-icon cache.
+
+---
+
 ## [1.64.16] - 2026-08-13
 
 File sizes now use the same decimal point as network speeds, everywhere in the app, whatever

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1202,8 +1202,9 @@ public partial class ArchitectureTests
 
                 // Writing to a temp/backup path IS the atomic pattern; the swap follows.
                 if (TempOrBackupTarget().IsMatch(target)) continue;
-                // Derived sidecars and a user-chosen export destination hold no existing user data.
-                if (target.Contains(".sha256", StringComparison.Ordinal)) continue;
+                // Derived sidecars hold no user data. Matched on the variable name as well as the
+                // literal, because UpdateService writes through `hashFile = target + ".sha256"`.
+                if (HashSidecarTarget().IsMatch(target)) continue;
                 if (name == "ProfileService.cs" && target == "path"
                     && source.Contains("ExportToFileAsync", StringComparison.Ordinal)
                     && match.Index > source.IndexOf("ExportToFileAsync", StringComparison.Ordinal)
@@ -1227,12 +1228,17 @@ public partial class ArchitectureTests
             + string.Join("\n  ", offenders));
     }
 
-    [GeneratedRegex(@"File\.Write(?:AllText|AllBytes|AllLines)(?:Async)?\s*\(\s*(?<target>[^,)]+)",
+    // (?&lt;!Atomic) is load-bearing: "AtomicFile.WriteAllText" ENDS IN "File.WriteAllText", so without
+    // the lookbehind this regex matches the fix as well as the defect and the guard fails on green.
+    [GeneratedRegex(@"(?<!Atomic)\bFile\.Write(?:AllText|AllBytes|AllLines)(?:Async)?\s*\(\s*(?<target>[^,)]+)",
                     RegexOptions.CultureInvariant)]
     private static partial Regex RawFileWrite();
 
     [GeneratedRegex(@"tmp|temp|\.bak|backup", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex TempOrBackupTarget();
+
+    [GeneratedRegex(@"\.sha256|hashFile", RegexOptions.CultureInvariant)]
+    private static partial Regex HashSidecarTarget();
 
     /// <summary>The app project directory — .xaml is not copied to the test output.</summary>
     private static string FindAppProjectDir()

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1169,6 +1169,71 @@ public partial class ArchitectureTests
             "Could not locate the repository root from " + AppContext.BaseDirectory);
     }
 
+    /// <summary>
+    /// A service that persists user data must write it atomically, via <c>AtomicFile</c>.
+    /// <para><c>File.WriteAllText</c> and friends truncate the destination and then write into it, so
+    /// an interrupted save leaves a torn file. That is not merely a corrupt-file risk here: several
+    /// loaders catch <c>JsonException</c> and substitute an empty list at Debug level, so a torn save
+    /// silently erases the user's activity history, speed-test history or presets rather than
+    /// reporting anything. 17 call sites across 15 services did this.</para>
+    /// <para>Exempt, by name and for a stated reason: a write whose target is itself a temp/backup
+    /// path (already the atomic pattern), <c>HostsFileService</c> (the original hand-rolled
+    /// implementation this helper generalises), <c>ProfileService.ExportToFileAsync</c> (writes a new
+    /// file the user picked — there is no existing data to lose), and the two <c>.sha256</c> sidecars
+    /// in the update path (derived values, regenerated on demand, not user data).</para>
+    /// </summary>
+    [Fact]
+    public void EveryServiceThatPersistsUserData_WritesItAtomically()
+    {
+        var servicesDir = Path.Combine(FindAppProjectDir(), "Services");
+        var offenders = new List<string>();
+        var scanned = 0;
+
+        foreach (var file in Directory.GetFiles(servicesDir, "*.cs"))
+        {
+            var name = Path.GetFileName(file);
+            if (name is "HostsFileService.cs") continue;
+
+            var source = File.ReadAllText(file);
+            foreach (var match in RawFileWrite().Matches(source).Cast<Match>())
+            {
+                scanned++;
+                var target = match.Groups["target"].Value.Trim();
+
+                // Writing to a temp/backup path IS the atomic pattern; the swap follows.
+                if (TempOrBackupTarget().IsMatch(target)) continue;
+                // Derived sidecars and a user-chosen export destination hold no existing user data.
+                if (target.Contains(".sha256", StringComparison.Ordinal)) continue;
+                if (name == "ProfileService.cs" && target == "path"
+                    && source.Contains("ExportToFileAsync", StringComparison.Ordinal)
+                    && match.Index > source.IndexOf("ExportToFileAsync", StringComparison.Ordinal)
+                    && match.Index < source.IndexOf("ImportFromFileAsync", StringComparison.Ordinal))
+                    continue;
+
+                var line = source[..match.Index].Count(c => c == '\n') + 1;
+                offenders.Add($"{name}:{line} writes {target} in place");
+            }
+        }
+
+        // Vacuity floor: if the regex stopped matching, this would pass while inspecting nothing.
+        Assert.True(scanned >= 5,
+            $"Only {scanned} raw File.Write* calls were seen across Services — the detection is "
+            + "broken, not the code. Fix this guard rather than trusting it.");
+
+        Assert.True(offenders.Count == 0,
+            "These services write user data in place, so an interrupted save leaves a torn file — and "
+            + "the loaders treat an unparseable file as no data, silently discarding it. Use "
+            + "AtomicFile.WriteAllText/WriteAllBytes (or the Async overloads) instead:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    [GeneratedRegex(@"File\.Write(?:AllText|AllBytes|AllLines)(?:Async)?\s*\(\s*(?<target>[^,)]+)",
+                    RegexOptions.CultureInvariant)]
+    private static partial Regex RawFileWrite();
+
+    [GeneratedRegex(@"tmp|temp|\.bak|backup", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex TempOrBackupTarget();
+
     /// <summary>The app project directory — .xaml is not copied to the test output.</summary>
     private static string FindAppProjectDir()
     {

--- a/SysManager/SysManager.Tests/AtomicFileTests.cs
+++ b/SysManager/SysManager.Tests/AtomicFileTests.cs
@@ -1,0 +1,178 @@
+// SysManager · AtomicFileTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Text;
+using SysManager.Helpers;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="AtomicFile"/>, the helper that replaced 17 in-place
+/// <c>File.WriteAllText</c> calls to user-data files.
+/// <para>The defect being pinned: <c>File.WriteAllText</c> truncates the destination before writing,
+/// so an interrupted save leaves a torn file. SysManager's loaders treat an unparseable file as "no
+/// data" — several catch <c>JsonException</c> and substitute an empty list at Debug level — so a torn
+/// save silently erased the user's activity history, speed-test history or volume presets instead of
+/// reporting anything.</para>
+/// <para>Every test writes only inside its own temp directory and deletes it in a finally, so the
+/// suite never touches the real user profile.</para>
+/// </summary>
+public class AtomicFileTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "smtest_atomic_" + Guid.NewGuid().ToString("N"));
+
+    public AtomicFileTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
+    private string Path_(string name) => Path.Combine(_dir, name);
+
+    [Fact]
+    public void WriteAllText_CreatesTheFile_WhenItDoesNotExistYet()
+    {
+        var path = Path_("new.json");
+
+        AtomicFile.WriteAllText(path, "{\"a\":1}");
+
+        Assert.Equal("{\"a\":1}", File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void WriteAllText_ReplacesExistingContents()
+    {
+        var path = Path_("existing.json");
+        File.WriteAllText(path, "old contents that must be gone");
+
+        AtomicFile.WriteAllText(path, "new");
+
+        Assert.Equal("new", File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void WriteAllText_CreatesAMissingDirectory()
+    {
+        var path = Path.Combine(_dir, "nested", "deeper", "file.json");
+
+        AtomicFile.WriteAllText(path, "[]");
+
+        Assert.True(File.Exists(path));
+    }
+
+    [Fact]
+    public void WriteAllText_LeavesNoTemporaryFileBehind()
+    {
+        // A leftover .tmp beside the real file would be visible to the user in their config folder,
+        // and on the next save File.Replace would be handed a stale source.
+        var path = Path_("clean.json");
+
+        AtomicFile.WriteAllText(path, "{}");
+        AtomicFile.WriteAllText(path, "{\"second\":true}");
+
+        Assert.Equal(["clean.json"], Directory.GetFiles(_dir).Select(Path.GetFileName));
+    }
+
+    /// <summary>
+    /// THE POINT OF THE HELPER. When the write itself fails, the previous file must survive
+    /// byte-for-byte — that is the difference from <c>File.WriteAllText</c>, which would already have
+    /// truncated it. Driven by making the temp path un-writable (a directory cannot be overwritten by
+    /// a file), which fails the write at the same moment a full disk or a crash would.
+    /// </summary>
+    [Fact]
+    public void WriteAllText_WhenTheWriteFails_TheOriginalFileIsUntouched()
+    {
+        var path = Path_("precious.json");
+        const string original = "{\"history\":[\"the user's data\"]}";
+        File.WriteAllText(path, original);
+
+        // Occupy the temp path with a directory so writing the temp file must fail.
+        Directory.CreateDirectory(path + ".tmp");
+
+        Assert.ThrowsAny<Exception>(() => AtomicFile.WriteAllText(path, "replacement"));
+
+        // The whole promise: not truncated, not empty, not partially written.
+        Assert.Equal(original, File.ReadAllText(path));
+    }
+
+    [Fact]
+    public async Task WriteAllTextAsync_WhenTheWriteFails_TheOriginalFileIsUntouched()
+    {
+        var path = Path_("precious-async.json");
+        const string original = "{\"speedTests\":[1,2,3]}";
+        File.WriteAllText(path, original);
+
+        Directory.CreateDirectory(path + ".tmp");
+
+        await Assert.ThrowsAnyAsync<Exception>(
+            () => AtomicFile.WriteAllTextAsync(path, "replacement"));
+
+        Assert.Equal(original, File.ReadAllText(path));
+    }
+
+    [Fact]
+    public async Task WriteAllTextAsync_ReplacesExistingContents()
+    {
+        var path = Path_("async.json");
+        File.WriteAllText(path, "old");
+
+        await AtomicFile.WriteAllTextAsync(path, "new");
+
+        Assert.Equal("new", File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void WriteAllBytes_ReplacesExistingContents()
+    {
+        var path = Path_("blob.bin");
+        File.WriteAllBytes(path, [0xDE, 0xAD]);
+
+        AtomicFile.WriteAllBytes(path, [0x01, 0x02, 0x03]);
+
+        Assert.Equal([0x01, 0x02, 0x03], File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public async Task WriteAllBytesAsync_ReplacesExistingContents()
+    {
+        var path = Path_("blob-async.bin");
+        File.WriteAllBytes(path, [0xFF]);
+
+        await AtomicFile.WriteAllBytesAsync(path, [0x0A, 0x0B]);
+
+        Assert.Equal([0x0A, 0x0B], File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void WriteAllText_WithAnExplicitEncoding_WritesNoByteOrderMark()
+    {
+        // ProfileService restores the user's config files and must not prepend a BOM, or the owning
+        // service may fail to parse what it wrote.
+        var path = Path_("no-bom.json");
+
+        AtomicFile.WriteAllText(path, "{}", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        var bytes = File.ReadAllBytes(path);
+        Assert.Equal((byte)'{', bytes[0]);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void WriteAllText_RejectsAnEmptyPath(string? path)
+    {
+        Assert.ThrowsAny<ArgumentException>(() => AtomicFile.WriteAllText(path!, "x"));
+    }
+
+    [Fact]
+    public void WriteAllText_RejectsNullContents()
+    {
+        Assert.Throws<ArgumentNullException>(() => AtomicFile.WriteAllText(Path_("x.json"), null!));
+    }
+}

--- a/SysManager/SysManager/Helpers/AtomicFile.cs
+++ b/SysManager/SysManager/Helpers/AtomicFile.cs
@@ -1,0 +1,155 @@
+// SysManager · AtomicFile
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Text;
+
+namespace SysManager.Helpers;
+
+/// <summary>
+/// Writes a file so that a crash, power loss or full disk can never leave a half-written one behind.
+/// <para>
+/// <see cref="File.WriteAllText(string, string)"/> truncates the destination and then writes into it.
+/// Interrupt that and the file on disk is neither the old contents nor the new — it is torn. That
+/// matters here because SysManager's loaders treat a file they cannot parse as "no data": several
+/// catch <see cref="System.Text.Json.JsonException"/> and substitute an empty list, at Debug level.
+/// So an interrupted save does not surface as an error — it silently erases the user's activity
+/// history, gaming profiles or volume presets.
+/// </para>
+/// <para>
+/// The fix is to write a temporary file in the same directory and then swap it in with a single
+/// filesystem operation. <see cref="File.Replace(string, string, string?)"/> is used when the
+/// destination already exists, because it preserves the destination's ACLs and attributes — a plain
+/// <c>Move(overwrite: true)</c> relinks a brand-new inode that inherits only the directory's default
+/// ACL, silently weakening the file. On first creation there is no descriptor to preserve, so a plain
+/// <see cref="File.Move(string, string, bool)"/> is correct. This mirrors
+/// <c>HostsFileService</c>, which already did it this way; the helper exists so the pattern is stated
+/// once rather than copied into every service that persists user data.
+/// </para>
+/// </summary>
+internal static class AtomicFile
+{
+    /// <summary>
+    /// Writes <paramref name="contents"/> to <paramref name="path"/> atomically, creating the
+    /// directory if needed. The destination is either fully replaced or left exactly as it was.
+    /// </summary>
+    public static void WriteAllText(string path, string contents)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(contents);
+
+        Write(path, temp => File.WriteAllText(temp, contents));
+    }
+
+    /// <summary>
+    /// Writes <paramref name="contents"/> to <paramref name="path"/> atomically using an explicit
+    /// <paramref name="encoding"/>, for callers that must control the byte-order mark.
+    /// </summary>
+    public static void WriteAllText(string path, string contents, Encoding encoding)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(contents);
+        ArgumentNullException.ThrowIfNull(encoding);
+
+        Write(path, temp => File.WriteAllText(temp, contents, encoding));
+    }
+
+    /// <summary>
+    /// Writes <paramref name="bytes"/> to <paramref name="path"/> atomically, creating the directory
+    /// if needed. The destination is either fully replaced or left exactly as it was.
+    /// </summary>
+    public static void WriteAllBytes(string path, byte[] bytes)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        Write(path, temp => File.WriteAllBytes(temp, bytes));
+    }
+
+    /// <summary>
+    /// Asynchronous counterpart of <see cref="WriteAllText(string, string)"/>. The swap itself stays
+    /// synchronous: it is a single metadata operation, and there is no async <c>File.Replace</c>.
+    /// </summary>
+    public static async Task WriteAllTextAsync(
+        string path, string contents, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(contents);
+
+        await WriteAsync(path, temp => File.WriteAllTextAsync(temp, contents, ct))
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronous counterpart of <see cref="WriteAllBytes(string, byte[])"/>.
+    /// </summary>
+    public static async Task WriteAllBytesAsync(
+        string path, byte[] bytes, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        await WriteAsync(path, temp => File.WriteAllBytesAsync(temp, bytes, ct))
+            .ConfigureAwait(false);
+    }
+
+    private static void Write(string path, Action<string> writeTemp)
+    {
+        var temp = PrepareTempPath(path);
+        try
+        {
+            writeTemp(temp);
+            Swap(temp, path);
+        }
+        finally
+        {
+            CleanUp(temp);
+        }
+    }
+
+    private static async Task WriteAsync(string path, Func<string, Task> writeTemp)
+    {
+        var temp = PrepareTempPath(path);
+        try
+        {
+            await writeTemp(temp).ConfigureAwait(false);
+            Swap(temp, path);
+        }
+        finally
+        {
+            CleanUp(temp);
+        }
+    }
+
+    private static string PrepareTempPath(string path)
+    {
+        var directory = Path.GetDirectoryName(Path.GetFullPath(path));
+        if (!string.IsNullOrEmpty(directory))
+            Directory.CreateDirectory(directory);
+
+        // Same directory as the destination: a cross-volume move is a copy+delete, which is not
+        // atomic and would reintroduce exactly the torn window this helper exists to close.
+        return path + ".tmp";
+    }
+
+    private static void Swap(string temp, string path)
+    {
+        if (File.Exists(path))
+            File.Replace(temp, path, destinationBackupFileName: null);
+        else
+            File.Move(temp, path, overwrite: false);
+    }
+
+    private static void CleanUp(string temp)
+    {
+        // The temp file survives only if the swap never happened. Deleting it is best-effort: failing
+        // to clean up a leftover must not become the exception the caller sees, which would hide the
+        // real write failure.
+        if (!File.Exists(temp)) return;
+
+        try { File.Delete(temp); }
+        catch (IOException) { /* leftover temp file; the destination is intact either way */ }
+        catch (UnauthorizedAccessException) { }
+    }
+}

--- a/SysManager/SysManager/Services/ActivityLogService.cs
+++ b/SysManager/SysManager/Services/ActivityLogService.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Text.Json;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -107,7 +108,7 @@ public sealed class ActivityLogService
             // WriteIndented = false is the default, so no options object is needed — allocating
             // one per save would only defeat System.Text.Json's per-options metadata cache.
             var json = JsonSerializer.Serialize(snapshot);
-            File.WriteAllText(_filePath, json);
+            AtomicFile.WriteAllText(_filePath, json);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {

--- a/SysManager/SysManager/Services/AppIconService.cs
+++ b/SysManager/SysManager/Services/AppIconService.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Windows.Media.Imaging;
 using Serilog;
+using SysManager.Helpers;
 
 namespace SysManager.Services;
 
@@ -97,7 +98,7 @@ public sealed class AppIconService
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(_settingsPath)!);
-            File.WriteAllText(_settingsPath, JsonSerializer.Serialize(new IconFetchPreference(enabled)));
+            AtomicFile.WriteAllText(_settingsPath, JsonSerializer.Serialize(new IconFetchPreference(enabled)));
         }
         catch (IOException ex) { Log.Debug(ex, "Icon-fetch preference write failed"); }
         catch (UnauthorizedAccessException ex) { Log.Debug(ex, "Icon-fetch preference write denied"); }
@@ -141,7 +142,7 @@ public sealed class AppIconService
             if (bytes.Length == 0) return null;
 
             Directory.CreateDirectory(_cacheDir);
-            await File.WriteAllBytesAsync(cachePath, bytes, ct).ConfigureAwait(false);
+            await AtomicFile.WriteAllBytesAsync(cachePath, bytes, ct).ConfigureAwait(false);
             return LoadFromFile(cachePath);
         }
         catch (HttpRequestException ex)

--- a/SysManager/SysManager/Services/ClosePreferenceService.cs
+++ b/SysManager/SysManager/Services/ClosePreferenceService.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Text.Json;
 using Serilog;
+using SysManager.Helpers;
 
 namespace SysManager.Services;
 
@@ -140,7 +141,7 @@ public sealed class ClosePreferenceService
                 if (File.Exists(_path)) File.Delete(_path);
                 return;
             }
-            File.WriteAllText(_path, Serialize(behavior));
+            AtomicFile.WriteAllText(_path, Serialize(behavior));
         }
         catch (IOException ex) { Log.Debug("Close preference save failed: {Error}", ex.Message); }
         catch (UnauthorizedAccessException ex) { Log.Debug("Close preference save denied: {Error}", ex.Message); }

--- a/SysManager/SysManager/Services/GamingProfileService.cs
+++ b/SysManager/SysManager/Services/GamingProfileService.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -469,7 +470,7 @@ public sealed class GamingProfileService : IGamingProfileService, IDisposable
             var json = JsonSerializer.Serialize(
                 store with { SchemaVersion = CurrentSchemaVersion },
                 JsonDefaults.Indented);
-            File.WriteAllText(_storePath, json);
+            AtomicFile.WriteAllText(_storePath, json);
         }
         catch (IOException ex) { Log.Warning(ex, "Failed to save gaming profile store"); }
         catch (UnauthorizedAccessException ex) { Log.Warning(ex, "Failed to save gaming profile store"); }

--- a/SysManager/SysManager/Services/PerformanceService.cs
+++ b/SysManager/SysManager/Services/PerformanceService.cs
@@ -11,6 +11,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Win32;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -152,7 +153,7 @@ public sealed partial class PerformanceService : IDisposable
             var json = JsonSerializer.SerializeToUtf8Bytes(snapshot, SnapshotJsonOptions);
             if (json.Length > MaxSnapshotBytes)
                 throw new InvalidDataException("The performance snapshot exceeds the supported size.");
-            File.WriteAllBytes(_snapshotPath, json);
+            AtomicFile.WriteAllBytes(_snapshotPath, json);
             Log.Information("Performance snapshot saved to {Path}", _snapshotPath);
             return true;
         }

--- a/SysManager/SysManager/Services/ProfileService.cs
+++ b/SysManager/SysManager/Services/ProfileService.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -155,7 +156,7 @@ public sealed class ProfileService
             var path = Path.Combine(dir, known.FileName);
             try
             {
-                File.WriteAllText(path, section.Json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                AtomicFile.WriteAllText(path, section.Json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
                 applied++;
             }
             catch (IOException ex) { Log.Warning("Profile: could not write {File}: {Error}", known.FileName, ex.Message); }

--- a/SysManager/SysManager/Services/ResourceHistoryService.cs
+++ b/SysManager/SysManager/Services/ResourceHistoryService.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Text;
 using System.Text.Json;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -377,7 +378,7 @@ public sealed class ResourceHistoryService : IDisposable
         try
         {
             Directory.CreateDirectory(_dataDir);
-            File.WriteAllText(_configPath, JsonSerializer.Serialize(new RetentionConfig(days)));
+            AtomicFile.WriteAllText(_configPath, JsonSerializer.Serialize(new RetentionConfig(days)));
         }
         catch (IOException ex) { Log.Debug("Resource history config save failed: {Error}", ex.Message); }
         catch (UnauthorizedAccessException ex) { Log.Debug("Resource history config save denied: {Error}", ex.Message); }

--- a/SysManager/SysManager/Services/ServiceStartupLedgerService.cs
+++ b/SysManager/SysManager/Services/ServiceStartupLedgerService.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Text.Json;
 using Serilog;
+using SysManager.Helpers;
 
 namespace SysManager.Services;
 
@@ -107,7 +108,7 @@ public sealed class ServiceStartupLedgerService
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
-            File.WriteAllText(_path, Serialize(ledger));
+            AtomicFile.WriteAllText(_path, Serialize(ledger));
         }
         catch (IOException ex) { Log.Debug("Service ledger save failed: {Error}", ex.Message); }
         catch (UnauthorizedAccessException ex) { Log.Debug("Service ledger save denied: {Error}", ex.Message); }

--- a/SysManager/SysManager/Services/SettingsWatchdogService.cs
+++ b/SysManager/SysManager/Services/SettingsWatchdogService.cs
@@ -7,6 +7,7 @@ using System.Security;
 using System.Text.Json;
 using Microsoft.Win32;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -204,7 +205,7 @@ public sealed class SettingsWatchdogService : ISettingsWatchdogService
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(_baselinePath)!);
-            File.WriteAllText(_baselinePath, JsonSerializer.Serialize(snapshot, JsonDefaults.Indented));
+            AtomicFile.WriteAllText(_baselinePath, JsonSerializer.Serialize(snapshot, JsonDefaults.Indented));
         }
         catch (IOException ex) { Log.Debug("Settings baseline save failed: {Error}", ex.Message); }
         catch (UnauthorizedAccessException ex) { Log.Debug("Settings baseline save denied: {Error}", ex.Message); }

--- a/SysManager/SysManager/Services/SpeedTestHistoryService.cs
+++ b/SysManager/SysManager/Services/SpeedTestHistoryService.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Text.Json;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -149,7 +150,7 @@ public sealed class SpeedTestHistoryService : IDisposable
             Directory.CreateDirectory(dir);
 
             var json = JsonSerializer.Serialize(entries, JsonOpts);
-            await File.WriteAllTextAsync(_historyPath, json, ct).ConfigureAwait(false);
+            await AtomicFile.WriteAllTextAsync(_historyPath, json, ct).ConfigureAwait(false);
         }
         catch (IOException ex)
         {
@@ -201,7 +202,7 @@ public sealed class SpeedTestHistoryService : IDisposable
             }).ToList();
 
             var json = JsonSerializer.Serialize(entries, JsonOpts);
-            await File.WriteAllTextAsync(_historyPath, json, ct).ConfigureAwait(false);
+            await AtomicFile.WriteAllTextAsync(_historyPath, json, ct).ConfigureAwait(false);
         }
         catch (IOException ex)
         {

--- a/SysManager/SysManager/Services/StandbyPreferenceService.cs
+++ b/SysManager/SysManager/Services/StandbyPreferenceService.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Text.Json;
 using Serilog;
+using SysManager.Helpers;
 
 namespace SysManager.Services;
 
@@ -78,7 +79,7 @@ public sealed class StandbyPreferenceService
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
-            File.WriteAllText(_path, Serialize(preference));
+            AtomicFile.WriteAllText(_path, Serialize(preference));
         }
         catch (IOException ex) { Log.Debug("Standby preference save failed: {Error}", ex.Message); }
         catch (UnauthorizedAccessException ex) { Log.Debug("Standby preference save denied: {Error}", ex.Message); }

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -8,6 +8,7 @@ using System.Windows;
 using System.Windows.Media;
 using System.Windows.Threading;
 using Serilog;
+using SysManager.Helpers;
 
 namespace SysManager.Services;
 
@@ -361,7 +362,7 @@ public sealed class ThemeService
                 CurrentTheme.Accent.ToString(), CurrentTheme.Background.ToString(),
                 CurrentTheme.Surface.ToString(), CurrentTheme.TextPrimary.ToString());
             var json = JsonSerializer.Serialize(data, JsonDefaults.Indented);
-            File.WriteAllText(SettingsPath, json);
+            AtomicFile.WriteAllText(SettingsPath, json);
         }
         catch (Exception ex) { Log.Debug("Theme save failed: {Error}", ex.Message); }
     }

--- a/SysManager/SysManager/Services/UpdateCheckPreferenceService.cs
+++ b/SysManager/SysManager/Services/UpdateCheckPreferenceService.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Text.Json;
 using Serilog;
+using SysManager.Helpers;
 
 namespace SysManager.Services;
 
@@ -85,7 +86,7 @@ public sealed class UpdateCheckPreferenceService
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
-            File.WriteAllText(_path, Serialize(preference));
+            AtomicFile.WriteAllText(_path, Serialize(preference));
         }
         catch (IOException ex) { Log.Debug("Update-check preference save failed: {Error}", ex.Message); }
         catch (UnauthorizedAccessException ex) { Log.Debug("Update-check preference save denied: {Error}", ex.Message); }

--- a/SysManager/SysManager/Services/VolumePresetService.cs
+++ b/SysManager/SysManager/Services/VolumePresetService.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -74,7 +75,7 @@ public sealed class VolumePresetService
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
-            File.WriteAllText(_path, Serialize(presets));
+            AtomicFile.WriteAllText(_path, Serialize(presets));
         }
         catch (IOException ex) { Log.Debug("Volume presets save failed: {Error}", ex.Message); }
         catch (UnauthorizedAccessException ex) { Log.Debug("Volume presets save denied: {Error}", ex.Message); }

--- a/SysManager/SysManager/Services/WindowsThemeService.cs
+++ b/SysManager/SysManager/Services/WindowsThemeService.cs
@@ -8,6 +8,7 @@ using System.Security;
 using System.Text.Json;
 using Microsoft.Win32;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -119,7 +120,7 @@ public sealed partial class WindowsThemeService : IWindowsThemeService
         {
             Directory.CreateDirectory(Path.GetDirectoryName(_schedulePath)!);
             string json = JsonSerializer.Serialize(schedule, JsonDefaults.Indented);
-            File.WriteAllText(_schedulePath, json);
+            AtomicFile.WriteAllText(_schedulePath, json);
         }
         catch (IOException ex) { Log.Warning("Dark-mode schedule save failed: {Error}", ex.Message); }
         catch (UnauthorizedAccessException ex) { Log.Warning("Dark-mode schedule save denied: {Error}", ex.Message); }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.64.16</Version>
-    <FileVersion>1.64.16.0</FileVersion>
-    <AssemblyVersion>1.64.16.0</AssemblyVersion>
+    <Version>1.64.17</Version>
+    <FileVersion>1.64.17.0</FileVersion>
+    <AssemblyVersion>1.64.17.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem

17 call sites across 15 services persisted user data with `File.WriteAllText` / `WriteAllBytes` / the `Async` variants. Those **truncate the destination first**, then write into it. Interrupt that — power cut, crash, full disk — and the file on disk is neither the old contents nor the new.

**Why that is worse than a generic corrupt-file risk here:** the loaders treat an unparseable file as *no data*. Several catch `JsonException` and substitute an empty list, logged at `Debug`. So an interrupted save never surfaces as an error. The user opens the app and their history is simply gone.

`ActivityLogService` is the clearest case — `Load()` catches `JsonException` and does `_entries = [];` at Debug level. `SpeedTestHistoryService` and `VolumePresetService` `return []`.

Affected: Activity log, Speed Test history, Volume presets, Gaming profiles, theme/appearance settings, close-behaviour preference, standby and update-check preferences, Settings Watchdog baseline, service-startup ledger, the performance snapshot used to undo tweaks, restored configuration backups, and the app-icon cache.

## Fix

`HostsFileService` already did this correctly, so this was a **half-migration, not an unknown**: temp file, then `File.Replace` when the destination exists — which preserves its ACLs, where a plain `Move(overwrite: true)` relinks a brand-new inode inheriting only the directory's default ACL — and a plain `Move` on first creation.

New `Helpers/AtomicFile.cs` states that pattern once, with sync + async overloads and one taking an explicit `Encoding` (`ProfileService` must not emit a BOM, or the owning service may fail to parse what it wrote). Temp file cleaned up in a `finally`, best-effort so a cleanup failure cannot mask the real write error.

## Deliberately not migrated

Each with a reason, and each encoded by name in the guard rather than left to judgement:

| Site | Why |
|---|---|
| writes targeting a `tmp`/`.bak` path | that IS the atomic pattern; the swap follows |
| `HostsFileService` | the original implementation this generalises |
| `ProfileService.ExportToFileAsync` | writes a file the user just picked — no existing data to lose |
| two `.sha256` sidecars in the update path | derived values, regenerated on demand |

## Guard

`ArchitectureTests.EveryServiceThatPersistsUserData_WritesItAtomically` scans `Services/` for raw `File.Write*` calls, with the exemptions above applied by name and a **vacuity floor** (`>= 5` raw calls seen) so a broken regex fails loudly instead of passing silently.

`AtomicFileTests` covers the helper — including the two that matter, sync and async: **an interrupted write leaves the previous file byte-for-byte intact**. Every test writes only inside its own temp directory and deletes it in `Dispose`.

## Regression proof — by runtime harness, not by grep

A torn write is exactly the thing source inspection cannot prove, so this was driven for real against both trees:

```
RED (main d279ee9)
  [PASS] the in-place write left a TORN file  -> on disk: {"history":["partial
  [PASS] the original contents are gone
  [PASS] the torn file does not parse, so a JsonException-catching loader yields nothing
  [FAIL] SysManager.Helpers.AtomicFile exists
  [FAIL] the save path goes through AtomicFile — still a raw in-place File.WriteAllText

GREEN (this branch)
  [PASS] an interrupted atomic write reports the failure
  [PASS] THE PREVIOUS CONTENTS SURVIVE BYTE-FOR-BYTE  (SHA256 compared before/after)
  [PASS] it leaves no .tmp behind
  [PASS] the save path goes through AtomicFile
  ALL PASS
```

The interruption is not faked with a mock: the temp path is occupied by a directory, so the write fails at the same point a full disk would. The red run's first three checks are the evidence the bug was real — they pass on **both** trees, because they demonstrate what `File.WriteAllText` does, not what our code does.

## Verification

- `dotnet build` app + tests, Release — 0 errors, 0 warnings each
- `dotnet format --verify-no-changes` — clean on both projects. It initially flagged imports ordering (my scripted `using` insertion guessed the convention) and a line-ending slip; both fixed, then **both projects rebuilt and the harness re-run**, since a formatter touching source after a green build invalidates it
- Identity leak scan over all 18 changed files — only hit is a pre-existing 2026 CHANGELOG line about a Privacy tab toggle, confirmed absent from this branch's additions
- CHANGELOG entry in this PR; version bumped to 1.64.17

## Note on the detection

My first sweep missed the `Async` variants and found 13 sites; catching `SpeedTestHistoryService`'s two async writes brought it to 17. A severity classifier I wrote to split "silent loss" from "reported" then disagreed with what I had read in `ActivityLogService` myself — the source was right and the classifier wrong. Both are why the guard checks the raw call rather than trying to infer severity.