### PR TITLE
fix: identify the power plan by its GUID, not by its editable name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.64.18] - 2026-08-13
+
+The Performance tab now names your power plan correctly, including on non-English Windows and when
+you have renamed a plan yourself.
+
+### Fixed
+- **The Performance tab could claim the wrong power plan was active.** It decided which plan you were on by looking at the plan’s NAME before its identity. Two consequences: if you had copied a plan and given it a name containing "Ultimate" — say "Ultimate Battery Saver", copied from Balanced — the tab announced "Active plan: Ultimate Performance" even though a normal balanced plan was running; and because Windows translates plan names, the genuine Ultimate Performance plan was never recognised on a Romanian, German, Spanish or French system, where it showed as "Performanță maximă" instead. The plan is now identified by the ID Windows assigns it, which is the same in every language and does not change when you rename a plan. The name is still used as a last resort, which is what correctly catches a copy of the Ultimate plan.
+- **The same wrong check also decided which plan appeared selected** in the three plan options, so the selection could disagree with the plan actually in use.
+
+---
+
 ## [1.64.17] - 2026-08-13
 
 If the PC loses power or crashes while SysManager is saving, your settings and history survive

--- a/SysManager/SysManager.Tests/PerformanceProfileTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceProfileTests.cs
@@ -55,6 +55,67 @@ public class PerformanceProfileTests
         Assert.Equal("My Custom Plan", p.ProfileSummary);
     }
 
+    // ---------- the plan is identified by GUID, not by its editable name ----------
+    // The name check used to run FIRST, so any plan whose name merely contained "ultimate" was
+    // reported as Ultimate Performance no matter which scheme was actually active — and the stock
+    // Ultimate GUID was never checked at all, so on non-English Windows the real Ultimate plan fell
+    // through to its localized name. Both are wrong on the one line the tab uses to tell the user
+    // which plan is on.
+
+    [Fact]
+    public void ProfileSummary_APlanMerelyNamedUltimate_IsNotReportedAsUltimate()
+    {
+        // Duplicating Balanced and naming it "Ultimate Battery Saver" keeps Balanced's GUID.
+        var p = new PerformanceProfile
+        {
+            ActivePlanGuid = "381b4222-f694-41f0-9685-ff5bb260df2e",
+            ActivePlanName = "Ultimate Battery Saver",
+        };
+
+        Assert.Equal("Balanced", p.ProfileSummary);
+    }
+
+    [Fact]
+    public void ProfileSummary_TheRealUltimatePlan_IsRecognisedByItsGuid()
+    {
+        var p = new PerformanceProfile
+        {
+            ActivePlanGuid = "e9a42b02-d5df-448d-aa00-03f14749eb61",
+            ActivePlanName = "Ultimate Performance",
+        };
+
+        Assert.Equal("Ultimate Performance", p.ProfileSummary);
+    }
+
+    [Theory]
+    [InlineData("Ultimative Leistung")]     // de-DE
+    [InlineData("Rendimiento máximo")]      // es-ES
+    [InlineData("Performances ultimes")]    // fr-FR
+    public void ProfileSummary_TheRealUltimatePlan_IsRecognisedOnNonEnglishWindows(string localizedName)
+    {
+        var p = new PerformanceProfile
+        {
+            ActivePlanGuid = "e9a42b02-d5df-448d-aa00-03f14749eb61",
+            ActivePlanName = localizedName,
+        };
+
+        Assert.Equal("Ultimate Performance", p.ProfileSummary);
+    }
+
+    [Fact]
+    public void ProfileSummary_ADuplicatedUltimateScheme_IsStillRecognisedByName()
+    {
+        // A duplicated scheme gets a fresh random GUID but keeps its name, so the name check still
+        // earns its place — as a LAST resort, once every stock GUID has been ruled out.
+        var p = new PerformanceProfile
+        {
+            ActivePlanGuid = "7a91b6c4-1111-2222-3333-444455556666",
+            ActivePlanName = "Ultimate Performance - Copy",
+        };
+
+        Assert.Equal("Ultimate Performance", p.ProfileSummary);
+    }
+
     [Fact]
     public void PropertyChange_Notifies()
     {

--- a/SysManager/SysManager.Tests/SettingsWatchdogViewModelTests.cs
+++ b/SysManager/SysManager.Tests/SettingsWatchdogViewModelTests.cs
@@ -25,7 +25,6 @@ public class SettingsWatchdogViewModelTests
         var svc = Substitute.For<ISettingsWatchdogService>();
         svc.Catalog.Returns([]);
         svc.LoadBaseline().Returns(new BaselineSnapshot(new DateTime(2026, 1, 1), []));
-        svc.HasBaseline.Returns(true);
         svc.DetectDrift().Returns(drifts);
         return svc;
     }
@@ -75,7 +74,6 @@ public class SettingsWatchdogViewModelTests
         var svc = Substitute.For<ISettingsWatchdogService>();
         svc.Catalog.Returns([]);
         svc.LoadBaseline().Returns((BaselineSnapshot?)null);
-        svc.HasBaseline.Returns(false);
         svc.DetectDrift().Returns([]);
         var vm = new SettingsWatchdogViewModel(svc);
 
@@ -166,7 +164,6 @@ public class SettingsWatchdogViewModelTests
         var svc = Substitute.For<ISettingsWatchdogService>();
         svc.Catalog.Returns([Setting("telemetry"), Setting("widgets"), Setting("web-search")]);
         svc.LoadBaseline().Returns(new BaselineSnapshot(new DateTime(2026, 1, 1), []));
-        svc.HasBaseline.Returns(true);
         svc.DetectDrift().Returns(drifts);
         svc.ReadCurrent().Returns(current);
         return svc;

--- a/SysManager/SysManager/Models/PerformanceProfile.cs
+++ b/SysManager/SysManager/Models/PerformanceProfile.cs
@@ -41,17 +41,28 @@ public sealed partial class PerformanceProfile : ObservableObject
     [ObservableProperty] private int _processorMinPercent;
 
     /// <summary>Friendly summary of the active profile.</summary>
-    public string ProfileSummary
+    /// <remarks>
+    /// GUID first, name last. The plan's display name is user-editable and localized, so matching on
+    /// it decided two things wrongly: a custom plan called e.g. "Ultimate Battery Saver" — copied from
+    /// Balanced, and carrying Balanced's GUID — was reported as "Ultimate Performance", and on
+    /// non-English Windows the real Ultimate plan ("Ultimative Leistung", "Rendimiento máximo") was
+    /// never recognised at all. The name check now only catches a DUPLICATE of the Ultimate scheme,
+    /// which gets a fresh random GUID but keeps the name, and it runs after every GUID has been ruled
+    /// out.
+    /// </remarks>
+    public string ProfileSummary => PlanLabel() ?? ActivePlanName;
+
+    private string? PlanLabel()
     {
-        get
-        {
-            if (ActivePlanName.Contains("Ultimate", StringComparison.OrdinalIgnoreCase))
-                return "Ultimate Performance";
-            if (ActivePlanGuid.Contains("8c5e7fda", StringComparison.OrdinalIgnoreCase))
-                return "High Performance";
-            if (ActivePlanGuid.Contains("381b4222", StringComparison.OrdinalIgnoreCase))
-                return "Balanced";
-            return ActivePlanName;
-        }
+        if (MatchesPlan(PowerPlans.UltimatePerformance)) return "Ultimate Performance";
+        if (MatchesPlan(PowerPlans.HighPerformance)) return "High Performance";
+        if (MatchesPlan(PowerPlans.Balanced)) return "Balanced";
+        // Only reached when the GUID is none of the stock three: a duplicated Ultimate scheme.
+        return ActivePlanName.Contains("Ultimate", StringComparison.OrdinalIgnoreCase)
+            ? "Ultimate Performance"
+            : null;
     }
+
+    private bool MatchesPlan(string planGuid) =>
+        ActivePlanGuid.Contains(planGuid, StringComparison.OrdinalIgnoreCase);
 }

--- a/SysManager/SysManager/Models/PowerPlans.cs
+++ b/SysManager/SysManager/Models/PowerPlans.cs
@@ -1,0 +1,32 @@
+// SysManager · PowerPlans
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// The GUIDs Windows assigns to its three stock power plans.
+/// <para>
+/// These identify a plan reliably; its display NAME does not. The name is editable by the user and
+/// localized by Windows, so deciding "which plan is active" from the name mislabels a renamed or
+/// duplicated plan and fails outright on a non-English system. Everything that identifies a plan
+/// matches on these values, and falls back to the name only when no GUID matches — which happens
+/// exactly when the user duplicated a stock scheme (a copy keeps the name but gets a new GUID).
+/// </para>
+/// <para>
+/// Declared here, in Models, because both the model and the service that reads powercfg need them;
+/// a model cannot depend on a service. <c>PerformanceService</c> re-exports them so its existing
+/// call sites and tests keep their current names.
+/// </para>
+/// </summary>
+internal static class PowerPlans
+{
+    /// <summary>Balanced — the Windows default.</summary>
+    public const string Balanced = "381b4222-f694-41f0-9685-ff5bb260df2e";
+
+    /// <summary>High performance.</summary>
+    public const string HighPerformance = "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c";
+
+    /// <summary>Ultimate Performance — hidden by default; present on Pro/Workstation editions.</summary>
+    public const string UltimatePerformance = "e9a42b02-d5df-448d-aa00-03f14749eb61";
+}

--- a/SysManager/SysManager/Services/ISettingsWatchdogService.cs
+++ b/SysManager/SysManager/Services/ISettingsWatchdogService.cs
@@ -13,11 +13,34 @@ namespace SysManager.Services;
 /// </summary>
 public interface ISettingsWatchdogService
 {
+    /// <summary>The settings this service watches, in display order.</summary>
     IReadOnlyList<WatchedSetting> Catalog { get; }
-    bool HasBaseline { get; }
+
+    /// <summary>Reads each watched setting's live value. A null value means "not readable".</summary>
     IReadOnlyDictionary<string, int?> ReadCurrent();
+
+    /// <summary>
+    /// Captures the current values as the new baseline and returns the snapshot just taken, so the
+    /// caller does not have to read it back.
+    /// </summary>
     IReadOnlyDictionary<string, int?> SaveBaseline(DateTime takenAt);
+
+    /// <summary>
+    /// The saved baseline, or <c>null</c> when none exists OR the stored file cannot be read or
+    /// parsed. Callers deciding whether a usable baseline exists must test this for null — a file
+    /// being present is not the same as a baseline being readable.
+    /// </summary>
     BaselineSnapshot? LoadBaseline();
+
+    /// <summary>
+    /// The settings that have changed since the baseline. Returns an EMPTY list — never null — when
+    /// there is no baseline or nothing drifted.
+    /// </summary>
     IReadOnlyList<SettingDrift> DetectDrift();
+
+    /// <summary>
+    /// Writes one drifted setting back to its baseline value. Returns false when it cannot be
+    /// restored: read-only, no baseline value recorded, or the write was denied.
+    /// </summary>
     bool Restore(SettingDrift drift);
 }

--- a/SysManager/SysManager/Services/PerformanceService.cs
+++ b/SysManager/SysManager/Services/PerformanceService.cs
@@ -37,9 +37,11 @@ public sealed partial class PerformanceService : IDisposable
     private bool _disposed;
 
     // ── Well-known power plan GUIDs ──
-    internal const string BalancedGuid = "381b4222-f694-41f0-9685-ff5bb260df2e";
-    internal const string HighPerfGuid = "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c";
-    internal const string UltimatePerfScheme = "e9a42b02-d5df-448d-aa00-03f14749eb61";
+    // Defined once in Models/PowerPlans so the model can identify a plan too; re-exported here
+    // under the names this service and its tests already use.
+    internal const string BalancedGuid = PowerPlans.Balanced;
+    internal const string HighPerfGuid = PowerPlans.HighPerformance;
+    internal const string UltimatePerfScheme = PowerPlans.UltimatePerformance;
 
     internal const int MaxSnapshotBytes = 64 * 1024;
     private static readonly JsonSerializerOptions SnapshotJsonOptions = new()

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.64.17</Version>
-    <FileVersion>1.64.17.0</FileVersion>
-    <AssemblyVersion>1.64.17.0</AssemblyVersion>
+    <Version>1.64.18</Version>
+    <FileVersion>1.64.18.0</FileVersion>
+    <AssemblyVersion>1.64.18.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
@@ -749,14 +749,25 @@ public sealed partial class PerformanceViewModel : ViewModelBase
     //  HELPERS
     // ═══════════════════════════════════════════════════════════════
 
+    /// <summary>
+    /// Which of the three plan options is shown as selected. GUID first: the plan's display name is
+    /// user-editable and localized, so a custom plan named "Ultimate Battery Saver" (a copy of
+    /// Balanced) selected Ultimate, and the real Ultimate plan on non-English Windows fell through to
+    /// Balanced. The name check now only catches a duplicated Ultimate scheme — which keeps the name
+    /// but gets a fresh GUID — and only once every stock GUID has been ruled out.
+    /// </summary>
     private string GetCurrentPlanKey()
     {
-        if (Profile.ActivePlanName.Contains("Ultimate", StringComparison.OrdinalIgnoreCase))
-            return "ultimate";
-        if (Profile.ActivePlanGuid.Contains("8c5e7fda", StringComparison.OrdinalIgnoreCase))
-            return "high";
-        return "balanced";
+        if (MatchesPlan(PowerPlans.UltimatePerformance)) return "ultimate";
+        if (MatchesPlan(PowerPlans.HighPerformance)) return "high";
+        if (MatchesPlan(PowerPlans.Balanced)) return "balanced";
+        return Profile.ActivePlanName.Contains("Ultimate", StringComparison.OrdinalIgnoreCase)
+            ? "ultimate"
+            : "balanced";
     }
+
+    private bool MatchesPlan(string planGuid) =>
+        Profile.ActivePlanGuid.Contains(planGuid, StringComparison.OrdinalIgnoreCase);
 
     private void SyncTogglesFromProfile()
     {


### PR DESCRIPTION
## Problem

Two places decided which power plan was active by matching `"Ultimate"` against the plan's **display name**, before checking any GUID — and neither checked the stock Ultimate Performance GUID at all:

```csharp
if (ActivePlanName.Contains("Ultimate", StringComparison.OrdinalIgnoreCase))
    return "Ultimate Performance";
if (ActivePlanGuid.Contains("8c5e7fda", ...)) return "High Performance";
if (ActivePlanGuid.Contains("381b4222", ...)) return "Balanced";
```

The name is the wrong input: the user can rename a plan, and Windows localizes the stock names. Two wrong answers follow.

**A plan merely named "Ultimate …" was reported as Ultimate Performance.** Duplicating Balanced and calling it "Ultimate Battery Saver" keeps Balanced's GUID — which the third line would have matched correctly — but the tab announced `Active plan: Ultimate Performance`. The user is told a max-performance plan is running when it is not.

**The real Ultimate plan was never recognised outside English.** Balanced and High performance were matched by GUID, so they worked in every language; Ultimate was matched by name, so on a Romanian system it reported `Performanță maximă` verbatim. An inconsistent detection strategy inside one method.

Both reach the screen through `PerformanceViewModel.UpdateSummary` → `Summary`, bound at `PerformanceView.xaml:77`. The same wrong check in `GetCurrentPlanKey` also drove **which of the three plan options appeared selected**, so the selection could disagree with the plan actually in use.

## Fix

GUID is primary in both places; the name check runs **last**, where it correctly catches a duplicated Ultimate scheme — a copy gets a fresh random GUID but keeps the name, so nothing else can identify it.

The three GUIDs move to `Models/PowerPlans` so the model can identify a plan without depending on a service. `PerformanceService` **re-exports** them under `BalancedGuid` / `HighPerfGuid` / `UltimatePerfScheme`, so its existing call sites and tests are untouched. Note the Ultimate GUID was already declared there as `UltimatePerfScheme` — the model was duplicating the other two as magic substrings and ignoring this one.

## Also: a dead interface member that was a trap

`ISettingsWatchdogService.HasBaseline` has **no production consumer through the seam**. The view model has its own `HasBaseline` (`[ObservableProperty] private bool _hasBaseline`, line 40) set from `LoadBaseline() is not null`, and lines 81/92 read that one.

Worse, the two **disagree**: the implementation is `File.Exists(_baselinePath)`, which is true for a corrupt baseline file that `LoadBaseline()` maps to `null`. A maintainer switching to the "obvious" member would have shown a saved baseline while drift detection was silently dead.

Removed from the interface; the concrete class keeps it for its own file-persistence tests (`HasBaseline_ReflectsTheGivenConfigDir`), and the three dead `svc.HasBaseline.Returns(...)` stubs are gone. While there, the interface gained the per-member contracts its sibling seams (`INotificationBlockerService`, `IAppBlockerService`) already document — including that `LoadBaseline` returns null for a **corrupt** file and not only a missing one, which is precisely the distinction that caused this.

## Regression proof

Driven through the real property on both trees, because the defect is the **order** of the checks — that shows up in the answer, not in the shape of the code:

```
RED (main 8c39840): 6 FAIL
  a Balanced copy named "Ultimate Battery Saver"  -> got 'Ultimate Performance'
  a High-perf copy named "My Ultimate Tweaks"     -> got 'Ultimate Performance'
  de-DE "Ultimative Leistung"                     -> got 'Ultimative Leistung'
  es-ES "Rendimiento máximo"                      -> got 'Rendimiento máximo'
  fr-FR "Performances ultimes"                    -> got 'Performances ultimes'
  ro-RO "Performanță maximă"                      -> got 'Performanță maximă'

GREEN (this branch): ALL PASS
```

The red run's passing checks matter too: the three stock plans, the duplicated-Ultimate case and an unrelated custom plan all pass on **both** trees, so the fix is proven not to have broken what already worked.

Six tests added to `PerformanceProfileTests`, including a `[Theory]` over de-DE / es-ES / fr-FR.

## Verification

- `dotnet build` app + tests, Release — 0 errors, 0 warnings each
- `dotnet format --verify-no-changes` — clean on both projects (a line-ending slip in the new file was fixed, then **both projects rebuilt and the harness re-run**, since formatting after a green build invalidates it)
- Identity leak scan over all 8 changed files — only hit is the pre-existing 2026 CHANGELOG line about a Privacy tab toggle, confirmed absent from this branch's additions
- CHANGELOG entry in this PR; version bumped to 1.64.18

## Refuted while triaging

Two findings from the same batch did **not** survive checking and are deliberately absent:

- *"`NotificationApp.IsEnabled` defaults to false but the doc says Windows defaults to allowed"* — the doc is imprecise, but the single construction site (`NotificationBlockerService.cs:124`) sets it explicitly. No failure mode; not worth a behaviour change in a fix PR.
- *"`BiosInfo.IsEmpty` ignores four of its fields, so it can report empty when data was gathered"* — the comment is genuinely inaccurate, but the property has **zero consumers** anywhere in the app or tests. A dead property with a wrong comment, not a live defect; it belongs in a dead-code sweep, not here.