### PR TITLE
test: make five tests assert what their names promise

### DIFF
--- a/SysManager/SysManager.IntegrationTests/DeepCleanupViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DeepCleanupViewModelTests.cs
@@ -253,14 +253,6 @@ public class DeepCleanupViewModelTests
     }
 
     [Fact]
-    public void ScanLocation_RecordHoldsValues()
-    {
-        var loc = new ScanLocation("Downloads", @"C:\Users\X\Downloads");
-        Assert.Equal("Downloads", loc.Label);
-        Assert.Equal(@"C:\Users\X\Downloads", loc.Path);
-    }
-
-    [Fact]
     public void ScanLocation_Records_EquateByValue()
     {
         var a = new ScanLocation("A", "p");

--- a/SysManager/SysManager.Tests/DeepCleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupViewModelTests.cs
@@ -477,14 +477,6 @@ public class DeepCleanupViewModelTests
     // ---------- ScanLocation record ----------
 
     [Fact]
-    public void ScanLocation_HoldsValues()
-    {
-        var loc = new ScanLocation("Downloads", @"C:\Users\X\Downloads");
-        Assert.Equal("Downloads", loc.Label);
-        Assert.Equal(@"C:\Users\X\Downloads", loc.Path);
-    }
-
-    [Fact]
     public void ScanLocation_ValueEquality()
     {
         var a = new ScanLocation("A", "p");

--- a/SysManager/SysManager.Tests/FriendlyEventEntryExtendedTests.cs
+++ b/SysManager/SysManager.Tests/FriendlyEventEntryExtendedTests.cs
@@ -19,7 +19,10 @@ public class FriendlyEventEntryExtendedTests
         {
             if (ev.PropertyName != null) raised.Add(ev.PropertyName);
         };
-        e.Timestamp = DateTime.Now;
+        // A fixed date, not DateTime.Now: the generated setter skips PropertyChanged when the new
+        // value equals the current one, so reading the wall clock made this assertion depend on
+        // machine time rather than on a value the test controls.
+        e.Timestamp = new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         e.LogName = "System";
         e.ProviderName = "x";
         e.EventId = 42;

--- a/SysManager/SysManager.Tests/PingViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PingViewModelTests.cs
@@ -8,21 +8,59 @@ namespace SysManager.Tests;
 
 public class PingViewModelTests
 {
+    /// <summary>
+    /// Construction must wire the shared state AND leave the commands the view binds available.
+    /// <para>This previously asserted only <c>Assert.Same(shared, vm.Shared)</c> — the argument
+    /// handed to the constructor, read straight back — so it could fail only if that one assignment
+    /// were deleted. A command left null would sail past it and surface as a dead button.</para>
+    /// </summary>
     [Fact]
     public void Constructor_SetsShared()
     {
         var shared = new NetworkSharedState(new Services.PingMonitorService(), new Services.TracerouteService(), new Services.TracerouteMonitorService(), new Services.SpeedTestService(), new Services.NetworkRepairService(new Services.PowerShellRunner()));
+
         var vm = new PingViewModel(shared);
+
         Assert.Same(shared, vm.Shared);
+        Assert.NotNull(vm.ClearHistoryCommand);
+        Assert.NotNull(vm.AddCustomTargetCommand);
     }
 
+    /// <summary>
+    /// Clearing must actually reset the per-target statistics.
+    /// <para>This test used to run the command against a freshly built state — where every target's
+    /// LastLatencyMs is ALREADY null — and then assert it was null. It asserted the initial state
+    /// rather than any effect of the command, so it would have passed with the command's body
+    /// deleted. It also leaned on Assert.All, which succeeds over an empty collection.</para>
+    /// <para>It now dirties every field ClearHistory resets, so dropping any one of them fails
+    /// here.</para>
+    /// </summary>
     [Fact]
     public void ClearHistoryCommand_ResetsStats()
     {
         var shared = new NetworkSharedState(new Services.PingMonitorService(), new Services.TracerouteService(), new Services.TracerouteMonitorService(), new Services.SpeedTestService(), new Services.NetworkRepairService(new Services.PowerShellRunner()));
         var vm = new PingViewModel(shared);
+
+        Assert.NotEmpty(shared.Targets);   // otherwise the Assert.All below succeeds over nothing
+        foreach (var t in shared.Targets)
+        {
+            t.LastLatencyMs = 42.5;
+            t.AverageMs = 40.0;
+            t.JitterMs = 3.25;
+            t.LossPercent = 12;
+            t.Status = "Online";
+        }
+
         vm.ClearHistoryCommand.Execute(null);
-        Assert.All(shared.Targets, t => Assert.Null(t.LastLatencyMs));
+
+        Assert.All(shared.Targets, t =>
+        {
+            Assert.Null(t.LastLatencyMs);
+            Assert.Null(t.AverageMs);
+            Assert.Null(t.JitterMs);
+            Assert.Equal(0, t.LossPercent);
+            Assert.Equal("—", t.Status);
+        });
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/UpdateServiceParseVersionBulkTests.cs
+++ b/SysManager/SysManager.Tests/UpdateServiceParseVersionBulkTests.cs
@@ -39,16 +39,20 @@ public class UpdateServiceParseVersionBulkTests
         var suffixes = new[] { "-alpha", "-beta", "-rc1", "-rc.2", "-preview.3", "+build", "+meta.1" };
         foreach (var s in suffixes)
         {
-            yield return new object[] { $"v0.5.0{s}" };
-            yield return new object[] { $"1.2.3{s}" };
+            yield return new object[] { $"v0.5.0{s}", new Version(0, 5, 0) };
+            yield return new object[] { $"1.2.3{s}", new Version(1, 2, 3) };
         }
     }
 
     [Theory]
     [MemberData(nameof(SuffixTags))]
-    public void ParseVersion_StripsAllSuffixes(string tag)
+    public void ParseVersion_StripsAllSuffixes(string tag, Version expected)
     {
-        Assert.NotNull(UpdateService.ParseVersion(tag));
+        // Asserting only NotNull let any regression that mangles the strip but still leaves
+        // something parseable pass: "v0.5.0-rc.2" collapsing to "0.5.02" becomes Version 0.5.2 and
+        // would have gone unnoticed — on the comparison that decides whether the user is offered an
+        // update.
+        Assert.Equal(expected, UpdateService.ParseVersion(tag));
     }
 
     public static IEnumerable<object[]> Garbage()
@@ -58,14 +62,22 @@ public class UpdateServiceParseVersionBulkTests
         foreach (var j in junk) yield return new object[] { j };
     }
 
+    /// <summary>
+    /// Every one of these must be REJECTED, not merely survived.
+    /// <para>This test used to discard the result with <c>_ = v;</c> under a comment claiming some
+    /// inputs "may legitimately parse", so despite its name it asserted nothing about rejection —
+    /// a regression returning a Version for "abc" or "1,2,3" passed all 18 cases. The comment was
+    /// also wrong: every input here returns null, "1.2.3.4.5.6" included (its four-plus components
+    /// survive the suffix cut, and Version.TryParse rejects six).</para>
+    /// <para>It matters because ParseVersion decides whether the user is told an update exists. A
+    /// garbage tag that parsed to some arbitrary version could offer a downgrade, or hide a real
+    /// update behind a bogus higher number.</para>
+    /// </summary>
     [Theory]
     [MemberData(nameof(Garbage))]
     public void ParseVersion_RejectsAllGarbage(string tag)
     {
-        var v = UpdateService.ParseVersion(tag);
-        // Some of these (like "1.2.3.4.5.6") may legitimately parse — we only
-        // require that the call does not throw.
-        _ = v;
+        Assert.Null(UpdateService.ParseVersion(tag));
     }
 
     public static IEnumerable<object[]> NewerPairs()


### PR DESCRIPTION
Each of these named a behaviour and then failed to check it. That is the worst kind of test — not merely useless, but actively misleading, because it makes the code look covered while the behaviour can break with the suite green.

`test:` — no release.

## 1. `ParseVersion_RejectsAllGarbage` asserted nothing at all

```csharp
var v = UpdateService.ParseVersion(tag);
// Some of these (like "1.2.3.4.5.6") may legitimately parse — we only
// require that the call does not throw.
_ = v;
```

18 theory cases, zero assertions about rejection. A regression returning a `Version` for `"abc"` or `"1,2,3"` passed every one of them.

**The comment was also wrong.** I measured all 18 inputs against the real implementation: every one returns null, `"1.2.3.4.5.6"` included — its components survive the suffix cut and `Version.TryParse` rejects more than four. So the excuse for not asserting never held.

This matters beyond hygiene: `ParseVersion` decides whether the user is told an update exists. A garbage tag that parsed to some arbitrary version could offer a downgrade, or hide a real update behind a bogus higher number.

## 2. `ParseVersion_StripsAllSuffixes` never checked what it stripped **to**

`Assert.NotNull` only. The data set now supplies the expected `Version` and the test asserts it.

## 3. `ClearHistoryCommand_ResetsStats` asserted the initial state

It ran the command against a freshly built `NetworkSharedState` — where every target's `LastLatencyMs` is *already* null — then asserted null. That is the starting value, not an effect of the command; **it would have passed with the command's body deleted.** It also leaned on `Assert.All`, which succeeds over an empty collection.

Now dirties all five fields `ClearHistory` resets (`LastLatencyMs`, `AverageMs`, `JitterMs`, `LossPercent`, `Status`) and asserts each, plus `Assert.NotEmpty`.

## 4. `Constructor_SetsShared` echoed its own argument

`Assert.Same(shared, vm.Shared)` could fail only if that one assignment were deleted. It now also asserts the two commands the view binds are non-null — a command left null would otherwise ship as a dead button.

## 5. Wall clock in a notification test

`e.Timestamp = DateTime.Now`. The MVVM-generated setter skips `PropertyChanged` when the value is unchanged, so machine time decided the outcome. Replaced with a fixed 2030 date.

## 6. Two pure round-trips, deleted

`ScanLocation_HoldsValues` (unit) and `ScanLocation_RecordHoldsValues` (integration) — the same test duplicated across both projects — constructed a record from two literals and asserted those literals back. They tested the C# compiler.

Deleted rather than propped up. The `ScanLocation_ValueEquality` / `ScanLocation_Records_EquateByValue` tests beside them pin real record behaviour and are deliberately untouched.

## Verified two ways

**Structurally** — red on `3b56455` (13 checks fail: the discard present, only `NotNull`, no dirty state, `DateTime.Now`, round-trips present), green here.

**By mutation**, because a structural proof shows the assertions *exist*, not that they *bite*. `ParseVersion` mutated to drop the patch component (`"1.2.3+meta"` → `1.2.0`) **passes the old suite and fails the new one**.

### Recorded honestly: three of my first four mutants did not discriminate

| Mutant | Why it proved nothing |
|---|---|
| strip the separator instead of truncating | `"0.5.0-rc.2"` → `"0.5.0rc.2"`; letters remain, `TryParse` rejects it, so the **old** `NotNull` already caught it. My initial claim that it becomes `0.5.2` was wrong. |
| skip the "still starts with a letter" guard | `TryParse` rejects `"abc"`/`"no"` anyway — that guard is defence in depth, not the thing doing the work |
| cut at index `>= 0` | `"-1.0.0"` empties the string; rejected either way |
| cut at the last dot | catches `"1.2.3-beta"` but not `"v0.5.0-rc.2"`, so the old suite fails on it too — does not isolate the difference |

**So the suffix upgrade is narrow** — it catches a wrong-but-parseable result, and little else. **The garbage upgrade is total** — that test asserted nothing whatsoever. Stating this rather than implying both changes carry equal weight.

## Verification

- `dotnet build` both test projects, Release — 0 errors, 0 warnings
- `dotnet format --verify-no-changes` — clean on both
- Identity leak scan over all 5 changed files — **0 hits**, with a control term proving the scan matches
- No production code touched, so no CHANGELOG entry and no version bump

## Note on process

My first edit script asserted mid-way through three replacements and exited, so the file was **never written** — and I read success from its earlier output. Only the red/green proof caught that two of the edits were missing. A multi-edit script must write per-edit or verify afterwards; the proof is what made the difference here, not the script's own report.