### PR TITLE
fix: print the same date on every regional setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.1] - 2026-08-13
+
+Dates and times now look the same on every PC. If your Windows is set to a language whose calendar is not the Western one — Thai or Arabic, for example — the app was printing the wrong year, and in a few places the wrong month, in lists, exported reports, and even in the names of the files it saved.
+
+### Fixed
+- **Dates were wrong, not just differently formatted, on some regional settings.** Where the app shows a date in a fixed layout — the Boot Analyzer, Privacy Monitor, Restore Points, Disk Analyzer, the bandwidth and resource charts, the crash notice, exported reports — it was letting Windows' regional setting pick the calendar. On a Thai setting, 4 August 2026 was shown as 2569-08-04; on an Arabic (Saudi) setting, as 1448-02-21, with the month changed too. On a Finnish setting the time lost its colon (13.45), which also broke sorting a column of timestamps. Every one of these now prints the same on every machine.
+- **Saved files could be named with the wrong date.** Exported reports, log CSVs, resource-history CSVs, saved settings profiles, and the automatic registry backup taken before a context-menu change all put a timestamp in the filename. On the regional settings above, that timestamp was a different year, so the files sorted wrongly and did not match the date inside them.
+- **The Dashboard could report no critical events on a PC that had them.** Its seven-day event-log scan builds a date filter that Windows parses literally. Under a non-Western calendar that filter asked for a year that has not happened, so the query came back empty and the Dashboard said nothing was wrong.
+- **"Updates paused until …" could state a date that was not the pause date.** The Windows Update panel formatted that promise the same way.
+
 ## [1.65.0] - 2026-08-13
 
 System Health now shows which slot each memory module is in, and whether your RAM is actually

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1240,6 +1240,99 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"\.sha256|hashFile", RegexOptions.CultureInvariant)]
     private static partial Regex HashSidecarTarget();
 
+    /// <summary>
+    /// Every date formatted with a fixed SHAPE must name the culture that shape belongs to.
+    /// <para>A custom pattern with no <c>IFormatProvider</c> formats through
+    /// <c>CultureInfo.CurrentCulture</c>, which Windows sets from the user's regional settings — so
+    /// the same code prints a different string, and on some installs a DIFFERENT DATE, per machine.
+    /// Measured for 2026-08-04 13:45:30 with this app's own patterns:</para>
+    /// <list type="bullet">
+    /// <item><c>yyyy-MM-dd</c> → <c>2026-08-04</c> on en-US, <c>2569-08-04</c> on th-TH (Buddhist
+    /// calendar), <c>1448-02-21</c> on ar-SA (Umm al-Qura) — the year AND the month change</item>
+    /// <item><c>HH:mm</c> → <c>13:45</c> on en-US, <c>13.45</c> on fi-FI — the ':' is the culture's
+    /// time separator, so an ISO-looking string is neither ISO nor lexicographically sortable, which
+    /// is the only reason to choose that pattern over <c>ToString("g")</c></item>
+    /// <item><c>yyyyMMdd_HHmmss</c> → <c>25690804_134530</c> on th-TH — and this one lands in a
+    /// registry-backup FILENAME, so the file is stamped with a date that is not the date</item>
+    /// </list>
+    /// <para>Both shapes carry the defect and both are checked: <c>x.ToString("pattern")</c> and the
+    /// interpolation hole <c>$"{x:pattern}"</c>. An interpolation hole cannot take a provider, so the
+    /// fix there is to format inside the hole.</para>
+    /// <para>Standard format specifiers (<c>"g"</c>, <c>"f"</c>, <c>"D"</c>) are deliberately NOT
+    /// flagged: localizing those IS correct, and they have no fixed shape to preserve.</para>
+    /// </summary>
+    [Fact]
+    public void EveryFixedShapeDateFormat_NamesItsCulture()
+    {
+        var appDir = FindAppProjectDir();
+        var offenders = new List<string>();
+        var scanned = 0;
+
+        foreach (var file in Directory.EnumerateFiles(appDir, "*.cs", SearchOption.AllDirectories))
+        {
+            if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                              StringComparison.Ordinal)) continue;
+
+            var source = File.ReadAllText(file);
+            var name = Path.GetFileName(file);
+
+            foreach (var match in CultureBlindDateFormat().Matches(source).Cast<Match>())
+            {
+                var pattern = match.Groups["pattern"].Value;
+
+                // A Serilog output template is not C# interpolation — Serilog parses it and the
+                // formatter is constructed with an explicit culture, so the hole never reaches
+                // string.Format. Recognised by Serilog's own token syntax, which C# has no notion of.
+                if (SerilogTemplateToken().IsMatch(source[match.Index..Math.Min(source.Length, match.Index + match.Length + 40)])) continue;
+
+                scanned++;
+                var line = source[..match.Index].Count(c => c == '\n') + 1;
+                offenders.Add($"{name}:{line} formats \"{pattern}\" through CurrentCulture");
+            }
+        }
+
+        // Vacuity floor: the codebase keeps ~35 culture-explicit date formats. If the pattern class
+        // stopped being recognised this test would pass while inspecting nothing, so prove the
+        // detector still sees the compliant calls before trusting a clean result.
+        var compliant = Directory
+            .EnumerateFiles(appDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                                    StringComparison.Ordinal))
+            .Sum(f => CultureExplicitDateFormat().Matches(File.ReadAllText(f)).Count);
+        Assert.True(compliant >= 25,
+            $"Only {compliant} culture-explicit date formats were found — the detection is broken, "
+            + "not the code. Fix this guard rather than trusting it.");
+
+        Assert.True(offenders.Count == 0,
+            "These dates are formatted with a fixed shape but no culture, so CurrentCulture decides the "
+            + "output: on a Thai or Saudi regional setting the year and month change, and on Finnish the "
+            + "time separator does. Pass CultureInfo.InvariantCulture (and for an interpolation hole, "
+            + "format inside the hole — a hole takes no provider):\n  "
+            + string.Join("\n  ", offenders)
+            + $"\n({scanned} culture-blind, {compliant} culture-explicit)");
+    }
+
+    // A fixed-shape date pattern is one naming a calendar/clock field: yyyy, MM, dd, HH, mm, ss.
+    // Alternative 1 — .ToString("pattern") with no second argument.
+    // Alternative 2 — an interpolation hole $"{value:pattern}", which cannot take a provider at all.
+    // Numeric specifiers (F1, N0, X8) are out of scope here: the decimal-separator class is a
+    // separate concern, and hex formatting consults no culture data.
+    // Both alternatives reuse the name "pattern" — .NET merges same-named groups, so whichever
+    // alternative matched reports through Groups["pattern"] and the caller needs no branch.
+    [GeneratedRegex(@"\.ToString\(""(?<pattern>[^""]*(?:yyyy|HH|mm:ss|MM-dd|dd MMM)[^""]*)""\s*\)"
+                    + @"|\{[^{}""]{1,60}:(?<pattern>[^{}]*(?:yyyy|HH:mm|mm:ss)[^{}]*)\}",
+                    RegexOptions.CultureInvariant)]
+    private static partial Regex CultureBlindDateFormat();
+
+    [GeneratedRegex(@"\.ToString\(""[^""]*(?:yyyy|HH|mm:ss|MM-dd|dd MMM)[^""]*""\s*,\s*(?:System\.Globalization\.)?CultureInfo\.",
+                    RegexOptions.CultureInvariant)]
+    private static partial Regex CultureExplicitDateFormat();
+
+    // Serilog's {Level:u3} / {Message:lj} tokens have no C# equivalent, so their presence right after
+    // the match identifies an output template rather than an interpolated string.
+    [GeneratedRegex(@"\{(?:Level:u3|Message:lj|NewLine|Exception)\}", RegexOptions.CultureInvariant)]
+    private static partial Regex SerilogTemplateToken();
+
     /// <summary>The app project directory — .xaml is not copied to the test output.</summary>
     private static string FindAppProjectDir()
     {

--- a/SysManager/SysManager.Tests/FixedShapeDateFormatTests.cs
+++ b/SysManager/SysManager.Tests/FixedShapeDateFormatTests.cs
@@ -1,0 +1,139 @@
+// SysManager · FixedShapeDateFormatTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Globalization;
+using SysManager.Models;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Pins the dates that must look identical on every machine.
+/// <para>Windows sets <c>CultureInfo.CurrentCulture</c> from the user's regional settings, so a custom
+/// pattern with no <c>IFormatProvider</c> renders differently per install — and under a non-Gregorian
+/// default calendar it renders a different DATE. Measured for 2026-08-04 13:45:30:</para>
+/// <list type="bullet">
+/// <item>th-TH (Buddhist calendar): <c>yyyy-MM-dd</c> → <c>2569-08-04</c></item>
+/// <item>ar-SA (Umm al-Qura): <c>yyyy-MM-dd</c> → <c>1448-02-21</c> — month too</item>
+/// <item>fi-FI: <c>HH:mm</c> → <c>13.45</c>, because ':' is the culture's time separator</item>
+/// </list>
+/// <para>These run the real display members under those cultures. Every case here FAILED before the
+/// fix on at least one locale, which is what makes them a regression test rather than a restatement.
+/// Grouped in one file because it is one defect class, not one type's behaviour.</para>
+/// </summary>
+public sealed class FixedShapeDateFormatTests
+{
+    private static readonly DateTime Moment = new(2026, 8, 4, 13, 45, 30, DateTimeKind.Utc);
+
+    /// <summary>ar-SA and th-TH shift the calendar; fi-FI shifts the time separator.</summary>
+    public static TheoryData<string> HostileCultures() => new() { "ar-SA", "th-TH", "fi-FI", "de-DE", "en-US", "" };
+
+    [Theory]
+    [MemberData(nameof(HostileCultures))]
+    public void BootRecord_WhenDisplay_IsTheSameOnEveryLocale(string culture)
+    {
+        var record = new BootRecord(Moment, 30_000, 12_000, 18_000);
+
+        WithCulture(culture, () => Assert.Equal("2026-08-04 13:45", record.WhenDisplay));
+    }
+
+    [Theory]
+    [MemberData(nameof(HostileCultures))]
+    public void PrivacyAccessEntry_LastUsedDisplay_StaysISO(string culture)
+    {
+        // Shown in the Privacy Monitor grid under a "Last used" column and sorted as text, so a
+        // Buddhist year would both misreport the date and break the ordering.
+        var entry = new PrivacyAccessEntry("Camera", "Camera app", Moment, false);
+
+        WithCulture(culture, () => Assert.Equal("2026-08-04 13:45", entry.LastUsedDisplay));
+    }
+
+    [Theory]
+    [MemberData(nameof(HostileCultures))]
+    public void LargeFileEntry_LastModifiedDisplay_NamesTheMonthInEnglish(string culture)
+    {
+        // The UI ships no translations, so a Finnish "elok." or Arabic "صفر" next to English column
+        // headers is not localization — it is one field speaking a different language than its label.
+        var entry = new LargeFileEntry
+        {
+            Path = @"C:\test\file.zip",
+            Name = "file.zip",
+            SizeBytes = 1000,
+            LastModified = Moment
+        };
+
+        WithCulture(culture, () => Assert.Equal("04 Aug 2026", entry.LastModifiedDisplay));
+    }
+
+    [Theory]
+    [MemberData(nameof(HostileCultures))]
+    public void BandwidthAxisTicks_AreStableOnEveryLocale(string culture)
+    {
+        var ticks = Moment.Ticks;
+
+        WithCulture(culture, () =>
+        {
+            Assert.Equal("13:45:30", BandwidthMonitorViewModel.FormatAxisTick(ticks, TimeSpan.Zero));
+            Assert.Equal("13:45", BandwidthMonitorViewModel.FormatAxisTick(ticks, TimeSpan.FromHours(1)));
+            Assert.Equal("08-04 13:45", BandwidthMonitorViewModel.FormatAxisTick(ticks, TimeSpan.FromDays(7)));
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(HostileCultures))]
+    public void WindowsUpdatePolicy_Summary_StatesTheRealPauseDate(string culture)
+    {
+        // This one is read as a promise ("paused until X"), so a wrong year is worse than an ugly one.
+        var policy = new WindowsUpdatePolicy(
+            DeferFeatureUpdates: false, FeatureDeferDays: 0, PauseActive: true, PauseUntil: Moment);
+
+        WithCulture(culture, () => Assert.Equal("Updates paused until 2026-08-04.", policy.Summary));
+    }
+
+    [Theory]
+    [MemberData(nameof(HostileCultures))]
+    public void RestorePoint_CreatedDisplay_IsTheSameOnEveryLocale(string culture)
+    {
+        var point = new RestorePoint(42, "Before driver update", Moment, "APPLICATION_INSTALL", "BEGIN_SYSTEM_CHANGE");
+
+        WithCulture(culture, () => Assert.Equal("2026-08-04 13:45", point.CreatedDisplay));
+    }
+
+    [Fact]
+    public void TheHostileCultures_ReallyDoDisagree_AboutTheseDates()
+    {
+        // Guards the guard. If a future runtime resolved ar-SA to the Gregorian calendar, every test
+        // above would pass while proving nothing — so assert the danger is real on this machine, and
+        // fail loudly if the premise stops holding rather than reporting false safety.
+        var thai = new CultureInfo("th-TH");
+        var saudi = new CultureInfo("ar-SA");
+        var finnish = new CultureInfo("fi-FI");
+
+        Assert.NotEqual("2026", Moment.ToString("yyyy", thai));
+        Assert.NotEqual("2026", Moment.ToString("yyyy", saudi));
+        Assert.NotEqual("13:45", Moment.ToString("HH:mm", finnish));
+
+        Assert.Equal("2026-08-04 13:45", Moment.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>
+    /// Runs <paramref name="assert"/> with the thread's culture switched, restoring it in a finally so
+    /// one test cannot leak a locale into the rest of the run. Deterministic: no ambient state is read.
+    /// </summary>
+    private static void WithCulture(string culture, Action assert)
+    {
+        var previous = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = culture.Length == 0
+                ? CultureInfo.InvariantCulture
+                : new CultureInfo(culture);
+            assert();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+}

--- a/SysManager/SysManager/Models/BootRecord.cs
+++ b/SysManager/SysManager/Models/BootRecord.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
+
 namespace SysManager.Models;
 
 /// <summary>
@@ -20,7 +22,7 @@ public sealed record BootRecord(
 
     public string MainPathDisplay => $"{MainPathBootTimeMs / 1000.0:F1} s";
     public string PostBootDisplay => $"{PostBootTimeMs / 1000.0:F1} s";
-    public string WhenDisplay => BootTime.ToString("yyyy-MM-dd HH:mm");
+    public string WhenDisplay => BootTime.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
 }
 
 /// <summary>
@@ -35,5 +37,5 @@ public sealed record BootDegradation(
     long DurationMs)
 {
     public string DurationDisplay => DurationMs >= 1000 ? $"{DurationMs / 1000.0:F1} s" : $"{DurationMs} ms";
-    public string WhenDisplay => When.ToString("yyyy-MM-dd HH:mm");
+    public string WhenDisplay => When.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
 }

--- a/SysManager/SysManager/Models/CleanupCategory.cs
+++ b/SysManager/SysManager/Models/CleanupCategory.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using SysManager.Helpers;
 
@@ -53,5 +54,5 @@ public sealed record LargeFileEntry
     public required long SizeBytes { get; init; }
     public required DateTime LastModified { get; init; }
     public string SizeDisplay => FormatHelper.FormatSize(SizeBytes);
-    public string LastModifiedDisplay => LastModified.ToString("dd MMM yyyy");
+    public string LastModifiedDisplay => LastModified.ToString("dd MMM yyyy", CultureInfo.InvariantCulture);
 }

--- a/SysManager/SysManager/Models/DriverEntry.cs
+++ b/SysManager/SysManager/Models/DriverEntry.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
+
 namespace SysManager.Models;
 
 /// <summary>
@@ -15,5 +17,5 @@ public sealed record DriverEntry
     public DateTime? DriverDate { get; init; }
 
     /// <summary>Formatted date for display (yyyy-MM-dd or empty).</summary>
-    public string DriverDateDisplay => DriverDate?.ToString("yyyy-MM-dd") ?? "";
+    public string DriverDateDisplay => DriverDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) ?? "";
 }

--- a/SysManager/SysManager/Models/FileLocker.cs
+++ b/SysManager/SysManager/Models/FileLocker.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
+
 namespace SysManager.Models;
 
 /// <summary>
@@ -17,7 +19,7 @@ public sealed record FileLocker(
     /// <summary>Friendly label, e.g. "explorer.exe (12345)".</summary>
     public string Display => $"{ProcessName} ({ProcessId})";
 
-    public string StartTimeDisplay => StartTime is { } t ? t.ToString("yyyy-MM-dd HH:mm:ss") : "—";
+    public string StartTimeDisplay => StartTime is { } t ? t.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture) : "—";
 
     /// <summary>
     /// True for processes the Restart Manager flags as critical/system — terminating

--- a/SysManager/SysManager/Models/FriendlyEventEntry.cs
+++ b/SysManager/SysManager/Models/FriendlyEventEntry.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using SysManager.Helpers;
 
@@ -72,7 +73,7 @@ public sealed partial class FriendlyEventEntry : ObservableObject
     /// <summary>
     /// Full timestamp for tooltip display.
     /// </summary>
-    public string FullTimestamp => Timestamp.ToString("yyyy-MM-dd HH:mm:ss");
+    public string FullTimestamp => Timestamp.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
 
     private static string FormatRelative(DateTime ts)
     {
@@ -83,7 +84,7 @@ public sealed partial class FriendlyEventEntry : ObservableObject
         if (span.TotalHours < 24) return $"{(int)span.TotalHours}h ago";
         if (span.TotalDays < 7) return $"{(int)span.TotalDays}d ago";
         if (span.TotalDays < 30) return $"{(int)(span.TotalDays / 7)}w ago";
-        return ts.ToString("yyyy-MM-dd");
+        return ts.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
     }
 }
 

--- a/SysManager/SysManager/Models/PrivacyAccessEntry.cs
+++ b/SysManager/SysManager/Models/PrivacyAccessEntry.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
+
 namespace SysManager.Models;
 
 /// <summary>
@@ -19,5 +21,5 @@ public sealed record PrivacyAccessEntry(
     /// <summary>Human-readable last-used timestamp, or "In use now" / "—".</summary>
     public string LastUsedDisplay =>
         InUse ? "In use now"
-              : LastUsed is { } t ? t.ToString("yyyy-MM-dd HH:mm") : "—";
+              : LastUsed is { } t ? t.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture) : "—";
 }

--- a/SysManager/SysManager/Models/RestorePoint.cs
+++ b/SysManager/SysManager/Models/RestorePoint.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
+
 namespace SysManager.Models;
 
 /// <summary>
@@ -16,7 +18,7 @@ public sealed record RestorePoint(
     string EventType)
 {
     /// <summary>Human-readable creation timestamp for the grid.</summary>
-    public string CreatedDisplay => CreationTime.ToString("yyyy-MM-dd HH:mm");
+    public string CreatedDisplay => CreationTime.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
 
     /// <summary>
     /// Friendly restore-point type label. Windows reports a small set of well-known

--- a/SysManager/SysManager/Models/ScheduledTaskInfo.cs
+++ b/SysManager/SysManager/Models/ScheduledTaskInfo.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
+
 namespace SysManager.Models;
 
 /// <summary>Safety classification for a scheduled task — drives UI color and confirmation.</summary>
@@ -42,6 +44,6 @@ public sealed record ScheduledTaskInfo(
     };
 
     public string FullPath => $"{Path}{Name}";
-    public string LastRunDisplay => LastRun is { } t ? t.ToString("yyyy-MM-dd HH:mm") : "—";
-    public string NextRunDisplay => NextRun is { } t ? t.ToString("yyyy-MM-dd HH:mm") : "—";
+    public string LastRunDisplay => LastRun is { } t ? t.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture) : "—";
+    public string NextRunDisplay => NextRun is { } t ? t.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture) : "—";
 }

--- a/SysManager/SysManager/Models/UpdateEntry.cs
+++ b/SysManager/SysManager/Models/UpdateEntry.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace SysManager.Models;
@@ -23,5 +24,5 @@ public sealed partial class UpdateEntry : ObservableObject
     public string UpdateId { get; init; } = "";
 
     /// <summary>Formatted date for display (yyyy-MM-dd or empty).</summary>
-    public string DateDisplay => Date?.ToString("yyyy-MM-dd") ?? "";
+    public string DateDisplay => Date?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) ?? "";
 }

--- a/SysManager/SysManager/Models/WindowsUpdatePolicy.cs
+++ b/SysManager/SysManager/Models/WindowsUpdatePolicy.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
+
 namespace SysManager.Models;
 
 /// <summary>
@@ -18,7 +20,7 @@ public sealed record WindowsUpdatePolicy(
     /// <summary>Plain-English summary of the active policy for the status line.</summary>
     public string Summary =>
         PauseActive && PauseUntil is { } until
-            ? $"Updates paused until {until:yyyy-MM-dd}."
+            ? $"Updates paused until {until.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}."
             : DeferFeatureUpdates
                 ? $"Feature updates deferred {FeatureDeferDays} day(s); security updates still install."
                 : "Default — Windows manages update timing.";

--- a/SysManager/SysManager/Services/ContextMenuService.cs
+++ b/SysManager/SysManager/Services/ContextMenuService.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Frozen;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Security;
 using System.Text.RegularExpressions;
@@ -298,7 +299,7 @@ public sealed partial class ContextMenuService
                 "SysManager", "Backups", "ContextMenu");
             Directory.CreateDirectory(backupDir);
 
-            var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+            var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
             var safeName = string.Join("_", registryPath.Split(Path.GetInvalidFileNameChars()));
             var backupFile = Path.Combine(backupDir, $"{safeName}_{timestamp}.reg");
 

--- a/SysManager/SysManager/Services/CrashMarkerService.cs
+++ b/SysManager/SysManager/Services/CrashMarkerService.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using System.IO;
 using System.Text.Json;
 using Serilog;
@@ -109,6 +110,6 @@ public sealed class CrashMarkerService
     /// target persona cannot act on either, and the log folder is already surfaced by the Logs tab.
     /// </summary>
     public static string DescribeForUser(CrashMarker marker) =>
-        $"SysManager closed unexpectedly on {marker.WhenUtc.ToLocalTime():d MMMM, HH:mm}. " +
+        $"SysManager closed unexpectedly on {marker.WhenUtc.ToLocalTime().ToString("d MMMM, HH:mm", CultureInfo.InvariantCulture)}. " +
         "Details were saved to its log, which you can open from the System Logs tab if you want to report it.";
 }

--- a/SysManager/SysManager/Services/SystemReportService.cs
+++ b/SysManager/SysManager/Services/SystemReportService.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using System.Management;
 using System.Text;
 using System.Text.Encodings.Web;
@@ -181,7 +182,7 @@ public sealed class SystemReportService
 
         sb.AppendLine("═══════════════════════════════════════════");
         sb.AppendLine("  SysManager System Report");
-        sb.AppendLine($"  Generated: {d.GeneratedAt:yyyy-MM-dd HH:mm:ss}");
+        sb.AppendLine($"  Generated: {d.GeneratedAt.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)}");
         sb.AppendLine("═══════════════════════════════════════════");
         sb.AppendLine();
 
@@ -312,7 +313,7 @@ public sealed class SystemReportService
         sb.AppendLine("</style></head><body><div class=\"wrap\">");
 
         sb.AppendLine($"<h1>SysManager System Report</h1>");
-        sb.AppendLine($"<div class=\"sub\">Generated {H(d.GeneratedAt.ToString("yyyy-MM-dd HH:mm:ss"))} · SysManager v{H(d.AppVersion)}</div>");
+        sb.AppendLine($"<div class=\"sub\">Generated {H(d.GeneratedAt.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture))} · SysManager v{H(d.AppVersion)}</div>");
 
         // OS
         OpenSection(sb, "Operating System");

--- a/SysManager/SysManager/Services/WindowsUpdatePolicyService.cs
+++ b/SysManager/SysManager/Services/WindowsUpdatePolicyService.cs
@@ -98,7 +98,7 @@ public sealed class WindowsUpdatePolicyService
             key.SetValue("PauseFeatureUpdatesEndTime", iso, RegistryValueKind.String);
             key.SetValue("PauseQualityUpdatesStartTime", now.ToString("o", CultureInfo.InvariantCulture), RegistryValueKind.String);
             key.SetValue("PauseQualityUpdatesEndTime", iso, RegistryValueKind.String);
-        }, $"pause updates until {until:yyyy-MM-dd}");
+        }, $"pause updates until {until.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}");
     }
 
     /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.0</Version>
-    <FileVersion>1.65.0.0</FileVersion>
-    <AssemblyVersion>1.65.0.0</AssemblyVersion>
+    <Version>1.65.1</Version>
+    <FileVersion>1.65.1.0</FileVersion>
+    <AssemblyVersion>1.65.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Net.Http;
 using System.Runtime.InteropServices;
@@ -257,7 +258,7 @@ public sealed partial class AboutViewModel : ViewModelBase
             LatestVersionLabel = $"v{latest.Version.ToString(3)}";
             LatestPublishedLabel = latest.PublishedAt == DateTimeOffset.MinValue
                 ? string.Empty
-                : latest.PublishedAt.LocalDateTime.ToString("dd MMM yyyy");
+                : latest.PublishedAt.LocalDateTime.ToString("dd MMM yyyy", CultureInfo.InvariantCulture);
             LatestNotes = latest.Body;
 
             if (UpdateService.IsNewer(latest.Version, UpdateService.CurrentVersion))
@@ -296,7 +297,7 @@ public sealed partial class AboutViewModel : ViewModelBase
             {
                 Version = $"v{r.Version.ToString(3)}",
                 Title = r.Name,
-                PublishedAt = r.PublishedAt == DateTimeOffset.MinValue ? "" : r.PublishedAt.LocalDateTime.ToString("dd MMM yyyy"),
+                PublishedAt = r.PublishedAt == DateTimeOffset.MinValue ? "" : r.PublishedAt.LocalDateTime.ToString("dd MMM yyyy", CultureInfo.InvariantCulture),
                 Body = r.Body,
                 Url = r.HtmlUrl,
                 IsCurrent = r.Version == UpdateService.CurrentVersion
@@ -627,7 +628,7 @@ public sealed partial class AboutViewModel : ViewModelBase
         // location. The dialog is shown before any work starts so cancelling costs nothing.
         var dlg = new SaveFileDialog
         {
-            FileName = $"SysManager-Report-{DateTime.Now:yyyy-MM-dd-HHmmss}.txt",
+            FileName = $"SysManager-Report-{DateTime.Now.ToString("yyyy-MM-dd-HHmmss", CultureInfo.InvariantCulture)}.txt",
             Filter = "Text file (*.txt)|*.txt|All files (*.*)|*.*"
         };
         if (dlg.ShowDialog() != true) return;
@@ -914,11 +915,11 @@ public sealed partial class AboutViewModel : ViewModelBase
             var dir = AppContext.BaseDirectory;
             var exe = Path.Join(dir, "SysManager.exe");
             if (File.Exists(exe))
-                return File.GetLastWriteTime(exe).ToString("dd MMM yyyy");
+                return File.GetLastWriteTime(exe).ToString("dd MMM yyyy", CultureInfo.InvariantCulture);
             // Fallback: try the DLL
             var dll = Path.Join(dir, "SysManager.dll");
             if (File.Exists(dll))
-                return File.GetLastWriteTime(dll).ToString("dd MMM yyyy");
+                return File.GetLastWriteTime(dll).ToString("dd MMM yyyy", CultureInfo.InvariantCulture);
         }
         catch (IOException ex) { Log.Debug(ex, "About: could not read build date from disk"); }
         catch (UnauthorizedAccessException ex) { Log.Debug(ex, "About: access denied reading build date"); }

--- a/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Collections.ObjectModel;
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using LiveChartsCore;
@@ -575,8 +576,8 @@ public sealed partial class BandwidthMonitorViewModel : ViewModelBase
     {
         if (ticks <= 0 || ticks >= DateTime.MaxValue.Ticks) return "";
         var at = new DateTime((long)ticks);
-        if (range <= TimeSpan.Zero) return at.ToString("HH:mm:ss");
-        return range > TimeSpan.FromHours(24) ? at.ToString("MM-dd HH:mm") : at.ToString("HH:mm");
+        if (range <= TimeSpan.Zero) return at.ToString("HH:mm:ss", CultureInfo.InvariantCulture);
+        return range > TimeSpan.FromHours(24) ? at.ToString("MM-dd HH:mm", CultureInfo.InvariantCulture) : at.ToString("HH:mm", CultureInfo.InvariantCulture);
     }
 
     private void RefreshTimeAxisLabeler()

--- a/SysManager/SysManager/ViewModels/ConsoleViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ConsoleViewModel.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -54,7 +55,7 @@ public sealed partial class ConsoleViewModel : ObservableObject
         lock (_gate) snapshot = Lines.ToArray();
         try
         {
-            var text = string.Join(Environment.NewLine, snapshot.Select(l => $"[{l.Timestamp:HH:mm:ss}] {l.Kind}: {l.Text}"));
+            var text = string.Join(Environment.NewLine, snapshot.Select(l => $"[{l.Timestamp.ToString("HH:mm:ss", CultureInfo.InvariantCulture)}] {l.Kind}: {l.Text}"));
             Clipboard.SetText(text);
         }
         catch (System.Runtime.InteropServices.ExternalException) { /* clipboard locked or unavailable */ }

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -531,7 +532,7 @@ public sealed partial class DashboardViewModel : ViewModelBase
             var since = DateTime.Now.AddDays(-7);
             var query = new System.Diagnostics.Eventing.Reader.EventLogQuery(
                 "System", System.Diagnostics.Eventing.Reader.PathType.LogName,
-                $"*[System[Level=1 and TimeCreated[@SystemTime>='{since:yyyy-MM-ddTHH:mm:ss}']]]");
+                $"*[System[Level=1 and TimeCreated[@SystemTime>='{since.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture)}']]]");
 
             int criticalCount = 0;
             using var reader = new System.Diagnostics.Eventing.Reader.EventLogReader(query);
@@ -829,7 +830,7 @@ public sealed partial class DashboardViewModel : ViewModelBase
             await LoadHealthScoreAsync();
             await LoadTemperaturesAsync();
             LoadActivity();
-            StatusMessage = $"Last scan: {DateTime.Now:HH:mm:ss}";
+            StatusMessage = $"Last scan: {DateTime.Now.ToString("HH:mm:ss", CultureInfo.InvariantCulture)}";
             ToastService.Instance.Show("Dashboard refreshed", "All systems scanned");
         }
         finally { IsBusy = false; }

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -5,6 +5,7 @@
 using System.Buffers;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -273,7 +274,7 @@ public sealed partial class LogsViewModel : ViewModelBase
         if (SelectedEntry is null) return;
         var e = SelectedEntry;
         var text = new StringBuilder()
-            .AppendLine($"[{e.Timestamp:yyyy-MM-dd HH:mm:ss}] {e.SeverityLabel} — {e.ProviderName} (Event {e.EventId})")
+            .AppendLine($"[{e.Timestamp.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)}] {e.SeverityLabel} — {e.ProviderName} (Event {e.EventId})")
             .AppendLine($"Log: {e.LogName}")
             .AppendLine()
             .AppendLine("Explanation:").AppendLine(e.Explanation)
@@ -292,7 +293,7 @@ public sealed partial class LogsViewModel : ViewModelBase
     {
         var dlg = new SaveFileDialog
         {
-            FileName = $"sysmanager-{SelectedLog}-{DateTime.Now:yyyyMMdd-HHmmss}.csv",
+            FileName = $"sysmanager-{SelectedLog}-{DateTime.Now.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture)}.csv",
             Filter = "CSV (*.csv)|*.csv|All files (*.*)|*.*"
         };
         if (dlg.ShowDialog() != true) return;
@@ -303,7 +304,7 @@ public sealed partial class LogsViewModel : ViewModelBase
             sw.WriteLine("Timestamp,Severity,Log,Provider,EventId,Message,Explanation,Recommendation");
             foreach (var e in Entries)
             {
-                sw.Write(Csv(e.Timestamp.ToString("yyyy-MM-dd HH:mm:ss"))); sw.Write(',');
+                sw.Write(Csv(e.Timestamp.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture))); sw.Write(',');
                 sw.Write(Csv(e.SeverityLabel)); sw.Write(',');
                 sw.Write(Csv(e.LogName)); sw.Write(',');
                 sw.Write(Csv(e.ProviderName)); sw.Write(',');

--- a/SysManager/SysManager/ViewModels/NetworkSharedState.cs
+++ b/SysManager/SysManager/ViewModels/NetworkSharedState.cs
@@ -5,6 +5,7 @@
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -564,7 +565,7 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
 
     internal static Axis BuildTimeAxis() => new()
     {
-        Labeler = v => new DateTime((long)v).ToString("HH:mm:ss"),
+        Labeler = v => new DateTime((long)v).ToString("HH:mm:ss", CultureInfo.InvariantCulture),
         TextSize = 12,
         // One tick per second minimum. Without it, an empty pre-run series makes LiveCharts
         // synthesise many sub-second ticks that the HH:mm:ss labeler collapses to a row of

--- a/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using System.Security;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -565,7 +566,7 @@ public sealed partial class PerformanceViewModel : ViewModelBase
         try
         {
             var ok = await _service.CreateRestorePointAsync(
-                $"SysManager — {DateTime.Now:yyyy-MM-dd HH:mm}");
+                $"SysManager — {DateTime.Now.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)}");
             StatusMessage = ok
                 ? "✓ Restore point created successfully."
                 : "✗ Failed to create restore point. Check Event Viewer for details.";

--- a/SysManager/SysManager/ViewModels/ProfileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProfileViewModel.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -63,7 +64,7 @@ public sealed partial class ProfileViewModel : ViewModelBase
 
         var dlg = new SaveFileDialog
         {
-            FileName = $"SysManager-Profile-{DateTime.Now:yyyy-MM-dd}.json",
+            FileName = $"SysManager-Profile-{DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}.json",
             Filter = "SysManager profile (*.json)|*.json|All files (*.*)|*.*"
         };
         if (dlg.ShowDialog() != true) return;
@@ -115,7 +116,7 @@ public sealed partial class ProfileViewModel : ViewModelBase
             var preview = string.Join("\n", profile.Sections.Select(s => $"  • {s.DisplayName}"));
             if (!DialogService.Instance.Confirm(
                     $"Import {profile.Sections.Count} section{(profile.Sections.Count == 1 ? "" : "s")} from this profile?\n\n{preview}\n\n" +
-                    $"Exported {profile.ExportedAt:yyyy-MM-dd} by SysManager v{profile.AppVersion}.\n\n" +
+                    $"Exported {profile.ExportedAt.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)} by SysManager v{profile.AppVersion}.\n\n" +
                     "This overwrites the matching SysManager settings on this PC. Restart SysManager afterwards for all changes to take effect.",
                     "Import profile"))
             {

--- a/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -212,7 +213,7 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
     {
         var dlg = new SaveFileDialog
         {
-            FileName = $"SysManager-Resources-{DateTime.Now:yyyy-MM-dd-HHmmss}.csv",
+            FileName = $"SysManager-Resources-{DateTime.Now.ToString("yyyy-MM-dd-HHmmss", CultureInfo.InvariantCulture)}.csv",
             Filter = "CSV file (*.csv)|*.csv|All files (*.*)|*.*"
         };
         if (dlg.ShowDialog() != true) return;
@@ -251,7 +252,7 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
 
     private static Axis BuildTimeAxis() => new()
     {
-        Labeler = v => v > 0 && v < DateTime.MaxValue.Ticks ? new DateTime((long)v).ToString("MM-dd HH:mm") : "",
+        Labeler = v => v > 0 && v < DateTime.MaxValue.Ticks ? new DateTime((long)v).ToString("MM-dd HH:mm", CultureInfo.InvariantCulture) : "",
         TextSize = 12,
         NamePaint = new SolidColorPaint(SKColor.Parse("A3ADBF")),
         LabelsPaint = new SolidColorPaint(SKColor.Parse("E6E9EE")) { SKTypeface = SKTypeface.FromFamilyName("Segoe UI") },

--- a/SysManager/SysManager/ViewModels/RestorePointsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/RestorePointsViewModel.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
@@ -86,7 +87,7 @@ public sealed partial class RestorePointsViewModel : ViewModelBase
     private async Task CreateAsync()
     {
         var description = string.IsNullOrWhiteSpace(NewDescription)
-            ? $"SysManager — {DateTime.Now:yyyy-MM-dd HH:mm}"
+            ? $"SysManager — {DateTime.Now.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)}"
             : NewDescription.Trim();
 
         // Disclose the side effect BEFORE doing it. Creating a checkpoint runs

--- a/SysManager/SysManager/ViewModels/ScheduledMaintenanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ScheduledMaintenanceViewModel.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
@@ -87,8 +88,8 @@ public sealed partial class ScheduledMaintenanceViewModel : ViewModelBase
         if (status.Exists)
         {
             CurrentSummary = $"Maintenance is scheduled (state: {status.State}).";
-            LastRun = status.LastRun is { } lr ? lr.ToString("yyyy-MM-dd HH:mm") : "—";
-            NextRun = status.NextRun is { } nr ? nr.ToString("yyyy-MM-dd HH:mm") : "—";
+            LastRun = status.LastRun is { } lr ? lr.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture) : "—";
+            NextRun = status.NextRun is { } nr ? nr.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture) : "—";
             LastResult = status.LastResultDescription ?? "";
             StatusMessage = "A maintenance task is registered. You can update or remove it below.";
         }

--- a/SysManager/SysManager/ViewModels/SettingsWatchdogViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SettingsWatchdogViewModel.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
@@ -62,7 +63,7 @@ public sealed partial class SettingsWatchdogViewModel : ViewModelBase
     {
         var baseline = _service.LoadBaseline();
         HasBaseline = baseline is not null;
-        BaselineTaken = baseline is not null ? $"Baseline saved {baseline.TakenAt:yyyy-MM-dd HH:mm}" : "";
+        BaselineTaken = baseline is not null ? $"Baseline saved {baseline.TakenAt.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)}" : "";
 
         var drifts = _service.DetectDrift();
         Drifts.ReplaceWith(drifts.Select(d => new DriftRow(d)));

--- a/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -101,7 +102,7 @@ public sealed partial class SystemHealthViewModel : ViewModelBase
             // BIOS read hits blocking WMI/registry — keep it off the UI thread.
             Bios = await Task.Run(_biosService.Read);
             Summary = $"OS {snap.Os.Caption}  —  CPU {snap.Cpu.Name} ({snap.Cpu.Cores}c/{snap.Cpu.LogicalProcessors}t)  —  RAM {snap.Memory.UsedGB:0.0}/{snap.Memory.TotalGB:0.0} GB  —  Disks {snap.Disks.Count}";
-            StatusMessage = $"Scan at {snap.CapturedAt:HH:mm:ss}";
+            StatusMessage = $"Scan at {snap.CapturedAt.ToString("HH:mm:ss", CultureInfo.InvariantCulture)}";
             ToastService.Instance.Show("System Health scan complete", $"{snap.Disks.Count} disks, {snap.Memory.Modules.Count} RAM modules");
             Log.Information("System health scan completed");
             await RefreshDrivesAsync();

--- a/SysManager/SysManager/ViewModels/SystemReportViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemReportViewModel.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Windows;
@@ -87,7 +88,7 @@ public sealed partial class SystemReportViewModel : ViewModelBase
     {
         var dlg = new SaveFileDialog
         {
-            FileName = $"SysManager-Report-{DateTime.Now:yyyy-MM-dd-HHmmss}.{extension}",
+            FileName = $"SysManager-Report-{DateTime.Now.ToString("yyyy-MM-dd-HHmmss", CultureInfo.InvariantCulture)}.{extension}",
             Filter = filter + "|All files (*.*)|*.*"
         };
         if (dlg.ShowDialog() != true) return;


### PR DESCRIPTION
## Problem

A date formatted with a custom pattern and no `IFormatProvider` goes through
`CultureInfo.CurrentCulture`, which Windows sets from the user's regional settings. For a
**fixed-shape** pattern that is not a formatting preference — it changes the value.

Measured on this machine for `2026-08-04 13:45:30`, using the app's own patterns:

| pattern | en-US | fi-FI | th-TH | ar-SA |
|---|---|---|---|---|
| `yyyy-MM-dd` | 2026-08-04 | 2026-08-04 | **2569**-08-04 | **1448-02-21** |
| `yyyy-MM-dd HH:mm` | 2026-08-04 13:45 | 2026-08-04 13**.**45 | **2569**-08-04 13:45 | **1448-02-21** 13:45 |
| `dd MMM yyyy` | 04 Aug 2026 | 04 elok. 2026 | 04 ส.ค. **2569** | **21 صفر 1448** |
| `yyyyMMdd_HHmmss` | 20260804_134530 | 20260804_134530 | **25690804**_134530 | **14480221**_134530 |

Under a non-Gregorian default calendar the **year and the month both change**, so the app
displayed, exported, and *named files with* a date that is not the date. On fi-FI `HH:mm`
also loses its colon, which breaks the lexicographic sort that is the only reason to pick
that pattern over `ToString("g")`.

Three consequences go beyond cosmetics:

- **Filenames.** Exported reports, log and resource-history CSVs, saved profiles, and the
  automatic registry backup taken before a context-menu change all stamp a timestamp into
  the name.
- **A silent wrong answer.** `DashboardViewModel` builds an XPath event-log filter from the
  date; Windows parses it literally, so a Buddhist year asks for a year that has not
  happened and the seven-day critical-event scan comes back empty — the Dashboard reports
  nothing wrong on a PC that has critical events.
- **A false promise.** "Updates paused until \<date\>" stated a date that was not the pause date.

## Fix

33 sites in two shapes:

- `x.ToString("pattern")` → `x.ToString("pattern", CultureInfo.InvariantCulture)` (26)
- `$"{x:pattern}"` → the value formatted inside the hole, because an interpolation hole
  takes no provider (7)

## Deliberately not changed — each verified, not assumed

| Left alone | Why, established by measurement |
|---|---|
| The 5 XAML `StringFormat` date bindings | A WPF binding formats through the element's `Language`, whose default metadata is `en-us` regardless of thread culture. A binding-engine probe confirmed all four cultures already render `2026-08-04 13:45`. |
| `LogService`'s Serilog output template | Serilog parses it, and `MessageTemplateTextFormatter` is already built with `CultureInfo.InvariantCulture`. The new guard recognises Serilog's own token syntax so it will not report this forever. |
| `PerformanceViewModel`'s `ToString("f")` | A standard specifier *should* localize; there is no fixed shape to preserve. |
| Numeric `{x:F1}` / `{x:N0}` holes | A real but different defect — the decimal separator, the class v1.64.16 fixed inside `FormatHelper`. One commit, one change; tracked separately. |

## Guard + tests

- **`ArchitectureTests.EveryFixedShapeDateFormat_NamesItsCulture`** scans both shapes across
  the whole app, exempts Serilog templates, and carries a vacuity floor (≥ 25 culture-explicit
  calls) so a broken detector cannot pass while inspecting nothing.
- **`FixedShapeDateFormatTests`** runs the real display members under ar-SA, th-TH, fi-FI,
  de-DE, en-US and invariant, restoring the culture in a `finally`.
  `TheHostileCultures_ReallyDoDisagree` guards the guard: if a future runtime resolved ar-SA
  to the Gregorian calendar, every other case would pass while proving nothing.

## Red/green

**Structural** — 16 checks FAIL at `29a5527`, all PASS here. The red run is what found 8
interpolation holes the first pass missed, because the proof's regex was written
independently of the fix's.

**Behavioural** — a console harness ran the real display members under all four cultures
against both trees:

```
BEFORE (29a5527): 8 of 8 sites differ by culture
  RestorePoint.CreatedDisplay   en-US '2026-08-04 13:45'   ar-SA '1448-02-21 13:45'
  LargeFileEntry.LastModified   en-US '04 Aug 2026'        ar-SA '21 صفر 1448'
  CrashMarker sentence          en-US '… on 4 August, 16:45.'   fi-FI '… on 4 elokuuta, 16.45.'
AFTER:            0 of 8 sites differ
```

## Verification

- `dotnet build -c Release` — 0 errors, 0 warnings on **all four** projects
- `dotnet format --verify-no-changes` — clean on all four (it caught two real issues first:
  my import ordering and my line wrapping)
- Leak scan against `leak-terms.txt` — clean
- Propagate check — no fixed-shape date format remains anywhere in the app or the test projects
