### PR TITLE
fix: use one decimal separator across the whole app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.2] - 2026-08-13
+
+Sizes and counts now use the same decimal point everywhere in the app. If your Windows is set to a language that writes numbers with a comma — Romanian, German, French, Finnish and most of Europe — the same screen could show "1.5 GB" in one place and "1,5 GB" right next to it.
+
+### Fixed
+- **Two different decimal marks on one screen.** A previous release made the shared size and speed formatter always use a point, but the numbers written directly into sentences still followed the Windows regional setting. On a comma locale that produced a visible mismatch — a size from one code path and a boot time from another, side by side, punctuated differently. Boot times, disk sizes, memory figures, download speeds, VRAM, drive temperatures, the tray tooltip and the exported system report all now match.
+- **Thousands were grouped differently depending on the language.** A file count of 1610 was shown as "1,610", "1.610" or "1 610" depending on the regional setting, and the space variant is a non-breaking space that does not survive a copy-paste. Counts in Deep Cleanup, Disk Analyzer, Duplicate Finder, Browser Cleaner, the Shortcut Cleaner, the Uninstaller and the File Shredder are now consistent, including in the activity log they write.
+
 ## [1.65.1] - 2026-08-13
 
 Dates and times now look the same on every PC. If your Windows is set to a language whose calendar is not the Western one — Thai or Arabic, for example — the app was printing the wrong year, and in a few places the wrong month, in lists, exported reports, and even in the names of the files it saved.

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1333,6 +1333,91 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"\{(?:Level:u3|Message:lj|NewLine|Exception)\}", RegexOptions.CultureInvariant)]
     private static partial Regex SerilogTemplateToken();
 
+    /// <summary>
+    /// Every number formatted with a decimal or grouped specifier must name its culture, so it agrees
+    /// with <c>FormatHelper</c>.
+    /// <para>v1.64.16 made <c>FormatHelper</c> invariant. It did not touch the interpolation holes,
+    /// which still went through <c>CurrentCulture</c> — so the fix left a MIXED screen rather than a
+    /// consistent one. Measured on ro-RO for the same 1.5 GB value:</para>
+    /// <code>
+    ///   FormatHelper.FormatSize(...)  ->  "1.5 GB"     (invariant, since v1.64.16)
+    ///   $"{gb:F1} GB"                 ->  "1,5 GB"     (CurrentCulture)
+    /// </code>
+    /// <para>Two different decimal marks, side by side, in the same sentence — which is the exact
+    /// inconsistency v1.64.16 set out to remove. The same applies to <c>N0</c> grouping: 1610 renders
+    /// as "1,610" invariant, "1.610" on ro-RO/de-DE, and "1 610" on fr-FR/fi-FI.</para>
+    /// <para>Only culture-SENSITIVE specifiers are checked. <c>F0</c> is deliberately excluded: a whole
+    /// number with no grouping renders identically on every culture, so requiring a wrapper there would
+    /// be churn with no behaviour change. Hex (<c>X8</c>) consults no culture data either.</para>
+    /// <para>The fix is <c>string.Create(CultureInfo.InvariantCulture, $"…")</c>, which wraps the WHOLE
+    /// string. That matters: a per-hole fix on a line with three holes can leave two of them behind,
+    /// which is precisely how the first pass of the date migration missed eight sites.</para>
+    /// </summary>
+    [Fact]
+    public void EveryCultureSensitiveNumberFormat_NamesItsCulture()
+    {
+        var appDir = FindAppProjectDir();
+        var offenders = new List<string>();
+        var wrapped = 0;
+
+        foreach (var file in Directory.EnumerateFiles(appDir, "*.cs", SearchOption.AllDirectories))
+        {
+            if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                              StringComparison.Ordinal)) continue;
+
+            var source = File.ReadAllText(file);
+            var name = Path.GetFileName(file);
+
+            foreach (var match in InterpolatedString().Matches(source).Cast<Match>())
+            {
+                if (!CultureSensitiveNumberHole().IsMatch(match.Value)) continue;
+
+                var before = source[Math.Max(0, match.Index - 120)..match.Index];
+
+                // A Serilog message template is not an interpolated string: Serilog parses it and
+                // LogService builds the formatter with InvariantCulture, so the hole never reaches
+                // string.Format. Rewriting one would also break structured logging.
+                if (SerilogCall().IsMatch(before)) continue;
+
+                if (InvariantWrapper().IsMatch(before)) { wrapped++; continue; }
+
+                var line = source[..match.Index].Count(c => c == '\n') + 1;
+                offenders.Add($"{name}:{line} {match.Value[..Math.Min(70, match.Value.Length)]}");
+            }
+        }
+
+        // Vacuity floor: if the interpolated-string pattern stopped matching, this would pass while
+        // inspecting nothing at all.
+        Assert.True(wrapped >= 30,
+            $"Only {wrapped} invariant-wrapped numeric strings were found — the detection is broken, "
+            + "not the code. Fix this guard rather than trusting it.");
+
+        Assert.True(offenders.Count == 0,
+            "These numbers are formatted through CurrentCulture while FormatHelper is invariant, so on "
+            + "a comma locale the same screen shows both \"1.5 GB\" and \"1,5 GB\". Wrap the whole string "
+            + "in string.Create(CultureInfo.InvariantCulture, $\"…\"):\n  "
+            + string.Join("\n  ", offenders)
+            + $"\n({wrapped} already wrapped)");
+    }
+
+    // An interpolated string literal. The nested-quote alternative is load-bearing: C# allows
+    // $"…{(b ? "y" : "n")}…", and a pattern without it silently skips those strings — one such site
+    // (ShortcutCleanerViewModel) was missed by exactly that omission.
+    [GeneratedRegex(@"\$""(?:[^""\\\n]|\\.|""(?=[^""\n]*""))*""", RegexOptions.CultureInvariant)]
+    private static partial Regex InterpolatedString();
+
+    // A decimal mark (F1+, N1+, P, 0.0) or a group separator (N0, #,#). F0 is absent on purpose.
+    [GeneratedRegex(@"\{[^{}]{1,120}?:(?:F[1-9]|N[1-9]|N0|P\d+|0\.0+|#,#)", RegexOptions.CultureInvariant)]
+    private static partial Regex CultureSensitiveNumberHole();
+
+    [GeneratedRegex(@"(?:string\.Create\(\s*(?:System\.Globalization\.)?CultureInfo\.InvariantCulture\s*,\s*"
+                    + @"|FormattableString\.Invariant\(\s*)$", RegexOptions.CultureInvariant)]
+    private static partial Regex InvariantWrapper();
+
+    [GeneratedRegex(@"\bLog(?:ger)?\s*\.\s*(?:Verbose|Debug|Information|Warning|Error|Fatal)\s*\([^)]*$",
+                    RegexOptions.CultureInvariant)]
+    private static partial Regex SerilogCall();
+
     /// <summary>The app project directory — .xaml is not copied to the test output.</summary>
     private static string FindAppProjectDir()
     {

--- a/SysManager/SysManager.Tests/NumberFormatAgreementTests.cs
+++ b/SysManager/SysManager.Tests/NumberFormatAgreementTests.cs
@@ -1,0 +1,113 @@
+// SysManager · NumberFormatAgreementTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Globalization;
+using SysManager.Helpers;
+using SysManager.Models;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Pins the separator agreement between <c>FormatHelper</c> and every number the app prints inline.
+/// <para>v1.64.16 made <c>FormatHelper</c> invariant but left the interpolation holes on
+/// <c>CurrentCulture</c>, so the fix produced a MIXED screen rather than a consistent one. Measured on
+/// ro-RO for one 1.5 GB value: the helper rendered <c>1.5 GB</c> while the hole beside it rendered
+/// <c>1,5 GB</c> — two decimal marks in the same sentence, which is the inconsistency v1.64.16 set out
+/// to remove.</para>
+/// <para>These tests assert AGREEMENT rather than testing each side alone: the defect was never "this
+/// number looks wrong", it was "these two numbers disagree". A test on one side in isolation would have
+/// passed throughout.</para>
+/// </summary>
+public sealed class NumberFormatAgreementTests
+{
+    /// <summary>ro-RO/de-DE use a comma decimal and dot group; fr-FR/fi-FI use a space group.</summary>
+    public static TheoryData<string> CommaCultures() => new() { "ro-RO", "de-DE", "fr-FR", "fi-FI", "en-US", "" };
+
+    [Theory]
+    [MemberData(nameof(CommaCultures))]
+    public void BootRecord_SecondsUseTheSameSeparatorAsTheHelpers(string culture)
+    {
+        var record = new BootRecord(new DateTime(2026, 8, 4, 13, 45, 30, DateTimeKind.Utc), 30_500, 12_250, 18_250);
+
+        WithCulture(culture, () =>
+        {
+            Assert.Equal("30.5 s", record.BootSecondsDisplay);
+            Assert.Equal("12.3 s", record.MainPathDisplay);
+            Assert.Equal("18.3 s", record.PostBootDisplay);
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(CommaCultures))]
+    public void ADecimalFromAHole_AgreesWithADecimalFromTheHelper(string culture)
+    {
+        // The defect in one assertion: one screen, one value, two code paths. Before this change the
+        // helper said "1.5 GB" and the hole said "1,5 GB" on every comma locale.
+        var record = new BootRecord(new DateTime(2026, 8, 4, 0, 0, 0, DateTimeKind.Utc), 1_500, 1_500, 1_500);
+
+        WithCulture(culture, () =>
+        {
+            var fromHelper = FormatHelper.FormatSize(1_610_612_736);   // "1.5 GB"
+            var fromHole = record.BootSecondsDisplay;                  // "1.5 s"
+
+            var helperMark = fromHelper.First(char.IsPunctuation);
+            var holeMark = fromHole.First(char.IsPunctuation);
+            Assert.Equal(helperMark, holeMark);
+            Assert.Equal('.', holeMark);
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(CommaCultures))]
+    public void CleanupCategory_GroupsThousandsTheSameEverywhere(string culture)
+    {
+        // N0 grouping differs three ways: "1,610" invariant, "1.610" on ro-RO/de-DE, "1 610" on
+        // fr-FR/fi-FI — and a space group separator is a non-breaking space, not a plain one, so it
+        // does not even round-trip through a copy-paste.
+        var category = new CleanupCategory
+        {
+            Name = "Temporary files",
+            Description = "d",
+            Paths = [],
+            TotalSizeBytes = 1024,
+            FileCount = 1610,
+            SkippedCount = 0,
+        };
+
+        WithCulture(culture, () => Assert.Contains("1,610", category.CountDisplay));
+    }
+
+    [Fact]
+    public void TheCommaCultures_ReallyDoDisagree_AboutTheseNumbers()
+    {
+        // Guards the guard. If a future runtime reported a dot decimal for ro-RO, every test above
+        // would pass while proving nothing — so assert the hazard exists on this machine.
+        var romanian = new CultureInfo("ro-RO");
+        var french = new CultureInfo("fr-FR");
+
+        Assert.Equal("1,5", 1.5.ToString("F1", romanian));
+        Assert.Equal("1.5", 1.5.ToString("F1", CultureInfo.InvariantCulture));
+        Assert.NotEqual("1,610", 1610.ToString("N0", french));
+    }
+
+    /// <summary>
+    /// Runs <paramref name="assert"/> with the thread's culture switched, restoring it in a finally so
+    /// one test cannot leak a locale into the rest of the run. Deterministic: no ambient state is read.
+    /// </summary>
+    private static void WithCulture(string culture, Action assert)
+    {
+        var previous = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = culture.Length == 0
+                ? CultureInfo.InvariantCulture
+                : new CultureInfo(culture);
+            assert();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+}

--- a/SysManager/SysManager.Tests/NumberFormatAgreementTests.cs
+++ b/SysManager/SysManager.Tests/NumberFormatAgreementTests.cs
@@ -28,13 +28,16 @@ public sealed class NumberFormatAgreementTests
     [MemberData(nameof(CommaCultures))]
     public void BootRecord_SecondsUseTheSameSeparatorAsTheHelpers(string culture)
     {
-        var record = new BootRecord(new DateTime(2026, 8, 4, 13, 45, 30, DateTimeKind.Utc), 30_500, 12_250, 18_250);
+        // Millisecond values chosen so the tenth is unambiguous. 12_250 would render "12.2", not
+        // "12.3": F1 rounds to even on an exact .x5 tie, and this test is about the SEPARATOR, so a
+        // rounding boundary in the input would only obscure what it is pinning.
+        var record = new BootRecord(new DateTime(2026, 8, 4, 13, 45, 30, DateTimeKind.Utc), 30_500, 12_300, 18_700);
 
         WithCulture(culture, () =>
         {
             Assert.Equal("30.5 s", record.BootSecondsDisplay);
             Assert.Equal("12.3 s", record.MainPathDisplay);
-            Assert.Equal("18.3 s", record.PostBootDisplay);
+            Assert.Equal("18.7 s", record.PostBootDisplay);
         });
     }
 

--- a/SysManager/SysManager/Models/BootRecord.cs
+++ b/SysManager/SysManager/Models/BootRecord.cs
@@ -18,10 +18,10 @@ public sealed record BootRecord(
     long PostBootTimeMs)
 {
     /// <summary>Total boot time as whole seconds, one decimal.</summary>
-    public string BootSecondsDisplay => $"{BootTimeMs / 1000.0:F1} s";
+    public string BootSecondsDisplay => string.Create(CultureInfo.InvariantCulture, $"{BootTimeMs / 1000.0:F1} s");
 
-    public string MainPathDisplay => $"{MainPathBootTimeMs / 1000.0:F1} s";
-    public string PostBootDisplay => $"{PostBootTimeMs / 1000.0:F1} s";
+    public string MainPathDisplay => string.Create(CultureInfo.InvariantCulture, $"{MainPathBootTimeMs / 1000.0:F1} s");
+    public string PostBootDisplay => string.Create(CultureInfo.InvariantCulture, $"{PostBootTimeMs / 1000.0:F1} s");
     public string WhenDisplay => BootTime.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
 }
 
@@ -36,6 +36,6 @@ public sealed record BootDegradation(
     string Name,
     long DurationMs)
 {
-    public string DurationDisplay => DurationMs >= 1000 ? $"{DurationMs / 1000.0:F1} s" : $"{DurationMs} ms";
+    public string DurationDisplay => DurationMs >= 1000 ? string.Create(CultureInfo.InvariantCulture, $"{DurationMs / 1000.0:F1} s") : $"{DurationMs} ms";
     public string WhenDisplay => When.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
 }

--- a/SysManager/SysManager/Models/CleanupCategory.cs
+++ b/SysManager/SysManager/Models/CleanupCategory.cs
@@ -33,7 +33,7 @@ public sealed partial class CleanupCategory : ObservableObject
     public bool IsRecycleBin { get; init; }
 
     public string SizeDisplay => FormatHelper.FormatSize(TotalSizeBytes);
-    public string CountDisplay => SkippedCount > 0 ? $"{FileCount:N0} files · {SkippedCount:N0} skipped" : $"{FileCount:N0} files";
+    public string CountDisplay => SkippedCount > 0 ? string.Create(CultureInfo.InvariantCulture, $"{FileCount:N0} files · {SkippedCount:N0} skipped") : string.Create(CultureInfo.InvariantCulture, $"{FileCount:N0} files");
 }
 
 public sealed record CleanupResult
@@ -42,7 +42,7 @@ public sealed record CleanupResult
     public int FilesDeleted { get; init; }
     public IReadOnlyList<string> Errors { get; init; } = [];
     public string Summary =>
-        $"Freed {FormatHelper.FormatSize(BytesFreed)} across {FilesDeleted:N0} files" +
+        string.Create(CultureInfo.InvariantCulture, $"Freed {FormatHelper.FormatSize(BytesFreed)} across {FilesDeleted:N0} files") +
         (Errors.Count > 0 ? $" · {Errors.Count} skipped" : string.Empty);
 }
 

--- a/SysManager/SysManager/Models/DiskHealthReport.cs
+++ b/SysManager/SysManager/Models/DiskHealthReport.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using SysManager.Helpers;
 
@@ -139,6 +140,6 @@ public sealed partial class DiskHealthReport : ObservableObject
         null => "—",
         < 24 => $"{PowerOnHours}h",
         < 8760 => $"{PowerOnHours / 24}d {PowerOnHours % 24}h",
-        _ => $"{PowerOnHours.Value / 8760.0:F1}y"
+        _ => string.Create(CultureInfo.InvariantCulture, $"{PowerOnHours.Value / 8760.0:F1}y")
     };
 }

--- a/SysManager/SysManager/Services/CliRunner.cs
+++ b/SysManager/SysManager/Services/CliRunner.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.Json;
@@ -161,7 +162,8 @@ public sealed class CliRunner
                 ? new CliResult(CliResult.Ok, Json(new { freedBytes = bytes, freedMB = Math.Round(mb, 1), filesDeleted = files, errors }))
                 : new CliResult(CliResult.Ok, request.Silent
                     ? $"{mb:F0} MB freed"
-                    : $"Cleanup complete: freed {mb:F1} MB across {files} file(s){(errors > 0 ? $", {errors} skipped" : "")}.");
+                    : string.Create(CultureInfo.InvariantCulture,
+                        $"Cleanup complete: freed {mb:F1} MB across {files} file(s){(errors > 0 ? $", {errors} skipped" : "")}."));
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {

--- a/SysManager/SysManager/Services/HealthAnalyzer.cs
+++ b/SysManager/SysManager/Services/HealthAnalyzer.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using SysManager.Helpers;
 using SysManager.Models;
 
@@ -68,7 +69,7 @@ public static class HealthAnalyzer
         {
             diag.Verdict = HealthVerdict.Good;
             diag.Headline = "Connection is healthy";
-            diag.Detail = $"Avg {diag.AveragePingMs:F0} ms · {diag.WorstLossPercent:F1}% worst loss · {diag.WorstJitterMs:F0} ms jitter.";
+            diag.Detail = string.Create(CultureInfo.InvariantCulture, $"Avg {diag.AveragePingMs:F0} ms · {diag.WorstLossPercent:F1}% worst loss · {diag.WorstJitterMs:F0} ms jitter.");
             diag.ColorHex = StatusColors.Good;
             return diag;
         }

--- a/SysManager/SysManager/Services/SystemReportService.cs
+++ b/SysManager/SysManager/Services/SystemReportService.cs
@@ -199,12 +199,12 @@ public sealed class SystemReportService
         sb.Append($"  {d.Cpu.Name}");
         if (d.Cpu.Cores > 0) sb.Append($" ({d.Cpu.Cores} cores / {d.Cpu.LogicalProcessors} threads)");
         sb.AppendLine();
-        if (d.Cpu.MaxClockMHz > 0) sb.AppendLine($"  Base: {d.Cpu.MaxClockMHz / 1000.0:F1} GHz");
+        if (d.Cpu.MaxClockMHz > 0) sb.AppendLine(string.Create(CultureInfo.InvariantCulture, $"  Base: {d.Cpu.MaxClockMHz / 1000.0:F1} GHz"));
         sb.AppendLine();
 
         AppendSection(sb, "Memory");
-        sb.AppendLine($"  {d.Memory.TotalGB:F1} GB total");
-        sb.AppendLine($"  Used: {d.Memory.UsedGB:F1} / {d.Memory.TotalGB:F1} GB ({d.Memory.UsedPercent:F0}%)");
+        sb.AppendLine(string.Create(CultureInfo.InvariantCulture, $"  {d.Memory.TotalGB:F1} GB total"));
+        sb.AppendLine(string.Create(CultureInfo.InvariantCulture, $"  Used: {d.Memory.UsedGB:F1} / {d.Memory.TotalGB:F1} GB ({d.Memory.UsedPercent:F0}%)"));
         if (d.Memory.Modules.Count > 0)
         {
             sb.AppendLine("  Slots:");
@@ -226,7 +226,7 @@ public sealed class SystemReportService
             foreach (var g in d.Gpus)
             {
                 sb.Append($"  {g.Name}");
-                if (g.VramGB.HasValue) sb.Append($" — VRAM: {g.VramGB:F1} GB");
+                if (g.VramGB.HasValue) sb.Append(string.Create(CultureInfo.InvariantCulture, $" — VRAM: {g.VramGB:F1} GB"));
                 if (!string.IsNullOrWhiteSpace(g.DriverVersion)) sb.Append($" — Driver: {g.DriverVersion}");
                 sb.AppendLine();
             }
@@ -328,13 +328,13 @@ public sealed class SystemReportService
         OpenSection(sb, "CPU");
         Row(sb, "Processor", d.Cpu.Name);
         if (d.Cpu.Cores > 0) Row(sb, "Cores / Threads", $"{d.Cpu.Cores} / {d.Cpu.LogicalProcessors}");
-        if (d.Cpu.MaxClockMHz > 0) Row(sb, "Base clock", $"{d.Cpu.MaxClockMHz / 1000.0:F1} GHz");
+        if (d.Cpu.MaxClockMHz > 0) Row(sb, "Base clock", string.Create(CultureInfo.InvariantCulture, $"{d.Cpu.MaxClockMHz / 1000.0:F1} GHz"));
         CloseSection(sb);
 
         // Memory
         OpenSection(sb, "Memory");
-        Row(sb, "Total", $"{d.Memory.TotalGB:F1} GB");
-        Row(sb, "In use", $"{d.Memory.UsedGB:F1} / {d.Memory.TotalGB:F1} GB ({d.Memory.UsedPercent:F0}%)");
+        Row(sb, "Total", string.Create(CultureInfo.InvariantCulture, $"{d.Memory.TotalGB:F1} GB"));
+        Row(sb, "In use", string.Create(CultureInfo.InvariantCulture, $"{d.Memory.UsedGB:F1} / {d.Memory.TotalGB:F1} GB ({d.Memory.UsedPercent:F0}%)"));
         foreach (var mod in d.Memory.Modules)
         {
             var v = $"{mod.CapacityGB:F0} GB";
@@ -351,7 +351,7 @@ public sealed class SystemReportService
             foreach (var g in d.Gpus)
             {
                 var v = g.Name;
-                if (g.VramGB.HasValue) v += $" · {g.VramGB:F1} GB VRAM";
+                if (g.VramGB.HasValue) v += string.Create(CultureInfo.InvariantCulture, $" · {g.VramGB:F1} GB VRAM");
                 if (!string.IsNullOrWhiteSpace(g.DriverVersion)) v += $" · driver {g.DriverVersion}";
                 Row(sb, "Adapter", v);
             }

--- a/SysManager/SysManager/Services/TrayIconService.cs
+++ b/SysManager/SysManager/Services/TrayIconService.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using System.Windows;
 using System.Windows.Threading;
 using H.NotifyIcon;
@@ -207,7 +208,7 @@ public sealed class TrayIconService : IDisposable
 
             var tooltip = $"SysManager\n" +
                           $"CPU: {snapshot.Cpu.LoadPercent:0}% | " +
-                          $"RAM: {snapshot.Memory.UsedGB:0.0}/{snapshot.Memory.TotalGB:0.0} GB ({snapshot.Memory.UsedPercent:0}%)\n" +
+                          string.Create(CultureInfo.InvariantCulture, $"RAM: {snapshot.Memory.UsedGB:0.0}/{snapshot.Memory.TotalGB:0.0} GB ({snapshot.Memory.UsedPercent:0}%)\n") +
                           $"Uptime: {snapshot.Os.Uptime.Days}d {snapshot.Os.Uptime.Hours}h";
 
             // TaskbarIcon tooltip max 127 chars

--- a/SysManager/SysManager/Services/WindowsUpdateService.cs
+++ b/SysManager/SysManager/Services/WindowsUpdateService.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using System.Runtime.InteropServices;
 using SysManager.Models;
 
@@ -377,9 +378,9 @@ public sealed class WindowsUpdateService
 
     internal static string FormatSize(long bytes) => bytes switch
     {
-        >= 1L << 30 => $"{bytes / (double)(1L << 30):F1} GB",
-        >= 1L << 20 => $"{bytes / (double)(1L << 20):F1} MB",
-        >= 1L << 10 => $"{bytes / (double)(1L << 10):F1} KB",
+        >= 1L << 30 => string.Create(CultureInfo.InvariantCulture, $"{bytes / (double)(1L << 30):F1} GB"),
+        >= 1L << 20 => string.Create(CultureInfo.InvariantCulture, $"{bytes / (double)(1L << 20):F1} MB"),
+        >= 1L << 10 => string.Create(CultureInfo.InvariantCulture, $"{bytes / (double)(1L << 10):F1} KB"),
         > 0 => $"{bytes} B",
         _ => "",
     };

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.1</Version>
-    <FileVersion>1.65.1.0</FileVersion>
-    <AssemblyVersion>1.65.1.0</AssemblyVersion>
+    <Version>1.65.2</Version>
+    <FileVersion>1.65.2.0</FileVersion>
+    <AssemblyVersion>1.65.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -488,7 +488,7 @@ public sealed partial class AboutViewModel : ViewModelBase
                         var mhz = mo["MaxClockSpeed"];
                         sb.Append("CPU: ").Append(name);
                         if (cores is not null) sb.Append($" ({cores}c/{threads}t)");
-                        if (mhz is uint speed) sb.Append($" @ {speed / 1000.0:F1} GHz");
+                        if (mhz is uint speed) sb.Append(string.Create(CultureInfo.InvariantCulture, $" @ {speed / 1000.0:F1} GHz"));
                         sb.AppendLine();
                         break;
                     }
@@ -507,7 +507,7 @@ public sealed partial class AboutViewModel : ViewModelBase
                         var totalKb = mo["TotalVisibleMemorySize"] as ulong? ?? 0;
                         var freeKb = mo["FreePhysicalMemory"] as ulong? ?? 0;
                         if (totalKb > 0)
-                            sb.AppendLine($"RAM: {totalKb / 1024.0 / 1024.0:F1} GB total, {freeKb / 1024.0 / 1024.0:F1} GB free");
+                            sb.AppendLine(string.Create(CultureInfo.InvariantCulture, $"RAM: {totalKb / 1024.0 / 1024.0:F1} GB total, {freeKb / 1024.0 / 1024.0:F1} GB free"));
                         break;
                     }
             }
@@ -530,7 +530,7 @@ public sealed partial class AboutViewModel : ViewModelBase
                         ulong? adapterRam = mo["AdapterRAM"] is { } ram ? Convert.ToUInt64(ram) : null;
                         var vramGB = SysManager.Helpers.GpuVramHelper.ResolveVramGB(pnpId, adapterRam);
                         sb.Append("GPU: ").Append(name);
-                        if (vramGB is > 0) sb.Append($" ({vramGB:F1} GB VRAM)");
+                        if (vramGB is > 0) sb.Append(string.Create(CultureInfo.InvariantCulture, $" ({vramGB:F1} GB VRAM)"));
                         if (!string.IsNullOrEmpty(driver)) sb.Append($" driver {driver}");
                         sb.AppendLine();
                     }

--- a/SysManager/SysManager/ViewModels/BootAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BootAnalyzerViewModel.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
@@ -90,9 +91,9 @@ public sealed partial class BootAnalyzerViewModel : ViewModelBase
         var pct = (latest - avg) / avg * 100.0;
         return pct switch
         {
-            > 15 => $"Last boot was {pct:F0}% slower than your recent average ({avg / 1000.0:F1} s).",
-            < -15 => $"Last boot was {-pct:F0}% faster than your recent average ({avg / 1000.0:F1} s).",
-            _ => $"Boot time is steady — recent average {avg / 1000.0:F1} s."
+            > 15 => string.Create(CultureInfo.InvariantCulture, $"Last boot was {pct:F0}% slower than your recent average ({avg / 1000.0:F1} s)."),
+            < -15 => string.Create(CultureInfo.InvariantCulture, $"Last boot was {-pct:F0}% faster than your recent average ({avg / 1000.0:F1} s)."),
+            _ => string.Create(CultureInfo.InvariantCulture, $"Boot time is steady — recent average {avg / 1000.0:F1} s.")
         };
     }
 

--- a/SysManager/SysManager/ViewModels/BrowserCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BrowserCleanerViewModel.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
@@ -125,7 +126,8 @@ public sealed partial class BrowserCleanerViewModel : ViewModelBase
             // Counts only. Naming the categories would record which browser/profile data the user
             // chose to erase, and activity.json is plain text under %LocalAppData%.
             ActivityLogService.Instance.Log("Browser Cleaner",
-                $"Removed {deleted:N0} file{(deleted == 1 ? "" : "s")} from {selected.Count} categor{(selected.Count == 1 ? "y" : "ies")}");
+                string.Create(CultureInfo.InvariantCulture,
+                    $"Removed {deleted:N0} file{(deleted == 1 ? "" : "s")} from {selected.Count} categor{(selected.Count == 1 ? "y" : "ies")}"));
             Log.Information("BrowserCleaner: cleaned {Count} categories, {Deleted} files", selected.Count, deleted);
             await ScanAsync().ConfigureAwait(true);
         }

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -160,7 +161,7 @@ public sealed partial class CleanupViewModel : ViewModelBase
                     catch (IOException) { /* skip inaccessible directory */ }
                     catch (UnauthorizedAccessException) { /* skip protected directory */ }
                 }
-                var tLabel = tempBytes > 0 ? $"{tempBytes / 1024.0 / 1024.0:F1} MB can be freed" : "Empty";
+                var tLabel = tempBytes > 0 ? string.Create(CultureInfo.InvariantCulture, $"{tempBytes / 1024.0 / 1024.0:F1} MB can be freed") : "Empty";
 
                 // Measure recycle bin (rough estimate via shell folder)
                 string bLabel;
@@ -181,7 +182,7 @@ public sealed partial class CleanupViewModel : ViewModelBase
                             catch (UnauthorizedAccessException) { /* skip protected file */ }
                         }
                     }
-                    bLabel = binBytes > 0 ? $"{binBytes / 1024.0 / 1024.0:F1} MB in Recycle Bin" : "Empty";
+                    bLabel = binBytes > 0 ? string.Create(CultureInfo.InvariantCulture, $"{binBytes / 1024.0 / 1024.0:F1} MB in Recycle Bin") : "Empty";
                 }
                 catch (IOException) { bLabel = "Unable to scan"; }
                 catch (UnauthorizedAccessException) { bLabel = "Unable to scan"; }

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -251,7 +251,7 @@ public sealed partial class DashboardViewModel : ViewModelBase
                 {
                     GpuPercent = usage;
                     GpuName = name;
-                    GpuVram = $"{memUsed:F1} / {memTotal:F1} GB VRAM";
+                    GpuVram = string.Create(CultureInfo.InvariantCulture, $"{memUsed:F1} / {memTotal:F1} GB VRAM");
                 });
                 return;
             }
@@ -658,7 +658,7 @@ public sealed partial class DashboardViewModel : ViewModelBase
             QuickActionProgress = 100;
             var freedMB = freed / 1024.0 / 1024.0;
             QuickActionDetail = freedMB >= 1024
-                ? $"Freed {freedMB / 1024:F1} GB"
+                ? string.Create(CultureInfo.InvariantCulture, $"Freed {freedMB / 1024:F1} GB")
                 : $"Freed {freedMB:F0} MB";
             ActivityLogService.Instance.Log("Quick Cleanup", QuickActionDetail);
         });

--- a/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -239,7 +240,7 @@ public sealed partial class DeepCleanupViewModel : ViewModelBase
         var totalBytes = selected.Sum(c => c.TotalSizeBytes);
         var fileCount = selected.Sum(c => c.FileCount);
         if (!DialogService.Instance.Confirm(
-                $"Permanently delete {fileCount:N0} files (~{FormatHelper.FormatSize(totalBytes)}) " +
+                string.Create(CultureInfo.InvariantCulture, $"Permanently delete {fileCount:N0} files (~{FormatHelper.FormatSize(totalBytes)}) ") +
                 $"across {selected.Count} categor{(selected.Count == 1 ? "y" : "ies")}?\n\n" +
                 (selected.Any(c => c.IsRecycleBin)
                     ? "This includes emptying the Recycle Bin on every drive, so whatever is in it now " +

--- a/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -160,7 +161,7 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
 
             ScanSummary = EntryCount == 0
                 ? "No subfolders found."
-                : $"{EntryCount} folders · {FormatSize(TotalSize)} total · {TotalFiles:N0} files";
+                : string.Create(CultureInfo.InvariantCulture, $"{EntryCount} folders · {FormatSize(TotalSize)} total · {TotalFiles:N0} files");
             HasScanned = true;
             StatusMessage = "Analysis complete.";
             ToastService.Instance.Show("Disk Analysis complete", $"{EntryCount} folders, {FormatSize(TotalSize)} total");

--- a/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -183,7 +184,7 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
     /// </summary>
     internal static string BuildScanStatus(DuplicateFileService.ScanProgress p)
     {
-        var counts = $"{p.Phase} — {p.FilesDiscovered:N0} found, {p.FilesHashed:N0} hashed";
+        var counts = string.Create(CultureInfo.InvariantCulture, $"{p.Phase} — {p.FilesDiscovered:N0} found, {p.FilesHashed:N0} hashed");
 
         // Path.GetFileName returns "" for a directory path ending in a separator, and the discovery phase
         // reports folders as well as files; fall back to the raw value rather than showing nothing.

--- a/SysManager/SysManager/ViewModels/FileShredderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/FileShredderViewModel.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -228,7 +229,8 @@ public sealed partial class FileShredderViewModel : ViewModelBase
             if (completed > 0)
             {
                 ActivityLogService.Instance.Log("File Shredder",
-                    $"Securely erased {completed:N0} item{(completed == 1 ? "" : "s")} ({(int)SelectedMethod}-pass overwrite)");
+                    string.Create(CultureInfo.InvariantCulture,
+                        $"Securely erased {completed:N0} item{(completed == 1 ? "" : "s")} ({(int)SelectedMethod}-pass overwrite)"));
             }
         }
         catch (OperationCanceledException)

--- a/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -139,7 +140,8 @@ public sealed partial class ShortcutCleanerViewModel : ViewModelBase
         // Records whether the shortcuts are recoverable, which is the part that matters if the user
         // later wonders where one went. Counts only, no shortcut names.
         ActivityLogService.Instance.Log("Shortcut Cleaner",
-            $"{(MoveToRecycleBin ? "Moved" : "Permanently deleted")} {deleted:N0} broken shortcut{(deleted == 1 ? "" : "s")}" +
+            string.Create(CultureInfo.InvariantCulture,
+                $"{(MoveToRecycleBin ? "Moved" : "Permanently deleted")} {deleted:N0} broken shortcut{(deleted == 1 ? "" : "s")}") +
             (MoveToRecycleBin ? " to the Recycle Bin" : ""));
         Log.Information("Deleted {Count} broken shortcuts (recycle bin: {RecycleBin})", deleted, MoveToRecycleBin);
     }

--- a/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
@@ -101,7 +101,7 @@ public sealed partial class SystemHealthViewModel : ViewModelBase
             Disks.ReplaceWith(snap.Disks);
             // BIOS read hits blocking WMI/registry — keep it off the UI thread.
             Bios = await Task.Run(_biosService.Read);
-            Summary = $"OS {snap.Os.Caption}  —  CPU {snap.Cpu.Name} ({snap.Cpu.Cores}c/{snap.Cpu.LogicalProcessors}t)  —  RAM {snap.Memory.UsedGB:0.0}/{snap.Memory.TotalGB:0.0} GB  —  Disks {snap.Disks.Count}";
+            Summary = string.Create(CultureInfo.InvariantCulture, $"OS {snap.Os.Caption}  —  CPU {snap.Cpu.Name} ({snap.Cpu.Cores}c/{snap.Cpu.LogicalProcessors}t)  —  RAM {snap.Memory.UsedGB:0.0}/{snap.Memory.TotalGB:0.0} GB  —  Disks {snap.Disks.Count}");
             StatusMessage = $"Scan at {snap.CapturedAt.ToString("HH:mm:ss", CultureInfo.InvariantCulture)}";
             ToastService.Instance.Show("System Health scan complete", $"{snap.Disks.Count} disks, {snap.Memory.Modules.Count} RAM modules");
             Log.Information("System health scan completed");

--- a/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
@@ -298,7 +299,8 @@ public sealed partial class UninstallerViewModel : ViewModelBase
             if (removed > 0)
             {
                 ActivityLogService.Instance.Log("Uninstaller",
-                    $"Uninstalled {removed:N0} app{(removed == 1 ? "" : "s")}" +
+                    string.Create(CultureInfo.InvariantCulture,
+                        $"Uninstalled {removed:N0} app{(removed == 1 ? "" : "s")}") +
                     (failed > 0 ? $" ({failed} failed)" : string.Empty) +
                     (cancellationRequested ? " — cancelled partway" : string.Empty));
             }

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -633,9 +633,9 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
             var bytes = el.GetInt64();
             return bytes switch
             {
-                >= 1L << 30 => $"{bytes / (double)(1L << 30):F1} GB",
-                >= 1L << 20 => $"{bytes / (double)(1L << 20):F1} MB",
-                >= 1L << 10 => $"{bytes / (double)(1L << 10):F1} KB",
+                >= 1L << 30 => string.Create(CultureInfo.InvariantCulture, $"{bytes / (double)(1L << 30):F1} GB"),
+                >= 1L << 20 => string.Create(CultureInfo.InvariantCulture, $"{bytes / (double)(1L << 20):F1} MB"),
+                >= 1L << 10 => string.Create(CultureInfo.InvariantCulture, $"{bytes / (double)(1L << 10):F1} KB"),
                 _ => $"{bytes} B"
             };
         }


### PR DESCRIPTION
## Problem

v1.64.16 made `FormatHelper` invariant. It did **not** touch the numbers written directly into
sentences, which still went through `CurrentCulture` — so that fix produced a *mixed* screen
rather than a consistent one. Measured on ro-RO for one value:

```
FormatHelper.FormatSize(1610612736)  ->  "1.5 GB"
$"{gb:F1} GB"                        ->  "1,5 GB"
```

Two different decimal marks, side by side, in the same sentence. That is the exact
inconsistency v1.64.16 set out to remove, so this is not more of the same fix — it is the half
that was missed.

`CleanupResult.Summary` shows it in a single string. Before, on ro-RO:

```
"Freed 1.5 GB across 1.610 files"
```

A dot as the decimal mark **and** as the thousands separator, in one line, because the size
came from the invariant helper and the count from a culture-bound hole.

Grouping differs three ways, not two:

| value | invariant | ro-RO / de-DE | fr-FR / fi-FI |
|---|---|---|---|
| `1610:N0` | 1,610 | 1.610 | 1 610 |

The space variant is a **non-breaking** space, so it does not even survive a copy-paste out of
the app.

## Fix

42 interpolated strings across 22 files now use `string.Create(CultureInfo.InvariantCulture, $"…")`.

That wraps the **whole string** on purpose: a per-hole fix on a line with three holes can leave
two behind, which is precisely how the first pass of the date migration (v1.65.1) missed eight
sites.

## Scope — measured, not assumed

Of 98 numeric holes in the app:

| kind | count | behaviour | action |
|---|---|---|---|
| decimal (`F1`, `0.0`) | 43 | always differs on a comma locale | fixed |
| grouped (`N0`) | 12 | differs at ≥ 1000 | fixed |
| whole (`F0`) | 43 | identical on every culture | **left alone** |

Touching the 43 `F0` holes would be churn with no behaviour change.

Also deliberately untouched: the two Serilog calls in `SpeedTestViewModel`. A
`Log.Information("… {Down:F1} …", x)` template is parsed by Serilog, not `string.Format`, and
`LogService` already builds its formatter with `InvariantCulture` — rewriting one would break
structured logging. The new guard recognises Serilog call syntax so it will not report them forever.

## Guard + tests

- **`ArchitectureTests.EveryCultureSensitiveNumberFormat_NamesItsCulture`** scans every
  interpolated string, skips Serilog calls and `F0`, and carries a vacuity floor (≥ 30 wrapped).
  Its interpolated-string regex handles a nested quote — `$"…{(b ? "y" : "n")}…"` — because the
  migration's stricter pattern silently skipped exactly one such site (`ShortcutCleanerViewModel`),
  and the **compiler caught four more** where the wrapper's closing paren landed inside the string.
- **`NumberFormatAgreementTests`** asserts *agreement* between the helper and the holes rather
  than testing either alone: the defect was two paths disagreeing, and a test on one side would
  have passed throughout. `TheCommaCultures_ReallyDoDisagree` guards the guard.

## Red/green (behavioural)

The harness ran the real display members under en-US, ro-RO, de-DE, fr-FR and fi-FI against both trees:

```
BEFORE: 4 of 5 sites vary by culture
  CleanupResult.Summary   en-US 'Freed 1.5 GB across 1,610 files'
                          ro-RO 'Freed 1.5 GB across 1.610 files'
                          fr-FR 'Freed 1.5 GB across 1 610 files'
  BootRecord seconds      en-US '30.5 s'    fi-FI '30,5 s'
  DiskHealthReport age    en-US '3.0y'      de-DE '3,0y'
AFTER:  0 of 5
```

## Verification

- `dotnet build -c Release` — 0 errors, 0 warnings on **all four** projects
- `dotnet format --verify-no-changes` — clean on all four (it caught an import-ordering issue first)
- Leak scan against `leak-terms.txt` — clean
- Independent post-check script — 42 wrapped, 2 Serilog (out of scope), **0 bare**
