### PR TITLE
fix: build the network tabs on first open, not at launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.3] - 2026-08-13
+
+The app does a little less work before its window appears. Four of the Network tabs were being built at launch even if you never opened them, and one of them read a file from disk every single time.
+
+### Fixed
+- **Ping, Traceroute, Speed Test and Network Repair were prepared at every launch.** Every other tab waits until you open it — that change was made precisely so starting the app does not run forty tabs' worth of setup first. These four had been left out, and Speed Test's setup reads your saved speed-test history from disk, so that read happened on every start whether or not you ever visited the tab. They now load on first open like the rest.
+- **Each of those four tabs was being created twice.** The app builds its parts through a shared registry, but these four were also constructed by hand next to it — so two copies of each existed and the registered ones were never used. There is now one of each.
+
 ## [1.65.2] - 2026-08-13
 
 Sizes and counts now use the same decimal point everywhere in the app. If your Windows is set to a language that writes numbers with a comma — Romanian, German, French, Finnish and most of Europe — the same screen could show "1.5 GB" in one place and "1,5 GB" right next to it.

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1065,6 +1065,78 @@ public partial class ArchitectureTests
     private static partial Regex NavRegistration();
 
     /// <summary>
+    /// Only the tabs with a stated reason may be built at startup.
+    /// <para>Every tab view model used to be constructed in <c>MainWindowViewModel</c>'s constructor, so
+    /// launching the app ran ~40 constructors — several of which start a scan or a timer — before the
+    /// first frame. The lazy <c>Tab&lt;TVm&gt;</c> factory fixed that by resolving each view model on
+    /// first open, and three tabs were documented as legitimate exceptions: Dashboard (the initially
+    /// selected tab), DarkMode (owns the always-on theme schedule) and About (its update check feeds the
+    /// shell banner). DarkMode and About are resolved directly in the constructor, not through the nav
+    /// table, so only Dashboard appears here.</para>
+    /// <para>The four network tabs nevertheless stayed on the eager path, and the justification comment
+    /// was widened to say "network tabs" instead of the tabs being made lazy — so
+    /// <c>SpeedTestViewModel</c>'s constructor read its history file from disk at every launch whether or
+    /// not anyone opened Speed Test. Worse, each was built with <c>new</c> while the container already
+    /// registered it as a singleton, so the app carried two instances of each and the DI registrations
+    /// were dead.</para>
+    /// <para>A comment cannot hold that line, so this asserts it. Adding a new eager tab fails here,
+    /// which is the intended prompt to either justify it in the list below or use <c>Tab&lt;TVm&gt;</c>.</para>
+    /// </summary>
+    [Fact]
+    public void OnlyTheJustifiedTabs_AreBuiltAtStartup()
+    {
+        var source = File.ReadAllText(
+            Path.Combine(FindAppProjectDir(), "ViewModels", "MainWindowViewModel.cs"));
+
+        // Scoped to the runtime nav table. BuildDesignerGraph below it constructs everything eagerly by
+        // design (there is no container in the designer/test path), so including it would flag the
+        // wrong thing.
+        // The end marker is the DECLARATION, not the bare method name: BuildDesignerGraph() also appears
+        // as a CALL in the constructor, ABOVE the nav table, so matching the bare name yields end < start
+        // and an empty slice — a guard that passes while reading nothing. The asserts below make that
+        // failure loud instead of silent.
+        var start = source.IndexOf("private NavGroup[] BuildNavGroups()", StringComparison.Ordinal);
+        var end = source.IndexOf("private Dictionary<Type, object> BuildDesignerGraph()",
+                                 StringComparison.Ordinal);
+        Assert.True(start >= 0 && end > start,
+            $"Could not locate the nav table in MainWindowViewModel (start={start}, end={end}) — "
+            + "fix this guard, do not trust its result.");
+        var navTable = source[start..end];
+        Assert.Contains("Tab<", navTable, StringComparison.Ordinal);
+
+        // Dashboard is the initially selected tab, so it is built immediately regardless.
+        string[] justified = ["Dashboard"];
+
+        var eager = EagerNavRegistration().Matches(navTable)
+            .Select(m => m.Groups["label"].Value)
+            .Where(label => !justified.Contains(label, StringComparer.Ordinal))
+            .ToList();
+
+        // Vacuity floor: if the regex or the slice stopped matching, this would pass while reading
+        // nothing at all.
+        var lazyCount = LazyNavRegistration().Matches(navTable).Count;
+        Assert.True(lazyCount >= 30,
+            $"Only {lazyCount} lazy tab registrations were seen — the guard is not reading the nav "
+            + "table. Fix this test rather than trusting its pass.");
+
+        Assert.True(eager.Count == 0,
+            "These tabs are constructed at startup with no stated reason, so their constructors run on "
+            + "every launch even when the user never opens them — the startup-herd regression the lazy "
+            + $"Tab<TVm> factory exists to prevent:\n  {string.Join("\n  ", eager)}\n"
+            + "Use Tab<TVm>(…) so the view model comes from the container on first open. If a tab "
+            + "genuinely must exist at startup, add it to the justified list in this test WITH its reason.");
+    }
+
+    // An eager registration in the nav table. `inDevelopment: true` placeholders are excluded by the
+    // negative lookahead: those carry a stub, so they cost nothing at startup.
+    [GeneratedRegex(@"EagerItem\(\s*""[\w-]+""\s*,\s*""(?<label>[^""]+)""(?![^)]*inDevelopment)",
+                    RegexOptions.Compiled)]
+    private static partial Regex EagerNavRegistration();
+
+    [GeneratedRegex(@"Tab<\w+>\(\s*""[\w-]+""\s*,\s*""[^""]+""", RegexOptions.Compiled)]
+    private static partial Regex LazyNavRegistration();
+
+    /// <summary>
     /// The options of one dropdown in an issue-form template, read line-wise. A full YAML parse is
     /// avoided deliberately: these files contain unquoted colons inside descriptions, which several
     /// parsers reject, and a guard that cannot read the file is worse than no guard.

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1104,8 +1104,14 @@ public partial class ArchitectureTests
         var navTable = source[start..end];
         Assert.Contains("Tab<", navTable, StringComparison.Ordinal);
 
-        // Dashboard is the initially selected tab, so it is built immediately regardless.
-        string[] justified = ["Dashboard"];
+        // The three exceptions the shell's own constructor documents, and the reason each earns it.
+        // Anything else appearing here is the regression this test exists to catch.
+        string[] justified =
+        [
+            "Dashboard",            // the initially selected tab — built immediately regardless
+            "Dark Mode Scheduler",  // owns the always-on theme schedule poll; nothing else runs it
+            "About",                // its constructor's update check feeds the shell's update banner
+        ];
 
         var eager = EagerNavRegistration().Matches(navTable)
             .Select(m => m.Groups["label"].Value)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.2</Version>
-    <FileVersion>1.65.2.0</FileVersion>
-    <AssemblyVersion>1.65.2.0</AssemblyVersion>
+    <Version>1.65.3</Version>
+    <FileVersion>1.65.3.0</FileVersion>
+    <AssemblyVersion>1.65.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -161,8 +161,8 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         return EagerItem(id, label, viewType, vm, inDevelopment);
     }
 
-    // An eagerly-provided VM (Dashboard, DarkMode, network tabs, placeholders). The instance is
-    // set as the NavItem's Content, so NavItem.Dispose disposes it on teardown like any other tab.
+    // An eagerly-provided VM (Dashboard and the designer/test graph). The instance is set as the
+    // NavItem's Content, so NavItem.Dispose disposes it on teardown like any other tab.
     private static NavItem EagerItem(string id, string label, Type viewType, object content, bool inDevelopment = false)
         => new()
         {
@@ -223,10 +223,10 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Tab<DuplicateFileViewModel>("nav-duplicates",   "Duplicate Finder", typeof(Views.DuplicateFileView))),
 
         Group("grp-network", "Network",
-            EagerItem("nav-ping",           "Ping",           typeof(Views.PingView),          new PingViewModel(Eager<NetworkSharedState>())),
-            EagerItem("nav-traceroute",     "Traceroute",     typeof(Views.TracerouteView),    new TracerouteViewModel(Eager<NetworkSharedState>())),
-            EagerItem("nav-speed-test",     "Speed Test",     typeof(Views.SpeedTestView),     new SpeedTestViewModel(Eager<NetworkSharedState>(), new SpeedTestHistoryService())),
-            EagerItem("nav-network-repair", "Network Repair", typeof(Views.NetworkRepairView), new NetworkRepairViewModel(Eager<NetworkSharedState>())),
+            Tab<PingViewModel>("nav-ping",                   "Ping",           typeof(Views.PingView)),
+            Tab<TracerouteViewModel>("nav-traceroute",       "Traceroute",     typeof(Views.TracerouteView)),
+            Tab<SpeedTestViewModel>("nav-speed-test",        "Speed Test",     typeof(Views.SpeedTestView)),
+            Tab<NetworkRepairViewModel>("nav-network-repair", "Network Repair", typeof(Views.NetworkRepairView)),
             Tab<DnsHostsViewModel>("nav-dns-hosts", "DNS & Hosts", typeof(Views.DnsHostsView))),
 
         Group("grp-apps", "Apps",
@@ -397,6 +397,9 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         var traceMonitor = new TracerouteMonitorService();
         var speedTest = new SpeedTestService();
         var netRepair = new NetworkRepairService(runner);
+        // One shared instance, as in the container: the four network view models coordinate through
+        // it (one tab's Start must disable the other's), so a second copy would silently split them.
+        var networkShared = new NetworkSharedState(pinger, tracer, traceMonitor, speedTest, netRepair);
         var restorePoints = new RestorePointService(runner);
         var gamingCpu = new CpuAffinityService();
 
@@ -415,7 +418,11 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             [typeof(UninstallerViewModel)] = new UninstallerViewModel(new UninstallerService(runner)),
             [typeof(PerformanceViewModel)] = new PerformanceViewModel(new PerformanceService(runner, restorePoints)),
             [typeof(StartupViewModel)] = new StartupViewModel(new StartupService()),
-            [typeof(NetworkSharedState)] = new NetworkSharedState(pinger, tracer, traceMonitor, speedTest, netRepair),
+            [typeof(NetworkSharedState)] = networkShared,
+            [typeof(PingViewModel)] = new PingViewModel(networkShared),
+            [typeof(TracerouteViewModel)] = new TracerouteViewModel(networkShared),
+            [typeof(SpeedTestViewModel)] = new SpeedTestViewModel(networkShared, new SpeedTestHistoryService()),
+            [typeof(NetworkRepairViewModel)] = new NetworkRepairViewModel(networkShared),
             [typeof(DriversViewModel)] = new DriversViewModel(runner),
             [typeof(LogsViewModel)] = new LogsViewModel(new EventLogService()),
             [typeof(AboutViewModel)] = new AboutViewModel(),


### PR DESCRIPTION
## Problem

Every tab view model used to be constructed in `MainWindowViewModel`'s constructor, so launching
the app ran ~40 constructors — several of which start a scan or a timer — before the first frame.
The lazy `Tab<TVm>` factory fixed that: each view model is resolved from the container on first
open. Three tabs were documented as legitimate exceptions (Dashboard, DarkMode, About).

**The four network tabs stayed on the eager path anyway**, and the justification comment was
widened to say "network tabs" rather than the tabs being made lazy. Two costs, both re-derived
from source:

1. **Disk I/O at every launch.** `SpeedTestViewModel`'s constructor calls
   `InitializeAsync(LoadHistoryAsync)`, which reads the saved speed-test history from disk — on
   every start, whether or not the user ever opens Speed Test.
2. **Two instances of each view model.** Each was built with `new` while `ServiceRegistration`
   already registers it as a singleton (lines 121-124), so the container's registrations were
   **dead code** and the app carried a second set of instances. `new SpeedTestHistoryService()`
   bypassed its singleton the same way.

## Fix

The four tabs use `Tab<TVm>`, so they come from the container on first open like every other tab.

`NetworkSharedState` **stays eager** and explicitly disposed — the four tabs coordinate through it
(one tab's Start must disable the other's), and its own doc comment records that it starts no
polling on construction, so it is not part of the herd.

Disposal is unchanged in both directions: `NavItem.Dispose` returns early when `_content` is null
(never opened → nothing built) and disposes whatever was built otherwise.

`BuildDesignerGraph` gains the four view models, sharing **one** `NetworkSharedState` local — a
second copy would silently split the coordination the shared state exists to provide.

## Guard

`ArchitectureTests.OnlyTheJustifiedTabs_AreBuiltAtStartup` asserts that the only eager
registration in the runtime nav table is Dashboard. In-development placeholders are excluded by a
lookahead rather than listed, since a stub costs nothing at startup. A comment cannot hold this
line — it already failed to — so it is mechanical now.

**A note on the guard's own correctness.** My first version ended the source slice at the bare
name `BuildDesignerGraph()`, which *also* appears as a call in the constructor **above** the nav
table — giving `end < start`, an empty slice, and a check that passed while inspecting nothing.
The red run caught it (section 2 reported PASS on the broken tree). Both the guard and the proof
now match on the declaration and assert the slice is non-empty, so that failure mode is loud.

## Red/green

18 checks FAIL at `6259f72`, all PASS here:

```
RED   section 1: none of the four uses Tab<TVm>
RED   section 2: `new PingViewModel(` … `new SpeedTestHistoryService(` all present
RED   section 6: the designer graph has none of the four
RED   section 7: no guard exists
GREEN ALL PASS
```

## Verification

- `dotnet build -c Release` — 0 errors, 0 warnings on **all four** projects
- `dotnet format --verify-no-changes` — clean on all four
- Regression: the four VMs' own unit tests construct them directly, so the registration change
  does not touch them; `NavItem` disposal verified for both the never-opened and opened paths
- Leak scan against `leak-terms.txt` — clean
