### PR TITLE
fix: draw the admin shield as an icon, not a colour emoji

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.4] - 2026-08-13
+
+The shield next to "Running as administrator" is now a proper icon instead of a colourful emoji, so it matches the rest of the app on all 27 pages that show it.
+
+### Fixed
+- **The admin shield was drawn as an emoji.** On every page that can run something as administrator, the banner you see once elevated used an emoji character with no icon font — so Windows substituted its own multi-colour emoji. The banner directly above it, before you elevate, already used the app's icon font, which meant the same banner drew its icon two different ways depending on state. All 27 pages now use the same shield icon.
+
 ## [1.65.3] - 2026-08-13
 
 The app does a little less work before its window appears. Four of the Network tabs were being built at launch even if you never opened them, and one of them read a file from disk every single time.

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1496,6 +1496,75 @@ public partial class ArchitectureTests
                     RegexOptions.CultureInvariant)]
     private static partial Regex SerilogCall();
 
+    /// <summary>
+    /// Every icon glyph names an icon font, so none of them renders as a colour emoji.
+    /// <para>A character reference above U+FFFF is outside Segoe Fluent Icons, so a <c>TextBlock</c>
+    /// carrying one with no <c>FontFamily</c> falls back to Segoe UI Emoji and Windows draws a
+    /// multi-colour emoji. The elevated admin banner did exactly that in 27 views:
+    /// <c>&amp;#x1F6E1;</c> (SHIELD) with no font — while the NOT-elevated banner a few lines above it,
+    /// in 25 of those same views, used <c>&amp;#xE83D;</c> with an explicit Fluent family. The two states
+    /// of one banner drew their icon from two different type systems, and the emoji one contradicts the
+    /// product rule that icons are real, never cartoonish.</para>
+    /// <para>Checked as a character range rather than a list of known emoji, so a NEW emoji is caught
+    /// too. A glyph that legitimately wants a colour emoji can still have one — it just has to say so
+    /// by naming a font.</para>
+    /// </summary>
+    [Fact]
+    public void EveryIconGlyph_NamesAnIconFont()
+    {
+        var viewsDir = Path.Combine(FindAppProjectDir(), "Views");
+        var offenders = new List<string>();
+        var scanned = 0;
+
+        var files = Directory.GetFiles(viewsDir, "*.xaml")
+            .Append(Path.Combine(FindAppProjectDir(), "MainWindow.xaml"))
+            .Where(File.Exists);
+
+        foreach (var file in files)
+        {
+            var source = File.ReadAllText(file);
+            var name = Path.GetFileName(file);
+
+            foreach (var match in AstralCharacterReference().Matches(source).Cast<Match>())
+            {
+                scanned++;
+
+                // The element this glyph sits on: from the opening '<' before it to the next '>'.
+                var open = source.LastIndexOf('<', match.Index);
+                var close = source.IndexOf('>', match.Index);
+                if (open < 0 || close < 0) continue;
+                var element = source[open..close];
+
+                if (element.Contains("FontFamily", StringComparison.Ordinal)) continue;
+
+                var line = source[..match.Index].Count(c => c == '\n') + 1;
+                offenders.Add($"{name}:{line} {match.Value} has no FontFamily");
+            }
+        }
+
+        // Vacuity floor: the views carry hundreds of Fluent glyphs, so if the scan read nothing the
+        // character-reference pattern is broken rather than the code being clean.
+        var glyphs = files.Sum(f => FluentGlyphReference().Matches(File.ReadAllText(f)).Count);
+        Assert.True(glyphs >= 100,
+            $"Only {glyphs} icon glyphs were seen across the views — the guard is not reading them. "
+            + "Fix this test rather than trusting its pass.");
+
+        Assert.True(offenders.Count == 0,
+            "These glyphs are above U+FFFF and name no font, so Windows falls back to Segoe UI Emoji "
+            + "and draws a colour emoji instead of an icon. Use the Segoe Fluent Icons equivalent with "
+            + "FontFamily=\"Segoe Fluent Icons,Segoe MDL2 Assets\" (the shield is &#xE83D;):\n  "
+            + string.Join("\n  ", offenders)
+            + $"\n({scanned} astral references seen, {glyphs} icon glyphs scanned)");
+    }
+
+    // A character reference above U+FFFF — i.e. &#x1F???; and up, which is where the emoji planes are.
+    // Five hex digits or more cannot be a BMP icon-font glyph.
+    [GeneratedRegex(@"&#x[0-9A-Fa-f]{5,};", RegexOptions.CultureInvariant)]
+    private static partial Regex AstralCharacterReference();
+
+    [GeneratedRegex(@"&#x[0-9A-Fa-f]{4};", RegexOptions.CultureInvariant)]
+    private static partial Regex FluentGlyphReference();
+
     /// <summary>The app project directory — .xaml is not copied to the test output.</summary>
     private static string FindAppProjectDir()
     {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.3</Version>
-    <FileVersion>1.65.3.0</FileVersion>
-    <AssemblyVersion>1.65.3.0</AssemblyVersion>
+    <Version>1.65.4</Version>
+    <FileVersion>1.65.4.0</FileVersion>
+    <AssemblyVersion>1.65.4.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AppBlockerView.xaml
+++ b/SysManager/SysManager/Views/AppBlockerView.xaml
@@ -51,7 +51,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — you can block and unblock applications."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml
@@ -45,7 +45,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — all packages can be upgraded."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/BandwidthMonitorView.xaml
+++ b/SysManager/SysManager/Views/BandwidthMonitorView.xaml
@@ -55,7 +55,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — you can enable precise per-app upload/download speeds below."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/BootAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/BootAnalyzerView.xaml
@@ -53,7 +53,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — the Windows boot-performance history can be read."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -51,7 +51,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — all applications can be installed."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -44,7 +44,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — you can run system file checks and repairs."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/ContextMenuView.xaml
+++ b/SysManager/SysManager/Views/ContextMenuView.xaml
@@ -52,7 +52,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — full access to all context menu entries."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -80,7 +80,7 @@
                     <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                             Margin="-12,-8,0,-8"/>
                     <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                        <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                        <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                         <TextBlock Text="Running as administrator — all sensors and quick actions have full access."
                                    Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                     </StackPanel>

--- a/SysManager/SysManager/Views/DefenderView.xaml
+++ b/SysManager/SysManager/Views/DefenderView.xaml
@@ -55,7 +55,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — you can change Defender settings."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -42,7 +42,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — you can change DNS settings and edit the hosts file."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/EdgeOneDriveView.xaml
+++ b/SysManager/SysManager/Views/EdgeOneDriveView.xaml
@@ -51,7 +51,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — you can disable Edge and remove OneDrive."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
+++ b/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
@@ -52,7 +52,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — both User and System variables are editable."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/FileLockView.xaml
+++ b/SysManager/SysManager/Views/FileLockView.xaml
@@ -54,7 +54,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — you can unlock and close handles on protected files."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/GamingProfileView.xaml
+++ b/SysManager/SysManager/Views/GamingProfileView.xaml
@@ -60,7 +60,7 @@
                      along its orientation, so this banner's TextWrapping was inert and clipped on a
                      narrow window (#1807). The stripe Border above is untouched. -->
                 <DockPanel Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Top" DockPanel.Dock="Left"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Top" DockPanel.Dock="Left"/>
                     <TextBlock Text="Running as administrator — every optimization, including freeing standby memory and pausing search indexing, can be applied."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center" TextWrapping="Wrap"/>
                 </DockPanel>

--- a/SysManager/SysManager/Views/NetworkRepairView.xaml
+++ b/SysManager/SysManager/Views/NetworkRepairView.xaml
@@ -39,7 +39,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — you can reset network settings."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/PerformanceView.xaml
+++ b/SysManager/SysManager/Views/PerformanceView.xaml
@@ -51,7 +51,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — you can apply performance tweaks and create restore points."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -50,7 +50,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — all privacy toggles are available."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/RestorePointsView.xaml
+++ b/SysManager/SysManager/Views/RestorePointsView.xaml
@@ -53,7 +53,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — you can create and restore restore points."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/SettingsWatchdogView.xaml
+++ b/SysManager/SysManager/Views/SettingsWatchdogView.xaml
@@ -77,7 +77,7 @@
                      along its orientation, so this banner's TextWrapping was inert and clipped on a
                      narrow window (#1807). The stripe Border above is untouched. -->
                 <DockPanel Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Top" DockPanel.Dock="Left"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Top" DockPanel.Dock="Left"/>
                     <TextBlock Text="Running as administrator — machine-wide watched settings can be restored, not just per-user ones."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center" TextWrapping="Wrap"/>
                 </DockPanel>

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml
@@ -52,7 +52,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — you can remove broken shortcuts everywhere."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/StandbyMemoryView.xaml
+++ b/SysManager/SysManager/Views/StandbyMemoryView.xaml
@@ -51,7 +51,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — you can purge the standby memory list."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/SystemFixesView.xaml
+++ b/SysManager/SysManager/Views/SystemFixesView.xaml
@@ -53,7 +53,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — all repairs are available."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -46,7 +46,7 @@
                         <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                                 Margin="-12,-8,0,-8"/>
                         <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                            <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                            <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                             <TextBlock Text="Running as administrator — you can run disk integrity checks."
                                        Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                         </StackPanel>

--- a/SysManager/SysManager/Views/TaskSchedulerView.xaml
+++ b/SysManager/SysManager/Views/TaskSchedulerView.xaml
@@ -54,7 +54,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — you can enable and disable scheduled tasks."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/TweaksHubView.xaml
+++ b/SysManager/SysManager/Views/TweaksHubView.xaml
@@ -97,7 +97,7 @@
                      along its orientation, so this banner's TextWrapping was inert and clipped on a
                      narrow window (#1807). The stripe Border above is untouched. -->
                 <DockPanel Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Top" DockPanel.Dock="Left"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Top" DockPanel.Dock="Left"/>
                     <TextBlock Text="Running as administrator — both Essential and Advanced (machine-wide) tweaks can be applied."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center" TextWrapping="Wrap"/>
                 </DockPanel>

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -76,7 +76,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — you can enable and disable Windows features."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -53,7 +53,7 @@
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
                         Margin="-12,-8,0,-8"/>
                 <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
+                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
                     <TextBlock Text="Running as administrator — you can list and install updates."
                                Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>


### PR DESCRIPTION
## Problem

The elevated admin banner used the character reference `&#x1F6E1;` (U+1F6E1 SHIELD) on a `TextBlock`
with **no `FontFamily`**. U+1F6E1 is outside Segoe Fluent Icons, so Windows falls back to Segoe UI
Emoji and draws a multi-colour emoji — against the product rule that icons are real, never
cartoonish.

Measured, not assumed: the emoji appears in **27 views**, and in **all 27** the `TextBlock` names no
font. It is also the only emoji codepoint used at any scale in the XAML (the other two astral
references in the app are a close glyph and a caret, both already fonted).

The sharper problem is internal inconsistency. In **25 of those same 27 views** the *not-elevated*
banner sits a few lines above and uses `&#xE83D;` with an explicit
`FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"` at `FontSize="16"`:

```xml
<!-- not elevated -->
<TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="16" .../>
<!-- elevated (same banner, two lines down) -->
<TextBlock Text="&#x1F6E1;" FontSize="13" VerticalAlignment="Center"/>
```

So the two states of **one** banner drew their icon from two different type systems at two different
sizes, depending only on whether the user had elevated.

## Fix

All 27 now use `&#xE83D;` with the same explicit family. The elevated banner keeps its own
`FontSize="13"` so the text baseline does not shift, and no `Foreground` is added — the shield
inherits `WarningText` from its parent, which is the intended treatment.

Only two exact line shapes existed (24 + 3 = 27), each rewritten by exact text with an asserted
count, so a shape I had not seen would have failed loudly rather than being skipped.

## Guard

`ArchitectureTests.EveryIconGlyph_NamesAnIconFont` fails any character reference above U+FFFF whose
element names no `FontFamily`.

Checked as a character **range**, not a list of known emoji, so a *new* emoji is caught too. A glyph
that genuinely wants a colour emoji may still have one — it just has to say so by naming a font.
Carries a vacuity floor (≥ 100 glyphs scanned) so a broken pattern cannot pass while reading nothing.

The batch-58 guard could not catch this: it is scoped to the single literal `"Run as administrator"`,
so it structurally cannot see any other control.

## Verification

Evaluated the guard's logic against **both** trees, so "it passes" is not the only evidence:

```
main   : 27 astral refs, 106 icon glyphs, 27 offenders
this PR:  0 astral refs, 133 icon glyphs,  0 offenders
```

- `dotnet build -c Release` — 0 errors, 0 warnings on all four projects
- `dotnet format --verify-no-changes` — clean
- Author headers verified intact on all 27 touched views
- Leak scan against `leak-terms.txt` — clean
- Rebased onto `dffaece` after #1877; CHANGELOG conflict resolved by renumbering to 1.65.4 and
  keeping both entries in order (per the serial-PR rule — parallel branches always collide here)
