### PR TITLE
test: assert the contracts these tests only claim to pin

### DIFF
--- a/SysManager/SysManager.Tests/AudioPolicyConfigTests.cs
+++ b/SysManager/SysManager.Tests/AudioPolicyConfigTests.cs
@@ -24,10 +24,14 @@ public class AudioPolicyConfigTests
         var plain = "{0.0.0.00000000}.{a1b2c3d4-0000-0000-0000-000000000000}";
         var wrapped = AudioPolicyConfigFactory.ToPolicyEndpointId(plain);
 
-        Assert.StartsWith(@"\\?\SWD#MMDEVAPI#", wrapped);
-        Assert.Contains(plain, wrapped);
-        // The render interface GUID suffix is what the interface keys the endpoint on.
-        Assert.EndsWith("{e6327cad-dcec-4949-ae8a-991e976a79d2}", wrapped);
+        // The WHOLE string, not three fragments. StartsWith + Contains + EndsWith all stay true if the
+        // interior "#" between the endpoint id and the render interface GUID is dropped or duplicated —
+        // exactly the subtle mistake the implementation's doc comment claims is "pinned by a test". The
+        // pass-through test below cannot cover it either: its input already carries the SWD prefix, so
+        // it returns at the guard and never reaches the string construction.
+        Assert.Equal(
+            @"\\?\SWD#MMDEVAPI#" + plain + "#{e6327cad-dcec-4949-ae8a-991e976a79d2}",
+            wrapped);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/BatteryHealthViewModelTests.cs
+++ b/SysManager/SysManager.Tests/BatteryHealthViewModelTests.cs
@@ -48,8 +48,17 @@ public class BatteryHealthViewModelTests
     [Fact]
     public void Summary_CanBeChanged()
     {
+        // Asserts the NOTIFICATION, not just the round-trip. A set/get pair passes on a plain auto-
+        // property, so it would stay green if [ObservableProperty] were dropped from Summary — and a
+        // bound label silently freezing is the only regression this property realistically has.
+        // Battery_CanBeReplaced two tests above already uses this pattern.
         var vm = new BatteryHealthViewModel(new Services.BatteryService());
+        var changed = new List<string>();
+        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+
         vm.Summary = "Custom summary";
+
+        Assert.Contains("Summary", changed);
         Assert.Equal("Custom summary", vm.Summary);
     }
 }

--- a/SysManager/SysManager.Tests/PerformanceXboxRestoreTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceXboxRestoreTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Text.Json;
 using SysManager.Services;
 
 namespace SysManager.Tests;
@@ -40,23 +41,42 @@ public class PerformanceXboxRestoreTests
     [InlineData(false, false)]
     public void Snapshot_PreservesBothXboxFlagsIndependently(bool bar, bool dvr)
     {
-        var snap = SnapshotWith(bar, dvr);
+        // Through the JSON the snapshot is actually PERSISTED as, not straight back out of the record.
+        // Reading positional-record properties back asserts the compiler's auto-property storage, so it
+        // cannot fail at runtime — the previous version of this test would have stayed green if the two
+        // flags were collapsed into one, which is precisely the regression the class doc claims to pin.
+        // The snapshot survives an app restart via SaveSnapshot/LoadSnapshot, so the serialized shape is
+        // the real contract: a field dropped or merged there loses the user's state for good.
+        var restored = RoundTrip(SnapshotWith(bar, dvr));
 
-        // The two flags must round-trip separately — never be merged into one value.
-        Assert.Equal(bar, snap.XboxGameBarEnabled);
-        Assert.Equal(dvr, snap.XboxGameDvrEnabled);
+        Assert.Equal(bar, restored.XboxGameBarEnabled);
+        Assert.Equal(dvr, restored.XboxGameDvrEnabled);
     }
 
     [Fact]
-    public void Snapshot_MismatchedXboxFlags_StayDistinct()
+    public void Snapshot_MismatchedXboxFlags_SurviveSeparately()
     {
-        var snap = SnapshotWith(bar: true, dvr: false);
+        // The bug scenario end to end: Game Bar ON, per-game DVR OFF. A collapsing restore
+        // (bar && dvr) treats this as a single "false" and forces both keys OFF, silently losing the
+        // Game Bar = ON state. Asserting after a real serialize/deserialize means a merged or missing
+        // field fails here instead of passing on record storage.
+        var restored = RoundTrip(SnapshotWith(bar: true, dvr: false));
 
-        // A collapsing restore (bar && dvr) would treat this as a single "false" and
-        // force both keys OFF, silently losing the Game Bar = ON state. Assert the
-        // snapshot keeps them distinct so restore can write each key from its own flag.
-        Assert.NotEqual(snap.XboxGameBarEnabled, snap.XboxGameDvrEnabled);
-        Assert.True(snap.XboxGameBarEnabled);
-        Assert.False(snap.XboxGameDvrEnabled);
+        Assert.True(restored.XboxGameBarEnabled);
+        Assert.False(restored.XboxGameDvrEnabled);
+    }
+
+    /// <summary>
+    /// Serializes and deserializes the snapshot the way <c>SaveSnapshot</c>/<c>LoadSnapshot</c> do.
+    /// <para>Both properties carry <c>[property: JsonRequired]</c>, so a field removed from the record
+    /// makes the deserialize throw rather than silently yielding <c>false</c> — the assertions above
+    /// therefore fail loudly rather than passing on a default.</para>
+    /// </summary>
+    private static PerformanceService.OriginalSnapshot RoundTrip(
+        PerformanceService.OriginalSnapshot snapshot)
+    {
+        var json = JsonSerializer.Serialize(snapshot);
+        return JsonSerializer.Deserialize<PerformanceService.OriginalSnapshot>(json)
+               ?? throw new InvalidOperationException("The snapshot did not survive the round-trip.");
     }
 }

--- a/SysManager/SysManager.Tests/SystemSnapshotTests.cs
+++ b/SysManager/SysManager.Tests/SystemSnapshotTests.cs
@@ -23,10 +23,16 @@ public class SystemSnapshotTests
     public void CpuInfo_StoresFields()
     {
         var cpu = new CpuInfo("AMD Ryzen 7 7800X3D", 8, 16, 4800, 27.5);
+
+        // Exact, not InRange(0, 100): a record that dropped LoadPercent returns default(double) = 0,
+        // which is inside that range — so the old assertion passed on the very failure it named. The
+        // name was not asserted at all, leaving two of the five fields this test claims to cover
+        // unverified.
+        Assert.Equal("AMD Ryzen 7 7800X3D", cpu.Name);
         Assert.Equal(8u, cpu.Cores);
         Assert.Equal(16u, cpu.LogicalProcessors);
         Assert.Equal(4800u, cpu.MaxClockMHz);
-        Assert.InRange(cpu.LoadPercent, 0, 100);
+        Assert.Equal(27.5, cpu.LoadPercent);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/WingetFailureTests.cs
+++ b/SysManager/SysManager.Tests/WingetFailureTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using SysManager.Helpers;
 using SysManager.ViewModels;
 
@@ -112,7 +113,28 @@ public class WingetFailureTests
     public void AllThreeWingetTabsUseTheSameMissingWingetSentence()
     {
         // The literal used to live on AppUpdatesViewModel and be referenced cross-VM, which is exactly
-        // how Bulk Installer ended up not using it at all.
+        // how Bulk Installer ended up not using it at all. The name promises all three tabs, so all
+        // three are read: asserting only the AppUpdates alias left the other two tabs free to
+        // reintroduce their own wording — the very drift this test is named for.
+        var vmDir = FindViewModelsDirectory();
+        var offenders = new List<string>();
+
+        foreach (var vm in new[] { "AppUpdatesViewModel.cs", "UninstallerViewModel.cs", "BulkInstallerViewModel.cs" })
+        {
+            var source = File.ReadAllText(Path.Combine(vmDir, vm));
+
+            // Each tab must reach the shared constant — directly, or through the AppUpdates alias that
+            // forwards to it. A tab spelling the sentence itself would satisfy neither.
+            if (!source.Contains("WingetFailure.WingetUnavailable", StringComparison.Ordinal)
+                && !source.Contains("WingetUnavailableMessage", StringComparison.Ordinal))
+                offenders.Add($"{vm} does not use the shared missing-winget sentence");
+        }
+
+        Assert.True(offenders.Count == 0,
+            "Every winget tab must show the SAME sentence when winget is missing, so the user reads one "
+            + "explanation rather than three:\n  " + string.Join("\n  ", offenders));
+
+        // And the alias really does forward to the shared constant rather than holding a second copy.
         Assert.Equal(WingetFailure.WingetUnavailable, AppUpdatesViewModel.WingetUnavailableMessage);
     }
 
@@ -131,5 +153,20 @@ public class WingetFailureTests
         // The point of the shared string: the tab needs a prerequisite, nothing broke.
         Assert.DoesNotContain("error", WingetFailure.WingetUnavailable, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("failed", WingetFailure.WingetUnavailable, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>The app project's ViewModels directory — .cs sources are not copied to the test output.</summary>
+    private static string FindViewModelsDirectory()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory is not null;
+             directory = directory.Parent)
+        {
+            var candidate = Path.Combine(directory.FullName, "SysManager", "ViewModels");
+            if (Directory.Exists(candidate)) return candidate;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate the SysManager ViewModels directory from " + AppContext.BaseDirectory);
     }
 }


### PR DESCRIPTION
## What this is

Five tests whose assertions were weaker than their names — or than the doc comments that cite
them — promised. `test:` only, so no release. Each finding was re-derived from current source, and
**one reported finding was refuted rather than shipped** (bottom).

## The five

**`AudioPolicyConfigTests.ToPolicyEndpointId_WrapsPlainEndpointId`**

Asserted `StartsWith` + `Contains` + `EndsWith` on three fragments, never the whole string. Drop or
duplicate the interior `#` between the endpoint id and the render interface GUID and **all three
still pass**. The implementation's own doc comment says:

> the format is easy to get subtly wrong, so it is pinned by a test

It was not. The pass-through test can't cover it either — its input already carries the SWD prefix,
so it returns at the guard one line above and never reaches the construction. Now one `Assert.Equal`
on the full expected string.

**`PerformanceXboxRestoreTests` — both tests**

Both only read positional-record properties back out of the record they had just built, which cannot
fail at runtime. The class doc says they pin the `bar && dvr` collapse regression; they didn't —
collapse the two flags and both stay green.

The obvious fix isn't available: `SetXboxGameBar` writes `Registry.CurrentUser` directly with no
seam, so a restore-path test would touch the user's real registry. But the snapshot is *persisted*
as JSON (`SaveSnapshot`/`LoadSnapshot`), and **that serialized shape is the real contract** — a field
merged or dropped there loses the user's state across a restart. Both tests now assert after a
genuine `JsonSerializer` round-trip; `[property: JsonRequired]` means a removed field throws rather
than silently yielding `false`.

**`WingetFailureTests.AllThreeWingetTabsUseTheSameMissingWingetSentence`**

Named for three tabs, asserted one. Its own comment records that Bulk Installer is exactly the tab
that got missed historically — so the test could not see the drift it exists to prevent. Now reads
all three view models. Verified by mutation:

```
AppUpdatesViewModel.cs     shared=True  alias=True  -> PASS  | if it drifted -> OFFENDER
UninstallerViewModel.cs    shared=False alias=True  -> PASS  | if it drifted -> OFFENDER
BulkInstallerViewModel.cs  shared=True  alias=False -> PASS  | if it drifted -> OFFENDER
```

**`SystemSnapshotTests.CpuInfo_StoresFields`**

Asserted `InRange(cpu.LoadPercent, 0, 100)`. A record that dropped the field returns
`default(double)` = 0 — **inside that range**, so the assertion passed on the very failure it named.
`Name` wasn't asserted at all, leaving two of five fields unverified. Now exact equality on both.

**`BatteryHealthViewModelTests.Summary_CanBeChanged`**

A set/get round-trip, which passes on a plain auto-property — so it stays green if
`[ObservableProperty]` is dropped and the bound label silently freezes. `Battery_CanBeReplaced` two
tests above already used the right pattern; `Summary` now matches it.

## Refuted, deliberately not shipped

An agent reported `BulkInstallerViewModel.cs:268` as hardcoded drift beside the shared constant.
**It isn't.** That line sets a *short* per-row grid status while the full sentence goes to
`StatusMessage` on the next line — a column cell can't hold the long text. Production is correct;
only the test was weak. Reporting it as a defect would have produced a wrong "fix".

## Verification

- `dotnet build -c Release` — 0 errors, 0 warnings on all four projects
- `dotnet format --verify-no-changes` — clean on all four
- Leak scan against `leak-terms.txt` — clean
- No production code changed; `test:` does not trigger a release
