### PR TITLE
fix: announce every control with the words printed on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.5] - 2026-08-14
+
+Buttons and checkboxes are now read out with the words actually printed on them. If you use Windows Speech Recognition or a screen reader, 36 controls used to be announced with different wording than what you could see — so saying the label out loud did not press the button.
+
+### Fixed
+- **36 controls said one thing and were announced as another.** A button reading "Clean TEMP" was announced as "Clean temporary files", "Ask a question" as "Open GitHub Discussions", "Enable 0.5 ms timer" as "Enable high-resolution timer". Voice control matches what is written on screen, so none of those could be activated by saying the visible label, and a screen reader described them differently than a sighted person would. Each name now begins with the words on the control and keeps the longer explanation after it, so both work.
+
 ## [1.65.4] - 2026-08-13
 
 The shield next to "Running as administrator" is now a proper icon instead of a colourful emoji, so it matches the rest of the app on all 27 pages that show it.

--- a/SysManager/SysManager.Tests/UiAutomationContractTests.cs
+++ b/SysManager/SysManager.Tests/UiAutomationContractTests.cs
@@ -15,14 +15,14 @@ public partial class UiAutomationContractTests
     private static readonly IReadOnlyDictionary<string, string> DescriptiveAccessibleNames =
         new Dictionary<string, string>(StringComparer.Ordinal)
         {
-            ["btn-cleanup-clean-temp"] = "Clean temporary files",
+            ["btn-cleanup-clean-temp"] = "Clean TEMP — clean temporary files",
             ["btn-cleanup-empty-recycle-bin"] = "Empty the Recycle Bin",
-            ["btn-cleanup-sfc"] = "Run SFC system file check",
+            ["btn-cleanup-sfc"] = "SFC /scannow — run SFC system file check",
             ["btn-cleanup-dism"] = "Run DISM RestoreHealth",
             ["btn-cleanup-cancel"] = "Cancel the running operation",
             ["btn-system-health-scan"] = "Scan system health",
             ["btn-system-health-smart"] = "Run SMART disk health check",
-            ["btn-system-health-memtest"] = "Schedule a memory test on next reboot",
+            ["btn-system-health-memtest"] = "Run MemTest (reboot) — schedule a memory test on next reboot",
             ["btn-logs-refresh"] = "Refresh logs",
             ["btn-logs-export-csv"] = "Export logs to CSV",
             ["btn-services-refresh"] = "Refresh services",
@@ -34,7 +34,7 @@ public partial class UiAutomationContractTests
             ["btn-drivers-list"] = "List drivers",
             ["btn-uninstaller-uninstall-selected"] = "Uninstall selected applications",
             ["btn-windows-update-install-module"] = "Install PSWindowsUpdate for update history",
-            ["btn-windows-update-check-module"] = "Check whether PSWindowsUpdate is installed",
+            ["btn-windows-update-check-module"] = "Check now — check whether PSWindowsUpdate is installed",
             ["btn-windows-update-list"] = "List available Windows updates",
             ["btn-windows-update-history"] = "Show Windows Update history",
             ["btn-windows-update-pending-reboot"] = "Check for a pending reboot",
@@ -45,7 +45,7 @@ public partial class UiAutomationContractTests
             // Renamed for #1647: this button sits beside "Open Event Viewer" on a tab titled
             // after the Windows Event Log, but opens SysManager's own diagnostic folder. The
             // accessible name now says whose logs, so a screen-reader user is not misled either.
-            ["btn-logs-open-folder"] = "Open SysManager's own log folder",
+            ["btn-logs-open-folder"] = "SysManager's own logs — open SysManager's own log folder",
             ["btn-ping-add-target"] = "Add target"
         };
 
@@ -192,6 +192,92 @@ public partial class UiAutomationContractTests
             + "reader says one thing while the screen says another and voice control cannot activate "
             + $"them:\n  {string.Join("\n  ", offenders)}");
     }
+
+    /// <summary>
+    /// EVERY control with visible text is announced with the words printed on it (WCAG 2.5.3, Label
+    /// in Name) — not only the elevation button above.
+    /// <para>When <c>AutomationProperties.Name</c> does not contain the visible <c>Content</c>, a
+    /// voice-control user who says the printed label cannot activate the control, and a screen reader
+    /// announces different wording than a sighted user reads. Measured before this guard existed: of
+    /// 324 controls carrying literal visible text, 273 had a name and <b>36 of those names did not
+    /// contain the label</b> — "Enable 0.5 ms timer" announced as "Enable high-resolution timer",
+    /// "Ask a question" as "Open GitHub Discussions", "Clean TEMP" as "Clean temporary files".</para>
+    /// <para>The elevation guard above could not see any of them: it is scoped to the one literal
+    /// "Run as administrator". A guard that fixes a single instance leaves the class open, which is
+    /// how 36 accumulated after that one was closed.</para>
+    /// <para>A name may still ADD detail — leading with the visible words and appending context is the
+    /// fix applied across all 36 — it just may not REPLACE them.</para>
+    /// <para>Two exclusions, both deliberate. A glyph-only label ("X", "▲") is a symbol rather than
+    /// text, so a descriptive name is the CORRECT treatment and flagging it would be wrong. A name
+    /// built from a <c>{Binding}</c> is produced at runtime, so the literal in the XAML is not what
+    /// gets announced.</para>
+    /// </summary>
+    [Fact]
+    public void EveryLabelledControl_IsAnnouncedWithTheWordsPrintedOnIt()
+    {
+        var views = Path.Combine(FindSolutionDirectory().FullName, "SysManager", "Views");
+        string[] controls = ["Button", "CheckBox", "RadioButton", "ToggleButton"];
+        var offenders = new List<string>();
+        var checkedControls = 0;
+
+        foreach (var view in Directory.EnumerateFiles(views, "*.xaml", SearchOption.TopDirectoryOnly))
+        {
+            XDocument document;
+            try { document = XDocument.Load(view); }
+            catch (System.Xml.XmlException) { continue; }
+
+            foreach (var element in document.Descendants()
+                         .Where(e => controls.Contains(e.Name.LocalName, StringComparer.Ordinal)))
+            {
+                var label = ((string?)element.Attribute("Content"))?.Trim();
+                var spoken = ((string?)element.Attribute("AutomationProperties.Name"))?.Trim();
+
+                if (string.IsNullOrEmpty(label) || label.StartsWith('{')) continue;
+                if (string.IsNullOrEmpty(spoken) || spoken.StartsWith('{')) continue;
+
+                var labelWords = LabelWords(label);
+                if (labelWords.Count == 0 || labelWords.TrueForAll(w => w.Length <= 1)) continue;
+
+                checkedControls++;
+                if (SpeaksTheLabel(labelWords, LabelWords(spoken))) continue;
+
+                offenders.Add($"{Path.GetFileName(view)}: shows \"{label}\" but announces \"{spoken}\"");
+            }
+        }
+
+        // Vacuity floor: the views carry hundreds of labelled controls, so a scan that inspected
+        // almost nothing means the parsing broke rather than the code being clean.
+        Assert.True(checkedControls >= 150,
+            $"only {checkedControls} labelled controls were inspected — fix this guard rather than "
+            + "trusting its pass.");
+
+        Assert.True(offenders.Count == 0,
+            "these controls are announced with different words than they display, so voice control "
+            + "cannot activate them by their visible label and a screen reader disagrees with the "
+            + "screen (WCAG 2.5.3). Lead the accessible name with the visible text and append any "
+            + $"extra context after it:\n  {string.Join("\n  ", offenders)}");
+    }
+
+    /// <summary>The words of a label, lower-cased and stripped of punctuation, for comparison.</summary>
+    private static List<string> LabelWords(string text)
+        => [.. NonWordRun().Replace(text.ToLowerInvariant(), " ")
+                .Split(' ', StringSplitOptions.RemoveEmptyEntries)];
+
+    /// <summary>True when the label's words all appear, IN ORDER, in the accessible name.</summary>
+    private static bool SpeaksTheLabel(List<string> label, List<string> spoken)
+    {
+        var from = 0;
+        foreach (var word in label)
+        {
+            var at = spoken.IndexOf(word, from);
+            if (at < 0) return false;
+            from = at + 1;
+        }
+        return true;
+    }
+
+    [GeneratedRegex("[^a-z0-9]+", RegexOptions.CultureInvariant)]
+    private static partial Regex NonWordRun();
 
     /// <summary>
     /// The event-log severity column must not convey severity by colour alone. It previously held

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.4</Version>
-    <FileVersion>1.65.4.0</FileVersion>
-    <AssemblyVersion>1.65.4.0</AssemblyVersion>
+    <Version>1.65.5</Version>
+    <FileVersion>1.65.5.0</FileVersion>
+    <AssemblyVersion>1.65.5.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AboutView.xaml
+++ b/SysManager/SysManager/Views/AboutView.xaml
@@ -85,7 +85,7 @@
                                     ToolTip="Open the bug-report form on GitHub, with your version and elevation state already filled in."/>
                             <Button Content="Ask a question" Command="{Binding OpenDiscussionsCommand}"
                                     Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"
-                                    AutomationProperties.Name="Open GitHub Discussions"
+                                    AutomationProperties.Name="Ask a question — open GitHub Discussions"
                                     ToolTip="Open GitHub Discussions for questions and ideas — for anything that is not a bug."/>
                             <Button Content="View license" Command="{Binding OpenLicenseCommand}"
                                     Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"/>
@@ -95,7 +95,7 @@
                                  spacing as the license button beside it. -->
                             <Button Content="What's new" Command="{Binding OpenChangelogCommand}"
                                     Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"
-                                    AutomationProperties.Name="Open the changelog on GitHub"
+                                    AutomationProperties.Name="What's new — open the changelog on GitHub"
                                     ToolTip="See what changed in this and previous versions"/>
                         </StackPanel>
 

--- a/SysManager/SysManager/Views/BandwidthMonitorView.xaml
+++ b/SysManager/SysManager/Views/BandwidthMonitorView.xaml
@@ -90,7 +90,7 @@
                     <CheckBox Content="Precise per-app rates (admin)"
                               IsChecked="{Binding PreciseRequested, Mode=TwoWay}"
                               IsEnabled="{Binding IsElevated}"
-                              AutomationProperties.Name="Enable precise per-app rates (requires administrator)"
+                              AutomationProperties.Name="Precise per-app rates (admin) — enable precise per-app rates (requires administrator)"
                               ToolTip="Use a kernel trace for exact per-app upload/download speeds. Requires administrator."/>
                     <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Right">
                         <TextBlock Text="Show" Style="{StaticResource Subtle}" VerticalAlignment="Center"/>

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -82,7 +82,7 @@
                 <WrapPanel Orientation="Horizontal">
                     <Button Content="Clean TEMP" Command="{Binding CleanTempCommand}" Style="{StaticResource PrimaryButton}" Margin="0,0,8,8"
                             AutomationProperties.AutomationId="btn-cleanup-clean-temp"
-                            AutomationProperties.Name="Clean temporary files"/>
+                            AutomationProperties.Name="Clean TEMP — clean temporary files"/>
                     <Button Content="Empty Recycle Bin" Command="{Binding EmptyRecycleBinCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
                             AutomationProperties.AutomationId="btn-cleanup-empty-recycle-bin"
                             AutomationProperties.Name="Empty the Recycle Bin"/>
@@ -97,7 +97,7 @@
                 <WrapPanel Orientation="Horizontal">
                     <Button Content="SFC /scannow" Command="{Binding RunSfcCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
                             AutomationProperties.AutomationId="btn-cleanup-sfc"
-                            AutomationProperties.Name="Run SFC system file check"
+                            AutomationProperties.Name="SFC /scannow — run SFC system file check"
                             IsEnabled="{Binding IsSfcRunning, Converter={StaticResource BoolInvert}}"/>
                     <Button Content="DISM RestoreHealth" Command="{Binding RunDismCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
                             AutomationProperties.AutomationId="btn-cleanup-dism"

--- a/SysManager/SysManager/Views/CpuAffinityView.xaml
+++ b/SysManager/SysManager/Views/CpuAffinityView.xaml
@@ -71,7 +71,7 @@
                         <Button Content="P-cores" Command="{Binding SelectPerformanceCoresCommand}"
                                 Style="{StaticResource SecondaryButton}" Margin="0,0,8,0" Padding="12,5"
                                 Visibility="{Binding IsHybrid, Converter={StaticResource FlexVis}}"
-                                AutomationProperties.Name="Select performance cores"/>
+                                AutomationProperties.Name="P-cores — select performance cores"/>
                         <Button Content="All cores" Command="{Binding SelectAllCoresCommand}"
                                 Style="{StaticResource SecondaryButton}" Padding="12,5"
                                 AutomationProperties.Name="Select all cores"/>

--- a/SysManager/SysManager/Views/DarkModeView.xaml
+++ b/SysManager/SysManager/Views/DarkModeView.xaml
@@ -42,7 +42,7 @@
                             AutomationProperties.Name="Switch to light theme"/>
                     <CheckBox Content="Also switch taskbar &amp; Start" IsChecked="{Binding ApplyToSystem}"
                               VerticalAlignment="Center"
-                              AutomationProperties.Name="Also switch the system theme"/>
+                              AutomationProperties.Name="Also switch taskbar &amp; Start — also switch the system theme"/>
                 </WrapPanel>
             </StackPanel>
         </Border>
@@ -51,7 +51,7 @@
         <Border Grid.Row="3" Style="{StaticResource Card}" Margin="0,0,0,12">
             <StackPanel>
                 <CheckBox Content="Automatically switch on a schedule" IsChecked="{Binding ScheduleEnabled}"
-                          FontWeight="SemiBold" AutomationProperties.Name="Enable the dark-mode schedule"/>
+                          FontWeight="SemiBold" AutomationProperties.Name="Automatically switch on a schedule — enable the dark-mode schedule"/>
                 <Grid Margin="0,12,0,0" IsEnabled="{Binding ScheduleEnabled}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -154,7 +154,7 @@
                         <DockPanel Margin="0,0,0,6"
                                    Visibility="{Binding TuneUpResult.BrokenShortcutsFound, Converter={StaticResource FlexVis}}">
                             <Button DockPanel.Dock="Right" Content="Clean up" Command="{Binding OpenTabCommand}" CommandParameter="nav-shortcut-cleaner"
-                                    AutomationProperties.Name="Open Shortcut Cleaner"
+                                    AutomationProperties.Name="Clean up — open Shortcut Cleaner"
                                     Style="{StaticResource SecondaryButton}" Padding="10,4" Margin="12,0,0,0"/>
                             <TextBlock VerticalAlignment="Center" TextWrapping="Wrap" Foreground="{DynamicResource TextSecondary}">
                                 <Run Text="{Binding TuneUpResult.BrokenShortcutsFound, Mode=OneWay}" FontWeight="SemiBold"/>
@@ -173,7 +173,7 @@
                         <DockPanel Margin="0,0,0,6"
                                    Visibility="{Binding TuneUpResult.RamWarning, Converter={StaticResource FlexVis}}">
                             <Button DockPanel.Dock="Right" Content="See what's running" Command="{Binding OpenTabCommand}" CommandParameter="nav-processes"
-                                    AutomationProperties.Name="Open Process Manager"
+                                    AutomationProperties.Name="See what's running — open Process Manager"
                                     Style="{StaticResource SecondaryButton}" Padding="10,4" Margin="12,0,0,0"/>
                             <TextBlock VerticalAlignment="Center" TextWrapping="Wrap" Foreground="{DynamicResource TextSecondary}">
                                 <Run Text="Memory is"/>

--- a/SysManager/SysManager/Views/DebloaterView.xaml
+++ b/SysManager/SysManager/Views/DebloaterView.xaml
@@ -29,7 +29,7 @@
         <Border Grid.Row="1" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
             <WrapPanel>
                 <Button Content="Select common bloat" Command="{Binding SelectCommonBloatCommand}"
-                        AutomationProperties.Name="Select commonly removed apps"
+                        AutomationProperties.Name="Select common bloat — select commonly removed apps"
                         Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"
                         ToolTip="Pre-select the curated set of commonly-removed apps."/>
                 <Button Content="Deselect All" Command="{Binding ClearSelectionCommand}"

--- a/SysManager/SysManager/Views/EdgeOneDriveView.xaml
+++ b/SysManager/SysManager/Views/EdgeOneDriveView.xaml
@@ -77,7 +77,7 @@
                                     ToolTip="Uninstall OneDrive for your account (reversible via Restore)."/>
                             <Button Content="Restore OneDrive" Command="{Binding RestoreOneDriveCommand}"
                                     Style="{StaticResource SecondaryButton}"
-                                    AutomationProperties.Name="Reinstall OneDrive"
+                                    AutomationProperties.Name="Restore OneDrive — reinstall OneDrive"
                                     ToolTip="Reinstall OneDrive and re-add its File Explorer sidebar entry."/>
                         </WrapPanel>
                     </StackPanel>
@@ -112,7 +112,7 @@
                                    Style="{StaticResource Subtle}" TextWrapping="Wrap" Margin="0,8,0,0"/>
                         <Button Content="Choose default browser…" Command="{Binding OpenDefaultAppsSettingsCommand}"
                                 Style="{StaticResource GhostButton}" HorizontalAlignment="Left" Margin="0,14,0,0"
-                                AutomationProperties.Name="Open Windows default-apps settings"/>
+                                AutomationProperties.Name="Choose default browser… — open Windows default-apps settings"/>
                     </StackPanel>
                 </Border>
 

--- a/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
+++ b/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
@@ -166,7 +166,7 @@
                         <TextBlock Text="Reorder with the arrows, remove entries, or strip duplicates. Missing folders are highlighted."
                                    Style="{StaticResource Subtle}" Margin="0,2,0,8" TextWrapping="Wrap"/>
                         <Button Content="Remove duplicates" Command="{Binding RemoveDuplicateDirectoriesCommand}"
-                                AutomationProperties.Name="Remove duplicate PATH directories"
+                                AutomationProperties.Name="Remove duplicates — remove duplicate PATH directories"
                                 Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left" Margin="0,0,0,8"/>
                     </StackPanel>
 

--- a/SysManager/SysManager/Views/GamingProfileView.xaml
+++ b/SysManager/SysManager/Views/GamingProfileView.xaml
@@ -104,10 +104,10 @@
                                   AutomationProperties.Name="Switch to the Ultimate Performance power plan"/>
                         <CheckBox Content="Reduce visual effects (animations, fades, shadows)" IsChecked="{Binding DisableVisualEffects}"
                                   Margin="0,4" FontWeight="SemiBold"
-                                  AutomationProperties.Name="Reduce visual effects"/>
+                                  AutomationProperties.Name="Reduce visual effects (animations, fades, shadows) — reduce visual effects"/>
                         <CheckBox Content="Finest timer resolution (~0.5 ms)" IsChecked="{Binding FinestTimerResolution}"
                                   Margin="0,4" FontWeight="SemiBold"
-                                  AutomationProperties.Name="Request the finest timer resolution"/>
+                                  AutomationProperties.Name="Finest timer resolution (~0.5 ms) — request the finest timer resolution"/>
                         <CheckBox Content="Silence notifications while gaming" IsChecked="{Binding SilenceNotifications}"
                                   Margin="0,4" FontWeight="SemiBold"
                                   AutomationProperties.Name="Silence notifications while gaming"/>
@@ -115,10 +115,10 @@
                         <!-- Admin-gated system optimizations -->
                         <CheckBox Content="Free standby memory (needs administrator)" IsChecked="{Binding PurgeStandbyMemory}"
                                   Margin="0,4" FontWeight="SemiBold" IsEnabled="{Binding IsElevated}"
-                                  AutomationProperties.Name="Free standby memory (requires administrator)"/>
+                                  AutomationProperties.Name="Free standby memory (needs administrator) — free standby memory (requires administrator)"/>
                         <CheckBox Content="Pause Windows Search indexing (needs administrator)" IsChecked="{Binding PauseSearchIndexing}"
                                   Margin="0,4" FontWeight="SemiBold" IsEnabled="{Binding IsElevated}"
-                                  AutomationProperties.Name="Pause Windows Search indexing (requires administrator)"/>
+                                  AutomationProperties.Name="Pause Windows Search indexing (needs administrator) — pause Windows Search indexing (requires administrator)"/>
 
                         <!-- Per-game optimizations (only meaningful with a game selected) -->
                         <Border Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
@@ -128,7 +128,7 @@
                                 <TextBlock Text="Applied to the selected game" Style="{StaticResource Caption}" Margin="0,0,0,6"/>
                                 <CheckBox Content="High CPU priority for the game" IsChecked="{Binding HighGameCpuPriority}"
                                           Margin="0,4" FontWeight="SemiBold"
-                                          AutomationProperties.Name="Set the game to high CPU priority"/>
+                                          AutomationProperties.Name="High CPU priority for the game — set the game to high CPU priority"/>
                                 <CheckBox Content="Pin the game to performance cores" IsChecked="{Binding PinGameToPerformanceCores}"
                                           Margin="0,4" FontWeight="SemiBold"
                                           AutomationProperties.Name="Pin the game to performance cores"/>

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -40,7 +40,7 @@
                      button sits next to "Open Event Viewer", so "Open log folder" read as the
                      Windows logs while it opens SysManager's own %LOCALAPPDATA% log directory.
                      The tooltip gives the full path so there is no ambiguity before clicking. -->
-                <Button Content="SysManager's own logs" AutomationProperties.AutomationId="btn-logs-open-folder" AutomationProperties.Name="Open SysManager's own log folder" Command="{Binding OpenLogFolderCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"
+                <Button Content="SysManager's own logs" AutomationProperties.AutomationId="btn-logs-open-folder" AutomationProperties.Name="SysManager's own logs — open SysManager's own log folder" Command="{Binding OpenLogFolderCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"
                         ToolTip="{Binding LogFolder, Mode=OneWay, StringFormat='Opens SysManager''s own diagnostic logs: {0}'}"/>
                 <Button Content="Export CSV" AutomationProperties.AutomationId="btn-logs-export-csv" AutomationProperties.Name="Export logs to CSV" Command="{Binding ExportCsvCommand}" Style="{StaticResource SecondaryButton}" Margin="6,0,0,0"/>
             </StackPanel>
@@ -149,19 +149,19 @@
                     <TextBlock Text="Time" Style="{StaticResource Subtle}" VerticalAlignment="Center"/>
                     <StackPanel Orientation="Horizontal" Margin="8,0,18,0">
                         <RadioButton Content="1h" GroupName="TimeRange" Margin="0,0,4,0"
-                                     AutomationProperties.Name="Time range: last hour"
+                                     AutomationProperties.Name="1h — time range: last hour"
                                      IsChecked="{Binding SelectedTimeRange, Converter={StaticResource IsEqual}, ConverterParameter='Last hour'}"
                                      Style="{StaticResource FilterChip}"/>
                         <RadioButton Content="24h" GroupName="TimeRange" Margin="0,0,4,0"
-                                     AutomationProperties.Name="Time range: last 24 hours"
+                                     AutomationProperties.Name="24h — time range: last 24 hours"
                                      IsChecked="{Binding SelectedTimeRange, Converter={StaticResource IsEqual}, ConverterParameter='Last 24 hours'}"
                                      Style="{StaticResource FilterChip}"/>
                         <RadioButton Content="7d" GroupName="TimeRange" Margin="0,0,4,0"
-                                     AutomationProperties.Name="Time range: last 7 days"
+                                     AutomationProperties.Name="7d — time range: last 7 days"
                                      IsChecked="{Binding SelectedTimeRange, Converter={StaticResource IsEqual}, ConverterParameter='Last 7 days'}"
                                      Style="{StaticResource FilterChip}"/>
                         <RadioButton Content="30d" GroupName="TimeRange" Margin="0,0,4,0"
-                                     AutomationProperties.Name="Time range: last 30 days"
+                                     AutomationProperties.Name="30d — time range: last 30 days"
                                      IsChecked="{Binding SelectedTimeRange, Converter={StaticResource IsEqual}, ConverterParameter='Last 30 days'}"
                                      Style="{StaticResource FilterChip}"/>
                         <RadioButton Content="All" GroupName="TimeRange"

--- a/SysManager/SysManager/Views/PerformanceView.xaml
+++ b/SysManager/SysManager/Views/PerformanceView.xaml
@@ -95,7 +95,7 @@
                         <StackPanel>
                             <RadioButton x:Name="RbBalanced"
                                          Content="Balanced (default — recommended for laptops)"
-                                         AutomationProperties.Name="Balanced power plan"
+                                         AutomationProperties.Name="Balanced (default — recommended for laptops) — balanced power plan"
                                          GroupName="PowerPlan" Margin="0,0,0,8"
                                          IsChecked="{Binding SelectedPlan, Converter={StaticResource IsEqual}, ConverterParameter=balanced}"/>
                             <RadioButton x:Name="RbHigh"
@@ -105,7 +105,7 @@
                                          IsChecked="{Binding SelectedPlan, Converter={StaticResource IsEqual}, ConverterParameter=high}"/>
                             <RadioButton x:Name="RbUltimate"
                                          Content="Ultimate Performance (max clocks, no throttling)"
-                                         AutomationProperties.Name="Ultimate Performance power plan"
+                                         AutomationProperties.Name="Ultimate Performance (max clocks, no throttling) — ultimate Performance power plan"
                                          GroupName="PowerPlan" Margin="0,0,0,12"
                                          IsChecked="{Binding SelectedPlan, Converter={StaticResource IsEqual}, ConverterParameter=ultimate}"/>
                             <Button Content="Apply Power Plan" Command="{Binding ApplyPowerPlanCommand}"

--- a/SysManager/SysManager/Views/StandbyMemoryView.xaml
+++ b/SysManager/SysManager/Views/StandbyMemoryView.xaml
@@ -95,7 +95,7 @@
             <StackPanel>
                 <CheckBox Content="Automatically purge when available RAM is low"
                           IsChecked="{Binding AutoPurgeEnabled}" IsEnabled="{Binding IsElevated}"
-                          FontWeight="SemiBold" AutomationProperties.Name="Enable automatic standby purge"/>
+                          FontWeight="SemiBold" AutomationProperties.Name="Automatically purge when available RAM is low — enable automatic standby purge"/>
                 <Grid Margin="0,12,0,0" IsEnabled="{Binding AutoPurgeEnabled}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>

--- a/SysManager/SysManager/Views/SystemFixesView.xaml
+++ b/SysManager/SysManager/Views/SystemFixesView.xaml
@@ -74,7 +74,7 @@
                                    FontSize="11" Foreground="{DynamicResource TextMuted}" TextWrapping="Wrap" Margin="0,2,0,0"/>
                     </StackPanel>
                     <Button Grid.Column="1" Content="Run" Command="{Binding ResetWindowsUpdateCommand}"
-                            AutomationProperties.Name="Reset Windows Update"
+                            AutomationProperties.Name="Run — reset Windows Update"
                             Style="{StaticResource SecondaryButton}" VerticalAlignment="Center" MinWidth="80"/>
                 </Grid>
 
@@ -89,7 +89,7 @@
                                    FontSize="11" Foreground="{DynamicResource TextMuted}" TextWrapping="Wrap" Margin="0,2,0,0"/>
                     </StackPanel>
                     <Button Grid.Column="1" Content="Run" Command="{Binding ReinstallWinGetCommand}"
-                            AutomationProperties.Name="Reinstall WinGet"
+                            AutomationProperties.Name="Run — reinstall WinGet"
                             Style="{StaticResource SecondaryButton}" VerticalAlignment="Center" MinWidth="80"/>
                 </Grid>
 

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -131,7 +131,7 @@
                                     Style="{StaticResource PrimaryButton}" Padding="14,8" Margin="0,0,8,0"/>
                             <Button Content="Run MemTest (reboot)" Command="{Binding ScheduleMemoryTestCommand}"
                                     AutomationProperties.AutomationId="btn-system-health-memtest"
-                                    AutomationProperties.Name="Schedule a memory test on next reboot"
+                                    AutomationProperties.Name="Run MemTest (reboot) — schedule a memory test on next reboot"
                                     Style="{StaticResource SecondaryButton}" Padding="14,8"/>
                         </StackPanel>
                     </Grid>
@@ -160,7 +160,7 @@
                         </StackPanel>
                         <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
                             <Button Content="Find BIOS update" Command="{Binding OpenBiosSupportCommand}"
-                                    AutomationProperties.Name="Open manufacturer support page for BIOS updates"
+                                    AutomationProperties.Name="Find BIOS update — open manufacturer support page for BIOS updates"
                                     Style="{StaticResource PrimaryButton}" Padding="14,8" Margin="0,0,8,0"/>
                             <Button Content="Copy info" Command="{Binding CopyBiosInfoCommand}"
                                     AutomationProperties.Name="Copy BIOS and motherboard info"
@@ -292,10 +292,10 @@
                             <TextBlock Text="File-system scan (chkdsk)" Style="{StaticResource SectionTitle}"/>
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Right">
                                 <Button Content="Refresh drives" Command="{Binding RefreshDrivesCommand}"
-                                        AutomationProperties.Name="Refresh drive list"
+                                        AutomationProperties.Name="Refresh drives — refresh drive list"
                                         Style="{StaticResource GhostButton}"/>
                                 <Button Content="Scan selected" Command="{Binding RunChkdskOnSelectedCommand}"
-                                        AutomationProperties.Name="Run chkdsk on selected drive"
+                                        AutomationProperties.Name="Scan selected — run chkdsk on selected drive"
                                         Style="{StaticResource PrimaryButton}" Margin="6,0,0,0"
                                         IsEnabled="{Binding IsChkdskRunning, Converter={StaticResource BoolInvert}}"/>
                                 <Button Content="Cancel" Command="{Binding CancelScanCommand}"

--- a/SysManager/SysManager/Views/TimerResolutionView.xaml
+++ b/SysManager/SysManager/Views/TimerResolutionView.xaml
@@ -85,7 +85,7 @@
         <WrapPanel Grid.Row="4" Orientation="Horizontal" VerticalAlignment="Top">
             <Button Content="Enable 0.5 ms timer" Command="{Binding EnableCommand}"
                     Style="{StaticResource PrimaryButton}" Margin="0,0,8,8"
-                    AutomationProperties.Name="Enable high-resolution timer"/>
+                    AutomationProperties.Name="Enable 0.5 ms timer — enable high-resolution timer"/>
             <Button Content="Restore default" Command="{Binding DisableCommand}"
                     Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
                     AutomationProperties.Name="Restore default timer resolution"/>

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -100,7 +100,7 @@
                 <Button DockPanel.Dock="Right" Content="Check now"
                         Command="{Binding CheckModuleCommand}"
                         AutomationProperties.AutomationId="btn-windows-update-check-module"
-                        AutomationProperties.Name="Check whether PSWindowsUpdate is installed"
+                        AutomationProperties.Name="Check now — check whether PSWindowsUpdate is installed"
                         ToolTip="Confirm now whether the PSWindowsUpdate module is available"
                         Style="{StaticResource GhostButton}" Padding="12,4" Margin="16,0,0,0"
                         VerticalAlignment="Center"/>
@@ -150,7 +150,7 @@
                                      AutomationProperties.Name="Days to defer feature updates" Margin="0,0,6,0"/>
                             <TextBlock Text="days" VerticalAlignment="Center" Margin="0,0,12,0"/>
                             <Button Content="Apply deferral" Command="{Binding DeferFeatureUpdatesCommand}"
-                                    AutomationProperties.Name="Defer feature updates"
+                                    AutomationProperties.Name="Apply deferral — defer feature updates"
                                     Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
                         </WrapPanel>
 


### PR DESCRIPTION
## Problem

When `AutomationProperties.Name` does not contain the visible `Content`, a voice-control user who says
the printed label **cannot activate the control**, and a screen reader announces different wording
than a sighted user reads (WCAG 2.5.3, *Label in Name*).

Measured across every view: **324** controls carry literal visible text, **273** of those have an
accessible name, and **36** of those names did not contain the label.

| shows | announced |
|---|---|
| `Clean TEMP` | Clean temporary files |
| `Ask a question` | Open GitHub Discussions |
| `Enable 0.5 ms timer` | Enable high-resolution timer |
| `SFC /scannow` | Run SFC system file check |
| `See what's running` | Open Process Manager |

## Fix

Each name now **leads with the visible words** and keeps its longer explanation after an em dash, so
the spoken label matches *and* the extra context still reaches a screen-reader user.

**Five of the 36 were pinned** by `UiAutomationContractTests.DescriptiveAccessibleNames`, which
asserts those exact strings. The dictionary and the XAML are one contract, so both moved in this
commit — renaming only the XAML would have turned CI red. My first pass did exactly that; it was
reverted before it left the worktree, and the split (31 free, 5 pinned) was then derived by reading
the dictionary rather than assumed.

## Deliberately not changed

| left alone | why flagging it would be wrong |
|---|---|
| glyph-only labels (`X`, `▲`) | a symbol is not a text label — a descriptive accessible name is the *correct* treatment. This is why the count is **36**, not the 41 a naive scan reports. |
| names built from a `{Binding}` | produced at runtime, so the literal in the XAML is not what gets announced |

## Guard

`EveryLabelledControl_IsAnnouncedWithTheWordsPrintedOnIt` applies the rule to every
`Button`/`CheckBox`/`RadioButton`/`ToggleButton` with literal text, with the same two exclusions and a
vacuity floor (≥ 150 controls inspected).

The existing elevation-button guard could not catch any of these — it is scoped to the single literal
`"Run as administrator"`. That is *how* 36 accumulated after that one instance was closed, and the
reason this one is general.

## Verification — three checks, independent of the guard

```
1. every view parses                     0 unparseable
   (the merged name put a raw "&" into DarkModeView once — escaped and re-checked)
2. pinned dictionary vs XAML             29 ids · 0 missing · 0 mismatched
3. Label in Name across all views        250 inspected · 0 violations
```

- `dotnet build -c Release` — 0 errors, 0 warnings on all four projects
- `dotnet format --verify-no-changes` — clean on all four
- Author headers verified intact on every touched view
- Leak scan against `leak-terms.txt` — clean
