### PR TITLE
docs: make the contributor checklist match what CI enforces

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,10 +10,15 @@ Closes #
 
 ## Type of change
 
-- [ ] Bug fix (`fix:`)
-- [ ] New feature (`feat:`)
+Only `fix:` and `feat:` publish a release. Everything else below merges without one — which changes
+what the rest of this checklist asks of you.
+
+- [ ] Bug fix (`fix:`) — releases a patch
+- [ ] New feature (`feat:`) — releases a minor
 - [ ] Documentation (`docs:`)
-- [ ] Code quality / CodeQL (`fix:`)
+- [ ] Tests (`test:`)
+- [ ] Refactor, no behaviour change (`refactor:`)
+- [ ] Code quality / CodeQL (`fix:`) — releases a patch
 - [ ] CI / build (`ci:`)
 - [ ] Dependency update (`chore:`)
 
@@ -21,9 +26,25 @@ Closes #
 
 - [ ] Branch created from `main` (not working on main directly)
 - [ ] Code compiles with 0 errors
+- [ ] `dotnet format <project> --verify-no-changes` passes on every project you touched — CI rejects
+      formatting drift, and a clean build does not catch it
 - [ ] Tests added/updated and passing locally
-- [ ] Author headers on all new/modified files
+- [ ] Author headers on all new/modified files — the three-line `// SysManager · <ClassName>` block;
+      copy it from the top of any existing `.cs` or `.xaml` file
 - [ ] Self-review completed (no debug code, no hardcoded values, no generic catch)
-- [ ] CHANGELOG updated
 - [ ] README updated (if features changed)
 - [ ] No AI/IDE tool references in code or comments
+
+### Releasing changes only (`fix:` / `feat:`)
+
+Skip these on `docs:` / `test:` / `refactor:` / `ci:` / `chore:` — **doing them there makes CI fail**,
+because the version gate requires the newest CHANGELOG heading to equal the csproj version, and a
+non-releasing PR leaves that version alone.
+
+- [ ] CHANGELOG entry added, opening with a one-line plain-English lead under the version heading
+      before the first `###` category (CI checks the lead separately, because the release notes are
+      copied from it verbatim)
+- [ ] `Version` / `FileVersion` / `AssemblyVersion` in `SysManager/SysManager/SysManager.csproj`
+      bumped one step from the newest release tag and equal to the new CHANGELOG heading
+      (`fix:` = patch, `feat:` = minor)
+- [ ] `feat:` only — supported-versions table in `SECURITY.md` updated to the new minor line

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,9 +59,10 @@ appointed representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement by opening a
-private security advisory on GitHub or contacting the maintainer through
-the email listed on their GitHub profile.
+reported privately to the maintainer by opening a
+[draft security advisory](https://github.com/laurentiu021/SystemManager/security/advisories/new).
+It is the project's only private channel, so it is used for conduct reports
+as well — only the maintainer can read it, and the report is never published.
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,14 @@ dotnet run --project SysManager/SysManager/SysManager.csproj
 dotnet test SysManager/SysManager.Tests/SysManager.Tests.csproj -c Release
 ```
 
+**Check the formatting** — CI runs this on all four projects and fails the PR on any
+difference. A clean build does not catch it, so run it before you push:
+
+```powershell
+dotnet format SysManager/SysManager/SysManager.csproj --verify-no-changes
+# drop --verify-no-changes to let it fix the file in place
+```
+
 ## Project layout
 
 ```
@@ -116,6 +124,28 @@ guide. That said, a few explicit rules:
 - Dark-gradient theme stays consistent; no hard-coded colours — use the
   existing brushes.
 - Accessibility: every interactive control has a label or `AutomationProperties.Name`.
+
+### Author headers
+
+Every source file opens with a three-line attribution block. All 688 of them
+carry it, and a test fails the build if a new file doesn't — so copy the shape
+exactly. In `.cs` files (the `— summary` after the class name is optional):
+
+```csharp
+// SysManager · UpdateService — GitHub releases client
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+```
+
+In `.xaml` files, one comment line above the root element:
+
+```xml
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+```
+
+Keep `Author:` as `laurentiu021` even in a PR you wrote — it names the project's
+maintainer, not the commit author, which Git already records. Your contribution
+is credited in the release notes and in `git log`.
 
 ## Running tests
 
@@ -175,7 +205,15 @@ fixed stuff
 ```
 
 Prefixes aren't required, but if you want a convention: `fix:`, `feat:`,
-`docs:`, `test:`, `refactor:`, `ci:` are all understood.
+`docs:`, `test:`, `refactor:`, `ci:`, `chore:` are all understood.
+
+One of them is more than a convention: the **PR title** decides whether merging
+publishes a release. `feat:` bumps the minor, `fix:` the patch, `feat!:`/`fix!:`
+the major; every other prefix merges without releasing. That is why a releasing
+PR must also bump the version and add a CHANGELOG entry, and a non-releasing one
+must do neither — the PR template splits the checklist along exactly that line.
+Don't worry about getting it right on a first contribution; say what your change
+does and the prefix can be adjusted before the squash merge.
 
 ## Pull request process
 

--- a/README.md
+++ b/README.md
@@ -918,7 +918,7 @@ offers, "rate us" prompts:
 
 ### In motion
 
-> The feature tour GIF is at the [top of this README](#sysmanager). Here's a
+> The feature tour GIF is at the [top of this README](#sysmanager-for-windows). Here's a
 > second one focused on cleanup & maintenance tools:
 
 <p>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,15 +26,15 @@ Report the issue anyway; being on a build newer than this table never means you 
 issues are visible to everyone and may put users at risk before a fix is
 available.
 
-Instead, use one of these private channels:
+Use **GitHub private vulnerability reporting**: go to the
+[Security tab](https://github.com/laurentiu021/SystemManager/security/advisories/new)
+and open a draft advisory. Only the maintainer sees it, you keep a thread to
+discuss the fix, and you are credited automatically when it is published.
 
-1. **GitHub private vulnerability reporting** (preferred) —
-   go to the [Security tab](https://github.com/laurentiu021/SystemManager/security)
-   of this repo and click **"Report a vulnerability"**. Only the maintainer
-   sees the report.
-2. **Email** the maintainer at the address on the
-   [GitHub profile](https://github.com/laurentiu021). Use a subject line
-   starting with `[SysManager security]`.
+A free GitHub account is required, because an advisory is the only channel this
+project has that is genuinely private — there is no published email, and asking
+you to send vulnerability details to an unencrypted inbox would be worse advice
+than asking you to sign up.
 
 Please include:
 

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -906,6 +906,254 @@ public partial class ArchitectureTests
     private static partial Regex SearchableFieldSpan();
 
     /// <summary>
+    /// Every commit prefix the release workflow treats as releasing must be offered by the PR template,
+    /// and every prefix the template offers must be one the project actually recognises.
+    /// <para>The template's "Type of change" list omitted <c>test:</c> and <c>refactor:</c> — 41 and 15
+    /// such commits exist on main, and CONTRIBUTING names both — so a contributor filling it in honestly
+    /// had no box to tick. That matters more than tidiness because the prefix is what decides whether the
+    /// merge publishes a release, and the rest of the checklist branches on that: a releasing PR must bump
+    /// the version and add a CHANGELOG entry, a non-releasing one must do neither or CI's version gate
+    /// fails it. The list and the workflow are one contract written in two places.</para>
+    /// </summary>
+    [Fact]
+    public void ThePullRequestTemplate_OffersEveryCommitPrefixTheWorkflowUnderstands()
+    {
+        var root = FindRepoRoot();
+        var lines = File.ReadAllLines(Path.Combine(root, ".github", "PULL_REQUEST_TEMPLATE.md"));
+        var autoRelease = File.ReadAllText(Path.Combine(root, ".github", "workflows", "auto-release.yml"));
+
+        // The prefixes auto-release maps to a bump, read from the workflow rather than restated here.
+        var releasing = ReleasingPrefixAlternation().Matches(autoRelease)
+            .SelectMany(m => m.Groups[1].Value.Split('|'))
+            .ToHashSet(StringComparer.Ordinal);
+        Assert.Equal(["feat", "fix"], releasing.Order(StringComparer.Ordinal));
+
+        var offered = lines
+            .Select(l => TemplatePrefix().Match(l))
+            .Where(m => m.Success)
+            .Select(m => m.Groups[1].Value)
+            .ToHashSet(StringComparer.Ordinal);
+        Assert.True(offered.Count >= 6,
+            $"only {offered.Count} prefixes were parsed out of the PR template — fix this guard rather "
+            + "than trusting its pass.");
+
+        // The non-releasing prefixes CONTRIBUTING tells contributors to use. Whatever the template
+        // offers must come from one of these two sets; anything else is a box mapping to no behaviour.
+        string[] silent = ["docs", "test", "refactor", "ci", "chore"];
+        var known = releasing.Concat(silent).ToHashSet(StringComparer.Ordinal);
+
+        var missing = known.Where(p => !offered.Contains(p)).Order(StringComparer.Ordinal).ToList();
+        Assert.True(missing.Count == 0,
+            "these commit prefixes are used on main and documented in CONTRIBUTING, but the PR template "
+            + $"offers no box for them, so a contributor cannot declare one: {string.Join(", ", missing)}");
+
+        var unknown = offered.Where(p => !known.Contains(p)).Order(StringComparer.Ordinal).ToList();
+        Assert.True(unknown.Count == 0,
+            "the PR template offers these prefixes, but neither auto-release nor CONTRIBUTING knows "
+            + $"them: {string.Join(", ", unknown)}");
+
+        // A releasing box must SAY it releases, because the checklist below it branches on exactly that.
+        foreach (var prefix in releasing.Order(StringComparer.Ordinal))
+        {
+            var silentBoxes = lines
+                .Where(l => TemplatePrefix().IsMatch(l)
+                            && TemplatePrefix().Match(l).Groups[1].Value == prefix
+                            && !l.Contains("releases", StringComparison.Ordinal))
+                .ToList();
+            Assert.True(silentBoxes.Count == 0,
+                $"a `{prefix}:` box publishes a release when merged, but does not say so:\n  "
+                + string.Join("\n  ", silentBoxes));
+        }
+    }
+
+    /// <summary>
+    /// The PR checklist must ask for the things CI hard-fails on, and must not ask a non-releasing PR
+    /// for the things that make CI fail.
+    /// <para>It asked for "CHANGELOG updated" unconditionally. Following that on a <c>docs:</c> or
+    /// <c>test:</c> PR turns the build red — the version gate requires the newest CHANGELOG heading to
+    /// equal the csproj version, and a non-releasing PR leaves that version alone. Meanwhile the two
+    /// checks that break most PRs, <c>dotnet format</c> and the version bump, were not mentioned at all:
+    /// a checklist that omits the real gates and demands a red one is worse than none, because it is
+    /// followed in good faith.</para>
+    /// </summary>
+    [Fact]
+    public void ThePullRequestChecklist_AsksForWhatCiEnforces()
+    {
+        var root = FindRepoRoot();
+        var lines = File.ReadAllLines(Path.Combine(root, ".github", "PULL_REQUEST_TEMPLATE.md"));
+        var ci = File.ReadAllText(Path.Combine(root, ".github", "workflows", "ci.yml"));
+
+        // Anchor on the CI steps themselves, so a renamed gate fails here rather than silently
+        // invalidating the expectations below.
+        foreach (var step in new[]
+                 {
+                     "name: Check formatting",
+                     "name: Check version consistency",
+                     "name: Check the version is the one the merge will tag",
+                     "name: Check the newest CHANGELOG entry has a plain-English lead"
+                 })
+        {
+            Assert.Contains(step, ci, StringComparison.Ordinal);
+        }
+
+        var items = lines
+            .Select((text, index) => (Text: text.Trim(), Line: index + 1))
+            .Where(item => item.Text.StartsWith("- [ ] ", StringComparison.Ordinal))
+            .ToList();
+        Assert.True(items.Count >= 12,
+            $"only {items.Count} checklist items were parsed — fix this guard rather than trusting it.");
+
+        // Where the checklist splits into the release-only section. Everything from that heading down is
+        // explicitly scoped to fix:/feat:, which is what makes asking for a CHANGELOG correct there.
+        var releaseSection = Array.FindIndex(
+            lines,
+            l => l.StartsWith("### ", StringComparison.Ordinal)
+                 && l.Contains("fix:", StringComparison.Ordinal)
+                 && l.Contains("feat:", StringComparison.Ordinal)) + 1;
+        Assert.True(releaseSection > 0,
+            "the template has no release-only checklist section — a CHANGELOG or version-bump item "
+            + "outside one applies to every PR, including the ones CI fails for doing it.");
+
+        foreach (var (needle, what) in new[]
+                 {
+                     ("CHANGELOG", "the CHANGELOG entry"),
+                     ("Version", "the version bump")
+                 })
+        {
+            var stray = items
+                .Where(item => item.Line < releaseSection
+                               && item.Text.Contains(needle, StringComparison.Ordinal))
+                .Select(item => $"line {item.Line}: {item.Text}")
+                .ToList();
+            Assert.True(stray.Count == 0,
+                $"{what} is asked of every PR, but on a docs:/test:/refactor:/ci:/chore: PR doing it "
+                + "fails CI's version gate. Move it under the release-only heading:\n  "
+                + string.Join("\n  ", stray));
+
+            Assert.Contains(items, item => item.Line > releaseSection
+                                           && item.Text.Contains(needle, StringComparison.Ordinal));
+        }
+
+        // The format gate fails more PRs than any other check and a clean build does not catch it, so
+        // the checklist has to name it — and CONTRIBUTING has to show the command.
+        Assert.Contains(items, item => item.Text.Contains("dotnet format", StringComparison.Ordinal));
+        Assert.Contains(
+            "dotnet format",
+            File.ReadAllText(Path.Combine(root, "CONTRIBUTING.md")),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Every private-reporting route must point at a channel that exists. SECURITY.md and
+    /// CODE_OF_CONDUCT.md both told reporters to email "the address on the GitHub profile" — that profile
+    /// publishes no email, so the one page a security reporter reads named a dead end. A vulnerability
+    /// that cannot be reported privately tends to be reported publicly, or not at all.
+    /// </summary>
+    [Fact]
+    public void EveryPrivateReportingRoute_NamesAChannelThatExists()
+    {
+        var root = FindRepoRoot();
+        string[] surfaces = ["SECURITY.md", "CODE_OF_CONDUCT.md", "SUPPORT.md"];
+
+        var offenders = new List<string>();
+        var advisoryLinks = 0;
+
+        foreach (var relative in surfaces)
+        {
+            var path = Path.Combine(root, relative);
+            Assert.True(File.Exists(path), $"{relative} not found — the guard would pass vacuously");
+
+            var lines = File.ReadAllLines(path);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                advisoryLinks += AdvisoryLink().Matches(lines[i]).Count;
+
+                // "the email listed on their GitHub profile", "contact the maintainer by email" and
+                // friends: any instruction to email that names no actual address routes nowhere.
+                foreach (var hit in EmailTheMaintainer().Matches(lines[i]).Cast<Match>())
+                    offenders.Add($"{relative}:{i + 1}  {hit.Value.Trim()}");
+            }
+        }
+
+        // Vacuity floor: the advisory route must be present on the pages that replaced the email one.
+        Assert.True(advisoryLinks >= 3,
+            $"expected the private-advisory link on the reporting pages, found {advisoryLinks} — the "
+            + "guard has gone vacuous");
+
+        Assert.True(offenders.Count == 0,
+            "these lines tell a reporter to email the maintainer, but no address is published anywhere "
+            + "(the GitHub profile has none), so the route is a dead end. Point at a private security "
+            + $"advisory instead:\n  {string.Join("\n  ", offenders)}");
+    }
+
+    /// <summary>
+    /// Every source file carries the three-line attribution header the PR template asks for.
+    /// <para>All 688 of them did already — but only because it was remembered every time, on a checklist
+    /// item whose exact shape was written down nowhere public: a contributor reading "Author headers on
+    /// all new/modified files" had to infer the format from a neighbouring file. CONTRIBUTING now shows
+    /// it, and this asserts it, so the instruction and the reality cannot drift apart.</para>
+    /// </summary>
+    [Fact]
+    public void EverySourceFile_CarriesTheAuthorHeader()
+    {
+        const string attribution = "Author: laurentiu021 · https://github.com/laurentiu021/SystemManager";
+        var solution = Path.Combine(FindRepoRoot(), "SysManager");
+
+        var offenders = new List<string>();
+        var scanned = 0;
+
+        foreach (var path in Directory
+                     .EnumerateFiles(solution, "*.*", SearchOption.AllDirectories)
+                     .Where(p => p.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
+                                 || p.EndsWith(".xaml", StringComparison.OrdinalIgnoreCase))
+                     .Where(p => !Path.GetRelativePath(solution, p)
+                         .Split(Path.DirectorySeparatorChar)
+                         .Any(segment => segment.Equals("obj", StringComparison.OrdinalIgnoreCase)
+                                         || segment.Equals("bin", StringComparison.OrdinalIgnoreCase))))
+        {
+            scanned++;
+
+            // The header is the first thing in the file, so only the opening lines are read: a stray
+            // match further down (a URL in a comment, say) must not satisfy the contract.
+            var opening = string.Join('\n', File.ReadLines(path).Take(5));
+            if (!opening.Contains("SysManager ·", StringComparison.Ordinal)
+                || !opening.Contains(attribution, StringComparison.Ordinal)
+                || !opening.Contains("License: MIT", StringComparison.Ordinal))
+            {
+                offenders.Add(Path.GetRelativePath(solution, path));
+            }
+        }
+
+        // Vacuity floor: the four projects hold ~690 files, so a scan that saw a handful means the
+        // enumeration broke rather than the codebase being clean.
+        Assert.True(scanned >= 600,
+            $"only {scanned} source files were scanned — fix this guard rather than trusting its pass.");
+
+        Assert.True(offenders.Count == 0,
+            "these files are missing the attribution header the PR template requires. Copy the block "
+            + "from the top of a neighbouring file; CONTRIBUTING.md shows the exact shape for .cs and "
+            + $".xaml:\n  {string.Join("\n  ", offenders)}");
+    }
+
+    /// <summary>The <c>feat|fix</c> alternation auto-release matches to decide a bump.</summary>
+    [GeneratedRegex(@"\^\((feat\|fix)\)", RegexOptions.Compiled)]
+    private static partial Regex ReleasingPrefixAlternation();
+
+    /// <summary>A commit prefix offered by a PR-template checkbox, e.g. <c>(`feat:`)</c>.</summary>
+    [GeneratedRegex(@"^- \[ \].*\(`([a-z]+):`\)", RegexOptions.Compiled)]
+    private static partial Regex TemplatePrefix();
+
+    /// <summary>A link that opens a private security advisory.</summary>
+    [GeneratedRegex(@"/security/advisories/new", RegexOptions.Compiled)]
+    private static partial Regex AdvisoryLink();
+
+    /// <summary>An instruction to email the maintainer that names no address.</summary>
+    [GeneratedRegex(
+        @"email(?:ing)?\s+(?:the\s+)?maintainer|(?:e-?mail|address)\s+(?:listed\s+)?on\s+(?:their|the)\s+GitHub\s+profile",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    private static partial Regex EmailTheMaintainer();
+
+    /// <summary>
     /// Every model property must be reachable: written by something, or shown by something. A property
     /// that is neither is a promise the app cannot keep — <c>BlockedApp.FullPath</c> was permanently empty
     /// because an IFEO key records only the executable name, and <c>ProcessEntry.UserName</c> was never
@@ -1181,14 +1429,19 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
-    /// The README's table of contents must resolve. It is 1300+ lines long, so the contents list is the
-    /// only practical way to navigate it — and a heading rename silently breaks an anchor, which renders
-    /// as a link that quietly does nothing rather than as an error.
+    /// Every in-page link in the docs must resolve. README is 1300+ lines long, so the contents list is
+    /// the only practical way to navigate it — and a heading rename silently breaks an anchor, which
+    /// renders as a link that quietly does nothing rather than as an error.
+    /// <para>Originally scoped to README's contents block, which is why it never saw
+    /// <c>[top of this README](#sysmanager)</c> further down the file: the h1 is "SysManager for
+    /// Windows", so that anchor slugs to <c>#sysmanager-for-windows</c> and the link had been inert since
+    /// it was written. Every in-page link on every doc page is now checked, in both directions.</para>
     /// </summary>
     [Fact]
     public void TheReadmeTableOfContents_HasNoDeadAnchors()
     {
-        var lines = File.ReadAllLines(Path.Combine(FindRepoRoot(), "README.md"));
+        var root = FindRepoRoot();
+        var lines = File.ReadAllLines(Path.Combine(root, "README.md"));
 
         // GitHub's anchor rule: lower-case, drop everything but word characters, spaces and hyphens,
         // then replace runs of whitespace with a single hyphen.
@@ -1212,9 +1465,38 @@ public partial class ArchitectureTests
                 dead.Add($"README.md:{i + 1}  #{m.Groups[1].Value}");
         }
 
+        // The whole doc set, not just README's contents block: a prose cross-reference breaks exactly the
+        // same way and is the one nobody re-reads.
+        var pages = 0;
+        foreach (var path in Directory.EnumerateFiles(root, "*.md", SearchOption.TopDirectoryOnly))
+        {
+            pages++;
+            var page = File.ReadAllLines(path);
+            var pageAnchors = page
+                .Select(l => HeadingLine().Match(l))
+                .Where(m => m.Success)
+                .Select(m => Slug(m.Groups[1].Value))
+                .ToHashSet(StringComparer.Ordinal);
+            // The h1 is an anchor too, and prose links back to the top of the page through it.
+            foreach (var l in page.Where(l => l.StartsWith("# ", StringComparison.Ordinal)))
+                pageAnchors.Add(Slug(l[2..]));
+
+            for (var i = 0; i < page.Length; i++)
+            {
+                foreach (var hit in InPageLink().Matches(page[i]).Cast<Match>())
+                {
+                    var anchor = hit.Groups[1].Value;
+                    if (!pageAnchors.Contains(anchor))
+                        dead.Add($"{Path.GetFileName(path)}:{i + 1}  #{anchor}");
+                }
+            }
+        }
+
+        Assert.True(pages >= 6, $"expected the top-level doc pages, found {pages}");
         Assert.True(entries >= 10, $"expected the full contents list, found {entries} entries");
         Assert.True(dead.Count == 0,
-            "these table-of-contents links point at headings that do not exist:\n  " + string.Join("\n  ", dead));
+            "these in-page links point at headings that do not exist, so they render as text that "
+            + $"quietly does nothing when clicked:\n  {string.Join("\n  ", dead)}");
     }
 
     private static string Slug(string heading) =>


### PR DESCRIPTION
## What does this PR do?

Makes the contributor-facing checklist describe what CI actually enforces, and points the two
security-reporting pages at a channel that exists. Five fitness functions hold each claim, because
every surface here is prose that nothing compiles.

### The checklist asked for something that fails the build

`- [ ] CHANGELOG updated` was unconditional. On a `docs:` / `test:` / `refactor:` / `ci:` / `chore:`
PR, following it turns CI red: the **Check version consistency** gate throws when the newest
`## [x.y.z]` CHANGELOG heading is not equal to the csproj `Version`, and a non-releasing PR leaves
that version alone. A contributor doing exactly what the template asked would get a red check and no
idea why.

Meanwhile the two gates that break most PRs were not mentioned at all:

- **Check formatting** — `dotnet format --verify-no-changes` on all four projects. A clean build does
  not catch it, so this is the single most common surprise failure.
- **Check the version is the one the merge will tag** — the bump has to be a single step from the
  newest tag, and it was on no checklist.

The checklist now splits along the line CI draws. Everything above the release-only heading applies
to every PR; the CHANGELOG entry, the version bump and the `SECURITY.md` supported-line update sit
below it, explicitly scoped to `fix:`/`feat:`, with a note that doing them on a non-releasing PR is
what fails.

### "Type of change" had no box for two prefixes in active use

It offered `fix:`, `feat:`, `docs:`, CodeQL, `ci:`, `chore:`. On main there are **41 `test:` commits
and 15 `refactor:` commits**, and `CONTRIBUTING.md` already said "`fix:`, `feat:`, `docs:`, `test:`,
`refactor:`, `ci:` are all understood". Both are now offered, and the releasing boxes say so — the
prefix in the PR title is what decides whether the merge publishes a release, which is precisely the
thing the rest of the checklist branches on.

### Two pages routed security reporters to an address that does not exist

`SECURITY.md:36` and `CODE_OF_CONDUCT.md:64` both said to email the maintainer at "the address on
the GitHub profile". That profile publishes no email — `gh api users/laurentiu021` returns
`"email": null` — so the one page a security reporter reads named a dead end, and a vulnerability
that cannot be reported privately tends to be reported publicly or not at all. Both now point at a
private security advisory, which is enabled on this repository (`private-vulnerability-reporting`
returns `{"enabled": true}`) and is the only genuinely private channel the project has. SECURITY.md
says plainly why an account is needed rather than pretending an alternative exists.

### The author-header requirement was documented nowhere public

`- [ ] Author headers on all new/modified files` has always been on the template, but the format
appeared in no public document — a contributor had to infer it from a neighbouring file.
`CONTRIBUTING.md` now shows the exact block for `.cs` and `.xaml`, and notes that `Author:` names the
maintainer rather than the commit author (Git already records that, and contributors are credited in
the release notes).

## The guards

| Guard | What it fails on |
|---|---|
| `ThePullRequestTemplate_OffersEveryCommitPrefixTheWorkflowUnderstands` | Reads the releasing prefixes out of `auto-release.yml` rather than restating them. Fails on a documented prefix with no box, a box naming an unknown prefix, or a releasing box that does not say it releases. |
| `ThePullRequestChecklist_AsksForWhatCiEnforces` | Anchors on the four CI step names, then fails if a CHANGELOG or version item appears outside the release-only section, if either is missing inside it, or if the format gate goes unmentioned in the template or CONTRIBUTING. |
| `EveryPrivateReportingRoute_NamesAChannelThatExists` | Any instruction to email the maintainer across SECURITY / CODE_OF_CONDUCT / SUPPORT, with a vacuity floor of three advisory links. |
| `EverySourceFile_CarriesTheAuthorHeader` | A `.cs` or `.xaml` file whose first five lines lack the attribution block. 688 files scanned, floor at 600. |
| `TheReadmeTableOfContents_HasNoDeadAnchors` (widened) | Every in-page link on every top-level doc page, in both directions — not only README's contents block. |

Widening the last one immediately found a real defect it had been unable to see: `README.md:921`
linked to `#sysmanager` ("the feature tour GIF is at the top of this README"), but the h1 is
"SysManager for Windows", so the anchor slugs to `#sysmanager-for-windows`. That link had been inert
since it was written, because the old guard only scanned inside the contents block.

## Verification

**Red before, green after.** Four of the five guards fail against the previous tree (`d0ae56d`), each
for its own defect:

```
RED    ThePullRequestTemplate_...      only 5 prefixes were parsed out of the PR template
RED    ThePullRequestChecklist_...     the template has no release-only checklist section
RED    EveryPrivateReportingRoute_...  expected the private-advisory link, found 1
GREEN  EverySourceFile_CarriesTheAuthorHeader
RED    TheReadmeTableOfContents_...    README.md:921  #sysmanager
```

The header guard passed there, because all 688 files already carried the header — so it was proved
non-vacuous by deleting the attribution line from `FormatHelper.cs` and confirming it named exactly
that file, then restoring it. Post-fix: **5 green, 0 red**, re-run after the rebase onto `#1882`.

Guards were exercised by invoking the test methods directly rather than via `dotnet test`, so no
listening socket and no firewall prompt; the same method bodies and asserts CI runs. An independently
written Python cross-check re-derives all five conclusions from the real files and agrees in both
directions.

- Build: all four projects, Release, **0 errors 0 warnings** (`TreatWarningsAsErrors` is on).
- Format gate: all four projects **CLEAN**.
- Version gates: csproj `1.65.4`, newest tag `v1.65.4`, CHANGELOG head `1.65.4`, SECURITY `1.65.x` —
  consistent, and untouched, which is what a `docs:` PR must do.
- Leak scan: 0 hits across all 32 terms on the full diff.

## Type of change

- [x] Documentation (`docs:`) — no release
- [x] Tests (`test:`) — the five fitness functions

`docs:` publishes no release, so per the rule this PR itself introduces: no CHANGELOG entry, no
version bump.
