### PR TITLE
ci: run the exe before publishing it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,90 @@ jobs:
         with:
           subject-path: publish/SysManager-v${{ steps.version.outputs.version }}.exe
 
+      # Nothing above this point has ever RUN the artifact being published. The unit tests
+      # exercise the code, but they load assemblies into a test host — they do not start the
+      # single-file, self-contained, compressed exe that users actually download. Those are
+      # different failure surfaces: a missing native library extracted from the bundle, a
+      # startup path that throws before the first frame, or a resource that resolves in a
+      # normal build but not from a packed one, all pass every test and then fail on launch.
+      # That shipped once already, which is why the standing rule is that a release is not
+      # trusted until the published binary has been seen alive.
+      #
+      # windows-latest provides a desktop session (the ui-tests job in ci.yml relies on the
+      # same thing), so the exe can be started here — the one place in the pipeline where the
+      # real artifact exists and nothing has been published yet. A failure aborts the run
+      # before the release, the winget submission and the announcement, instead of after.
+      #
+      # Deliberately a smoke check, not a UI test: start it, hold it, confirm the process is
+      # still alive and that it left no crash marker, then close it. No assertions about what
+      # is on screen — ci.yml's FlaUI job owns that, and duplicating it here would make the
+      # release depend on UI timing.
+      - name: Smoke-check the published exe
+        shell: pwsh
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          $exe = Resolve-Path "publish/SysManager-v$env:VERSION.exe"
+          $marker = Join-Path $env:LOCALAPPDATA 'SysManager\last-crash.json'
+          $logs = Join-Path $env:LOCALAPPDATA 'SysManager\logs'
+
+          # A marker from an earlier run on this image would be read as this run's crash.
+          # The runner is ephemeral, so this is belt-and-braces, but a false PASS and a false
+          # FAIL are both worse than one Remove-Item.
+          Remove-Item $marker -ErrorAction SilentlyContinue
+
+          Write-Host "Launching $exe"
+          $app = Start-Process -FilePath $exe -PassThru
+
+          # Long enough for the shell to build, the eager view models to construct and the
+          # first frame to render. A crash on this path is immediate, not gradual.
+          Start-Sleep -Seconds 25
+
+          $alive = -not $app.HasExited
+          $exitCode = if ($app.HasExited) { $app.ExitCode } else { $null }
+
+          if ($alive) {
+              Write-Host "Process $($app.Id) is alive after 25s; closing it."
+              # Ask first, so the normal shutdown path runs and any teardown fault surfaces.
+              $app.CloseMainWindow() | Out-Null
+              if (-not $app.WaitForExit(15000)) {
+                  Write-Host "::warning::The window did not close within 15s; killing the process."
+                  $app.Kill()
+                  $app.WaitForExit(10000) | Out-Null
+              }
+          }
+
+          # The log is written even when the app dies before showing a window, so it is the
+          # only diagnostic available for the failing case. Emitted before the throw.
+          if (Test-Path $logs) {
+              $log = Get-ChildItem $logs -Filter '*.log' |
+                     Sort-Object LastWriteTime -Descending |
+                     Select-Object -First 1
+              if ($log) {
+                  Write-Host "--- tail of $($log.Name) ---"
+                  Get-Content $log.FullName -Tail 40 | ForEach-Object { Write-Host $_ }
+                  Write-Host "--- end of log ---"
+              }
+          }
+
+          if (-not $alive) {
+              throw "The published exe exited on its own within 25 seconds (exit code " +
+                    "$exitCode). It builds and passes the unit tests but does not run, so this " +
+                    "release must not be published. The log tail above is from the failed launch."
+          }
+
+          # An unhandled exception on a background thread kills the process, but one on the UI
+          # thread is handled and logged while the window stays up — so "still alive" alone is
+          # not proof of a clean start. App.xaml.cs writes this marker on the fatal path.
+          if (Test-Path $marker) {
+              Write-Host "--- last-crash.json ---"
+              Get-Content $marker -Raw | Write-Host
+              throw "The published exe recorded a crash marker during startup. It survived the " +
+                    "25-second window but faulted, so this release must not be published."
+          }
+
+          Write-Host "The published exe started, stayed alive for 25s and recorded no crash."
+
       - name: Extract release notes from CHANGELOG
         id: notes
         shell: pwsh

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1847,6 +1847,73 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"&#x[0-9A-Fa-f]{4};", RegexOptions.CultureInvariant)]
     private static partial Regex FluentGlyphReference();
 
+    /// <summary>
+    /// The release workflow must RUN the exe it is about to publish, and must do so while a failure
+    /// can still stop the release.
+    /// <para>Nothing in the pipeline ever started the artifact. The unit tests exercise the code, but
+    /// they load assemblies into a test host — they do not launch the single-file, self-contained,
+    /// compressed exe a user downloads, and those are different failure surfaces: a native library that
+    /// does not extract from the bundle, a startup path that throws before the first frame, a resource
+    /// that resolves in a normal build but not a packed one. All of them pass every test and then fail
+    /// on launch, which is exactly what shipped once.</para>
+    /// <para>Position is the whole point, so it is asserted rather than trusted to review. A smoke check
+    /// placed after "Create GitHub Release" still runs and still goes red — but the release, the winget
+    /// submission and the announcement are already out, so it reports a fact instead of preventing one.
+    /// It must sit after the artifact exists (the publish) and before anything is published.</para>
+    /// </summary>
+    [Fact]
+    public void TheReleaseWorkflow_LaunchesTheExeBeforeItPublishesAnything()
+    {
+        var lines = File.ReadAllLines(
+            Path.Combine(FindRepoRoot(), ".github", "workflows", "release.yml"));
+
+        int StepLine(string name)
+        {
+            var at = Array.FindIndex(lines, l => l.Trim() == $"- name: {name}");
+            Assert.True(at >= 0,
+                $"release.yml has no step named \"{name}\". If it was renamed, update this guard in the "
+                + "same PR — do not delete it.");
+            return at;
+        }
+
+        var publish = StepLine("Publish single-file exe");
+        var rename = StepLine("Rename exe with version");
+        var smoke = StepLine("Smoke-check the published exe");
+        var release = StepLine("Create GitHub Release");
+        var winget = StepLine("Sync the winget-pkgs fork with upstream");
+        var announce = StepLine("Post announcement to Discussions");
+
+        Assert.True(smoke > rename,
+            $"the smoke check (line {smoke + 1}) runs before the exe is named (line {rename + 1}), so "
+            + "there is no artifact for it to launch.");
+        Assert.True(publish < smoke, "the exe must be published to disk before it can be launched.");
+
+        foreach (var (step, at) in new[]
+                 {
+                     ("Create GitHub Release", release),
+                     ("Sync the winget-pkgs fork with upstream", winget),
+                     ("Post announcement to Discussions", announce)
+                 })
+        {
+            Assert.True(smoke < at,
+                $"the smoke check (line {smoke + 1}) runs AFTER \"{step}\" (line {at + 1}). A launch "
+                + "failure would then be reported rather than prevented — the release, the package "
+                + "submission and the announcement would already be public.");
+        }
+
+        // The step body has to actually start the process and judge the outcome. Without these it
+        // could be reduced to an echo and still satisfy the ordering above.
+        var body = string.Join('\n', lines[smoke..release]);
+        foreach (var required in new[] { "Start-Process", "HasExited", "last-crash.json", "throw" })
+        {
+            Assert.Contains(required, body, StringComparison.Ordinal);
+        }
+
+        // A check that never fails the job is decoration. continue-on-error on this step would make
+        // the launch advisory, which is the one thing it must not be.
+        Assert.DoesNotContain("continue-on-error", body, StringComparison.Ordinal);
+    }
+
     /// <summary>The app project directory — .xaml is not copied to the test output.</summary>
     private static string FindAppProjectDir()
     {


### PR DESCRIPTION
## What does this PR do?

Makes the release pipeline **run the exe it is about to publish**, and fails the release if that
exe does not start.

Nothing in the pipeline had ever done this. The unit tests exercise the code, but they load
assemblies into a test host — they do not launch the single-file, self-contained, compressed exe a
user downloads. Those are genuinely different failure surfaces:

- a native library that does not extract from the bundle at runtime,
- a startup path that throws before the first frame,
- a resource that resolves in a normal build but not from a packed one.

Each passes every test and then fails on launch. One already shipped that way, which is why the
standing rule is that a release is not trusted until the published binary has been seen alive — but
that check was manual, on a second machine, *after* publication.

## The step

Inserted after **Attest build provenance** and before **Extract release notes**, so it runs when the
artifact exists and while a failure can still stop the release:

```
9  Attest build provenance
10 Smoke-check the published exe     <-- new
11 Extract release notes from CHANGELOG
12 Append verification instructions
13 Create GitHub Release
14 Sync the winget-pkgs fork
...
22 Post announcement to Discussions
```

It starts the exe, holds it 25 seconds, then closes it via `CloseMainWindow()` so the normal
shutdown path runs (killing only if the window does not close within 15s).

**Two conditions, not one.** A process that exits on its own is the obvious failure. A process that
survives is not automatically healthy: an unhandled exception on the UI thread is handled and logged
while the window stays up, so `App.xaml.cs`'s `last-crash.json` is checked as well. Any stale marker
is removed *before* the launch, so an earlier run cannot produce either a false pass or a false
failure. The tail of the newest log is printed before either throw — it is the only diagnostic
available when the app dies before showing a window.

Deliberately a smoke check, **not** a UI test: it asserts nothing about what is on screen. `ci.yml`'s
FlaUI job owns that, and duplicating it here would make every release depend on UI timing.

`windows-latest` provides a desktop session — the `ui-tests` job in `ci.yml` already relies on the
same thing — so this is the one point in the pipeline where the real artifact exists, a desktop is
available, and nothing has been published yet.

## The guard

`TheReleaseWorkflow_LaunchesTheExeBeforeItPublishesAnything` pins it, because **position is the
entire value**. A smoke check placed after "Create GitHub Release" still runs and still goes red —
but the release, the winget submission and the announcement are already public, so it reports a fact
instead of preventing one.

The guard reads the step order out of `release.yml` rather than restating it, requires the body to
actually start a process and judge the result, and rejects `continue-on-error`.

## Verification

The step cannot be executed on the main workstation — the application is never launched there — so
it was verified two ways instead.

**1. Mutation testing of the guard.** Four mutations, each isolating one claim:

| Mutation | Result |
|---|---|
| step deleted (i.e. `main` before this PR) | RED — `no step named "Smoke-check the published exe"` |
| moved after `Create GitHub Release` | RED — `runs AFTER "Create GitHub Release" … reported rather than prevented` |
| body gutted to `Write-Host "smoke check"` | RED — `Assert.Contains` failure, `Start-Process` not found |
| `continue-on-error: true` added | RED — `Assert.DoesNotContain` failure |

`release.yml` was restored byte-for-byte afterwards and re-asserted equal to the original.

**2. Behaviour of the step's own logic**, against stand-in processes whose behaviour is chosen. The
script under test is extracted verbatim from `release.yml`; only `$exe` and the marker/log paths are
redirected, and every substitution is asserted to have applied (an earlier version used regex, three
of four patterns silently matched nothing, and it reported a pass while reading the real log
directory — that is fixed and the assertion is why it was caught):

```
OK     alive, no marker         pass, and said so
OK     exits at once            fail, and said so
OK     alive + marker mid-run   fail, and said so
OK     stale marker cleared     pass, and said so
```

The third case is the one a bare "is it running" check would wave through.

**Other checks:**

- All four projects build Release, **0 errors 0 warnings** (`TreatWarningsAsErrors` is on).
- Format gate on all four projects: **CLEAN**.
- All four workflow files parse as YAML, and the step order is confirmed from the parsed document,
  not by reading the diff.
- CI's release-notes-footer ASCII gate re-derived independently: the insertion sits above the
  template, and the gate still resolves the same 47-line footer with the expected markers, 0
  non-ASCII. That gate broke a release once by slicing the wrong lines, so it was checked rather
  than assumed.
- The six workflow/doc guards now in `ArchitectureTests` all pass together after the rebase onto
  #1883.
- Leak scan: 0 hits across all 32 terms.
- Version untouched — csproj `1.65.5`, newest tag `v1.65.5`, CHANGELOG head `1.65.5`, correct for a
  non-releasing PR.

## Type of change

- [x] CI / build (`ci:`)

`ci:` publishes no release, so no CHANGELOG entry and no version bump.

## Note on cost

The step adds roughly 45 seconds to a release. The failure it prevents is a published release, a
winget submission and an announcement for a binary that does not start.
