### PR TITLE
fix: make the keyboard focus ring visible on every fill

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,6 +43,16 @@ controls. Their inner visuals consume selection through the shared `SidebarNavRo
 `SidebarNavText`, and `SidebarActiveMark` styles, while `SelectionStatus` exposes
 the same state to UI Automation. Group headers are keyboard-focusable toggles;
 collapsed content is disabled so visually hidden leaves cannot receive focus.
+
+Keyboard focus is drawn by ONE shared resource, `FocusRing` in `App.xaml`, applied through
+`FocusVisualStyle` on every style whose template replaces the default one — a custom template
+otherwise takes the framework's focus adorner with it. It is a two-`Rectangle` adorner (white inner
+stroke, near-black outer) rather than a themed border, because the ring must stay visible on
+`PrimaryButton`'s accent fill, `DangerButton`'s red, a raised grey and a card surface; any single
+colour, accent included, falls to 1.00:1 against at least one of those.
+`ArchitectureTests.NoStyle_SuppressesTheKeyboardFocusIndicator` forbids
+`FocusVisualStyle="{x:Null}"` anywhere and asserts the ring keeps both strokes.
+
 Every tab is backed by a real view and view-model. A shared WIP placeholder view
 existed while tabs were still being built; the last tab graduated off it, so it was
 removed rather than left as unreachable code. A tab that is implemented but not yet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.6] - 2026-08-14
+
+If you use the keyboard instead of the mouse, you can now see where you are. Pressing Tab moves a
+visible outline from control to control; before this, the outline was drawn in the app's purple on
+top of purple buttons, so it was completely invisible on the most important buttons — and checkboxes,
+filter chips and table cells had no outline at all.
+
+### Fixed
+- **The keyboard outline was invisible on every colour theme.** The outline was drawn in the theme's
+  own accent colour, which is also what fills the main action buttons — purple on purple, measured at
+  1.00:1 contrast, i.e. nothing to see. The Delete buttons were the same story in red. It also fell
+  below the readable minimum on the Sky Breeze, Warm Sand and Mint Fresh themes even for ordinary
+  grey buttons. The outline is now two thin lines of opposite shade, a light one and a dark one, so
+  one of them always stands out whatever it is drawn on — measured across all 12 themes, the worst
+  case is now 4.5 times the required contrast instead of none.
+- **Checkboxes, filter chips, mode buttons and table cells had no outline at all.** Space still
+  ticked a checkbox and the arrow keys still moved through a table, so a keyboard user could change a
+  setting or select a row without ever seeing which one they were on — worst on the pages that are a
+  full column of checkboxes (Privacy, Debloater, Tweaks). All of them now show the same outline as
+  every other control.
+
 ## [1.65.5] - 2026-08-14
 
 Buttons and checkboxes are now read out with the words actually printed on them. If you use Windows Speech Recognition or a screen reader, 36 controls used to be announced with different wording than what you could see — so saying the label out loud did not press the button.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,18 @@ A palette button in the top-right corner opens an appearance popup with:
 - Background shade slider for fine-tuning lightness/darkness
 - Settings persist between sessions
 
+### Keyboard navigation
+The app is operable without a mouse, and the control you are on is always visible. `Tab` moves
+forward, `Shift+Tab` back, `Space` presses a button or ticks a checkbox, and the arrow keys move
+within a table or a row of filter chips.
+
+The focus outline is deliberately two thin lines of opposite shade — one light, one dark — rather
+than a single accent-coloured ring. A single colour cannot be visible everywhere: it has to show up
+on a purple primary button, a red delete button, a grey secondary button and a plain card, and any
+one colour disappears against at least one of those. With two, one line always contrasts whatever is
+underneath. Measured across all 12 themes, the outline stays at 4.5:1 or better against every surface
+it is drawn on — above the 3:1 WCAG asks of a non-text indicator.
+
 ### Context Menu Manager
 Manage Windows Explorer right-click entries — toggle them on or off without
 deleting anything (uses the standard `LegacyDisable` registry mechanism):

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1914,6 +1914,88 @@ public partial class ArchitectureTests
         Assert.DoesNotContain("continue-on-error", body, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// No style may suppress the keyboard focus indicator without providing a replacement.
+    /// <para><c>FocusVisualStyle="{x:Null}"</c> removes the only cue a keyboard user has, and four
+    /// styles did exactly that with nothing in its place: ButtonBase, ToggleSwitch, DataGridCell and
+    /// ConsoleView's log rows. ButtonBase's template substituted an Accent-coloured border, which
+    /// cannot work for the styles derived from it — PrimaryButton's fill IS the accent (1.00:1,
+    /// invisible on all 12 presets) and DangerButton's is red (1.02–1.75:1), both far below WCAG
+    /// 1.4.11's 3:1 for a non-text indicator. Seven templated interactive styles never had a ring at
+    /// all.</para>
+    /// <para>The fix is one shared <c>FocusRing</c> adorner, so this asserts the SHAPE of the fix
+    /// rather than the count: nulling the focus visual is allowed nowhere, and every style that
+    /// replaces the default template of a focusable control must name the shared ring. That way the
+    /// next templated control is caught at build time instead of by a keyboard user.</para>
+    /// </summary>
+    [Fact]
+    public void NoStyle_SuppressesTheKeyboardFocusIndicator()
+    {
+        var appDir = FindAppProjectDir();
+        var files = Directory
+            .EnumerateFiles(appDir, "*.xaml", SearchOption.AllDirectories)
+            .Where(f => !Path.GetRelativePath(appDir, f)
+                .Split(Path.DirectorySeparatorChar)
+                .Any(segment => segment.Equals("obj", StringComparison.OrdinalIgnoreCase)
+                                || segment.Equals("bin", StringComparison.OrdinalIgnoreCase)))
+            .ToArray();
+        Assert.True(files.Length >= 60, $"only {files.Length} XAML files were found — fix this guard.");
+
+        var nulled = new List<string>();
+        var ringUses = 0;
+
+        foreach (var path in files)
+        {
+            var lines = File.ReadAllLines(path);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (NulledFocusVisual().IsMatch(lines[i]))
+                    nulled.Add($"{Path.GetFileName(path)}:{i + 1}");
+                if (lines[i].Contains("FocusVisualStyle", StringComparison.Ordinal)
+                    && lines[i].Contains("FocusRing", StringComparison.Ordinal))
+                {
+                    ringUses++;
+                }
+            }
+        }
+
+        Assert.True(nulled.Count == 0,
+            "these styles remove the keyboard focus indicator and put nothing back, so a keyboard user "
+            + "cannot see what is focused (WCAG 2.4.7). Point FocusVisualStyle at the shared FocusRing "
+            + $"instead of {{x:Null}}:\n  {string.Join("\n  ", nulled)}");
+
+        // Vacuity floor: the ring must actually be referenced. Deleting every reference would satisfy
+        // the assert above while leaving the app with no focus cue at all.
+        Assert.True(ringUses >= 6,
+            $"only {ringUses} styles reference the shared FocusRing — a control whose template replaces "
+            + "the default one loses the focus adorner, so it has to name the ring explicitly.");
+
+        // And the ring itself must be two strokes of opposite tone. A single-colour ring is what failed
+        // on the accent and red fills; reducing it back to one would restore the defect while keeping
+        // every assertion above green.
+        var app = File.ReadAllText(Path.Combine(appDir, "App.xaml"));
+        var start = app.IndexOf("<Style x:Key=\"FocusRing\">", StringComparison.Ordinal);
+        Assert.True(start >= 0, "App.xaml no longer defines FocusRing — update this guard, don't drop it.");
+        var end = app.IndexOf("</Style>", start, StringComparison.Ordinal);
+        Assert.True(end > start, "the FocusRing style is not terminated; the slice below would be empty.");
+
+        var ring = app[start..end];
+        Assert.Equal(2, StrokeAttribute().Matches(ring).Count);
+        Assert.Contains("Stroke=\"#111111\"", ring, StringComparison.Ordinal);
+        Assert.Contains("Stroke=\"#FFFFFF\"", ring, StringComparison.Ordinal);
+        // Accent must NOT be the ring colour: that is the whole defect, and it is also the hover and
+        // selection colour, so a well-meaning "use the theme brush" edit would reintroduce 1.00:1.
+        Assert.DoesNotContain("Accent", ring, StringComparison.Ordinal);
+    }
+
+    /// <summary>A style that suppresses the focus indicator outright.</summary>
+    [GeneratedRegex(@"FocusVisualStyle""\s*Value=""\{x:Null\}""", RegexOptions.Compiled)]
+    private static partial Regex NulledFocusVisual();
+
+    /// <summary>A literal Stroke colour on the focus ring's rectangles.</summary>
+    [GeneratedRegex(@"Stroke=""#[0-9A-Fa-f]{6}""", RegexOptions.Compiled)]
+    private static partial Regex StrokeAttribute();
+
     /// <summary>The app project directory — .xaml is not copied to the test output.</summary>
     private static string FindAppProjectDir()
     {

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -151,6 +151,59 @@
             <CornerRadius x:Key="RadiusPill">999</CornerRadius>
 
             <!-- ============================================================ -->
+            <!-- Keyboard focus ring — ONE definition for every control        -->
+            <!-- ============================================================ -->
+            <!-- The keyboard focus cue was an Accent-coloured BORDER set inside each control's own
+                 template. That cannot work on every control, because the ring is then drawn ON the
+                 control's fill: PrimaryButton's fill IS the accent (1.00:1 — literally invisible) and
+                 DangerButton's is red (1.02–1.75:1). Measured across all 12 presets, both failed on
+                 EVERY one; ButtonBase/Secondary also failed on Sky Breeze, Warm Sand and Mint Fresh
+                 (2.24–2.53:1) and Ghost on two, against WCAG 1.4.11's 3:1 bar for a non-text indicator.
+
+                 A single colour cannot solve it: the ring has to land on the accent, on red, on a
+                 raised grey and on a card surface. So the ring is TWO strokes of opposite tone — a
+                 white inner and a near-black outer, 18.9:1 apart from each other. Whatever fill the
+                 control sits on, at least one stroke contrasts it; the worst case over 12 presets ×
+                 6 fills is 4.47:1 (Midnight Indigo / Clean Indigo accent), and no fill scores under
+                 3:1 on both. Both strokes are always drawn, so nothing has to detect the fill at
+                 runtime — the guarantee is arithmetic, not conditional.
+
+                 Drawn as a FocusVisualStyle adorner rather than a per-template border, which is the
+                 point: an adorner renders in the adorner layer ABOVE the control, so it needs no
+                 template change, no reserved BorderThickness, and it cannot be swallowed by a style
+                 that overrides BorderBrush. Four styles set FocusVisualStyle="{x:Null}" with nothing
+                 in its place (ButtonBase, ToggleSwitch, DataGridCell, ConsoleView's rows) and seven
+                 templated styles never had a ring at all; all of them now inherit this one.
+
+                 Accent is deliberately NOT used here. It stays the hover and selection colour, so
+                 the purple identity is unchanged — this is only the keyboard cue. -->
+            <Style x:Key="FocusRing">
+                <Setter Property="Control.Template">
+                    <Setter.Value>
+                        <ControlTemplate>
+                            <!-- SnapsToDevicePixels keeps a 1px stroke from blurring across two
+                                 device pixels at fractional DPI, where it reads as a grey haze
+                                 rather than a ring. -->
+                            <Grid SnapsToDevicePixels="True">
+                                <!-- Outer, near-black: contrasts a light fill and a light page.
+                                     Margin -3 puts it just outside the control's own bounds. -->
+                                <Rectangle Margin="-3"
+                                           RadiusX="6" RadiusY="6"
+                                           Stroke="#111111" StrokeThickness="2"
+                                           IsHitTestVisible="False"/>
+                                <!-- Inner, white: contrasts a dark fill, and separates the ring from
+                                     the control edge so it never reads as part of the border. -->
+                                <Rectangle Margin="-1"
+                                           RadiusX="5" RadiusY="5"
+                                           Stroke="#FFFFFF" StrokeThickness="1.5"
+                                           IsHitTestVisible="False"/>
+                            </Grid>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <!-- ============================================================ -->
             <!-- Sidebar Expander — smooth slide animation                      -->
             <!-- ============================================================ -->
             <Style x:Key="SidebarExpander" TargetType="Expander">
@@ -245,6 +298,9 @@
             <!-- Theme popup styles                                             -->
             <!-- ============================================================ -->
             <Style x:Key="ModePill" TargetType="RadioButton">
+                <!-- A templated RadioButton loses the default dotted adorner, so the mode pills were
+                     keyboard-operable (arrow keys move the selection) with no cue at all. -->
+                <Setter Property="FocusVisualStyle" Value="{StaticResource FocusRing}"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="RadioButton">
@@ -332,7 +388,10 @@
                 <Setter Property="Padding" Value="14,8"/>
                 <Setter Property="Cursor" Value="Hand"/>
                 <Setter Property="SnapsToDevicePixels" Value="True"/>
-                <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+                <!-- Was {x:Null}: the default dotted adorner was suppressed and the accent border in
+                     the template below stood in for it, which is invisible once a derived style makes
+                     the fill accent-coloured (PrimaryButton) or red (DangerButton). -->
+                <Setter Property="FocusVisualStyle" Value="{StaticResource FocusRing}"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="Button">
@@ -427,7 +486,10 @@
                 <Setter Property="Width" Value="40"/>
                 <Setter Property="Height" Value="22"/>
                 <Setter Property="Cursor" Value="Hand"/>
-                <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+                <!-- The template's own accent ring stays as the resting affordance; this adds the
+                     two-tone adorner, which is what survives the ON state where the track fill IS
+                     the accent (1.00:1 against that border). -->
+                <Setter Property="FocusVisualStyle" Value="{StaticResource FocusRing}"/>
                 <Setter Property="SnapsToDevicePixels" Value="True"/>
                 <Setter Property="Template">
                     <Setter.Value>
@@ -480,6 +542,9 @@
             <!-- Filter Chips — safety level radio buttons                    -->
             <!-- ============================================================ -->
             <Style x:Key="FilterChip" TargetType="RadioButton">
+                <!-- FilterChipCaution and FilterChipCritical derive from this style, so all three
+                     filter chips inherit the ring from here. -->
+                <Setter Property="FocusVisualStyle" Value="{StaticResource FocusRing}"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="RadioButton">
@@ -969,6 +1034,11 @@
                 <Setter Property="VerticalContentAlignment" Value="Center"/>
                 <Setter Property="Cursor" Value="Hand"/>
                 <Setter Property="Padding" Value="8,0,0,0"/>
+                <!-- The custom template below replaces the default one, which took the default focus
+                     adorner with it. Space toggles the box, so a keyboard user could change a setting
+                     without ever seeing which one they were on — worst on the pages that are a column
+                     of checkboxes (Privacy, Debloater, Tweaks). -->
+                <Setter Property="FocusVisualStyle" Value="{StaticResource FocusRing}"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="CheckBox">
@@ -1117,7 +1187,11 @@
                 <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
                 <Setter Property="BorderThickness" Value="0"/>
                 <Setter Property="Padding" Value="10,6"/>
-                <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+                <!-- Was {x:Null} with no replacement, and the template below drops the focus adorner
+                     too, so arrow-key navigation through a grid moved an invisible cursor: the row
+                     highlight does not move per cell, and IsSelected renders a transparent
+                     background. This is the only cue that the current cell exists. -->
+                <Setter Property="FocusVisualStyle" Value="{StaticResource FocusRing}"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="DataGridCell">

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.5</Version>
-    <FileVersion>1.65.5.0</FileVersion>
-    <AssemblyVersion>1.65.5.0</AssemblyVersion>
+    <Version>1.65.6</Version>
+    <FileVersion>1.65.6.0</FileVersion>
+    <AssemblyVersion>1.65.6.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/ConsoleView.xaml
+++ b/SysManager/SysManager/Views/ConsoleView.xaml
@@ -36,7 +36,10 @@
                         <Setter Property="Padding" Value="8,1"/>
                         <Setter Property="Background" Value="Transparent"/>
                         <Setter Property="BorderThickness" Value="0"/>
-                        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+                        <!-- Was {x:Null} with a transparent background and no border, so arrow-keying
+                             through the output moved a selection nothing rendered. The shared ring is
+                             the only cue that a log line is current. -->
+                        <Setter Property="FocusVisualStyle" Value="{StaticResource FocusRing}"/>
                     </Style>
                 </ListBox.ItemContainerStyle>
                 <ListBox.ItemTemplate>


### PR DESCRIPTION
## What does this PR do?

Makes the keyboard focus ring visible. Today it is invisible on the most important buttons in the
app, on **every one of the 12 colour presets**.

## The defect, measured

The focus cue was an `Accent`-coloured border set *inside each control's own template*, so it is
drawn **on** the control's fill. `PrimaryButton`'s fill IS the accent, and `DangerButton`'s is red:

| Style | Ring vs its own fill | Presets failing 3:1 |
|---|---|---|
| `PrimaryButton` | **1.00:1** — literally the same colour | **all 12** |
| `DangerButton` | 1.02 – 1.75:1 | **all 12** |
| `ButtonBase` / `SecondaryButton` | 2.24 – 2.53:1 | Sky Breeze, Warm Sand, Mint Fresh |
| `GhostButton` | 2.60, 2.86:1 | Sky Breeze, Warm Sand |

WCAG 1.4.11 (Non-text Contrast) asks 3:1 of a focus indicator. Every number above was derived from
`ThemeService.cs` — including `Surface3 = Lerp(Surface2, TextPrimary, 0.05)`, read from the
`SetBrush` calls rather than guessed (an earlier pass assumed a lerp toward black/white and produced
wrong figures).

Separately: **four styles** set `FocusVisualStyle="{x:Null}"` with nothing in its place — `ButtonBase`,
`ToggleSwitch`, `DataGridCell`, and ConsoleView's log rows — and **five templated styles** never
carried a ring at all (`ModePill`, `FilterChip` + its two derived variants, `CheckBox`). Space still
ticks a checkbox and arrow keys still move through a grid, so a keyboard user could change a Privacy
setting or select a row without ever seeing which one they were on.

## Why two-tone, and what was rejected

No single colour can work, because the ring has to land on the accent, on red, on a raised grey and
on a card surface. Two alternatives were measured and rejected:

- **Accent ring offset outside the control** — still 2.60:1 against Sky Breeze's card surface.
- **`TextPrimary`-coloured ring** — 1.93:1 against Warm Ember's amber accent.

The ring is now **two strokes of opposite tone**: a white inner and a near-black outer, 18.9:1 apart
from each other. Whatever fill it lands on, at least one stroke contrasts it.

```
worst case of max(white-vs-fill, black-vs-fill), 12 presets x 6 fills:  4.47:1
tightest fills: midnight-indigo/accent 4.47 · clean-indigo/accent 4.47 · soft-blossom/accent 4.60
no fill scores under 3.0 on BOTH strokes:                               True
```

Both strokes are always drawn, so nothing has to detect the fill at runtime — the guarantee is
arithmetic, not conditional.

**Accent is deliberately not used.** It stays the hover and selection colour, so the purple identity
is unchanged; this only affects the keyboard cue.

## Why one adorner instead of eleven template borders

`FocusRing` is defined once in `App.xaml` and applied through `FocusVisualStyle`. An adorner renders
in the adorner layer *above* the control, so it needs no template change, no reserved
`BorderThickness`, and — the point — it cannot be swallowed by a derived style that overrides
`BorderBrush`, which is exactly how `PrimaryButton` broke the inherited ring. The existing
per-template `IsKeyboardFocused` triggers are left in place as the resting affordance on neutral
fills; all 9 of them still build.

## Two findings refuted, not fixed

- **`ComboBoxToggleButton`** is `Focusable="False"` — it can never receive keyboard focus, so a ring
  there would be dead markup.
- **`ComboBoxItem`** already has an `IsHighlighted` trigger, which is what a dropdown moves with the
  arrow keys. Adding a focus ring would be the wrong mechanism.

Both were flagged by my own scan for templated interactive styles without a ring; neither is a defect.

## Verification

**Red before, green after.** The guard fails on the pre-fix tree naming all four suppressed sites:

```
RED  ...FocusVisualStyle at the shared FocusRing instead of {x:Null}:
       App.xaml:335   App.xaml:430   App.xaml:1120   ConsoleView.xaml:39
```

**Each of the guard's four claims was then shown to fail on its own** — green-after-fix alone would
not prove the guard enforces the *shape* of the fix:

| Mutation | Result |
|---|---|
| one `FocusVisualStyle` re-nulled | RED — names the re-nulled style |
| every `FocusRing` reference deleted | RED — "only 1 styles reference the shared FocusRing" |
| ring collapsed to a single stroke | RED — `Assert.Equal` 2 strokes, got 1 |
| ring repainted with `{DynamicResource Accent}` | RED — `Assert.Equal` 2 strokes, got 1 |

`App.xaml` was restored byte-for-byte afterwards and re-asserted equal to the original.

One note on the method: my first attempt at the single-stroke mutation produced invalid XAML, the
build failed, the guard never ran, and my script read "no RED in the output" as green — i.e. it
reported the guard as *not* enforcing that claim. The harness now treats a build failure as its own
verdict, and the mutation writes a valid one-Rectangle `Grid` in full. Worth stating because the
first result was wrong in the direction that would have shipped a false claim in this description.

**Other checks:**

- All four projects build Release, **0 errors 0 warnings** (`TreatWarningsAsErrors` is on).
- Format gate on all four projects: **CLEAN**.
- All 64 XAML files parse.
- The 9 workflow/doc/architecture guards in `ArchitectureTests` all pass together.
- Version gates: csproj `1.65.6`, one patch step from `v1.65.5`, CHANGELOG head `1.65.6`,
  SECURITY `1.65.x` still correct (patch bump, so the minor line is unchanged).
- Leak scan: 0 hits across all 32 terms.

## Docs

- `README.md` — new **Keyboard navigation** section under Features, explaining the two-line outline
  in plain language and why one colour cannot work.
- `ARCHITECTURE.md` — records that focus is one shared `FocusRing` resource, why it is an adorner
  rather than a border, and which test pins it.
- `CHANGELOG.md` — 1.65.6 entry, written for someone who uses the keyboard rather than for a
  reviewer.

## Type of change

- [x] Bug fix (`fix:`) — releases a patch
