### PR TITLE
ci: stop the smoke-check from clicking a prompt nobody can answer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,13 +238,26 @@ jobs:
           $exitCode = if ($app.HasExited) { $app.ExitCode } else { $null }
 
           if ($alive) {
-              Write-Host "Process $($app.Id) is alive after 25s; closing it."
-              # Ask first, so the normal shutdown path runs and any teardown fault surfaces.
-              $app.CloseMainWindow() | Out-Null
-              if (-not $app.WaitForExit(15000)) {
-                  Write-Host "::warning::The window did not close within 15s; killing the process."
-                  $app.Kill()
-                  $app.WaitForExit(10000) | Out-Null
+              # Killed outright, NOT closed via CloseMainWindow(). The first version asked politely,
+              # on the theory that the normal shutdown path would surface a teardown fault. On a CI
+              # runner that theory is wrong, and provably so: a runner is always a FIRST launch, so
+              # close-preference.json does not exist, ClosePreferenceService.Load() returns Ask, and
+              # MainWindow.OnClosing shows a modal MessageBox asking whether to keep running in the
+              # notification area. Nobody answers it, so WM_CLOSE never completes and the step warned
+              # "the window did not close within 15s" on the very first release that ran it (v1.65.6).
+              #
+              # That prompt is correct behaviour — it is the fix for #1639/#1827 — so the check was
+              # wrong, not the app. A warning that fires on every single release is worse than no
+              # warning: it trains everyone to ignore the one that eventually matters.
+              #
+              # This step has exactly one job: prove the published binary starts and survives. A clean
+              # shutdown is a different property, it needs a real desktop and a pre-seeded preference,
+              # and it belongs to the FlaUI suite rather than to the release gate.
+              Write-Host "Process $($app.Id) is alive after 25s; stopping it."
+              $app.Kill()
+              if (-not $app.WaitForExit(10000)) {
+                  throw "The process did not exit within 10 seconds of being killed, which means the " +
+                        "runner cannot reclaim it. Investigate before trusting this release."
               }
           }
 

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1912,6 +1912,20 @@ public partial class ArchitectureTests
         // A check that never fails the job is decoration. continue-on-error on this step would make
         // the launch advisory, which is the one thing it must not be.
         Assert.DoesNotContain("continue-on-error", body, StringComparison.Ordinal);
+
+        // It must also NOT close the window politely. A CI runner is always a FIRST launch, so
+        // close-preference.json does not exist, ClosePreferenceService.Load() returns Ask, and
+        // MainWindow.OnClosing raises a modal MessageBox asking whether to keep running in the
+        // notification area. Nothing answers it, so the polite close times out — the step warned
+        // "the window did not close within 15s" on the very first release that ran it (v1.65.6).
+        // The prompt is correct behaviour (it is the fix for #1639/#1827); the polite close was the
+        // wrong check, and a warning that fires on every release is how a gate gets ignored.
+        //
+        // Matched as a CALL — `.CloseMainWindow(` — not as the bare word, because the step's own
+        // comment has to be able to name the thing it deliberately does not do. Asserting on the word
+        // made this fail against the fixed tree, which is a guard that forbids its own explanation.
+        Assert.DoesNotContain(".CloseMainWindow(", body, StringComparison.Ordinal);
+        Assert.Contains(".Kill()", body, StringComparison.Ordinal);
     }
 
     /// <summary>


### PR DESCRIPTION
## What does this PR do?

Fixes the release smoke-check I added in #1885. It warned on the very first release that ran it, and
the warning was the check's fault, not the app's.

## What happened

v1.65.6's release log:

```
Launching D:\a\SystemManager\SystemManager\publish\SysManager-v1.65.6.exe
Process 9260 is alive after 25s; closing it.
##[warning]The window did not close within 15s; killing the process.
```

The step asked the window to close politely first, on the theory that the normal shutdown path would
surface a teardown fault. On a CI runner that theory is wrong, and the chain is fully derivable from
source:

1. `App.xaml.cs:124` — `_trayService` is always created at startup, so it is non-null and
   `OnClosing` does **not** take the early `base.OnClosing(e)` path.
2. `MainWindow.xaml.cs:190` — `_closePreference.Load()`.
3. `ClosePreferenceService.cs:123` — `if (!File.Exists(_path)) return CloseBehavior.Ask;`. A runner
   is always a first launch, so `close-preference.json` does not exist.
4. `MainWindow.xaml.cs:193` — `behavior == CloseBehavior.Ask`, so it calls
   `DialogService.Instance.AskCloseOrMinimize(...)`.
5. `DialogService.cs:43` — the no-UI guard is `if (Application.Current == null)`. The app **is**
   running, so the guard does not apply and `MessageBox.Show` at line 53 really appears — modal.
6. Nothing answers it → `WM_CLOSE` never completes → 15s timeout → kill.

**The prompt is correct behaviour.** It is the fix for #1639/#1827: the first time someone presses X,
the app asks once whether to keep running in the notification area, and remembers the answer.

Worth being explicit, since I raised this as a suspected regression: **it is not one.** #1827 was
"the process survives with no window AND no tray icon", and that fix is intact —
`MainWindow.xaml.cs:239` still calls `Application.Current?.Shutdown()` before `base.OnClosing(e)` on
the exit branch.

## The change

The step kills the process directly after the 25-second hold, and throws if it cannot be reclaimed
within 10 seconds of that. Everything else is untouched: it still launches the real published exe,
still requires the process to be alive after 25s, still checks `last-crash.json`, and still dumps the
log tail before either throw.

A clean shutdown is a genuinely different property. It needs a real desktop and a pre-seeded
preference file, so it belongs to `ci.yml`'s FlaUI job, not to the release gate.

I considered seeding `close-preference.json` with `Exit` before launching instead. Rejected: it would
make the gate exercise a path that most users do not have on first run, and the step's job is to
prove the binary *starts*, not to rehearse shutdown.

## Why a warning was worth a PR

It would have fired on every single release from here on. That is how a gate stops being read — and
this one exists precisely to be believed the day it reports something real.

## Guard

`TheReleaseWorkflow_LaunchesTheExeBeforeItPublishesAnything` gains the missing half of the contract:

- must **not** call `.CloseMainWindow(`
- must call `.Kill()`

Matched as a **call**, not as the bare word. My first version asserted on the word and went red
against the fixed tree — the step's own comment explains what it deliberately does not do, so a
word-level assertion forbids its own explanation. Caught by running it, not by reasoning about it.

## Verification

Red before, green after, each new claim isolated:

| Mutation | Result |
|---|---|
| previous step body, taken verbatim from `HEAD` via `git show` | RED — `Assert.DoesNotContain` failure |
| `.Kill()` removed, everything else kept | RED — `Assert.Contains` failure |
| unmutated | GREEN |

Mutation 1 uses the real previous body from git rather than a hand-written approximation, so it
proves the guard rejects exactly what shipped. `release.yml` was restored byte-for-byte and
re-asserted equal to the original afterwards.

**Other checks:**

- All four projects build Release, **0 errors 0 warnings**.
- Format gate on all four projects: **CLEAN**.
- All four workflows parse as YAML; step order re-read from the parsed document (Smoke-check still at
  index 10, between Attest and Extract release notes).
- The release-notes footer ASCII gate re-derived independently: same 47-line footer, expected markers
  present, 0 non-ASCII. This edit sits above the template, and that gate has broken a release before
  by slicing the wrong lines, so it was checked rather than assumed.
- The other three `ArchitectureTests` doc/workflow guards still pass alongside it.
- Version untouched — csproj `1.65.6`, newest tag `v1.65.6`, CHANGELOG head `1.65.6`.
- Leak scan: 0 hits across all 32 terms.

## Type of change

- [x] CI / build (`ci:`)

`ci:` publishes no release, so no CHANGELOG entry and no version bump.
