### PR TITLE
fix: log the sensor topology once per session, not once every two seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.7] - 2026-08-14
+
+The diagnostic log no longer fills up with the same repeated line. If you ever need to send a log to
+report a problem, what is in it is now actually about your problem — before, roughly two lines every
+second were the app re-listing the same temperature sensors, which pushed everything else out.
+
+### Fixed
+- **The log recorded the same sensor list every two seconds, forever.** Each time the Dashboard
+  refreshed temperatures — every two seconds while the app is open — it wrote one line per piece of
+  hardware describing how many temperature sensors that hardware has. That list never changes while
+  the app is running, so on a typical machine it was four identical lines a second time, and again,
+  and again. The log keeps a bounded amount of history, so this steadily evicted the entries that
+  would actually explain a fault: when a release check dumped the last 40 lines, all 40 were this one
+  message. The sensor list is now recorded once per run, where it is genuinely useful, and the
+  repetition is gone.
+
 ## [1.65.6] - 2026-08-14
 
 If you use the keyboard instead of the mouse, you can now see where you are. Pressing Tab moves a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2010,6 +2010,54 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"Stroke=""#[0-9A-Fa-f]{6}""", RegexOptions.Compiled)]
     private static partial Regex StrokeAttribute();
 
+    /// <summary>
+    /// No log statement sits unguarded inside a hardware-enumeration loop that a poll re-enters.
+    /// <para><c>TemperatureService.ReadViaLibreHardwareMonitor</c> logged one line per hardware item
+    /// per call, and the Dashboard polls it every 2 seconds
+    /// (<c>DashboardViewModel.StartTemperaturePolling</c>, <c>Task.Delay(2000)</c>) — so a machine with
+    /// four LHM devices produced four Debug lines every two seconds for as long as the app ran. The
+    /// v1.65.6 release smoke-check dumps the last 40 log lines when a launch fails; all 40 were that
+    /// one message, which means a real fault would have been pushed out of the window by noise. The log
+    /// is also the only diagnostic a user can send, and it is bounded (10 MB × 14 files), so the spam
+    /// evicts genuine history.</para>
+    /// <para>Sensor topology is static hardware identity — the same class already memoizes disk names
+    /// and NvAPI init for exactly that reason — so it is logged once per session behind a flag. This
+    /// asserts the flag exists, guards the log, and is only set after the loop completes, because
+    /// setting it before would lose the remaining hardware if a read threw partway through.</para>
+    /// <para>Cannot be a behavioural test: the LHM path needs administrator rights and real sensors,
+    /// so <c>ReadAllAsync</c> returns early under <c>skipHardwareInit</c> in every test. The shape of
+    /// the fix is assertable from source; the behaviour is not.</para>
+    /// </summary>
+    [Fact]
+    public void TheSensorTopologyLog_RunsOncePerSession_NotOncePerPoll()
+    {
+        var source = File.ReadAllText(
+            Path.Combine(FindAppProjectDir(), "Services", "TemperatureService.cs"));
+
+        const string flag = "_loggedSensorTopology";
+        Assert.Contains($"private bool {flag};", source, StringComparison.Ordinal);
+
+        // The poll loop is the thing that makes an unguarded log expensive, so pin that it is still a
+        // loop: if the enumeration were ever restructured, this guard should be revisited, not passed.
+        var loopAt = source.IndexOf("foreach (var hardware in _computer.Hardware)", StringComparison.Ordinal);
+        Assert.True(loopAt > 0, "the LHM hardware loop was not found — fix this guard, do not delete it.");
+
+        var logAt = source.IndexOf("LHM: {Type}", StringComparison.Ordinal);
+        Assert.True(logAt > loopAt, "the topology log is no longer inside the hardware loop.");
+
+        // The log must sit behind the flag. Checked as the text between the loop head and the log call,
+        // so a guard placed anywhere else in the file cannot satisfy this.
+        var beforeLog = source[loopAt..logAt];
+        Assert.Contains($"if (!{flag})", beforeLog, StringComparison.Ordinal);
+
+        // And the flag must be set AFTER the loop body, not before or inside it: setting it on the
+        // first hardware item would drop every later device from the one session that logs them.
+        var setAt = source.IndexOf($"{flag} = true;", StringComparison.Ordinal);
+        Assert.True(setAt > logAt,
+            $"{flag} is set at {setAt} but the log is at {logAt} — it must be set after the loop, so a "
+            + "read that throws partway through can still log the rest on its next attempt.");
+    }
+
     /// <summary>The app project directory — .xaml is not copied to the test output.</summary>
     private static string FindAppProjectDir()
     {

--- a/SysManager/SysManager/Services/TemperatureService.cs
+++ b/SysManager/SysManager/Services/TemperatureService.cs
@@ -41,6 +41,20 @@ public sealed class TemperatureService : IDisposable
     private List<string>? _cachedStorageFriendlyNames; // DiskHealthService friendly names, guarded by _enrichGate
     private readonly SemaphoreSlim _enrichGate = new(1, 1);
 
+    // The sensor TOPOLOGY — which hardware exists and how many temperature sensors each exposes — is
+    // static hardware identity, exactly like the disk names above, so it is logged once per session
+    // instead of once per hardware item per poll. It was 4 lines every 2 seconds (the Dashboard's
+    // temperature poll, DashboardViewModel.cs:379), i.e. ~2 lines/second for as long as the app runs.
+    //
+    // That matters because the rotating log is the ONLY diagnostic a user can send, and it is the only
+    // evidence available when the app dies before showing a window. The release smoke-check dumps the
+    // last 40 lines on failure; on v1.65.6 all 40 were this one message, so a real fault would have
+    // been pushed out of the window by noise. Bounded at 10 MB x 14 files (LogService), so the spam
+    // also evicts genuine history.
+    //
+    // Guarded by _sensorLock, which is already held wherever this is read or written.
+    private bool _loggedSensorTopology;
+
     public TemperatureService(DiskHealthService diskHealth, bool skipHardwareInit = false)
     {
         _diskHealth = diskHealth;
@@ -105,9 +119,15 @@ public sealed class TemperatureService : IDisposable
                     foreach (var subHardware in hardware.SubHardware)
                         subHardware.Update();
 
-                    Log.Debug("LHM: {Type} '{Name}' — {SensorCount} temp sensors",
-                        hardware.HardwareType, hardware.Name,
-                        hardware.Sensors.Count(s => s.SensorType == SensorType.Temperature));
+                    // Topology once per session, not once per hardware item per 2s poll — see
+                    // _loggedSensorTopology. The diagnostic value is "what sensors does this machine
+                    // expose", which is answered by the first read and unchanged by the 30th.
+                    if (!_loggedSensorTopology)
+                    {
+                        Log.Debug("LHM: {Type} '{Name}' — {SensorCount} temp sensors",
+                            hardware.HardwareType, hardware.Name,
+                            hardware.Sensors.Count(s => s.SensorType == SensorType.Temperature));
+                    }
 
                     var component = hardware.HardwareType switch
                     {
@@ -209,6 +229,10 @@ public sealed class TemperatureService : IDisposable
                         }
                     }
                 }
+
+                // Set only after the loop completed, so a read that threw partway through can log the
+                // remaining hardware on its next attempt rather than losing it for the session.
+                _loggedSensorTopology = true;
             }
             catch (Exception ex)
             {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.6</Version>
-    <FileVersion>1.65.6.0</FileVersion>
-    <AssemblyVersion>1.65.6.0</AssemblyVersion>
+    <Version>1.65.7</Version>
+    <FileVersion>1.65.7.0</FileVersion>
+    <AssemblyVersion>1.65.7.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## What does this PR do?

Stops the diagnostic log from filling with one repeated line. Found by the release smoke-check added
in #1885 — the first thing it caught that was a genuine app defect.

## The defect

`TemperatureService.ReadViaLibreHardwareMonitor` logged one Debug line per hardware item on **every
call**, and the Dashboard calls it every two seconds (`DashboardViewModel.cs:379`, `Task.Delay(2000)`).
Four LHM devices means four lines every two seconds — roughly **two lines per second** — for as long
as the app is open, all repeating information that cannot change: which hardware exists and how many
temperature sensors it exposes.

Cadence confirmed from the v1.65.6 release log timestamps rather than assumed:

```
35.052  35.766  37.072  39.099  41.126  43.135
deltas:  0.71   1.31    2.03    2.03    2.01     -> steady 2s poll after the first tick
```

**Why it matters more than "noisy logs".** The smoke-check dumps the last 40 log lines when a launch
fails, because the log is the only diagnostic available if the app dies before showing a window. On
v1.65.6 **all 40 lines were this one message**. So the safety net that exists precisely for a silent
crash would have shown nothing useful. The log is also the only thing a user can send us, and it is
bounded (10 MB × 14 files in `LogService`), so the repetition steadily evicts real history.

## The fix

Sensor topology is static hardware identity, and this class already memoizes exactly that kind of
thing for exactly this reason — `_cachedWmiDiskNames`, `_cachedStorageFriendlyNames`,
`_nvApiInitTried`, each with a comment saying "resolve static hardware once". So the fix follows the
established pattern rather than inventing one: a `_loggedSensorTopology` flag guards the log.

Set **after** the loop completes, not on the first item: a read that throws partway through can then
log the remaining hardware on its next attempt instead of losing it for the whole session. Guarded by
`_sensorLock`, which is already held at both sites.

The line itself is unchanged and still emitted — once, where it is genuinely useful.

## Guard

`TheSensorTopologyLog_RunsOncePerSession_NotOncePerPoll` asserts the shape of the fix: the flag
exists, the log is still inside the hardware loop, the `if (!flag)` sits *between the loop head and
the log call* (so a guard placed elsewhere in the file cannot satisfy it), and the flag is set after
the log rather than before.

**It cannot be a behavioural test, and that is the point.** The LHM path needs administrator rights
and real sensors, so `ReadAllAsync` returns early under `skipHardwareInit` in every existing test —
which is exactly how two lines per second went unnoticed. The shape is assertable from source; the
behaviour is not, and I would rather say so than write a test that asserts nothing.

## Verification

Red before, green after. Four mutations, each isolating one claim:

| Mutation | Result |
|---|---|
| pre-fix file restored from `HEAD` via `git show` | RED — `Assert.Contains`: flag not found |
| flag declaration deleted | RED — `Assert.Contains`: flag not found |
| log unguarded, flag kept | RED — `Assert.Contains`: `if (!flag)` not found |
| flag set *before* the loop | RED — "set at 5788 but the log is at 6451" |

Mutation 1 uses the real pre-fix file from git, so it proves the guard rejects exactly what shipped in
v1.65.6. `TemperatureService.cs` restored byte-for-byte and re-asserted equal afterwards.

One honest note on method: my first attempt at the third mutation **did not compile**. Removing the
guard leaves the flag written but never read, and `TreatWarningsAsErrors` turns CS0414 into an error —
a real second line of defence worth knowing about. But a mutation that never builds proves nothing
about the *guard*, and my harness initially read "no RED in the output" as green, i.e. it reported the
guard as not enforcing that claim. The harness now treats a build failure as its own verdict, and the
mutation gives the flag a harmless read to isolate the assertion under test.

**Other checks:**

- All four projects build Release, **0 errors 0 warnings**.
- Format gate on all four projects: **CLEAN**.
- All **10** `ArchitectureTests` doc/workflow/architecture guards pass together after the rebase onto
  #1888.
- Version gates: csproj `1.65.7`, one patch step from `v1.65.6`, CHANGELOG head `1.65.7`,
  SECURITY `1.65.x` unchanged (patch bump, so the minor line is correct as-is).
- Leak scan: 0 hits across all 32 terms.
- No debug code, TODO or HACK in the additions.

## Docs

`CHANGELOG.md` — 1.65.7 entry written for someone who might one day be asked to send a log, not for a
reviewer. No README or ARCHITECTURE change: nothing user-visible in the UI changed, and the logging
model is already documented there.

## Type of change

- [x] Bug fix (`fix:`) — releases a patch
