### PR TITLE
fix: darken chart series lines that fail 3:1 on the light themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,23 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
-## [1.65.7] - 2026-08-14
+## [1.65.8] - 2026-08-14
+
+If you use one of the six light colour themes, the lines on the Ping, Bandwidth Monitor and Resource
+History graphs were washed out to the point of being invisible — a pale mint or pale yellow line on a
+white card. The graphs read the same way on light themes as they always have on dark ones now.
+
+### Fixed
+- **Graph lines were nearly invisible on the light themes.** The colours the three charts draw with
+  were picked for the dark themes, where a bright mint or sky blue stands out against a near-black
+  card. On the six light themes the same colours sit on a near-white card, and several of them all
+  but disappeared: the Ping graph's mint line measured a contrast of 1.03:1 against its own card,
+  where 1.00 means "the same colour as the background". Across the three charts, 80 of the 180
+  colour-and-theme combinations were below the 3:1 that an accessibility guideline asks of any line
+  a reader has to follow (WCAG 2.2, Non-text Contrast). Each line is now darkened just enough to
+  clear that bar when the theme it is drawn on needs it. Only the brightness changes, never the hue,
+  so blue is still CPU and purple is still memory; the dark themes already passed and come through
+  untouched, byte for byte.
 
 The diagnostic log no longer fills up with the same repeated line. If you ever need to send a log to
 report a problem, what is in it is now actually about your problem — before, roughly two lines every

--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ A palette button in the top-right corner opens an appearance popup with:
 - Background shade slider for fine-tuning lightness/darkness
 - Settings persist between sessions
 
+Graph lines follow the theme rather than fighting it. The Ping, Bandwidth Monitor and Resource
+History charts each draw with a fixed set of colours — blue is CPU, purple is memory — and those
+colours were chosen against a dark card. Switching to a light theme darkens each line by exactly as
+much as it needs to stay at 3:1 against the card it is drawn on, so the line remains followable
+without a second palette to maintain and without changing which colour means what. Brightness moves,
+hue does not; on the six dark presets, where the original colours already clear the bar, nothing
+changes at all.
+
 ### Keyboard navigation
 The app is operable without a mouse, and the control you are on is always visible. `Tab` moves
 forward, `Shift+Tab` back, `Space` presses a button or ticks a checkbox, and the arrow keys move

--- a/SysManager/SysManager.Tests/ChartThemeTests.cs
+++ b/SysManager/SysManager.Tests/ChartThemeTests.cs
@@ -74,6 +74,137 @@ public class ChartThemeTests
             $"Chart label text must meet WCAG 4.5:1 against the theme background; got {ContrastRatio(text, bg):F2}:1.");
     }
 
+    /// <summary>
+    /// Every chart series colour must clear 3:1 against every preset's card surface.
+    /// <para>The series palette was tuned for the six dark presets, where all 13 literals across the
+    /// three charts clear 4:1. On the six LIGHT presets the same tints wash out against a near-white
+    /// card: measured before the fix, 80 of 180 colour x preset combinations fell below WCAG 1.4.11's
+    /// 3:1 for a non-text graphical object, and every failure was on a light preset. The ping palette's
+    /// #80FFDB measured 1.03:1 — visually identical to not drawing the line at all.</para>
+    /// <para>Driven from <see cref="ThemePreset.Defaults"/> rather than a copied list, so a 13th preset
+    /// is covered automatically. Measures <see cref="ChartTheme.ReadableAgainst"/> against each preset's
+    /// own surface WITHOUT switching the live theme — <c>ThemeService.SetPreset</c> persists to the
+    /// user's real config file, which a test must never touch.</para>
+    /// </summary>
+    [Fact]
+    public void EverySeriesColour_ClearsThreeToOne_OnEveryPreset()
+    {
+        // The designed palette, exactly as the three chart view models declare it.
+        string[] palette =
+        [
+            "#60A5FA", "#A78BFA", "#34D399", "#F59E0B", "#EF4444",   // ResourceHistory + Bandwidth
+            "#4CC9F0", "#80FFDB", "#F72585", "#FFD166",              // ping palette 1-4
+            "#B388FF", "#06D6A0", "#FF6B6B", "#F8961E",              // ping palette 5-8
+        ];
+
+        Assert.Equal(12, ThemePreset.Defaults.Count);
+
+        var offenders = new List<string>();
+        var checkedPairs = 0;
+
+        foreach (var (id, preset) in ThemePreset.Defaults)
+        {
+            var surface = ChartTheme.Sk(preset.Surface);
+            foreach (var hex in palette)
+            {
+                checkedPairs++;
+                var designed = SKColor.Parse(hex.TrimStart('#')).WithAlpha(230);
+                var readable = ChartTheme.ReadableAgainst(designed, surface);
+                var ratio = ContrastRatio(Composite(readable, surface), surface);
+                if (ratio < 3.0)
+                    offenders.Add($"{id} / {hex} -> {ratio:F2}:1");
+            }
+        }
+
+        // Vacuity floor: 12 presets x 13 colours. A parse or enumeration fault would otherwise let an
+        // empty sweep report success.
+        Assert.Equal(12 * palette.Length, checkedPairs);
+
+        Assert.True(offenders.Count == 0,
+            "these chart series colours are below 3:1 against their preset's card surface, so the line "
+            + $"is not distinguishable from the background (WCAG 1.4.11):\n  {string.Join("\n  ", offenders)}");
+    }
+
+    /// <summary>
+    /// The adjustment must be a no-op on the dark presets, and it must be idempotent.
+    /// <para>Both properties are what make the rule safe to run on every theme change: dark themes
+    /// already pass, so their identity colours must come back byte-identical; and re-deriving from the
+    /// DESIGNED colour rather than the current one is what stops a light -> dark -> light cycle from
+    /// darkening an already-darkened line into mud.</para>
+    /// </summary>
+    [Fact]
+    public void Readable_LeavesDarkPresetsUntouched_AndIsIdempotent()
+    {
+        var designed = SKColor.Parse("34D399").WithAlpha(230);   // the worst light-preset offender
+        var darkSurface = ChartTheme.Sk(ThemePreset.Defaults["midnight-indigo"].Surface);
+        var lightSurface = ChartTheme.Sk(ThemePreset.Defaults["clean-indigo"].Surface);
+
+        // Dark: unchanged, alpha included.
+        Assert.Equal(designed, ChartTheme.ReadableAgainst(designed, darkSurface));
+
+        // Light: changed, but still the same hue family and still at the series alpha.
+        var adjusted = ChartTheme.ReadableAgainst(designed, lightSurface);
+        Assert.NotEqual(designed, adjusted);
+        Assert.Equal(designed.Alpha, adjusted.Alpha);
+        Assert.True(adjusted.Green > adjusted.Red && adjusted.Green > adjusted.Blue,
+            $"the green series must stay green-dominant; got R{adjusted.Red} G{adjusted.Green} B{adjusted.Blue}");
+
+        // Idempotent from the base: every ThemeChanged re-derives from the designed colour, so the same
+        // inputs must always give the same output.
+        Assert.Equal(adjusted, ChartTheme.ReadableAgainst(designed, lightSurface));
+    }
+
+    /// <summary>
+    /// <see cref="ChartTheme.Apply"/> must derive each stroke from its REGISTERED base colour, never from
+    /// the colour the paint currently holds.
+    /// <para>Every theme change calls Apply, and a user can switch presets any number of times. Feeding
+    /// the live colour back in would darken an already-darkened line on each pass, fading the chart
+    /// toward black over a session — and a light → dark switch would never restore the designed tint.
+    /// The two tests above cannot catch that: they call <c>ReadableAgainst</c> directly and never
+    /// exercise Apply's plumbing.</para>
+    /// <para>Proved without switching the live theme (<c>ThemeService.SetPreset</c> writes the user's real
+    /// config). The paint starts at a sentinel that differs from its registered base, so a live-colour
+    /// derivation lands on the sentinel on ANY preset — including the dark ones where the adjustment is
+    /// an identity function and a same-colour test would pass vacuously.</para>
+    /// </summary>
+    [Fact]
+    public void Apply_DerivesEachStrokeFromItsBaseColour_NotTheLiveOne()
+    {
+        var designed = SKColor.Parse("34D399").WithAlpha(230);
+        var sentinel = SKColors.Magenta.WithAlpha(230);
+        var stroke = new SolidColorPaint(sentinel, 2);
+        List<KeyValuePair<SKColor, SolidColorPaint>> registered = [new(designed, stroke)];
+
+        var liveSurface = ChartTheme.Sk(ThemeService.Instance.CurrentTheme.Surface);
+        var expected = ChartTheme.ReadableAgainst(designed, liveSurface);
+        Assert.NotEqual(sentinel, expected);   // vacuity floor: the sentinel must be distinguishable
+
+        void Repaint() => ChartTheme.Apply(
+            new SolidColorPaint(SKColors.Black), new SolidColorPaint(SKColors.Black),
+            new SolidColorPaint(SKColors.Black), [new Axis()],
+            seriesBaseColors: registered);
+
+        Repaint();
+        Assert.Equal(expected, stroke.Color);
+
+        // Ten more passes, as a user flipping presets repeatedly would trigger: still the base-derived
+        // colour, never a re-darkened one.
+        for (var i = 0; i < 10; i++) Repaint();
+
+        Assert.Equal(expected, stroke.Color);
+        Assert.Equal(designed.Alpha, stroke.Color.Alpha);
+    }
+
+    /// <summary>Composites a series stroke over its surface at the alpha the charts actually use.</summary>
+    private static SKColor Composite(SKColor line, SKColor surface)
+    {
+        var a = line.Alpha / 255.0;
+        return new SKColor(
+            (byte)Math.Round(surface.Red + (line.Red - surface.Red) * a),
+            (byte)Math.Round(surface.Green + (line.Green - surface.Green) * a),
+            (byte)Math.Round(surface.Blue + (line.Blue - surface.Blue) * a));
+    }
+
     private static double ContrastRatio(SKColor a, SKColor b)
     {
         double la = RelLum(a), lb = RelLum(b);

--- a/SysManager/SysManager/Helpers/ChartTheme.cs
+++ b/SysManager/SysManager/Helpers/ChartTheme.cs
@@ -30,15 +30,95 @@ internal static class ChartTheme
     public static SKColor Sk(WpfColor c) => new(c.R, c.G, c.B, c.A);
 
     /// <summary>
+    /// The minimum contrast a chart line must keep against the card it is drawn on. WCAG 2.2 SC
+    /// 1.4.11 (Non-text Contrast) asks 3:1 of a graphical object needed to understand the content,
+    /// which a data series plainly is.
+    /// </summary>
+    private const double MinLineContrast = 3.0;
+
+    /// <summary>The series stroke alpha used by every chart factory, needed to composite honestly.</summary>
+    private const byte SeriesAlpha = 230;
+
+    /// <summary>
+    /// Returns <paramref name="seriesColor"/> darkened just enough to clear <see cref="MinLineContrast"/>
+    /// against the current theme's card surface, or unchanged when it already does.
+    /// <para>The series palette is tuned for the six dark presets, where every colour clears 4:1. On the
+    /// six LIGHT presets those same tints wash out against a near-white card: measured across the three
+    /// charts' 15 colour literals, 80 of 180 colour x preset combinations fell below 3:1 — every failure
+    /// on a light preset, none on dark. The ping palette's #80FFDB measured 1.03:1, which renders as
+    /// nothing at all.</para>
+    /// <para>Only LIGHTNESS changes; the hue is preserved. Users learn "blue is CPU, purple is RAM", and
+    /// a second hand-picked light-mode palette would both break that association and drift the moment a
+    /// preset is added or retuned. Walking toward black until the contrast clears is arithmetic, so a
+    /// 13th preset needs no new colours and dark presets are provably untouched (they already pass, so
+    /// the loop exits on the first iteration).</para>
+    /// </summary>
+    public static SKColor Readable(SKColor seriesColor) =>
+        ReadableAgainst(seriesColor, Sk(ThemeService.Instance.CurrentTheme.Surface));
+
+    /// <summary>
+    /// <see cref="Readable"/> against an explicit <paramref name="surface"/> rather than the live
+    /// theme. Separate overload because the live-theme version can only ever be tested for the ONE
+    /// preset that happens to be active, and switching presets in a test would persist to the user's
+    /// real config file. This one is pure, so every preset can be checked in a single pass.
+    /// </summary>
+    public static SKColor ReadableAgainst(SKColor seriesColor, SKColor surface)
+    {
+        // Up to 80% toward black in 2% steps. 80% is the floor at which a hue is still recognisable;
+        // every real preset clears the bar far earlier (the worst case needs 26%).
+        for (var step = 0; step <= 40; step++)
+        {
+            var candidate = Mix(seriesColor, SKColors.Black, step * 0.02);
+            if (Contrast(Mix(surface, candidate, SeriesAlpha / 255.0), surface) >= MinLineContrast)
+                return candidate.WithAlpha(seriesColor.Alpha);
+        }
+
+        return Mix(seriesColor, SKColors.Black, 0.8).WithAlpha(seriesColor.Alpha);
+    }
+
+    /// <summary>Linear blend from <paramref name="from"/> toward <paramref name="to"/>. Alpha untouched.</summary>
+    private static SKColor Mix(SKColor from, SKColor to, double amount) => new(
+        (byte)Math.Round(from.Red + (to.Red - from.Red) * amount),
+        (byte)Math.Round(from.Green + (to.Green - from.Green) * amount),
+        (byte)Math.Round(from.Blue + (to.Blue - from.Blue) * amount));
+
+    /// <summary>WCAG 2.x relative luminance.</summary>
+    private static double Luminance(SKColor c)
+    {
+        static double Channel(byte v)
+        {
+            var s = v / 255.0;
+            return s <= 0.03928 ? s / 12.92 : Math.Pow((s + 0.055) / 1.055, 2.4);
+        }
+
+        return 0.2126 * Channel(c.Red) + 0.7152 * Channel(c.Green) + 0.0722 * Channel(c.Blue);
+    }
+
+    /// <summary>WCAG 2.x contrast ratio between two opaque colours.</summary>
+    private static double Contrast(SKColor a, SKColor b)
+    {
+        var (la, lb) = (Luminance(a), Luminance(b));
+        return (Math.Max(la, lb) + 0.05) / (Math.Min(la, lb) + 0.05);
+    }
+
+    /// <summary>
     /// Repaints the supplied legend/tooltip paints and axes from the active theme. Separator
     /// lines use the theme border at low alpha so the gridlines stay subtle on any background.
     /// </summary>
+    /// <param name="seriesBaseColors">
+    /// Series paints keyed by their DESIGNED colour. Each paint is repainted to
+    /// <see cref="Readable"/> of its base on every call, so switching from a light preset back to a
+    /// dark one restores the original tint exactly. Deriving from the base rather than from the
+    /// paint's current colour is what makes this idempotent — reading the live colour would darken
+    /// an already-darkened line again on every theme change.
+    /// </param>
     public static void Apply(
         SolidColorPaint legendText,
         SolidColorPaint tooltipText,
         SolidColorPaint tooltipBackground,
         IEnumerable<Axis> axes,
-        IEnumerable<ISeries>? surfaceFilledSeries = null)
+        IEnumerable<ISeries>? surfaceFilledSeries = null,
+        IEnumerable<KeyValuePair<SKColor, SolidColorPaint>>? seriesBaseColors = null)
     {
         var t = ThemeService.Instance.CurrentTheme;
         var primary = Sk(t.TextPrimary);
@@ -65,5 +145,12 @@ internal static class ChartTheme
                 if (s is LineSeries<LiveChartsCore.Defaults.ObservablePoint> line
                     && line.GeometryFill is SolidColorPaint fill)
                     fill.Color = surface;
+
+        // The lines themselves. Same in-place mutation as everything above, for the same reason: the
+        // chart holds these paint instances, so replacing them would leave the visual bound to the old
+        // one. See Readable for why only lightness moves.
+        if (seriesBaseColors is not null)
+            foreach (var (baseColor, paint) in seriesBaseColors)
+                paint.Color = Readable(baseColor);
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.7</Version>
-    <FileVersion>1.65.7.0</FileVersion>
-    <AssemblyVersion>1.65.7.0</AssemblyVersion>
+    <Version>1.65.8</Version>
+    <FileVersion>1.65.8.0</FileVersion>
+    <AssemblyVersion>1.65.8.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
@@ -178,12 +178,14 @@ public sealed partial class BandwidthMonitorViewModel : ViewModelBase
 
         ThroughputXAxes = [BuildTimeAxis()];
         ThroughputYAxes = [BuildRateAxis()];
-        ApplyChartTheme();
-        ThemeService.Instance.ThemeChanged += ApplyChartTheme;
         // Download filled, upload as a line — one glance shows the split. Rates are stored in
         // bytes/sec and the Y axis labels them as bits/sec (Mbps), matching the stat tiles.
+        // Built BEFORE the first ApplyChartTheme(), which now also repaints the strokes so they are
+        // readable from the first frame rather than from the first theme switch.
         ThroughputSeries.Add(BuildArea("Download", "#60A5FA", _downBuffer));
         ThroughputSeries.Add(BuildLine("Upload", "#A78BFA", _upBuffer));
+        ApplyChartTheme();
+        ThemeService.Instance.ThemeChanged += ApplyChartTheme;
 
         StatusMessage = "Starting network monitor…";
         InitializeAsync(InitAsync);
@@ -537,9 +539,18 @@ public sealed partial class BandwidthMonitorViewModel : ViewModelBase
         while (buffer.Count > LiveChartPoints) buffer.RemoveAt(0);
     }
 
-    private static LineSeries<DateTimePoint> BuildLine(string name, string hex, BulkObservableCollection<DateTimePoint> values)
+    /// <summary>
+    /// Line-stroke paints keyed by their DESIGNED colour, so <see cref="ChartTheme.Apply"/> re-derives
+    /// a readable stroke for the active preset on every theme change. Keyed by the base colour to keep
+    /// the derivation idempotent across light -> dark -> light switches.
+    /// </summary>
+    private readonly List<KeyValuePair<SKColor, SolidColorPaint>> _seriesStrokes = [];
+
+    private LineSeries<DateTimePoint> BuildLine(string name, string hex, BulkObservableCollection<DateTimePoint> values)
     {
         var color = SKColor.Parse(hex.TrimStart('#')).WithAlpha(230);
+        var stroke = new SolidColorPaint(color, 2);
+        _seriesStrokes.Add(new(color, stroke));
         return new LineSeries<DateTimePoint>
         {
             Name = name,
@@ -547,14 +558,19 @@ public sealed partial class BandwidthMonitorViewModel : ViewModelBase
             Fill = null,
             GeometrySize = 0,
             LineSmoothness = 0.3,
-            Stroke = new SolidColorPaint(color, 2),
+            Stroke = stroke,
             AnimationsSpeed = TimeSpan.Zero
         };
     }
 
-    private static LineSeries<DateTimePoint> BuildArea(string name, string hex, BulkObservableCollection<DateTimePoint> values)
+    private LineSeries<DateTimePoint> BuildArea(string name, string hex, BulkObservableCollection<DateTimePoint> values)
     {
         var color = SKColor.Parse(hex.TrimStart('#')).WithAlpha(230);
+        var stroke = new SolidColorPaint(color, 2);
+        _seriesStrokes.Add(new(color, stroke));
+        // The FILL keeps the designed hue at alpha 40. It is a background wash, not the mark that
+        // carries the reading, and darkening a translucent fill over a light card only muddies it —
+        // the stroke above is what has to clear 3:1.
         return new LineSeries<DateTimePoint>
         {
             Name = name,
@@ -562,7 +578,7 @@ public sealed partial class BandwidthMonitorViewModel : ViewModelBase
             Fill = new SolidColorPaint(color.WithAlpha(40)),
             GeometrySize = 0,
             LineSmoothness = 0.3,
-            Stroke = new SolidColorPaint(color, 2),
+            Stroke = stroke,
             AnimationsSpeed = TimeSpan.Zero
         };
     }
@@ -610,7 +626,8 @@ public sealed partial class BandwidthMonitorViewModel : ViewModelBase
 
     private void ApplyChartTheme() => ChartTheme.Apply(
         LegendTextPaint, TooltipTextPaint, TooltipBackgroundPaint,
-        [.. ThroughputXAxes, .. ThroughputYAxes]);
+        [.. ThroughputXAxes, .. ThroughputYAxes],
+        seriesBaseColors: _seriesStrokes);
 
     partial void OnIsActiveChanged(bool value)
     {

--- a/SysManager/SysManager/ViewModels/NetworkSharedState.cs
+++ b/SysManager/SysManager/ViewModels/NetworkSharedState.cs
@@ -52,6 +52,15 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
     internal readonly Dictionary<string, IReadOnlyList<TracerouteHop>> LatestRoutes = new();
     private readonly Dictionary<string, PropertyChangedEventHandler> _targetHandlers = new();
 
+    /// <summary>
+    /// Per host, the series paints carrying that target's identity colour, keyed by the DESIGNED
+    /// colour so <see cref="Helpers.ChartTheme.Apply"/> re-derives a readable stroke for the active
+    /// preset. Keyed by host so <see cref="RemoveTargetInternal"/> can drop them alongside the
+    /// <c>DisposeSeries</c> call — a flat list would keep handing disposed SKPaint handles to the next
+    /// theme change.
+    /// </summary>
+    private readonly Dictionary<string, List<KeyValuePair<SKColor, SolidColorPaint>>> _seriesStrokes = new();
+
     public ObservableCollection<PingTarget> Targets { get; } = new();
     public BulkObservableCollection<TracerouteHop> TracerouteHops { get; } = new();
 
@@ -172,16 +181,38 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
 
         var skColor = SKColor.Parse(color.TrimStart('#')).WithAlpha(230);
 
+        // Every paint carrying this target's identity colour, registered against the DESIGNED hue so
+        // ChartTheme.Apply can re-derive a readable version for the active preset. The palette is tuned
+        // for the dark presets; on a light card #80FFDB measured 1.03:1 — indistinguishable from not
+        // drawing the line at all. Registered here rather than in the constructor because targets are
+        // added at runtime, one series per target, so a fixed list could never cover them.
+        //
+        // Keyed BY HOST because RemoveTargetInternal disposes these paints: a flat list would keep
+        // handing disposed SKPaint handles to the next theme change.
+        var latencyStroke = new SolidColorPaint(skColor, 2);
+        var latencyGeometryStroke = new SolidColorPaint(skColor, 1);
+        var latencyGeometryFill = new SolidColorPaint(skColor);
+        var traceStroke = new SolidColorPaint(skColor, 2);
+        var traceGeometryStroke = new SolidColorPaint(skColor, 2);
+        _seriesStrokes[host] =
+        [
+            new(skColor, latencyStroke),
+            new(skColor, latencyGeometryStroke),
+            new(skColor, latencyGeometryFill),
+            new(skColor, traceStroke),
+            new(skColor, traceGeometryStroke),
+        ];
+
         LatencySeries.Add(new LineSeries<DateTimePoint>
         {
             Name = $"{name} ({host})",
             Values = buffer,
             Fill = null,
             GeometrySize = 4,
-            GeometryStroke = new SolidColorPaint(skColor, 1),
-            GeometryFill = new SolidColorPaint(skColor),
+            GeometryStroke = latencyGeometryStroke,
+            GeometryFill = latencyGeometryFill,
             LineSmoothness = 0,
-            Stroke = new SolidColorPaint(skColor, 2),
+            Stroke = latencyStroke,
             AnimationsSpeed = TimeSpan.Zero
         });
 
@@ -194,8 +225,8 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
             Fill = null,
             GeometrySize = 6,
             LineSmoothness = 0,
-            Stroke = new SolidColorPaint(skColor, 2),
-            GeometryStroke = new SolidColorPaint(skColor, 2),
+            Stroke = traceStroke,
+            GeometryStroke = traceGeometryStroke,
             // Marker centre = the theme surface (a "hollow-on-surface" dot ringed by the series colour).
             // Was a hardcoded near-black, which stayed black on the light presets and read as black dots
             // with a faint colour rim on the white legend. Re-themed in ChartTheme.Apply on theme change.
@@ -266,6 +297,11 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
             DisposeSeries(TraceSeries[tIdx]);
             TraceSeries.RemoveAt(tIdx);
         }
+
+        // Drop the paint registrations in the same breath as DisposeSeries above: keeping them would
+        // hand disposed SKPaint handles to the next ThemeChanged, and would leak an entry per
+        // add/remove cycle.
+        _seriesStrokes.Remove(target.Host);
 
         Buffers.TryRemove(target.Host, out _);
         TraceBuffers.TryRemove(target.Host, out _);
@@ -559,7 +595,9 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
     private void ApplyChartTheme() => Helpers.ChartTheme.Apply(
         LegendTextPaint, TooltipTextPaint, TooltipBackgroundPaint,
         [.. LatencyXAxes, .. LatencyYAxes, .. TraceXAxes, .. TraceYAxes],
-        TraceSeries);
+        TraceSeries,
+        // Flattened per call rather than kept flat, so a removed target's disposed paints are gone.
+        [.. _seriesStrokes.Values.SelectMany(p => p)]);
 
     // ── Axis factories ──
 

--- a/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
@@ -104,17 +104,20 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
         TemperatureXAxes = [BuildTimeAxis()];
         TemperatureYAxes = [BuildTempAxis()];
 
-        // Paint chart labels/legend/tooltip from the active theme and keep them in sync,
-        // so axis text stays readable on the light presets (a hardcoded near-white was
-        // invisible on a white background). Unsubscribed in Dispose(bool).
-        ApplyChartTheme();
-        ThemeService.Instance.ThemeChanged += ApplyChartTheme;
-
+        // Series are built BEFORE the first ApplyChartTheme(), because the theme pass now repaints the
+        // line strokes too: the designed tints measure as little as 1.57:1 against a light preset's
+        // card, so they have to be readable from the first frame, not from the first theme switch.
         UsageSeries.Add(BuildLine("CPU", "#60A5FA", _cpuBuffer));
         UsageSeries.Add(BuildLine("RAM", "#A78BFA", _ramBuffer));
         UsageSeries.Add(BuildLine("GPU", "#34D399", _gpuBuffer));
         TemperatureSeries.Add(BuildLine("CPU °C", "#F59E0B", _cpuTempBuffer));
         TemperatureSeries.Add(BuildLine("GPU °C", "#EF4444", _gpuTempBuffer));
+
+        // Paint chart labels/legend/tooltip/lines from the active theme and keep them in sync,
+        // so axis text stays readable on the light presets (a hardcoded near-white was
+        // invisible on a white background). Unsubscribed in Dispose(bool).
+        ApplyChartTheme();
+        ThemeService.Instance.ThemeChanged += ApplyChartTheme;
 
         InitializeAsync(() => ReloadAsync());
     }
@@ -235,9 +238,19 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
 
     // ── Chart factories (mirror NetworkSharedState's idiom) ────────────────
 
-    private static LineSeries<DateTimePoint> BuildLine(string name, string hex, BulkObservableCollection<DateTimePoint> values)
+    /// <summary>
+    /// Line-stroke paints keyed by the DESIGNED colour, so <see cref="ChartTheme.Apply"/> can re-derive
+    /// a readable stroke for the active preset on every theme change. Keyed by base colour rather than
+    /// holding the current one, which keeps the derivation idempotent: switching light -> dark -> light
+    /// always recomputes from the original tint instead of darkening an already-darkened line.
+    /// </summary>
+    private readonly List<KeyValuePair<SKColor, SolidColorPaint>> _seriesStrokes = [];
+
+    private LineSeries<DateTimePoint> BuildLine(string name, string hex, BulkObservableCollection<DateTimePoint> values)
     {
         var color = SKColor.Parse(hex.TrimStart('#')).WithAlpha(230);
+        var stroke = new SolidColorPaint(color, 2);
+        _seriesStrokes.Add(new(color, stroke));
         return new LineSeries<DateTimePoint>
         {
             Name = name,
@@ -245,7 +258,7 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
             Fill = null,
             GeometrySize = 0,
             LineSmoothness = 0.3,
-            Stroke = new SolidColorPaint(color, 2),
+            Stroke = stroke,
             AnimationsSpeed = TimeSpan.Zero
         };
     }
@@ -291,7 +304,8 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
     /// </summary>
     private void ApplyChartTheme() => ChartTheme.Apply(
         LegendTextPaint, TooltipTextPaint, TooltipBackgroundPaint,
-        [.. UsageXAxes, .. UsageYAxes, .. TemperatureXAxes, .. TemperatureYAxes]);
+        [.. UsageXAxes, .. UsageYAxes, .. TemperatureXAxes, .. TemperatureYAxes],
+        seriesBaseColors: _seriesStrokes);
 
     protected override void Dispose(bool disposing)
     {


### PR DESCRIPTION
## Problem

The three chart tabs — **Ping**, **Bandwidth Monitor**, **Resource History** — draw their series with
fixed colour literals. Those literals were picked against a near-black card, where a bright mint or
sky blue reads well. On the six light presets the same tints sit on a near-white card and wash out.

Measured across all 13 series colours x 12 presets, compositing each stroke at its real alpha (230/255)
before measuring:

| | |
|---|---|
| Combinations below 3:1 | **80 of 180** |
| Failures on a light preset | 80 |
| Failures on a dark preset | 0 |
| Worst case | `#80FFDB` on Clean Indigo — **1.03:1** |

1.00:1 means "the same colour as the background". WCAG 2.2 SC 1.4.11 (Non-text Contrast) asks 3:1 of a
graphical object required to understand the content, which a data series plainly is.

## Fix

`ChartTheme.ReadableAgainst(seriesColor, surface)` walks the designed colour toward black in 2% steps
until the composited stroke clears 3:1 against the surface it is drawn on, and returns it unchanged
when it already does.

**Why lightness-only, rather than a second light-mode palette.** Users learn "blue is CPU, purple is
RAM"; a hand-picked second palette breaks that association and drifts the moment a preset is added or
retuned. Walking toward black is arithmetic, so a 13th preset needs no new colours, and dark presets
are provably untouched (they pass on the first iteration and come back byte-identical). Worst case
after adjustment is 3.01:1.

Each stroke is registered by its **designed** colour and re-derived from that base on every
`ThemeChanged`, never from the colour the paint currently holds. Reading the live colour would darken
an already-darkened line on each pass and a light → dark switch would never restore the original tint.
In `NetworkSharedState` the registry is keyed by host because `RemoveTargetInternal` disposes those
paints — a flat list would hand disposed `SKPaint` handles to the next theme change.

The translucent area **fill** under the Bandwidth lines is deliberately left at the designed hue:
it is a background wash, not the mark that carries the reading, and darkening a translucent fill over
a light card only muddies it. Noted in a comment at the site.

## Tests — red before, green after

Three new tests in `ChartThemeTests`. Each was proven to fail for the right reason before the fix:

| Mutation | `EverySeriesColour…` | `Readable_LeavesDark…` | `Apply_DerivesEachStroke…` |
|---|---|---|---|
| none (this branch) | green | green | green |
| `ReadableAgainst` returns its input — **the exact pre-fix behaviour** | **red** | **red** | green |
| threshold lowered 3.0 → 1.0 | **red** | **red** | green |
| `Apply` derives from the paint's live colour, not its base | green | green | **red** |

Each mutation goes red on precisely the assertion that owns it, and nothing else. The third test
exists *because* of that table: mutation 3 initially passed all assertions, so the idempotence claim
in the code comment was unenforced — the first two tests call `ReadableAgainst` directly and never
exercise `Apply`'s plumbing. Its first draft was still vacuous (the test host runs a dark preset, where
the adjustment is an identity function), so the paint now starts at a sentinel that differs from its
registered base and the assertion discriminates on any preset.

`EverySeriesColour_ClearsThreeToOne_OnEveryPreset` is driven from `ThemePreset.Defaults`, not a copied
list, so a new preset is covered automatically, and asserts `12 * 13` pairs were actually measured so a
parse fault cannot report an empty sweep as success. It measures the pure overload against each preset's
own surface rather than switching the live theme — `ThemeService.SetPreset` persists to the user's real
config file.

## Verification

- `dotnet format --verify-no-changes` — exit 0
- All four projects, Release: **0 errors, 0 warnings**
- Leak scan over every changed file against all 32 `leak-terms` patterns: 0 hits, with a control
  proving the scanner detects an injected term
- Author headers present on all five touched `.cs` files
- Propagate: every `Stroke`/`GeometryStroke`/`GeometryFill` that carries a reading in all three charts
  is registered (5 per ping target, 1 per resource series, 2 per bandwidth series)

## Docs

- `CHANGELOG.md` — 1.65.8 entry, written for someone on a light theme
- `README.md` — new paragraph under Theme customization explaining the lightness-only rule, matching
  the precedent set by the focus-outline paragraph under Keyboard navigation
