### PR TITLE
test: validate the whole DI graph in CI, not on the tab click

### DIFF
--- a/SysManager/SysManager.Tests/ServiceRegistrationGraphTests.cs
+++ b/SysManager/SysManager.Tests/ServiceRegistrationGraphTests.cs
@@ -1,0 +1,107 @@
+// SysManager · ServiceRegistrationGraphTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Proves the whole DI graph is resolvable, in CI, on every pull request.
+/// <para>The gap these tests close: <c>App.OnStartup</c> builds the container with default options, so a
+/// registration that cannot be satisfied — someone adds a constructor parameter and forgets to register
+/// its type — is not detected when the container is built. It is detected when that one type is first
+/// resolved. Since tab construction became lazy, "first resolved" means "the user clicked that tab", so
+/// a wiring mistake ships silently and reaches the user as an error dialog on a tab that never opens.
+/// Nothing in either test project built the container before this file existed.</para>
+/// <para><see cref="ServiceProviderOptions.ValidateOnBuild"/> walks every registration's constructor
+/// call sites and reports all unsatisfiable ones at once, WITHOUT invoking any constructor — so this is
+/// safe for services that touch WMI, the registry or the filesystem in their constructors. It ran in
+/// 16 ms against the real 131-registration graph.</para>
+/// <para>Deliberately a test rather than a production setting. <c>ConfigureServices</c> is static and
+/// unconditional, so the graph built here is the graph the app builds — CI catches the break before it
+/// merges. Turning the flag on in <c>App.OnStartup</c> instead would convert "one tab is broken" into
+/// "the app does not start at all" for the least technical user, which is a strictly worse failure for
+/// a bug CI has already caught.</para>
+/// </summary>
+public class ServiceRegistrationGraphTests
+{
+    private static ServiceProviderOptions StrictOptions => new() { ValidateOnBuild = true, ValidateScopes = true };
+
+    private static IServiceCollection RealGraph()
+    {
+        var services = new ServiceCollection();
+        services.ConfigureServices();
+        return services;
+    }
+
+    /// <summary>
+    /// Every registration in <see cref="ServiceRegistration.ConfigureServices"/> must be resolvable.
+    /// </summary>
+    [Fact]
+    public void TheWholeGraph_IsResolvable()
+    {
+        var services = RealGraph();
+
+        // Vacuity floor. An empty or partially-built collection would validate trivially and this test
+        // would report success while proving nothing. 131 registrations at the time of writing; the
+        // floor is deliberately loose so adding a service does not fail an unrelated test.
+        Assert.True(services.Count >= 120,
+            $"expected the real graph to hold 120+ registrations; got {services.Count}. Either "
+            + "ConfigureServices stopped registering most of the app, or this test is no longer "
+            + "building the real graph — in both cases the validation below proves nothing.");
+
+        // BuildServiceProvider throws AggregateException listing EVERY unresolvable descriptor, so a
+        // failure names all the broken wiring at once rather than the first one.
+        using var provider = services.BuildServiceProvider(StrictOptions);
+        Assert.NotNull(provider);
+    }
+
+    /// <summary>
+    /// The validation above must actually be able to fail — a missing dependency has to be caught.
+    /// <para>Without this, <see cref="TheWholeGraph_IsResolvable"/> could pass because validation is
+    /// silently disabled (a wrong options object, a future default change) rather than because the graph
+    /// is sound, and it would keep passing while broken wiring merged.</para>
+    /// </summary>
+    [Fact]
+    public void TheValidation_CatchesAnUnregisteredDependency()
+    {
+        var services = RealGraph();
+        services.AddSingleton<ProbeWithMissingDependency>();
+
+        var ex = Assert.Throws<AggregateException>(() => services.BuildServiceProvider(StrictOptions));
+        Assert.Contains(nameof(ProbeWithMissingDependency), ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// <see cref="ServiceProviderOptions.ValidateScopes"/> must be on: a singleton may not capture a
+    /// scoped service. The app registers no scoped services today, so this asserts the guard is armed
+    /// for the first one that is added rather than describing a current defect.
+    /// </summary>
+    [Fact]
+    public void TheValidation_CatchesASingletonCapturingAScopedService()
+    {
+        var services = RealGraph();
+        services.AddScoped<ScopedProbe>();
+        services.AddSingleton<SingletonCapturingScopedProbe>();
+
+        var ex = Assert.Throws<AggregateException>(() => services.BuildServiceProvider(StrictOptions));
+        Assert.Contains(nameof(SingletonCapturingScopedProbe), ex.Message, StringComparison.Ordinal);
+    }
+
+    // Probes for the two negative tests. Intentionally never registered as a dependency of anything in
+    // the real graph — each exists only to give validation something it must reject.
+    private sealed class NeverRegistered;
+
+    private sealed class ProbeWithMissingDependency(NeverRegistered missing)
+    {
+        private readonly NeverRegistered _missing = missing;
+    }
+
+    private sealed class ScopedProbe;
+
+    private sealed class SingletonCapturingScopedProbe(ScopedProbe scoped)
+    {
+        private readonly ScopedProbe _scoped = scoped;
+    }
+}

--- a/TESTING.md
+++ b/TESTING.md
@@ -115,6 +115,22 @@ collection definitions (all defined in `TestCollections.cs`, each with
   progress assertions need no `Task.Delay`.
 - `StaHelper` — runs a delegate on an STA thread for WPF-dependent types.
 
+### Dependency-graph validation
+
+`ServiceRegistrationGraphTests` builds the real container from `ServiceRegistration.ConfigureServices`
+with `ValidateOnBuild` and `ValidateScopes` enabled, so a registration that cannot be satisfied fails
+CI instead of the tab that resolves it. `ValidateOnBuild` walks constructor call sites without invoking
+any constructor, which is what makes it safe for services that touch WMI, the registry or the
+filesystem — the whole graph validates in milliseconds.
+
+The flag is deliberately a test rather than a production setting: `ConfigureServices` is static and
+unconditional, so the graph the test builds is the graph the app builds, and enabling validation in
+`App.OnStartup` would turn a broken tab into a refusal to start. Two negative tests assert the
+validation is actually armed — one adds a type whose dependency is unregistered, one makes a singleton
+capture a scoped service — because a passing graph test proves nothing if validation is silently off.
+The single factory-lambda registration (`IGamingProfileService`) is opaque to validation; every other
+registration is covered.
+
 ### Conventions
 
 - Pure logic tests (parsers, analyzers, converters) need no mocking.


### PR DESCRIPTION
## Problem

`App.OnStartup` builds the DI container with default options:

```csharp
Services = serviceCollection.BuildServiceProvider();
```

With default options, a registration that cannot be satisfied — someone adds a constructor parameter
and forgets to register its type — is **not** detected when the container is built. It is detected when
that one type is first resolved. Since tab construction became lazy (#1877), "first resolved" means
"the user clicked that tab", so the mistake ships silently and reaches the user as an error dialog on a
tab that never opens.

Nothing covered this. Verified against current source:

```
$ grep -rn "ConfigureServices\|BuildServiceProvider" SysManager/SysManager.Tests/ SysManager/SysManager.IntegrationTests/
(no matches)
$ grep -rn "ValidateOnBuild\|ServiceProviderOptions" SysManager/ --include=*.cs
(no matches)
```

131 registrations, 60+ ViewModels, zero graph coverage.

## Fix

`ServiceRegistrationGraphTests` builds the real graph from `ServiceRegistration.ConfigureServices` with
`ValidateOnBuild = true, ValidateScopes = true`. Validation resolves constructor call sites **without
invoking any constructor**, so it is safe for services that touch WMI, the registry or the filesystem —
it validated the real graph in **16 ms**, and reports every unsatisfiable descriptor at once rather
than the first.

**Why a test and not a production setting.** `ConfigureServices` is static and unconditional, so the
graph this test builds is byte-for-byte the graph the app builds; CI catches the break before it merges.
Turning the flag on in `App.OnStartup` instead would convert "one tab is broken" into "the app does not
start at all" for the least technical user — strictly worse for a bug CI has already caught. There are
also zero `AddScoped` registrations today, so `ValidateScopes` would guard nothing at runtime.

**Coverage boundary, stated honestly:** the one factory-lambda registration
(`IGamingProfileService`, `ServiceRegistration.cs:98`) is opaque to `ValidateOnBuild`, because
validation cannot see inside a `sp => new ...` closure. 130 of 131 registrations are covered.

## Tests — red before, green after

| Mutation | `TheWholeGraph_IsResolvable` | `…CatchesAnUnregisteredDependency` | `…CatchesASingletonCapturingAScopedService` |
|---|---|---|---|
| none (this branch) | green | green | green |
| delete `AddSingleton<SystemInfoService>()` — the real field mistake | **red** | green | green |
| `ConfigureServices` registers nothing (0 descriptors) | **red** (count floor) | green | green |
| `ValidateOnBuild`/`ValidateScopes` set to `false` | green | **red** | **red** |

Row 2 is the mistake this exists for. Row 3 is the vacuity floor: an empty collection validates
trivially, so without the `Count >= 120` assertion the test would report success while proving nothing.
Row 4 is why the two negative tests exist — they assert the validation is *armed*, so the graph test
cannot pass because validation was silently disabled.

The two probe types are `private sealed` nested classes registered only inside the negative tests, so
they cannot affect the real graph.

## Verification

- `dotnet format --verify-no-changes` — exit 0
- All four projects, Release: **0 errors, 0 warnings**
- Standalone harness confirmed the discriminating controls independently before the tests were written:
  real graph PASS (131 registrations), missing dependency FAIL, scoped-from-root FAIL
- Leak scan over both changed files against all 32 `leak-terms` patterns: 0 hits
- Author header present on the new file

## Docs

`TESTING.md` — new "Dependency-graph validation" subsection under Test infrastructure, covering what is
validated, why the flag is a test rather than a production setting, and the factory-lambda blind spot.

`test:` prefix — no release, no version bump.
