### PR TITLE
docs: stop claiming a publisher pin the update path does not enforce yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -887,11 +887,15 @@ offers, "rate us" prompts:
   download is blocked, a "Manual download" button opens GitHub in the
   browser.
 - SHA256 hash verification before install — the downloaded build is checked
-  against the published `.sha256`, so a corrupted or tampered download is
-  blocked. The build is also inspected for an Authenticode signature: if one is
-  present it must belong to the expected publisher and its certificate chain must
-  validate, so a build signed by someone else is refused. SysManager currently
-  ships unsigned, so today the SHA256 match is what guarantees integrity.
+  against the published `.sha256`, so a damaged or truncated download is blocked.
+  Both files come from the same release, so this catches a corrupted download rather
+  than a substituted release asset — see [Verifying the download](#verifying-the-download)
+  for the stronger check, the build attestation, which you run yourself.
+- The build is also inspected for an Authenticode signature, and the check fails
+  closed if a signature is present but cannot be read. SysManager ships unsigned
+  today and no publisher is pinned yet, so a signature is not currently an integrity
+  gate; the publisher-and-certificate-chain check is written and switches on with a
+  one-line change the day a signing certificate exists.
 - One-click "Install" replaces the running executable in-place and
   restarts automatically (no manual file copying needed).
 - **"Go back to the previous version"** — the build being replaced is kept, so an
@@ -1195,11 +1199,13 @@ unmodified build. The attestation is the stronger of the two, and it will remain
 after signing arrives: it records *which commit and workflow* produced a given binary,
 which a signature alone does not.
 
-The update path is already prepared for signing. When a downloaded build carries a
-signature, the app checks that it belongs to the expected publisher and that its
-certificate chain validates, and refuses the update otherwise — so the check cannot
-quietly become a formality on the day signing is switched on. See
-[SECURITY.md](SECURITY.md#security-model) for the detail.
+The update path is already written for signing, but not yet armed. The publisher it
+compares against is a single constant that is deliberately **empty** until a certificate
+exists, so today a signed build is accepted on the strength of the SHA-256 check alone; a
+signature that is present but unreadable is still refused. On the day signing is switched
+on, filling in that one constant turns on the publisher match and the certificate-chain
+validation together — the point of writing them now is that the check cannot quietly become
+a formality later. See [SECURITY.md](SECURITY.md#security-model) for the detail.
 
 ### Code signing policy
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -126,13 +126,15 @@ What the app can and cannot do by design:
   gate, and it is what catches a modified download. The binary is also inspected
   for an Authenticode signature: an unsigned build is accepted, because SysManager
   currently ships unsigned, while a signature that cannot be parsed is rejected.
-  If a signature IS present, the signer must match the pinned publisher and its
-  certificate chain must validate to a trusted root with online revocation —
-  the same policy already applied to the third-party Ookla CLI. That pin is a
-  single constant, empty until a code-signing certificate exists, so the check
-  cannot quietly become a no-op the day signing is switched on: without it, merely
-  *carrying* a signature would pass, and a binary signed by an attacker's own
-  self-issued certificate would be accepted like a legitimate build. Note that
+  The publisher comparison is a single constant that is empty until a code-signing
+  certificate exists, so no publisher is pinned yet: today a signed build is accepted
+  on the strength of the SHA256 comparison alone. Once that constant is filled in, a
+  present signature has to match the pinned publisher AND its certificate chain has to
+  validate to a trusted root with online revocation, or the update is refused — the same
+  policy already applied to the third-party Ookla CLI. Writing both halves now is what
+  stops the check from quietly becoming a no-op the day signing is switched on: without
+  the pin, merely *carrying* a signature would pass, and a binary signed by an attacker's
+  own self-issued certificate would be accepted like a legitimate build. Note that
   Authenticode inspection reads the signer certificate; it does not by itself
   validate the file against the signature, which is why SHA256 remains the
   integrity gate rather than a fallback. The swap is then performed

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1135,6 +1135,90 @@ public partial class ArchitectureTests
             + $".xaml:\n  {string.Join("\n  ", offenders)}");
     }
 
+    /// <summary>
+    /// No public document may claim the update path enforces a publisher while
+    /// <c>UpdateService.ExpectedSignerSubject</c> is still empty.
+    /// <para>The README said, in the present tense, that a signed update "must belong to the expected
+    /// publisher and its certificate chain must validate, so a build signed by someone else is
+    /// refused". The pin is empty until a certificate exists, so <c>VerifyAuthenticode</c> returns true
+    /// for ANY signed binary and neither the subject comparison nor the chain build is reached — the
+    /// document described the code that will run one day, not the code that ships. A reader deciding
+    /// whether to trust an auto-update was being told a check protects them that does not run yet.</para>
+    /// <para>The claim is not wrong forever, which is exactly why a human reviewer misses it: it becomes
+    /// TRUE the day the constant is filled in. So this guard is conditional rather than a blocklist —
+    /// while the pin is empty the assertive phrasings are forbidden, and once it is set they are
+    /// required, which also catches the opposite drift of shipping signing while the docs still say
+    /// "unsigned". SECURITY.md's wording was already honest ("empty until a code-signing certificate
+    /// exists") and passes unchanged; that asymmetry is what proved the README was the drift.</para>
+    /// </summary>
+    [Fact]
+    public void NoPublicDocument_ClaimsAPublisherPinThatIsNotArmed()
+    {
+        var root = FindRepoRoot();
+        var pinIsArmed = SysManager.Services.UpdateService.ExpectedSignerSubject.Length > 0;
+
+        string[] surfaces = ["README.md", "SECURITY.md"];
+        var offenders = new List<string>();
+        var honestDisclosures = 0;
+
+        foreach (var relative in surfaces)
+        {
+            var path = Path.Combine(root, relative);
+            Assert.True(File.Exists(path), $"{relative} not found — the guard would pass vacuously");
+
+            var lines = File.ReadAllLines(path);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                // Counts the phrasing that discloses the pin is not armed yet, in either document.
+                if (UnarmedPinDisclosure().IsMatch(lines[i])) honestDisclosures++;
+
+                if (!pinIsArmed && AssertsPublisherIsEnforced().IsMatch(lines[i]))
+                    offenders.Add($"{relative}:{i + 1}  {lines[i].Trim()}");
+            }
+        }
+
+        if (pinIsArmed)
+        {
+            // Signing went live: the docs must now SAY so. Flip side of the same contract.
+            Assert.True(honestDisclosures == 0,
+                "ExpectedSignerSubject is now set, so the publisher check really does run — but a public "
+                + "document still says no publisher is pinned. Update the docs to match the code.");
+            return;
+        }
+
+        // Vacuity floor: both documents must disclose the not-yet-armed state, or this guard is
+        // measuring a corpus that no longer discusses the pin at all.
+        Assert.True(honestDisclosures >= 2,
+            "expected the docs to disclose that the publisher pin is not armed yet; found "
+            + $"{honestDisclosures} such statements. Either the wording changed shape or the guard has "
+            + "gone vacuous — fix the guard rather than trusting its pass.");
+
+        Assert.True(offenders.Count == 0,
+            "these lines claim the update path enforces a publisher or refuses a foreign signature, but "
+            + "UpdateService.ExpectedSignerSubject is empty, so VerifyAuthenticode accepts any signed "
+            + "binary and the pin and chain checks are unreachable. State that the check is written but "
+            + $"not yet armed:\n  {string.Join("\n  ", offenders)}");
+    }
+
+    /// <summary>
+    /// Prose asserting the publisher check is enforced today: "must belong to the expected publisher",
+    /// "signed by someone else is refused", "checks that it belongs to the expected publisher".
+    /// Deliberately matches the ASSERTION, not the words "expected publisher" alone, so a sentence that
+    /// explains the pin is empty does not trip it.
+    /// </summary>
+    [GeneratedRegex(@"(?:must (?:belong to|match) the (?:expected|pinned) publisher"
+        + @"|checks that it belongs to the expected publisher"
+        + @"|signed by (?:someone|anyone) else (?:is|will be) refused)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    private static partial Regex AssertsPublisherIsEnforced();
+
+    /// <summary>Prose disclosing that the pin is not armed yet — the honest counterpart.</summary>
+    [GeneratedRegex(@"(?:no publisher is pinned yet"
+        + @"|empty until a (?:code-signing )?certificate exists"
+        + @"|not yet armed)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    private static partial Regex UnarmedPinDisclosure();
+
     /// <summary>The <c>feat|fix</c> alternation auto-release matches to decide a bump.</summary>
     [GeneratedRegex(@"\^\((feat\|fix)\)", RegexOptions.Compiled)]
     private static partial Regex ReleasingPrefixAlternation();


### PR DESCRIPTION
## Problem

Three public passages described the auto-updater's signature check in the **present tense**, as if the
publisher were enforced today:

| Where | Claim |
|---|---|
| `README.md:891` | "it **must belong to the expected publisher** and its certificate chain must validate, so a build signed by someone else is **refused**" |
| `README.md:1203` | "the app **checks that it belongs to the expected publisher**" |
| `SECURITY.md:129` | "the signer **must match the pinned publisher**" |

`UpdateService.ExpectedSignerSubject` is `""` until a code-signing certificate exists:

```csharp
internal const string ExpectedSignerSubject = "";   // UpdateService.cs:424
...
if (ExpectedSignerSubject.Length == 0)              // :460
{
    Serilog.Log.Information("... (no expected publisher pinned yet)");
    return true;                                    // ANY signed binary passes
}
if (!cert.Subject.Contains(ExpectedSignerSubject, ...)) // :471 — unreachable today
```

So the subject comparison and the chain build are both unreachable. A reader deciding whether to trust
an auto-update was being told a check protects them that **does not run**. `SECURITY.md` did disclose
the empty pin — but two lines *after* asserting the enforcement, so a reader hitting line 129 first gets
the false claim either way.

The same README bullet also said the SHA256 match "**guarantees integrity**" and that a "**tampered**
download is blocked", contradicting `README.md:1139-1141`, which correctly explains that the `.sha256`
is published onto the same release as the binary and therefore catches a *damaged* download, not a
substituted asset.

**Behaviour is unchanged and was already safe** — SHA256 runs first and does gate, and a signature that
is present but unreadable is still refused (`:503-509`). This is the documentation catching up to the
code, which is why it is `docs:` and ships no release.

## Fix

Reworded all three passages so the condition precedes the claim: the pin is empty, so today a signed
build is accepted on the strength of the SHA-256 comparison alone; filling in that one constant switches
on the publisher match and the chain validation together. The "guarantees integrity" bullet now points
at the attestation as the stronger check the reader can run themselves.

## The guard

`ArchitectureTests.NoPublicDocument_ClaimsAPublisherPinThatIsNotArmed` makes it mechanical, and
**conditionally on the constant** rather than as a phrase blocklist:

- while `ExpectedSignerSubject` is empty → the assertive phrasings fail the build;
- once it is set → those phrasings become **required**, so the opposite drift (shipping signing while
  the docs still say "no publisher is pinned") fails too.

That conditionality is the point. The claim is not wrong *forever* — it becomes true the day the
constant is filled in — which is exactly why a human reviewer reads past it.

**The guard found a defect I had already cleared.** I had judged `SECURITY.md` honest and was about to
ship only the two README edits; the guard went red on `SECURITY.md:129` on its first run.

## Tests — red before, green after

| Case | Expected | Got |
|---|---|---|
| this branch, unmutated | green | **green** |
| restore the shipped `README.md` bullet | red | **red** |
| restore the shipped `README.md` signing paragraph | red | **red** |
| restore the shipped `SECURITY.md` ordering | red | **red** |
| arm the pin (`= "O=Example"`) but leave the docs saying unarmed | red | **red** |
| strip both honest disclosures (vacuity floor) | red | **red** |

Rows 2–4 are the **real pre-fix text**, restored verbatim — not synthetic mutations. Row 5 proves the
reverse direction. Row 6 proves the guard cannot pass on a corpus that stopped discussing the pin.

All three files were confirmed restored byte-for-byte after the run.

## Verification

- `dotnet format --verify-no-changes` — exit 0
- All four projects, Release: **0 errors, 0 warnings**
- Leak scan over all changed files against every `leak-terms` pattern: 0 hits, with a control proving
  the scanner discriminates
- `#verifying-the-download` anchor confirmed against the live `### Verifying the download` heading
- Propagate: grepped every `.md`, `.xaml` and `.cs` for the same overclaim. The only other hit is
  `CHANGELOG.md:496-499`, which is **correct as-is** — it is the historical record of the PR that added
  the pin, written in the conditional ("when SysManager is code-signed, an update signed by someone else
  will be refused"), so it is deliberately left untouched.

`docs:` — no release, no version bump, no CHANGELOG entry required.
