### PR TITLE
docs: answer "my antivirus flagged the download", and check cross-page anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1182,6 +1182,51 @@ first-launch prompt does not appear.
 > **and** whose hash you verified. The same dialog protects you from genuinely malicious
 > files, so it is worth reading rather than reflexively dismissing.
 
+### If your antivirus flags the download
+
+Windows Defender or another antivirus may flag or quarantine the `.exe` — sometimes days
+after it ran fine, because these tools also score a file on how widely it has been seen
+before. This is the second-most-likely thing to happen after the SmartScreen box above, so
+it is worth explaining rather than leaving you to guess.
+
+**Why it happens.** Two reasons, and neither is about what the code does:
+
+- **The shape of the file.** SysManager ships as one large executable that carries
+  everything it needs inside it, compressed, and unpacks itself into a temporary folder when
+  you launch it. That is a legitimate way to ship a portable app with no installer — and it
+  is also what some malware does to hide, so a scanner that judges structure rather than
+  behaviour treats it as suspicious. Add an unknown publisher and no signature, and a
+  heuristic engine has every reason to be cautious.
+- **What the app genuinely does.** It deletes files, changes registry settings and stops
+  processes. That *is* the job of a maintenance tool, and it is also a fair description of
+  something you would not want running unasked.
+
+**How to check, instead of guessing.** Take the SHA-256 from the
+[release page](https://github.com/laurentiu021/SystemManager/releases/latest) and open
+
+```
+https://www.virustotal.com/gui/file/<paste-the-sha256-here>
+```
+
+VirusTotal addresses files by hash, so if that exact build has been scanned this shows the
+report — including which engines flagged it and which did not. If nobody has submitted that
+build yet the page will say so, and you can upload it there yourself.
+
+Then read the [Verifying the download](#verifying-the-download) section above and run the
+build attestation. That is the check that actually settles the question: it proves the file
+you hold is the output of a public workflow, built from a public commit in this repository.
+
+> **Be honest about what a scan proves.** A couple of hits out of ~70 engines on an unsigned,
+> compressed, self-extracting build is the ordinary pattern for this kind of file — it is not
+> by itself evidence of a problem. Equally, a completely clean sheet is not proof that a file
+> is safe; plenty of malware is clean on the day it is released. The attestation is stronger
+> than either, because it ties the binary to source you can read.
+
+**If it has already been quarantined**, restore it or add an exclusion **only after** the
+SHA-256 matches and `gh attestation verify` succeeds. If either check fails, delete the file
+and download it again from the releases page — do not add an exclusion for a file you have
+not verified.
+
 ### Code signing
 
 Releases are currently **unsigned**, which is why the warning above appears. The intention is

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -43,4 +43,13 @@ A few quick things that make bug reports land faster:
 - [ARCHITECTURE.md](ARCHITECTURE.md) — how the app is organised internally
 - [CHANGELOG.md](CHANGELOG.md) — what changed in each release
 
+Two things people hit before the app even starts, both answered in the README rather than
+needing an issue:
+
+- **"Windows protected your PC"** on first launch —
+  [what that box means and why](README.md#first-launch-windows-will-warn-you).
+- **Your antivirus flagged or quarantined the download** —
+  [why an unsigned single-file build gets scored that way, and how to check the file for
+  yourself](README.md#if-your-antivirus-flags-the-download).
+
 Thanks for using SysManager!

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1576,10 +1576,48 @@ public partial class ArchitectureTests
             }
         }
 
+        // Cross-PAGE anchors — [text](SECURITY.md#security-model) — break the same silent way, and were
+        // invisible to the sweep above: InPageLink only matches "](#anchor)", never "](other.md#anchor)".
+        // Six such links already existed when this was added, all resolving by luck rather than by check.
+        var crossPage = 0;
+        var headingsByPage = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var path in Directory.EnumerateFiles(root, "*.md", SearchOption.TopDirectoryOnly))
+        {
+            var page = File.ReadAllLines(path);
+            var set = page
+                .Select(l => HeadingLine().Match(l))
+                .Where(m => m.Success)
+                .Select(m => Slug(m.Groups[1].Value))
+                .ToHashSet(StringComparer.Ordinal);
+            foreach (var l in page.Where(l => l.StartsWith("# ", StringComparison.Ordinal)))
+                set.Add(Slug(l[2..]));
+            headingsByPage[Path.GetFileName(path)] = set;
+        }
+
+        foreach (var path in Directory.EnumerateFiles(root, "*.md", SearchOption.TopDirectoryOnly))
+        {
+            var page = File.ReadAllLines(path);
+            for (var i = 0; i < page.Length; i++)
+            {
+                foreach (var hit in CrossPageLink().Matches(page[i]).Cast<Match>())
+                {
+                    crossPage++;
+                    var (target, anchor) = (hit.Groups["file"].Value, hit.Groups["anchor"].Value);
+                    if (!headingsByPage.TryGetValue(target, out var targetHeadings))
+                        dead.Add($"{Path.GetFileName(path)}:{i + 1}  {target}#{anchor}  (no such page)");
+                    else if (!targetHeadings.Contains(anchor))
+                        dead.Add($"{Path.GetFileName(path)}:{i + 1}  {target}#{anchor}");
+                }
+            }
+        }
+
         Assert.True(pages >= 6, $"expected the top-level doc pages, found {pages}");
         Assert.True(entries >= 10, $"expected the full contents list, found {entries} entries");
+        Assert.True(crossPage >= 4,
+            $"expected the doc set's cross-page anchor links, found {crossPage} — either they were "
+            + "removed or the pattern no longer matches them, and this half of the guard is vacuous");
         Assert.True(dead.Count == 0,
-            "these in-page links point at headings that do not exist, so they render as text that "
+            "these links point at headings that do not exist, so they render as text that "
             + $"quietly does nothing when clicked:\n  {string.Join("\n  ", dead)}");
     }
 
@@ -1593,6 +1631,14 @@ public partial class ArchitectureTests
     /// <summary>An in-page markdown link, capturing the anchor.</summary>
     [GeneratedRegex(@"\]\(#([^)]+)\)", RegexOptions.Compiled)]
     private static partial Regex InPageLink();
+
+    /// <summary>
+    /// A link into ANOTHER top-level doc page's heading, capturing the file and the anchor —
+    /// <c>](SECURITY.md#security-model)</c>. Relative paths with a directory are excluded: this guard
+    /// only knows the headings of the top-level pages it enumerated.
+    /// </summary>
+    [GeneratedRegex(@"\]\((?<file>[A-Za-z0-9_.-]+\.md)#(?<anchor>[^)]+)\)", RegexOptions.Compiled)]
+    private static partial Regex CrossPageLink();
 
     /// <summary>Characters GitHub strips when building an anchor.</summary>
     [GeneratedRegex(@"[^\w\s-]", RegexOptions.Compiled)]


### PR DESCRIPTION
## Problem

`README.md:1148-1179` spends 32 lines on the SmartScreen dialog and stops. The next thing a user hits is
their antivirus flagging or quarantining the file — and nothing answered it:

```
$ grep -ril "virustotal|false.positive|antivirus|quarantine" README.md SECURITY.md SUPPORT.md CONTRIBUTING.md TESTING.md
(no matches)
```

That is the one unanswered question in a section whose entire purpose is pre-emptive trust
documentation — it already walks through SmartScreen, states the code-signing status honestly, and
publishes a signing policy written before any certificate exists.

**The premise is not hypothetical.** `release.yml:124` calls `publish.ps1`, which sets:

```powershell
'-p:PublishSingleFile=true',
'-p:IncludeNativeLibrariesForSelfExtract=true',
'-p:EnableCompressionInSingleFile=true',
```

So the shipped artifact is a **compressed, self-extracting, unsigned single file** — for an app that
legitimately deletes files, edits the registry and stops processes. That is precisely the shape a
heuristic engine scores, and precisely the behaviour it scores it for.

## Fix

New `### If your antivirus flags the download`, placed between the SmartScreen block and
`### Code signing` — the order a user experiences: what you see first, what may happen next, why both
happen and what the plan is. No TOC edit: the TOC indexes only `##` headings, and every sibling here is
`###`.

Five beats, in the register of the surrounding section:

1. what may happen, including days later (reputation-based scoring)
2. why — the *shape* of the file, and separately the *behaviour*, neither of which is a defect
3. how to check instead of guessing — the VirusTotal **hash permalink**, worded so it does not promise a
   report exists for a build nobody submitted
4. the honest caveat: a couple of hits out of ~70 engines on a build like this is the ordinary pattern
   and proves nothing; a clean sheet is not proof of safety either; the attestation is stronger than
   both because it ties the binary to source you can read
5. what to do if it is already quarantined — restore or exclude **only after** the hash and the
   attestation both check out

`gh attestation verify` is **already** documented at `README.md:1136`, so this links it rather than
re-documenting it. `SUPPORT.md` now points at both this and the SmartScreen section, since that is where
someone in trouble looks first.

### What I deliberately did not do

A VirusTotal upload Action in the release workflow was the obvious move and it is the wrong one:
the asset is **84,694,811 bytes** against VirusTotal's 32 MB standard upload endpoint, it needs a new
API-key secret, and it would insert a third-party Action into the SHA-pinned workflow that builds the
very binary users are asked to trust. The hash permalink needs no key, no secret and no upload.

## A gap this exposed

Writing two `](README.md#anchor)` links revealed that `TheReadmeTableOfContents_HasNoDeadAnchors` could
not see them: `InPageLink()` matches only `](#anchor)`. **Six cross-page links already existed** —
`README.md → SECURITY.md#security-model`, `SECURITY.md → README.md#code-signing-policy`, and others —
all resolving by luck rather than by check. Renaming a heading would have broken them silently.

The guard now resolves every cross-page link against the target page's real headings, distinguishes
"no such page" from "no such heading", and carries its own vacuity floor.

## Tests — red before, green after

| Mutation | Expected | Got |
|---|---|---|
| this branch, unmutated | green | **green** |
| rename the heading `SUPPORT.md` links to | red | **red** |
| point a link at a page that does not exist | red | **red** (reported as *no such page*) |
| break a **pre-existing** link (`SECURITY.md → README.md#code-signing-policy`) | red | **red** |
| strip every cross-page link (new vacuity floor) | red | **red** |
| break a same-page TOC anchor (original half still armed) | red | **red** |

Row 4 is the point: that link shipped long before this PR and nothing verified it. All three files were
confirmed restored byte-for-byte afterwards.

## Verification

- `dotnet format --verify-no-changes` — exit 0
- All four projects, Release: **0 errors, 0 warnings**
- All four docs guards green together (anchors, publisher-pin truth, reporting routes, author headers)
- Leak scan over every changed file against every `leak-terms` pattern: 0 hits, with a control proving
  the scanner discriminates
- Both new anchors confirmed against the live heading text, including the colon-dropping slug rule for
  `### First launch: Windows will warn you`

`docs:` — no release, no version bump.
