### PR TITLE
fix: list 32-bit startup entries, and show the task detail already fetched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,30 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
-## [1.65.8] - 2026-08-14
+## [1.65.9] - 2026-08-14
+
+Startup Manager was missing a whole class of programs that start with Windows — anything installed by
+a 32-bit installer, which on a typical PC means a VPN client, a printer helper or an older updater.
+Those now appear alongside everything else, and can be turned off from here like the rest. Task
+Scheduler also shows what each task is for and when it will run next, instead of only when it last ran.
+
+### Fixed
+- **Startup Manager did not list programs installed by 32-bit installers.** 64-bit Windows keeps the
+  startup list of a 32-bit program in a separate place, and the app only ever read the main one. So an
+  application that genuinely runs at every boot simply was not in the list — and since the point of the
+  tab is to tell you what starts with Windows, its answer was incomplete without saying so. Windows'
+  own Task Manager shows these, so anyone comparing the two would have seen the gap. They are now
+  listed, and disabling one writes to the place Windows actually reads for that kind of entry, so
+  "Disabled" means disabled rather than looking disabled while the program keeps starting.
+
+### Added
+- **Task Scheduler now shows what a task is for, and when it runs next.** The tab was already asking
+  Windows for each task's description, who created it, and its next scheduled run — on every single
+  scan — and then displaying none of it. "Next run" is now a column beside "Last run", there is a
+  "What it does" column with Windows' own description, and hovering it shows which publisher created
+  the task, which is also what decides whether it is labelled System, Telemetry or Third-party. No
+  extra work is done to collect any of this; it was being fetched and thrown away.
+
 
 If you use one of the six light colour themes, the lines on the Ping, Bandwidth Monitor and Resource
 History graphs were washed out to the point of being invisible — a pale mint or pale yellow line on a

--- a/README.md
+++ b/README.md
@@ -341,7 +341,9 @@ a confirmation before it runs:
 - Read-only; reading the log requires administrator (elevation banner shown)
 
 ### Task Scheduler
-- **Browse every Windows scheduled task** with its state, type, and last/next run
+- **Browse every Windows scheduled task** with its state, type, last and next run, and what the task
+  is for in Windows' own words — hovering that shows which publisher created it, which is what decides
+  the type label
 - **Color-coded by type** — Third-party, well-known **Telemetry** (Compatibility
   Appraiser, CEIP, Feedback, Error Reporting), and **System** — so it's obvious
   what's safe to touch
@@ -416,8 +418,12 @@ a confirmation before it runs:
   is disabled by design so a mis-click can never hurt anything.
 
 ### Startup Manager
-- Lists every program that runs at Windows boot (Registry Run / RunOnce keys)
-- Toggle on/off without deleting the original entry (same mechanism as Task Manager)
+- Lists every program that runs at Windows boot: the Run and RunOnce registry keys for both your
+  account and the whole machine, **including the separate location 64-bit Windows uses for programs
+  installed by a 32-bit installer**, plus both Startup folders and logon-triggered scheduled tasks
+- Toggle on/off without deleting the original entry (same mechanism as Task Manager) — the disable
+  flag is written to the location Windows actually reads for that kind of entry, so a disabled item
+  really stays down
 - Sort by name, publisher, safety, or status via clickable column headers
 - Plain-language description for recognised programs (from the built-in database) instead
   of a raw command line, plus a Safety chip — Windows / Known app / Not recognised — so you

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1640,6 +1640,13 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"\]\((?<file>[A-Za-z0-9_.-]+\.md)#(?<anchor>[^)]+)\)", RegexOptions.Compiled)]
     private static partial Regex CrossPageLink();
 
+    /// <summary>
+    /// An XML/XAML comment block. Stripped before asserting that a view BINDS something: a comment that
+    /// merely names a property would otherwise satisfy a substring check on the raw file.
+    /// </summary>
+    [GeneratedRegex(@"<!--.*?-->", RegexOptions.Compiled | RegexOptions.Singleline)]
+    private static partial Regex XmlComment();
+
     /// <summary>Characters GitHub strips when building an anchor.</summary>
     [GeneratedRegex(@"[^\w\s-]", RegexOptions.Compiled)]
     private static partial Regex NonAnchorCharacter();
@@ -2186,6 +2193,114 @@ public partial class ArchitectureTests
         Assert.True(setAt > logAt,
             $"{flag} is set at {setAt} but the log is at {logAt} — it must be set after the loop, so a "
             + "read that throws partway through can still log the rest on its next attempt.");
+    }
+
+    /// <summary>
+    /// Every machine-wide Run key the scan enumerates must have its enable/disable state read from, and
+    /// written to, the matching <c>StartupApproved</c> subkey.
+    /// <para>Windows keeps the disabled-state of a <c>Wow6432Node\...\Run</c> item under
+    /// <c>StartupApproved\Run32</c>, not <c>StartupApproved\Run</c>. Mapping a 32-bit entry to the 64-bit
+    /// approved key puts the disable blob where Windows never looks: the item keeps running at every boot
+    /// while the tab reports "Disabled". That exact failure already shipped once for the all-users startup
+    /// folder, which is why <c>CommonStartupFolder</c> exists as its own source — this pins the same
+    /// contract for the 32-bit registry view so the pattern cannot be reintroduced by adding a key to the
+    /// array and reusing the nearest source value.</para>
+    /// <para>Asserted at source level because <c>SetEnabledAsync</c> writes to the live registry, so the
+    /// mapping cannot be exercised from a unit test without touching the user's real machine.</para>
+    /// </summary>
+    [Fact]
+    public void EveryMachineRunKey_ReadsAndWritesItsOwnStartupApprovedKey()
+    {
+        var source = File.ReadAllText(Path.Combine(FindAppProjectDir(), "Services", "StartupService.cs"));
+
+        // The 32-bit Run key must actually be enumerated. Without this the rest of the guard would pass
+        // on a scan that never produces a 32-bit entry at all — which is precisely the pre-fix state.
+        Assert.Contains(@"SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Run", source, StringComparison.Ordinal);
+        Assert.Contains("StartupSource.RegistryLocalMachine32", source, StringComparison.Ordinal);
+
+        // Read path: ApplyApprovedState must map the 32-bit source to the Run32 dictionary, and must NOT
+        // fall back between the two views — "hklmApproved ?? hklm32Approved" reads the wrong key whenever
+        // both exist.
+        var readAt = source.IndexOf("private static void ApplyApprovedState", StringComparison.Ordinal);
+        Assert.True(readAt > 0, "ApplyApprovedState was not found — fix this guard, do not delete it.");
+        var writeAt = source.IndexOf("public static async Task<bool> SetEnabledAsync", StringComparison.Ordinal);
+        Assert.True(writeAt > readAt,
+            "SetEnabledAsync is expected after ApplyApprovedState; the slices below assume that order.");
+
+        var readBody = source[readAt..writeAt];
+        Assert.Contains("StartupSource.RegistryLocalMachine32 => hklm32Approved", readBody, StringComparison.Ordinal);
+        Assert.Contains("StartupSource.RegistryLocalMachine => hklmApproved,", readBody, StringComparison.Ordinal);
+        // Match the ARM of the switch, not the bare phrase: the comment above the 32-bit arm explains the
+        // old fallback by naming it, and a guard that forbids its own explanation goes red on the fixed
+        // tree (that mistake was made once already, in the release-workflow guard).
+        Assert.DoesNotContain(
+            "StartupSource.RegistryLocalMachine => hklmApproved ?? hklm32Approved",
+            readBody, StringComparison.Ordinal);
+
+        // Write path: the same source must target ApprovedRun32HKLM.
+        var writeBody = source[writeAt..];
+        Assert.Contains(
+            "StartupSource.RegistryLocalMachine32 => (Registry.LocalMachine, ApprovedRun32HKLM)",
+            writeBody, StringComparison.Ordinal);
+        Assert.Contains(
+            "StartupSource.RegistryLocalMachine => (Registry.LocalMachine, ApprovedRunHKLM)",
+            writeBody, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Everything the scheduled-task query pays to fetch must reach the screen.
+    /// <para>The Task Scheduler tab queried <c>Author</c>, <c>Description</c> and <c>NextRunTime</c> from
+    /// Windows on every scan, carried all three through <c>ScheduledTaskInfo</c>, and even defined a
+    /// formatted <c>NextRunDisplay</c> — while the view bound Name, Path, Type, State and Last run only.
+    /// A user asking the one question this tab exists for, "when will this run next?", could not see the
+    /// answer the app already had. This is SysManager's most persistent defect class: state that is
+    /// implemented, unit-tested, and bound by nothing, which neither the compiler nor a view-model test
+    /// can see — only an assertion against the shipped XAML.</para>
+    /// </summary>
+    [Fact]
+    public void EveryScheduledTaskFieldTheQueryFetches_IsBoundInTheView()
+    {
+        var service = File.ReadAllText(
+            Path.Combine(FindAppProjectDir(), "Services", "TaskSchedulerService.cs"));
+        var view = File.ReadAllText(
+            Path.Combine(FindAppProjectDir(), "Views", "TaskSchedulerView.xaml"));
+
+        // XAML comments are stripped before matching. A comment in the view that merely NAMES a property
+        // would otherwise satisfy the check — the first draft of this guard stayed green with the "Next
+        // run" column deleted, because the comment above it mentioned NextRunDisplay. Only a real binding
+        // counts.
+        var bindings = XmlComment().Replace(view, string.Empty);
+
+        // Only assert on fields the service genuinely asks Windows for — otherwise this guard drifts into
+        // demanding UI for data that is not collected.
+        (string Fetched, string Bound)[] contract =
+        [
+            ("Author", "{Binding AuthorDisplay}"),
+            ("Description", "{Binding Description}"),
+            ("NextRunTime", "{Binding NextRunDisplay}"),
+            ("LastRunTime", "{Binding LastRunDisplay}"),
+        ];
+
+        var notFetched = new List<string>();
+        var notBound = new List<string>();
+        foreach (var (fetched, bound) in contract)
+        {
+            if (!service.Contains(fetched, StringComparison.Ordinal))
+                notFetched.Add(fetched);
+            else if (!bindings.Contains(bound, StringComparison.Ordinal))
+                notBound.Add($"{fetched} -> expected a real '{bound}' in TaskSchedulerView.xaml");
+        }
+
+        // Vacuity floor: if the service stopped selecting these, the loop above would silently check
+        // nothing at all and report success.
+        Assert.True(notFetched.Count == 0,
+            "the scheduled-task query no longer fetches these, so this guard is measuring nothing — "
+            + $"fix the guard rather than trusting its pass:\n  {string.Join("\n  ", notFetched)}");
+
+        Assert.True(notBound.Count == 0,
+            "the Task Scheduler query pays to fetch these fields on every scan and the view displays "
+            + "none of them, so the work is thrown away and the user cannot see data the app already "
+            + $"holds:\n  {string.Join("\n  ", notBound)}");
     }
 
     /// <summary>The app project directory — .xaml is not copied to the test output.</summary>

--- a/SysManager/SysManager.Tests/StartupToggleTests.cs
+++ b/SysManager/SysManager.Tests/StartupToggleTests.cs
@@ -113,6 +113,7 @@ public class StartupToggleTests
     [Theory]
     [InlineData(StartupSource.RegistryCurrentUser)]
     [InlineData(StartupSource.RegistryLocalMachine)]
+    [InlineData(StartupSource.RegistryLocalMachine32)]
     public async Task SetEnabledAsync_RunOnce_ReturnsFalseWithHonestMessage_AndDoesNotDisable(StartupSource source)
     {
         // Regression (P2 #35): Windows has no StartupApproved\RunOnce and never consults

--- a/SysManager/SysManager/Models/ScheduledTaskInfo.cs
+++ b/SysManager/SysManager/Models/ScheduledTaskInfo.cs
@@ -46,4 +46,13 @@ public sealed record ScheduledTaskInfo(
     public string FullPath => $"{Path}{Name}";
     public string LastRunDisplay => LastRun is { } t ? t.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture) : "—";
     public string NextRunDisplay => NextRun is { } t ? t.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture) : "—";
+
+    /// <summary>
+    /// Who registered the task, phrased for a tooltip. Many tasks report no author at all, and a
+    /// tooltip bound straight to <see cref="Author"/> would then render as an empty box on hover —
+    /// worse than none, because it looks like something failed to load.
+    /// </summary>
+    public string AuthorDisplay => string.IsNullOrWhiteSpace(Author)
+        ? "No publisher recorded for this task."
+        : $"Created by: {Author}";
 }

--- a/SysManager/SysManager/Models/StartupEntry.cs
+++ b/SysManager/SysManager/Models/StartupEntry.cs
@@ -53,6 +53,17 @@ public enum StartupSource
 {
     RegistryCurrentUser,
     RegistryLocalMachine,
+    /// <summary>
+    /// Machine-wide Run key of a 32-bit application on 64-bit Windows
+    /// (<c>SOFTWARE\Wow6432Node\...\CurrentVersion\Run</c>) — approved-state in
+    /// <c>StartupApproved\Run32</c>, NOT <c>StartupApproved\Run</c>.
+    /// <para>A distinct source rather than a flag on <see cref="RegistryLocalMachine"/> because the
+    /// enable/disable state lives in a different key: writing the disable blob to
+    /// <c>StartupApproved\Run</c> for one of these items would put it where Windows never looks, so the
+    /// item would still run at boot while the UI reported "Disabled" — the same failure the Common
+    /// startup folder had before <see cref="CommonStartupFolder"/> was split out.</para>
+    /// </summary>
+    RegistryLocalMachine32,
     /// <summary>Per-user shell Startup folder (%AppData%\...\Startup) — approved-state in HKCU.</summary>
     StartupFolder,
     /// <summary>All-users (Common) shell Startup folder (%ProgramData%\...\Startup) — approved-state in HKLM.</summary>

--- a/SysManager/SysManager/Services/StartupService.cs
+++ b/SysManager/SysManager/Services/StartupService.cs
@@ -27,11 +27,22 @@ public sealed class StartupService
         (@"SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce", StartupSource.RegistryCurrentUser),
     };
 
-    // Machine-wide Run keys (read-only unless elevated)
+    // Machine-wide Run keys (read-only unless elevated).
+    //
+    // The Wow6432Node pair is where 64-bit Windows puts the Run keys of 32-bit installers, and a great
+    // many still are 32-bit — a VPN client, a printer tray, an older updater. Those entries were
+    // invisible here: the scan only ever read the 64-bit view, so an item that genuinely runs at every
+    // boot did not appear in a tab whose whole purpose is to list what runs at boot. Task Manager's
+    // Startup tab shows them, which makes the omission visible to anyone who compares the two.
+    //
+    // Their approved-state lives under StartupApproved\Run32, so they carry their own source value
+    // rather than reusing RegistryLocalMachine — see StartupSource.RegistryLocalMachine32.
     private static readonly (string Key, StartupSource Source)[] MachineRunKeys =
     {
         (@"SOFTWARE\Microsoft\Windows\CurrentVersion\Run", StartupSource.RegistryLocalMachine),
         (@"SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce", StartupSource.RegistryLocalMachine),
+        (@"SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Run", StartupSource.RegistryLocalMachine32),
+        (@"SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\RunOnce", StartupSource.RegistryLocalMachine32),
     };
 
     // Approved key where Windows stores disabled startup items
@@ -398,7 +409,12 @@ public sealed class StartupService
             Dictionary<string, byte[]>? approved = entry.Source switch
             {
                 StartupSource.RegistryCurrentUser => hkcuApproved,
-                StartupSource.RegistryLocalMachine => hklmApproved ?? hklm32Approved,
+                StartupSource.RegistryLocalMachine => hklmApproved,
+                // 32-bit machine-wide items keep their state in StartupApproved\Run32. This used to be
+                // an "hklmApproved ?? hklm32Approved" fallback on the 64-bit source, which reads the
+                // wrong key whenever both exist — and since nothing enumerated the 32-bit Run key, the
+                // Run32 dictionary had no entries to match anyway.
+                StartupSource.RegistryLocalMachine32 => hklm32Approved,
                 StartupSource.StartupFolder => folderApproved,
                 StartupSource.CommonStartupFolder => commonFolderApproved,
                 _ => null
@@ -461,6 +477,10 @@ public sealed class StartupService
             {
                 StartupSource.RegistryCurrentUser => (Registry.CurrentUser, ApprovedRunHKCU),
                 StartupSource.RegistryLocalMachine => (Registry.LocalMachine, ApprovedRunHKLM),
+                // Windows consults StartupApproved\Run32 for Wow6432Node Run items. Writing the disable
+                // blob to StartupApproved\Run instead would land where Windows never looks: the item
+                // would keep running at boot while this tab reported "Disabled".
+                StartupSource.RegistryLocalMachine32 => (Registry.LocalMachine, ApprovedRun32HKLM),
                 StartupSource.StartupFolder => (Registry.CurrentUser, ApprovedStartupFolder),
                 // Common (all-users) folder items live under HKLM — writing to HKCU (as before)
                 // put the disable blob where Windows never looks, so the item still ran while the

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.8</Version>
-    <FileVersion>1.65.8.0</FileVersion>
-    <AssemblyVersion>1.65.8.0</AssemblyVersion>
+    <Version>1.65.9</Version>
+    <FileVersion>1.65.9.0</FileVersion>
+    <AssemblyVersion>1.65.9.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/TaskSchedulerView.xaml
+++ b/SysManager/SysManager/Views/TaskSchedulerView.xaml
@@ -132,6 +132,26 @@
                     </DataGridTemplateColumn>
                     <DataGridTextColumn Header="State" Binding="{Binding State}" Width="90"/>
                     <DataGridTextColumn Header="Last run" Binding="{Binding LastRunDisplay}" Width="140"/>
+                    <!-- Next run answers the question this tab exists for — "when is this going to
+                         happen?" — and it was already being fetched: the per-task query that fills
+                         Last run selects NextRunTime in the same call, ScheduledTaskInfo carries it,
+                         and NextRunDisplay was formatting it for a column that did not exist. -->
+                    <DataGridTextColumn Header="Next run" Binding="{Binding NextRunDisplay}" Width="140"/>
+                    <!-- What the task is for, in Windows' own words, with the publisher on hover.
+                         Both came back with every scan (TaskSchedulerService selects Author and
+                         Description) and neither was displayed anywhere. Author matters because it is
+                         what the category chip is derived from, so a user who wonders why something is
+                         labelled "System" can now see the answer. Same trimming + hover shape as the
+                         Description column in ServicesView. -->
+                    <DataGridTextColumn Header="What it does" Binding="{Binding Description}"
+                                        Width="*" MinWidth="120" SortMemberPath="Description">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+                                <Setter Property="ToolTip" Value="{Binding AuthorDisplay}"/>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
                 </DataGrid.Columns>
             </DataGrid>
 


### PR DESCRIPTION
## Problem A — Startup Manager cannot see 32-bit startup entries

`StartupService` enumerated only `SOFTWARE\Microsoft\Windows\CurrentVersion\Run` and `RunOnce`, for HKCU
and HKLM. On 64-bit Windows, the Run key of a program installed by a **32-bit** installer lives under
`SOFTWARE\Wow6432Node\...` — and nothing read it. A program that genuinely starts with Windows was
simply absent from the tab whose entire purpose is to list what starts with Windows.

**Reproduced on real hardware**, not inferred:

```
HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Run
  value: Cisco Secure Client
```

That entry starts at every boot and SysManager could not show it. Windows' own Task Manager lists these,
so the omission is visible to anyone comparing the two.

The service already knew the key existed — it read `StartupApproved\Run32` for toggle state at
`StartupService.cs:391` — it just never enumerated the entries that key describes.

### Why this needed more than one line

Adding the key alone would have shipped a worse bug than the one it fixed. Windows keeps the
disabled-state of a `Wow6432Node` item under `StartupApproved\Run32`, so a toggle routed to
`StartupApproved\Run` writes where Windows never looks: **the item keeps starting while the UI reports
"Disabled"**. That exact failure already shipped once for the all-users startup folder — which is why
`CommonStartupFolder` exists as its own source, with a comment in the code saying so.

So `RegistryLocalMachine32` is a distinct `StartupSource` with its own read *and* write mapping. The old
read path also carried `hklmApproved ?? hklm32Approved` on the 64-bit arm, which picks the wrong
dictionary whenever both keys exist; that is now an explicit per-source mapping.

## Problem B — Task Scheduler fetches three fields and displays none

`TaskSchedulerService` selects `Author` and `Description` on every scan (`:37-38`, `:64`) and
`NextRunTime` in the per-task query (`:50`, `:103`). `ScheduledTaskInfo` carries all three and even
defines a formatted `NextRunDisplay` (`:48`). The view bound **Name, Path, Type, State, Last run** —
nothing else.

So a user asking the one question this tab exists for, *"when is this going to run?"*, could not see the
answer the app already had. This is SysManager's most persistent defect class — state implemented,
unit-tested, and bound by nothing, invisible to both the compiler and a view-model test.

No new queries were added: the per-task call that fills **Last run** already selects `NextRunTime` in
the same statement, so the cost was being paid and thrown away.

Following `ServicesView`'s Description column exactly (trimming + hover). `AuthorDisplay` keeps a task
with no recorded author from rendering an empty tooltip, which reads as a load failure.

## Tests — red before, green after

| Mutation | `EveryMachineRunKey…` | `EveryScheduledTaskField…` |
|---|---|---|
| this branch, unmutated | green | green |
| remove the `Wow6432Node` keys (**the pre-fix enumeration**) | **red** | green |
| restore the `hklmApproved ?? hklm32Approved` fallback | **red** | green |
| point the 32-bit **write** at `ApprovedRunHKLM` (the silent "still runs" bug) | **red** | green |
| remove the "Next run" column (**pre-fix view**) | green | **red** |
| remove the "What it does" column + author tooltip (**pre-fix view**) | green | **red** |
| service stops fetching `Author`/`Description` (vacuity floor) | green | **red** |

Each mutation fires on exactly the guard that owns it and on nothing else.

**The proof caught a hole in my own guard.** The "Next run column removed" row was initially **green**:
`view.Contains("NextRunDisplay")` was satisfied by the *explanatory comment* above the column, so
deleting the column changed nothing. The guard now strips XML comments before matching and requires a
real `{Binding …}`. That is the same trap as a guard forbidding its own explanation — worth stating
because a reviewer cannot see it from the diff.

`EveryMachineRunKey…` asserts at source level deliberately: `SetEnabledAsync` writes to the live
registry, so the mapping cannot be exercised from a unit test without touching the user's real machine.
The `RunOnce` theory in `StartupToggleTests` gains the new source as an `[InlineData]` row — that path
short-circuits before any registry write, so it is safe to execute.

## Verification

- `dotnet format --verify-no-changes` — exit 0
- All four projects, Release: **0 errors, 0 warnings**
- Propagate: grepped every `StartupSource.` consumer. The view does not display the source, so the new
  value flows through existing columns with no UI mapping to update; no exhaustive switch warns.
- Leak scan over every changed file against every `leak-terms` pattern: 0 hits, with a control
- Author headers present on all touched files

## Docs

- `README.md:419` claimed Startup Manager "lists **every** program that runs at Windows boot" — which
  was false. It now names the locations, including the 32-bit one, and states that a disabled item stays
  down. `README.md:344` already promised "last/**next** run" before the column existed; now true.
- `CHANGELOG.md` — 1.65.9, written for someone who wonders why a program they know starts wasn't listed
- csproj bumped to 1.65.9
