### PR TITLE
fix: report a failed history save, and make the ETA follow the real rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,30 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
-## [1.65.9] - 2026-08-14
+## [1.65.10] - 2026-08-14
+
+Two things that were quietly telling you the wrong thing. A speed test result could fail to save without
+saying so, and the "time remaining" on long jobs could climb upward while the bar stood completely still.
+
+Note on versions: 1.65.9 was tagged but never published — its release build stopped on the very save bug
+fixed below. Everything 1.65.9 contained is in this release.
+
+### Fixed
+- **A speed test result could vanish without telling you.** Saving a result to history writes a file, and
+  if that write failed — a moment of disk contention, a permissions problem — the app noted it in the
+  diagnostic log and then carried on exactly as if it had worked. The reading stayed on screen, so
+  nothing looked wrong until you came back later and found a gap in your history. Now a failed save says
+  so on the Speed Test tab, and the reading still stays visible for the session so you do not lose the
+  number you just waited for.
+- **"Time remaining" grew while progress stood still.** The estimate was worked out from the average
+  speed since the start, and recalculated only when a job reported new progress. Long steps report the
+  same percentage repeatedly, and each of those reports made the estimate *bigger*: measured on a job
+  stuck at 12%, it climbed from about one minute to about thirty-seven while nothing moved. Between
+  reports it froze instead, so a stalled job showed a confident "10 seconds left" for minutes. And a slow
+  first step could show "about 1 hour 39 minutes" for something that finished in ninety seconds.
+  The estimate now follows how fast progress is *currently* moving, counts down on its own while a job is
+  quiet, and says "calculating…" rather than guessing from the first few percent.
+
 
 Startup Manager was missing a whole class of programs that start with Windows — anything installed by
 a 32-bit installer, which on a typical PC means a VPN client, a printer helper or an older updater.

--- a/SysManager/SysManager.Tests/EtaCalculatorTests.cs
+++ b/SysManager/SysManager.Tests/EtaCalculatorTests.cs
@@ -6,21 +6,44 @@ using SysManager.Helpers;
 
 namespace SysManager.Tests;
 
+/// <summary>
+/// Tests for <see cref="EtaCalculator"/>.
+/// <para>Every timing assertion drives an injected <see cref="TestTimeProvider"/> instead of sleeping.
+/// The two tests that once called <c>Thread.Sleep</c> could only assert "some estimate came back" —
+/// they could not check the number, which is why the estimate could grow while the progress bar stood
+/// still and nothing failed. With a controlled clock the arithmetic itself is pinned.</para>
+/// </summary>
 public class EtaCalculatorTests
 {
+    /// <summary>
+    /// A <see cref="TimeProvider"/> whose clock only moves when a test says so. Hand-written rather than
+    /// taking a dependency on Microsoft.Extensions.TimeProvider.Testing: the calculator needs only
+    /// <c>GetTimestamp</c> and <c>GetElapsedTime</c>, and <c>GetElapsedTime</c> derives from
+    /// <c>TimestampFrequency</c>, so overriding those two is the whole seam.
+    /// </summary>
+    private sealed class TestTimeProvider : TimeProvider
+    {
+        private long _ticks;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+        public override long GetTimestamp() => _ticks;
+
+        public void Advance(TimeSpan by) => _ticks += by.Ticks;
+    }
+
     [Fact]
     public void Reset_ClearsState()
     {
-        var eta = new EtaCalculator();
+        var eta = new EtaCalculator(new TestTimeProvider());
         eta.Reset();
         Assert.Null(eta.Remaining);
-        Assert.Equal(string.Empty, eta.RemainingText);
+        Assert.Equal("calculating…", eta.RemainingText);
     }
 
     [Fact]
     public void Update_AtZeroPercent_ReturnsCalculating()
     {
-        var eta = new EtaCalculator();
+        var eta = new EtaCalculator(new TestTimeProvider());
         eta.Reset();
         var text = eta.Update(0);
         Assert.Equal("calculating…", text);
@@ -30,7 +53,7 @@ public class EtaCalculatorTests
     [Fact]
     public void Update_At100Percent_ReturnsDone()
     {
-        var eta = new EtaCalculator();
+        var eta = new EtaCalculator(new TestTimeProvider());
         eta.Reset();
         var text = eta.Update(100);
         Assert.Equal("done", text);
@@ -38,34 +61,19 @@ public class EtaCalculatorTests
     }
 
     [Fact]
-    public void Update_AtMidProgress_ReturnsEstimate()
-    {
-        var eta = new EtaCalculator();
-        eta.Reset();
-        // Simulate some elapsed time by updating at 50%
-        Thread.Sleep(100);
-        var text = eta.Update(50);
-        Assert.NotEqual(string.Empty, text);
-        Assert.NotNull(eta.Remaining);
-        Assert.True(eta.Remaining >= TimeSpan.Zero);
-    }
-
-    [Fact]
     public void Update_ClampsAbove100()
     {
-        var eta = new EtaCalculator();
+        var eta = new EtaCalculator(new TestTimeProvider());
         eta.Reset();
-        var text = eta.Update(150);
-        Assert.Equal("done", text);
+        Assert.Equal("done", eta.Update(150));
     }
 
     [Fact]
     public void Update_ClampsBelow0()
     {
-        var eta = new EtaCalculator();
+        var eta = new EtaCalculator(new TestTimeProvider());
         eta.Reset();
-        var text = eta.Update(-5);
-        Assert.Equal("calculating…", text);
+        Assert.Equal("calculating…", eta.Update(-5));
     }
 
     [Theory]
@@ -76,30 +84,168 @@ public class EtaCalculatorTests
     [InlineData(3660, "~1 h 1 min")]
     public void FormatTimeSpan_FormatsCorrectly(int seconds, string expected)
     {
-        var result = EtaCalculator.FormatTimeSpan(TimeSpan.FromSeconds(seconds));
-        Assert.Equal(expected, result);
+        Assert.Equal(expected, EtaCalculator.FormatTimeSpan(TimeSpan.FromSeconds(seconds)));
     }
 
     [Fact]
     public void Update_WithoutReset_ReturnsCalculating()
     {
-        var eta = new EtaCalculator();
-        // No Reset() called — stopwatch not running
-        var text = eta.Update(50);
-        Assert.Equal("calculating…", text);
+        var eta = new EtaCalculator(new TestTimeProvider());
+        // No Reset() — there is no start instant to measure from.
+        Assert.Equal("calculating…", eta.Update(50));
+    }
+
+    /// <summary>A steady 1%/s run must produce exactly the seconds remaining, not an approximation of it.</summary>
+    [Fact]
+    public void Update_AtSteadyRate_ProjectsTheExactRemainingTime()
+    {
+        var time = new TestTimeProvider();
+        var eta = new EtaCalculator(time);
+        eta.Reset();
+
+        // 10 s to reach 10% => 1%/s => 90% left => 90 s.
+        time.Advance(TimeSpan.FromSeconds(10));
+        var text = eta.Update(10);
+
+        Assert.Equal(TimeSpan.FromSeconds(90), eta.Remaining);
+        Assert.Equal("~1 min 30 s", text);
+    }
+
+    /// <summary>
+    /// The regression that motivated this rewrite. Callers derive percent by integer division, so during
+    /// one long step the SAME percent arrives repeatedly. Under the old average-since-start formula
+    /// (<c>elapsed * (100 - p) / p</c>) the estimate GREW every time: measured at 12%, it went 1.2 min →
+    /// 3.7 → 7.3 → 14.7 → 36.7 min while the bar never moved. The remaining time must fall.
+    /// </summary>
+    [Fact]
+    public void Update_RepeatedAtTheSamePercent_CountsDownInsteadOfGrowing()
+    {
+        var time = new TestTimeProvider();
+        var eta = new EtaCalculator(time);
+        eta.Reset();
+
+        time.Advance(TimeSpan.FromSeconds(10));
+        eta.Update(10);
+        var first = eta.Remaining!.Value;
+
+        var previous = first;
+        foreach (var _ in Enumerable.Range(0, 4))
+        {
+            time.Advance(TimeSpan.FromSeconds(20));
+            eta.Update(10);   // stalled: identical percent
+            var now = eta.Remaining!.Value;
+            Assert.True(now < previous,
+                $"remaining grew from {previous} to {now} while progress stood still — the stall bug is back.");
+            previous = now;
+        }
+
+        Assert.True(previous < first - TimeSpan.FromSeconds(60),
+            $"after 80 s of stall the estimate only moved from {first} to {previous}.");
+    }
+
+    /// <summary>
+    /// Reading between progress reports must count down, not hold the last value. A stalled operation
+    /// showing a frozen "~10 s" for minutes is the visible half of the same defect.
+    /// </summary>
+    [Fact]
+    public void Remaining_BetweenUpdates_KeepsCountingDown()
+    {
+        var time = new TestTimeProvider();
+        var eta = new EtaCalculator(time);
+        eta.Reset();
+
+        time.Advance(TimeSpan.FromSeconds(10));
+        eta.Update(10);
+        Assert.Equal(TimeSpan.FromSeconds(90), eta.Remaining);
+
+        // No Update at all — only the clock moves.
+        time.Advance(TimeSpan.FromSeconds(30));
+        Assert.Equal(TimeSpan.FromSeconds(60), eta.Remaining);
+
+        time.Advance(TimeSpan.FromSeconds(120));
+        Assert.Equal(TimeSpan.Zero, eta.Remaining);   // clamped, never negative
+    }
+
+    /// <summary>
+    /// A slow first step must not be extrapolated. Under the old formula, 1% after 60 s displayed
+    /// "~1 h 39 min" for an operation that finished in 90 s.
+    /// </summary>
+    [Fact]
+    public void Update_BelowTheEstimateFloor_SaysCalculatingRatherThanGuessing()
+    {
+        var time = new TestTimeProvider();
+        var eta = new EtaCalculator(time);
+        eta.Reset();
+
+        time.Advance(TimeSpan.FromSeconds(60));
+        Assert.Equal("calculating…", eta.Update(1));
+        Assert.Null(eta.Remaining);
+
+        time.Advance(TimeSpan.FromSeconds(1));
+        Assert.Equal("calculating…", eta.Update(2));
+        Assert.Null(eta.Remaining);
+
+        // Past the floor, an estimate appears — and it reflects the RECENT rate, not the slow start.
+        time.Advance(TimeSpan.FromSeconds(1));
+        eta.Update(10);
+        Assert.NotNull(eta.Remaining);
+        Assert.True(eta.Remaining < TimeSpan.FromMinutes(10),
+            $"the slow first step is still dominating the estimate: {eta.Remaining}.");
+    }
+
+    /// <summary>A sustained slowdown must be reflected, or the estimate is just the opening rate forever.</summary>
+    [Fact]
+    public void Update_WhenProgressSlowsDown_TheEstimateGrowsToMatch()
+    {
+        var time = new TestTimeProvider();
+        var eta = new EtaCalculator(time);
+        eta.Reset();
+
+        // Fast opening: 10%/s.
+        for (var p = 10; p <= 40; p += 10)
+        {
+            time.Advance(TimeSpan.FromSeconds(1));
+            eta.Update(p);
+        }
+        var fast = eta.Remaining!.Value;
+
+        // Then a tenth of that pace, sustained.
+        for (var p = 50; p <= 70; p += 10)
+        {
+            time.Advance(TimeSpan.FromSeconds(10));
+            eta.Update(p);
+        }
+        var slow = eta.Remaining!.Value;
+
+        Assert.True(slow > fast,
+            $"progress slowed 10x but the estimate fell from {fast} to {slow} — the rate is not being tracked.");
     }
 
     [Fact]
     public void MultipleResets_WorkCorrectly()
     {
-        var eta = new EtaCalculator();
+        var time = new TestTimeProvider();
+        var eta = new EtaCalculator(time);
         eta.Reset();
-        Thread.Sleep(50);
+        time.Advance(TimeSpan.FromSeconds(5));
         eta.Update(50);
         Assert.NotNull(eta.Remaining);
 
         eta.Reset();
         Assert.Null(eta.Remaining);
-        Assert.Equal(string.Empty, eta.RemainingText);
+        Assert.Equal("calculating…", eta.RemainingText);
+    }
+
+    /// <summary>
+    /// The default constructor must still use the real clock, so the six view models that call
+    /// <c>new EtaCalculator()</c> keep working untouched.
+    /// </summary>
+    [Fact]
+    public void DefaultConstructor_UsesTheSystemClock()
+    {
+        var eta = new EtaCalculator();
+        eta.Reset();
+        Assert.Equal("calculating…", eta.RemainingText);
+        Assert.Equal("done", eta.Update(100));
     }
 }

--- a/SysManager/SysManager.Tests/SpeedTestHistoryServiceTests.cs
+++ b/SysManager/SysManager.Tests/SpeedTestHistoryServiceTests.cs
@@ -159,23 +159,35 @@ public sealed class SpeedTestHistoryServiceTests : IDisposable
         Assert.Null(ex);
     }
 
+    /// <summary>
+    /// MaxPerEngine is 20; save 25 with increasing timestamps and assert the oldest 5 are dropped rather
+    /// than the newest. Deterministic timestamps, no wall clock.
+    /// <para>Asserts the WHOLE surviving window rather than spot-checking membership. The spot-check
+    /// version failed once during a release with <c>DoesNotContain: filter matched</c> and a dumped
+    /// collection — which took reading the raw dump to interpret. The window had slid down by exactly one
+    /// entry (ending s5, s4 instead of s6, s5), meaning one save had been lost; the old
+    /// <see cref="SpeedTestHistoryService.SaveAsync"/> swallowed the write failure and reported nothing,
+    /// so the count assertion still passed and only the incidental <c>DoesNotContain("s4")</c> caught it.
+    /// Every save is now checked for success as it happens, and the surviving set is compared exactly, so
+    /// a dropped write names itself.</para>
+    /// </summary>
     [Fact]
     public async Task SaveAsync_TrimsToMaxPerEngine_KeepingTheNewest()
     {
-        // MaxPerEngine is 20; save 25 with increasing timestamps and assert the oldest 5 are dropped
-        // rather than the newest. Deterministic timestamps, no wall clock.
         using var svc = NewService();
         var start = new DateTime(2026, 1, 1, 0, 0, 0);
         for (int i = 0; i < 25; i++)
-            await svc.SaveAsync(Result("HTTP", down: i, server: $"s{i}", at: start.AddMinutes(i)));
+        {
+            var saved = await svc.SaveAsync(Result("HTTP", down: i, server: $"s{i}", at: start.AddMinutes(i)));
+            Assert.True(saved, $"save {i} (s{i}) failed to reach disk — every later assertion would be "
+                             + "measuring a history with a hole in it.");
+        }
 
         var loaded = await svc.LoadAsync();
 
-        Assert.Equal(SpeedTestHistoryService.MaxPerEngine, loaded.Count);
-        Assert.Equal("s24", loaded[0].Server);                       // newest first
-        Assert.DoesNotContain(loaded, r => r.Server == "s0");        // oldest trimmed
-        Assert.DoesNotContain(loaded, r => r.Server == "s4");
-        Assert.Contains(loaded, r => r.Server == "s5");              // 25 - 20 = first kept
+        // Newest first, exactly s24 down to s5: 25 saved, 20 kept.
+        var expected = Enumerable.Range(5, 20).Reverse().Select(i => $"s{i}").ToArray();
+        Assert.Equal(expected, loaded.Select(r => r.Server).ToArray());
     }
 
     [Fact]

--- a/SysManager/SysManager/Helpers/EtaCalculator.cs
+++ b/SysManager/SysManager/Helpers/EtaCalculator.cs
@@ -2,77 +2,160 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.Diagnostics;
-
 namespace SysManager.Helpers;
 
 /// <summary>
-/// Calculates estimated time remaining (ETA) for any operation that reports
-/// progress as a percentage (0–100). Uses a simple linear extrapolation based
-/// on elapsed time and current progress.
+/// Calculates estimated time remaining (ETA) for any operation that reports progress as a percentage
+/// (0–100), from a smoothed estimate of how fast progress is actually moving.
 /// <para>
-/// Usage: call <see cref="Reset"/> when the operation starts, then call
-/// <see cref="Update"/> each time progress changes. Read <see cref="Remaining"/>
-/// or <see cref="RemainingText"/> for the current estimate.
+/// Usage: call <see cref="Reset"/> when the operation starts, then call <see cref="Update"/> each time
+/// progress changes. Read <see cref="Remaining"/> or <see cref="RemainingText"/> for the current
+/// estimate — both are evaluated when read, so they keep counting down between progress reports rather
+/// than holding whatever the last report produced.
 /// </para>
 /// <para>
-/// Thread safety: this class is NOT thread-safe. All calls must be made from
-/// the same thread (typically the UI thread via Progress&lt;T&gt; callbacks).
+/// This used to extrapolate from the average since the start (<c>elapsed * 100 / percent</c>), computed
+/// only when a caller reported progress. Three consequences, all measured against the old formula:
+/// callers derive percent by integer division, so during one long step the SAME percent arrives
+/// repeatedly — and the estimate GREW with elapsed time, climbing from "~1 min" to "~37 min" while the
+/// bar never moved; between reports the text froze on a number that was already stale; and a slow first
+/// step displayed "~1.6 h" moments before the real answer turned out to be 90 s.
+/// </para>
+/// <para>
+/// Thread safety: this class is NOT thread-safe. All calls must be made from the same thread (typically
+/// the UI thread via Progress&lt;T&gt; callbacks).
 /// </para>
 /// </summary>
 public sealed class EtaCalculator
 {
-    private readonly Stopwatch _sw = new();
+    /// <summary>
+    /// Weight given to the newest rate sample. 0.3 stays responsive to a genuine slowdown within a few
+    /// samples while ignoring the jitter of one slow step — the usual low-pass constant for transfer
+    /// dialogs. Higher jumps around; lower reacts too late to be useful.
+    /// </summary>
+    private const double RateSmoothing = 0.3;
+
+    /// <summary>
+    /// No estimate is shown below this mark. Early samples are dominated by start-up cost — opening
+    /// handles, enumerating a tree — and extrapolating from them is what produced the "~1.6 h" that
+    /// became 90 s. "calculating…" is more honest than a number certain to be wrong.
+    /// </summary>
+    private const int MinPercentForEstimate = 3;
+
+    private readonly TimeProvider _time;
+
+    private long _startTimestamp;
+    private long _lastSampleTimestamp;
+    private bool _started;
+    private bool _completed;
     private int _lastPercent;
 
-    /// <summary>Estimated time remaining, or null if not enough data.</summary>
-    public TimeSpan? Remaining { get; private set; }
+    /// <summary>Percent per second, exponentially smoothed. Zero until a real advance has been seen.</summary>
+    private double _rate;
 
-    /// <summary>Human-readable ETA string (e.g. "~2 min 15 s" or "calculating…").</summary>
-    public string RemainingText { get; private set; } = string.Empty;
+    /// <summary>Elapsed-since-start at which progress is projected to reach 100%. Null when unknown.</summary>
+    private TimeSpan? _projectedFinish;
+
+    /// <param name="timeProvider">
+    /// Time source, defaulting to <see cref="TimeProvider.System"/>. A test passes a fake and advances it,
+    /// so the ETA maths is verified deterministically. This class held a private <c>Stopwatch</c> before,
+    /// which is precisely why its tests used <c>Thread.Sleep</c> — the non-deterministic pattern the
+    /// project's testing discipline rules out.
+    /// </param>
+    public EtaCalculator(TimeProvider? timeProvider = null) => _time = timeProvider ?? TimeProvider.System;
+
+    /// <summary>
+    /// Estimated time remaining, or null when there is not enough data yet.
+    /// <para>Derived at read time from the projected finish, so an operation that has gone quiet shows
+    /// its remaining time running down instead of a frozen value.</para>
+    /// </summary>
+    public TimeSpan? Remaining
+    {
+        get
+        {
+            if (_completed) return TimeSpan.Zero;
+            if (_projectedFinish is not { } finish) return null;
+            var left = finish - Elapsed;
+            return left < TimeSpan.Zero ? TimeSpan.Zero : left;
+        }
+    }
+
+    /// <summary>Human-readable ETA string (e.g. "~2 min 15 s", "calculating…", "done").</summary>
+    public string RemainingText
+    {
+        get
+        {
+            if (_completed) return "done";
+            if (!_started) return string.Empty;
+            return Remaining is { } left ? FormatTimeSpan(left) : "calculating…";
+        }
+    }
+
+    private TimeSpan Elapsed => _started ? _time.GetElapsedTime(_startTimestamp) : TimeSpan.Zero;
 
     /// <summary>Resets the calculator. Call at the start of each operation.</summary>
     public void Reset()
     {
-        _sw.Restart();
+        _startTimestamp = _time.GetTimestamp();
+        _lastSampleTimestamp = _startTimestamp;
+        _started = true;
+        _completed = false;
         _lastPercent = 0;
-        Remaining = null;
-        RemainingText = string.Empty;
+        _rate = 0;
+        _projectedFinish = null;
     }
 
     /// <summary>
-    /// Updates the estimate with the current progress percentage (0–100).
-    /// Returns the formatted ETA string for convenience.
+    /// Updates the estimate with the current progress percentage (0–100). Returns the formatted ETA
+    /// string for convenience.
     /// </summary>
     public string Update(int percent)
     {
-        _lastPercent = Math.Clamp(percent, 0, 100);
+        var clamped = Math.Clamp(percent, 0, 100);
 
-        if (_lastPercent <= 0 || !_sw.IsRunning)
+        // Update before Reset: report honestly rather than measuring from an unset start.
+        if (!_started)
         {
-            Remaining = null;
-            RemainingText = "calculating…";
+            _lastPercent = clamped;
+            return "calculating…";
+        }
+
+        if (clamped >= 100)
+        {
+            _lastPercent = 100;
+            _completed = true;
+            _projectedFinish = null;
             return RemainingText;
         }
 
-        if (_lastPercent >= 100)
+        _completed = false;
+
+        var advanced = clamped - _lastPercent;
+        var sinceLastSample = _time.GetElapsedTime(_lastSampleTimestamp);
+
+        // A repeated or backwards percent carries no rate information — and re-projecting on one is the
+        // whole bug in a different costume. `Elapsed + secondsLeft` would push the finish forward by
+        // exactly the time that just passed, so the displayed value would never move (the first draft of
+        // this fix did that, and the stall test caught it). Returning early leaves the existing
+        // projection in place, and because Remaining is derived at read time, it counts down on its own.
+        if (advanced <= 0 || sinceLastSample <= TimeSpan.Zero)
         {
-            Remaining = TimeSpan.Zero;
-            RemainingText = "done";
+            _lastPercent = clamped;
             return RemainingText;
         }
 
-        // Linear extrapolation: total_time = elapsed / (percent / 100)
-        // remaining = total_time - elapsed
-        var elapsed = _sw.Elapsed;
-        var totalEstimate = elapsed * (100.0 / _lastPercent);
-        var remaining = totalEstimate - elapsed;
+        var sample = advanced / sinceLastSample.TotalSeconds;
+        _rate = _rate <= 0 ? sample : (RateSmoothing * sample) + ((1 - RateSmoothing) * _rate);
+        _lastSampleTimestamp = _time.GetTimestamp();
+        _lastPercent = clamped;
 
-        if (remaining < TimeSpan.Zero)
-            remaining = TimeSpan.Zero;
+        if (clamped < MinPercentForEstimate || _rate <= 0)
+        {
+            _projectedFinish = null;
+            return RemainingText;
+        }
 
-        Remaining = remaining;
-        RemainingText = FormatTimeSpan(remaining);
+        _projectedFinish = Elapsed + TimeSpan.FromSeconds((100 - clamped) / _rate);
         return RemainingText;
     }
 

--- a/SysManager/SysManager/Services/SpeedTestHistoryService.cs
+++ b/SysManager/SysManager/Services/SpeedTestHistoryService.cs
@@ -120,8 +120,17 @@ public sealed class SpeedTestHistoryService : IDisposable
     /// <summary>
     /// Saves a new result, appending to existing history. Trims to
     /// <see cref="MaxPerEngine"/> per engine type.
+    /// <para>Returns <c>true</c> when the result reached disk and <c>false</c> when the write failed. It
+    /// used to return a bare <c>Task</c> and swallow <see cref="IOException"/> into a log warning, so a
+    /// transient filesystem failure discarded the user's result while every caller — and the UI — carried
+    /// on as though it had been stored. That is silent data loss of the only record the Speed Test tab
+    /// keeps, and it is not theoretical: it surfaced as a one-off unit-test failure during a release, where
+    /// the loaded history came back with its window shifted by exactly one entry — the signature of a
+    /// single dropped write — on a run whose predecessor had passed.</para>
+    /// <para>The exception is still not rethrown: losing one reading must not take the tab down. But the
+    /// outcome is now reported, so a caller can tell the user instead of pretending.</para>
     /// </summary>
-    public async Task SaveAsync(SpeedTestResult result, CancellationToken ct = default)
+    public async Task<bool> SaveAsync(SpeedTestResult result, CancellationToken ct = default)
     {
         await _fileLock.WaitAsync(ct).ConfigureAwait(false);
         try
@@ -151,14 +160,17 @@ public sealed class SpeedTestHistoryService : IDisposable
 
             var json = JsonSerializer.Serialize(entries, JsonOpts);
             await AtomicFile.WriteAllTextAsync(_historyPath, json, ct).ConfigureAwait(false);
+            return true;
         }
         catch (IOException ex)
         {
             Log.Warning(ex, "Failed to save speed test result");
+            return false;
         }
         catch (UnauthorizedAccessException ex)
         {
             Log.Warning(ex, "Access denied saving speed test history");
+            return false;
         }
         finally
         {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.9</Version>
-    <FileVersion>1.65.9.0</FileVersion>
-    <AssemblyVersion>1.65.9.0</AssemblyVersion>
+    <Version>1.65.10</Version>
+    <FileVersion>1.65.10.0</FileVersion>
+    <AssemblyVersion>1.65.10.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
@@ -110,8 +110,12 @@ public sealed partial class SpeedTestViewModel : ViewModelBase
             // result next to an Ookla one — the two engines measure differently.
             HttpVerdict = SpeedVerdictAnalyzer.Analyze(HttpResult, HttpHistory.FirstOrDefault());
 
-            // Persist result to history.
-            await _history.SaveAsync(HttpResult);
+            // Persist result to history. The in-memory list is still updated when the write fails, so the
+            // reading stays on screen for this session — but the status says so, because a result the user
+            // believes was recorded and then cannot find next launch is worse than one they were warned
+            // about. SaveAsync does not throw; it reports.
+            if (!await _history.SaveAsync(HttpResult))
+                HttpStatus = "HTTP done — result could not be saved to history";
             HttpHistory.Insert(0, HttpResult);
             if (HttpHistory.Count > SpeedTestHistoryService.MaxPerEngine)
                 HttpHistory.RemoveAt(HttpHistory.Count - 1);
@@ -154,8 +158,9 @@ public sealed partial class SpeedTestViewModel : ViewModelBase
             // Before the insert, for the same reason as the HTTP path above.
             OoklaVerdict = SpeedVerdictAnalyzer.Analyze(OoklaResult, OoklaHistory.FirstOrDefault());
 
-            // Persist result to history.
-            await _history.SaveAsync(OoklaResult);
+            // Persist result to history, reporting a failed write — same contract as the HTTP path above.
+            if (!await _history.SaveAsync(OoklaResult))
+                OoklaStatus = "Ookla done — result could not be saved to history";
             OoklaHistory.Insert(0, OoklaResult);
             if (OoklaHistory.Count > SpeedTestHistoryService.MaxPerEngine)
                 OoklaHistory.RemoveAt(OoklaHistory.Count - 1);


### PR DESCRIPTION
## Why these ship together

**v1.65.9 was tagged but never published.** Its Release build stopped at `Run unit tests (must pass)` on
a single test — and that test was not flaky. It was reporting the first defect below. Everything 1.65.9
contained is in 1.65.10; the orphan tag gets removed once this release lands so it cannot claim the
Latest badge.

## Defect 1 — a speed-test result could vanish silently (this is what failed the release)

```csharp
catch (IOException ex) { Log.Warning(ex, "Failed to save speed test result"); }   // then returns normally
```

`SaveAsync` returned a bare `Task`, so **no caller could distinguish a successful write from a discarded
one.** A moment of disk contention dropped the user's result while the tab went on displaying it; the gap
only appeared on the next launch, on the only record this tab keeps.

**The evidence, from the failed release job:**

```
Assert.DoesNotContain() Failure: Filter matched in collection
Collection: [···, s8, s7, s6, s5, s4]
```

Twenty entries, correct count, `s24` first — but the window ends **s5, s4** instead of **s6, s5**. Slid
down by exactly one: the signature of one lost write. The old assertions caught it only through an
incidental `DoesNotContain("s4")` and reported it as "filter matched", which took reading the raw dump to
interpret.

Not reproducible in isolation — **80 rounds, sequential and at 16-way parallelism, all clean** — which is
consistent with a transient I/O failure and is exactly why this has been reading as flakiness.

**Fix:** `SaveAsync` returns `bool`. Both call sites in `SpeedTestViewModel` surface a failed save in the
status line **while keeping the reading on screen for the session** — losing the number the user just
waited two minutes for would be a second insult. The exception is still not rethrown: one lost reading
must not take the tab down.

## Defect 2 — "time remaining" grew while progress stood still

`EtaCalculator` extrapolated from the average since the start (`elapsed * 100 / percent`) and recomputed
only when a caller reported progress. Callers derive percent by integer division, so a long step reports
the same value repeatedly. Measured against the old formula:

| elapsed, stuck at 12% | old estimate |
|---|---|
| 10 s | ~1.2 min |
| 60 s | ~7.3 min |
| 300 s | **~36.7 min** |

The bar never moved and the estimate climbed. Between reports it froze on a stale number instead. And a
slow first step showed **~1 h 39 min** for a job that finished in 90 s.

**Fix:** a smoothed percent-per-second rate (EWMA, α=0.3), `Remaining` derived at **read** time so a
quiet job counts down rather than freezing, and no estimate below 3%.

### The real reason this was invisible

A private `Stopwatch` left no seam, so the tests used `Thread.Sleep` and could only assert *"some
estimate came back"* — they could not check the number, which is why an estimate that grows during a
stall never failed anything. `TimeProvider` is injected now (a hand-written fake, not a new NuGet
dependency: the class needs only `GetTimestamp` + `TimestampFrequency`).

**That paid off immediately.** The stall test caught a bug in *this very fix*: re-projecting on a repeated
percent pushed the finish forward by exactly the elapsed time, so the value never moved. Caught by a test,
not by review.

## Tests — red before, green after

**Save (4 cases):**

| Mutation | Expected | Got |
|---|---|---|
| unmutated | green | **green** |
| drop exactly one write, report success (the real defect) | red | **red** — names `s12` |
| same loss, with the **old** spot-check assertions | red | **red** — opaque `DoesNotContain` |
| `SaveAsync` returns `true` on a real failure | red | **red** |

**ETA (5 cases):**

| Mutation | Expected | Got |
|---|---|---|
| unmutated | green | **green** |
| **the original implementation, verbatim as shipped** | red ×3 | **red ×3** |
| re-project on a repeated percent (my own first-draft bug) | red | **red** |
| remove the 3% floor | red | **red** |
| freeze `Remaining` at update time | red | **red** |

The ETA row that matters is the second: the code that actually shipped through v1.65.9 fails all three
new behaviour tests.

## Verification

- `dotnet format --verify-no-changes` — exit 0
- All four projects, Release: **0 errors, 0 warnings**
- All three affected test classes run together: **47/47 green**, including `SpeedTestViewModelTests`
  whose call sites changed
- Leak scan over every changed file against every `leak-terms` pattern: 0 hits, with a control
- Propagate: every `SaveAsync` caller checked; the `Task` → `Task<bool>` change is source-compatible for
  `await`, and no other consumer inspects the result. `RemainingText` becoming computed is safe — the six
  view models set their **own** bound string for visibility and never read the property directly.

## A note on the proof itself

The first run of the save proof reported the **baseline** as red, with the mutation's own signature. The
cause was my proof script, not the code: it ran the baseline before flushing its restore, so the build
output was stale. It now writes pristine content explicitly and **aborts** if the baseline is not green —
a proof whose baseline is not known-clean can label a correct tree broken, which is worse than no proof.
