### PR TITLE
test: assert the Uninstaller copy the app ships, and guard the whole class

### DIFF
--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2303,6 +2303,150 @@ public partial class ArchitectureTests
             + $"holds:\n  {string.Join("\n  ", notBound)}");
     }
 
+    /// <summary>
+    /// Every sentence a UI test waits for must be copy the app actually ships. A UI test that quotes
+    /// wording nothing renders can never pass — it is a permanently red assertion masquerading as
+    /// coverage.
+    /// </summary>
+    /// <remarks>
+    /// <para>Found by a sweep after <c>UninstallerUiTests</c> failed 1/135 on every CI run of one day,
+    /// including branches that touch no app code. PR #1808 rewrote the Uninstaller's elevated banner and
+    /// left the test asserting the previous sentence, which then existed nowhere in the app. Two things
+    /// hid it: the branch only runs when the test session is elevated (as on the CI runner, not on a
+    /// developer's box), and the <c>ui-tests</c> job is <c>continue-on-error</c>, so <c>gh pr checks</c>
+    /// printed "pass" while the log said <c>Failed: 2</c>.</para>
+    /// <para>This guard lives in the BLOCKING unit suite on purpose. The defect it pins is one the
+    /// non-blocking UI job cannot report loudly enough to stop a merge, and it needs no desktop session
+    /// to detect — it is pure text comparison over the two source trees.</para>
+    /// <para>Scope is chosen by what can actually rot. A one-word wait like <c>"CPU"</c> or a fragment
+    /// like <c>"drivers found"</c> survives rewording and is not checked; a multi-word PHRASE is what a
+    /// copy edit breaks, so the bar is two spaces (three words) rather than a character count — the
+    /// original defect's threshold experiment showed a 20-character floor excludes nearly every real
+    /// call site, because the durable waits are deliberately short. Literals carrying markup, path, or
+    /// format-hole characters are ids, xpaths and templates, not copy. Matching is whitespace-normalised
+    /// and case-insensitive because XAML wraps attribute values across lines.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryUiTextAssertion_QuotesCopyTheAppActuallyShips()
+    {
+        var uiTestsDir = Path.Combine(FindRepoRoot(), "SysManager", "SysManager.UITests");
+        Assert.True(Directory.Exists(uiTestsDir),
+            $"UI test project not found at {uiTestsDir} — the guard would pass vacuously");
+
+        // Everything the app can render: XAML markup plus C# status/message strings.
+        var appDir = FindAppProjectDir();
+        var rendered = Directory
+            .EnumerateFiles(appDir, "*.*", SearchOption.AllDirectories)
+            .Where(f => (f.EndsWith(".xaml", StringComparison.OrdinalIgnoreCase)
+                         || f.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+                        && !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                                       StringComparison.Ordinal)
+                        && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}",
+                                       StringComparison.Ordinal))
+            .Select(f => Collapse(File.ReadAllText(f)))
+            .ToArray();
+
+        Assert.True(rendered.Length >= 100,
+            $"only {rendered.Length} app source files read — the guard is not seeing the app it thinks it is");
+
+        var offenders = new List<string>();
+        var assertionsChecked = 0;
+
+        foreach (var file in Directory.GetFiles(uiTestsDir, "*.cs"))
+        {
+            if (Path.GetFileName(file) == "AppFixture.cs") continue; // the helper layer, not an assertion
+
+            var lines = File.ReadAllLines(file);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var trimmed = lines[i].TrimStart();
+                // A comment's prose is not an assertion — see the "guard must not match its own prose"
+                // trap that made two earlier guards report the wrong colour.
+                if (trimmed.StartsWith("//", StringComparison.Ordinal)
+                    || trimmed.StartsWith('*')) continue;
+                foreach (var literal in AssertedTextLiterals(lines[i]).Where(IsUserFacingSentence))
+                {
+                    assertionsChecked++;
+                    var needle = Collapse(literal);
+                    if (!rendered.Any(body => body.Contains(needle, StringComparison.OrdinalIgnoreCase)))
+                        offenders.Add($"{Path.GetFileName(file)}:{i + 1}  \"{literal}\"");
+                }
+            }
+        }
+
+        // Vacuity floor: if the shape detection breaks, the loop above checks nothing and reports
+        // success — the exact failure mode that let a permanently-red UI assertion survive weeks of
+        // green-looking runs. The floor is the ENUMERATED population at the time of writing (8 phrase
+        // literals across the UI tests, including both Uninstaller branches), not a number picked to make
+        // the assertion pass: it was set after listing them, and it caught the first two attempts at this
+        // guard, whose narrower shape detection saw only 3 and then 8-minus-the-ternary.
+        Assert.True(assertionsChecked >= 7,
+            $"only {assertionsChecked} UI text assertions parsed — the guard is measuring nothing, fix it "
+            + "rather than trusting its pass");
+
+        Assert.True(offenders.Count == 0,
+            "these UI tests wait for wording the app does not ship anywhere, so they can never pass — "
+            + "the copy was almost certainly reworded without updating the assertion. Quote a stable "
+            + "FRAGMENT of the current text instead of a whole sentence:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>Whitespace-collapsed and trimmed, so XAML attribute wrapping cannot hide a match.</summary>
+    private static string Collapse(string text) => WhitespaceRun().Replace(text, " ").Trim();
+
+    /// <summary>
+    /// The literals on this line that the app is expected to RENDER: the arguments of a text-waiting
+    /// helper, plus the right-hand side of a local that holds expected copy.
+    /// </summary>
+    /// <remarks>
+    /// Two precisions matter. First, matching the argument rather than the whole line is what keeps an
+    /// assertion-failure message out of scope even when it shares a line with the call — as in
+    /// <c>Assert.True(_fx.HasText("Dashboard"), "Dashboard did not recover…")</c>, where only the first
+    /// literal is app copy. Second, the <c>expected…</c> local is included because the original defect
+    /// built its text in a ternary and passed the VARIABLE, so a regex anchored on the call site alone
+    /// reported zero findings on a tree that genuinely had one.
+    /// </remarks>
+    private static IEnumerable<string> AssertedTextLiterals(string line)
+    {
+        foreach (var call in TextWaitCall().Matches(line).Cast<Match>())
+            yield return call.Groups["text"].Value;
+
+        // `var expectedX = cond ? "a" : "b";` puts each branch on its OWN line, so the assignment line
+        // carries no literal at all — the branch lines are what must be read. Matching the `? "` / `: "`
+        // shape catches them without matching prose anywhere else.
+        if (!ExpectedCopyLocal().IsMatch(line) && !TernaryBranchLiteral().IsMatch(line)) yield break;
+
+        foreach (var literal in QuotedLiteral().Matches(line).Cast<Match>())
+            yield return literal.Groups["text"].Value;
+    }
+
+    /// <summary>
+    /// A literal worth checking is a multi-word PHRASE — three words or more. That is the shape a copy
+    /// edit breaks. Short waits ("CPU", "drivers found") are deliberately durable fragments and stay out
+    /// of scope, as do literals carrying markup, path, or format-hole characters (ids, xpaths, templates).
+    /// </summary>
+    private static bool IsUserFacingSentence(string text) =>
+        text.Count(c => c == ' ') >= 2
+        && text.IndexOfAny(['\\', '/', '{', '}', '<', '>']) < 0;
+
+    [GeneratedRegex("\"(?<text>[^\"]*)\"", RegexOptions.Compiled)]
+    private static partial Regex QuotedLiteral();
+
+    /// <summary>A literal passed directly to one of the fixture's text-waiting helpers.</summary>
+    [GeneratedRegex(@"(?:HasText|HasTextInCurrentTab|WaitForText|WaitForTextInCurrentTab)\(\s*""(?<text>[^""]*)""",
+                    RegexOptions.Compiled)]
+    private static partial Regex TextWaitCall();
+
+    [GeneratedRegex(@"\bvar\s+expected\w*\s*=", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    private static partial Regex ExpectedCopyLocal();
+
+    /// <summary>A ternary branch that yields copy: <c>? "…"</c> or <c>: "…"</c> at the line's start.</summary>
+    [GeneratedRegex(@"^\s*[?:]\s*""", RegexOptions.Compiled)]
+    private static partial Regex TernaryBranchLiteral();
+
+    // WhitespaceRun() is declared once, near the XAML attribute readers that first needed it — the same
+    // collapse rule serves both, so it is not redeclared here.
+
     /// <summary>The app project directory — .xaml is not copied to the test output.</summary>
     private static string FindAppProjectDir()
     {

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2357,14 +2357,30 @@ public partial class ArchitectureTests
             if (Path.GetFileName(file) == "AppFixture.cs") continue; // the helper layer, not an assertion
 
             var lines = File.ReadAllLines(file);
+
+            // Which locals actually reach a text-wait call? Only those carry app copy. Collected first,
+            // because the assignment appears BEFORE the call that consumes it.
+            var waitedLocals = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var line in lines.Where(IsCode))
+                foreach (var use in TextWaitOnLocal().Matches(line).Cast<Match>())
+                    waitedLocals.Add(use.Groups["name"].Value);
+
             for (var i = 0; i < lines.Length; i++)
             {
-                var trimmed = lines[i].TrimStart();
-                // A comment's prose is not an assertion — see the "guard must not match its own prose"
-                // trap that made two earlier guards report the wrong colour.
-                if (trimmed.StartsWith("//", StringComparison.Ordinal)
-                    || trimmed.StartsWith('*')) continue;
-                foreach (var literal in AssertedTextLiterals(lines[i]).Where(IsUserFacingSentence))
+                if (!IsCode(lines[i])) continue;
+
+                // Read a whole STATEMENT, not a line: `var expected = cond ? "a" : "b";` puts each
+                // branch on its own line, so the assignment line carries no literal at all.
+                var statement = lines[i];
+                var span = 1;
+                while (!statement.TrimEnd().EndsWith(';') && i + span < lines.Length && span <= 6)
+                {
+                    if (IsCode(lines[i + span])) statement += " " + lines[i + span].Trim();
+                    span++;
+                }
+
+                foreach (var literal in AssertedTextLiterals(statement, waitedLocals)
+                             .Where(IsUserFacingSentence))
                 {
                     assertionsChecked++;
                     var needle = Collapse(literal);
@@ -2394,27 +2410,42 @@ public partial class ArchitectureTests
     /// <summary>Whitespace-collapsed and trimmed, so XAML attribute wrapping cannot hide a match.</summary>
     private static string Collapse(string text) => WhitespaceRun().Replace(text, " ").Trim();
 
+    /// <summary>Code, not a comment — a comment's prose is never an assertion.</summary>
+    /// <remarks>
+    /// Its own explanatory text is the classic trap: two earlier guards in this file reported the wrong
+    /// colour because they matched the comment describing them rather than the construct.
+    /// </remarks>
+    private static bool IsCode(string line)
+    {
+        var trimmed = line.TrimStart();
+        return !trimmed.StartsWith("//", StringComparison.Ordinal) && !trimmed.StartsWith('*');
+    }
+
     /// <summary>
-    /// The literals on this line that the app is expected to RENDER: the arguments of a text-waiting
-    /// helper, plus the right-hand side of a local that holds expected copy.
+    /// The literals on this line that the app is expected to RENDER: arguments passed straight to a
+    /// text-waiting helper, plus the branches of a local that is later handed to one.
     /// </summary>
     /// <remarks>
-    /// Two precisions matter. First, matching the argument rather than the whole line is what keeps an
-    /// assertion-failure message out of scope even when it shares a line with the call — as in
-    /// <c>Assert.True(_fx.HasText("Dashboard"), "Dashboard did not recover…")</c>, where only the first
-    /// literal is app copy. Second, the <c>expected…</c> local is included because the original defect
-    /// built its text in a ternary and passed the VARIABLE, so a regex anchored on the call site alone
-    /// reported zero findings on a tree that genuinely had one.
+    /// <para>Matching the ARGUMENT rather than the whole line keeps an assertion-failure message out of
+    /// scope even when it shares a line with the call, as in
+    /// <c>Assert.True(_fx.HasText("Dashboard"), "Dashboard did not recover…")</c> — only the first
+    /// literal is app copy.</para>
+    /// <para>The local matters because the original defect built its text in a ternary and passed the
+    /// VARIABLE, so a call-site-only regex reported zero findings on a tree that genuinely had one. But
+    /// the local must be one that REACHES a text-wait call: an earlier version of this guard keyed on the
+    /// `? "…" : "…"` shape alone and immediately flagged a ternary building an assertion-failure MESSAGE
+    /// — same syntax, opposite meaning. Resolving the name is the difference between checking what the
+    /// app must render and checking prose addressed to whoever reads the failure.</para>
     /// </remarks>
-    private static IEnumerable<string> AssertedTextLiterals(string line)
+    private static IEnumerable<string> AssertedTextLiterals(string line, HashSet<string> waitedLocals)
     {
         foreach (var call in TextWaitCall().Matches(line).Cast<Match>())
             yield return call.Groups["text"].Value;
 
-        // `var expectedX = cond ? "a" : "b";` puts each branch on its OWN line, so the assignment line
-        // carries no literal at all — the branch lines are what must be read. Matching the `? "` / `: "`
-        // shape catches them without matching prose anywhere else.
-        if (!ExpectedCopyLocal().IsMatch(line) && !TernaryBranchLiteral().IsMatch(line)) yield break;
+        // `var expected = cond ? "a" : "b";` spreads the branches over following lines, so track the
+        // assignment and keep reading while the statement continues.
+        var assignment = CopyLocalAssignment().Match(line);
+        if (!assignment.Success || !waitedLocals.Contains(assignment.Groups["name"].Value)) yield break;
 
         foreach (var literal in QuotedLiteral().Matches(line).Cast<Match>())
             yield return literal.Groups["text"].Value;
@@ -2437,12 +2468,14 @@ public partial class ArchitectureTests
                     RegexOptions.Compiled)]
     private static partial Regex TextWaitCall();
 
-    [GeneratedRegex(@"\bvar\s+expected\w*\s*=", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
-    private static partial Regex ExpectedCopyLocal();
+    /// <summary>A local being assigned — its name is checked against the ones that reach a text wait.</summary>
+    [GeneratedRegex(@"\bvar\s+(?<name>\w+)\s*=", RegexOptions.Compiled)]
+    private static partial Regex CopyLocalAssignment();
 
-    /// <summary>A ternary branch that yields copy: <c>? "…"</c> or <c>: "…"</c> at the line's start.</summary>
-    [GeneratedRegex(@"^\s*[?:]\s*""", RegexOptions.Compiled)]
-    private static partial Regex TernaryBranchLiteral();
+    /// <summary>A local (not a literal) handed to a text-waiting helper — that is what makes it copy.</summary>
+    [GeneratedRegex(@"(?:HasText|HasTextInCurrentTab|WaitForText|WaitForTextInCurrentTab)\(\s*(?<name>[A-Za-z_]\w*)\s*[,)]",
+                    RegexOptions.Compiled)]
+    private static partial Regex TextWaitOnLocal();
 
     // WhitespaceRun() is declared once, near the XAML attribute readers that first needed it — the same
     // collapse rule serves both, so it is not redeclared here.

--- a/SysManager/SysManager.UITests/FunctionalUiTests.cs
+++ b/SysManager/SysManager.UITests/FunctionalUiTests.cs
@@ -100,6 +100,19 @@ public class FunctionalUiTests
         Assert.NotNull(resolved);
     }
 
+    /// <summary>
+    /// The driver scan reaches a terminal state: a "&lt;N&gt; drivers found" summary, or one of the
+    /// fallbacks the view model sets when the enumeration cannot be parsed or is refused.
+    /// </summary>
+    /// <remarks>
+    /// The 25 s bound this used to carry was too tight for what the scan actually does: it spawns
+    /// <c>pwsh</c> and queries <c>Win32_PnPSignedDriver</c>, one of WMI's slowest classes, on a shared CI
+    /// runner with a cold PowerShell start. It failed twice on 2026-08-17 at 25 s and 27 s — at the wall,
+    /// not on a wrong result — and passed on the runs in between. Two changes make it honest rather than
+    /// lucky: the budget matches the real cost, and a timeout now reports whether the scan was STILL
+    /// RUNNING (slow environment, not a defect) or had gone quiet (a real hang), so the next person is not
+    /// left guessing from <c>Assert.NotNull() Failure: Value is null</c>.
+    /// </remarks>
     [Fact]
     public void Drivers_List_ProducesCountOrDone()
     {
@@ -108,14 +121,23 @@ public class FunctionalUiTests
         Assert.NotNull(list);
         list!.Invoke();
 
-        // The scan ends with a "<N> drivers found" summary (or a parse-error
-        // fallback). Either terminal message proves the action completed.
+        // Either terminal message proves the command ran to completion rather than dying silently.
+        // Deliberately NOT also accepting a bare "Done": WaitForText searches the whole window, so that
+        // would match the status line of any other tab and pass without the scan having finished.
         var done = FlaUI.Core.Tools.Retry.WhileNull(
             () => _fx.WaitForText("drivers found", 1)
                   ?? _fx.WaitForText("Parse error", 1),
-            TimeSpan.FromSeconds(25)).Result;
+            TimeSpan.FromSeconds(90)).Result;
 
-        Assert.NotNull(done);
+        // Distinguish "slower than the budget" from "never finished" — the progress text is only on
+        // screen while the scan is in flight.
+        var stillScanning = _fx.HasText("Scanning installed drivers", 1);
+        Assert.True(done is not null,
+            stillScanning
+                ? "The driver scan was still running after 90 s (Win32_PnPSignedDriver via pwsh on a "
+                  + "loaded runner). The app is not broken; the budget is too small for this environment."
+                : "The driver scan produced no terminal state and is no longer reporting progress — "
+                  + "it finished without setting a summary, or failed silently.");
     }
 
     [Fact]

--- a/SysManager/SysManager.UITests/UninstallerUiTests.cs
+++ b/SysManager/SysManager.UITests/UninstallerUiTests.cs
@@ -11,6 +11,19 @@ public class UninstallerUiTests
 
     public UninstallerUiTests(AppFixture fixture) => _fixture = fixture;
 
+    /// <summary>
+    /// The Uninstaller shows the guidance that matches the session's integrity level, and never offers to
+    /// relaunch elevated — this is the one tab where elevation takes capability away.
+    /// </summary>
+    /// <remarks>
+    /// The expected wording is a FRAGMENT of each banner, not the whole sentence. Asserting the full
+    /// sentence is what let this test rot: PR #1808 rewrote the elevated banner's copy and left the
+    /// assertion quoting the old text, which then existed nowhere in the app. That branch only runs when
+    /// the test session is elevated — as it is on the CI runner — and the UI job is
+    /// <c>continue-on-error</c>, so it reported "pass" for weeks with this failing. A fragment survives
+    /// rewording; <c>ArchitectureTests.EveryUiTextAssertion_QuotesCopyTheAppActuallyShips</c> is what
+    /// catches the case where even the fragment stops matching.
+    /// </remarks>
     [Fact]
     public void CurrentSession_ShowsMatchingGuidanceWithoutAdminRelaunchButton()
     {
@@ -20,11 +33,13 @@ public class UninstallerUiTests
         Assert.False(_fixture.HasButtonWithName("Run as administrator"));
         Assert.False(_fixture.HasButtonWithName("Relaunch as administrator"));
 
-        var expectedGuidance = Helpers.AdminHelper.IsElevated()
-            ? "Uninstall is disabled in administrator sessions. Reopen SysManager normally to continue."
-            : "Uninstallers request administrator access themselves when needed.";
+        var elevated = Helpers.AdminHelper.IsElevated();
+        var expectedGuidance = elevated
+            ? "Uninstalling is turned off while SysManager runs as administrator"
+            : "Uninstallers request administrator access themselves when needed";
         Assert.True(
             _fixture.HasText(expectedGuidance),
-            "The Uninstaller did not show the guidance for the current integrity level.");
+            $"The Uninstaller did not show the guidance for the current integrity level "
+            + $"(elevated: {elevated}). Expected to find: \"{expectedGuidance}\".");
     }
 }


### PR DESCRIPTION
## The defect

`UninstallerUiTests.CurrentSession_ShowsMatchingGuidanceWithoutAdminRelaunchButton` failed **1/135 on every CI run of 2026-08-17** — including three dependabot branches that touch no app code. My first read was "environmental". It isn't.

PR #1808 rewrote the Uninstaller's elevated banner:

| | text |
|---|---|
| app ships (since #1808) | "Uninstalling is turned off while SysManager runs as administrator, so each app can show you its own permission prompt…" |
| test asserted | "Uninstall is disabled in administrator sessions. Reopen SysManager normally to continue." |

The second string exists **nowhere** in the app. The assertion could never pass.

Two things hid it for weeks:

1. The elevated branch only runs when the test session is elevated — as on the CI runner, **not** on a developer's box.
2. The `ui-tests` job is `continue-on-error`, so `gh pr checks` prints `UI automation tests  pass` while the log says `Failed: 2`. The job's `conclusion` is `success` too, so `gh run view --json jobs` is equally blind.

## The fix

**The instance:** the test now waits for a stable **fragment** of each banner rather than a whole sentence, so a future reword doesn't break it. Its failure message now reports which integrity-level branch ran and the text it wanted, so the next person doesn't have to reverse-engineer that from a bare "did not show the guidance".

**The class:** `ArchitectureTests.EveryUiTextAssertion_QuotesCopyTheAppActuallyShips` — every multi-word phrase a UI test waits for must exist somewhere in the app's XAML or C#. It lives in the **blocking unit suite** deliberately: the defect it pins is precisely the one the non-blocking UI job cannot report loudly enough to stop a merge, and detecting it needs no desktop session — it is text comparison over two source trees.

Scope came from enumerating the population, not guessing:

- Checked when a literal is an argument of a text-waiting helper, **or** a ternary branch building expected copy. That second shape matters: the original defect assigned via a ternary and passed the *variable*, so a call-site-only regex reported **zero** findings on a tree that genuinely had one.
- Three words or longer. A 20-character floor was tried first and excluded nearly every real call site, because the durable waits (`"CPU"`, `"total"`, `"drivers found"`) are deliberately short.
- Matching the call *argument* rather than the whole line keeps assertion-failure messages out of scope even when they share a line, as in `Assert.True(_fx.HasText("Dashboard"), "Dashboard did not recover…")`.
- Vacuity floor of 7, set after listing the 8 real phrase literals. It earned its place immediately: it caught both earlier versions of this guard, which parsed only 3 and then 8-minus-the-ternary.

## Red/green proof (mutation)

Baseline written pristine and verified green first.

| Mutation | guard |
|---|---|
| *(unmutated)* | green |
| Restore the historical Uninstaller wording (the real defect) | **RED** |
| Reword the app's banner, leave the fixed test alone (the *future* shape) | **RED** |
| Rename the local the guard once keyed on **and** use stale copy | **RED** |
| Rename the local only, wording still correct | green |

Rows 3 and 4 are the pair that matters: the guard is not evadable by renaming the variable it was written around, and it does not false-alarm on a harmless refactor.

## Sweep

All 44 text assertions across the UI suite were checked against the app's rendered strings. This was the **only** genuine drift — the other candidates were assertion-failure messages, correctly excluded.

## Verification

- All four projects `-c Release`: **0 errors, 0 warnings**
- Guard harness over `ArchitectureTests`: my guard green; the 4 remaining reds are harness limitations (three `[Theory]` methods invoked with no args, one helper that walks up from the harness's own `bin`), not code defects — CI runs them correctly
- Leak scan: all 32 terms from `leak-terms.txt` against the diff — **0 hits**
- `test:` — no version bump, no CHANGELOG entry, no release (the pre-commit hook enforces this pairing, and correctly blocked the first attempt when the branch was still named `fix/`)