### PR TITLE
fix: sample bandwidth off the UI thread in both modes, and bound the ETW PID table

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -137,7 +137,7 @@ QA-verified is marked with `IsInDevelopment` (surfaced as a PREVIEW badge) inste
 - `BrowserCleanerViewModel` — scan per-browser cache/history/cookies/sessions with sizes and clean the selected categories; cookies/sessions default unticked.
 - `EdgeOneDriveViewModel` — reversibly de-integrate Edge and OneDrive (Edge/OneDrive Remover tab): OneDrive is fully removed per-user (no admin) with restore; Edge is only disabled & de-integrated (background/startup-boost policy + auto-update tasks, admin-gated) with restore — never uninstalled; guides the user to Windows settings to change the default browser. Every action confirms first and reports its honest outcome (success / needs-admin / not-applicable).
 - `PrivacyMonitorViewModel` — read-only camera/mic/location access history from the consent store; hands off to Windows settings to change permissions.
-- `BandwidthMonitorViewModel` — live total download/upload speed with a rolling throughput chart and a per-app usage list (Bandwidth Monitor tab). Polls the active `IBandwidthMonitorService` on a ~1&#160;s loop, paused while the tab is hidden (`IsActive`), reconciling rows in place by PID so icons/order don't flicker. Defaults to the no-admin connection source; when elevated and opted in, switches to the ETW source for precise per-app rates and falls back automatically if ETW can't start. Threshold-alert derivation and rate formatting come from `BandwidthFormat`/`FormatHelper`. Read-only.
+- `BandwidthMonitorViewModel` — live total download/upload speed with a rolling throughput chart and a per-app usage list (Bandwidth Monitor tab). Polls the active `IBandwidthMonitorService` on a ~1&#160;s loop, paused while the tab is hidden (`IsActive`) and wrapping every sample in one `Task.Run` so no source runs its work on the render thread, reconciling rows in place by PID so icons/order don't flicker. Defaults to the no-admin connection source; when elevated and opted in, switches to the ETW source for precise per-app rates and falls back automatically if ETW can't start. Threshold-alert derivation and rate formatting come from `BandwidthFormat`/`FormatHelper`. Read-only.
 - `ConsoleViewModel` — shared, per-tab scrollable console (each tab gets its own
   instance; lines capped at 5000 to bound memory) backing the in-app Console mirror
   used by Cleanup, Windows Update, System Health, App Updates, and Uninstaller.
@@ -484,7 +484,12 @@ Key services:
   throughput and reads the extended TCP/UDP tables via iphlpapi P/Invoke (`GetExtendedTcpTable`/
   `GetExtendedUdpTable`) to attribute active connections to PIDs; `EtwBandwidthSource` (admin) opens
   a kernel ETW session (TraceEvent) for true per-process byte rates and falls back cleanly if the
-  session can't start. `BandwidthHistoryService` persists total-throughput samples as NDJSON in
+  session can't start; it drops PIDs idle for ten minutes so the per-tick sort tracks what is
+  currently active rather than everything the session has ever seen. Both sources are deliberately
+  SYNCHRONOUS — `BandwidthMonitorViewModel.PollOnceAsync` owns the single off-UI-thread hop, so a new
+  source cannot forget it (the per-source arrangement is what let precise mode keep sampling on the
+  render thread through 1.61.9-1.65.11; `ArchitectureTests.EveryBandwidthSource_LeavesTheOffloadToIts
+  Consumer` now pins it). `BandwidthHistoryService` persists total-throughput samples as NDJSON in
   `%LocalAppData%\SysManager\bandwidth-history.ndjson` (serialize/parse/prune/downsample are pure,
   unit-tested; the directory is injectable so tests never touch the user's own history), and the VM
   reads it back through a range picker — Live plus last hour/24 hours/7 days, capped at the service's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.12] - 2026-08-17
+
+The Bandwidth Monitor's precise mode — the one that needs administrator — was doing its measuring on the
+same thread that draws the window, and the amount of work grew the longer you left the tab open. Both are
+fixed, so it now behaves like the ordinary mode already did.
+
+### Fixed
+- **Precise bandwidth mode stuttered, and got worse the longer it ran.** The 1.61.9 release fixed this
+  stutter for the ordinary mode and stated that precise mode was never affected. That was wrong: precise
+  mode did all of its per-second work on the thread that draws the window. Worse, that work kept growing —
+  it re-sorted every program that had used the network since you opened the tab, so an installer that ran
+  once in the morning was still being sorted at five o'clock. Programs that have sent nothing for ten
+  minutes are now dropped from that list, and the measuring happens on a background thread for both modes,
+  so the cost no longer depends on how long the tab has been open.
+
 ## [1.65.11] - 2026-08-17
 
 The Volume Control tab is smoother. The moving bars beside each app were being measured in a way that made

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2304,6 +2304,73 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// No bandwidth source may wrap its own sample in <c>Task.Run</c>. The offload belongs to the
+    /// consumer, once, so every source is covered by construction.
+    /// </summary>
+    /// <remarks>
+    /// <para>#1816: the 1.61.9 fix put the offload inside <c>ConnectionBandwidthSource</c> and left
+    /// <c>EtwBandwidthSource</c> returning <c>Task.FromResult</c>, so precise mode still did a per-tick
+    /// allocation and a two-key sort of every PID the session had ever seen on the render thread — in the
+    /// mode the CHANGELOG stated was never affected. Each source was internally consistent, so nothing
+    /// short of comparing them could see it, and <c>IBandwidthMonitorService</c> documents no
+    /// thread-affinity contract, which is precisely why an unwritten one drifted.</para>
+    /// <para>The rule is "sources stay synchronous" rather than "sources must offload" because the second
+    /// version is what failed: it is satisfiable one implementor at a time. With the offload at the single
+    /// consumer, a source re-adding its own is both a redundant hop and a sign someone believed the old
+    /// contract — worth failing over either way.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryBandwidthSource_LeavesTheOffloadToItsConsumer()
+    {
+        var servicesDir = Path.Combine(FindAppProjectDir(), "Services");
+        var sources = Directory.GetFiles(servicesDir, "*BandwidthSource.cs");
+
+        // Vacuity floor: two implementors exist (connection + ETW). If the glob stops matching them, the
+        // loop below inspects nothing and the guard reports success.
+        Assert.True(sources.Length >= 2,
+            $"only {sources.Length} bandwidth sources found in {servicesDir} — the guard is measuring "
+            + "nothing, fix it rather than trusting its pass");
+
+        var offenders = new List<string>();
+        foreach (var file in sources)
+        {
+            var body = SampleAsyncBody(File.ReadAllText(file));
+            Assert.False(body.Length == 0,
+                $"{Path.GetFileName(file)}: could not locate a SampleAsync body — the guard would pass "
+                + "vacuously on this file");
+
+            if (body.Contains("Task.Run", StringComparison.Ordinal))
+                offenders.Add(Path.GetFileName(file));
+        }
+
+        Assert.True(offenders.Count == 0,
+            "these bandwidth sources offload their own sample, but BandwidthMonitorViewModel.PollOnceAsync "
+            + "already wraps every source in Task.Run — a second hop per tick, and a sign the per-source "
+            + "contract that let #1816 hide is creeping back. Keep SampleAsync synchronous and let the "
+            + $"consumer own the offload:\n  {string.Join("\n  ", offenders)}");
+    }
+
+    /// <summary>
+    /// The text of <c>SampleAsync</c> up to the next member declaration — enough to see whether the method
+    /// itself offloads, without matching a <c>Task.Run</c> elsewhere in the file (a source legitimately
+    /// uses one to run its ETW processing loop).
+    /// </summary>
+    private static string SampleAsyncBody(string source)
+    {
+        var start = source.IndexOf("SampleAsync(CancellationToken", StringComparison.Ordinal);
+        if (start < 0) return "";
+
+        // Stop at the next member so the slice is the method, not the rest of the class. Every following
+        // member in these files opens with a doc comment or an access modifier at four-space indentation.
+        var rest = source[start..];
+        var end = NextMemberDeclaration().Match(rest, 1);
+        return end.Success ? rest[..end.Index] : rest;
+    }
+
+    [GeneratedRegex(@"\r?\n    (?:///|private |public |internal |protected )", RegexOptions.Compiled)]
+    private static partial Regex NextMemberDeclaration();
+
+    /// <summary>
     /// Every sentence a UI test waits for must be copy the app actually ships. A UI test that quotes
     /// wording nothing renders can never pass — it is a permanently red assertion masquerading as
     /// coverage.

--- a/SysManager/SysManager.Tests/BandwidthAggregationTests.cs
+++ b/SysManager/SysManager.Tests/BandwidthAggregationTests.cs
@@ -114,82 +114,49 @@ public class BandwidthAggregationTests
     // continuously while the tab was open, and nothing in the ViewModel looked wrong, because the
     // signature claimed to be async.
 
+    // The OFFLOAD moved to BandwidthMonitorViewModel.PollOnceAsync (#1816). This source used to wrap
+    // itself in Task.Run, which fixed it and left the ETW sibling running inline — an asymmetry the
+    // interface did not document and no test enforced. So "the work leaves the caller's context" is now
+    // asserted at the ViewModel, in BandwidthMonitorViewModelTests; the two tests that used to make that
+    // claim here would go red against a deliberately synchronous source. What stays testable HERE is that
+    // the source enumerates, projects, and honours its token — plus, in ArchitectureTests, that no source
+    // re-adds a private Task.Run and hides the contract again.
+
     private sealed class ContextRecordingSource : ConnectionBandwidthSource
     {
         public bool Ran { get; private set; }
-        public SynchronizationContext? ContextDuringWork { get; private set; }
 
         protected override IReadOnlyList<ConnectionRow> EnumerateConnections()
         {
             Ran = true;
-            ContextDuringWork = SynchronizationContext.Current;
-            return [new(100, "chrome.exe", 443, true)];
-        }
-    }
-
-    /// <summary>A stand-in for the UI's dispatcher context — only its identity matters here.</summary>
-    private sealed class MarkerContext : SynchronizationContext;
-
-    [Fact]
-    public async Task SampleAsync_DoesNotRunTheWorkOnTheCallersContext()
-    {
-        // Asserted through the SynchronizationContext rather than the thread id. A thread-id comparison
-        // looks like the obvious test and is quietly flaky: xUnit runs the test on a pool thread, that
-        // thread returns to the pool the moment this method awaits, and Task.Run may then legitimately
-        // pick the very same thread — which is exactly how it failed in CI, not because the offload was
-        // missing. The context is deterministic instead: Task.Run always schedules onto the pool, where
-        // Current is null, while a synchronous implementation runs inline and would observe the marker
-        // installed below — standing in for the real dispatcher context on the UI thread.
-        var previous = SynchronizationContext.Current;
-        var marker = new MarkerContext();
-        SynchronizationContext.SetSynchronizationContext(marker);
-        try
-        {
-            var src = new ContextRecordingSource();
-            src.Start();
-
-            await src.SampleAsync();
-
-            Assert.True(src.Ran);   // the work ran at all
-            Assert.NotSame(marker, src.ContextDuringWork);
-            Assert.Null(src.ContextDuringWork);
-        }
-        finally { SynchronizationContext.SetSynchronizationContext(previous); }
-    }
-
-    /// <summary>
-    /// Blocks inside the enumeration until released, then reports one row.
-    /// </summary>
-    /// <remarks>
-    /// The wait is BOUNDED rather than indefinite on purpose. Against a synchronous implementation the
-    /// caller would block inside SampleAsync on a gate only it can release — a deadlock, which in CI
-    /// means the whole job hangs to its ceiling instead of reporting a failure. A short timeout turns
-    /// that into a clean, fast assertion failure.
-    /// </remarks>
-    private sealed class GatedSource(SemaphoreSlim gate) : ConnectionBandwidthSource
-    {
-        protected override IReadOnlyList<ConnectionRow> EnumerateConnections()
-        {
-            gate.Wait(TimeSpan.FromSeconds(5));
             return [new(100, "chrome.exe", 443, true)];
         }
     }
 
     [Fact]
-    public async Task SampleAsync_ReturnsBeforeTheWorkCompletes()
+    public async Task SampleAsync_RunsTheEnumeration_AndProjectsIt()
     {
-        // The stronger statement: the returned Task must be genuinely incomplete while the work is still
-        // running. A synchronous implementation completes the whole sample before returning, so
-        // IsCompleted would already be true here.
-        var gate = new SemaphoreSlim(0);
-        var src = new GatedSource(gate);
+        var src = new ContextRecordingSource();
         src.Start();
 
-        var pending = src.SampleAsync();
+        var snap = await src.SampleAsync();
 
-        Assert.False(pending.IsCompleted);   // still working, on some other thread
-        gate.Release();
-        var snap = await pending;
+        Assert.True(src.Ran);
         Assert.Single(snap.Processes);
+        Assert.Equal(100, snap.Processes[0].ProcessId);
+    }
+
+    [Fact]
+    public async Task SampleAsync_HonoursCancellation_BeforeDoingTheWork()
+    {
+        // The source is synchronous now, so the token is no longer observed by a Task.Run wrapper — it
+        // has to be checked explicitly, or a cancelled poll would still pay for a full enumeration.
+        var src = new ContextRecordingSource();
+        src.Start();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => src.SampleAsync(cts.Token));
+        Assert.False(src.Ran);
     }
 }

--- a/SysManager/SysManager.Tests/BandwidthMonitorViewModelTests.cs
+++ b/SysManager/SysManager.Tests/BandwidthMonitorViewModelTests.cs
@@ -604,6 +604,71 @@ public class BandwidthMonitorViewModelTests : IDisposable
         public void Dispose() => _release.Set();   // Dispose must not deadlock a waiting sample
     }
 
+    // ── The poll offloads, whatever the source does ─────────────────────────
+
+    /// <summary>
+    /// A source that does its work INLINE and hands back a completed Task — the real
+    /// <c>EtwBandwidthSource</c> shape before #1816.
+    /// </summary>
+    private sealed class InlineSource : IBandwidthMonitorService
+    {
+        public SynchronizationContext? ContextDuringWork { get; private set; }
+        public bool Ran { get; private set; }
+        public BandwidthMode Mode => BandwidthMode.PreciseEtw;
+        public bool IsAvailable => true;
+        public bool Start() => true;
+
+        public Task<BandwidthSnapshot> SampleAsync(CancellationToken ct = default)
+        {
+            Ran = true;
+            ContextDuringWork = SynchronizationContext.Current;
+            return Task.FromResult(new BandwidthSnapshot(BandwidthMode.PreciseEtw, 1, 2, []));
+        }
+
+        public void Dispose() { }
+    }
+
+    /// <summary>A stand-in for the UI's dispatcher context — only its identity matters here.</summary>
+    private sealed class MarkerContext : SynchronizationContext;
+
+    /// <summary>
+    /// The poll must get the sample off the caller's context even when the SOURCE is fully synchronous.
+    /// </summary>
+    /// <remarks>
+    /// <para>This is the #1816 defect in one assertion. The 1.61.9 fix put the offload inside
+    /// <c>ConnectionBandwidthSource</c>; <c>EtwBandwidthSource</c> returned <c>Task.FromResult</c> and so
+    /// ran inline under the poll's <c>ConfigureAwait(true)</c> — a per-tick allocation plus a two-key sort
+    /// of every PID the session had ever seen, on the render thread, in the mode the CHANGELOG said was
+    /// never affected. Testing the source could not catch it: each source was individually consistent
+    /// with itself. Only the CONSUMER can be asked "do you offload whatever you are given".</para>
+    /// <para>Asserted through the SynchronizationContext rather than the thread id: xUnit runs the test on
+    /// a pool thread, that thread returns to the pool at the first await, and Task.Run may legitimately
+    /// pick the same one — a thread-id comparison failed in CI for that reason, not because an offload was
+    /// missing. Task.Run always schedules onto the pool, where Current is null, while inline work would
+    /// observe the marker installed below.</para>
+    /// </remarks>
+    [Fact]
+    public async Task PollOnce_OffloadsTheSample_EvenWhenTheSourceIsSynchronous()
+    {
+        var previous = SynchronizationContext.Current;
+        var marker = new MarkerContext();
+        SynchronizationContext.SetSynchronizationContext(marker);
+        try
+        {
+            var inline = new InlineSource();
+            var vm = NewVm(connFactory: () => inline);
+
+            var poll = typeof(BandwidthMonitorViewModel)
+                .GetMethod("PollOnceAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            await (Task)poll.Invoke(vm, [CancellationToken.None])!;
+
+            Assert.True(inline.Ran);                            // the sample happened at all
+            Assert.NotSame(marker, inline.ContextDuringWork);   // …but not on the caller's context
+            Assert.Null(inline.ContextDuringWork);              // it ran on the thread pool
+        }
+        finally { SynchronizationContext.SetSynchronizationContext(previous); }
+    }
+
     [Fact]
     public async Task DisposeDuringAnInFlightPoll_DoesNotTouchTheTornDownViewModel()
     {

--- a/SysManager/SysManager.Tests/EtwBandwidthSourceTests.cs
+++ b/SysManager/SysManager.Tests/EtwBandwidthSourceTests.cs
@@ -1,0 +1,148 @@
+// SysManager · EtwBandwidthSourceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="EtwBandwidthSource"/>'s bookkeeping — the parts that need no kernel ETW session.
+/// <para>The session itself requires administrator and is refused cleanly when absent (<c>Start</c> returns
+/// false), so these drive the accumulate path directly through the <c>internal</c> <c>Add</c> seam and read
+/// results through <c>SampleAsync</c>, with an injected clock instead of real waiting. What is covered is
+/// the PID-eviction contract added for #1816: before it, <c>_counters</c> was cleared only in
+/// <c>Dispose</c>, so every PID the session ever saw stayed in a per-tick allocate-and-two-key-sort for the
+/// tab's whole lifetime.</para>
+/// <para>The COM/ETW subscription and the rate arithmetic itself are not covered here — the former needs a
+/// real elevated session, the latter lives in <c>BandwidthFormat</c> and is tested in
+/// <see cref="BandwidthFormatTests"/>.</para>
+/// </summary>
+public class EtwBandwidthSourceTests
+{
+    /// <summary>
+    /// A clock that only moves when a test says so. Hand-written to match
+    /// <c>EtaCalculatorTests.TestTimeProvider</c>; this one overrides <c>GetUtcNow</c> because the source's
+    /// eviction stamp is wall-clock, not a performance timestamp.
+    /// </summary>
+    private sealed class TestClock : TimeProvider
+    {
+        private DateTimeOffset _now = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan by) => _now = _now.Add(by);
+    }
+
+    private static async Task<IReadOnlyList<int>> PidsAsync(EtwBandwidthSource src)
+    {
+        var snap = await src.SampleAsync();
+        return [.. snap.Processes.Select(p => p.ProcessId)];
+    }
+
+    [Fact]
+    public async Task Sample_ReportsAPidThatTransferredBytes()
+    {
+        var clock = new TestClock();
+        using var src = new EtwBandwidthSource(clock);
+
+        src.Add(1234, down: 5_000, up: 0, "chrome.exe");
+
+        Assert.Equal([1234], await PidsAsync(src));
+    }
+
+    /// <summary>
+    /// A PID silent past the eviction window is dropped, so the per-tick cost tracks what is CURRENTLY
+    /// active rather than everything the session has ever seen.
+    /// </summary>
+    [Fact]
+    public async Task Sample_EvictsAPidIdlePastTheWindow()
+    {
+        var clock = new TestClock();
+        using var src = new EtwBandwidthSource(clock);
+        src.Add(1234, down: 5_000, up: 0, "chrome.exe");
+
+        // One sample inside the window: still present.
+        Assert.Equal([1234], await PidsAsync(src));
+
+        clock.Advance(TimeSpan.FromMinutes(11));
+
+        // The sample on which it ages out still lists it — eviction runs after the snapshot is built, so a
+        // row does not vanish from under a user mid-glance…
+        Assert.Equal([1234], await PidsAsync(src));
+
+        // …and the next one no longer does.
+        Assert.Empty(await PidsAsync(src));
+    }
+
+    /// <summary>
+    /// Eviction measures INACTIVITY, not age. A long-lived process that keeps transferring must survive
+    /// indefinitely — a cutoff against creation time would drop exactly the busiest apps.
+    /// </summary>
+    [Fact]
+    public async Task Sample_KeepsAPidThatIsStillTransferring_HoweverOld()
+    {
+        var clock = new TestClock();
+        using var src = new EtwBandwidthSource(clock);
+        src.Add(1234, down: 1_000, up: 0, "chrome.exe");
+
+        // Well past the window in total, but never silent for a whole one.
+        for (var i = 0; i < 4; i++)
+        {
+            clock.Advance(TimeSpan.FromMinutes(9));
+            src.Add(1234, down: 1_000, up: 0, "chrome.exe");
+            await src.SampleAsync();
+        }
+
+        // Asserted on the SESSION TOTAL, not on the PID being present, and that distinction was found by
+        // mutation. Freezing the activity stamp at first-seen — the plausible wrong implementation — does
+        // evict this PID mid-run, but the very next event re-adds it through GetOrAdd with a fresh
+        // counter, so "is 1234 in the list" is green either way. What the user actually loses is the
+        // running total for an app that never stopped transferring: five events of 1,000 bytes must read
+        // as 5,000, not as however much arrived since a silent eviction reset it.
+        var row = Assert.Single((await src.SampleAsync()).Processes);
+        Assert.Equal(1234, row.ProcessId);
+        Assert.Equal(5_000, row.TotalDownBytes);
+    }
+
+    [Fact]
+    public async Task Sample_EvictsOnlyTheIdlePid_NotItsActiveNeighbour()
+    {
+        var clock = new TestClock();
+        using var src = new EtwBandwidthSource(clock);
+        src.Add(1111, down: 1_000, up: 0, "idle.exe");
+        src.Add(2222, down: 1_000, up: 0, "busy.exe");
+
+        clock.Advance(TimeSpan.FromMinutes(11));
+        src.Add(2222, down: 1_000, up: 0, "busy.exe");   // only this one is still going
+
+        await src.SampleAsync();                          // the pass that ages 1111 out
+        Assert.Equal([2222], await PidsAsync(src));
+    }
+
+    [Fact]
+    public async Task Add_IgnoresPidZero_AndNegatives()
+    {
+        // The idle/system pseudo-process carries kernel traffic that belongs to no app the user can act
+        // on, and a negative id is not a PID at all.
+        var clock = new TestClock();
+        using var src = new EtwBandwidthSource(clock);
+
+        src.Add(0, down: 9_999, up: 9_999, "Idle");
+        src.Add(-1, down: 9_999, up: 9_999, "?");
+
+        Assert.Empty(await PidsAsync(src));
+    }
+
+    [Fact]
+    public void Start_WithoutAdministrator_RefusesCleanly()
+    {
+        // The whole fallback story depends on this returning false rather than throwing: the ViewModel
+        // reads IsAvailable and silently uses the no-admin source instead.
+        var clock = new TestClock();
+        using var src = new EtwBandwidthSource(clock);
+
+        if (Helpers.AdminHelper.IsElevated()) return;   // elevated CI runner: the negative path is moot
+
+        Assert.False(src.Start());
+        Assert.False(src.IsAvailable);
+    }
+}

--- a/SysManager/SysManager/Services/ConnectionBandwidthSource.cs
+++ b/SysManager/SysManager/Services/ConnectionBandwidthSource.cs
@@ -50,26 +50,28 @@ public class ConnectionBandwidthSource : IBandwidthMonitorService
     }
 
     /// <summary>
-    /// Takes one snapshot, entirely on a worker thread.
+    /// Takes one snapshot. Synchronous by design — the caller owns the offload.
     /// </summary>
     /// <remarks>
-    /// <para>The offload is the point. This method was <c>Task</c>-returning but fully synchronous — it
-    /// did all the work inline and handed back <c>Task.FromResult</c> — and the ViewModel awaits it with
-    /// <c>ConfigureAwait(true)</c>, so every tick of the 1 Hz poll ran on the UI thread: enumerating all
-    /// network interfaces and reading per-interface IP statistics, two native TCP/UDP table queries, and a
-    /// <c>Process.GetProcessById</c> for each PID not yet in the name cache. None of that is bounded by a
-    /// small constant — a machine with many adapters or a browser holding dozens of sockets pays for all
-    /// of it — so the window stuttered continuously for as long as the tab was open. A signature that says
-    /// "async" while blocking the caller is the worst version of this: nothing in the ViewModel looks
-    /// wrong.</para>
+    /// <para>Getting this off the UI thread is the point, and it now happens ONCE, in
+    /// <c>BandwidthMonitorViewModel.PollOnceAsync</c>. The work here is not bounded by a small constant:
+    /// enumerating all network interfaces and reading per-interface IP statistics, two native TCP/UDP
+    /// table queries, and a <c>Process.GetProcessById</c> for each PID not yet in the name cache. A
+    /// machine with many adapters or a browser holding dozens of sockets pays for all of it, so running
+    /// it inline made the window stutter continuously for as long as the tab was open (1.61.9).</para>
+    /// <para>This method used to wrap itself in <c>Task.Run</c>. That fixed this source and left its
+    /// ETW sibling — which returned <c>Task.FromResult</c> — running inline, an asymmetry no test
+    /// enforced and the interface did not document. The offload moved to the consumer so both modes are
+    /// covered by construction; wrapping again here would just add a second hop.</para>
     /// <para>Everything the poll touches is confined to this call and its own fields, which only this
-    /// timer-driven path writes, so moving it wholesale is safe. The returned snapshot is immutable; the
-    /// ViewModel marshals back to the UI thread when it assigns properties, exactly as before.</para>
+    /// timer-driven path writes, so running it on a worker thread is safe. The returned snapshot is
+    /// immutable; the ViewModel marshals back to the UI thread when it assigns properties.</para>
     /// </remarks>
     public Task<BandwidthSnapshot> SampleAsync(CancellationToken ct = default)
     {
         if (!_primed) Start();
-        return Task.Run(() => SampleCore(), ct);
+        ct.ThrowIfCancellationRequested();
+        return Task.FromResult(SampleCore());
     }
 
     /// <summary>

--- a/SysManager/SysManager/Services/EtwBandwidthSource.cs
+++ b/SysManager/SysManager/Services/EtwBandwidthSource.cs
@@ -46,6 +46,19 @@ public sealed class EtwBandwidthSource : IBandwidthMonitorService
     // fire on the session's processing thread while SampleAsync reads on the UI/poll thread.
     private readonly ConcurrentDictionary<int, PidCounters> _counters = new();
 
+    /// <summary>
+    /// How long a PID may sit with no new bytes before it is dropped from <see cref="_counters"/>.
+    /// <para>Without this the dictionary only ever grew — it was cleared in <see cref="Dispose"/> and
+    /// nowhere else — so every PID that ever resolved a DNS name stayed in the per-tick sort for the
+    /// tab's lifetime: installers, updaters, every browser child process. An all-day elevated session
+    /// accumulated thousands, and each second re-allocated and re-sorted all of them. Ten minutes keeps
+    /// a genuinely idle-but-running app (a mail client polling on a long interval) visible with its
+    /// session totals, while a process that has been gone for a workday does not cost anything. Windows
+    /// recycles PIDs, so a stale entry is not merely useless — a new process inheriting the number would
+    /// inherit its totals.</para>
+    /// </summary>
+    private static readonly TimeSpan IdleEviction = TimeSpan.FromMinutes(10);
+
     private sealed class PidCounters
     {
         public long DownBytes;
@@ -53,6 +66,9 @@ public sealed class EtwBandwidthSource : IBandwidthMonitorService
         public long PrevDownBytes;
         public long PrevUpBytes;
         public string Name = "";
+
+        /// <summary>Tick count when bytes last arrived — the eviction clock. Written by ETW callbacks.</summary>
+        public long LastActivityTicks;
     }
 
     public bool Start()
@@ -119,13 +135,21 @@ public sealed class EtwBandwidthSource : IBandwidthMonitorService
         }
     }
 
-    private void Add(int pid, int down, int up, string name)
+    /// <summary>
+    /// Accumulate one event's bytes against a PID. <c>internal</c> rather than private so the eviction
+    /// contract can be tested without a kernel ETW session (which needs administrator): the tests drive
+    /// this and <see cref="SampleAsync"/> directly with a fake clock. Same seam idea as
+    /// <c>EtaCalculator</c>'s injected <see cref="TimeProvider"/>.
+    /// </summary>
+    internal void Add(int pid, int down, int up, string name)
     {
         if (pid <= 0) return;
         var c = _counters.GetOrAdd(pid, _ => new PidCounters());
         if (down > 0) System.Threading.Interlocked.Add(ref c.DownBytes, down);
         if (up > 0) System.Threading.Interlocked.Add(ref c.UpBytes, up);
         if (c.Name.Length == 0 && !string.IsNullOrEmpty(name)) c.Name = name;
+        // Stamped on every event, so eviction measures real inactivity rather than age.
+        System.Threading.Volatile.Write(ref c.LastActivityTicks, NowTicks());
     }
 
     public Task<BandwidthSnapshot> SampleAsync(CancellationToken ct = default)
@@ -169,10 +193,46 @@ public sealed class EtwBandwidthSource : IBandwidthMonitorService
             .ThenByDescending(r => r.TotalDownBytes + r.TotalUpBytes)
             .ToList();
 
+        EvictIdlePids(nowTicks);
+
         return Task.FromResult(new BandwidthSnapshot(BandwidthMode.PreciseEtw, totalDown, totalUp, ordered));
     }
 
-    private static long NowTicks() => Environment.TickCount64 * TimeSpan.TicksPerMillisecond;
+    /// <summary>
+    /// Drops PIDs that have transferred nothing for <see cref="IdleEviction"/>, bounding the per-tick
+    /// cost by what is CURRENTLY active rather than by everything the session has ever seen.
+    /// </summary>
+    /// <remarks>
+    /// Runs after the snapshot is built, so a PID evicted on this tick still appears one last time — the
+    /// list does not lose a row the user was looking at mid-glance. <c>TryRemove</c> on a
+    /// <see cref="ConcurrentDictionary{TKey,TValue}"/> races safely against the ETW callback thread: if
+    /// bytes arrive for an evicted PID the very next event re-adds it via <c>GetOrAdd</c>, and the only
+    /// cost is that its session totals restart — acceptable for a process that has been silent for ten
+    /// minutes, and unavoidable anyway, since Windows recycles PIDs.
+    /// </remarks>
+    private void EvictIdlePids(long nowTicks)
+    {
+        long cutoff = nowTicks - IdleEviction.Ticks;
+        foreach (var (pid, c) in _counters)
+        {
+            // A PID that has never had an event stamped (added, then nothing) is measured from 0, which
+            // is always older than the cutoff — so read the stamp and skip the unset case explicitly.
+            long last = System.Threading.Volatile.Read(ref c.LastActivityTicks);
+            if (last != 0 && last < cutoff) _counters.TryRemove(pid, out _);
+        }
+    }
+
+    /// <summary>
+    /// The eviction/rate clock. Injectable so the eviction contract is testable without waiting ten real
+    /// minutes — the tests pass a <see cref="FakeTimeProvider"/>-style stub and advance it. Production
+    /// passes nothing and gets <see cref="TimeProvider.System"/>.
+    /// </summary>
+    private readonly TimeProvider _time;
+
+    /// <param name="timeProvider">Test seam; defaults to the system clock.</param>
+    public EtwBandwidthSource(TimeProvider? timeProvider = null) => _time = timeProvider ?? TimeProvider.System;
+
+    private long NowTicks() => _time.GetUtcNow().UtcTicks;
 
     private void SafeStop()
     {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.11</Version>
-    <FileVersion>1.65.11.0</FileVersion>
-    <AssemblyVersion>1.65.11.0</AssemblyVersion>
+    <Version>1.65.12</Version>
+    <FileVersion>1.65.12.0</FileVersion>
+    <AssemblyVersion>1.65.12.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
@@ -253,8 +253,19 @@ public sealed partial class BandwidthMonitorViewModel : ViewModelBase
 
     private async Task PollOnceAsync(CancellationToken ct)
     {
-        if (_source is null) return;
-        var snap = await _source.SampleAsync(ct).ConfigureAwait(true);
+        var source = _source;
+        if (source is null) return;
+
+        // Offload HERE rather than trusting each source to do it. ConnectionBandwidthSource wrapped its
+        // own work in Task.Run; EtwBandwidthSource returned Task.FromResult and so ran inline — under the
+        // ConfigureAwait(true) below that put a per-tick allocation and a two-key sort of every PID seen
+        // since the session started straight onto the render thread, reproducing in precise mode exactly
+        // the 1 Hz stutter the connection-mode fix removed in 1.61.9. IBandwidthMonitorService documents
+        // no thread-affinity contract, so "one implementor offloads, the other doesn't" was an invariant
+        // nothing enforced. One offload at the consumer covers every source, present and future;
+        // ArchitectureTests.EveryBandwidthSource_LeavesTheOffloadToItsConsumer keeps the sources honest
+        // about not double-wrapping.
+        var snap = await Task.Run(() => source.SampleAsync(ct), ct).ConfigureAwait(true);
 
         // Re-check AFTER the await, not just before it. SampleAsync now genuinely yields (its work runs
         // on a worker thread), so Dispose() — which cancels _pollCts and disposes _source plus every


### PR DESCRIPTION
Closes #1816

## The defect

The 1.61.9 release fixed the Bandwidth Monitor's UI-thread stutter and its CHANGELOG stated that precise (ETW) mode *"was never affected — its work was already just arithmetic on counters collected in the background"*. That was wrong, and the issue was right to call it out.

`EtwBandwidthSource.SampleAsync` returned `Task.FromResult`, so under the poll's `ConfigureAwait(true)` it ran **entirely on the render thread**. And its work is not O(1):

| | connection mode | precise (ETW) mode |
|---|---|---|
| before this PR | `Task.Run(...)` — off-thread | `Task.FromResult(...)` — **inline** |

Worse, the cost **grew without bound**. `_counters` was cleared only in `Dispose`, and the zero-rate filter deliberately keeps any PID with non-zero *cumulative* bytes — so each second allocated a fresh `List` and ran a two-key `OrderByDescending().ThenByDescending()` over every process that had touched the network since the tab opened. Installers, updaters, every browser child process, anything that resolved DNS once. An elevated user leaving the tab open through a workday accumulated thousands of dead PIDs and paid for all of them every second.

Every claim above was re-verified against current source before any code was written.

## The fix

**The offload moves to the consumer.** `BandwidthMonitorViewModel.PollOnceAsync` wraps whichever source is active in one `Task.Run`, so both modes — and any future source — are covered by construction. `ConnectionBandwidthSource`'s own `Task.Run` is removed (it would now be a second hop per tick) and it checks the cancellation token explicitly, which `Task.Run` had been doing for it.

**The PID table is bounded.** `EtwBandwidthSource` drops PIDs idle for ten minutes. Two details matter:
- Eviction measures **inactivity, not age** — the stamp is refreshed on every event, so a permanently busy process survives indefinitely while one silent since morning costs nothing. An age-based cutoff would drop exactly the busiest apps.
- It runs **after** the snapshot is built, so a row never vanishes from under the user mid-glance.

Windows recycles PIDs, so a stale entry was not merely wasteful: a new process inheriting the number inherited its totals.

**A test seam.** `EtwBandwidthSource` gains an injectable `TimeProvider` and an `internal Add`, matching `EtaCalculator`'s existing seam, so the eviction contract is testable without a kernel session (which needs admin). Six new tests in `EtwBandwidthSourceTests`.

**The ratchet.** `ArchitectureTests.EveryBandwidthSource_LeavesTheOffloadToItsConsumer` states *"sources stay synchronous"* rather than *"sources must offload"* — deliberately, because the second form is satisfiable one implementor at a time, which is precisely how this hid for four releases.

Two existing tests asserted that `ConnectionBandwidthSource` offloads its **own** work. That claim now belongs to the ViewModel, so they are replaced by `PollOnce_OffloadsTheSample_EvenWhenTheSourceIsSynchronous`, which asserts it against an inline, ETW-shaped source.

## Red/green proof (mutation)

| Mutation | offload | ratchet | evicts | keeps-active |
|---|---|---|---|---|
| *(unmutated)* | green | green | green | green |
| Consumer awaits the source directly (the shipped defect) | **RED** | green | green | green |
| Restore the 1.61.9 per-source shape | **RED** | **RED** | green | green |
| Drop the eviction call | green | green | **RED** | green |
| Evict on age (freeze the activity stamp) | green | green | green | **RED** |

Row 3 is the argument of the batch: the offload test uses an **inline** source, so per-source offloading does not cover it — exactly the hole #1816 sat in while the source that *did* offload looked fine. The ratchet independently reports the arrangement went back to per-source.

Row 5 took three attempts and changed what I understood the defect to be. Asserting "is the PID still listed" stayed **green** under the mutation, because an evicted PID is re-added by its very next event with a fresh counter — presence looks identical. What the user actually loses is the **running total** for an app that never stopped transferring. The test now asserts the session total, and only then does it discriminate. Found by mutation, not by reading.

## Verification

- All four projects `-c Release`: **0 errors, 0 warnings**
- `dotnet format --verify-no-changes`: clean on all four
- Guard harness over `ArchitectureTests` + the three bandwidth test classes: **84/85 green**; the single red is a harness limitation (a helper that walks up from the harness's own `bin` to find test sources), not a code defect — CI runs it correctly
- Leak scan: all 32 terms from `leak-terms.txt` against the diff — **0 hits**
- Author headers present on all touched source files
- `ARCHITECTURE.md` updated: the ETW entry now states the eviction window, and both the source and ViewModel entries state where the offload lives
- CHANGELOG entry in this same PR with the plain-English lead paragraph; csproj bumped to 1.65.12