### PR TITLE
fix: four defects an adversarial audit of the last nine PRs found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.13] - 2026-08-17
+
+Three things an audit of the last few releases turned up. Clearing your speed-test history could say it
+worked when it had not, the precise bandwidth readings could show a nonsense spike if your PC corrected
+its clock, and the Task Scheduler's two "run time" columns looked broken because they only fill in when
+you click a row. The version history in this file was also missing three releases' notes.
+
+### Fixed
+- **"Clear history" could report success after failing.** Deleting your saved speed-test results rewrites
+  a file, and if that write failed the app logged it quietly and emptied the list on screen anyway — after
+  a dialog that told you the data was gone for good. It came back on the next launch, with nothing to say
+  which was real. This is the same fault fixed for *saving* a result in 1.65.10; clearing was missed at the
+  time, and it is the worse half, because you have just confirmed the data should be destroyed. The rows now
+  stay on screen with an explanation when the file cannot be written.
+- **Precise bandwidth could show an absurd spike after a clock correction.** The per-app readings are
+  worked out by dividing bytes by elapsed time, and elapsed time was measured with the wall clock. When
+  Windows corrects the clock backwards — a routine time sync — that measurement went negative, got clamped
+  to a single millisecond, and every rate on that reading was multiplied by roughly a thousand. A large
+  forward correction had the opposite effect: every program was treated as idle and dropped from the list,
+  losing its session totals. Both are gone: the timing now uses a clock that cannot run backwards.
+- **Task Scheduler's "Last run" and "Next run" showed a dash on every row.** Both times come from a
+  separate lookup that only runs for the row you select, so the columns sat empty until clicked and read as
+  missing data. They now say "(on select)" in the heading, which is what actually happens — fetching them
+  for every task up front would mean one lookup per scheduled task, hundreds on a normal PC. The publisher
+  tooltip on "What it does" is also reachable now on tasks that have no description, which is exactly where
+  it was the only information available.
+- **Three releases had no entry in this file.** The notes for 1.65.7, 1.65.8 and 1.65.9 were all welded
+  under the 1.65.10 heading, so this file jumped from 1.65.10 straight to 1.65.6 while carrying five
+  separate sets of fixes under one version. Since the release workflow copies each entry into the download
+  page and the announcement, three releases published nothing describing themselves. Each now has its own
+  entry, 1.56.7 (tagged but never published) is recorded too, and a check now fails the build if a version
+  between two documented ones is ever missing again.
+
 ## [1.65.12] - 2026-08-17
 
 The Bandwidth Monitor's precise mode — the one that needs administrator — was doing its measuring on the
@@ -39,7 +72,7 @@ you dragged them.
   refresh of the app list. The result was bars that jittered instead of moving smoothly, and sliders that
   lagged behind the mouse. The levels are now read for every app in a single request, and that request runs
   on a background thread — the window only receives the finished numbers, and the tab goes completely idle
-  the moment you switch away from it. Present since the tab shipped in 1.52.37; the same defect was fixed
+  the moment you switch away from it. Present since the tab shipped in 1.52.38; the same defect was fixed
   for the Bandwidth Monitor in 1.61.9, at a twentieth of this cadence.
 
 ## [1.65.10] - 2026-08-14
@@ -47,8 +80,9 @@ you dragged them.
 Two things that were quietly telling you the wrong thing. A speed test result could fail to save without
 saying so, and the "time remaining" on long jobs could climb upward while the bar stood completely still.
 
-Note on versions: 1.65.9 was tagged but never published — its release build stopped on the very save bug
-fixed below. Everything 1.65.9 contained is in this release.
+Note on versions: the 1.65.9 tag exists but no download was ever published for it — its release build
+stopped on the very save bug fixed below. Its own entry is kept for the record; everything that entry
+describes reached users here.
 
 ### Fixed
 - **A speed test result could vanish without telling you.** Saving a result to history writes a file, and
@@ -65,7 +99,7 @@ fixed below. Everything 1.65.9 contained is in this release.
   first step could show "about 1 hour 39 minutes" for something that finished in ninety seconds.
   The estimate now follows how fast progress is *currently* moving, counts down on its own while a job is
   quiet, and says "calculating…" rather than guessing from the first few percent.
-
+## [1.65.9] - 2026-08-14
 
 Startup Manager was missing a whole class of programs that start with Windows — anything installed by
 a 32-bit installer, which on a typical PC means a VPN client, a printer helper or an older updater.
@@ -90,6 +124,8 @@ Scheduler also shows what each task is for and when it will run next, instead of
   extra work is done to collect any of this; it was being fetched and thrown away.
 
 
+## [1.65.8] - 2026-08-14
+
 If you use one of the six light colour themes, the lines on the Ping, Bandwidth Monitor and Resource
 History graphs were washed out to the point of being invisible — a pale mint or pale yellow line on a
 white card. The graphs read the same way on light themes as they always have on dark ones now.
@@ -105,6 +141,8 @@ white card. The graphs read the same way on light themes as they always have on 
   clear that bar when the theme it is drawn on needs it. Only the brightness changes, never the hue,
   so blue is still CPU and purple is still memory; the dark themes already passed and come through
   untouched, byte for byte.
+
+## [1.65.7] - 2026-08-14
 
 The diagnostic log no longer fills up with the same repeated line. If you ever need to send a log to
 report a problem, what is in it is now actually about your problem — before, roughly two lines every
@@ -806,6 +844,12 @@ moved, and the work below ships here instead.
 - **Made old recovery points clear and testable.** New snapshots record their UTC capture time and show it in local time in the `Restore All` confirmation, while snapshots created by older releases remain loadable with an explicit unknown-time label. Snapshot storage now has an injected test directory, and regression coverage recreates an app restart with a second service instance, verifies the real command reaches confirmation, and keeps legacy JSON compatible without touching the user's profile.
 - **Hardened the persisted recovery boundary and failure semantics.** Snapshot files are size-bounded, require a complete non-duplicated schema, and reject malformed GUIDs, spoofable plan names, out-of-range processor values, and unsafe GPU subkeys before enabling restore. Power-plan, processor, and GPU restore failures now remain failures instead of reporting success and deleting the only recovery point; failed snapshot saves prevent any setting change, and failed cleanup keeps `Restore All` available for a retry.
 - **Made the Performance Mode lock-guard test deterministic.** The guard test seeded the recovery snapshot while initialization was still loading the persisted one, and that load's deferred assignment overwrote the seeded value. On a fast machine the load finished first and the test passed; on a slower one it did not, so `Restore All` reported "nothing to restore" and never reached the guard under test. The test now waits for initialization before seeding. Test-only change, no effect on shipped behavior.
+
+## [1.56.7] - 2026-08-04
+
+Tagged but never published: the release run failed at the unit-test gate, so no download, notes or
+announcement exist for this version. The tag is kept rather than moved, and the work it carried
+shipped in 1.56.8 below. Recorded here so the version history has no unexplained gap.
 
 ## [1.56.6] - 2026-08-04
 

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2304,6 +2304,97 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// The CHANGELOG's version headers must form an unbroken descending run — no version may be missing
+    /// between the newest and oldest entry, and none may appear twice.
+    /// </summary>
+    /// <remarks>
+    /// <para>Found by an audit, after three releases' notes were discovered welded into a single
+    /// <c>## [1.65.10]</c> heading: 1.65.7, 1.65.8 and 1.65.9 had no heading at all, so the file jumped
+    /// straight from 1.65.10 to 1.65.6 while carrying five <c>### Fixed</c> sections under one version.
+    /// Anyone reading the file to find out what a release changed found nothing for three of them, and the
+    /// release workflow copies each entry verbatim into the GitHub release body and the announcement — so
+    /// the omission reached two public surfaces.</para>
+    /// <para>Nothing caught it, because the existing gate only checks that the NEWEST entry opens with a
+    /// plain-English lead. A missing middle entry is invisible to that check and to the compiler, and it is
+    /// easy to cause: the mistake was appending a new entry's body without its heading while resolving a
+    /// merge. A gap is mechanically detectable, so it should never need a human to notice again.</para>
+    /// <para>Deliberately checks CONTIGUITY within the file rather than comparing against git tags: the
+    /// test project has no git access, and a tag that was cut but never published (1.65.9) still deserves
+    /// an entry, so the file's own sequence is the stronger contract.</para>
+    /// <para>Scoped to 1.x on purpose, and this is a real limit rather than a convenient one. Pre-1.0
+    /// development predates the release discipline: the 0.28 line alone has 35 tags against 31 entries, and
+    /// there are 171 pre-1.0 entries in total. Those gaps are from a period when versions were cut by hand
+    /// several times an hour; retro-writing user-facing notes for them now would be invention, not
+    /// documentation. The contract this guard enforces — every released version explains itself — applies
+    /// to the versions users actually download, and the boundary is stated here so nobody later reads the
+    /// pass as "the whole file is contiguous".</para>
+    /// </remarks>
+    [Fact]
+    public void TheChangelogVersionHeaders_FormAnUnbrokenDescendingRun()
+    {
+        var path = Path.Combine(FindRepoRoot(), "CHANGELOG.md");
+        Assert.True(File.Exists(path), $"CHANGELOG.md not found at {path} — the guard would pass vacuously");
+
+        var versions = new List<(int Major, int Minor, int Patch, string Raw, int Line)>();
+        var lines = File.ReadAllLines(path);
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var m = ChangelogVersionHeading().Match(lines[i]);
+            if (!m.Success) continue;
+
+            var major = int.Parse(m.Groups["ma"].Value);
+            if (major < 1) continue;   // pre-1.0 predates the release discipline — see the remarks
+
+            versions.Add((major, int.Parse(m.Groups["mi"].Value),
+                          int.Parse(m.Groups["pa"].Value), m.Groups["v"].Value, i + 1));
+        }
+
+        // Vacuity floor over the 1.x range this guard governs — the file carries well over a hundred such
+        // entries, so a floor of 50 catches the heading pattern breaking without encoding today's count.
+        Assert.True(versions.Count >= 50,
+            $"only {versions.Count} 1.x CHANGELOG version headings parsed — the guard is measuring nothing, "
+            + "fix it rather than trusting its pass");
+
+        var duplicates = versions.GroupBy(v => v.Raw).Where(g => g.Count() > 1)
+            .Select(g => $"{g.Key} appears {g.Count()} times (lines {string.Join(", ", g.Select(v => v.Line))})")
+            .ToList();
+        Assert.True(duplicates.Count == 0,
+            $"a version has more than one CHANGELOG entry:\n  {string.Join("\n  ", duplicates)}");
+
+        // Only PATCH gaps inside one minor line are checked. A minor or major bump legitimately restarts
+        // the patch counter, and this project has never skipped a minor, so a rule spanning those would
+        // encode history rather than a contract.
+        var gaps = new List<string>();
+        for (var i = 0; i < versions.Count - 1; i++)
+        {
+            var newer = versions[i];
+            var older = versions[i + 1];
+            if (newer.Major != older.Major || newer.Minor != older.Minor) continue;
+
+            if (newer.Patch <= older.Patch)
+            {
+                gaps.Add($"{newer.Raw} (line {newer.Line}) is not newer than {older.Raw} "
+                         + $"(line {older.Line}) — entries must descend");
+                continue;
+            }
+
+            for (var missing = older.Patch + 1; missing < newer.Patch; missing++)
+                gaps.Add($"{newer.Major}.{newer.Minor}.{missing} has no entry — the file jumps from "
+                         + $"{newer.Raw} (line {newer.Line}) to {older.Raw} (line {older.Line})");
+        }
+
+        Assert.True(gaps.Count == 0,
+            "the CHANGELOG is missing an entry for a version between two it does document. Every released "
+            + "version needs its own heading and lead paragraph — the release workflow copies each entry "
+            + "into the GitHub release body and the announcement, so a gap is published, not just local. If "
+            + "a version was tagged but never shipped, it still gets an entry saying so:\n  "
+            + string.Join("\n  ", gaps));
+    }
+
+    [GeneratedRegex(@"^## \[(?<v>(?<ma>\d+)\.(?<mi>\d+)\.(?<pa>\d+))\]", RegexOptions.Compiled)]
+    private static partial Regex ChangelogVersionHeading();
+
+    /// <summary>
     /// No bandwidth source may wrap its own sample in <c>Task.Run</c>. The offload belongs to the
     /// consumer, once, so every source is covered by construction.
     /// </summary>

--- a/SysManager/SysManager.Tests/EtwBandwidthSourceTests.cs
+++ b/SysManager/SysManager.Tests/EtwBandwidthSourceTests.cs
@@ -21,15 +21,24 @@ namespace SysManager.Tests;
 public class EtwBandwidthSourceTests
 {
     /// <summary>
-    /// A clock that only moves when a test says so. Hand-written to match
-    /// <c>EtaCalculatorTests.TestTimeProvider</c>; this one overrides <c>GetUtcNow</c> because the source's
-    /// eviction stamp is wall-clock, not a performance timestamp.
+    /// A clock that only moves when a test says so, overriding the same two members as
+    /// <c>EtaCalculatorTests.TestTimeProvider</c>.
     /// </summary>
+    /// <remarks>
+    /// <c>GetTimestamp</c>, not <c>GetUtcNow</c>: the source needs a MONOTONIC clock, because it subtracts
+    /// two readings both to compute rates and to age out PIDs, and a wall clock steps backwards on an NTP
+    /// correction. This mattered in practice — the source shipped one release reading
+    /// <c>GetUtcNow().UtcTicks</c>, and a stub overriding the wall clock could not have caught it, because
+    /// a stub only ever moves forward, which is exactly the property the real wall clock lacks.
+    /// </remarks>
     private sealed class TestClock : TimeProvider
     {
-        private DateTimeOffset _now = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
-        public override DateTimeOffset GetUtcNow() => _now;
-        public void Advance(TimeSpan by) => _now = _now.Add(by);
+        private long _ticks;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+        public override long GetTimestamp() => _ticks;
+
+        public void Advance(TimeSpan by) => _ticks += by.Ticks;
     }
 
     private static async Task<IReadOnlyList<int>> PidsAsync(EtwBandwidthSource src)

--- a/SysManager/SysManager/Services/EtwBandwidthSource.cs
+++ b/SysManager/SysManager/Services/EtwBandwidthSource.cs
@@ -215,24 +215,50 @@ public sealed class EtwBandwidthSource : IBandwidthMonitorService
         long cutoff = nowTicks - IdleEviction.Ticks;
         foreach (var (pid, c) in _counters)
         {
-            // A PID that has never had an event stamped (added, then nothing) is measured from 0, which
-            // is always older than the cutoff — so read the stamp and skip the unset case explicitly.
-            long last = System.Threading.Volatile.Read(ref c.LastActivityTicks);
-            if (last != 0 && last < cutoff) _counters.TryRemove(pid, out _);
+            // Entries are only ever created by Add, which stamps before it returns, so every one has a
+            // stamp. This deliberately does NOT treat 0 as "unstamped": zero is a legitimate reading —
+            // a monotonic clock starts there, both in a test that has not advanced it and on a real
+            // machine in the first tick after the source starts — and skipping it made a PID stamped at
+            // 0 immortal. Not hypothetical: it turned two eviction tests red the moment the clock became
+            // monotonic, which is exactly what a sentinel value inside the real value range does.
+            if (System.Threading.Volatile.Read(ref c.LastActivityTicks) < cutoff)
+                _counters.TryRemove(pid, out _);
         }
     }
 
     /// <summary>
     /// The eviction/rate clock. Injectable so the eviction contract is testable without waiting ten real
-    /// minutes — the tests pass a <see cref="FakeTimeProvider"/>-style stub and advance it. Production
-    /// passes nothing and gets <see cref="TimeProvider.System"/>.
+    /// minutes — a test passes a stub and advances it. Production passes nothing and gets
+    /// <see cref="TimeProvider.System"/>.
     /// </summary>
     private readonly TimeProvider _time;
 
     /// <param name="timeProvider">Test seam; defaults to the system clock.</param>
     public EtwBandwidthSource(TimeProvider? timeProvider = null) => _time = timeProvider ?? TimeProvider.System;
 
-    private long NowTicks() => _time.GetUtcNow().UtcTicks;
+    /// <summary>
+    /// A MONOTONIC tick count, in <see cref="TimeSpan"/> ticks. Both callers subtract two readings, so this
+    /// clock must only ever move forward.
+    /// </summary>
+    /// <remarks>
+    /// <para>This was <c>Environment.TickCount64</c>, which is monotonic. Adding the injectable seam
+    /// briefly made it <c>GetUtcNow().UtcTicks</c> — the WALL clock — and that breaks both callers, because
+    /// a wall clock steps backwards on an NTP correction or when the user sets the time.</para>
+    /// <para>In <c>SampleAsync</c> the byte delta is divided by the elapsed seconds. A backwards step makes
+    /// that difference negative, <c>Math.Max(0.001, …)</c> clamps it to a millisecond, and every rate on
+    /// that tick is multiplied by roughly a thousand — an absurd spike in the one place this tab exists to
+    /// report accurately. <c>BandwidthFormat.RatePerSecond</c> guards a non-positive elapsed and a negative
+    /// delta, but not a tiny elapsed, so nothing downstream catches it.</para>
+    /// <para>In <c>EvictIdlePids</c> each PID's stamp is compared against <c>now</c> minus ten minutes. A
+    /// forward step larger than the window makes every stamp look stale at once, dropping the whole table
+    /// and every session total with it.</para>
+    /// <para><see cref="TimeProvider.GetTimestamp"/> is the monotonic reading, and
+    /// <see cref="TimeProvider.GetElapsedTime(long, long)"/> converts a pair using the provider's own
+    /// <c>TimestampFrequency</c> — so this stays in TimeSpan ticks whatever the platform's raw frequency is,
+    /// and a stub only has to override those two members, which is what the existing fake in
+    /// <c>EtaCalculatorTests</c> already does.</para>
+    /// </remarks>
+    private long NowTicks() => _time.GetElapsedTime(0, _time.GetTimestamp()).Ticks;
 
     private void SafeStop()
     {

--- a/SysManager/SysManager/Services/SpeedTestHistoryService.cs
+++ b/SysManager/SysManager/Services/SpeedTestHistoryService.cs
@@ -179,9 +179,19 @@ public sealed class SpeedTestHistoryService : IDisposable
     }
 
     /// <summary>
-    /// Clears history for a specific engine, or all history if engine is null.
+    /// Clears history for a specific engine, or all history if engine is null. Returns true only when the
+    /// disk now matches what the caller asked for.
     /// </summary>
-    public async Task ClearAsync(string? engine = null, CancellationToken ct = default)
+    /// <remarks>
+    /// Returns <c>bool</c> for the same reason <see cref="SaveAsync"/> does, and this was the half the
+    /// original fix missed. Both methods swallowed their write failure and logged it, so the tab carried on
+    /// as if it had worked; that shipped as a lost speed-test result in 1.65.9. Clearing is worse than
+    /// saving, because the user has just confirmed a dialog saying the data will be gone for good: on a
+    /// failure the grid emptied, the file did not, and the readings reappeared on the next launch — the
+    /// opposite of what was promised, with no way to tell which state is real. The caller now surfaces the
+    /// failure instead of guessing.
+    /// </remarks>
+    public async Task<bool> ClearAsync(string? engine = null, CancellationToken ct = default)
     {
         await _fileLock.WaitAsync(ct).ConfigureAwait(false);
         try
@@ -190,7 +200,7 @@ public sealed class SpeedTestHistoryService : IDisposable
             {
                 if (File.Exists(_historyPath))
                     File.Delete(_historyPath);
-                return;
+                return true;
             }
 
             var all = await LoadCoreAsync(ct).ConfigureAwait(false);
@@ -200,7 +210,7 @@ public sealed class SpeedTestHistoryService : IDisposable
             {
                 if (File.Exists(_historyPath))
                     File.Delete(_historyPath);
-                return;
+                return true;
             }
 
             var entries = filtered.Select(r => new SpeedTestHistoryEntry
@@ -215,14 +225,17 @@ public sealed class SpeedTestHistoryService : IDisposable
 
             var json = JsonSerializer.Serialize(entries, JsonOpts);
             await AtomicFile.WriteAllTextAsync(_historyPath, json, ct).ConfigureAwait(false);
+            return true;
         }
         catch (IOException ex)
         {
             Log.Warning(ex, "Failed to clear speed test history");
+            return false;
         }
         catch (UnauthorizedAccessException ex)
         {
             Log.Warning(ex, "Access denied clearing speed test history");
+            return false;
         }
         finally
         {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.12</Version>
-    <FileVersion>1.65.12.0</FileVersion>
-    <AssemblyVersion>1.65.12.0</AssemblyVersion>
+    <Version>1.65.13</Version>
+    <FileVersion>1.65.13.0</FileVersion>
+    <AssemblyVersion>1.65.13.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
@@ -183,6 +183,12 @@ public sealed partial class SpeedTestViewModel : ViewModelBase
     /// Confirms, then drops one engine's saved results. ClearAsync rewrites the history file
     /// immediately, so the past measurements cannot be recovered afterwards.
     /// </summary>
+    /// <remarks>
+    /// The grid is emptied only if the disk write actually succeeded. Emptying it regardless is a worse
+    /// version of the save bug fixed in 1.65.10: the user has just confirmed a dialog saying the data is
+    /// gone for good, so a silent failure showed an empty list over a file that still held every reading —
+    /// and they came back on the next launch, with nothing to say which state was real.
+    /// </remarks>
     private async Task ClearHistoryAsync(string engine, BulkObservableCollection<SpeedTestResult> history)
     {
         int count = history.Count;
@@ -192,7 +198,19 @@ public sealed partial class SpeedTestViewModel : ViewModelBase
                 $"Clear {engine} History — Confirm"))
             return;
 
-        await _history.ClearAsync(engine);
+        if (!await _history.ClearAsync(engine))
+        {
+            // Reported under the engine's OWN card. The two engines have separate status lines in separate
+            // cards (SpeedTestView.xaml binds OoklaStatus and HttpStatus independently), so writing to the
+            // wrong one would put an Ookla failure under the HTTP heading.
+            var message = $"{engine} history could not be cleared — the saved file could not be written.";
+            if (string.Equals(engine, "Ookla", StringComparison.OrdinalIgnoreCase)) OoklaStatus = message;
+            else HttpStatus = message;
+
+            // Leave the rows on screen: they still exist on disk, so showing them is the honest state.
+            return;
+        }
+
         history.Clear();
     }
 

--- a/SysManager/SysManager/Views/TaskSchedulerView.xaml
+++ b/SysManager/SysManager/Views/TaskSchedulerView.xaml
@@ -131,12 +131,16 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
                     <DataGridTextColumn Header="State" Binding="{Binding State}" Width="90"/>
-                    <DataGridTextColumn Header="Last run" Binding="{Binding LastRunDisplay}" Width="140"/>
-                    <!-- Next run answers the question this tab exists for — "when is this going to
-                         happen?" — and it was already being fetched: the per-task query that fills
-                         Last run selects NextRunTime in the same call, ScheduledTaskInfo carries it,
-                         and NextRunDisplay was formatting it for a column that did not exist. -->
-                    <DataGridTextColumn Header="Next run" Binding="{Binding NextRunDisplay}" Width="140"/>
+                    <!-- Both run times come from LoadRunInfoAsync, a SEPARATE per-task PowerShell query
+                         that runs when a row is SELECTED — the bulk scan does not fetch them. So both
+                         columns legitimately read "—" until the user clicks the row, and the header says
+                         so rather than looking like missing data. Fetching them for every row up front
+                         would mean one PowerShell round-trip per scheduled task, which is hundreds on a
+                         normal machine; the tab lists first and fills the detail on demand by design.
+                         (The comment here previously claimed Next run "was already being fetched". It was
+                         not: the field existed and the query for it ran per selection only.) -->
+                    <DataGridTextColumn Header="Last run (on select)" Binding="{Binding LastRunDisplay}" Width="140"/>
+                    <DataGridTextColumn Header="Next run (on select)" Binding="{Binding NextRunDisplay}" Width="140"/>
                     <!-- What the task is for, in Windows' own words, with the publisher on hover.
                          Both came back with every scan (TaskSchedulerService selects Author and
                          Description) and neither was displayed anywhere. Author matters because it is
@@ -149,6 +153,12 @@
                             <Style TargetType="TextBlock">
                                 <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
                                 <Setter Property="ToolTip" Value="{Binding AuthorDisplay}"/>
+                                <!-- Many tasks ship no Description, and an empty TextBlock has no
+                                     hit-test surface — so the publisher tooltip was unreachable on
+                                     exactly the rows where it is the only information available.
+                                     A transparent background gives the cell something to hover. -->
+                                <Setter Property="Background" Value="Transparent"/>
+                                <Setter Property="HorizontalAlignment" Value="Stretch"/>
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>


### PR DESCRIPTION
A nine-lens read-only audit of everything shipped since v1.65.7 (nine PRs, 1524 added lines), with every finding attacked by three independent refuters — reachability, misread, already-handled — before it counted. **Three of the four below are mine, from this week's batches.** Each was re-verified by hand against current source before being touched; I did not act on an agent's word.

## 1. `ClearAsync` still swallowed its write failure — HIGH

Batch 82 gave `SaveAsync` a `bool` and surfaced it. The sibling method **in the same file** kept catching `IOException`, logging, and returning bare `Task`:

```csharp
catch (IOException ex) { Log.Warning(ex, "Failed to clear speed test history"); }   // then Task completes
```

So the grid emptied over a file that still held every reading — immediately after a dialog promising the data was gone for good. On the next launch the results came back, with nothing to say which state was real. This is the worse half of the same defect, because the user has already confirmed the destruction.

Now returns `bool`; the rows **stay on screen** on failure. The message goes to that engine's *own* status line — the two engines have separate cards binding `OoklaStatus` and `HttpStatus` independently, so writing to the wrong one would report an Ookla failure under the HTTP heading.

This is a "fix the class, not the instance" miss on my part: batch 82 was a half-migration.

## 2. `NowTicks` lost monotonicity — HIGH, introduced by me in batch 85

Adding the injectable clock seam changed `Environment.TickCount64` to `GetUtcNow().UtcTicks` — a **wall** clock. Two callers subtract two readings:

- **Rates.** A backwards NTP step makes the divisor negative, `Math.Max(0.001, …)` clamps it to a millisecond, and every rate on that tick is multiplied by roughly a thousand. `BandwidthFormat.RatePerSecond` guards a non-positive elapsed and a negative delta — but not a *tiny* elapsed, so nothing downstream catches it.
- **Eviction.** A forward step past the ten-minute window makes every stamp look stale at once: the whole PID table is dropped and every session total goes with it.

Now `GetTimestamp`/`GetElapsedTime` — monotonic, and the exact pair the existing fake in `EtaCalculatorTests` already overrides.

**The test clock changed with it, and that immediately exposed a second bug.** `EvictIdlePids` treated a stamp of `0` as "never stamped" and skipped it, so a PID stamped at tick 0 was **immortal**. A monotonic clock legitimately starts at 0 — in a test that has not advanced it, and on a real machine in the first tick after the source starts. Two eviction tests went red the moment the clock became honest. The sentinel is gone; `Add` always stamps, so no entry can lack one. A sentinel inside the real value range is a bug waiting for the value to occur.

## 3. Task Scheduler's run-time columns read "—" on every row — HIGH, batch 80, also mine

Both times come from `LoadRunInfoAsync` — *"Fetch last/next run for one task (separate per-task query)"* — which runs on **selection**. The bulk scan never fetches them. So both columns sat empty until a row was clicked and read as missing data.

The headings now say **"(on select)"**, which is what actually happens. Fetching them per row up front would be one PowerShell round-trip per scheduled task — hundreds on a normal machine; the tab lists first and fills detail on demand by design.

My XAML comment claiming Next run *"was already being fetched"* is corrected. It was not — a small overclaim of exactly the kind I spent batch 78 removing from the README.

Also: the publisher tooltip on "What it does" was unreachable on rows with **no** Description — an empty `TextBlock` has no hit-test surface, and those are precisely the rows where the publisher is the only information available. Transparent background + stretch fixes it.

## 4. Three releases had no CHANGELOG entry — HIGH, public surface

`1.65.7`, `1.65.8` and `1.65.9` were all welded under the `## [1.65.10]` heading — **five `###` sections and four lead paragraphs under one version** — so the file jumped from 1.65.10 straight to 1.65.6. The release workflow copies each entry verbatim into the GitHub release body *and* the announcement discussion, so three releases published nothing describing themselves.

Split by reading each lead paragraph to find its real boundary (my first attempt cut 1.65.7 mid-sentence; the structure check caught it). 1.65.9's "tagged but never published" note is reworded now that it has its own entry.

`TheChangelogVersionHeaders_FormAnUnbrokenDescendingRun` is the guard — and it immediately **found a second gap I did not know about**: `1.56.7`, tagged but never published, described in prose *inside* the 1.56.8 entry but with no heading of its own. It has one now.

The guard is scoped to **1.x** and says why in its own remarks: pre-1.0 has 35 tags against 31 entries in the 0.28 line alone, across 171 pre-1.0 entries. Retro-writing user-facing notes for versions cut by hand back then would be invention, not documentation. The boundary is stated so nobody later reads the pass as "the whole file is contiguous".

## What the audit did NOT find

Six lenses are still running (audio lifecycle, bandwidth concurrency, ETA arithmetic, guard vacuity, test honesty, startup registry). This PR ships only what three lenses found **and I independently confirmed**. Anything the remaining six surface will be handled on its own merits rather than rushed in here.

## Verification

- All four projects `-c Release`: **0 errors, 0 warnings**
- `dotnet format --verify-no-changes`: clean on all four
- Guard harness: **56/57 green** — the one red is a known harness limitation (a helper that walks up from the harness's own `bin` to find test sources), not a code defect; CI runs it correctly
- The new CHANGELOG guard verified against the **broken** file first: it reported the 1.65.7 gap, then 1.56.7, then went green only once both were real entries
- Leak scan: all 32 terms from `leak-terms.txt` — **0 hits**
- csproj bumped to 1.65.13; CHANGELOG entry in this same PR with its plain-English lead