### PR TITLE
fix: create the StartupApproved key when absent, and repair two vacuous guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.14] - 2026-08-17
+
+Turning off a startup program could fail on a PC where nothing had ever been turned off before — which is
+most PCs. That is fixed, along with two internal checks that were quietly passing when they should have
+been failing.
+
+### Fixed
+- **"Disable" failed with a confusing error on a clean machine.** Windows keeps the on/off state of startup
+  programs in a list it only creates the first time something is disabled — through this app, Task Manager,
+  or Settings. On a PC where that had never happened the list does not exist, and SysManager reported
+  "StartupApproved key not found" and refused, rather than creating the list the way Windows itself does.
+  So the feature failed on exactly the machines most likely to need it, for every kind of startup entry and
+  not only the 32-bit ones added in 1.65.10. The list is now created when it is missing. If the write is
+  genuinely refused — the all-users entries need administrator — the message now says that instead of
+  blaming a missing key.
+
 ## [1.65.13] - 2026-08-17
 
 Three things an audit of the last few releases turned up. Clearing your speed-test history could say it

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2215,8 +2215,16 @@ public partial class ArchitectureTests
 
         // The 32-bit Run key must actually be enumerated. Without this the rest of the guard would pass
         // on a scan that never produces a 32-bit entry at all — which is precisely the pre-fix state.
-        Assert.Contains(@"SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Run", source, StringComparison.Ordinal);
-        Assert.Contains("StartupSource.RegistryLocalMachine32", source, StringComparison.Ordinal);
+        //
+        // Matched as the whole TUPLE, not the path alone. The bare path is a PREFIX of the RunOnce path on
+        // the very next line, so Contains(@"…\CurrentVersion\Run") stayed satisfied by the RunOnce row even
+        // with the Run row deleted — and RunOnce is explicitly undisableable (SetEnabledAsync refuses it),
+        // so this guard would have passed while the only disableable 32-bit key was gone. Found by an
+        // adversarial audit of the guard itself; reasoning about the two 32-bit and 64-bit paths missed it,
+        // because the collision is with the neighbouring RunOnce row rather than the other bitness.
+        Assert.Contains(
+            @"(@""SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Run"", StartupSource.RegistryLocalMachine32)",
+            source, StringComparison.Ordinal);
 
         // Read path: ApplyApprovedState must map the 32-bit source to the Run32 dictionary, and must NOT
         // fall back between the two views — "hklmApproved ?? hklm32Approved" reads the wrong key whenever
@@ -2245,6 +2253,18 @@ public partial class ArchitectureTests
         Assert.Contains(
             "StartupSource.RegistryLocalMachine => (Registry.LocalMachine, ApprovedRunHKLM)",
             writeBody, StringComparison.Ordinal);
+
+        // The approved key must be CREATED if absent, not merely opened. Windows creates each
+        // StartupApproved subkey lazily, on the first disable through that list, so on a machine where
+        // nothing has ever been disabled the key does not exist — OpenSubKey(writable: true) returns null
+        // and disabling failed with "StartupApproved key not found" on exactly the machines most likely to
+        // need it. Verified against the live registry while fixing it: OpenSubKey on a missing key returns
+        // null, CreateSubKey returns a handle and creates it.
+        //
+        // Matched inside the write body and by CALL SHAPE, so the explanatory comment above the call — which
+        // necessarily names OpenSubKey to explain what was wrong — cannot satisfy or break this assertion.
+        Assert.Contains("root.CreateSubKey(approvedPath)", writeBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("root.OpenSubKey(approvedPath", writeBody, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -2273,12 +2293,19 @@ public partial class ArchitectureTests
 
         // Only assert on fields the service genuinely asks Windows for — otherwise this guard drifts into
         // demanding UI for data that is not collected.
+        //
+        // Each Fetched string is matched against the SELECTION it appears in, not the bare field name. The
+        // bare name was vacuous for "Author": every file in this project carries the mandatory
+        // "// Author: laurentiu021 …" header, so service.Contains("Author") was satisfied by line 2 and
+        // could not fail however the query changed. Found by an adversarial audit of this guard. A
+        // selection fragment cannot be supplied by a comment, and stripping comments is not enough here —
+        // the field genuinely appears in prose too.
         (string Fetched, string Bound)[] contract =
         [
-            ("Author", "{Binding AuthorDisplay}"),
-            ("Description", "{Binding Description}"),
-            ("NextRunTime", "{Binding NextRunDisplay}"),
-            ("LastRunTime", "{Binding LastRunDisplay}"),
+            ("@{ n='State'; e={ [string]$_.State } }, Author, Description", "{Binding AuthorDisplay}"),
+            ("Author, Description", "{Binding Description}"),
+            ("Select-Object LastRunTime, NextRunTime", "{Binding NextRunDisplay}"),
+            ("Select-Object LastRunTime, NextRunTime", "{Binding LastRunDisplay}"),
         ];
 
         var notFetched = new List<string>();

--- a/SysManager/SysManager/Services/StartupService.cs
+++ b/SysManager/SysManager/Services/StartupService.cs
@@ -490,10 +490,23 @@ public sealed class StartupService
                 _ => (Registry.CurrentUser, ApprovedRunHKCU)
             };
 
-            using var key = root.OpenSubKey(approvedPath, writable: true);
+            // CreateSubKey, not OpenSubKey(writable: true): Windows creates each StartupApproved subkey
+            // LAZILY, the first time something is disabled through that particular list. On a machine where
+            // nothing has ever been disabled — a fresh install, or a user who has never opened Task
+            // Manager's Startup tab — the key is absent, OpenSubKey returns null, and this returned false
+            // with "StartupApproved key not found". So disabling was impossible on exactly the machines
+            // most likely to need it, for EVERY source rather than only the 32-bit list added in 1.65.10.
+            // CreateSubKey opens an existing key unchanged and creates a missing one, so the write lands
+            // where Windows actually reads either way. Eleven other services here already use CreateSubKey
+            // for this reason; this method was the outlier.
+            //
+            // The null branch is KEPT and remains reachable: CreateSubKey returns null when the hive itself
+            // cannot be written, and the HKLM sources need elevation. That is a different failure with a
+            // different remedy, so it now says so instead of blaming a missing key.
+            using var key = root.CreateSubKey(approvedPath);
             if (key is null)
             {
-                entry.StatusText = "Error — StartupApproved key not found";
+                entry.StatusText = "Error — no permission to write the StartupApproved key";
                 return false;
             }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.13</Version>
-    <FileVersion>1.65.13.0</FileVersion>
-    <AssemblyVersion>1.65.13.0</AssemblyVersion>
+    <Version>1.65.14</Version>
+    <FileVersion>1.65.14.0</FileVersion>
+    <AssemblyVersion>1.65.14.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
The HIGH finding from the v1.65.12 audit that I deliberately did **not** rush into PR #1910, plus the two vacuous guards from the same lens — each now with the mutation that proves it fails.

## The defect

Windows creates each `StartupApproved` subkey **lazily** — the first time something is disabled through that particular list, whether by this app, Task Manager, or Settings. On a machine where that has never happened the key does not exist:

```csharp
using var key = root.OpenSubKey(approvedPath, writable: true);   // null when absent
if (key is null) { entry.StatusText = "Error — StartupApproved key not found"; return false; }
```

So **disabling a startup program was impossible on exactly the machines most likely to need it** — a fresh install, or any user who has never opened Task Manager's Startup tab — for *every* source, not only the 32-bit list added in 1.65.10.

**Verified against the live registry before changing anything.** In a throwaway HKCU key I own (created and removed in the same command, nowhere near a real startup location): `OpenSubKey(writable: true)` on a missing key → `null`; `CreateSubKey` → handle, key created.

Worth recording: all four `StartupApproved` keys exist **and are populated** on this machine, so the defect could not be reproduced here. That is the point — an audit lens reading the code found what hands-on testing on one machine could not.

`CreateSubKey` opens an existing key unchanged and creates a missing one, so the write lands where Windows actually reads either way. Eleven other services in this project already use `CreateSubKey` for the same reason; this method was the outlier — so this is matching the existing idiom, not inventing one.

The null branch is **kept and still reachable**: `CreateSubKey` returns null when the hive cannot be written, and the HKLM sources need elevation. It now says *"no permission to write the StartupApproved key"* — a different failure with a different remedy.

## Two guards that could not fail

**`EveryMachineRunKey_ReadsAndWritesItsOwnStartupApprovedKey`** asserted the 32-bit Run *path*:

```
asserted:  SOFTWARE\Wow6432Node\...\CurrentVersion\Run
next line: SOFTWARE\Wow6432Node\...\CurrentVersion\RunOnce      ← contains the above as a prefix
```

Deleting the Run row left the guard **green** via the RunOnce row — and `RunOnce` is explicitly undisableable (`SetEnabledAsync` refuses it), so the guard passed while the only disableable 32-bit key was gone. Now matches the whole tuple.

My own first reading of this **missed it**: I compared the 32-bit path against the 64-bit one, found no collision, and nearly refuted the finding. The collision is with the neighbouring `RunOnce` row, not the other bitness. Recording that because it is the second time this session that checking the *plausible* direction wasn't enough.

**`EveryScheduledTaskFieldTheQueryFetches_IsBoundInTheView`** checked `service.Contains("Author")`. Every file in this project carries the mandatory `// Author: laurentiu021 …` header, so that was satisfied by **line 2** and could never fail however the query changed. Stripping comments would not help — the field appears in prose legitimately. Each entry now matches the PowerShell selection it belongs to.

## Red/green proof (mutation)

| Mutation | startup guard | task guard |
|---|---|---|
| *(unmutated)* | green | green |
| `OpenSubKey` instead of `CreateSubKey` (the shipped defect) | **RED** | green |
| Delete the 32-bit Run row, leaving RunOnce | **RED** | green |
| Drop `Author` from the `Select-Object` | green | **RED** |
| Delete the 32-bit arm of the write switch | **RED** | green |

Rows 3 and 4 are the ones that matter: **both stayed green before this batch.** Row 5 is recorded to show the tuple rewrite did not weaken the assertion it replaced.

## Verification

- All four projects `-c Release`: **0 errors, 0 warnings**; `dotnet format --verify-no-changes` clean on all four
- Guard harness: **55/56 green** — the one red is the known harness limitation (a helper that walks up from the harness's own `bin`), not a code defect
- Leak scan: all 32 terms from `leak-terms.txt` — **0 hits**
- csproj bumped to 1.65.14; CHANGELOG entry in this same PR with its plain-English lead
- No unit test added: `SetEnabledAsync` is static and writes to the live registry, so exercising it would touch the user's real startup settings — a hard rule here. The contract is pinned at source level, which is what the existing guard already does and says in its own remarks.