### PR TITLE
fix: the time-remaining estimate lied in three distinct ways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.15] - 2026-08-17
+
+The "time remaining" estimate now tells the truth when an operation stalls or when Windows reports its
+progress in a burst — before, it could sit on "a few seconds" for the rest of a long repair. Speed Test also
+stops leaving "done" printed under both of its cards after a finished test.
+
+### Fixed
+- **"Time remaining" got stuck on "a few seconds" for the rest of a scan.** `sfc` and DISM do not report
+  progress on a timer — Windows flushes several lines at once, so two different percentages can arrive
+  microseconds apart. The estimate divided the progress by that gap, concluded the repair was running
+  thousands of times faster than it was, and needed roughly thirty more updates to recover — more than a
+  scan produces. A System File Checker run with a quarter of an hour left announced "a few seconds" and
+  never corrected itself. Progress reported faster than four times a second is now measured over a
+  slightly longer window instead of being taken at face value, and nothing is thrown away in the process.
+- **An operation that stopped for ten minutes was still described as nearly finished.** When progress
+  resumed after a long pause, the new — and only honest — measurement was outweighed by the pace from
+  before the pause, so a job with hours left reported about two minutes. Each measurement now counts for
+  as much time as it actually covers, which makes the one spanning the pause the one that decides.
+- **Past its own estimate, the app kept promising "a few seconds".** The countdown stopped at zero and
+  stayed there, so an operation that overran and then hung looked identical to one about to finish: an
+  estimate of a minute and forty seconds read "a few seconds" for the following twenty-five minutes. Well
+  past its estimate the app now says "taking longer than expected", which is what it actually knows.
+- **Speed Test left "done" under both cards after a test finished.** The estimate line was only cleared
+  when the next test started, and both the Ookla and HTTP cards share it — so a finished HTTP test labelled
+  the Ookla card too, and a cancelled one stranded "a few seconds" there until the next run.
+- **Precise bandwidth mode could reset an app's session total to a few kilobytes.** A program's counter
+  became visible a fraction before it was stamped with the time, and a reading taken in that window treated
+  it as ten minutes idle and dropped it. The counter restarted from zero on the app's next packet, so the
+  running total for something downloading continuously could fall back to almost nothing.
+
 ## [1.65.14] - 2026-08-17
 
 Turning off a startup program could fail on a PC where nothing had ever been turned off before — which is

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -697,9 +697,17 @@ public partial class ArchitectureTests
                     continue;   // not disposed here — nothing to require
 
                 checkedFields++;
-                if (!body.Contains($"{field}?.Cancel()", StringComparison.Ordinal)
-                    && !body.Contains($"{field}.Cancel()", StringComparison.Ordinal))
-                    offenders.Add($"{Path.GetFileName(file)} · {field}");
+
+                // ORDER, not co-presence — the name says "IsCancelledFirst" and the failure message says
+                // "before the Dispose()". Co-presence accepted `_cts.Dispose(); _cts.Cancel();`, where the
+                // Cancel throws ObjectDisposedException and in-flight work (shredder overwrites, cleanup
+                // deletes) survives teardown: the exact defect, with both tokens present.
+                var cancelAt = FirstIndexOfAny(body, $"{field}?.Cancel()", $"{field}.Cancel()");
+                var disposeAt = FirstIndexOfAny(body, $"{field}?.Dispose()", $"{field}.Dispose()");
+                if (cancelAt < 0)
+                    offenders.Add($"{Path.GetFileName(file)} · {field} — never cancelled");
+                else if (cancelAt > disposeAt)
+                    offenders.Add($"{Path.GetFileName(file)} · {field} — cancelled AFTER being disposed");
             }
         }
 
@@ -710,9 +718,24 @@ public partial class ArchitectureTests
             "the detection is probably no longer matching the field declarations.");
 
         Assert.True(offenders.Count == 0,
-            "These cancellation sources are disposed without being cancelled, so work already in "
+            "These cancellation sources are disposed without being cancelled first, so work already in "
             + "flight keeps running after teardown — Dispose() does not cancel. Add a Cancel() before "
             + "the Dispose():\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// Index of whichever needle appears first, or -1 when neither does. Used to compare the POSITION of
+    /// two calls rather than merely their presence.
+    /// </summary>
+    private static int FirstIndexOfAny(string haystack, params string[] needles)
+    {
+        var best = -1;
+        foreach (var needle in needles)
+        {
+            var at = haystack.IndexOf(needle, StringComparison.Ordinal);
+            if (at >= 0 && (best < 0 || at < best)) best = at;
+        }
+        return best;
     }
 
     /// <summary>A field declared as a cancellation source, e.g. <c>private CancellationTokenSource? _cts;</c>.</summary>
@@ -2040,11 +2063,40 @@ public partial class ArchitectureTests
 
         // The step body has to actually start the process and judge the outcome. Without these it
         // could be reduced to an echo and still satisfy the ordering above.
-        var body = string.Join('\n', lines[smoke..release]);
-        foreach (var required in new[] { "Start-Process", "HasExited", "last-crash.json", "throw" })
+        //
+        // Sliced to the END OF THIS STEP, not to "Create GitHub Release": two unrelated steps sit in
+        // between ("Extract release notes from CHANGELOG" and "Append verification instructions"), and
+        // between them they contain five `throw`s. Against the wider slice, replacing this step's own
+        // `throw` with a Write-Warning — turning the launch gate into exactly the "decoration" the
+        // paragraph below forbids — still left the assertion green.
+        var stepEnd = Array.FindIndex(lines, smoke + 1, l => l.TrimStart().StartsWith("- name:", StringComparison.Ordinal));
+        Assert.True(stepEnd > smoke && stepEnd <= release,
+            $"the smoke-check step has no following step before \"Create GitHub Release\" (found {stepEnd}). "
+          + "The slice must end at this step's own boundary: widening it to the next few steps lets THEIR "
+          + "five throws stand in for this gate's, which is how a neutered launch check stayed green.");
+        var body = string.Join('\n', lines[smoke..stepEnd]);
+        Assert.True(body.Length > 500,
+            $"the smoke-check step body is only {body.Length} characters — the slice has collapsed, so "
+          + "the token checks below would pass by measuring nothing.");
+        foreach (var foreign in new[] { "Extract release notes from CHANGELOG", "Create GitHub Release" })
+        {
+            Assert.DoesNotContain(foreign, body, StringComparison.Ordinal);
+        }
+        foreach (var required in new[] { "Start-Process", "HasExited", "last-crash.json" })
         {
             Assert.Contains(required, body, StringComparison.Ordinal);
         }
+
+        // `throw` is counted on non-comment lines only, and more than one is required: the step raises on
+        // three distinct verdicts (the exe self-exited, it left a crash marker, it would not die when
+        // killed). A bare Contains was satisfied by the word "throw" in this step's own explanatory
+        // comment, and by whichever verdict was left intact when another was turned into a Write-Warning.
+        var throwingLines = body.Split('\n')
+            .Count(l => !l.TrimStart().StartsWith('#') && l.Contains("throw ", StringComparison.Ordinal));
+        Assert.True(throwingLines >= 3,
+            $"the smoke check raises on only {throwingLines} verdict(s). It must fail the job when the exe "
+          + "self-exits, when it leaves a crash marker, AND when it will not terminate — a verdict "
+          + "downgraded to a warning makes the launch advisory, which is the one thing it must not be.");
 
         // A check that never fails the job is decoration. continue-on-error on this step would make
         // the launch advisory, which is the one thing it must not be.
@@ -2664,6 +2716,209 @@ public partial class ArchitectureTests
 
     // WhitespaceRun() is declared once, near the XAML attribute readers that first needed it — the same
     // collapse rule serves both, so it is not redeclared here.
+
+    /// <summary>
+    /// Every ETA text property must either be cleared when its operation ends, or live inside a section
+    /// the view hides when the operation is not running. Otherwise the last value stays on screen: Speed
+    /// Test left the literal word "done" under BOTH its cards — they share one property — until the next
+    /// run, and after a cancel it stranded whatever the last tick produced, typically "a few seconds".
+    /// <para>Two accepted shapes, because both are already in use and both are correct: clear it in
+    /// <c>finally</c> (AppUpdates, BulkInstaller, Uninstaller, Cleanup, and now SpeedTest), or gate the
+    /// containing panel on an <c>Is…ing</c> flag (DeepCleanup). What is NOT accepted is neither.</para>
+    /// <para>Matched on the CLEARING STATEMENT, not on the words of this comment: a guard that keys on
+    /// prose passes because of its own explanation. The population is enumerated from the view models that
+    /// actually own an ETA property, so adding a seventh consumer without clearing it fails here.</para>
+    /// </summary>
+    [Fact]
+    public void EveryEtaTextProperty_IsClearedWhenItsOperationEnds()
+    {
+        var appDir = FindAppProjectDir();
+        var vmDir = Path.Combine(appDir, "ViewModels");
+        var viewsDir = Path.Combine(appDir, "Views");
+
+        var offenders = new List<string>();
+        var checkedProperties = 0;
+
+        foreach (var file in Directory.GetFiles(vmDir, "*ViewModel.cs"))
+        {
+            var source = File.ReadAllText(file);
+            var vmName = Path.GetFileNameWithoutExtension(file);
+
+            foreach (var property in EtaTextProperties(source))
+            {
+                checkedProperties++;
+
+                // Shape 1: EVERY try/finally that feeds this property also clears it, so a run ending any
+                // way at all — success, error, cancel — leaves nothing behind.
+                //
+                // Counted per block, not "somewhere in the file": an `Any` over the whole source let one
+                // operation drop its clear while a sibling supplied the match. Speed Test has two, Ookla
+                // and HTTP, sharing one property — exactly the shape in which a half-fix reads as done.
+                var feedingBlocks = TryFinallyBlocksFeeding(source, property);
+                if (feedingBlocks.Count > 0 && feedingBlocks.All(b => ClearsProperty(b, property)))
+                    continue;
+
+                // Shape 2: the ETA element sits inside a container the view hides while the operation is
+                // not running, so a stale value can never be seen.
+                //
+                // Scoped to the ETA element's OWN ancestor chain, not to "this file mentions an Is…ing
+                // binding somewhere". The looser form waved SpeedTestView through on the strength of the
+                // Visibility bindings on its ProgressBar and Cancel button, which have nothing to do with
+                // the ETA TextBlock — leaving this guard green against the exact defect it was written for.
+                var viewPath = Path.Combine(viewsDir, vmName.Replace("ViewModel", "View") + ".xaml");
+                if (File.Exists(viewPath) && EtaElementSitsInAFlagGatedContainer(viewPath, property))
+                    continue;
+
+                offenders.Add($"{vmName}.{property}");
+            }
+        }
+
+        // Vacuity floor from an enumerated population: AppUpdates, BulkInstaller, Cleanup (×2),
+        // DeepCleanup (×2), SpeedTest, Uninstaller — eight ETA properties across six view models. A
+        // regex that silently stopped matching would otherwise make this pass by checking nothing.
+        Assert.True(checkedProperties >= 8,
+            $"only {checkedProperties} ETA properties were found — EtaBackingField() has stopped "
+          + "matching, so this guard is measuring nothing.");
+
+        Assert.True(offenders.Count == 0,
+            "these ETA texts are neither cleared in a finally nor hidden with their section, so the last "
+          + "value stays on screen after the operation ends: " + string.Join(", ", offenders));
+    }
+
+    /// <summary>
+    /// Names of the ETA text properties a view model owns. Matches the <c>[ObservableProperty]</c> backing
+    /// field, whose generated property is what the view binds.
+    /// </summary>
+    private static IEnumerable<string> EtaTextProperties(string source)
+    {
+        foreach (Match m in EtaBackingField().Matches(source))
+        {
+            var field = m.Groups["name"].Value;   // _upgradeEtaText
+            yield return char.ToUpperInvariant(field[1]) + field[2..];
+        }
+    }
+
+    /// <summary>
+    /// True when the element displaying <paramref name="property"/> has an ANCESTOR whose
+    /// <c>Visibility</c> binds to an <c>Is…ing</c> flag — so the whole section disappears when the
+    /// operation is not running and a stale value is unreachable.
+    /// <para>Walks the real XAML tree rather than searching the file, and deliberately ignores a
+    /// <c>Visibility</c> on the ETA element itself: binding an element's visibility to the very string it
+    /// displays is not a gate, it is what kept the stale text on screen.</para>
+    /// </summary>
+    private static bool EtaElementSitsInAFlagGatedContainer(string viewPath, string property)
+    {
+        var root = System.Xml.Linq.XDocument.Load(viewPath).Root;
+        if (root is null) return false;
+
+        var binding = $"{{Binding {property}}}";
+        foreach (var element in root.Descendants())
+        {
+            if ((string?)element.Attribute("Text") != binding) continue;
+
+            for (var ancestor = element.Parent; ancestor is not null; ancestor = ancestor.Parent)
+            {
+                var visibility = (string?)ancestor.Attribute("Visibility");
+                if (visibility is not null && Regex.IsMatch(visibility, @"^\{Binding\s+Is\w+ing\b"))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// The <c>finally</c> body of every method that ASSIGNS <paramref name="property"/> — i.e. every
+    /// operation that can leave a value on screen. A method that assigns it but has no <c>finally</c>
+    /// yields an empty string, which fails <see cref="ClearsProperty"/> and is reported.
+    /// </summary>
+    private static List<string> TryFinallyBlocksFeeding(string source, string property)
+    {
+        var bodies = new List<string>();
+        foreach (var method in MethodBodies(source))
+        {
+            // An assignment FROM the ETA calculator is what makes this method a feeder; the clear itself
+            // (`= string.Empty`) must not count, or a method that only resets it would look like one.
+            if (!Regex.IsMatch(method, Regex.Escape(property) + @"\s*=\s*(?!string\.Empty|"""")"))
+                continue;
+
+            var finallyBodies = FinallyBodies(method).ToList();
+            bodies.Add(finallyBodies.Count > 0 ? string.Join('\n', finallyBodies) : string.Empty);
+        }
+        return bodies;
+    }
+
+    /// <summary>True when the block assigns the property an empty string.</summary>
+    private static bool ClearsProperty(string block, string property) =>
+        block.Contains($"{property} = string.Empty", StringComparison.Ordinal)
+        || block.Contains($"{property} = \"\"", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Each method body in a source file, brace-balanced from its opening <c>{</c>. Coarse by design: it
+    /// only has to separate one operation's try/finally from another's.
+    /// </summary>
+    private static IEnumerable<string> MethodBodies(string source)
+    {
+        foreach (Match m in MethodSignature().Matches(source))
+        {
+            var open = source.IndexOf('{', m.Index + m.Length - 1);
+            if (open < 0) continue;
+
+            var depth = 0;
+            for (var i = open; i < source.Length; i++)
+            {
+                if (source[i] == '{') depth++;
+                else if (source[i] == '}' && --depth == 0)
+                {
+                    yield return source[(open + 1)..i];
+                    break;
+                }
+            }
+        }
+    }
+
+    /// <summary>A method declaration line — the anchor from which a body is brace-matched.</summary>
+    [GeneratedRegex(@"^\s{4}(?:\[[^\]]+\]\s*)?(?:private|internal|public|protected)[^;=\r\n]*\([^;)]*\)\s*$",
+                    RegexOptions.Compiled | RegexOptions.Multiline)]
+    private static partial Regex MethodSignature();
+
+    /// <summary>
+    /// The body of each <c>finally</c> block in a source file. Brace-balanced rather than regex-matched,
+    /// because a finally body contains braces of its own.
+    /// </summary>
+    private static IEnumerable<string> FinallyBodies(string source)
+    {
+        var at = 0;
+        while (true)
+        {
+            var keyword = source.IndexOf("finally", at, StringComparison.Ordinal);
+            if (keyword < 0) break;
+            at = keyword + "finally".Length;
+
+            var open = source.IndexOf('{', keyword);
+            if (open < 0) break;
+
+            var depth = 0;
+            for (var i = open; i < source.Length; i++)
+            {
+                if (source[i] == '{') depth++;
+                else if (source[i] == '}' && --depth == 0)
+                {
+                    yield return source[(open + 1)..i];
+                    at = i;
+                    break;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// An <c>[ObservableProperty]</c> field holding ETA text — the thing that must not go stale. Both
+    /// spellings in use are matched: seven fields are named <c>…EtaText</c>, and Speed Test's is
+    /// <c>_estimatedTime</c>. Keying on "eta" alone missed exactly the one that carried the defect.
+    /// </summary>
+    [GeneratedRegex(@"\[ObservableProperty\]\s*private\s+string\s+(?<name>_\w*(?:[Ee]ta|[Ee]stimated)\w*)\s*=",
+                    RegexOptions.Compiled)]
+    private static partial Regex EtaBackingField();
 
     /// <summary>The app project directory — .xaml is not copied to the test output.</summary>
     private static string FindAppProjectDir()

--- a/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
@@ -226,7 +226,12 @@ public class AudioMixerViewModelTests
     {
         var service = ServiceWith(Session("s1"), Session("s2"));
         Peaks(service, ("s1", 0.6f), ("s2", 0.2f));
-        var vm = NewVm(service);
+        using var vm = NewVm(service);
+        // Active, because that is the only state in which the meters are read: MainWindowViewModel calls
+        // SetActive(content, IsWindowVisible) the moment a tab's VM is materialised, so a peak sample never
+        // lands on an inactive tab in production. Sampling with IsActive false is a state the app does not
+        // have, and asserting levels there asks the post-await guard to write onto rows it just zeroed.
+        vm.IsActive = true;
 
         await vm.UpdatePeaksAsync(CancellationToken.None);
 
@@ -247,7 +252,8 @@ public class AudioMixerViewModelTests
     {
         var service = ServiceWith(Session("s1"), Session("s2"), Session("s3"));
         Peaks(service, ("s1", 0.1f), ("s2", 0.2f), ("s3", 0.3f));
-        var vm = NewVm(service);
+        using var vm = NewVm(service);
+        vm.IsActive = true;
 
         await vm.UpdatePeaksAsync(CancellationToken.None);
 
@@ -267,7 +273,11 @@ public class AudioMixerViewModelTests
     [Fact]
     public void HiddenTab_ParksThePeakLoop_RatherThanTickingAndSkipping()
     {
-        var vm = NewVm(ServiceWith(Session("s1")));
+        // Disposed, and left INACTIVE, deliberately. Ending on IsActive = true without disposing left this
+        // VM's peak loop waking ~20 times a second against the stub for the remainder of the test process
+        // — the exact cost this test is named after, reintroduced by the test itself. It also kept the
+        // process alive past the end of the run, locking its own output assemblies against the next build.
+        using var vm = NewVm(ServiceWith(Session("s1")));
 
         var gate = typeof(AudioMixerViewModel)
             .GetField("_activated", BindingFlags.NonPublic | BindingFlags.Instance)!;
@@ -282,6 +292,8 @@ public class AudioMixerViewModelTests
         // after the first time the user navigated away.
         vm.IsActive = true;
         Assert.True(((TaskCompletionSource)gate.GetValue(vm)!).Task.IsCompleted);
+
+        vm.IsActive = false;
     }
 
     [Fact]
@@ -289,13 +301,64 @@ public class AudioMixerViewModelTests
     {
         var service = ServiceWith(Session("s1"));
         Peaks(service, ("s1", 0.9f));
-        var vm = NewVm(service);
+        using var vm = NewVm(service);
         vm.IsActive = true;
         await vm.UpdatePeaksAsync(CancellationToken.None);
         Assert.Equal(0.9f, vm.Sessions.Single().PeakLevel);
 
         // Leaving the tab zeroes the bars (no stale lit level); the loop itself skips while hidden.
         vm.IsActive = false;
+
+        Assert.Equal(0f, vm.Sessions.Single().PeakLevel);
+    }
+
+    /// <summary>
+    /// The sibling of <see cref="UpdatePeaks_WhenDisposedMidSample_DoesNotWriteBackOntoTheTornDownRows"/>,
+    /// and the half of that guard that was missing. Hiding the tab — or minimising the window, which
+    /// routes to the same <c>SetActive(false)</c> — zeroes every row; the sample already in flight then
+    /// resumed and wrote the old levels straight back. The loop parks on its next iteration, so those
+    /// stale bars survive for as long as the tab stays hidden: on re-show the user sees a lit meter from
+    /// minutes ago until a fresh sample lands.
+    /// <para>Both waits are BOUNDED for the same reason as the dispose test: on the correct shape neither
+    /// timeout is reached, but a wrong shape would hang the whole suite instead of failing one test.</para>
+    /// </summary>
+    [Fact]
+    public async Task UpdatePeaks_WhenTheTabIsHiddenMidSample_DoesNotRelightTheZeroedRows()
+    {
+        var service = ServiceWith(Session("s1"));
+        using var vm = NewVm(service);
+        vm.IsActive = true;
+
+        var sampleReached = new TaskCompletionSource();
+        var releaseSample = new TaskCompletionSource();
+        service.GetPeaks(Arg.Any<IEnumerable<string>>()).Returns(call =>
+        {
+            sampleReached.TrySetResult();
+            releaseSample.Task.Wait(TimeSpan.FromSeconds(10));
+            return ((IEnumerable<string>)call[0]).ToDictionary(id => id, _ => 0.8f, StringComparer.Ordinal);
+        });
+        // Held open the same way, so this test is about the post-await guard and not about which call
+        // shape reads the levels — see the dispose test for why that distinction matters.
+        service.GetPeak(Arg.Any<string>()).Returns(_ =>
+        {
+            sampleReached.TrySetResult();
+            releaseSample.Task.Wait(TimeSpan.FromSeconds(10));
+            return 0.8f;
+        });
+
+        try
+        {
+            var inFlight = vm.UpdatePeaksAsync(CancellationToken.None);
+            await sampleReached.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            vm.IsActive = false;             // zeroes the rows while the sample is outstanding
+            releaseSample.SetResult();
+            await inFlight;
+        }
+        finally
+        {
+            releaseSample.TrySetResult();
+        }
 
         Assert.Equal(0f, vm.Sessions.Single().PeakLevel);
     }

--- a/SysManager/SysManager.Tests/EtaCalculatorTests.cs
+++ b/SysManager/SysManager.Tests/EtaCalculatorTests.cs
@@ -248,4 +248,190 @@ public class EtaCalculatorTests
         Assert.Equal("calculating…", eta.RemainingText);
         Assert.Equal("done", eta.Update(100));
     }
+
+    /// <summary>
+    /// Progress does not arrive on a timer. <c>sfc</c> and DISM emit their redraws through
+    /// <c>Process.OutputDataReceived</c>, which flushes buffered lines back-to-back, so two different
+    /// percents can be microseconds apart. Dividing an advance by a microsecond yields thousands of
+    /// percent per second, and one such sample used to pin the display at "a few seconds" for the rest of
+    /// the run: it takes ~29 further forward samples for a 0.3-weighted average to work 6000 %/s back down,
+    /// more than SFC emits in the remainder of a scan.
+    /// </summary>
+    [Fact]
+    public void Update_WhenTwoPercentsArriveMicrosecondsApart_DoesNotBelieveTheImpliedRate()
+    {
+        var time = new TestTimeProvider();
+        var eta = new EtaCalculator(time);
+        eta.Reset();
+
+        // Establish an honest 0.1 %/s: 10% in 100 s => 90% left => ~900 s.
+        time.Advance(TimeSpan.FromSeconds(100));
+        eta.Update(10);
+        var honest = eta.Remaining!.Value;
+        Assert.True(honest > TimeSpan.FromMinutes(10), $"the baseline estimate is already wrong: {honest}.");
+
+        // Now the flush: 11% and 12% land 50 microseconds apart. Naively that is 20,000 %/s.
+        time.Advance(TimeSpan.FromMilliseconds(0.05));
+        eta.Update(11);
+        time.Advance(TimeSpan.FromMilliseconds(0.05));
+        eta.Update(12);
+
+        Assert.NotEqual("a few seconds", eta.RemainingText);
+        Assert.True(eta.Remaining!.Value > TimeSpan.FromMinutes(5),
+            $"a 50 µs sample collapsed the estimate to {eta.Remaining} — the burst is being taken as a rate.");
+    }
+
+    /// <summary>
+    /// The advance under the sample floor must be CARRIED, not discarded: an operation reporting faster
+    /// than the floor must still be measured, just over a coalesced window. Discarding it instead would
+    /// lose progress permanently and hold the ETA at the opening rate forever.
+    /// </summary>
+    [Fact]
+    public void Update_BelowTheSampleFloor_CarriesTheAdvanceIntoTheNextSample()
+    {
+        var time = new TestTimeProvider();
+        var eta = new EtaCalculator(time);
+        eta.Reset();
+
+        // Ten reports at 100 ms each: every one is under the 250 ms floor on its own, but together they
+        // span 1 s and 10% of progress — an honest 10 %/s, so 90% left is ~9 s.
+        for (var p = 1; p <= 10; p++)
+        {
+            time.Advance(TimeSpan.FromMilliseconds(100));
+            eta.Update(p);
+        }
+
+        var remaining = eta.Remaining;
+        Assert.NotNull(remaining);
+        Assert.InRange(remaining!.Value, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(15));
+    }
+
+    /// <summary>
+    /// A sample spanning a long stall IS the better measurement and must dominate. Under the old fixed
+    /// 0.3 weight the resuming rate was outvoted 7:3 by a pace that no longer existed, so a 10-minute
+    /// stall followed by 1% of progress reported "~2 min" when the observed pace implied hours.
+    /// </summary>
+    [Fact]
+    public void Update_AfterALongStall_TrustsTheResumingRateOverThePreStallPace()
+    {
+        var time = new TestTimeProvider();
+        var eta = new EtaCalculator(time);
+        eta.Reset();
+
+        // 1 %/s established over ten seconds.
+        for (var p = 1; p <= 10; p++)
+        {
+            time.Advance(TimeSpan.FromSeconds(1));
+            eta.Update(p);
+        }
+
+        // Ten minutes of silence, then one more percent. Observed pace: 1% per 600 s => 89% => ~14.8 h.
+        time.Advance(TimeSpan.FromMinutes(10));
+        eta.Update(11);
+
+        Assert.True(eta.Remaining!.Value > TimeSpan.FromHours(1),
+            $"after a 10-minute stall the estimate is {eta.Remaining} — the pre-stall rate still dominates.");
+    }
+
+    /// <summary>
+    /// Past its projected finish the text must stop claiming the operation is nearly done. Remaining
+    /// clamps at zero, so an operation that overshoots and then hangs is otherwise indistinguishable from
+    /// one about to complete — it showed "a few seconds" for as long as the hang lasted.
+    /// </summary>
+    [Fact]
+    public void RemainingText_WellPastTheProjectedFinish_SaysItIsTakingLongerRatherThanAlmostDone()
+    {
+        var time = new TestTimeProvider();
+        var eta = new EtaCalculator(time);
+        eta.Reset();
+
+        // 1 %/s at 10% => projected finish at t = 100 s.
+        time.Advance(TimeSpan.FromSeconds(10));
+        eta.Update(10);
+
+        // Just past the projection, still inside the grace: "a few seconds" is fair, it may be finishing.
+        time.Advance(TimeSpan.FromSeconds(95));
+        Assert.Equal(TimeSpan.Zero, eta.Remaining);
+        Assert.Equal("a few seconds", eta.RemainingText);
+
+        // Well past it: the projection has expired and the text must say so.
+        time.Advance(TimeSpan.FromMinutes(25));
+        Assert.Equal("taking longer than expected", eta.RemainingText);
+
+        // And completion still wins over overdue.
+        Assert.Equal("done", eta.Update(100));
+    }
+
+    /// <summary>
+    /// Reset must clear the RATE, not merely the projection. <c>Remaining</c> is null after any reset
+    /// because <c>_projectedFinish</c> is nulled, so a test that only asserts null cannot tell whether the
+    /// samples were cleared — a second run would silently inherit the first run's pace.
+    /// </summary>
+    [Fact]
+    public void Reset_ClearsTheRate_SoASecondRunDoesNotInheritTheFirstRunsPace()
+    {
+        var time = new TestTimeProvider();
+        var eta = new EtaCalculator(time);
+
+        // Run 1: a fast 10 %/s.
+        eta.Reset();
+        time.Advance(TimeSpan.FromSeconds(5));
+        eta.Update(50);
+
+        // Run 2: 5% in 1 s => 5 %/s => 95% left => exactly 19 s. Any inherited rate makes it smaller.
+        eta.Reset();
+        time.Advance(TimeSpan.FromSeconds(1));
+        eta.Update(5);
+
+        Assert.Equal(TimeSpan.FromSeconds(19), eta.Remaining);
+    }
+
+    /// <summary>
+    /// A clock that advances on every reading, so concurrent callers see a monotonically increasing time
+    /// without any test-controlled stepping. Needed because the threading test below cannot advance a
+    /// frozen clock from inside the parallel body, and the real clock moves too little across a
+    /// <c>Parallel.For</c> for any sample to clear the minimum interval.
+    /// </summary>
+    private sealed class TickingClock : TimeProvider
+    {
+        private long _ticks;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        // Half a second per reading: comfortably over MinSampleInterval, so samples are accepted.
+        // Fully qualified from the global namespace — inside a TimeProvider subclass, `System.Threading`
+        // binds to the inherited `TimeProvider.System` member first.
+        public override long GetTimestamp() =>
+            global::System.Threading.Interlocked.Add(ref _ticks, TimeSpan.TicksPerSecond / 2);
+    }
+
+    /// <summary>
+    /// The class is fed from <c>PowerShellRunner.LineReceived</c>, which is raised on the
+    /// <c>OutputDataReceived</c> AND <c>ErrorDataReceived</c> threadpool threads with nothing marshalling
+    /// in between — two threads into one handler. <c>_projectedFinish</c> is a <c>TimeSpan?</c> (a 16-byte
+    /// struct on x64), so an unsynchronised read can pair a live <c>HasValue</c> with a stale tick count
+    /// and print an arbitrary duration.
+    /// <para>Threading tests cannot prove the ABSENCE of a race, so this is a smoke check with teeth: it
+    /// asserts every observed estimate is a sane duration, and that concurrent callers still produce
+    /// estimates at all rather than deadlocking or leaving the state permanently unusable.</para>
+    /// </summary>
+    [Fact]
+    public void Update_FromManyThreadsAtOnce_NeverProducesANegativeOrAbsurdEstimate()
+    {
+        var eta = new EtaCalculator(new TickingClock());
+        eta.Reset();
+
+        var observed = new System.Collections.Concurrent.ConcurrentBag<TimeSpan>();
+        Parallel.For(0, 400, i =>
+        {
+            // Percent must only ever go forward — a backwards report is a no-op by design, so a shuffled
+            // sequence would exercise the early return instead of the arithmetic under contention.
+            eta.Update(Math.Min(99, (i / 4) + 5));
+            if (eta.Remaining is { } left) observed.Add(left);
+            _ = eta.RemainingText;
+        });
+
+        Assert.NotEmpty(observed);
+        Assert.All(observed, t => Assert.InRange(t, TimeSpan.Zero, TimeSpan.FromDays(365)));
+    }
 }

--- a/SysManager/SysManager.Tests/EtwBandwidthSourceTests.cs
+++ b/SysManager/SysManager.Tests/EtwBandwidthSourceTests.cs
@@ -141,6 +141,67 @@ public class EtwBandwidthSourceTests
         Assert.Empty(await PidsAsync(src));
     }
 
+    /// <summary>
+    /// A clock that is already past the eviction window when the test starts — like the real one, which is
+    /// QPC-since-boot — and which can run a callback at a chosen reading. The offset matters: the plain
+    /// <see cref="TestClock"/> starts at 0, so <c>cutoff = 0 - 10 min</c> is negative and NOTHING is
+    /// evictable, which is exactly why no existing test can reach the window below.
+    /// </summary>
+    private sealed class InterleavingClock(TimeSpan uptime) : TimeProvider
+    {
+        private long _ticks = uptime.Ticks;
+        private int _reads;
+
+        /// <summary>1-based index of the <c>GetTimestamp</c> call that fires <see cref="OnRead"/>.</summary>
+        public int FireOnRead { get; set; }
+
+        public Action? OnRead { get; set; }
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp()
+        {
+            var now = _ticks;
+            if (++_reads == FireOnRead)
+            {
+                var callback = OnRead;
+                OnRead = null;      // one-shot: the callback reads the clock itself
+                callback?.Invoke();
+            }
+            return now;
+        }
+    }
+
+    /// <summary>
+    /// A brand-new PID must never be evictable before it is stamped. <c>GetOrAdd</c> PUBLISHES the entry
+    /// the instant its factory returns, so stamping afterwards leaves a window in which <c>_counters</c>
+    /// holds an entry reading <c>LastActivityTicks == 0</c> — and against a monotonic clock 0 is far below
+    /// the cutoff, so a poll landing there evicts a PID that is actively transferring. Its next event
+    /// re-adds it with a zeroed counter, which the user sees as a busy app's session total resetting.
+    /// <para>Deterministic rather than threaded: the clock fires a sample at the exact reading <c>Add</c>
+    /// takes for its stamp. Stamping inside the factory means the entry is not published yet, so that
+    /// sample has nothing to evict. Stamping after publication means it is, so the sample drops it and the
+    /// bytes are lost. Uptime is set past the window because a machine up for 20 minutes is the ordinary
+    /// case — and it is the case the zero-based <see cref="TestClock"/> cannot express, which is why the
+    /// existing eviction tests cannot see this.</para>
+    /// </summary>
+    [Fact]
+    public async Task Add_StampsBeforeTheEntryIsVisible_SoAFirstEventIsNeverEvictedAsIdle()
+    {
+        var clock = new InterleavingClock(TimeSpan.FromMinutes(20));
+        using var src = new EtwBandwidthSource(clock);
+
+        // Reading 1 is Add's stamp for this brand-new PID. Sample from inside it.
+        clock.FireOnRead = 1;
+        clock.OnRead = () => src.SampleAsync().GetAwaiter().GetResult();
+
+        src.Add(4242, down: 7_000, up: 0, "chrome.exe");
+
+        var row = Assert.Single((await src.SampleAsync()).Processes);
+        Assert.Equal(4242, row.ProcessId);
+        Assert.Equal(7_000, row.TotalDownBytes);
+    }
+
     [Fact]
     public void Start_WithoutAdministrator_RefusesCleanly()
     {

--- a/SysManager/SysManager.Tests/SpeedTestHistoryServiceTests.cs
+++ b/SysManager/SysManager.Tests/SpeedTestHistoryServiceTests.cs
@@ -103,7 +103,8 @@ public sealed class SpeedTestHistoryServiceTests : IDisposable
         await svc.SaveAsync(Result("Ookla", 200, 20, 6, "ookla-server"));
         Assert.Equal(2, (await svc.LoadAsync()).Count);
 
-        await svc.ClearAsync("HTTP");
+        Assert.True(await svc.ClearAsync("HTTP"),
+            "ClearAsync reported failure — the view model turns that into \"history could not be cleared\" and leaves the rows on screen.");
 
         var remaining = await svc.LoadAsync();
         var only = Assert.Single(remaining);
@@ -117,7 +118,7 @@ public sealed class SpeedTestHistoryServiceTests : IDisposable
         using var svc = NewService();
         await svc.SaveAsync(Result("HTTP", server: "http-server"));
 
-        await svc.ClearAsync("http");   // lower case — the service compares OrdinalIgnoreCase
+        Assert.True(await svc.ClearAsync("http"), "ClearAsync reported failure.");   // lower case — the service compares OrdinalIgnoreCase
 
         Assert.Empty(await svc.LoadAsync());
     }
@@ -129,7 +130,7 @@ public sealed class SpeedTestHistoryServiceTests : IDisposable
         await svc.SaveAsync(Result("HTTP"));
         Assert.True(File.Exists(HistoryFile));
 
-        await svc.ClearAsync("HTTP");
+        Assert.True(await svc.ClearAsync("HTTP"), "ClearAsync reported failure.");
 
         Assert.False(File.Exists(HistoryFile));   // no empty-array file left behind
         Assert.Empty(await svc.LoadAsync());
@@ -142,7 +143,7 @@ public sealed class SpeedTestHistoryServiceTests : IDisposable
         await svc.SaveAsync(Result("HTTP"));
         await svc.SaveAsync(Result("Ookla"));
 
-        await svc.ClearAsync(null);
+        Assert.True(await svc.ClearAsync(null), "ClearAsync reported failure.");
 
         Assert.False(File.Exists(HistoryFile));
         Assert.Empty(await svc.LoadAsync());
@@ -154,9 +155,14 @@ public sealed class SpeedTestHistoryServiceTests : IDisposable
         using var svc = NewService();
         Assert.False(File.Exists(HistoryFile));
 
-        var ex = await Record.ExceptionAsync(() => svc.ClearAsync("HTTP"));
+        var cleared = false;
+        var ex = await Record.ExceptionAsync(async () => cleared = await svc.ClearAsync("HTTP"));
 
         Assert.Null(ex);
+        // Nothing to delete is SUCCESS. Returning false here would surface "history could not be
+        // cleared" for a no-op, which is the failure mode the bool was added to prevent.
+        Assert.True(cleared, "clearing an absent file reported failure, so the user would be told the "
+                           + "clear failed when there was simply nothing to clear.");
     }
 
     /// <summary>
@@ -197,14 +203,23 @@ public sealed class SpeedTestHistoryServiceTests : IDisposable
         using var svc = NewService();
         var start = new DateTime(2026, 1, 1, 0, 0, 0);
         for (int i = 0; i < 22; i++)
-            await svc.SaveAsync(Result("HTTP", server: $"h{i}", at: start.AddMinutes(i)));
-        await svc.SaveAsync(Result("Ookla", server: "ookla-kept", at: start.AddMinutes(100)));
+        {
+            // Checked per save, like the sibling above. Without this the test is blind to a dropped
+            // write: 21 saves also trim to 20, so both counts still match and only the bool differs.
+            var saved = await svc.SaveAsync(Result("HTTP", server: $"h{i}", at: start.AddMinutes(i)));
+            Assert.True(saved, $"HTTP save {i} (h{i}) failed to reach disk.");
+        }
+        Assert.True(await svc.SaveAsync(Result("Ookla", server: "ookla-kept", at: start.AddMinutes(100))),
+            "the Ookla save failed to reach disk.");
 
         var loaded = await svc.LoadAsync();
 
+        // The exact surviving HTTP set, newest first: h21 down to h2. Counts alone do not discriminate —
+        // any 20 of the 22 would satisfy them, including a window that trimmed from the wrong end.
+        var expectedHttp = Enumerable.Range(2, 20).Reverse().Select(i => $"h{i}").ToArray();
+        Assert.Equal(expectedHttp, loaded.Where(r => r.Engine == "HTTP").Select(r => r.Server).ToArray());
+        Assert.Equal(["ookla-kept"], loaded.Where(r => r.Engine == "Ookla").Select(r => r.Server).ToArray());
         Assert.Equal(SpeedTestHistoryService.MaxPerEngine + 1, loaded.Count);
-        Assert.Contains(loaded, r => r.Server == "ookla-kept");
-        Assert.Equal(SpeedTestHistoryService.MaxPerEngine, loaded.Count(r => r.Engine == "HTTP"));
     }
 
     [Fact]

--- a/SysManager/SysManager/Helpers/EtaCalculator.cs
+++ b/SysManager/SysManager/Helpers/EtaCalculator.cs
@@ -22,18 +22,54 @@ namespace SysManager.Helpers;
 /// step displayed "~1.6 h" moments before the real answer turned out to be 90 s.
 /// </para>
 /// <para>
-/// Thread safety: this class is NOT thread-safe. All calls must be made from the same thread (typically
-/// the UI thread via Progress&lt;T&gt; callbacks).
+/// Thread safety: every public member is serialized on an internal lock, so callers may report progress
+/// from whatever thread it reaches them on. That is not a convenience — <c>CleanupViewModel</c> feeds this
+/// from <c>PowerShellRunner.LineReceived</c>, raised on the <c>OutputDataReceived</c> and
+/// <c>ErrorDataReceived</c> threadpool threads with nothing marshalling in between, and the previous
+/// "callers must be single-threaded" contract was simply not being met.
 /// </para>
 /// </summary>
 public sealed class EtaCalculator
 {
     /// <summary>
-    /// Weight given to the newest rate sample. 0.3 stays responsive to a genuine slowdown within a few
-    /// samples while ignoring the jitter of one slow step — the usual low-pass constant for transfer
-    /// dialogs. Higher jumps around; lower reacts too late to be useful.
+    /// Time constant of the rate smoother, in seconds. The weight given to a sample is
+    /// <c>1 - e^(-Δt / τ)</c>, so it grows with the interval the sample actually covers instead of being
+    /// the same for every report.
+    /// <para>2.8 s is chosen so nothing changes at the cadence callers really report at: at Δt = 1 s the
+    /// weight is <c>1 - e^(-1/2.8) = 0.30</c>, exactly the fixed 0.3 this replaced. It stays responsive to
+    /// a genuine slowdown within a few samples while ignoring the jitter of one slow step.</para>
+    /// <para>The fixed weight was wrong in both directions. A sample spanning a 10-minute stall got the
+    /// same 0.3 as a sample spanning one second, so the resuming rate — the only honest measurement
+    /// available — was outvoted 7:3 by a pace that no longer existed: 1%/s established, 600 s stall, then
+    /// 1% more read as "~2 min" when the observed pace implied hours. And a sub-millisecond interval made
+    /// <c>advance / Δt</c> explode, which the fixed weight passed straight through. Time-weighting bounds
+    /// that: the contribution is <c>(Δt/τ)·(advance/Δt) = advance/τ</c>, independent of how small Δt
+    /// is.</para>
     /// </summary>
-    private const double RateSmoothing = 0.3;
+    private const double RateTimeConstantSeconds = 2.8;
+
+    /// <summary>
+    /// Shortest interval accepted as a rate sample. Below it the advance is CARRIED — neither the percent
+    /// nor the sample timestamp moves — so it is measured over the real interval on the next report rather
+    /// than over a microsecond one. Carrying rather than discarding is what makes a floor safe at any
+    /// speed: a fast operation reporting every 100 ms simply coalesces into ~250 ms windows, and the ratio
+    /// the rate is computed from is unchanged.
+    /// <para>Needed because progress does not arrive on a timer. <c>sfc</c> and DISM emit their redraws
+    /// through <c>Process.OutputDataReceived</c>, which flushes buffered lines back-to-back, so two
+    /// different percents can be microseconds apart. Rejecting only a ZERO interval was not enough:
+    /// 1% in 50 µs is 20,000 %/s.</para>
+    /// </summary>
+    private static readonly TimeSpan MinSampleInterval = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>
+    /// Fraction of the projected duration an operation may overrun before the text stops claiming it is
+    /// nearly done. Proportional, with <see cref="MinOverdueGrace"/> as a floor, because 30 s past a
+    /// "few seconds" estimate is a broken promise while 30 s past a two-hour estimate is noise.
+    /// </summary>
+    private const double OverdueFraction = 0.1;
+
+    /// <summary>Lower bound on the overdue grace, so a short projection is not called stale immediately.</summary>
+    private static readonly TimeSpan MinOverdueGrace = TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// No estimate is shown below this mark. Early samples are dominated by start-up cost — opening
@@ -43,6 +79,16 @@ public sealed class EtaCalculator
     private const int MinPercentForEstimate = 3;
 
     private readonly TimeProvider _time;
+
+    /// <summary>
+    /// Serializes every read and write of the fields below. Cheap (uncontended in the common case) and it
+    /// removes a real hazard rather than a theoretical one: <c>CleanupViewModel</c> calls
+    /// <see cref="Update"/> straight from <c>PowerShellRunner.LineReceived</c>, which is raised on
+    /// <c>Process.OutputDataReceived</c> AND <c>ErrorDataReceived</c> — two threadpool threads into one
+    /// handler, with nothing marshalling to the UI thread. <c>_projectedFinish</c> is a
+    /// <c>TimeSpan?</c>, so a torn read there yields an arbitrary duration on screen.
+    /// </summary>
+    private readonly object _gate = new();
 
     private long _startTimestamp;
     private long _lastSampleTimestamp;
@@ -71,6 +117,12 @@ public sealed class EtaCalculator
     /// </summary>
     public TimeSpan? Remaining
     {
+        get { lock (_gate) return RemainingLocked; }
+    }
+
+    /// <summary>Body of <see cref="Remaining"/>. Caller holds <see cref="_gate"/>.</summary>
+    private TimeSpan? RemainingLocked
+    {
         get
         {
             if (_completed) return TimeSpan.Zero;
@@ -80,14 +132,44 @@ public sealed class EtaCalculator
         }
     }
 
-    /// <summary>Human-readable ETA string (e.g. "~2 min 15 s", "calculating…", "done").</summary>
+    /// <summary>
+    /// True once the operation has run measurably past its projected finish — the projection has expired
+    /// and the calculator no longer has a usable estimate.
+    /// <para>Separated from "almost done" deliberately. <see cref="Remaining"/> clamps at zero, so a run
+    /// that overshoots its projection and then hangs is indistinguishable from one about to finish: an
+    /// operation projected to end at 100 s that stalls at 40% reported "a few seconds" for the following
+    /// 25 minutes. Beyond the grace, <see cref="RemainingText"/> says so instead of promising.</para>
+    /// </summary>
+    private bool IsOverdue
+    {
+        get
+        {
+            if (_completed || _projectedFinish is not { } finish) return false;
+            var overrun = Elapsed - finish;
+            if (overrun <= TimeSpan.Zero) return false;
+            var grace = finish * OverdueFraction;
+            return overrun > (grace > MinOverdueGrace ? grace : MinOverdueGrace);
+        }
+    }
+
+    /// <summary>
+    /// Human-readable ETA string (e.g. "~2 min 15 s", "calculating…", "taking longer than expected",
+    /// "done").
+    /// </summary>
     public string RemainingText
+    {
+        get { lock (_gate) return RemainingTextLocked; }
+    }
+
+    /// <summary>Body of <see cref="RemainingText"/>. Caller holds <see cref="_gate"/>.</summary>
+    private string RemainingTextLocked
     {
         get
         {
             if (_completed) return "done";
             if (!_started) return string.Empty;
-            return Remaining is { } left ? FormatTimeSpan(left) : "calculating…";
+            if (IsOverdue) return "taking longer than expected";
+            return RemainingLocked is { } left ? FormatTimeSpan(left) : "calculating…";
         }
     }
 
@@ -96,13 +178,16 @@ public sealed class EtaCalculator
     /// <summary>Resets the calculator. Call at the start of each operation.</summary>
     public void Reset()
     {
-        _startTimestamp = _time.GetTimestamp();
-        _lastSampleTimestamp = _startTimestamp;
-        _started = true;
-        _completed = false;
-        _lastPercent = 0;
-        _rate = 0;
-        _projectedFinish = null;
+        lock (_gate)
+        {
+            _startTimestamp = _time.GetTimestamp();
+            _lastSampleTimestamp = _startTimestamp;
+            _started = true;
+            _completed = false;
+            _lastPercent = 0;
+            _rate = 0;
+            _projectedFinish = null;
+        }
     }
 
     /// <summary>
@@ -110,6 +195,12 @@ public sealed class EtaCalculator
     /// string for convenience.
     /// </summary>
     public string Update(int percent)
+    {
+        lock (_gate) return UpdateLocked(percent);
+    }
+
+    /// <summary>Body of <see cref="Update"/>. Caller holds <see cref="_gate"/>.</summary>
+    private string UpdateLocked(int percent)
     {
         var clamped = Math.Clamp(percent, 0, 100);
 
@@ -125,7 +216,7 @@ public sealed class EtaCalculator
             _lastPercent = 100;
             _completed = true;
             _projectedFinish = null;
-            return RemainingText;
+            return RemainingTextLocked;
         }
 
         _completed = false;
@@ -138,25 +229,35 @@ public sealed class EtaCalculator
         // exactly the time that just passed, so the displayed value would never move (the first draft of
         // this fix did that, and the stall test caught it). Returning early leaves the existing
         // projection in place, and because Remaining is derived at read time, it counts down on its own.
-        if (advanced <= 0 || sinceLastSample <= TimeSpan.Zero)
+        if (advanced <= 0)
         {
             _lastPercent = clamped;
-            return RemainingText;
+            return RemainingTextLocked;
         }
 
+        // Too soon to measure a rate from. Leave BOTH _lastPercent and _lastSampleTimestamp alone so the
+        // advance is carried into the next report and divided by the real interval — dividing it by a
+        // microsecond is what produced 20,000 %/s. Discarding the advance instead would lose progress
+        // permanently for a caller that reports faster than the floor.
+        if (sinceLastSample < MinSampleInterval) return RemainingTextLocked;
+
         var sample = advanced / sinceLastSample.TotalSeconds;
-        _rate = _rate <= 0 ? sample : (RateSmoothing * sample) + ((1 - RateSmoothing) * _rate);
+
+        // Weight by the interval the sample covers, not per call: a sample spanning a long gap IS the
+        // better measurement and must dominate, and a short one must not overturn an established rate.
+        var weight = 1 - Math.Exp(-sinceLastSample.TotalSeconds / RateTimeConstantSeconds);
+        _rate = _rate <= 0 ? sample : (weight * sample) + ((1 - weight) * _rate);
         _lastSampleTimestamp = _time.GetTimestamp();
         _lastPercent = clamped;
 
         if (clamped < MinPercentForEstimate || _rate <= 0)
         {
             _projectedFinish = null;
-            return RemainingText;
+            return RemainingTextLocked;
         }
 
         _projectedFinish = Elapsed + TimeSpan.FromSeconds((100 - clamped) / _rate);
-        return RemainingText;
+        return RemainingTextLocked;
     }
 
     /// <summary>Formats a TimeSpan into a human-friendly short string.</summary>

--- a/SysManager/SysManager/Services/EtwBandwidthSource.cs
+++ b/SysManager/SysManager/Services/EtwBandwidthSource.cs
@@ -144,7 +144,13 @@ public sealed class EtwBandwidthSource : IBandwidthMonitorService
     internal void Add(int pid, int down, int up, string name)
     {
         if (pid <= 0) return;
-        var c = _counters.GetOrAdd(pid, _ => new PidCounters());
+
+        // Stamp inside the factory, not after GetOrAdd returns. GetOrAdd PUBLISHES the entry the instant it
+        // is created, so stamping afterwards leaves a window where _counters holds an entry whose
+        // LastActivityTicks is still 0 — and against a monotonic clock 0 is far below the cutoff, so a poll
+        // landing in that window evicts a PID that is actively transferring. Its next event re-adds it with
+        // a zeroed counter, which the user sees as the session total for a busy app resetting to a few KB.
+        var c = _counters.GetOrAdd(pid, _ => new PidCounters { LastActivityTicks = NowTicks() });
         if (down > 0) System.Threading.Interlocked.Add(ref c.DownBytes, down);
         if (up > 0) System.Threading.Interlocked.Add(ref c.UpBytes, up);
         if (c.Name.Length == 0 && !string.IsNullOrEmpty(name)) c.Name = name;
@@ -215,8 +221,10 @@ public sealed class EtwBandwidthSource : IBandwidthMonitorService
         long cutoff = nowTicks - IdleEviction.Ticks;
         foreach (var (pid, c) in _counters)
         {
-            // Entries are only ever created by Add, which stamps before it returns, so every one has a
-            // stamp. This deliberately does NOT treat 0 as "unstamped": zero is a legitimate reading —
+            // Entries are only ever created by Add, which stamps them in the GetOrAdd factory, so an entry
+            // is never visible here unstamped. (Stamping after GetOrAdd returned was not enough: the entry
+            // is published on creation, so a poll could see a 0 and evict a PID mid-transfer.)
+            // This deliberately does NOT treat 0 as "unstamped": zero is a legitimate reading —
             // a monotonic clock starts there, both in a test that has not advanced it and on a real
             // machine in the first tick after the source starts — and skipping it made a PID stamped at
             // 0 immortal. Not hypothetical: it turned two eviction tests red the moment the clock became

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.14</Version>
-    <FileVersion>1.65.14.0</FileVersion>
-    <AssemblyVersion>1.65.14.0</AssemblyVersion>
+    <Version>1.65.15</Version>
+    <FileVersion>1.65.15.0</FileVersion>
+    <AssemblyVersion>1.65.15.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AudioMixerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AudioMixerViewModel.cs
@@ -229,7 +229,13 @@ public sealed partial class AudioMixerViewModel : ViewModelBase
 
         // Dispose can land while the sample is in flight; the rows have already been zeroed by then,
         // so writing these levels back would re-light meters on a torn-down tab.
-        if (_reconcileCts is null || ct.IsCancellationRequested) return;
+        //
+        // !IsActive belongs in the SAME guard for the same reason, and was the half that was missing: the
+        // Task.Run genuinely yields, so hiding the tab or minimising the window mid-sample zeroes every
+        // row in OnIsActiveChanged and the continuation then writes the old levels straight back. The loop
+        // parks on its next iteration, so those stale bars survive for as long as the tab stays hidden —
+        // on re-show the user sees a lit meter from minutes ago until the next sample lands.
+        if (_reconcileCts is null || ct.IsCancellationRequested || !IsActive) return;
 
         foreach (var row in Sessions)
             if (peaks.TryGetValue(row.SessionId, out var peak))

--- a/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
@@ -125,7 +125,11 @@ public sealed partial class SpeedTestViewModel : ViewModelBase
         { HttpStatus = "Error: " + ex.Message; }
         catch (InvalidOperationException ex)
         { HttpStatus = "Error: " + ex.Message; }
-        finally { IsSpeedTesting = false; IsHttpTesting = false; }
+        // EstimatedTime must be cleared here, not just on the next run. Its TextBlock's Visibility binds
+        // to the string itself, so a leftover value stays on screen indefinitely — and because both cards
+        // share this one property, a finished HTTP run left the word "done" sitting under the Ookla card
+        // too. Matches AppUpdates/BulkInstaller/Uninstaller, which all clear their ETA text in `finally`.
+        finally { IsSpeedTesting = false; IsHttpTesting = false; EstimatedTime = string.Empty; }
     }
 
     [RelayCommand]
@@ -170,7 +174,7 @@ public sealed partial class SpeedTestViewModel : ViewModelBase
         { OoklaStatus = "Error: " + ex.Message; }
         catch (InvalidOperationException ex)
         { OoklaStatus = "Error: " + ex.Message; }
-        finally { IsSpeedTesting = false; IsOoklaTesting = false; }
+        finally { IsSpeedTesting = false; IsOoklaTesting = false; EstimatedTime = string.Empty; }
     }
 
     [RelayCommand]


### PR DESCRIPTION
## What a user sees

The "time remaining" line on System File Checker, DISM, Speed Test and the batch installer/uninstaller now tells the truth. Before, a repair with a quarter of an hour left could announce **"a few seconds"** and never correct itself for the rest of the scan.

Speed Test also stops leaving the word **"done"** printed under *both* of its cards after a finished test.

## The three ETA defects

Each was verified against current source before any code was written, and each has its own mutation in the red proof.

### 1. No floor on the sample interval — HIGH

`sfc` and DISM do not report progress on a timer. Windows flushes several lines at once through `Process.OutputDataReceived`, so two different percentages can arrive **microseconds** apart. The guard rejected only a *zero* interval:

```csharp
if (advanced <= 0 || sinceLastSample <= TimeSpan.Zero)   // only ZERO, not "tiny"
```

1% in 50 µs is 20,000 %/s. With a 0.3-weighted average, recovery needs `0.7^n · 6000 < 0.2` — about **29 further forward samples**, more than SFC emits in the remainder of a scan.

Fixed with a 250 ms floor under which the advance is **carried** — neither `_lastPercent` nor `_lastSampleTimestamp` moves — so it is divided by the real interval on the next report. Carrying rather than discarding is what makes a floor safe at any speed: a caller reporting every 100 ms simply coalesces into ~250 ms windows and the ratio is unchanged.

### 2. The smoothing weight ignored how much time a sample covered — MEDIUM

The EMA weight was fixed at 0.3 **per call**. A sample spanning a 10-minute stall therefore counted for exactly as much as one spanning a second, so the resuming rate — the only honest measurement available — was outvoted 7:3 by a pace that no longer existed:

- 1 %/s established, 600 s stall, then 1% more gives `_rate = 0.3(0.001667) + 0.7(1.0) = 0.7005 %/s`
- displayed **~2 min 7 s** when the observed pace implies **~14.8 h**

Now `weight = 1 - e^(-dt/tau)` with `tau = 2.8 s`, chosen so that at dt = 1 s — the cadence callers actually report at — the weight is **0.30**, i.e. exactly what it was. Nothing changes in the normal case; a 600 s gap now approaches weight 1.

This also *bounds* defect 1 independently: the contribution is `(dt/tau)(advance/dt) = advance/tau`, independent of how small dt is.

### 3. Past its estimate, the app kept promising "a few seconds" — MEDIUM-HIGH

`Remaining` clamps at zero, so an operation that overran its projection and then hung was indistinguishable from one about to finish. A run projected to end at t = 100 s that stalls at 40% showed "a few seconds" from t = 100 until it exited 25 minutes later. `RemainingText` now reports **"taking longer than expected"** past a proportional grace (10% of the projection, floor 30 s) — proportional because 30 s past a "few seconds" estimate is a broken promise while 30 s past a two-hour estimate is noise.

### Thread safety, while in there

`EtaCalculator`'s doc comment required single-threaded callers. `CleanupViewModel` does not meet that contract: it calls `Update` straight from `PowerShellRunner.LineReceived`, which is raised on the `OutputDataReceived` **and** `ErrorDataReceived` threadpool threads with nothing marshalling in between — two threads into one handler. `_projectedFinish` is a `TimeSpan?`, so an unsynchronised read can pair a live `HasValue` with a stale tick count and print an arbitrary duration. Every public member is now serialized on an internal lock, and the class comment says so instead of asking for a discipline that was not being kept.

## Two more defects in the same family

**Speed Test left its ETA on screen.** `EstimatedTime` was only cleared when the *next* run started, and the `TextBlock`'s `Visibility` binds to the string itself — so a finished HTTP run left "done" under the Ookla card too (they share the one property), and a cancelled run stranded "a few seconds" there. Now cleared in both `finally` blocks, matching `AppUpdates`/`BulkInstaller`/`Uninstaller`/`Cleanup`.

**Precise bandwidth mode could reset an app's session total.** `EtwBandwidthSource.Add` stamped `LastActivityTicks` *after* `GetOrAdd` returned — but `GetOrAdd` publishes the entry the instant its factory returns, so `_counters` briefly held an entry reading `0`, which against a monotonic clock is far below the 10-minute cutoff. A poll landing in that window evicted a PID that was actively transferring; its next event re-added it with a zeroed counter, so the running total for something downloading continuously could fall back to a few kilobytes. Stamping moved into the factory.

The eviction comment asserted the opposite — *"Add, which stamps before it returns, so every one has a stamp"* — true of the **method**, false of the **entry**. Corrected.

**Volume Control re-lit meters it had just zeroed.** `UpdatePeaksAsync`'s post-await guard covered `Dispose` but not deactivation, though the reasoning is identical: the `Task.Run` genuinely yields, so hiding the tab (or minimising the window) zeroes every row and the continuation writes the old levels straight back. The loop parks on its next iteration, so on re-show the user sees a lit meter from minutes ago.

## Three guards of mine that could not fail

Found by an adversarial vacuity pass over `ArchitectureTests`, and all three are mine from earlier batches.

| Guard | Why it could not fail | Now |
|---|---|---|
| `TheReleaseWorkflow_LaunchesTheExeBeforeItPublishesAnything` | Sliced `lines[smoke..release]`, swallowing two unrelated steps whose **five** `throw`s stood in for this gate's. Downgrading one launch verdict to `Write-Warning` — making the gate exactly the "decoration" its own comment forbids — left it green. | Slice ends at the step boundary (asserted, and asserted to contain no foreign step name); at least 3 verdicts required on **non-comment** lines, so the word "throw" in the step's own comment no longer counts |
| `EveryDisposedCancellationSource_IsCancelledFirst` | Asserted co-presence while its name and message both promise **order**. `_cts.Dispose(); _cts.Cancel();` satisfied it — and there the `Cancel` throws `ObjectDisposedException`, so in-flight shredder overwrites and cleanup deletes survive teardown | Compares positions |
| `EveryEtaTextProperty_IsClearedWhenItsOperationEnds` (new) | Took two rescopes before it could fail: `Any` over the whole file let one operation drop its clear while its sibling supplied the match (Speed Test has two sharing one property), and a file-wide search for an `Is…ing` `Visibility` binding was satisfied by `SpeedTestView`'s ProgressBar and Cancel button, which have nothing to do with the ETA `TextBlock` | Per-operation, and walks the element's own ancestor chain |

`HiddenTab_ParksThePeakLoop` also ended on `IsActive = true` without disposing, leaving that VM's peak loop waking ~20 times a second against the stub for the rest of the test process — the exact cost the test is named after, reintroduced by the test itself.

## Verification

**Red proof: 11 mutations, every one reddening only its own target, all 7 touched files restored byte-for-byte.**

| Mutation | Test that must go red |
|---|---|
| fixed 0.3 EMA weight | `Update_AfterALongStall_TrustsTheResumingRateOverThePreStallPace` |
| reject only a zero interval (shipped defect) | `Update_WhenTwoPercentsArriveMicrosecondsApart_DoesNotBelieveTheImpliedRate` |
| discard the sub-floor advance | `Update_BelowTheSampleFloor_CarriesTheAdvanceIntoTheNextSample` |
| drop the overdue branch | `RemainingText_WellPastTheProjectedFinish_SaysItIsTakingLongerRatherThanAlmostDone` |
| `Reset` leaves `_rate` behind | `Reset_ClearsTheRate_SoASecondRunDoesNotInheritTheFirstRunsPace` |
| stamp after publish (shipped ETW order) | `Add_StampsBeforeTheEntryIsVisible_SoAFirstEventIsNeverEvictedAsIdle` |
| stop clearing `EstimatedTime` | `EveryEtaTextProperty_IsClearedWhenItsOperationEnds` |
| downgrade one launch verdict | `TheReleaseWorkflow_LaunchesTheExeBeforeItPublishesAnything` |
| widen the workflow slice | same |
| cancel after dispose | `EveryDisposedCancellationSource_IsCancelledFirst` |
| drop `!IsActive` from the peak guard | `UpdatePeaks_WhenTheTabIsHiddenMidSample_DoesNotRelightTheZeroedRows` |

Two of those mutations — `Reset` keeping the rate, and the wide workflow slice — stayed **green** before this PR, which is what makes them worth adding.

Other checks: all four projects build 0 errors / 0 warnings; `dotnet format --verify-no-changes` clean on both; leak scan over all 32 terms gives 0 hits in the diff; author headers present on every touched file.

### One note on the ETA tests

`Reset_ClearsTheRate` is worth reading twice. `Reset()` nulls `_projectedFinish`, so `Remaining` is null after **any** reset — meaning the pre-existing `MultipleResets_WorkCorrectly` could not tell whether the samples were cleared. Deleting `_rate = 0;` left it green while a second run silently inherited the first run's pace. The new test pins the exact arithmetic (5% in 1 s gives 95% left gives **19 s**), which no inherited rate produces.

### Pre-existing, not from this PR

`CleanupViewModelTests.PreScan_EventuallyPopulatesLabels` fails on this workstation. It polls for 15 s waiting on a real temp-folder and recycle-bin scan and touches nothing in this diff. Confirmed by building `main` (22cee3a) unchanged in a separate worktree and reproducing the identical failure there — that control also showed one red this branch does not.
