### PR TITLE
fix: a volume, mute or output-device change could silently do nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.16] - 2026-08-18
+
+Volume Control now tells you when a change did not take. Before, if Windows refused a volume, mute or
+output-device change, the slider still moved to where you put it while the app kept playing at the old
+setting, with nothing on screen to explain it.
+
+### Fixed
+- **A volume, mute or "play on" change could silently do nothing.** All three of those controls ask
+  Windows to apply the change and get back a yes or no, and the app was ignoring the answer. When the
+  answer was no — which happens for a second or so after an app stops playing, while the list of audio
+  sessions is being rebuilt — the slider or switch stayed where you left it and the sound did not change.
+  Dragging Chrome to 20% could leave it playing at 80% with the label reading 20%. All three now say so
+  in the status line under the list, naming the app, and the app keeps the control where you put it
+  rather than yanking it back under your cursor. A change that succeeds stays silent, and the once-a-second
+  background refresh never reports anything, so the message only ever appears for something you did.
+
 ## [1.65.15] - 2026-08-17
 
 The "time remaining" estimate now tells the truth when an operation stalls or when Windows reports its

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2920,6 +2920,64 @@ public partial class ArchitectureTests
                     RegexOptions.Compiled)]
     private static partial Regex EtaBackingField();
 
+    /// <summary>
+    /// Every write on <c>IAudioMixerService</c> that reports whether it was applied must have that answer
+    /// CONSULTED at each call site. All three returned <c>bool</c>, documented "Returns true if the change
+    /// was applied", and all three results were discarded — so a refused write left the slider sitting at
+    /// the new value while the app kept playing at the old one, silently.
+    /// <para>Phrased over the INTERFACE, not over the call sites: the population is discovered from
+    /// <c>IAudioMixerService</c>'s bool-returning members, so adding a fourth write and ignoring it fails
+    /// here. The satisfiable-one-at-a-time form ("this call site must check") would not have caught the
+    /// original defect either, because no call site checked.</para>
+    /// <para>Consulted means the result reaches a condition or a variable — <c>if (!x.Set…)</c>,
+    /// <c>var ok = x.Set…</c>, <c>return x.Set…</c>. A bare statement call is the defect.</para>
+    /// </summary>
+    [Fact]
+    public void EveryAudioWriteThatReportsSuccess_HasThatAnswerConsulted()
+    {
+        var appDir = FindAppProjectDir();
+
+        var contract = File.ReadAllText(Path.Combine(appDir, "Services", "IAudioMixerService.cs"));
+        var writes = BoolReturningMember().Matches(contract).Select(m => m.Groups["name"].Value).ToList();
+
+        // Vacuity floor from an enumerated population: SetVolume, SetMute, SetSessionOutputDevice.
+        Assert.True(writes.Count >= 3,
+            $"only {writes.Count} bool-returning writes found on IAudioMixerService — the member regex has "
+          + "stopped matching, so this guard is measuring nothing.");
+
+        var offenders = new List<string>();
+        foreach (var file in Directory.GetFiles(Path.Combine(appDir, "ViewModels"), "*.cs"))
+        {
+            var lines = File.ReadAllLines(file);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var code = lines[i].Trim();
+                if (code.StartsWith("//", StringComparison.Ordinal)) continue;   // never match our own prose
+
+                foreach (var write in writes)
+                {
+                    if (!code.Contains($".{write}(", StringComparison.Ordinal)) continue;
+
+                    // A bare statement call: the line IS the invocation and nothing receives the answer.
+                    var bare = code.StartsWith("_service.", StringComparison.Ordinal)
+                            && code.EndsWith(");", StringComparison.Ordinal)
+                            && !code.Contains('=', StringComparison.Ordinal);
+                    if (bare)
+                        offenders.Add($"{Path.GetFileName(file)}:{i + 1} — {write} result discarded");
+                }
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "These audio writes report whether they were applied and the answer is thrown away, so a "
+          + "refused change leaves the control showing a value the system never took, with nothing said "
+          + "to the user:\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>A bool-returning member on an interface — a write that reports its own outcome.</summary>
+    [GeneratedRegex(@"^\s+bool\s+(?<name>\w+)\s*\(", RegexOptions.Compiled | RegexOptions.Multiline)]
+    private static partial Regex BoolReturningMember();
+
     /// <summary>The app project directory — .xaml is not copied to the test output.</summary>
     private static string FindAppProjectDir()
     {

--- a/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
@@ -201,6 +201,80 @@ public class AudioMixerViewModelTests
         service.Received(1).SetMute("s1", true);
     }
 
+    /// <summary>
+    /// A refused write must be reported, not swallowed. All three service writes return whether they were
+    /// applied and all three results used to be discarded, so the slider sat at 20% while the app kept
+    /// playing at 80% with nothing on screen to say so.
+    /// <para>Reachable, not theoretical: <c>EnumerateGroupsLocked</c> releases the COM group cache before
+    /// repopulating it, and a failure part way through leaves <c>_groups</c> empty — so every write for up
+    /// to a second afterwards hits the dictionary-miss branch and returns false. The service's own tests
+    /// (<c>Service_SetVolume_UnknownSession_IsRejected</c>) already prove that branch returns false; this
+    /// pins what the USER is told when it does.</para>
+    /// </summary>
+    [Fact]
+    public void RowVolumeChange_WhenTheServiceRefusesIt_SaysSoInTheStatus()
+    {
+        var service = ServiceWith(Session("s1", volume: 0.5f, name: "Chrome"));
+        service.SetVolume(Arg.Any<string>(), Arg.Any<float>()).Returns(false);
+        using var vm = NewVm(service);
+        var row = vm.Sessions.Single();
+
+        row.Volume = 0.25f;
+
+        Assert.Contains("Could not change the volume", vm.StatusMessage, StringComparison.Ordinal);
+        Assert.Contains("Chrome", vm.StatusMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RowMuteToggle_WhenTheServiceRefusesIt_SaysSoInTheStatus()
+    {
+        var service = ServiceWith(Session("s1", muted: false, name: "Spotify"));
+        service.SetMute(Arg.Any<string>(), Arg.Any<bool>()).Returns(false);
+        using var vm = NewVm(service);
+        var row = vm.Sessions.Single();
+
+        row.ToggleMuteCommand.Execute(null);
+
+        Assert.Contains("Could not mute Spotify", vm.StatusMessage, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The successful path must stay silent — a status line that fires on every slider move would bury the
+    /// one that matters. This is the negative half of the pair above: without it, reporting
+    /// unconditionally would pass both tests.
+    /// </summary>
+    [Fact]
+    public void RowVolumeChange_WhenItSucceeds_LeavesTheStatusAlone()
+    {
+        var service = ServiceWith(Session("s1", volume: 0.5f));
+        service.SetVolume(Arg.Any<string>(), Arg.Any<float>()).Returns(true);
+        using var vm = NewVm(service);
+        var before = vm.StatusMessage;
+
+        vm.Sessions.Single().Volume = 0.25f;
+
+        Assert.Equal(before, vm.StatusMessage);
+    }
+
+    /// <summary>
+    /// A refresh-driven write must not report either: <c>ApplyUpdate</c> sets Volume/IsMuted from the
+    /// service's own snapshot behind the echo guard, so it never calls the service at all — and a status
+    /// line appearing once a second from a reconcile pass nobody triggered would be pure noise.
+    /// </summary>
+    [Fact]
+    public void ExternalUpdate_DoesNotReportAFailure_EvenWhenWritesWouldBeRefused()
+    {
+        var service = ServiceWith(Session("s1", volume: 0.5f));
+        service.SetVolume(Arg.Any<string>(), Arg.Any<float>()).Returns(false);
+        service.SetMute(Arg.Any<string>(), Arg.Any<bool>()).Returns(false);
+        using var vm = NewVm(service);
+        var before = vm.StatusMessage;
+
+        vm.Sessions.Single().ApplyUpdate(Session("s1", volume: 0.8f, muted: true));
+
+        Assert.Equal(before, vm.StatusMessage);
+    }
+
     [Fact]
     public void MergeInto_ExternalUpdate_DoesNotEchoBackToService()
     {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.15</Version>
-    <FileVersion>1.65.15.0</FileVersion>
-    <AssemblyVersion>1.65.15.0</AssemblyVersion>
+    <Version>1.65.16</Version>
+    <FileVersion>1.65.16.0</FileVersion>
+    <AssemblyVersion>1.65.16.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AudioMixerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AudioMixerViewModel.cs
@@ -183,7 +183,9 @@ public sealed partial class AudioMixerViewModel : ViewModelBase
                 row.ApplyUpdate(info);
             else
             {
-                var newRow = new AudioSessionRowViewModel(_service, info, OutputDevices.ToList(), RoutingSupported);
+                var newRow = new AudioSessionRowViewModel(
+                    _service, info, OutputDevices.ToList(), RoutingSupported,
+                    reportFailure: message => StatusMessage = message);
                 if (RoutingSupported && !info.IsSystemSounds)
                     newRow.SetOutputDeviceFromService(_service.GetSessionOutputDevice(info.SessionId));
                 Sessions.Add(newRow);

--- a/SysManager/SysManager/ViewModels/AudioSessionRowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AudioSessionRowViewModel.cs
@@ -23,6 +23,12 @@ public sealed partial class AudioSessionRowViewModel : ObservableObject
 {
     private readonly IAudioMixerService _service;
 
+    /// <summary>
+    /// Where a refused write is reported, so the user is told instead of watching a control move while
+    /// nothing happens. Null only in tests that do not assert on the message.
+    /// </summary>
+    private readonly Action<string>? _reportFailure;
+
     // Set while applying values that came FROM the service, so the property-changed
     // callbacks don't turn an external/refresh update into a redundant write back.
     private bool _suppressPropagation;
@@ -89,10 +95,18 @@ public sealed partial class AudioSessionRowViewModel : ObservableObject
     /// <summary>Volume as a friendly percentage, e.g. "65%".</summary>
     public string VolumeDisplay => $"{Volume * 100:F0}%";
 
+    /// <param name="reportFailure">
+    /// Called with a finished, user-facing sentence when a write to the audio service is refused. Passed in
+    /// rather than raised as an event on purpose: a row is created and dropped on every reconcile pass, so
+    /// an event would need unsubscribing and that is the lifecycle bug this codebase keeps paying for. A
+    /// delegate held by a row the parent owns needs no teardown.
+    /// </param>
     public AudioSessionRowViewModel(IAudioMixerService service, AudioSessionInfo info,
-        IReadOnlyList<AudioDevice>? outputDevices = null, bool routingSupported = false)
+        IReadOnlyList<AudioDevice>? outputDevices = null, bool routingSupported = false,
+        Action<string>? reportFailure = null)
     {
         _service = service;
+        _reportFailure = reportFailure;
         SessionId = info.SessionId;
         ProcessId = info.ProcessId;
         IsSystemSounds = info.IsSystemSounds;
@@ -147,16 +161,26 @@ public sealed partial class AudioSessionRowViewModel : ObservableObject
         }
     }
 
+    /// <summary>
+    /// The user moved the slider. Every one of these three writes returns whether it was applied, and all
+    /// three used to discard it — so a refused write left the control sitting at the new value while the
+    /// app kept playing at the old one, with nothing on screen to say so. That is reachable, not
+    /// theoretical: a reconcile pass releases and re-enumerates the COM session cache, and a failure part
+    /// way through leaves it empty, so every write for up to a second afterwards is refused.
+    /// </summary>
     partial void OnVolumeChanged(float value)
     {
         if (_suppressPropagation) return;
-        _service.SetVolume(SessionId, value);
+        if (!_service.SetVolume(SessionId, value))
+            _reportFailure?.Invoke($"Could not change the volume for {DisplayName} — it may have just stopped playing.");
     }
 
     partial void OnIsMutedChanged(bool value)
     {
         if (_suppressPropagation) return;
-        _service.SetMute(SessionId, value);
+        if (!_service.SetMute(SessionId, value))
+            _reportFailure?.Invoke(
+                $"Could not {(value ? "mute" : "unmute")} {DisplayName} — it may have just stopped playing.");
     }
 
     /// <summary>Flip the mute state; the change propagates via <see cref="OnIsMutedChanged"/>.</summary>
@@ -165,13 +189,17 @@ public sealed partial class AudioSessionRowViewModel : ObservableObject
 
     /// <summary>
     /// User picked an output device for this app → route it via the service. Skipped when the
-    /// change came from a refresh (guard) or when in-app routing isn't supported. A failed write
-    /// (the service returned false) is left to the parent VM's status; the picker keeps the choice.
+    /// change came from a refresh (guard) or when in-app routing isn't supported. The picker keeps the
+    /// choice on failure — reverting it would fight the user's own click — but the status now SAYS the
+    /// routing did not take, which the old comment promised ("left to the parent VM's status") without
+    /// anything ever reporting it.
     /// </summary>
     partial void OnSelectedOutputDeviceChanged(AudioDevice? value)
     {
         if (_suppressPropagation || !RoutingSupported || value is null) return;
-        _service.SetSessionOutputDevice(SessionId, value.IsDefault ? string.Empty : value.Id);
+        if (!_service.SetSessionOutputDevice(SessionId, value.IsDefault ? string.Empty : value.Id))
+            _reportFailure?.Invoke(
+                $"Could not move {DisplayName} to {value.FriendlyName} — Windows refused the change.");
     }
 
     /// <summary>


### PR DESCRIPTION
## What a user sees

Drag Chrome's volume to 20% in Volume Control. The slider moves, the label reads "20%", and Chrome keeps playing at 80%. Nothing on screen explains it.

That is fixed: the app now says so, in the status line already under the list, naming the app.

## The defect

All three writes on `IAudioMixerService` return whether the change was applied:

```csharp
/// Returns true if the change was applied.
bool SetVolume(string sessionId, float level);
bool SetMute(string sessionId, bool muted);
bool SetSessionOutputDevice(string sessionId, string deviceId);
```

All three results were discarded:

```csharp
partial void OnVolumeChanged(float value)
{
    if (_suppressPropagation) return;
    _service.SetVolume(SessionId, value);      // answer thrown away
}
```

**Reachable, not theoretical.** `EnumerateGroupsLocked` calls `ReleaseGroups()` *before* it repopulates the COM session cache, and it can then bail (a `GetCount` failure) or throw into its broad catch — leaving `_groups` **empty**. For up to a second afterwards, every write hits the dictionary-miss branch at `AudioMixerService.cs:242` and returns `false`. `SetVolume` also swallows a per-control `COMException` and can return `false` with nothing applied.

The service's own tests already prove that branch returns false — `Service_SetVolume_UnknownSession_IsRejected`, `Service_SetVolume_AfterDispose_IsRejected`. What was missing was any *consequence*.

The routing path's comment even claimed the failure was handled: *"A failed write (the service returned false) is left to the parent VM's status."* The parent VM set no status for it and never observed the call. Now that sentence is true.

## The fix

The row reports through a callback the parent supplies, which sets the `StatusMessage` already bound at `AudioMixerView.xaml:183`.

**A callback, not an event, on purpose.** Rows are created and dropped on every reconcile pass, so an event would need unsubscribing — and that is precisely the lifecycle bug this codebase keeps paying for (batches 40, 46, 53, 83, 85). A delegate held by a row the parent owns needs no teardown.

Three deliberate choices, each pinned by its own test:

| Choice | Why |
|---|---|
| The control **keeps** the user's value on failure | Snapping a slider back out from under a moving cursor is worse than a sentence. The picker likewise keeps the chosen device. |
| A **successful** write stays silent | A status line firing on every slider move would bury the one that matters. |
| The **refresh** path reports nothing | `ApplyUpdate` writes the service's own snapshot behind the echo guard and never calls the service. A reconcile pass runs once a second, triggered by nobody — a message from there is pure noise. |

## Ratchet

`ArchitectureTests.EveryAudioWriteThatReportsSuccess_HasThatAnswerConsulted` discovers its population from `IAudioMixerService`'s bool-returning members, so adding a fourth write and ignoring its answer fails the build.

Phrased over the **interface**, not over the call sites, deliberately: the satisfiable-one-at-a-time form ("this call site must check its result") would not have caught the original defect, because *no* call site checked. Same reasoning as `EveryBandwidthSource_LeavesTheOffloadToItsConsumer` in v1.65.12. It skips comment lines so it cannot be satisfied by its own prose, and carries a vacuity floor of 3 from the enumerated population.

## Verification

**Red proof: 5 mutations, all 3 touched files restored byte-for-byte.**

| Mutation | Must go red |
|---|---|
| discard the `SetVolume` result (the shipped defect) | the volume report test **and** the guard |
| discard the `SetMute` result | the mute report test **and** the guard |
| report unconditionally (drop the `!`) | `RowVolumeChange_WhenItSucceeds_LeavesTheStatusAlone` |
| report from the echo-suppressed path too | `ExternalUpdate_DoesNotReportAFailure_EvenWhenWritesWouldBeRefused` |
| break the member regex so the population shrinks to 2 | the guard's **vacuity floor** |

Two independent detectors on one defect is the point: the tests pin what the user is told, the guard pins that no future write may drop its answer.

One note on mutation 5: changing the interface member's return type to `int` does **not** compile (the implementation still returns `bool`), so the population is shrunk the way a real edit would — by breaking the declaration's indentation, which the leading-whitespace-anchored member regex stops seeing while the C# stays valid. A mutation that fails to build proves nothing.

Other checks: all four projects build 0 errors / 0 warnings; `dotnet format --verify-no-changes` clean on both; leak scan over all 32 terms gives 0 hits in the diff; author headers present on all four touched files.

## Not in this PR

The same audio lens raised six more items, queued separately rather than padding this diff: `AudioSessionRowViewModel.IsActive` is computed and change-notified but bound by no XAML (so an idle session looks identical to a playing one); `RefreshDevicesAsync` runs once at tab-open and rows get a snapshot copy, so a USB headset plugged in later never appears in an existing row's picker; `SetVolume`/`SetMute` take the same `_gate` the 1 Hz COM enumeration holds, on the UI thread, once per mouse-move during a drag; `ReconcileCommand` is dead surface whose only reference is an assertion that cannot fail; two COM references leak on cast-failure branches; and an `InvalidCastException` escaping init kills both loops silently with no bound command to recover. Each needs refuting against current source before it drives a change.
