### PR TITLE
test: make the peak-batching assertion deterministic, not loop-sensitive

### DIFF
--- a/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
@@ -325,14 +325,44 @@ public class AudioMixerViewModelTests
     public async Task UpdatePeaks_ReadsEveryRowInOneServiceCall()
     {
         var service = ServiceWith(Session("s1"), Session("s2"), Session("s3"));
-        Peaks(service, ("s1", 0.1f), ("s2", 0.2f), ("s3", 0.3f));
+
+        // Recorded by the stubs themselves into thread-safe collections, and asserted on THOSE rather than
+        // through NSubstitute's Received(). Two reasons, both learned the hard way:
+        //
+        // 1. Activating the tab releases the peak loop, which samples every 50 ms — so an exact
+        //    Received(1) is not an observable property, and a second sample landing first failed a
+        //    release. What the name actually claims is "one call carried every row", not "one call total".
+        // 2. An NSubstitute substitute is NOT thread-safe. With the loop recording calls concurrently, a
+        //    Received(...) assertion enumerates a collection that is being mutated and reports "received
+        //    no matching calls" even when a matching call was made. That is exactly what happened: this
+        //    test passed 8/8 alone and failed inside the full class, where the slower run gives the loop
+        //    time to tick during the assertion.
+        var batchSizes = new System.Collections.Concurrent.ConcurrentBag<int>();
+        var perRowReads = new System.Collections.Concurrent.ConcurrentBag<string>();
+        var levels = new Dictionary<string, float>(StringComparer.Ordinal)
+        { ["s1"] = 0.1f, ["s2"] = 0.2f, ["s3"] = 0.3f };
+        service.GetPeaks(Arg.Any<IEnumerable<string>>()).Returns(call =>
+        {
+            var ids = ((IEnumerable<string>)call[0]).ToArray();
+            batchSizes.Add(ids.Length);
+            return ids.ToDictionary(id => id, id => levels.GetValueOrDefault(id), StringComparer.Ordinal);
+        });
+        service.GetPeak(Arg.Any<string>()).Returns(call =>
+        {
+            perRowReads.Add((string)call[0]);
+            return levels.GetValueOrDefault((string)call[0]);
+        });
+
         using var vm = NewVm(service);
         vm.IsActive = true;
 
         await vm.UpdatePeaksAsync(CancellationToken.None);
 
-        service.Received(1).GetPeaks(Arg.Any<IEnumerable<string>>());
-        service.DidNotReceive().GetPeak(Arg.Any<string>());
+        // Every batch that happened covered all three rows, and no row was ever read on its own. A per-row
+        // refactor fails both halves: its batches would be size 1, and GetPeak would be called.
+        Assert.NotEmpty(batchSizes);
+        Assert.All(batchSizes, size => Assert.Equal(3, size));
+        Assert.Empty(perRowReads);
     }
 
     /// <summary>


### PR DESCRIPTION
## Why

`UpdatePeaks_ReadsEveryRowInOneServiceCall` went flaky in v1.65.15 and **failed the v1.65.16 Release**. It passed on both PRs (4689/4689) and then failed on main with 1 of 4689 — the shape of a race, not a defect. No release was published; the tag exists without one.

Both causes are mine, both from adding `vm.IsActive = true` to that test in v1.65.15 (which was itself the right fix for the *sibling* test, where the guard legitimately needs an active tab).

## Cause 1 — an exact call count is not observable here

Activating the tab **releases the peak loop**, which samples every 50 ms. So a second, entirely legitimate `GetPeaks` can land before the assertion and `Received(1)` fails for a reason unrelated to the claim. What the name promises is *one call carried every row* — never *one call happened in total*.

## Cause 2 — NSubstitute substitutes are not thread-safe

My first attempt replaced the count with an `Arg.Is` matcher on the id set. It passed **8/8 in isolation** and still failed inside the full class:

```
Expected to receive a call matching:
    GetPeaks(ids => ids.Count() == 3 && ids.Contains("s1") && ...)
Actually received no matching calls.
```

A matching call *was* made. With the loop recording concurrently, `Received(...)` enumerates a collection being mutated and misses it. The isolated-passes / cluster-fails split is what identified this — the slower cluster run gives the loop time to tick during the assertion.

## The fix

The stubs record into a `ConcurrentBag` and the assertions read that:

```csharp
Assert.NotEmpty(batchSizes);
Assert.All(batchSizes, size => Assert.Equal(3, size));   // every batch covered all three rows
Assert.Empty(perRowReads);                               // no row was ever read on its own
```

Deterministic under a concurrent caller, and **exactly as discriminating**: a per-row refactor fails both halves — its batches are size 1, and `GetPeak` gets called.

## Verified

- The per-row mutation (`ids.ToDictionary(id => id, id => _service.GetPeak(id))`) reddens it; the file is restored byte-for-byte afterwards.
- The audio class is **39/39 green on three consecutive runs**; the previous shape failed 1 of 39 on the first.
- `dotnet format --verify-no-changes` clean. No production code changed.

## After merge

v1.65.16's Release must be re-dispatched — it died in "Run unit tests (must pass)", so the tag exists with no release behind it.