### PR TITLE
fix: refresh the Volume Control output-device list while the tab is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.18] - 2026-08-18
+
+Volume Control now notices audio devices you plug in while it is open. Before, the "play on" list was read
+once when you first opened the tab and never again, so a headset connected afterwards simply never showed up.
+
+### Fixed
+- **A headset or speaker plugged in after opening Volume Control never appeared.** The list of output
+  devices was read a single time, when the tab first loaded, and each app's "play on" dropdown got its own
+  private copy of that list — so even a refresh would not have reached a dropdown that already existed. The
+  tab stays loaded for as long as the app runs, which meant the only way to see a new device was to restart
+  SysManager. The list is now re-read every ten seconds and every dropdown shares it, so a device appears on
+  its own. Ten seconds rather than every second because asking Windows for the device list is expensive, and
+  plugging something in is not something you do several times a second.
+- **Changing your default output device could make each app's dropdown forget where you sent it.** Refreshing
+  the list replaces its contents, and Windows reports the default flag as part of each device — so switching
+  the default made every entry count as different, and the dropdown lost the app you had routed. Each
+  selection is now re-matched by device identity after a refresh.
+
 ## [1.65.17] - 2026-08-18
 
 A safety fix for how SysManager saves its own small settings and history files. Under a specific bit of

--- a/README.md
+++ b/README.md
@@ -220,7 +220,9 @@ Edit Windows environment variables without the cramped built-in dialog:
 - **Per-app output routing** — send one app to your headset and another to your speakers.
   Where Windows exposes the routing interface, each app gets an output-device picker in the
   row; on builds where it doesn't, the row shows a "Choose output device…" button that opens
-  Windows' per-app sound settings so you're never left without a path
+  Windows' per-app sound settings so you're never left without a path. Plug a headset in while
+  the tab is open and it appears on its own — the device list is re-read every ten seconds, and
+  each app keeps the destination you picked for it
 - **Volume presets** — save the current per-app volumes and mutes as a named preset (e.g.
   "Gaming", "Focus") and re-apply it in one click; presets are keyed by app so they work
   across restarts, and are stored locally in `%LocalAppData%\SysManager`

--- a/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
@@ -174,6 +174,120 @@ public class AudioMixerViewModelTests
         Assert.Equal(0.7f, vm.Sessions.Single().Volume);
     }
 
+    // ── Output-device list freshness ────────────────────────────────────────
+
+    private static AudioDevice Speakers => new("{spk}", "Speakers", IsDefault: true);
+    private static AudioDevice Headset => new("{hdst}", "USB Headset", IsDefault: false);
+
+    /// <summary>
+    /// A device plugged in after the tab was opened must appear in the picker of a row that ALREADY exists.
+    /// <para>Two separate reasons it did not. <c>RefreshDevicesAsync</c> was called only from
+    /// <c>InitAsync</c>, so the view model's list was read once and never again — and a tab's view model
+    /// lives as long as the app does. And each row received <c>OutputDevices.ToList()</c>, an immutable
+    /// snapshot, so even refreshing the view model's list would not have reached an existing picker.</para>
+    /// <para>Deliberately does NOT activate the tab: <c>ReconcileAsync</c> does not need it, and leaving the
+    /// loops parked keeps the pass count exactly what this test drives.</para>
+    /// </summary>
+    [Fact]
+    public async Task DeviceAddedAfterTheTabOpened_ReachesAnAlreadyExistingRowsPicker()
+    {
+        var service = ServiceWith(Session("s1"));
+        service.IsRoutingSupported.Returns(true);
+        service.GetRenderDevices().Returns(_ => new List<AudioDevice> { Speakers });
+        using var vm = NewVm(service);
+        var row = vm.Sessions.Single();
+        Assert.Equal(["Speakers"], row.OutputDevices.Select(d => d.FriendlyName).ToArray());
+
+        // The user plugs in a headset. Drive enough reconcile passes to cross the device-refresh cadence.
+        service.GetRenderDevices().Returns(_ => new List<AudioDevice> { Speakers, Headset });
+        for (var i = 0; i < 10; i++) await vm.ReconcileAsync();
+
+        Assert.Contains("USB Headset", row.OutputDevices.Select(d => d.FriendlyName));
+    }
+
+    /// <summary>
+    /// After a refresh, the row's selection must still be an element OF the current list — not a stale
+    /// instance left over from the previous one.
+    /// <para>That is the assertion that can actually fail, and finding it took a wrong turn worth recording.
+    /// <c>ReplaceWith</c> clears and refills, and a bound <c>SelectedItem</c> survives only while an EQUAL
+    /// element comes back; <c>AudioDevice</c> is a record, so its equality covers <c>IsDefault</c>. Move the
+    /// Windows default and every element is unequal, so the real <c>ComboBox</c> drops the selection and the
+    /// picker forgets where the user sent that app. But a unit test has no ComboBox: nothing clears the VM's
+    /// property, so asserting the id alone passes with or without the fix. What DOES discriminate is
+    /// membership — without the re-resolve the selected instance is absent from the new list, which is
+    /// precisely the condition that makes the real control drop it.</para>
+    /// </summary>
+    [Fact]
+    public async Task RefreshingDevices_KeepsEachRowsChoice_EvenWhenTheDefaultMoves()
+    {
+        var service = ServiceWith(Session("s1"));
+        service.IsRoutingSupported.Returns(true);
+        service.GetRenderDevices().Returns(_ => new List<AudioDevice> { Speakers, Headset });
+        service.GetSessionOutputDevice("s1").Returns("{hdst}");
+        using var vm = NewVm(service);
+        var row = vm.Sessions.Single();
+        Assert.Equal("{hdst}", row.SelectedOutputDevice?.Id);
+
+        // Windows' default moves to the headset, so every AudioDevice record comes back UNEQUAL.
+        service.GetRenderDevices().Returns(_ => new List<AudioDevice>
+        {
+            new("{spk}", "Speakers", IsDefault: false),
+            new("{hdst}", "USB Headset", IsDefault: true),
+        });
+        for (var i = 0; i < 10; i++) await vm.ReconcileAsync();
+
+        Assert.Equal("{hdst}", row.SelectedOutputDevice?.Id);
+        Assert.Contains(row.SelectedOutputDevice, row.OutputDevices);
+    }
+
+    /// <summary>
+    /// Devices must NOT be re-enumerated on every reconcile pass. Enumerating endpoints is COM-heavy and
+    /// reconcile runs at 1 Hz; trading a stale list for that every second would be a worse bug than the one
+    /// being fixed. Counted inside the stub rather than with <c>Received(n)</c> — an NSubstitute substitute
+    /// is not thread-safe, and a call count is only meaningful here because the loops are parked.
+    /// </summary>
+    [Fact]
+    public async Task Reconcile_DoesNotReEnumerateDevicesOnEveryPass()
+    {
+        var service = ServiceWith(Session("s1"));
+        service.IsRoutingSupported.Returns(true);
+        var enumerations = 0;
+        service.GetRenderDevices().Returns(_ =>
+        {
+            System.Threading.Interlocked.Increment(ref enumerations);
+            return new List<AudioDevice> { Speakers };
+        });
+
+        using var vm = NewVm(service);
+        Assert.Equal(1, enumerations);                // init reads the list exactly once
+
+        for (var i = 0; i < 3; i++) await vm.ReconcileAsync();
+
+        Assert.Equal(1, enumerations);                // three passes later, still no re-read
+    }
+
+    /// <summary>
+    /// A device refresh must not hand the system-sounds pseudo-session a routing destination. Windows cannot
+    /// reroute it, so its picker is collapsed (<c>RoutingSupported</c> is false for that row) and the
+    /// construction path in <c>MergeInto</c> already gates on exactly that. The refresh path re-resolves
+    /// selections and has to keep the same gate, or the row starts claiming a destination nothing can act on.
+    /// </summary>
+    [Fact]
+    public async Task RefreshingDevices_LeavesTheSystemSoundsRowWithoutADestination()
+    {
+        var service = ServiceWith(Session("sys", systemSounds: true));
+        service.IsRoutingSupported.Returns(true);
+        service.GetRenderDevices().Returns(_ => new List<AudioDevice> { Speakers, Headset });
+        using var vm = NewVm(service);
+        var row = vm.Sessions.Single();
+        Assert.False(row.RoutingSupported);
+        Assert.Null(row.SelectedOutputDevice);
+
+        for (var i = 0; i < 10; i++) await vm.ReconcileAsync();
+
+        Assert.Null(row.SelectedOutputDevice);
+    }
+
     // ── Volume / mute propagation + echo suppression ───────────────────────
 
     [Fact]

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.17</Version>
-    <FileVersion>1.65.17.0</FileVersion>
-    <AssemblyVersion>1.65.17.0</AssemblyVersion>
+    <Version>1.65.18</Version>
+    <FileVersion>1.65.18.0</FileVersion>
+    <AssemblyVersion>1.65.18.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AudioMixerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AudioMixerViewModel.cs
@@ -41,8 +41,22 @@ public sealed partial class AudioMixerViewModel : ViewModelBase
 
     public BulkObservableCollection<AudioSessionRowViewModel> Sessions { get; } = new();
 
-    /// <summary>Output devices offered in each row's routing picker (refreshed with the session list).</summary>
+    /// <summary>
+    /// Output devices offered in each row's routing picker. Every row is handed THIS collection, not a copy,
+    /// so a refresh reaches pickers that already exist — rows used to receive <c>OutputDevices.ToList()</c>,
+    /// which froze each picker at the moment its row was created.
+    /// </summary>
     public BulkObservableCollection<AudioDevice> OutputDevices { get; } = new();
+
+    /// <summary>
+    /// Reconcile passes between device re-enumerations. Reconcile runs at 1 Hz and enumerating endpoints is
+    /// COM-heavy, so devices are re-read every tenth pass (~10 s) rather than every one. Devices change when
+    /// somebody plugs something in, which is a human-timescale event; sessions change when an app starts
+    /// playing, which is not — hence the two cadences.
+    /// </summary>
+    private const int ReconcilePassesPerDeviceRefresh = 10;
+
+    private int _passesSinceDeviceRefresh;
 
     /// <summary>Saved volume presets the user can apply or delete.</summary>
     public BulkObservableCollection<VolumePreset> Presets { get; } = new();
@@ -158,6 +172,16 @@ public sealed partial class AudioMixerViewModel : ViewModelBase
     {
         var snapshot = await Task.Run(_service.GetSessions).ConfigureAwait(true);
         MergeInto(snapshot);
+
+        // Re-read the device list on a slower cadence than the sessions. Before this it was read ONCE, in
+        // InitAsync, so a headset plugged in after the tab opened never appeared in any picker for the rest
+        // of the session — and the tab's view model lives as long as the app does.
+        if (++_passesSinceDeviceRefresh >= ReconcilePassesPerDeviceRefresh)
+        {
+            _passesSinceDeviceRefresh = 0;
+            await RefreshDevicesAsync().ConfigureAwait(true);
+        }
+
         HasSessions = Sessions.Count > 0;
         StatusMessage = Sessions.Count > 0
             ? $"{Sessions.Count} app{(Sessions.Count == 1 ? "" : "s")} playing audio."
@@ -184,7 +208,10 @@ public sealed partial class AudioMixerViewModel : ViewModelBase
             else
             {
                 var newRow = new AudioSessionRowViewModel(
-                    _service, info, OutputDevices.ToList(), RoutingSupported,
+                    // The LIVE collection, not a snapshot: a device plugged in after this row was created
+                    // must appear in its picker. BulkObservableCollection raises collection-changed, so the
+                    // bound ComboBox updates itself.
+                    _service, info, OutputDevices, RoutingSupported,
                     reportFailure: message => StatusMessage = message);
                 if (RoutingSupported && !info.IsSystemSounds)
                     newRow.SetOutputDeviceFromService(_service.GetSessionOutputDevice(info.SessionId));
@@ -244,13 +271,29 @@ public sealed partial class AudioMixerViewModel : ViewModelBase
                 row.PeakLevel = peak;
     }
 
-    /// <summary>Re-enumerate output devices (off the UI thread) into the shared picker list.</summary>
+    /// <summary>
+    /// Re-enumerate output devices (off the UI thread) into the shared picker list, preserving each row's
+    /// current choice across the replacement.
+    /// <para>Preserving it is not optional. <c>ReplaceWith</c> clears and refills, so a bound
+    /// <c>SelectedItem</c> survives only while the new list contains an EQUAL element — and
+    /// <c>AudioDevice</c> is a record, so equality also covers <c>IsDefault</c>. Change the Windows default
+    /// output and every row's selection would silently fall to null, i.e. the picker forgets where the user
+    /// sent that app. Re-resolving by endpoint id is what keeps it.</para>
+    /// </summary>
     private async Task RefreshDevicesAsync()
     {
         // Defensive: a substituted/edge-case service could return null; treat it as "no devices"
         // rather than letting ReplaceWith's null-guard throw into the fire-and-forget init.
         var devices = await Task.Run(_service.GetRenderDevices).ConfigureAwait(true);
+
+        var chosen = Sessions.ToDictionary(r => r.SessionId, r => r.SelectedOutputDevice?.Id ?? string.Empty,
+                                           StringComparer.Ordinal);
         OutputDevices.ReplaceWith(devices ?? []);
+        // Gated on the row's own routing capability, matching the construction-time gate in MergeInto: the
+        // system-sounds pseudo-session shows no picker, so it must not be handed a destination it cannot use.
+        foreach (var row in Sessions)
+            if (row.RoutingSupported && chosen.TryGetValue(row.SessionId, out var id))
+                row.SetOutputDeviceFromService(id);
     }
 
     /// <summary>


### PR DESCRIPTION
## What a user sees

Open Volume Control. Plug in a USB headset. Open any app's "play on" picker — the headset is not
there. It never will be, for as long as SysManager stays running.

## The defect

Two independent causes, and fixing either one alone would have left the bug in place.

**1. The list was read once.** `RefreshDevicesAsync` had exactly one caller:

```csharp
// InitAsync — the only call site
await RefreshDevicesAsync().ConfigureAwait(true);
```

`ReconcileAsync` runs at 1 Hz and refreshes *sessions*, never devices. A tab's view model lives
as long as the process, so "once at tab-open" meant once per app launch.

**2. Each row got a snapshot.** Even a refreshed view-model list could not have reached a picker
that already existed:

```csharp
var newRow = new AudioSessionRowViewModel(
    _service, info, OutputDevices.ToList(), RoutingSupported, ...);
//                                ^^^^^^^^ frozen at the moment this row was created
```

`ToList()` was not obviously wrong — rows are recreated on every reconcile pass, so the copy looks
short-lived. But `MergeInto` deliberately *preserves* surviving rows (that is what keeps a dragged
slider from being dropped), so a row for an app that keeps playing is never rebuilt.

## The fix

Rows receive the live `BulkObservableCollection`, and devices are re-enumerated every tenth
reconcile pass.

**Ten seconds, not one, on purpose.** Enumerating endpoints is COM-heavy and reconcile runs at
1 Hz. Plugging hardware in is a human-timescale event; an app starting to play is not — hence the
two cadences. Trading a stale list for a COM enumeration every second would have been a worse bug
than the one being fixed, which is why the cadence has its own test.

### The part that took a wrong turn

Refreshing had to stop losing each row's choice, and the first version of that test passed with or
without the fix:

```csharp
public sealed record AudioDevice(string Id, string FriendlyName, bool IsDefault);
```

`ReplaceWith` clears and refills, and a bound `SelectedItem` survives only while an **equal**
element comes back. `AudioDevice` is a record, so its equality covers `IsDefault` — move the
Windows default output and every element is unequal, the real `ComboBox` drops the selection, and
the picker forgets where the user sent that app. But a unit test has no `ComboBox`: nothing clears
the VM's property, so asserting the id alone is green either way.

What discriminates is **membership** — without the re-resolve the selected instance is absent from
the new list, which is precisely the condition that makes the real control drop it:

```csharp
Assert.Equal("{hdst}", row.SelectedOutputDevice?.Id);
Assert.Contains(row.SelectedOutputDevice, row.OutputDevices);   // <- the assertion that can fail
```

The re-resolve is gated on `row.RoutingSupported`, matching the construction-time gate in
`MergeInto`: the system-sounds pseudo-session shows no picker because Windows cannot reroute it, so
it must not be handed a destination nothing can act on. That gate has its own test too.

## Verification

**Red proof: 5 mutations, the touched file restored byte-for-byte.**

| Mutation | Must go red |
|---|---|
| rows get `OutputDevices.ToList()` again (half the shipped defect) | `DeviceAddedAfterTheTabOpened_ReachesAnAlreadyExistingRowsPicker` |
| remove the throttled refresh from `ReconcileAsync` (the other half) | the same test |
| drop the selection re-resolve after `ReplaceWith` | `RefreshingDevices_KeepsEachRowsChoice_EvenWhenTheDefaultMoves` |
| refresh devices on **every** pass | `Reconcile_DoesNotReEnumerateDevicesOnEveryPass` |
| drop the routing gate on the re-resolve | `RefreshingDevices_LeavesTheSystemSoundsRowWithoutADestination` |

Each mutation reddened exactly its own test and nothing else. Mutation 2 removes the pass counter
*with* the block it feeds — left behind it is `CS0169` under warnings-as-errors, and a mutation that
does not compile proves nothing.

**No test activates the tab.** `ReconcileAsync` does not need it, and leaving the loops parked keeps
the pass count exactly what the test drives. Setting `IsActive = true` releases the peak-meter and
reconcile loops, and that is what made `UpdatePeaks_ReadsEveryRowInOneServiceCall` fail the v1.65.16
release: a substitute is not thread-safe while a live loop records against it. The one test here that
counts calls counts inside the stub, not with `Received(n)`.

Other checks: all four projects build 0 errors / 0 warnings; `dotnet format --verify-no-changes`
exit 0 on both; the audio class plus every architecture guard run 79 green (the 2 reds are the
scratch harness's own files, not repo code); leak scan over all 32 terms gives 0 hits in the diff;
author headers present on both touched code files.

## Not in this PR

The remaining items from the same audio lens, each still to be refuted against current source before
it drives a change: `SetVolume`/`SetMute` take the same gate the 1 Hz COM enumeration holds, on the
UI thread, once per mouse-move during a drag; `AudioSessionRowViewModel.IsActive` is computed and
change-notified but bound by no XAML; `ReconcileCommand` is dead surface; two COM references leak on
cast-failure branches; and an `InvalidCastException` escaping init kills both loops silently with no
bound command to recover.
