### PR TITLE
fix: give every atomic save a temp file only it can name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.17] - 2026-08-18
+
+A safety fix for how SysManager saves its own small settings and history files. Under a specific bit of
+bad timing, a setting you changed could quietly fail to save — no error, it just would not stick. Most
+people would never have hit it, but "most" is not "none", and a save that loses your data without saying
+so is exactly the kind of thing this app must never do.
+
+### Fixed
+- **A setting or history entry could silently fail to save if two saves of the same file overlapped.**
+  SysManager writes these files safely — to a temporary file first, then swaps it into place, so a crash
+  mid-write can never leave a half-written file. But every save of a given file used the same fixed name
+  for that temporary file, and cleaned it up afterwards. If two saves of the same file ran at once — for
+  example the About screen recording its update-check time in the background while you toggled the
+  "check for updates" box — one could delete the other's temporary file mid-swap, and both saves were
+  lost with nothing written and nothing reported. Each save now uses a temporary name only it knows, so
+  overlapping saves can no longer interfere; the last one simply wins. Applied to the shared save helper
+  and to the two Hosts-file writers, which had the same pattern.
+
 ## [1.65.16] - 2026-08-18
 
 Volume Control now tells you when a change did not take. Before, if Windows refused a volume, mute or

--- a/SysManager/SysManager.Tests/AtomicFileTests.cs
+++ b/SysManager/SysManager.Tests/AtomicFileTests.cs
@@ -79,40 +79,75 @@ public class AtomicFileTests : IDisposable
     }
 
     /// <summary>
-    /// THE POINT OF THE HELPER. When the write itself fails, the previous file must survive
-    /// byte-for-byte — that is the difference from <c>File.WriteAllText</c>, which would already have
-    /// truncated it. Driven by making the temp path un-writable (a directory cannot be overwritten by
-    /// a file), which fails the write at the same moment a full disk or a crash would.
+    /// THE POINT OF THE HELPER. When the save fails, the previous file must survive byte-for-byte —
+    /// that is the difference from <c>File.WriteAllText</c>, which would already have truncated it.
+    /// <para>Driven by holding the destination open with <c>FileShare.None</c>, which is what an
+    /// antivirus scanner or a backup agent does to a file it is reading: the temp is written and the
+    /// swap is then refused. Deliberately NOT driven by occupying the temp path any more — the temp
+    /// name is private to each call (see the ownership test below), so a test that named it would be
+    /// asserting an implementation detail it is no longer entitled to know.</para>
     /// </summary>
     [Fact]
-    public void WriteAllText_WhenTheWriteFails_TheOriginalFileIsUntouched()
+    public void WriteAllText_WhenTheSaveFails_TheOriginalFileIsUntouched()
     {
         var path = Path_("precious.json");
         const string original = "{\"history\":[\"the user's data\"]}";
         File.WriteAllText(path, original);
 
-        // Occupy the temp path with a directory so writing the temp file must fail.
-        Directory.CreateDirectory(path + ".tmp");
-
-        Assert.ThrowsAny<Exception>(() => AtomicFile.WriteAllText(path, "replacement"));
+        using (File.Open(path, FileMode.Open, FileAccess.Read, FileShare.None))
+            Assert.ThrowsAny<Exception>(() => AtomicFile.WriteAllText(path, "replacement"));
 
         // The whole promise: not truncated, not empty, not partially written.
         Assert.Equal(original, File.ReadAllText(path));
+        // …and the failed attempt left nothing beside it.
+        Assert.Equal(["precious.json"], Directory.GetFiles(_dir).Select(Path.GetFileName));
     }
 
     [Fact]
-    public async Task WriteAllTextAsync_WhenTheWriteFails_TheOriginalFileIsUntouched()
+    public async Task WriteAllTextAsync_WhenTheSaveFails_TheOriginalFileIsUntouched()
     {
         var path = Path_("precious-async.json");
         const string original = "{\"speedTests\":[1,2,3]}";
         File.WriteAllText(path, original);
 
-        Directory.CreateDirectory(path + ".tmp");
-
-        await Assert.ThrowsAnyAsync<Exception>(
-            () => AtomicFile.WriteAllTextAsync(path, "replacement"));
+        using (File.Open(path, FileMode.Open, FileAccess.Read, FileShare.None))
+            await Assert.ThrowsAnyAsync<Exception>(
+                () => AtomicFile.WriteAllTextAsync(path, "replacement"));
 
         Assert.Equal(original, File.ReadAllText(path));
+        Assert.Equal(["precious-async.json"], Directory.GetFiles(_dir).Select(Path.GetFileName));
+    }
+
+    /// <summary>
+    /// A save must never touch a temporary file it did not create.
+    /// <para>Every write used to claim the same name, <c>&lt;path&gt;.tmp</c>, and <c>CleanUp</c> runs in
+    /// a <c>finally</c> — so two writers to one destination shared one temp file and could destroy each
+    /// other's work. The reachable sequence: the second writer fails to open the temp because the first
+    /// still holds it, the first closes but has not yet swapped, and the second's <c>CleanUp</c> then
+    /// deletes the first's finished temp. The first's swap finds nothing, BOTH writes are lost, and the
+    /// destination never appears — silently, because callers log a failed save at Debug.</para>
+    /// <para>Not hypothetical: <c>AboutViewModel</c>'s startup update-check records its timestamp on a
+    /// background thread while the user's checkbox writes the same file from the UI thread. It surfaced
+    /// as a one-in-thousands CI failure of
+    /// <c>AboutViewModelTests.ConstructingTheViewModel_DoesNotTouchTheRealPreferenceFile</c>.</para>
+    /// <para>Stated single-threadedly on purpose. Racing two real writers would be probabilistic, and a
+    /// flaky test is a broken test; the pre-existing file below stands in for the other writer's temp
+    /// and pins the invariant that makes the race impossible.</para>
+    /// </summary>
+    [Fact]
+    public void WriteAllText_DoesNotTouchATemporaryFileItDoesNotOwn()
+    {
+        var path = Path_("shared.json");
+        var foreignTemp = path + ".tmp";                       // the name every write used to claim
+        const string foreignContents = "another writer's finished temp, not yet swapped";
+        File.WriteAllText(foreignTemp, foreignContents);
+
+        AtomicFile.WriteAllText(path, "{\"mine\":true}");
+
+        Assert.Equal("{\"mine\":true}", File.ReadAllText(path));
+        Assert.True(File.Exists(foreignTemp),
+            "the save claimed a temp file it did not create — a concurrent writer's save is destroyed");
+        Assert.Equal(foreignContents, File.ReadAllText(foreignTemp));
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/HostsFileServiceTests.cs
+++ b/SysManager/SysManager.Tests/HostsFileServiceTests.cs
@@ -173,7 +173,9 @@ public class HostsFileServiceTests
 
             Assert.Equal(original, File.ReadAllText(hosts));
             Assert.Equal(stamp, File.GetCreationTimeUtc(hosts));
-            Assert.False(File.Exists(hosts + ".sysmanager.restore.tmp"), "restore temp file left behind");
+            // Any sibling, not one fixed name: the staging path is unique per call now, so naming it
+            // here would make this assertion unfalsifiable (AtomicFile.UniqueTempPath explains why).
+            Assert.Empty(Directory.GetFiles(dir, "*.tmp"));
         }
         finally
         {
@@ -339,8 +341,10 @@ public class HostsFileServiceTests
     [Fact]
     public void SaveHosts_LeavesNoTempFileBehind()
     {
-        // Regression (atomic write): SaveHosts writes to a temp file then moves it
-        // into place. After a successful save no ".sysmanager.tmp" must remain.
+        // Regression (atomic write): SaveHosts stages the new content in a temp file then moves it
+        // into place. After a successful save no staging file must remain — asserted over any sibling
+        // rather than one fixed name, because the staging path is unique per call now (a name-specific
+        // assertion would be unfalsifiable; AtomicFile.UniqueTempPath explains the uniqueness).
         var (svc, hosts, dir) = NewServiceWithTempHosts("127.0.0.1 localhost\n");
         try
         {
@@ -348,9 +352,74 @@ public class HostsFileServiceTests
             {
                 new() { IpAddress = "127.0.0.1", Hostname = "localhost", IsEnabled = true }
             });
-            Assert.False(File.Exists(hosts + ".sysmanager.tmp"), "temp file was left behind after save");
+            Assert.Empty(Directory.GetFiles(dir, "*.tmp"));
             Assert.True(File.Exists(hosts));
             Assert.Contains("localhost", File.ReadAllText(hosts));
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Saving must not touch a staging file it did not create.
+    /// <para>Both hosts writers used a fixed staging name and delete it in a <c>finally</c>, so two
+    /// overlapping writes shared one file and could destroy each other: the second fails to open the
+    /// staging file while the first holds it, the first closes but has not yet swapped, and the second's
+    /// cleanup deletes the finished staging file out from under it. Both writes are then lost — for the
+    /// hosts file that means the user's blocked sites silently do not take effect.</para>
+    /// <para>Single-threaded on purpose: racing two writers would be probabilistic, and a flaky test is
+    /// a broken test. The pre-existing file stands in for the other writer's staging file.</para>
+    /// </summary>
+    [Fact]
+    public void SaveHosts_DoesNotTouchAStagingFileItDoesNotOwn()
+    {
+        var (svc, hosts, dir) = NewServiceWithTempHosts("127.0.0.1 localhost\n");
+        var foreign = hosts + ".sysmanager.tmp";              // the name every save used to claim
+        const string foreignContents = "another writer's staged hosts file, not yet swapped";
+        try
+        {
+            File.WriteAllText(foreign, foreignContents);
+
+            svc.SaveHosts(new List<HostsEntry>
+            {
+                new() { IpAddress = "9.9.9.9", Hostname = "blocked", IsEnabled = true }
+            });
+
+            Assert.Contains("blocked", File.ReadAllText(hosts));
+            Assert.True(File.Exists(foreign),
+                "the save claimed a staging file it did not create — a concurrent write is destroyed");
+            Assert.Equal(foreignContents, File.ReadAllText(foreign));
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>Restoring the backup owns its staging file too — same reasoning as the save above.</summary>
+    [Fact]
+    public void RestoreBackup_DoesNotTouchAStagingFileItDoesNotOwn()
+    {
+        var (svc, hosts, dir) = NewServiceWithTempHosts("# pristine\n127.0.0.1 localhost\n");
+        var foreign = hosts + ".sysmanager.restore.tmp";      // the name every restore used to claim
+        const string foreignContents = "another writer's staged restore, not yet swapped";
+        try
+        {
+            // The first save is what creates the backup that RestoreBackup needs.
+            svc.SaveHosts(new List<HostsEntry>
+            {
+                new() { IpAddress = "9.9.9.9", Hostname = "managed", IsEnabled = true }
+            });
+            File.WriteAllText(foreign, foreignContents);
+
+            Assert.True(svc.RestoreBackup());
+
+            Assert.Contains("pristine", File.ReadAllText(hosts));
+            Assert.True(File.Exists(foreign),
+                "the restore claimed a staging file it did not create — a concurrent write is destroyed");
+            Assert.Equal(foreignContents, File.ReadAllText(foreign));
         }
         finally
         {

--- a/SysManager/SysManager/Helpers/AtomicFile.cs
+++ b/SysManager/SysManager/Helpers/AtomicFile.cs
@@ -30,6 +30,9 @@ namespace SysManager.Helpers;
 /// </summary>
 internal static class AtomicFile
 {
+    /// <summary>Distinguishes the temp files of overlapping writes; see <see cref="PrepareTempPath"/>.</summary>
+    private static int _tempSequence;
+
     /// <summary>
     /// Writes <paramref name="contents"/> to <paramref name="path"/> atomically, creating the
     /// directory if needed. The destination is either fully replaced or left exactly as it was.
@@ -122,6 +125,24 @@ internal static class AtomicFile
         }
     }
 
+    /// <summary>
+    /// A scratch path in <paramref name="path"/>'s own directory that no other writer can name, ending
+    /// in <paramref name="tag"/>. Public to the assembly so every service that swaps a temp into place
+    /// derives the name here rather than composing its own.
+    /// <para>Uniqueness is load-bearing, not tidiness. A fixed <c>"&lt;path&gt;.tmp"</c> is shared by
+    /// every writer to the same destination, and cleanup runs in a <c>finally</c> — so a second writer
+    /// that fails to open the temp (the first still holds it) deletes it on the way out, and if the
+    /// first has closed but not yet swapped, its swap then finds nothing. BOTH writes are lost and the
+    /// destination never appears, silently, because callers log a failed save at Debug. With a name
+    /// only one call knows, cleanup can only ever delete its own file and the last writer to swap
+    /// simply wins.</para>
+    /// <para>Deliberately NOT paired with a sweep of stale sibling temps: deleting a temp this call did
+    /// not create is precisely the bug above. A leftover survives only a hard kill inside the window
+    /// between writing the temp and swapping it, and costs a few hundred bytes.</para>
+    /// </summary>
+    public static string UniqueTempPath(string path, string tag = "tmp") =>
+        $"{path}.{Environment.ProcessId}-{Interlocked.Increment(ref _tempSequence)}.{tag}";
+
     private static string PrepareTempPath(string path)
     {
         var directory = Path.GetDirectoryName(Path.GetFullPath(path));
@@ -130,7 +151,7 @@ internal static class AtomicFile
 
         // Same directory as the destination: a cross-volume move is a copy+delete, which is not
         // atomic and would reintroduce exactly the torn window this helper exists to close.
-        return path + ".tmp";
+        return UniqueTempPath(path);
     }
 
     private static void Swap(string temp, string path)

--- a/SysManager/SysManager/Services/HostsFileService.cs
+++ b/SysManager/SysManager/Services/HostsFileService.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Net;
 using System.Text.RegularExpressions;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -205,7 +206,8 @@ public sealed partial class HostsFileService
         // Write atomically: a crash midway through File.WriteAllLines would otherwise
         // leave the hosts file truncated or empty. Write to a temp file in the same
         // directory, then swap it into place in one operation.
-        var tempPath = HostsPath + ".sysmanager.tmp";
+        // Unique per call — see the note in RestoreBackup and AtomicFile.UniqueTempPath.
+        var tempPath = AtomicFile.UniqueTempPath(HostsPath, "sysmanager.tmp");
         try
         {
             File.WriteAllLines(tempPath, lines);
@@ -246,7 +248,10 @@ public sealed partial class HostsFileService
         // existing target's security descriptor onto the replacement. A plain
         // File.Copy(overwrite:true) would relink a new inode that inherits only the
         // directory's default ACL, silently weakening the file.
-        var tempPath = HostsPath + ".sysmanager.restore.tmp";
+        // Unique per call: the cleanup below runs in a finally, so a fixed name would let two
+        // overlapping writers delete each other's staged file and lose both. AtomicFile owns the
+        // naming so the rule is stated once (see AtomicFile.UniqueTempPath).
+        var tempPath = AtomicFile.UniqueTempPath(HostsPath, "sysmanager.restore.tmp");
         try
         {
             File.Copy(BackupPath, tempPath, overwrite: true);

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.16</Version>
-    <FileVersion>1.65.16.0</FileVersion>
-    <AssemblyVersion>1.65.16.0</AssemblyVersion>
+    <Version>1.65.17</Version>
+    <FileVersion>1.65.17.0</FileVersion>
+    <AssemblyVersion>1.65.17.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## What a user sees

You change a setting — say you turn off "check for updates on startup" — and it does not stick. No
error, no message: the next launch it is back on. It is rare and timing-dependent, so it reads as
"huh, weird" rather than a bug. For an app whose whole promise is *safe*, a save that loses your data
without saying so is the worst kind of defect.

## The defect

SysManager writes its small state files (settings, activity/speed-test/bandwidth history, volume
presets, the hosts file) *atomically*: write a temp file in the same directory, then swap it into
place. A crash mid-write can then only leave a stray temp, never a torn destination. That part is
correct and worth keeping.

The flaw is the temp **name**. Every save of a given destination used the same fixed one:

```csharp
return path + ".tmp";      // shared by every writer to `path`
```

…and deletes it in a `finally`. So two saves of the *same* file share a single temp and can destroy
each other:

```
writer A  writes temp, holds the handle
writer B  fails to open the same temp (A holds it)
A         closes, but has not yet swapped
B finally File.Delete(temp)   <-- deletes A's finished temp
A         Swap -> temp is gone -> throws -> swallowed at Debug
```

Both writes are lost, the destination is never created, and nothing is reported — the caller logs a
failed save at `Debug`.

**Reachable in the running app, not just in theory.** `AboutViewModel` (built with `autoCheck: true`)
records its startup update-check timestamp on a background thread, via `RecordCheck`, while the user
toggling the "check for updates" checkbox writes the *same* `update-check.json` from the UI thread.
That is exactly two overlapping writers to one destination. It surfaced as a one-in-thousands CI
failure of `AboutViewModelTests.ConstructingTheViewModel_DoesNotTouchTheRealPreferenceFile` (1 of
4693). It is not the earlier `codeload` 503 — that was a GitHub outage in "Set up job", zero code run,
verified in the logs.

## The fix

Each write derives a temp name only *that call* knows:

```csharp
public static string UniqueTempPath(string path, string tag = "tmp") =>
    $"{path}.{Environment.ProcessId}-{Interlocked.Increment(ref _tempSequence)}.{tag}";
```

Now `CleanUp` can only ever delete its own file, so overlapping writers cannot interfere — the last
one to swap simply wins.

**Fixed the class, not the instance.** `AtomicFile` backs 17 user-data writes (batch 61), but two more
services carried the identical fixed-name-plus-`finally` pattern directly: `HostsFileService.SaveHosts`
and `RestoreBackup`. They now derive their staging names from the same `UniqueTempPath`, so the rule is
stated once. `ResourceHistoryService`/`BandwidthHistoryService` also use a `+ ".tmp"` name but guard
every write behind a `SemaphoreSlim` and never delete on the failure path, so they are not exposed;
left untouched to keep the diff to the actual defect.

**Deliberately no sweep of stale sibling temps.** Deleting a temp a call did not create is *precisely*
this bug. A leftover now survives only a hard kill inside the write→swap window and costs a few hundred
bytes.

## Verification

**Red proof: 7 mutations, both touched source files restored byte-for-byte.**

| Mutation | Must go red |
|---|---|
| `AtomicFile` takes a fixed temp name again (the shipped defect) | all three ownership tests (shared source) |
| `SaveHosts` takes a fixed staging name | `SaveHosts_DoesNotTouchAStagingFileItDoesNotOwn` |
| `RestoreBackup` takes a fixed staging name | `RestoreBackup_DoesNotTouchAStagingFileItDoesNotOwn` |
| `AtomicFile` skips cleanup after a failed save | both `WhenTheSaveFails…` tests' "nothing beside it" |
| `AtomicFile` copies instead of swapping + keeps temp | `WriteAllText_LeavesNoTemporaryFileBehind` |
| `SaveHosts` copies instead of swapping + keeps staging | `SaveHosts_LeavesNoTempFileBehind` |
| `Swap` swallows a refused swap | both `WhenTheSaveFails…` tests |

Three new **ownership** tests state the invariant single-threadedly — a pre-existing file stands in for
the other writer's temp, so nothing races and there is no flake (a flaky test is a broken test). The
two failure tests were rewritten to drive the failure by holding the destination open with
`FileShare.None` (what an antivirus or backup agent does) instead of occupying the now-private temp
name, and mutation 7 proves that new driver still catches a swallowed swap.

One honest gap, logged as a follow-up rather than faked: the end-to-end *atomicity under a real
concurrent race* is not unit-asserted — observing it needs file-identity APIs the tests project does
not use, and a threaded race would be probabilistic. The ownership invariant above is what makes the
race impossible, and it is what is pinned.

Other checks: all four projects build 0 errors / 0 warnings; `dotnet format --verify-no-changes` exit 0
on both; the AtomicFile + Hosts + About clusters run green; leak scan over all 32 terms gives 0 hits in
the diff; author headers present on all touched files.
