### PR TITLE
test: drain all reloads before ConcurrentReloads asserts at rest

### DIFF
--- a/SysManager/SysManager.Tests/ResourceHistoryViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ResourceHistoryViewModelTests.cs
@@ -94,8 +94,8 @@ public class ResourceHistoryViewModelReloadTests : IDisposable
         //
         // WHAT THIS TEST CAN AND CANNOT PROVE: the corruption needs a RENDERED chart for LiveCharts to
         // attach its observer, which never happens in a headless test — so this asserts the reachable
-        // invariant (the series stay coherent, nothing escapes) rather than reproducing the observer
-        // corruption. The gate is justified by the proven CI failure on the identical sibling.
+        // invariant (the series stay coherent at rest, nothing escapes) rather than reproducing the
+        // observer corruption. The gate is justified by the proven CI failure on the identical sibling.
         var now = DateTime.Now;
         using var service = SeededService(
             new ResourceSample(now.AddMinutes(-30), 10, 20, 30, 40, 50),
@@ -104,16 +104,26 @@ public class ResourceHistoryViewModelReloadTests : IDisposable
         using var vm = new ResourceHistoryViewModel(service);
         await vm.InitializationComplete;
 
-        // Rapid range assignment starts a reload from the changed-handler each time, bypassing the
-        // command — that is what genuinely overlaps.
+        // Force the overlap: each SelectedRange assignment starts a fire-and-forget reload from the
+        // changed-handler, and the command on the same line starts a second, independent one — both
+        // through the one gate. Collect every command task so ALL of them can be awaited.
+        //
+        // The "all series equal length" invariant only holds AT REST: a reload applies its five
+        // ReplaceWith calls one at a time, and between two of them the lengths legitimately differ
+        // (0 mid-clear, then 3). In the real app the reader is the LiveCharts observer on the SAME UI
+        // thread as the reload, so it never observes that transient; a headless test on the thread
+        // pool would, if it read while a fire-and-forget reload was still in flight. Awaiting only one
+        // reload while 20 more were fired after it is exactly that bug — it reddened CI ~1-in-4700
+        // ([0, 3]). So await every command task, then one final lone reload with nothing fired after
+        // it: a guaranteed coherent rest state (proven: 297/300 torn reads before this, 0/300 after).
+        var inFlight = new List<Task>();
         for (int i = 0; i < 20; i++)
-            vm.SelectedRange = vm.RangeOptions[i % vm.RangeOptions.Count];
-
-        // Fire the command mid-flight: the second, independent entry point.
-        var refresh = vm.ReloadCommand.ExecuteAsync(null);
-        for (int i = 0; i < 20; i++)
-            vm.SelectedRange = vm.RangeOptions[(i + 1) % vm.RangeOptions.Count];
-        await refresh;
+        {
+            vm.SelectedRange = vm.RangeOptions[i % vm.RangeOptions.Count];   // the fire-and-forget path
+            inFlight.Add(vm.ReloadCommand.ExecuteAsync(null));              // the command path
+        }
+        await Task.WhenAll(inFlight);
+        await vm.ReloadCommand.ExecuteAsync(null);   // final reload, nothing fired after it → at rest
 
         // All three usage series are rebuilt from the same downsampled points, so their lengths must
         // agree. A torn ReplaceWith is exactly what makes them diverge.


### PR DESCRIPTION
## The symptom

`ResourceHistoryViewModelReloadTests.ConcurrentReloadsDoNotCorruptTheChartSeries` reddened CI
~1-in-4700:

```
Assert.Single() Failure: The collection contained 2 items
Collection: [0, 3]
```

It passed on the PR that introduced its neighbourhood and on thousands of other runs; it failed once,
on an unrelated merge. That profile — rare, load-dependent, in a test whose name is literally about
concurrency — is the one this project has learned not to wave away as "flaky".

## Root cause: a test that read mid-flight, not a product bug

`ReloadAsync` applies its five `ReplaceWith` calls one at a time (cpu, ram, gpu, then two temp
series). Between two of them a series is legitimately mid-clear — 0 points — while an earlier one is
already refilled to 3. **At rest** all five agree; **mid-reload** they don't. `[0, 3]` is that
transient.

In the running app the reader is the LiveCharts observer on the **same UI thread** as the reload, so
it never observes the in-between state. A headless test resumes the reload on the thread pool, so a
cross-thread read *can* see it — and that is exactly what the test did:

```csharp
for (int i = 0; i < 20; i++) vm.SelectedRange = ...;   // 20 fire-and-forget reloads
var refresh = vm.ReloadCommand.ExecuteAsync(null);
for (int i = 0; i < 20; i++) vm.SelectedRange = ...;   // 20 MORE, fired after
await refresh;                                          // awaits only ONE
// ...assert here, while the 20 trailing reloads are still applying ReplaceWith
```

It awaited a single reload while twenty more were still in flight, then read the series. The invariant
it checks ("all usage series equal length") only holds at rest, and the test never reached rest.

## The fix (test only)

Route every reload through the command so its `Task` can be collected, await them all, then one final
lone reload with nothing fired after it — a guaranteed coherent rest state. Both entry points (the
`SelectedRange` changed-handler *and* the command) still overlap through the one gate, so the
concurrency under test is unchanged; only the drain is added.

```csharp
var inFlight = new List<Task>();
for (int i = 0; i < 20; i++)
{
    vm.SelectedRange = vm.RangeOptions[i % vm.RangeOptions.Count];   // fire-and-forget path
    inFlight.Add(vm.ReloadCommand.ExecuteAsync(null));              // command path, collected
}
await Task.WhenAll(inFlight);
await vm.ReloadCommand.ExecuteAsync(null);   // final reload, nothing after it → at rest
```

No production change. Adding a lock so a cross-thread reader never sees the transient would be dead
complexity for a race the single-threaded-UI app cannot have.

## Verification (reproduced and fixed deterministically)

The single-read failure is ~1-in-thousands and would not reproduce in a warm isolated loop (7,200
runs, all green — no thread-pool pressure). So I demonstrated the *mechanism* deterministically
instead: after the old storm, spin-read the three series lengths right where the assertion sits.

| Structure | Rounds observing a torn `[0, n]` read |
|---|---|
| current test (await one, 20 fired after) | **297 / 300** |
| drained (collect all + WhenAll + final reload) | **0 / 300** |

That 297/300 is the same window the single-read assertion lands in ~1-in-4700 on loaded CI. With the
drain the window is gone. The fixed test then ran **4,000×** at 8-wide concurrency (mimicking xUnit's
parallel collections) with zero failures.

`test:` — no release. All four projects build 0/0; diff is one test file; leak scan clean.
