### PR TITLE
docs: give the four param-only constructors a summary

### DIFF
--- a/SysManager/SysManager/Helpers/EtaCalculator.cs
+++ b/SysManager/SysManager/Helpers/EtaCalculator.cs
@@ -102,6 +102,10 @@ public sealed class EtaCalculator
     /// <summary>Elapsed-since-start at which progress is projected to reach 100%. Null when unknown.</summary>
     private TimeSpan? _projectedFinish;
 
+    /// <summary>
+    /// Creates a calculator holding no samples: <see cref="Remaining"/> stays null and the rate stays zero
+    /// until the first <c>Update</c> reports a real advance.
+    /// </summary>
     /// <param name="timeProvider">
     /// Time source, defaulting to <see cref="TimeProvider.System"/>. A test passes a fake and advances it,
     /// so the ETA maths is verified deterministically. This class held a private <c>Stopwatch</c> before,

--- a/SysManager/SysManager/Services/EtwBandwidthSource.cs
+++ b/SysManager/SysManager/Services/EtwBandwidthSource.cs
@@ -241,6 +241,11 @@ public sealed class EtwBandwidthSource : IBandwidthMonitorService
     /// </summary>
     private readonly TimeProvider _time;
 
+    /// <summary>
+    /// Creates the source without opening an ETW session — that happens in <see cref="Start"/>. Constructing
+    /// this is therefore free and needs no elevation, which is what lets the view model hold one and only
+    /// pay for the trace if the user turns per-process mode on while running elevated.
+    /// </summary>
     /// <param name="timeProvider">Test seam; defaults to the system clock.</param>
     public EtwBandwidthSource(TimeProvider? timeProvider = null) => _time = timeProvider ?? TimeProvider.System;
 

--- a/SysManager/SysManager/ViewModels/AudioSessionRowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AudioSessionRowViewModel.cs
@@ -95,6 +95,15 @@ public sealed partial class AudioSessionRowViewModel : ObservableObject
     /// <summary>Volume as a friendly percentage, e.g. "65%".</summary>
     public string VolumeDisplay => $"{Volume * 100:F0}%";
 
+    /// <summary>
+    /// Builds one row of the mixer from a session snapshot. Volume, mute, name and peak are seeded through
+    /// their backing fields so the change handlers do not fire and write the value straight back to the
+    /// service — the same echo suppression <see cref="ApplyUpdate"/> relies on for later refreshes.
+    /// </summary>
+    /// <param name="outputDevices">
+    /// The parent's live device list, shared rather than copied: a device plugged in after this row was
+    /// created must appear in its picker.
+    /// </param>
     /// <param name="reportFailure">
     /// Called with a finished, user-facing sentence when a write to the audio service is refused. Passed in
     /// rather than raised as an event on purpose: a row is created and dropped on every reconcile pass, so

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -91,6 +91,11 @@ public sealed partial class DashboardViewModel : ViewModelBase
     // ── IsActive (pause polling when tab not visible) ────────────────────
     [ObservableProperty] private bool _isActive;
 
+    /// <summary>
+    /// Wires the dashboard's services and starts <c>InitAsync</c> fire-and-forget: it reports any previous
+    /// crash, loads static info, drives, activity and the health score, then starts the vitals, temperature
+    /// and alert loops. Elevation is read once here because it cannot change without relaunching the app.
+    /// </summary>
     /// <param name="crashMarkers">
     /// Required, not optional. It used to default to <c>new CrashMarkerService()</c>, which resolved
     /// the real profile — and because <see cref="CrashMarkerService.TakePending"/> CONSUMES the marker


### PR DESCRIPTION
## What raised this

CodeQL alert **#1724** — `cs/xmldoc/missing-summary` on `AudioSessionRowViewModel.cs:104`, created when
batch 89 merged. That batch added a `<param>` block for the new `reportFailure` callback but no
`<summary>` above it, so the constructor's doc block documented one argument of a member whose purpose
was never stated.

Severity is `note` and nothing is broken. It is here because it is a **new** alert introduced by my own
change, and the standard on this repo is to leave none behind.

## Fixed the shape, not the alert

Swept the whole source for the pattern (a doc block that starts at `<param>` with no `<summary>` anywhere
above it) and found **four** constructors, of which CodeQL had reported only two:

| Constructor | Alert | Introduced by |
|---|---|---|
| `AudioSessionRowViewModel` | #1724 | batch 89 (`reportFailure`) |
| `DashboardViewModel` | #1715 (pre-existing) | the `crashMarkers` required-arg change (#1772) |
| `EtaCalculator` | *not reported* | batch 81 (`TimeProvider` seam) |
| `EtwBandwidthSource` | *not reported* | batch 86 (`TimeProvider` seam) |

The two CodeQL missed are the same defect, and both are mine — a grep keyed on the shape found them
where the alert list would have left half a migration behind. Post-change sweep: **0 blocks remaining.**

The convention copied is `BandwidthMonitorViewModel`, whose two constructors already lead with a summary.

## Each summary says something the signature does not

Every line was verified against the body rather than guessed:

- **`AudioSessionRowViewModel`** — seeds volume/mute/name/peak through the *backing fields*, so the
  change handlers never fire and write the value straight back to the service; the same echo suppression
  `ApplyUpdate` relies on. (Verified: `_volume`/`_isMuted`/`_displayName`/`_peakLevel` are direct field
  assignments, and the class doc states the `ApplyUpdate` re-entrancy guard.)
- **`EtaCalculator`** — starts with no samples, so `Remaining` stays null and the rate stays zero until
  the first `Update` reports a real advance.
- **`EtwBandwidthSource`** — opens **no** ETW session; that happens in `Start()`. Which is precisely why
  the view model can hold one and only pay for the trace if per-process mode is switched on while
  elevated. (Verified: `_session` has no initializer; `new TraceEventSession(...)` is inside `Start()`.)
- **`DashboardViewModel`** — starts `InitAsync` fire-and-forget (previous-crash report, static info,
  drives, activity, health score, then the vitals/temperature/alert loops) and reads elevation once
  because it cannot change without a relaunch.

## Not touched, deliberately

The four `cs/constant-condition` alerts (`BandwidthMonitorViewModel:278/470`,
`ResourceHistoryViewModel:164/190`) remain open. They sit on the post-await `if (_disposed) return;`
guards, which CodeQL reads as constant because it cannot see the field being written from `Dispose` on
another turn. Removing them would reintroduce the use-after-dispose crashes fixed in batches 35/40.
They are false positives and stay.

## Verification

Comments only — zero executable lines changed. All four projects build 0 errors / 0 warnings;
`dotnet format --verify-no-changes` exit 0; author headers intact on all four files; leak scan over all
32 terms gives 0 hits. `docs:` so no version bump and no release.
