### PR TITLE
test: assert the consequence, not the setter round-trip

### DIFF
--- a/SysManager/SysManager.Tests/AppPackageTests.cs
+++ b/SysManager/SysManager.Tests/AppPackageTests.cs
@@ -32,16 +32,9 @@ public class AppPackageTests
         Assert.Contains(nameof(AppPackage.IsSelected), raised);
     }
 
-    [Fact]
-    public void Status_Transitions_ArePossible()
-    {
-        var p = new AppPackage();
-        foreach (var s in new[] { "Pending", "Upgrading...", "Done", "Failed (exit 1)" })
-        {
-            p.Status = s;
-            Assert.Equal(s, p.Status);
-        }
-    }
+    // Status_Transitions_ArePossible was removed: assigning four strings to a string property and
+    // reading each back cannot fail. "Transitions are possible" was never in question — what would
+    // be worth pinning is who WRITES those values, which belongs to the winget service's tests.
 
     [Fact]
     public void ScenarioLikeRealData_IsStored()

--- a/SysManager/SysManager.Tests/CleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/CleanupViewModelTests.cs
@@ -330,16 +330,9 @@ public class CleanupViewModelTests
         Assert.Equal("hello", vm.StatusMessage);
     }
 
-    [Fact]
-    public void Progress_AcceptsFullRange()
-    {
-        var vm = NewVm();
-        foreach (var p in new[] { 0, 1, 50, 99, 100 })
-        {
-            vm.Progress = p;
-            Assert.Equal(p, vm.Progress);
-        }
-    }
+    // Progress_AcceptsFullRange was removed: it looped five values through a bare
+    // [ObservableProperty] and read each back. The name implied a 0-100 contract that nothing
+    // enforces (ViewModelBase._progress is unclamped; the ProgressBar clamps visually).
 
     [Fact]
     public void IsProgressIndeterminate_TogglesCleanly()
@@ -386,22 +379,9 @@ public class CleanupViewModelTests
         Assert.NotEqual("Scanning…", vm.RecycleBinLabel);
     }
 
-    [Fact]
-    public void TempSizeLabel_CanBeSetDirectly()
-    {
-        var vm = NewVm();
-        vm.TempSizeLabel = "42.0 MB can be freed";
-        Assert.Equal("42.0 MB can be freed", vm.TempSizeLabel);
-    }
-
-    [Fact]
-    public void RecycleBinLabel_CanBeSetDirectly()
-    {
-        var vm = NewVm();
-        vm.RecycleBinLabel = "Empty";
-        Assert.Equal("Empty", vm.RecycleBinLabel);
-    }
-
+    // A "…_CanBeSetDirectly" round-trip was removed here: it set a bare [ObservableProperty]
+    // and read it straight back, so only the source generator could fail it. The labels' real
+    // behaviour is covered by …_DefaultIsScanning and PreScan_EventuallyPopulatesLabels above.
     // ---------- progress feedback (regression) ----------
     // CleanupView.xaml binds a progress bar to IsBusy and the sidebar spinner reads the same flag,
     // but this VM never assigned it — so nothing appeared while SFC or DISM ran, which is minutes of

--- a/SysManager/SysManager.Tests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DashboardViewModelTests.cs
@@ -89,47 +89,27 @@ public class DashboardViewModelTests
     }
 
     // ---------- property setters ----------
-
-    [Fact]
-    public void OsLine_Setter_Works()
-    {
-        var vm = NewVm();
-        vm.OsLine = "Windows 11 Pro";
-        Assert.Equal("Windows 11 Pro", vm.OsLine);
-    }
-
-    [Fact]
-    public void UptimeLine_Setter_Works()
-    {
-        var vm = NewVm();
-        vm.UptimeLine = "Uptime 3d 5h";
-        Assert.Equal("Uptime 3d 5h", vm.UptimeLine);
-    }
-
-    [Fact]
-    public void CpuPercent_Setter_Works()
-    {
-        var vm = NewVm();
-        vm.CpuPercent = 42.5;
-        Assert.Equal(42.5, vm.CpuPercent);
-    }
-
-    [Fact]
-    public void RamPercent_Setter_Works()
-    {
-        var vm = NewVm();
-        vm.RamPercent = 67.3;
-        Assert.Equal(67.3, vm.RamPercent);
-    }
+    // The four "…_Setter_Works" round-trips that lived here were removed: each set a bare
+    // [ObservableProperty] and read it straight back, which can only fail if the CommunityToolkit
+    // source generator breaks. What a binding depends on — the change notification — is covered by
+    // Setter_FiresPropertyChanged below, which the two percentages were added to.
 
     // ---------- PropertyChanged ----------
 
+    /// <summary>
+    /// Every bound property must raise <c>PropertyChanged</c>: the dashboard is written by a background
+    /// poll loop, so the UI only updates on the notification. The parameter is <c>object</c> so the two
+    /// percentages can join the string rows — they arrived here when their standalone round-trip tests
+    /// were removed, because notification is the half that a binding actually depends on.
+    /// </summary>
     [Theory]
     [InlineData(nameof(DashboardViewModel.OsLine), "test")]
     [InlineData(nameof(DashboardViewModel.UptimeLine), "test")]
     [InlineData(nameof(DashboardViewModel.CpuName), "test")]
     [InlineData(nameof(DashboardViewModel.GpuName), "test")]
-    public void Setter_FiresPropertyChanged(string propName, string value)
+    [InlineData(nameof(DashboardViewModel.CpuPercent), 42.5)]
+    [InlineData(nameof(DashboardViewModel.RamPercent), 67.3)]
+    public void Setter_FiresPropertyChanged(string propName, object value)
     {
         var vm = NewVm();
         var fired = false;

--- a/SysManager/SysManager.Tests/DuplicateFileViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DuplicateFileViewModelTests.cs
@@ -106,13 +106,10 @@ public class DuplicateFileViewModelTests
         Assert.NotNull(vm.BrowseFolderCommand);
     }
 
-    [Fact]
-    public void MinSizeKb_CanBeChanged()
-    {
-        var vm = NewVm();
-        vm.MinSizeKb = 500;
-        Assert.Equal(500, vm.MinSizeKb);
-    }
+    // MinSizeKb_CanBeChanged was removed as a setter round-trip. The property's real consequence is
+    // `var minBytes = MinSizeKb * 1024` in ScanAsync, and asserting THAT needs a guard the code does
+    // not have yet (a large typed value overflows long and inverts the filter) — tracked separately
+    // so this test-only change stays behaviour-neutral.
 
     [Fact]
     public void SelectedFolder_CanBeChanged()

--- a/SysManager/SysManager.Tests/FriendlyEventEntryExtendedTests.cs
+++ b/SysManager/SysManager.Tests/FriendlyEventEntryExtendedTests.cs
@@ -67,13 +67,32 @@ public class FriendlyEventEntryExtendedTests
         Assert.Equal(StatusColors.Neutral, e.SeverityColor);
     }
 
+    /// <summary>
+    /// The extreme timestamps a real event log can hand us must not produce nonsense in the two strings
+    /// the user actually sees.
+    /// <para>Replaces an assertion that stored <c>DateTime.MinValue</c>/<c>MaxValue</c> and read them back
+    /// — a round-trip through a generated setter, proving only that a <c>DateTime</c> field holds a
+    /// <c>DateTime</c>. The reachable question is what <c>RelativeTime</c> and <c>FullTimestamp</c> DO with
+    /// those values, since both are computed from <c>Timestamp</c> and <c>RelativeTime</c> subtracts it
+    /// from <c>DateTime.Now</c>.</para>
+    /// <para>This pins the behaviour rather than changing it: MinValue is special-cased to an em dash, and
+    /// a FUTURE stamp (a clock correction, or a log copied from a machine running ahead) yields "just now",
+    /// because the negative span falls into the first branch. Imprecise but harmless — and far better than
+    /// printing "in -3d". Asserted so a future reordering of those branches cannot silently start showing
+    /// the user a negative duration.</para>
+    /// </summary>
     [Fact]
-    public void TimestampsVastlyDifferent_StillStorable()
+    public void ExtremeTimestamps_ProduceSaneDisplayStrings()
     {
-        var e = new FriendlyEventEntry { Timestamp = DateTime.MinValue };
-        Assert.Equal(DateTime.MinValue, e.Timestamp);
-        e.Timestamp = DateTime.MaxValue;
-        Assert.Equal(DateTime.MaxValue, e.Timestamp);
+        var min = new FriendlyEventEntry { Timestamp = DateTime.MinValue };
+        Assert.Equal("—", min.RelativeTime);
+        Assert.Equal("0001-01-01 00:00:00", min.FullTimestamp);
+
+        var future = new FriendlyEventEntry { Timestamp = DateTime.MaxValue };
+        Assert.Equal("just now", future.RelativeTime);
+        Assert.Equal("9999-12-31 23:59:59", future.FullTimestamp);
+        // The point of the assertion: no negative duration ever reaches the user.
+        Assert.DoesNotContain("-", future.RelativeTime);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
@@ -123,13 +123,8 @@ public class PerformanceViewModelTests
 
     // ── Property changes ──
 
-    [Fact]
-    public void SelectedPlan_CanBeChanged()
-    {
-        var vm = NewVm();
-        vm.SelectedPlan = "ultimate";
-        Assert.Equal("ultimate", vm.SelectedPlan);
-    }
+    // SelectedPlan_CanBeChanged was removed as a pure setter round-trip: the default is pinned by
+    // Constructor_SelectedPlan_DefaultBalanced and the notification by SelectedPlan_NotifiesPropertyChanged.
 
     [Fact]
     public void WantVisualEffectsReduced_CanBeToggled()

--- a/SysManager/SysManager.Tests/PingTargetTests.cs
+++ b/SysManager/SysManager.Tests/PingTargetTests.cs
@@ -90,15 +90,7 @@ public class PingTargetTests
         Assert.Equal(role, t.Role);
     }
 
-    [Fact]
-    public void Stats_CanBeUpdated()
-    {
-        var t = new PingTarget();
-        t.AverageMs = 25.3;
-        t.JitterMs = 2.1;
-        t.LossPercent = 5.0;
-        Assert.Equal(25.3, t.AverageMs);
-        Assert.Equal(2.1, t.JitterMs);
-        Assert.Equal(5.0, t.LossPercent);
-    }
+    // Stats_CanBeUpdated was removed: three doubles assigned and read back on a model with no
+    // computed members over them. PingTarget's meaningful behaviour is in the ping service, which
+    // has its own tests.
 }

--- a/SysManager/SysManager.Tests/ProcessManagerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ProcessManagerViewModelTests.cs
@@ -43,12 +43,50 @@ public class ProcessManagerViewModelTests
         Assert.Equal("", vm.FilterText);
     }
 
+    /// <summary>
+    /// Typing in the search box must actually narrow the bound list.
+    /// <para>Replaces an assertion that set <c>FilterText</c> and then read <c>FilterText</c> back — a
+    /// round-trip through a generated <c>[ObservableProperty]</c> setter, which can only fail if the
+    /// source generator itself breaks. What the user depends on is the CONSEQUENCE:
+    /// <c>OnFilterTextChanged</c> calls <c>ApplyFilter</c>, which rebuilds <c>FilteredProcesses</c> —
+    /// the collection the DataGrid binds to. A filter wired to nothing is a defect this project has
+    /// shipped before (batch 30, five unreachable Services filters), and the old assertion could not
+    /// have caught it.</para>
+    /// </summary>
     [Fact]
-    public void FilterText_CanBeChanged()
+    public void FilterText_NarrowsTheBoundList()
     {
         var vm = new ProcessManagerViewModel(new Services.ProcessManagerService());
+        vm.Processes.Clear();
+        vm.Processes.Add(new ProcessEntry { Pid = 1, Name = "chrome", MemoryBytes = 300 });
+        vm.Processes.Add(new ProcessEntry { Pid = 2, Name = "notepad", MemoryBytes = 200 });
+
         vm.FilterText = "chrome";
-        Assert.Equal("chrome", vm.FilterText);
+
+        Assert.Equal(["chrome"], vm.FilteredProcesses.Select(p => p.Name).ToArray());
+
+        // …and clearing it restores the full list, so the filter is not one-way.
+        vm.FilterText = "";
+        Assert.Equal(2, vm.FilteredProcesses.Count);
+    }
+
+    /// <summary>
+    /// The filter matches a PID and the description fields too, not only the name: three separate
+    /// <c>Matches…</c> helpers feed it and only the name path was ever exercised.
+    /// </summary>
+    [Fact]
+    public void FilterText_AlsoMatchesPidAndDescription()
+    {
+        var vm = new ProcessManagerViewModel(new Services.ProcessManagerService());
+        vm.Processes.Clear();
+        vm.Processes.Add(new ProcessEntry { Pid = 4321, Name = "svchost", PlainDescription = "Windows service host" });
+        vm.Processes.Add(new ProcessEntry { Pid = 9, Name = "notepad" });
+
+        vm.FilterText = "4321";
+        Assert.Equal(["svchost"], vm.FilteredProcesses.Select(p => p.Name).ToArray());
+
+        vm.FilterText = "service host";
+        Assert.Equal(["svchost"], vm.FilteredProcesses.Select(p => p.Name).ToArray());
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/UninstallerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/UninstallerViewModelTests.cs
@@ -56,12 +56,46 @@ public class UninstallerViewModelTests
         Assert.False(string.IsNullOrEmpty(vm.Summary));
     }
 
+    /// <summary>
+    /// Typing in the search box must narrow the bound list AND correct the count and summary the user
+    /// reads above it. Replaces a <c>FilterText</c> round-trip that only exercised the generated setter;
+    /// <c>ApplyFilter</c> rebuilds <c>FilteredApps</c>, recomputes <c>AppCount</c> and rewrites
+    /// <c>Summary</c>, and none of those three was asserted anywhere.
+    /// </summary>
     [Fact]
-    public void FilterText_CanBeChanged()
+    public void FilterText_NarrowsTheListAndCorrectsTheCountAndSummary()
     {
         var vm = NewVm();
+        vm.AllApps.Clear();
+        vm.AllApps.Add(new InstalledApp { Name = "Google Chrome", Id = "Google.Chrome" });
+        vm.AllApps.Add(new InstalledApp { Name = "Notepad++", Id = "Notepad.Plus" });
+
         vm.FilterText = "chrome";
-        Assert.Equal("chrome", vm.FilterText);
+
+        Assert.Equal(["Google Chrome"], vm.FilteredApps.Select(a => a.Name).ToArray());
+        Assert.Equal(1, vm.AppCount);
+        Assert.Contains("of 2 total", vm.Summary);
+
+        // Clearing it restores everything, and the summary drops the "(of N total)" qualifier because
+        // nothing is filtered out any more.
+        vm.FilterText = "";
+        Assert.Equal(2, vm.FilteredApps.Count);
+        Assert.Equal(2, vm.AppCount);
+        Assert.DoesNotContain("of 2 total", vm.Summary);
+    }
+
+    /// <summary>The filter matches the package Id too, not just the display name.</summary>
+    [Fact]
+    public void FilterText_AlsoMatchesThePackageId()
+    {
+        var vm = NewVm();
+        vm.AllApps.Clear();
+        vm.AllApps.Add(new InstalledApp { Name = "Google Chrome", Id = "Google.Chrome" });
+        vm.AllApps.Add(new InstalledApp { Name = "Notepad++", Id = "Notepad.Plus" });
+
+        vm.FilterText = "Notepad.Plus";
+
+        Assert.Equal(["Notepad++"], vm.FilteredApps.Select(a => a.Name).ToArray());
     }
 
     [Fact]


### PR DESCRIPTION
## What this is

A mechanical sweep for **pure-echo tests** — set a property, assert that same property, no production
call in between — found **15** in the suite:

```csharp
[Fact]
public void OsLine_Setter_Works()
{
    var vm = NewVm();
    vm.OsLine = "Windows 11 Pro";
    Assert.Equal("Windows 11 Pro", vm.OsLine);   // round-trips a generated setter
}
```

Every one of these exercises the CommunityToolkit `[ObservableProperty]` source generator, not this
codebase. They cannot fail on a real defect, and they inflate the test count and the confidence that
number implies. Backlog item #127.

The backlog guessed ~50% false positives. Triaging each one against current source gave a different
and more useful split.

## Replaced — the consequence was real and asserted nowhere (5)

**Both `FilterText` properties are wired** (`OnFilterTextChanged → ApplyFilter`), and `ApplyFilter`
rebuilds the collection the DataGrid binds to. The echo tests never looked at it. A filter wired to
nothing is a defect this project has already shipped — batch 30, *five unreachable Services filters* —
and the old assertion could not have caught it. Now asserted:

| Claim | Test |
|---|---|
| the bound list narrows, and clearing restores it | `ProcessManager…FilterText_NarrowsTheBoundList` |
| PID and description match too, not just the name | `ProcessManager…FilterText_AlsoMatchesPidAndDescription` |
| list narrows **and** `AppCount` + the "(of N total)" summary follow | `Uninstaller…NarrowsTheListAndCorrectsTheCountAndSummary` |
| the package Id matches, not just the display name | `Uninstaller…FilterText_AlsoMatchesThePackageId` |

**`FriendlyEventEntry` extreme timestamps** — storing `MinValue`/`MaxValue` proved a `DateTime` field
holds a `DateTime`. The reachable question is what `RelativeTime` and `FullTimestamp` *do* with them,
because `RelativeTime` subtracts from `DateTime.Now`, so a future stamp produces a **negative span**.
Behaviour is pinned as-is (MinValue → em dash, future → "just now") plus an assertion that no negative
duration can reach the user if those branches are ever reordered. Deliberately not "fixed": "just now"
for a clock-corrected event is imprecise but harmless, and far better than printing "in -3d".

## Removed — nothing left to assert (9), each verified case by case

- **Dashboard `OsLine`/`UptimeLine`/`CpuPercent`/`RamPercent` `_Setter_Works`** — notification is what a
  binding depends on, and `Setter_FiresPropertyChanged` already covers it. The two percentages were
  *missing* from that theory, so they were **added** to it (parameter widened to `object`) rather than
  simply dropped.
- **Cleanup `TempSizeLabel`/`RecycleBinLabel` `_CanBeSetDirectly`** — covered by `_DefaultIsScanning`
  and `PreScan_EventuallyPopulatesLabels`.
- **Cleanup `Progress_AcceptsFullRange`** — the name implied a 0-100 contract nothing enforces
  (`ViewModelBase._progress` is unclamped; the ProgressBar clamps visually).
- **Performance `SelectedPlan_CanBeChanged`** — default *and* notification both already covered.
- **`AppPackage.Status_Transitions_ArePossible`, `PingTarget.Stats_CanBeUpdated`** — model echoes with
  no computed members over them.
- **`DuplicateFile.MinSizeKb_CanBeChanged`** — its real consequence is `minBytes = MinSizeKb * 1024` in
  `ScanAsync`, and asserting that needs a guard the code does not have: a large typed value overflows
  `long` and **inverts** the filter (asking for "≥ 9 quadrillion KB" returns everything). Tracked
  separately so this change stays behaviour-neutral.

## Verification

**Red proof: 6 mutations, all 3 touched source files restored byte-for-byte.** Every replacement goes
red when its claim is broken — which is the whole point, since the tests it replaced could not go red
at all:

| Mutation | Must go red |
|---|---|
| unwire `ProcessManager.OnFilterTextChanged` (the batch-30 defect) | both ProcessManager filter tests |
| unwire `Uninstaller.OnFilterTextChanged` | both Uninstaller filter tests |
| `MatchesPid` always false | the PID/description test |
| Uninstaller stops matching `Id` | the package-Id test |
| `Summary` drops the "(of N total)" qualifier | the count/summary test |
| let a negative span fall past the "just now" branch | the extreme-timestamp test |

No production code changed. All four projects build 0 errors / 0 warnings;
`dotnet format --verify-no-changes` exit 0; author headers intact on all 9 files; leak scan over all 32
terms gives 0 hits. Net **-9** `[Fact]`/`[Theory]` attributes (14 removed, 5 added) plus 2 new theory
rows, so the CI count should read **4689**. `test:` — no version bump, no release.
