### PR TITLE
fix: bound the Duplicate Files minimum-size box so it cannot invert its filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.19] - 2026-08-18
+
+A fix for the Duplicate Files finder: a stray minus sign or an enormous number typed into the
+"minimum size" box could quietly turn the filter inside out and make it scan every file instead of
+only the large ones.
+
+### Fixed
+- **The "minimum size (KB)" box in Duplicate Files could invert its own filter.** The scan keeps a
+  file when its size is at least the number you type. That number is multiplied by 1024 to get bytes,
+  and the box accepted anything — so a leading minus, or a value large enough to overflow when
+  multiplied, produced a NEGATIVE threshold. Every file is larger than a negative size, so "only files
+  above X" silently became "scan and hash every file in the folder" — the opposite of what you asked,
+  and much slower. The typed value is now bounded before it is used, so the filter can only ever mean
+  what it says.
+
 ## [1.65.18] - 2026-08-18
 
 Volume Control now notices audio devices you plug in while it is open. Before, the "play on" list was read

--- a/SysManager/SysManager.Tests/DuplicateFileViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DuplicateFileViewModelTests.cs
@@ -106,10 +106,52 @@ public class DuplicateFileViewModelTests
         Assert.NotNull(vm.BrowseFolderCommand);
     }
 
-    // MinSizeKb_CanBeChanged was removed as a setter round-trip. The property's real consequence is
-    // `var minBytes = MinSizeKb * 1024` in ScanAsync, and asserting THAT needs a guard the code does
-    // not have yet (a large typed value overflows long and inverts the filter) — tracked separately
-    // so this test-only change stays behaviour-neutral.
+    // ---------- the minimum-size threshold the user types ----------
+
+    /// <summary>An ordinary value scales to bytes untouched — the bound must not disturb normal use.</summary>
+    [Theory]
+    [InlineData(1L, 1024L)]
+    [InlineData(500L, 512_000L)]
+    [InlineData(1024L, 1_048_576L)]
+    public void MinBytesFor_ScalesAnOrdinaryValue(long kb, long expectedBytes)
+        => Assert.Equal(expectedBytes, DuplicateFileViewModel.MinBytesFor(kb));
+
+    /// <summary>
+    /// A negative figure must not invert the filter. The scan skips a file with
+    /// <c>fi.Length &lt; minSizeBytes</c>, so a negative threshold skips nothing: "only files above X"
+    /// silently becomes "scan and hash EVERY file in the folder". One stray leading minus in an unbounded
+    /// TextBox is all it takes — exactly the input that has to be bounded at the boundary rather than
+    /// trusted.
+    /// </summary>
+    [Theory]
+    [InlineData(-1L)]
+    [InlineData(-5_000L)]
+    [InlineData(long.MinValue)]
+    public void MinBytesFor_NeverReturnsANegativeThreshold(long kb)
+        => Assert.Equal(0L, DuplicateFileViewModel.MinBytesFor(kb));
+
+    /// <summary>
+    /// A very large figure must not overflow into a negative threshold — the same inversion by a
+    /// different route, since anything above <c>long.MaxValue / 1024</c> wraps when scaled. Pinned at the
+    /// exact boundary and one past it, because an off-by-one in the bound is precisely what would let the
+    /// wrap back in.
+    /// </summary>
+    [Fact]
+    public void MinBytesFor_ClampsInsteadOfOverflowing()
+    {
+        // The boundary itself still scales exactly, with no wrap.
+        Assert.Equal(DuplicateFileViewModel.MaxMinSizeKb * 1024,
+                     DuplicateFileViewModel.MinBytesFor(DuplicateFileViewModel.MaxMinSizeKb));
+
+        // One past it, and the most extreme value the TextBox can produce, both land on the boundary…
+        Assert.Equal(DuplicateFileViewModel.MaxMinSizeKb * 1024,
+                     DuplicateFileViewModel.MinBytesFor(DuplicateFileViewModel.MaxMinSizeKb + 1));
+        Assert.Equal(DuplicateFileViewModel.MaxMinSizeKb * 1024,
+                     DuplicateFileViewModel.MinBytesFor(long.MaxValue));
+
+        // …and every result stays positive, which is the property that actually protects the scan.
+        Assert.True(DuplicateFileViewModel.MinBytesFor(long.MaxValue) > 0);
+    }
 
     [Fact]
     public void SelectedFolder_CanBeChanged()

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.18</Version>
-    <FileVersion>1.65.18.0</FileVersion>
-    <AssemblyVersion>1.65.18.0</AssemblyVersion>
+    <Version>1.65.19</Version>
+    <FileVersion>1.65.19.0</FileVersion>
+    <AssemblyVersion>1.65.19.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
@@ -33,6 +33,14 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
     public ObservableCollection<string> PresetFolders { get; } = new();
 
     [ObservableProperty] private string _selectedFolder = "";
+
+    /// <summary>
+    /// Minimum file size to consider, in KB, typed straight into a TextBox by the user.
+    /// <para>Deliberately NOT clamped in the setter: the box uses
+    /// <c>UpdateSourceTrigger=PropertyChanged</c>, so rewriting the value on every keystroke would
+    /// fight the caret (typing "-" then a digit would snap the field out from under them). The bound
+    /// is applied where the value is USED — see <see cref="MinBytesFor"/>.</para>
+    /// </summary>
     [ObservableProperty] private long _minSizeKb = 1;
     [ObservableProperty] private long _totalWasted;
     [ObservableProperty] private int _groupCount;
@@ -125,7 +133,7 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
 
         try
         {
-            var minBytes = MinSizeKb * 1024;
+            var minBytes = MinBytesFor(MinSizeKb);
             var progress = new Progress<DuplicateFileService.ScanProgress>(p =>
             {
                 CurrentFile = p.CurrentFile;
@@ -173,6 +181,23 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
             CurrentFile = "";
         }
     }
+
+    /// <summary>The largest <see cref="MinSizeKb"/> that still scales into a <c>long</c> byte count.</summary>
+    internal const long MaxMinSizeKb = long.MaxValue / 1024;
+
+    /// <summary>
+    /// Converts the user's KB figure into the byte threshold the scan compares against, bounded so a
+    /// typed value can never INVERT the filter.
+    /// <para>The scan skips a file with <c>if (fi.Length &lt; minSizeBytes) continue;</c>. A negative
+    /// threshold makes that comparison false for EVERY file, so "only files above X" silently becomes
+    /// "every file in the folder" — the opposite of the request, and a slow one, because every file then
+    /// gets hashed. Two typed values reach it: a stray leading minus, and any figure above
+    /// <see cref="MaxMinSizeKb"/>, which overflows <c>long</c> when multiplied by 1024 and lands
+    /// negative. The TextBox binds a <c>long</c> and imposes no bounds of its own, so both are
+    /// reachable.</para>
+    /// <para>Pure and static so the bound is testable without touching a filesystem.</para>
+    /// </summary>
+    internal static long MinBytesFor(long minSizeKb) => Math.Clamp(minSizeKb, 0, MaxMinSizeKb) * 1024;
 
     /// <summary>
     /// The scan's status line: phase, running counts, and the file currently being read.


### PR DESCRIPTION
## What a user sees

Open **Duplicate Files**, type a stray `-` (or a very large number) into "minimum size (KB)", and
Scan. Instead of finding only large duplicates it grinds through — and hashes — *every* file in the
folder. The one control meant to make the scan cheaper makes it maximally expensive, silently.

## The defect

The scan keeps a file when it is at least the requested size:

```csharp
if (fi.Length < minSizeBytes) continue;      // DuplicateFileService.Scan
```

and `minSizeBytes` was `MinSizeKb * 1024`, straight from a `long`-bound TextBox with no limits of its
own. Two typed values make that product **negative**:

- a leading minus — `-1` → `-1024`;
- anything above `long.MaxValue / 1024` — the multiply overflows and wraps negative.

Every real file length is `≥ 0 > negative`, so the skip never fires: *"only files above X"* becomes
*"every file in the folder"*. Nothing throws; the scan just does the opposite of what was asked, slowly.

## The fix

The KB→bytes conversion moves into a pure, bounded helper:

```csharp
internal const long MaxMinSizeKb = long.MaxValue / 1024;
internal static long MinBytesFor(long minSizeKb) => Math.Clamp(minSizeKb, 0, MaxMinSizeKb) * 1024;
```

so the threshold can never be negative by either route.

**Deliberately not clamped in the setter.** The box uses `UpdateSourceTrigger=PropertyChanged`, so
rewriting the value on every keystroke would fight the caret (type `-`, then a digit, and the field
would jump out from under you). The bound belongs where the value is *used*, not where it is typed —
the same reasoning the codebase already applies to live-updating inputs.

Found while triaging the pure-echo test `MinSizeKb_CanBeChanged` in batch 94, whose only "assertion"
set the property and read it back — it could never have caught this.

## Verification

**Red proof: 4 mutations, the touched source file restored byte-for-byte.**

| Mutation | Result |
|---|---|
| drop the clamp entirely (the shipped code) | negative **and** overflow tests both red |
| keep the lower bound only (`Math.Max`) | overflow test red, negative test green — isolates the upper bound |
| keep the upper bound only (`Math.Min`) | negative test red, overflow test green — isolates the lower bound |
| push `MaxMinSizeKb` one past the real limit | **fails to compile** (CS0220): the test asserts against the constant expression `MaxMinSizeKb * 1024`, which overflows at compile time — so the boundary itself cannot drift silently |

That last one is a stronger guard than a runtime assertion: an off-by-one in the limit is rejected by
the compiler, not merely by a failing test. The three runtime tests are `[Theory]` rows covering
ordinary values (unchanged behaviour), negatives (`-1`, `-5000`, `long.MinValue`), and the exact
overflow boundary.

Other checks: all four projects build 0 errors / 0 warnings; `dotnet format --verify-no-changes` exit 0
on both; author headers intact; leak scan over all 32 terms gives 0 hits. `fix:` → patch release
(1.65.19).
