### PR TITLE
refactor: make ThemeService's settings path redirectable for tests

### DIFF
--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -92,17 +92,18 @@ public partial class ArchitectureTests
         //   · SettingsWatchdogService and WindowsThemeService — both constructed concretely by tests,
         //     both now behind the shared `string? configDir = null` seam.
         //
-        // The two that remain are the two hard ones, and they are hard for different reasons:
-        //   · ThemeService is heavily static (20 static members) and is reached from XAML resource
-        //     resolution, so a constructor seam is a wider refactor than a path change.
+        // The ONE that remains is the hard one:
         //   · LogService is a `static partial class` by design — Serilog's sink is configured once per
-        //     process — so it has no instance to hang a seam on. It is also the only one no test
-        //     constructs, so its risk is the lowest of the set.
-        // Both need a design decision rather than a mechanical edit; neither is touched here.
+        //     process — so it has no instance to hang the shared `string? configDir = null` seam on. It
+        //     is also the only offender no test constructs, so its risk is the lowest of the set; it
+        //     needs a design decision (dropping the static-sink model) rather than a mechanical edit.
+        //
+        // ThemeService came off in #1741's follow-up: its path moved to an instance field set from the
+        // same seam, and its one WPF touch-point (Apply) now no-ops without an Application, so the
+        // persistence path is exercised headlessly by ThemeServiceTests instead of being left untested.
         string[] known =
         [
             "LogService.<LogDir>k__BackingField",
-            "ThemeService.SettingsPath",
         ];
 
         var profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);

--- a/SysManager/SysManager.Tests/ThemeServiceTests.cs
+++ b/SysManager/SysManager.Tests/ThemeServiceTests.cs
@@ -1,0 +1,97 @@
+// SysManager · ThemeServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Text.Json;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="ThemeService"/> persistence, made possible by the <c>configDir</c> seam added
+/// for #1741. Before it, <c>SettingsPath</c> was a <c>static readonly</c> built from
+/// <see cref="Environment.SpecialFolder.ApplicationData"/> — impossible to redirect, because that API
+/// ignores the <c>APPDATA</c> environment variable — so any test that constructed the service and saved
+/// would overwrite the developer's real <c>theme.json</c>. That is the exact data loss that hit
+/// <c>SpeedTestHistoryService</c> (#1734).
+/// <para>These run headless: <see cref="ThemeService.Apply"/> no-ops without an
+/// <c>Application.Current</c>, so <c>Load</c>/<c>SetPreset</c> can run in the test host. They assert the
+/// seam genuinely redirects the file AND that the real profile path is never touched.</para>
+/// </summary>
+public class ThemeServiceTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "smtest_theme_" + Guid.NewGuid().ToString("N"));
+
+    public ThemeServiceTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch (IOException) { /* a leftover temp dir must never fail a run */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private string ThemeFile => Path.Combine(_dir, "theme.json");
+
+    [Fact]
+    public void SetPreset_WritesToTheConfiguredDirectory_NotTheRealProfile()
+    {
+        var realPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "SysManager", "theme.json");
+        var existedBefore = File.Exists(realPath);
+        var contentBefore = existedBefore ? File.ReadAllText(realPath) : null;
+
+        var svc = new ThemeService(_dir);
+        svc.SetPreset("deep-ocean");
+
+        // The choice landed in the temp file…
+        Assert.True(File.Exists(ThemeFile), "the theme was not written to the configured directory");
+        Assert.Contains("deep-ocean", File.ReadAllText(ThemeFile));
+
+        // …and the developer's real theme.json is byte-for-byte what it was (untouched, not created).
+        Assert.Equal(existedBefore, File.Exists(realPath));
+        if (existedBefore) Assert.Equal(contentBefore, File.ReadAllText(realPath));
+    }
+
+    [Fact]
+    public void Initialize_ReadsBackWhatWasSaved()
+    {
+        // A first instance persists a choice…
+        new ThemeService(_dir).SetPreset("dark-forest");
+
+        // …and a second, pointed at the same directory, loads it on Initialize.
+        var reloaded = new ThemeService(_dir);
+        reloaded.Initialize();
+
+        Assert.Equal("dark-forest", reloaded.CurrentPresetId);
+    }
+
+    [Fact]
+    public void Initialize_WithNoFile_KeepsTheDefaultPreset()
+    {
+        var svc = new ThemeService(_dir);   // empty temp dir, no theme.json
+        svc.Initialize();
+
+        Assert.Equal("midnight-indigo", svc.CurrentPresetId);
+        Assert.False(File.Exists(ThemeFile), "Initialize must not create a file when none exists");
+    }
+
+    [Fact]
+    public void SetShade_PersistedValue_SurvivesAReload()
+    {
+        var svc = new ThemeService(_dir);
+        svc.SetPreset("deep-ocean");
+        // SetShade debounces its save behind a DispatcherTimer, which never ticks headless; SetPreset
+        // saves immediately, so persist the shade by re-selecting the preset after moving it.
+        svc.SetShade(0.8);
+        svc.SetPreset("deep-ocean");
+
+        var reloaded = new ThemeService(_dir);
+        reloaded.Initialize();
+
+        Assert.Equal(0.8, reloaded.ShadePosition, precision: 3);
+    }
+}

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -17,9 +17,7 @@ public sealed class ThemeService
     private static ThemeService? _instance;
     public static ThemeService Instance => _instance ??= new ThemeService();
 
-    private static readonly string SettingsPath = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-        "SysManager", "theme.json");
+    private readonly string _settingsPath;
 
     public event Action? ThemeChanged;
 
@@ -50,7 +48,22 @@ public sealed class ThemeService
     private static readonly Dictionary<string, string> LightToDark =
         DarkToLight.ToDictionary(kv => kv.Value, kv => kv.Key);
 
-    private ThemeService() { }
+    /// <summary>
+    /// Production goes through <see cref="Instance"/>, which passes null and lands on the real
+    /// <c>%AppData%\SysManager\theme.json</c> (ROAMING, where this file has always lived — changing it
+    /// would strand a user's saved theme). The <paramref name="configDir"/> seam exists so a test can
+    /// point the service at a temp directory instead of the developer's real theme; without it, every
+    /// test that constructed the service and saved would overwrite that file, the same class of data
+    /// loss that hit SpeedTestHistoryService (#1734, #1741). Internal because nothing outside the
+    /// assembly should build a second theme service — the app has exactly one, via <see cref="Instance"/>.
+    /// </summary>
+    internal ThemeService(string? configDir = null)
+    {
+        _settingsPath = Path.Combine(
+            configDir ?? Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "SysManager"),
+            "theme.json");
+    }
 
     public void Initialize()
     {
@@ -155,6 +168,12 @@ public sealed class ThemeService
 
     public void Apply(ThemePreset theme)
     {
+        // No running app means no resource dictionary to repaint — a no-op, not a crash. This is the one
+        // WPF touch-point in the service; guarding it lets Load/Initialize (and thus the persistence
+        // seam) run in a headless unit test, and is harmless in production where Application.Current is
+        // always set. Without it, every public entry point NPEs the moment it is reached off the UI app.
+        if (Application.Current is null) return;
+
         var res = Application.Current.Resources;
         SetBrush(res, "Surface0", theme.Background);
         SetBrush(res, "Surface1", theme.Surface);
@@ -356,13 +375,13 @@ public sealed class ThemeService
     {
         try
         {
-            var dir = Path.GetDirectoryName(SettingsPath)!;
+            var dir = Path.GetDirectoryName(_settingsPath)!;
             Directory.CreateDirectory(dir);
             var data = new ThemeSettings(CurrentPresetId, CurrentMode, ShadePosition,
                 CurrentTheme.Accent.ToString(), CurrentTheme.Background.ToString(),
                 CurrentTheme.Surface.ToString(), CurrentTheme.TextPrimary.ToString());
             var json = JsonSerializer.Serialize(data, JsonDefaults.Indented);
-            AtomicFile.WriteAllText(SettingsPath, json);
+            AtomicFile.WriteAllText(_settingsPath, json);
         }
         catch (Exception ex) { Log.Debug("Theme save failed: {Error}", ex.Message); }
     }
@@ -371,8 +390,8 @@ public sealed class ThemeService
     {
         try
         {
-            if (!File.Exists(SettingsPath)) return;
-            var json = File.ReadAllText(SettingsPath);
+            if (!File.Exists(_settingsPath)) return;
+            var json = File.ReadAllText(_settingsPath);
             var data = JsonSerializer.Deserialize<ThemeSettings>(json);
             if (data is null) return;
 


### PR DESCRIPTION
## Why

`ThemeService` held its settings path in a `static readonly SettingsPath` built from
`Environment.SpecialFolder.ApplicationData`. That known-folder API **ignores the `APPDATA` environment
variable** (verified in #1741), so no test could point the service at a temp directory — any test that
constructed it and saved would overwrite the developer's real `theme.json`. It is the same
untestable-static-path class that already caused data loss in `SpeedTestHistoryService` (#1734), and
the last instance-backed offender on the
`ArchitectureTests.Services_DoNotHoldUserDataPathsInStaticFields` ratchet.

## What

- The path moves to an instance field set from the shared `string? configDir = null` constructor seam
  the other persistence services already use. Production is unchanged: it reaches the service through
  the `Instance` singleton, which passes null → the real `%AppData%\SysManager\theme.json` (ROAMING, as
  before). The ctor is `internal` because the app has exactly one theme service.
- `ThemeService.SettingsPath` comes off the ratchet's known-list, leaving only `LogService` — a
  `static partial class` by Serilog-sink design, which needs a genuine design decision (drop the
  static-sink model), not a mechanical edit, and which no test constructs (lowest risk).
- **One enabling change:** `Apply()` now no-ops when `Application.Current is null` instead of throwing.
  It is the service's single WPF touch-point, reached from every public entry, so guarding it is what
  lets the persistence path run in a headless unit test. Harmless in production, where
  `Application.Current` is always set; a no-op is the correct behaviour when there is no resource
  dictionary to repaint.

## Verification

New `ThemeServiceTests`, headless:

- `SetPreset` writes to the configured directory **and leaves the real profile byte-for-byte untouched**
  (the actual data-loss guard);
- a second instance pointed at the same directory reads the choice back;
- an empty directory keeps the default and creates no file;
- a shade value survives a reload.

**Red proof: 3 mutations, both touched source files restored byte-for-byte.**

| Mutation | Must go red |
|---|---|
| ignore `configDir`, hard-code the real `%AppData%` path (the shipped defect) | `SetPreset_WritesToTheConfiguredDirectory_NotTheRealProfile` |
| re-introduce a static user-data path anywhere in `Services` | the ratchet |
| remove the `Apply` null-guard (throws again headless) | all the headless theme tests |

The read-back and shade tests deliberately do **not** discriminate the path mutation — they round-trip
over whatever single path both instances share — which is why the "…NotTheRealProfile" test is the
load-bearing one for #1741.

Behaviour in the running app is identical, so this is `refactor:` — all four projects build 0/0,
`dotnet format --verify-no-changes` exit 0 on both, author headers present, leak scan over all 32 terms
gives 0 hits. No version bump, no release.
