### PR TITLE
ci: verify the published binary reports the tag before anything is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,43 @@ jobs:
           Rename-Item $src -NewName $newName
           Write-Host "Renamed to publish/$newName"
 
+      - name: Verify the embedded version stamp
+        shell: pwsh
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # publish.ps1 injects Version, FileVersion and AssemblyVersion from the tag, and until now
+          # nothing ever looked at what actually landed in the binary — ci.yml only checks that the
+          # three csproj values agree with EACH OTHER, which says nothing about the artifact. A
+          # broken injection would ship a binary that misreports itself in About, in the bug-report
+          # URL, in the profile export, in the system report, and worst of all in the update check:
+          # AboutViewModel compares UpdateService.CurrentVersion against the newest release, so a
+          # stale stamp offers every user the same update forever, or hides a real one.
+          #
+          # Placed before the SBOM and the attestation on purpose. Attesting is a public, signed
+          # claim about a specific binary; making that claim about a mis-stamped one and retracting
+          # it afterwards is far worse than never making it.
+          $exe = Resolve-Path "publish/SysManager-v$env:VERSION.exe"
+          $info = (Get-Item $exe).VersionInfo
+
+          # publish.ps1 appends a fourth component to FileVersion (-p:FileVersion=$Version.0).
+          if ($info.FileVersion -ne "$env:VERSION.0") {
+              throw "FileVersion drift: the binary reports '$($info.FileVersion)' but the tag " +
+                    "requires '$env:VERSION.0'. The version injection in publish.ps1 did not take, " +
+                    "so this artifact would misreport itself to every user. Not publishing it."
+          }
+
+          # ProductVersion is the informational version. ContinuousIntegrationBuild + SourceLink
+          # suffix it with '+<commit sha>', so compare only the part before the '+' — and keep the
+          # whole value in the log, because it is where the artifact records the commit it came from.
+          $product = ($info.ProductVersion -split '\+')[0]
+          if ($product -ne $env:VERSION) {
+              throw "ProductVersion drift: the binary reports '$($info.ProductVersion)' but the " +
+                    "tag requires '$env:VERSION'. Not publishing it."
+          }
+
+          Write-Host "Version resource matches the tag: FileVersion $($info.FileVersion), ProductVersion $($info.ProductVersion)."
+
       - name: Compute SHA256
         id: hash
         shell: pwsh
@@ -289,6 +326,35 @@ jobs:
               throw "The published exe recorded a crash marker during startup. It survived the " +
                     "25-second window but faulted, so this release must not be published."
           }
+
+          # The version the RUNNING app reports, which is a different property from the version
+          # resource checked before the SBOM. About, the update check, the bug-report URL, the
+          # profile export and the system report all read UpdateService.CurrentVersion — the managed
+          # assembly version, which is absent from the Win32 resource and cannot be read out of a
+          # single-file bundle (AssemblyName.GetAssemblyName throws on the apphost). This launch is
+          # the only place it is observable, so it is asserted here rather than by starting the app a
+          # second time just to ask.
+          if (-not $log) {
+              throw "No log file was produced, so the version the running app reports could not be " +
+                    "verified. LogService.Init writes the startup line before any window appears, " +
+                    "so its absence is itself a failure."
+          }
+
+          $expected = "SysManager $env:VERSION started"
+          $startup = Get-Content $log.FullName |
+                     Where-Object { $_ -match '\[INF\] SysManager .* started' } |
+                     Select-Object -First 1
+          if (-not $startup) {
+              throw "The log has no 'SysManager <version> started' line, so nothing here verified " +
+                    "the version. Either LogService.StartupMessage changed shape — update this gate " +
+                    "in the same PR, do not delete it — or the app never got as far as logging it."
+          }
+          if ($startup -notlike "*$expected*") {
+              throw "Runtime version drift: the app logged '$($startup.Trim())' but the tag requires " +
+                    "'$expected'. The assembly version injection did not take, so About and the " +
+                    "update check would misreport this build. Not publishing it."
+          }
+          Write-Host "The running app reports version $env:VERSION."
 
           Write-Host "The published exe started, stayed alive for 25s and recorded no crash."
 

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2119,6 +2119,131 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// The release workflow must prove the artifact reports the tag it was built from — statically,
+    /// and again at runtime.
+    /// <para>publish.ps1 injects Version, FileVersion and AssemblyVersion from the tag and nothing
+    /// downstream ever read them back. ci.yml checks that the three csproj values agree with each
+    /// OTHER, which says nothing about the binary. A silently broken injection ships a build that
+    /// misreports itself in About, in the bug-report URL, in the profile export and in the system
+    /// report — and in the update check, where AboutViewModel compares UpdateService.CurrentVersion
+    /// against the newest release, so a stale stamp offers every user the same update forever or
+    /// hides a real one.</para>
+    /// <para>Two assertions, because two different values are at risk. The Win32 version resource
+    /// (FileVersion/ProductVersion) is readable without running anything, so it is checked before the
+    /// SBOM and the attestation: attesting a mis-stamped binary is a signed public claim that cannot
+    /// be taken back. The managed assembly version — the one every user-visible version actually
+    /// reads — is NOT in that resource, and AssemblyName.GetAssemblyName throws on a single-file
+    /// apphost, so the only place it is observable is the startup line in the log of the launch the
+    /// smoke check already performs.</para>
+    /// <para>The expected log shape is DERIVED from <see cref="LogService.StartupMessage"/> rather
+    /// than written out again here, so the workflow's pattern and the app's message cannot drift into
+    /// a gate that greps for a line the app no longer writes.</para>
+    /// </summary>
+    [Fact]
+    public void TheReleaseWorkflow_ProvesThePublishedBinaryReportsTheTag()
+    {
+        var lines = File.ReadAllLines(
+            Path.Combine(FindRepoRoot(), ".github", "workflows", "release.yml"));
+
+        int StepLine(string name)
+        {
+            var at = Array.FindIndex(lines, l => l.Trim() == $"- name: {name}");
+            Assert.True(at >= 0,
+                $"release.yml has no step named \"{name}\". If it was renamed, update this guard in the "
+                + "same PR — do not delete it.");
+            return at;
+        }
+
+        // Sliced to the step's OWN boundary and required to be substantial: a collapsed slice would
+        // make every token check below pass by measuring nothing.
+        string CodeOf(string step, int at)
+        {
+            var end = Array.FindIndex(lines, at + 1,
+                l => l.TrimStart().StartsWith("- name:", StringComparison.Ordinal));
+            Assert.True(end > at,
+                $"\"{step}\" is the last step in the file, so its slice is unbounded and this guard "
+                + "would measure the rest of the workflow instead of the step.");
+            // Comment lines are dropped before any assertion. This step's own explanation names
+            // FileVersion, ProductVersion and the assembly version, so a Contains against the raw
+            // slice would be satisfied by the prose describing the check rather than the check.
+            var code = string.Join('\n', lines[at..end]
+                .Where(l => !l.TrimStart().StartsWith('#')));
+            Assert.True(code.Length > 300,
+                $"the code in \"{step}\" is only {code.Length} characters once comments are removed — "
+                + "the check has been reduced to its own description.");
+            return code;
+        }
+
+        var rename = StepLine("Rename exe with version");
+        var stamp = StepLine("Verify the embedded version stamp");
+        var sbom = StepLine("Generate CycloneDX SBOM");
+        var attest = StepLine("Attest build provenance");
+        var smoke = StepLine("Smoke-check the published exe");
+        var release = StepLine("Create GitHub Release");
+
+        Assert.True(stamp > rename,
+            $"the stamp check (line {stamp + 1}) runs before the exe is named (line {rename + 1}), so "
+            + "the file it resolves does not exist yet.");
+        foreach (var (step, at) in new[] { ("Generate CycloneDX SBOM", sbom),
+                                           ("Attest build provenance", attest),
+                                           ("Create GitHub Release", release) })
+        {
+            Assert.True(stamp < at,
+                $"the stamp check (line {stamp + 1}) runs AFTER \"{step}\" (line {at + 1}). The "
+                + "attestation is a signed public claim about a specific binary — it must never be "
+                + "made about one whose version was not verified first.");
+        }
+
+        var stampCode = CodeOf("Verify the embedded version stamp", stamp);
+        foreach (var required in new[] { "VersionInfo", "FileVersion", "ProductVersion" })
+        {
+            Assert.Contains(required, stampCode, StringComparison.Ordinal);
+        }
+
+        // Both halves must be able to FAIL the job. One throw would leave whichever value lost its
+        // verdict silently unverified, which is the state this whole guard exists to end.
+        var stampThrows = stampCode.Split('\n').Count(l => l.Contains("throw ", StringComparison.Ordinal));
+        Assert.True(stampThrows >= 2,
+            $"the stamp check raises on only {stampThrows} verdict(s); it must fail the job for a wrong "
+            + "FileVersion AND for a wrong ProductVersion.");
+        Assert.DoesNotContain("continue-on-error", stampCode, StringComparison.Ordinal);
+        Assert.DoesNotContain("Write-Warning", stampCode, StringComparison.Ordinal);
+
+        // The runtime half lives inside the smoke check because that is where the app is running.
+        var smokeCode = CodeOf("Smoke-check the published exe", smoke);
+        Assert.Contains(
+            LogService.StartupMessage.Replace("{Version}", ".*", StringComparison.Ordinal),
+            smokeCode, StringComparison.Ordinal);
+        Assert.Contains(
+            LogService.StartupMessage.Replace("{Version}", "$env:VERSION", StringComparison.Ordinal),
+            smokeCode, StringComparison.Ordinal);
+        Assert.DoesNotContain("Write-Warning", smokeCode, StringComparison.Ordinal);
+
+        // A missing log or a missing startup line must be a failure, not a silent pass — an absent
+        // line is indistinguishable from a matching one to any check that only compares when it
+        // finds something.
+        var startupChecks = smokeCode.Split('\n')
+            .Count(l => l.Contains("throw ", StringComparison.Ordinal));
+        Assert.True(startupChecks >= 6,
+            $"the smoke check raises on only {startupChecks} verdict(s). Three belong to the launch "
+            + "(self-exit, crash marker, will not die) and three to the version (no log, no startup "
+            + "line, wrong version) — an unverifiable version must fail rather than pass quietly.");
+
+        // Finally, the app side of the contract: the gate can only read a version out of the log
+        // while Init still puts one there.
+        Assert.StartsWith("SysManager ", LogService.StartupMessage, StringComparison.Ordinal);
+        Assert.Contains("{Version}", LogService.StartupMessage, StringComparison.Ordinal);
+
+        var initCall = File.ReadAllLines(
+                Path.Combine(FindRepoRoot(), "SysManager", "SysManager", "Services", "LogService.cs"))
+            .Where(l => !l.TrimStart().StartsWith("//", StringComparison.Ordinal))
+            .FirstOrDefault(l => l.Contains("Information(StartupMessage", StringComparison.Ordinal));
+        Assert.False(initCall is null,
+            "LogService no longer logs StartupMessage, so the release gate reads a line nobody writes.");
+        Assert.Contains("UpdateService.CurrentVersion", initCall!, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// No style may suppress the keyboard focus indicator without providing a replacement.
     /// <para><c>FocusVisualStyle="{x:Null}"</c> removes the only cue a keyboard user has, and four
     /// styles did exactly that with nothing in its place: ButtonBase, ToggleSwitch, DataGridCell and

--- a/SysManager/SysManager.Tests/LogServiceSinkScrubbingTests.cs
+++ b/SysManager/SysManager.Tests/LogServiceSinkScrubbingTests.cs
@@ -197,6 +197,28 @@ public sealed class LogServiceSinkScrubbingTests : IDisposable
         Assert.All(lines, line => Assert.Matches(@"\[INF\] Line \d+ at ", line));
     }
 
+    // ── The startup line names the build ─────────────────────────────────────
+    // release.yml greps this line to prove the published binary reports the tag it was built from.
+    // It has to be read out of the log because the value at risk is the managed assembly version —
+    // what UpdateService.CurrentVersion returns, and so what About, the update check, the
+    // bug-report URL, the profile export and the system report all show. That version is absent
+    // from the Win32 version resource and AssemblyName.GetAssemblyName cannot read it out of a
+    // single-file bundle (it throws), so a launch is the only place it is observable. That makes
+    // the rendered shape of this one line a contract with CI, not just cosmetics.
+
+    [Fact]
+    public void TheStartupLine_RendersTheVersionUnquoted()
+    {
+        // `{Message:lj}` renders string properties literally, so the line reads
+        // "SysManager 1.65.19 started" and not "SysManager \"1.65.19\" started". The release gate
+        // matches the bare form; a quoted version would break it, and would read as a placeholder
+        // rather than a build in an attached support log.
+        var text = WriteAndRead(log => log.Information(LogService.StartupMessage, "1.65.19"));
+
+        Assert.Contains("SysManager 1.65.19 started", text);
+        Assert.DoesNotContain("\"1.65.19\"", text);
+    }
+
     // ── The log file is bounded ──────────────────────────────────────────────
     // The sink passed no fileSizeLimitBytes and no rollOnFileSizeLimit, so it took Serilog's
     // defaults: 1 GB per file with rolling OFF. The only bound on the folder was the 14-FILE count,

--- a/SysManager/SysManager/Services/LogService.cs
+++ b/SysManager/SysManager/Services/LogService.cs
@@ -27,6 +27,15 @@ public static partial class LogService
     /// <summary>How many rolled files to keep. Combines with <see cref="MaxLogFileBytes"/>.</summary>
     internal const int RetainedFileCount = 14;
 
+    /// <summary>
+    /// First line of every log file. Held as a constant because two other things depend on its exact
+    /// shape: a bug report arrives as an attached log (SUPPORT.md), so the file has to name the build
+    /// it came from, and the release workflow greps this line to prove the published binary reports
+    /// the tag it was built from — the managed assembly version is not in the Win32 version resource
+    /// and cannot be read out of a single-file bundle without running it.
+    /// </summary>
+    internal const string StartupMessage = "SysManager {Version} started";
+
     public static string LogDir { get; } =
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager", "logs");
 
@@ -72,7 +81,9 @@ public static partial class LogService
                 retainedFileCountLimit: RetainedFileCount))
             .CreateLogger();
         Log.Logger = Logger;
-        Logger.Information("SysManager started");
+        // The same source the About tab and the updater read, so a log, a crash marker and a release
+        // can all be matched to one another rather than guessed at.
+        Logger.Information(StartupMessage, UpdateService.CurrentVersion.ToString(3));
     }
 
     /// <summary>


### PR DESCRIPTION
## What does this PR do?

Closes the second half of #1658. The first half shipped in #1885 — the release job now launches the
exe and proves it starts. Nothing ever checked what version that exe reports.

`publish.ps1` injects `Version`, `FileVersion` and `AssemblyVersion` from the tag, and nothing
downstream read them back. `ci.yml:98-104` checks that the three csproj values agree with *each
other*, which says nothing about the artifact. A silently broken injection publishes a binary that
misreports itself in About, in the bug-report URL, in the profile export and in the system report —
and in the update check, where `AboutViewModel:264` compares `UpdateService.CurrentVersion` against
the newest release, so a stale stamp offers every user the same update forever or hides a real one.

Two different values are at risk, so there are two assertions.

**Static — new step, `Verify the embedded version stamp`.** The Win32 version resource is readable
without running anything: `FileVersion` must equal `<tag>.0`, and `ProductVersion` (informational,
which SourceLink suffixes with `+<sha>` on a `ContinuousIntegrationBuild`) must equal the tag before
the `+`. Placed right after the rename and **before the SBOM and the attestation** — attesting is a
signed public claim about a specific binary, and making it about a mis-stamped one cannot be retracted.

**Runtime — inside the existing smoke check.** The managed assembly version is the one every
user-visible version actually reads, it is *not* in the Win32 resource, and
`AssemblyName.GetAssemblyName` throws on a single-file apphost (verified locally). The only place it
is observable is a running process, so the startup line is read out of the log of the launch the
smoke check already performs and compared to the tag. A missing log, or a missing startup line, fails
the job — an absent line is otherwise indistinguishable from a matching one.

That needed the startup line to carry a version at all, which it did not: `LogService` logged a bare
`"SysManager started"`. It now logs the version from the same source About and the updater read. Side
benefit, and the reason it is worth doing beyond the gate: an attached support log finally names the
build it came from.

## Related issues

Closes #1658

## Type of change

- [x] CI / build (`ci:`)

Same classification as the sibling change that added the smoke check (`ci: run the exe before
publishing it`, #1885). No release, so no CHANGELOG entry and no version bump.

## Checklist

- [x] Branch created from `main`
- [x] Code compiles with 0 errors — all four projects, 0 warnings
- [x] `dotnet format --verify-no-changes` passes on both touched projects
- [x] Tests added/updated and passing locally
- [x] Author headers on all modified files
- [x] Self-review completed
- [x] README updated (if features changed) — n/a: no new service/VM/file, no tab change, no count
      claim. `ARCHITECTURE.md` does not enumerate release steps and `TESTING.md` covers the three
      test projects, so neither has a home for this.
- [x] No AI/IDE tool references

## How this was verified

Three proofs, because a guard that only checks the gate is *present* cannot show it *works*.

**1. The guard catches every way of weakening the gate** — 8 mutations, each expected test red, all
files restored byte-for-byte afterwards:

| Mutation | Red |
|---|---|
| stamp step moved to just before the announcement | guard |
| `ProductVersion` verdict downgraded to `Write-Host` | guard |
| `continue-on-error: true` on the stamp step | guard |
| whole `FileVersion` verdict commented out (prose still names it) | guard |
| runtime assertion deleted from the smoke check | guard |
| `StartupMessage` reverted to the unversioned line | guard **+** render test |
| `{Message:lj}` → `{Message:j}` (version comes out quoted) | render test |
| call site passes a literal instead of `UpdateService.CurrentVersion` | guard |

**2. The shipped static check discriminates on real binaries.** The step body is extracted verbatim
from `release.yml` — never a retyped copy — and run against published artifacts:

- a binary stamped `9.9.9` checked as `9.9.9` → exit 0
- the same binary presented as `1.65.19` → exit 1, `FileVersion drift`
- a binary deliberately built with `FileVersion 9.9.9.0` but `Version 8.8.8`, checked as `9.9.9` →
  exit 1, `ProductVersion drift`

The third case is what proves the second verdict is not dead code.

**3. The shipped runtime check discriminates.** The version block is extracted from the smoke step
(asserted to contain no `Start-Process`, so the extraction cannot launch the app) and driven against
log fixtures: matching version → exit 0; drifted version → `Runtime version drift`; log with no
startup line → fails; no log at all → fails.

Local proof runs used Windows PowerShell 5.1 (`pwsh` is not installed on that machine). The
constructs used are identical in both hosts, and the em-dashes in the new strings follow the pattern
already shipping in this file (`release.yml:41,51,54,102,221,558,672`).

## Deliberately not in scope

The workflow still does not re-verify its own published SHA256 or its attestation in-job. Both are
covered by the manual post-release ritual; folding them in is a separate change.