### PR TITLE
test: pin the default output-device entry as the clear-the-override path

### DIFF
--- a/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
@@ -240,6 +240,90 @@ public class AudioMixerViewModelTests
         Assert.Contains(row.SelectedOutputDevice, row.OutputDevices);
     }
 
+    // ── The default entry means "follow the system default", in both directions ──────────
+    // The picker holds real endpoints only — there is no "System default" item — so the entry flagged
+    // IsDefault carries that meaning instead, and an empty endpoint id is the pivot. Reading, an empty
+    // id selects that entry; writing, selecting that entry sends an empty id, which is what
+    // SetPersistedDefaultAudioEndpoint treats as CLEAR THE OVERRIDE.
+    //
+    // Nothing pinned either direction. `value.IsDefault ? string.Empty : value.Id` reads like a needless
+    // special case, and simplifying it to `value.Id` compiles, keeps every existing test green, and
+    // silently removes the only way a user can stop routing an app — the override would stay in Windows
+    // forever, re-pinned to whichever device is default at the time of the pick. Same
+    // invisible-capability-loss class as a command bound by no XAML.
+    //
+    // Calls are captured inside the stub rather than asserted with Received(n), for the reason the
+    // neighbouring test gives: an NSubstitute substitute is not thread-safe.
+
+    private static IAudioMixerService RoutableService(
+        List<(string Session, string Device)> writes, string? route = null)
+    {
+        var service = ServiceWith(Session("s1"));
+        service.IsRoutingSupported.Returns(true);
+        service.GetRenderDevices().Returns(_ => new List<AudioDevice> { Speakers, Headset });
+        if (route is not null) service.GetSessionOutputDevice("s1").Returns(route);
+        service.SetSessionOutputDevice(Arg.Any<string>(), Arg.Any<string>()).Returns(call =>
+        {
+            writes.Add(((string)call[0], (string)call[1]));
+            return true;
+        });
+        return service;
+    }
+
+    /// <summary>
+    /// Routing an app to a device and then putting it back on the default must CLEAR the override, not pin
+    /// the app to whichever device happens to be default right now.
+    /// <para>Goes headset-then-default rather than selecting the default directly: the row is built with the
+    /// default already selected (the service's route-read is a stub returning empty), so assigning it again
+    /// is not a property change, the write path would never run, and the test would pass while asserting
+    /// nothing.</para>
+    /// </summary>
+    [Fact]
+    public void PuttingAnAppBackOnTheDefaultDevice_ClearsTheOverride()
+    {
+        var writes = new List<(string Session, string Device)>();
+        using var vm = NewVm(RoutableService(writes));
+        var row = vm.Sessions.Single();
+
+        row.SelectedOutputDevice = row.OutputDevices.Single(d => d.Id == "{hdst}");
+        row.SelectedOutputDevice = row.OutputDevices.Single(d => d.IsDefault);
+
+        Assert.Equal([("s1", "{hdst}"), ("s1", "")], writes);
+    }
+
+    /// <summary>
+    /// A real device keeps its own endpoint id on the way to the service — the clear-the-override branch
+    /// must not swallow an ordinary pick.
+    /// </summary>
+    [Fact]
+    public void RoutingAnAppToANonDefaultDevice_SendsThatDevicesEndpointId()
+    {
+        var writes = new List<(string Session, string Device)>();
+        using var vm = NewVm(RoutableService(writes));
+
+        vm.Sessions.Single().SelectedOutputDevice = Headset;
+
+        Assert.Equal([("s1", "{hdst}")], writes);
+    }
+
+    /// <summary>
+    /// The read mirror: a route the service cannot resolve selects the default entry, and doing so must NOT
+    /// write back. A refresh that echoed its own snapshot would re-assert a route on every pass, and on the
+    /// failure branch would report a routing error the user never caused.
+    /// </summary>
+    [Theory]
+    [InlineData("", "the route-read stub returns empty, so nothing is known about this app's route")]
+    [InlineData("{unplugged}", "the persisted route names a device that is no longer present")]
+    public void ARouteTheServiceCannotResolve_SelectsTheDefaultEntry_AndWritesNothing(string route, string why)
+    {
+        var writes = new List<(string Session, string Device)>();
+        using var vm = NewVm(RoutableService(writes, route));
+
+        var row = vm.Sessions.Single();
+        Assert.True(row.SelectedOutputDevice?.IsDefault, why);
+        Assert.Empty(writes);
+    }
+
     /// <summary>
     /// Devices must NOT be re-enumerated on every reconcile pass. Enumerating endpoints is COM-heavy and
     /// reconcile runs at 1 Hz; trading a stale list for that every second would be a worse bug than the one

--- a/SysManager/SysManager/Services/AudioPolicyConfig.cs
+++ b/SysManager/SysManager/Services/AudioPolicyConfig.cs
@@ -84,8 +84,18 @@ internal static class AudioPolicyConfigFactory
 
     /// <summary>
     /// Route-read is intentionally not attempted (its out-string marshaling is the most build-variant
-    /// slot); the UI shows "System default" and lets the user pick. Returns null. Kept as the seam so
-    /// a future, verified read path can slot in without changing callers.
+    /// slot). Returns null. Kept as the seam so a future, verified read path can slot in without
+    /// changing callers.
+    /// <para>What the null actually produces, because the previous note here said "the UI shows
+    /// <c>System default</c>" and that is not what happens: <c>AudioMixerService.GetSessionOutputDevice</c>
+    /// turns it into an empty id, and <c>AudioSessionRowViewModel.SetOutputDeviceFromService</c> resolves an
+    /// empty id to the entry flagged <c>IsDefault</c> — so the picker preselects the current default device
+    /// BY NAME. There is no "System default" item; the list holds real endpoints only. An app genuinely
+    /// routed elsewhere is therefore indistinguishable from one following the default (#1585).</para>
+    /// <para>The empty id is the pivot in both directions: selecting the <c>IsDefault</c> entry sends empty
+    /// back through <c>SetPersistedDefaultAudioEndpoint</c>, which CLEARS the override. That makes the
+    /// default entry the only way a user can stop routing an app, which is why the round trip is pinned by
+    /// tests rather than left to this comment.</para>
     /// </summary>
     public static string? GetPersistedDefaultEndpoint(object policyConfig, uint processId)
     {


### PR DESCRIPTION
## What does this PR do?

Volume Control's output picker holds **real endpoints only** — there is no "System default" item — so
the entry flagged `IsDefault` carries that meaning instead, and an empty endpoint id is the pivot in
both directions:

- **Read:** `AudioSessionRowViewModel.SetOutputDeviceFromService` resolves an empty id to the
  `IsDefault` entry (`:238-241`).
- **Write:** `OnSelectedOutputDeviceChanged` sends `string.Empty` when the picked entry `IsDefault`
  (`:209`), and `SetPersistedDefaultAudioEndpoint` treats empty as **clear the override**
  (`AudioPolicyConfig.cs:97-100`).

So the default entry is **the only way a user can stop routing an app**, and nothing pinned it.
`value.IsDefault ? string.Empty : value.Id` reads like a needless special case; simplifying it to
`value.Id` compiles, keeps every pre-existing test green, and silently removes that capability — the
override would stay in Windows forever, re-pinned to whichever device was default at the time of the
pick. Same invisible-capability-loss class as a command bound by no XAML.

Three tests, four cases:

| Test | Pins |
|---|---|
| `PuttingAnAppBackOnTheDefaultDevice_ClearsTheOverride` | the sequence is `("{hdst}")` then `("")` |
| `RoutingAnAppToANonDefaultDevice_SendsThatDevicesEndpointId` | an ordinary pick keeps its own id |
| `ARouteTheServiceCannotResolve_SelectsTheDefaultEntry_AndWritesNothing` ×2 | empty **and** gone-device routes select the default entry and write **nothing** |

The clear test goes headset-then-default rather than selecting the default directly: the row is
constructed with the default already selected (the route-read is a stub returning empty), so
assigning it again is not a property change, the write path would never run, and the test would pass
while asserting nothing.

Also corrects the note on `GetPersistedDefaultEndpoint`. It claimed "the UI shows `System default`",
which is **not** what happens — the null becomes an empty id and the picker preselects the current
default device **by name**, so an app genuinely routed elsewhere is indistinguishable from one
following the default. That is the live half of #1585 and the comment was pointing away from it.

## Related issues

Partially addresses #1658's neighbour #1585 — see the note below. Not closed.

## Type of change

- [x] Tests (`test:`)

## Checklist

- [x] Branch created from `main`
- [x] Code compiles with 0 errors — all four projects, 0 warnings
- [x] `dotnet format --verify-no-changes` passes on both touched projects
- [x] Tests added/updated and passing locally — audio class 55 green, 0 red; with `AudioPolicyConfigTests`
      + `ArchitectureTests`, 105 green
- [x] Author headers on all modified files
- [x] Self-review completed
- [x] README updated (if features changed) — n/a, no behaviour change
- [x] No AI/IDE tool references

## How this was verified

Five mutations, each expected test red, file restored byte-for-byte:

| Mutation | Red | Shows |
|---|---|---|
| `value.IsDefault ? string.Empty : value.Id` → `value.Id` | clear test **only** | the plausible simplification is caught, and the ordinary-pick test is not what catches it |
| always send `string.Empty` | pick test (+ clear) | the ordinary-pick test discriminates too, rather than passing on any write |
| empty id → `null` instead of the default entry | read row `""` **only** | |
| unknown-id fallback dropped | read row `{unplugged}` **only** | the two Theory rows cover different branches, not one twice |
| echo suppression removed from the read path | all four | the read path would write its own snapshot back |

Mutations 1, 3 and 4 each fire exactly one case, so every branch is individually pinned rather than
covered by one blanket assertion.

## What this deliberately does NOT do

`AudioPolicyConfigFactory.GetPersistedDefaultEndpoint` is still a stub returning `null`
(`AudioPolicyConfig.cs:90-95`), so the picker still cannot show an app's *actual* persisted route —
the live half of #1585. Implementing it means adding an undocumented COM vtable slot whose
out-string marshaling is the most build-variant part of the interface, which is exactly why it was
skipped, and it cannot be exercised on a machine that never runs the app. The alternative — showing a
neutral placeholder instead of a device name — changes what the picker means and where the
clear-the-override action lives, which is a product decision rather than a mechanical fix. This PR
pins the contract that any such change must preserve, and #1585 keeps the decision.