### PR TITLE
fix: make row controls announce which row they act on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.20] - 2026-08-24
+
+Two fixes for anyone using SysManager with a screen reader. In Startup Manager, every row's "Open"
+button announced just the word "Open", so there was no way to hear which program you were about to
+open the folder for. In App Blocker, the tick box on each row announced nothing at all.
+
+### Fixed
+- **Startup Manager's per-row "Open" button now says which program it opens.** The button carries the
+  same label on every row, so a screen reader read out "Open" and nothing else — with dozens of
+  startup entries listed, that is a button you cannot safely press. It now announces "Open file
+  location for <program>", matching the on/off switch in the same row, which already named its entry.
+- **App Blocker's row tick boxes were announced as unlabelled.** The name was set on the column rather
+  than on the tick box itself. A column is a definition rather than something on screen, so the label
+  never reached the tick box that gets created for each row, and a screen reader had nothing to read.
+  Each one now announces "Select <program>". Six other tabs with the same kind of tick-box column were
+  already doing this correctly; App Blocker was the one that had been missed, and a test now fails the
+  build if a row control is unlabelled, or is labelled identically on every row.
+
 ## [1.65.19] - 2026-08-18
 
 A fix for the Duplicate Files finder: a stray minus sign or an enormous number typed into the

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2317,6 +2317,136 @@ public partial class ArchitectureTests
         Assert.DoesNotContain("Accent", ring, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Every control inside a DataGrid row must announce WHICH ROW it belongs to, and the name must be
+    /// somewhere an automation peer can actually read it.
+    /// <para>Two distinct defects, both of which look correct in the markup. App Blocker set
+    /// <c>AutomationProperties.Name="Select application"</c> on the <c>DataGridCheckBoxColumn</c> itself —
+    /// but a column is a definition, not a visual, so it has no automation peer and the generated
+    /// CheckBox in every cell stayed unlabelled. Startup Manager's per-row "Open" button had no name at
+    /// all, so all of its rows announced the single word "Open" with nothing to say which program would
+    /// be opened. A row control that announces the same thing on every row is barely better than one
+    /// that announces nothing: the user can hear it but cannot tell the rows apart.</para>
+    /// <para>Both populations are derived from the XAML tree rather than from a known list, so the next
+    /// column or the next row button is caught without editing this test. Attribute lookup is by local
+    /// name: <c>AutomationProperties.Name</c> is written unprefixed in XAML, so it arrives as a single
+    /// attribute whose name contains a dot.</para>
+    /// </summary>
+    [Fact]
+    public void EveryRowControl_AnnouncesTheRowItIsOn()
+    {
+        var appDir = FindAppProjectDir();
+        var files = Directory
+            .EnumerateFiles(appDir, "*.xaml", SearchOption.AllDirectories)
+            .Where(f => !Path.GetRelativePath(appDir, f)
+                .Split(Path.DirectorySeparatorChar)
+                .Any(segment => segment.Equals("obj", StringComparison.OrdinalIgnoreCase)
+                                || segment.Equals("bin", StringComparison.OrdinalIgnoreCase)))
+            .ToArray();
+        Assert.True(files.Length >= 60, $"only {files.Length} XAML files were found — fix this guard.");
+
+        static bool HasName(System.Xml.Linq.XElement e) =>
+            e.Attributes().Any(a => a.Name.LocalName == "AutomationProperties.Name");
+
+        static bool IsInsideAColumn(System.Xml.Linq.XElement e) =>
+            e.Ancestors().Any(a => a.Name.LocalName.EndsWith("Column", StringComparison.Ordinal));
+
+        var namedOnTheColumn = new List<string>();
+        var unnamedRowControls = new List<string>();
+        var sameOnEveryRow = new List<string>();
+        var columnsSeen = 0;
+        var namedRowControls = 0;
+        var rowNameSetters = 0;
+
+        foreach (var path in files)
+        {
+            var root = System.Xml.Linq.XDocument.Load(path).Root;
+            if (root is null) continue;
+            var file = Path.GetFileName(path);
+
+            foreach (var element in root.DescendantsAndSelf())
+            {
+                var name = element.Name.LocalName;
+
+                // A column definition. Its own Name reaches nothing.
+                if (name.EndsWith("Column", StringComparison.Ordinal)
+                    && !name.EndsWith("ColumnDefinition", StringComparison.Ordinal))
+                {
+                    columnsSeen++;
+                    if (HasName(element))
+                        namedOnTheColumn.Add($"{file} — <{name}> carries the name itself");
+                    continue;
+                }
+
+                // The ElementStyle form: a Setter reaching the control the column generates. This is
+                // where a CheckBox column's name belongs, and six columns already do it this way.
+                if (name == "Setter"
+                    && (string?)element.Attribute("Property") == "AutomationProperties.Name"
+                    && IsInsideAColumn(element))
+                {
+                    rowNameSetters++;
+                    var value = (string?)element.Attribute("Value") ?? "";
+                    if (!value.Contains("{Binding", StringComparison.Ordinal))
+                        sameOnEveryRow.Add($"{file} — <Setter> value \"{value}\"");
+                    continue;
+                }
+
+                // A pressable control living in a cell template.
+                if (name is not ("Button" or "ToggleButton" or "RepeatButton")) continue;
+                if (!IsInsideAColumn(element)) continue;
+
+                var declared = element.Attributes()
+                    .FirstOrDefault(a => a.Name.LocalName == "AutomationProperties.Name")?.Value;
+                if (declared is null)
+                {
+                    var content = (string?)element.Attribute("Content")
+                                  ?? (string?)element.Attribute("ToolTip")
+                                  ?? "(no Content)";
+                    unnamedRowControls.Add($"{file} — <{name}> \"{content}\"");
+                }
+                else
+                {
+                    namedRowControls++;
+                    if (!declared.Contains("{Binding", StringComparison.Ordinal))
+                        sameOnEveryRow.Add($"{file} — <{name}> name \"{declared}\"");
+                }
+            }
+        }
+
+        // Vacuity floors. Both checks are absence-based, so a selector that stopped matching would
+        // report a clean sweep of nothing at all.
+        Assert.True(columnsSeen >= 100,
+            $"only {columnsSeen} DataGrid columns were found across {files.Length} views — the element "
+            + "selector has stopped matching, so the column check below is measuring nothing.");
+        Assert.True(namedRowControls >= 10,
+            $"only {namedRowControls} named row controls were found — either the ancestor test or the "
+            + "attribute lookup has stopped matching, and the sweep proves nothing.");
+        Assert.True(rowNameSetters >= 10,
+            $"only {rowNameSetters} ElementStyle name setters were found — six checkbox columns carry a "
+            + "pair each, so a lower count means the Setter selector has stopped matching.");
+
+        Assert.True(namedOnTheColumn.Count == 0,
+            "AutomationProperties.Name is set on a DataGrid COLUMN, which is a definition rather than a "
+            + "visual: it has no automation peer, so the control generated in each cell is announced "
+            + "unlabelled. Move it into the column's ElementStyle (and EditingElementStyle for an "
+            + "editable column) as a Setter, where the row is the DataContext and the name can name "
+            + "it:\n  " + string.Join("\n  ", namedOnTheColumn));
+
+        Assert.True(unnamedRowControls.Count == 0,
+            "these controls sit in a DataGrid cell template with no accessible name, so every row "
+            + "announces the same word — or nothing — and a screen-reader user cannot tell which row "
+            + "the control belongs to. Bind the name to a property of the row, as the sibling columns "
+            + $"do:\n  " + string.Join("\n  ", unnamedRowControls));
+
+        // A constant name is the same defect one step later: present, readable, and identical on all
+        // forty rows, so it still cannot tell them apart. Every one of the existing names binds a row
+        // property, so this is the established shape rather than a new demand.
+        Assert.True(sameOnEveryRow.Count == 0,
+            "these row names are constants, so every row announces the same words and a screen-reader "
+            + "user still cannot tell which row the control acts on. Bind a property of the row "
+            + $"instead:\n  " + string.Join("\n  ", sameOnEveryRow));
+    }
+
     /// <summary>A style that suppresses the focus indicator outright.</summary>
     [GeneratedRegex(@"FocusVisualStyle""\s*Value=""\{x:Null\}""", RegexOptions.Compiled)]
     private static partial Regex NulledFocusVisual();

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.19</Version>
-    <FileVersion>1.65.19.0</FileVersion>
-    <AssemblyVersion>1.65.19.0</AssemblyVersion>
+    <Version>1.65.20</Version>
+    <FileVersion>1.65.20.0</FileVersion>
+    <AssemblyVersion>1.65.20.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AppBlockerView.xaml
+++ b/SysManager/SysManager/Views/AppBlockerView.xaml
@@ -88,8 +88,23 @@
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling">
             <DataGrid.Columns>
-                <DataGridCheckBoxColumn Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" Width="40" MinWidth="40" CanUserResize="False"
-                                        AutomationProperties.Name="Select application" />
+                <DataGridCheckBoxColumn Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" Width="40" MinWidth="40" CanUserResize="False">
+                    <!-- The name has to sit on the generated CheckBox, not on the column: a
+                         DataGridColumn is a definition, not a visual, so a name set there reaches no
+                         automation peer and a screen reader announces an unlabelled checkbox. Named
+                         per row as well, so 40 identical "Select application" checkboxes become the
+                         one the user is actually on. Same shape as AppUpdatesView. -->
+                    <DataGridCheckBoxColumn.ElementStyle>
+                        <Style TargetType="CheckBox">
+                            <Setter Property="AutomationProperties.Name" Value="{Binding ExecutableName, StringFormat='Select {0}'}"/>
+                        </Style>
+                    </DataGridCheckBoxColumn.ElementStyle>
+                    <DataGridCheckBoxColumn.EditingElementStyle>
+                        <Style TargetType="CheckBox">
+                            <Setter Property="AutomationProperties.Name" Value="{Binding ExecutableName, StringFormat='Select {0}'}"/>
+                        </Style>
+                    </DataGridCheckBoxColumn.EditingElementStyle>
+                </DataGridCheckBoxColumn>
                 <DataGridTextColumn Header="Executable" Binding="{Binding ExecutableName}" Width="*" MinWidth="120" IsReadOnly="True" />
             </DataGrid.Columns>
         </DataGrid>

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -245,9 +245,13 @@
                     <DataGridTemplateColumn Header="" Width="80" MinWidth="80" CanUserSort="False" CanUserResize="False">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
+                                <!-- Named per row like the toggle above it: "Open" alone is what every
+                                     row announced, so a screen reader user heard the same word on all
+                                     of them with nothing to say which program it opens. -->
                                 <Button Content="Open" ToolTip="Open file location"
                                         Command="{Binding DataContext.OpenFileLocationCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                         CommandParameter="{Binding}"
+                                        AutomationProperties.Name="{Binding Name, StringFormat='Open file location for {0}'}"
                                         Style="{StaticResource GhostButton}" Padding="8,4" FontSize="14"/>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
## What does this PR do?

Two accessibility defects, both of which read as correct in the markup.

**App Blocker** set `AutomationProperties.Name="Select application"` on the `DataGridCheckBoxColumn`
itself. A column is a *definition*, not a visual — it has no automation peer, so the name reached
nothing and the CheckBox generated in each row stayed unlabelled. Moved into `ElementStyle` and
`EditingElementStyle`, where the row is the DataContext, and bound per row. That is the shape **six**
other checkbox columns already use (App Updates, DNS/Hosts, Shortcut Cleaner, Uninstaller, Windows
Update); App Blocker was the single instance that had been missed.

**Startup Manager's** per-row "Open" button had no name at all, so every row announced the one word
"Open" with nothing to say which program's folder would open. It now announces
`Open file location for <name>`, matching the on/off switch in the same row, which already named its
entry.

Closes #1539 and #1557.

## Related issues

Closes #1539
Closes #1557

## Type of change

- [x] Bug fix (`fix:`) — releases a patch

## Checklist

- [x] Branch created from `main`
- [x] Code compiles with 0 errors — all four projects, 0 warnings
- [x] `dotnet format --verify-no-changes` passes on both touched projects
- [x] Tests added/updated and passing locally
- [x] Author headers on all modified files
- [x] Self-review completed
- [x] README updated (if features changed) — n/a: no new feature, tab or count claim. The only
      user-visible surface is what a screen reader reads out, and the CHANGELOG entry covers it;
      README's single accessibility line (`:174`, the focus ring's contrast) is unaffected.
- [x] No AI/IDE tool references

### Releasing changes only

- [x] CHANGELOG.md updated in this same PR — `1.65.20`
- [x] csproj `Version` / `FileVersion` / `AssemblyVersion` bumped to 1.65.20

## Neither was a half-migration

Confirmed by parsing every view as XML rather than grepping, because `grep -A 3` conflates a
column-level name with a correct one on an inner element:

| Population | Correct | Defective |
|---|---|---|
| DataGrid columns | 166 carry no name themselves | **1** (App Blocker) |
| Row buttons in a cell template | 17 named | **1** (Startup Manager) |
| `ElementStyle` name setters | 12, all bound to a row property | 0 |

## The guard

`EveryRowControl_AnnouncesTheRowItIsOn` derives both populations from the XAML tree, so the next
column or row button is caught without editing the test. It fails on:

1. a name set on a `*Column` element (reaches no automation peer),
2. a Button/ToggleButton/RepeatButton in a cell template with no name,
3. a row name that is a **constant** rather than a binding — a label identical on all forty rows is
   present, readable, and still cannot tell them apart.

All 18 existing row names and all 12 `ElementStyle` setters already bind a row property, so rule 3 is
the established shape rather than a new demand. Three vacuity floors back it, because every assertion
is absence-based: a selector that quietly stopped matching would otherwise report a clean sweep of
nothing at all.

## How this was verified

Six mutations, each expected to redden **a specific named assertion** — not merely "the test fails":

| Mutation | Assertion that fired |
|---|---|
| name put back on the column | column-level name |
| Open button's name removed | unnamed row control |
| App Blocker name → constant | constant row name |
| Open button name → constant | constant row name |
| guard's column selector broken (`Column` → `Colummn`) | columns-seen floor |
| guard's attribute lookup broken (`…Name` → `…Nam`) | named-controls floor |

The last two mutate the guard on purpose: the floors exist for a future selector break, and a floor
nobody has watched fail is a decoration. All three files restored byte-for-byte afterwards.

Regression: 129 tests green across `ArchitectureTests` + the Startup Manager and App Blocker suites,
with the only two reds being pre-existing artifacts of the local runner (verified identical with the
change stashed).