### PR TITLE
fix: let voice control activate 41 controls by their printed label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.21] - 2026-08-24
+
+If you drive Windows by voice, 41 buttons and tick boxes could not be pressed by saying what is
+printed on them. They now answer to their own labels.
+
+### Fixed
+- **41 controls could not be activated by voice.** Windows Voice Access and similar tools listen for
+  the words a control is announced by and match them against what you say. On these 41 the announced
+  name had been reworded rather than extended — the button printed "Export CSV" but announced "Export
+  logs to CSV", "Clear History" announced "Clear alert history", "Empty Recycle Bin" announced "Empty
+  the Recycle Bin". Saying the printed label matched nothing, and the failure was silent: a screen
+  reader read the announced wording out perfectly well, so nothing looked wrong unless you tried to
+  speak to it. Each name now begins with the words printed on the control and adds any extra detail
+  after them, which is what the other 209 controls already did.
+- **The check meant to prevent this had been accepting them.** It asked only that the label's words
+  appear in order somewhere in the announced name, which "Clear alert history" does. It now asks for
+  them as one unbroken phrase, so a name may still add detail but can no longer reword the label.
+
 ## [1.65.20] - 2026-08-24
 
 Two fixes for anyone using SysManager with a screen reader. In Startup Manager, every row's "Open"

--- a/SysManager/SysManager.Tests/UiAutomationContractTests.cs
+++ b/SysManager/SysManager.Tests/UiAutomationContractTests.cs
@@ -16,15 +16,15 @@ public partial class UiAutomationContractTests
         new Dictionary<string, string>(StringComparer.Ordinal)
         {
             ["btn-cleanup-clean-temp"] = "Clean TEMP — clean temporary files",
-            ["btn-cleanup-empty-recycle-bin"] = "Empty the Recycle Bin",
+            ["btn-cleanup-empty-recycle-bin"] = "Empty Recycle Bin",
             ["btn-cleanup-sfc"] = "SFC /scannow — run SFC system file check",
             ["btn-cleanup-dism"] = "Run DISM RestoreHealth",
             ["btn-cleanup-cancel"] = "Cancel the running operation",
             ["btn-system-health-scan"] = "Scan system health",
-            ["btn-system-health-smart"] = "Run SMART disk health check",
+            ["btn-system-health-smart"] = "Run SMART check — disk health",
             ["btn-system-health-memtest"] = "Run MemTest (reboot) — schedule a memory test on next reboot",
             ["btn-logs-refresh"] = "Refresh logs",
-            ["btn-logs-export-csv"] = "Export logs to CSV",
+            ["btn-logs-export-csv"] = "Export CSV — the event log",
             ["btn-services-refresh"] = "Refresh services",
             ["btn-services-clear-marks"] = "Clear all marked services",
             ["btn-ping-start"] = "Start ping monitoring",
@@ -35,9 +35,9 @@ public partial class UiAutomationContractTests
             ["btn-uninstaller-uninstall-selected"] = "Uninstall selected applications",
             ["btn-windows-update-install-module"] = "Install PSWindowsUpdate for update history",
             ["btn-windows-update-check-module"] = "Check now — check whether PSWindowsUpdate is installed",
-            ["btn-windows-update-list"] = "List available Windows updates",
+            ["btn-windows-update-list"] = "List updates — available Windows updates",
             ["btn-windows-update-history"] = "Show Windows Update history",
-            ["btn-windows-update-pending-reboot"] = "Check for a pending reboot",
+            ["btn-windows-update-pending-reboot"] = "Pending reboot? — check whether a reboot is pending",
             ["btn-windows-update-install-selected"] = "Install selected Windows updates",
             ["btn-app-updates-scan"] = "Scan for updates",
             ["btn-system-health-memory-errors"] = "Check memory errors",
@@ -207,6 +207,11 @@ public partial class UiAutomationContractTests
     /// how 36 accumulated after that one was closed.</para>
     /// <para>A name may still ADD detail — leading with the visible words and appending context is the
     /// fix applied across all 36 — it just may not REPLACE them.</para>
+    /// <para>A later pass tightened <see cref="SpeaksTheLabel"/> from "the label's words appear in
+    /// order" to "they appear as a contiguous phrase", because the loose reading was weaker than the
+    /// sentence above promises: 41 further names passed it while still being unsayable — "Clear History"
+    /// announced as "Clear alert history", "Empty Recycle Bin" as "Empty the Recycle Bin". All 41 were
+    /// repaired in the same change.</para>
     /// <para>Two exclusions, both deliberate. A glyph-only label ("X", "▲") is a symbol rather than
     /// text, so a descriptive name is the CORRECT treatment and flagging it would be wrong. A name
     /// built from a <c>{Binding}</c> is produced at runtime, so the literal in the XAML is not what
@@ -263,17 +268,37 @@ public partial class UiAutomationContractTests
         => [.. NonWordRun().Replace(text.ToLowerInvariant(), " ")
                 .Split(' ', StringSplitOptions.RemoveEmptyEntries)];
 
-    /// <summary>True when the label's words all appear, IN ORDER, in the accessible name.</summary>
+    /// <summary>
+    /// True when the label's words appear as a CONTIGUOUS run inside the accessible name.
+    /// <para>This used to accept the words merely in order, anywhere in the name — a weaker rule than
+    /// the guard's own summary promises ("leading with the visible words and appending context").
+    /// Forty-one names satisfied the loose reading while still failing WCAG 2.5.3 in the way that
+    /// matters: "Clear History" announced as "Clear alert history", "Export CSV" as "Export logs to
+    /// CSV", "Empty Recycle Bin" as "Empty the Recycle Bin". Every word is present and in order, yet a
+    /// speech-recognition user who says the printed phrase matches nothing, because the matcher looks
+    /// for the phrase and not for a scatter of its words.</para>
+    /// <para>Contiguity is checked over the normalised WORD lists rather than the raw strings on
+    /// purpose: that keeps the existing case- and punctuation-insensitivity, so "Enable / Disable" is
+    /// satisfied by "Enable / Disable — the selected task", and a name stays free to re-case the label
+    /// while continuing the sentence.</para>
+    /// </summary>
     private static bool SpeaksTheLabel(List<string> label, List<string> spoken)
     {
-        var from = 0;
-        foreach (var word in label)
+        if (label.Count == 0 || label.Count > spoken.Count) return false;
+
+        for (var start = 0; start <= spoken.Count - label.Count; start++)
         {
-            var at = spoken.IndexOf(word, from);
-            if (at < 0) return false;
-            from = at + 1;
+            var matches = true;
+            for (var offset = 0; offset < label.Count; offset++)
+            {
+                if (string.Equals(spoken[start + offset], label[offset], StringComparison.Ordinal))
+                    continue;
+                matches = false;
+                break;
+            }
+            if (matches) return true;
         }
-        return true;
+        return false;
     }
 
     [GeneratedRegex("[^a-z0-9]+", RegexOptions.CultureInvariant)]

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.20</Version>
-    <FileVersion>1.65.20.0</FileVersion>
-    <AssemblyVersion>1.65.20.0</AssemblyVersion>
+    <Version>1.65.21</Version>
+    <FileVersion>1.65.21.0</FileVersion>
+    <AssemblyVersion>1.65.21.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AppAlertsView.xaml
+++ b/SysManager/SysManager/Views/AppAlertsView.xaml
@@ -41,7 +41,7 @@
                             AutomationProperties.Name="Acknowledge all alerts"
                             Style="{StaticResource SecondaryButton}" Padding="12,8" Margin="0,0,8,0"/>
                     <Button Content="Clear History" Command="{Binding ClearHistoryCommand}"
-                            AutomationProperties.Name="Clear alert history"
+                            AutomationProperties.Name="Clear History — app alerts"
                             Style="{StaticResource DangerButton}" Padding="12,8"/>
                 </StackPanel>
                 <TextBlock DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right"

--- a/SysManager/SysManager/Views/AudioMixerView.xaml
+++ b/SysManager/SysManager/Views/AudioMixerView.xaml
@@ -45,7 +45,7 @@
                          ToolTip="Name the current per-app volumes as a preset."/>
                 <Button Content="Save current as preset" Command="{Binding SavePresetCommand}"
                         Style="{StaticResource PrimaryButton}" Padding="12,6"
-                        AutomationProperties.Name="Save current volumes as a preset"/>
+                        AutomationProperties.Name="Save current as preset — the current app volumes"/>
             </WrapPanel>
         </Border>
 

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -85,7 +85,7 @@
                             AutomationProperties.Name="Clean TEMP — clean temporary files"/>
                     <Button Content="Empty Recycle Bin" Command="{Binding EmptyRecycleBinCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
                             AutomationProperties.AutomationId="btn-cleanup-empty-recycle-bin"
-                            AutomationProperties.Name="Empty the Recycle Bin"/>
+                            AutomationProperties.Name="Empty Recycle Bin"/>
                     <Button Content="Rescan" Command="{Binding RescanCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
                             AutomationProperties.Name="Rescan cleanup sizes"/>
                 </WrapPanel>

--- a/SysManager/SysManager/Views/CpuAffinityView.xaml
+++ b/SysManager/SysManager/Views/CpuAffinityView.xaml
@@ -120,7 +120,7 @@
                     AutomationProperties.Name="Restore original affinity"/>
             <Button Grid.Column="2" Content="Apply affinity" Command="{Binding ApplyCommand}"
                     Style="{StaticResource PrimaryButton}" Padding="16,8"
-                    AutomationProperties.Name="Apply CPU affinity"/>
+                    AutomationProperties.Name="Apply affinity — the selected CPU cores"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/DebloaterView.xaml
+++ b/SysManager/SysManager/Views/DebloaterView.xaml
@@ -44,7 +44,7 @@
                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
 
                 <Button Content="Remove selected…" Command="{Binding RemoveSelectedCommand}"
-                        AutomationProperties.Name="Remove selected apps"
+                        AutomationProperties.Name="Remove selected… — the selected apps"
                         Style="{StaticResource DangerButton}" Margin="0,0,16,0"
                         ToolTip="Uninstall the ticked apps for the current user (reversible via the Store)."/>
 

--- a/SysManager/SysManager/Views/DefenderView.xaml
+++ b/SysManager/SysManager/Views/DefenderView.xaml
@@ -135,7 +135,7 @@
                     <TextBlock Grid.Column="0" Text="Scan exclusions (folders)" Style="{StaticResource SectionTitle}" VerticalAlignment="Center"/>
                     <Button Grid.Column="1" Content="Add folder…" Command="{Binding AddExclusionCommand}"
                             Style="{StaticResource PrimaryButton}" Margin="0,0,8,0" Padding="12,6"
-                            AutomationProperties.Name="Add an exclusion folder"/>
+                            AutomationProperties.Name="Add folder… — an exclusion folder"/>
                     <!-- Removing an exclusion makes Defender scan that folder again — it
                          strengthens protection, so it is neutral list-management, not a
                          destructive action. Reserve DangerButton for actions that weaken

--- a/SysManager/SysManager/Views/DisplayProfileView.xaml
+++ b/SysManager/SysManager/Views/DisplayProfileView.xaml
@@ -76,7 +76,7 @@
                         AutomationProperties.Name="Keep the new display settings"/>
                 <Button Grid.Column="2" Content="Revert now" Command="{Binding RevertNowCommand}"
                         Style="{StaticResource SecondaryButton}" Padding="14,6"
-                        AutomationProperties.Name="Revert display settings now"/>
+                        AutomationProperties.Name="Revert now — the display settings"/>
             </Grid>
         </Border>
 
@@ -117,7 +117,7 @@
             </DockPanel>
             <Button Grid.Column="1" Content="Apply mode" Command="{Binding ApplyCommand}"
                     Style="{StaticResource PrimaryButton}" Padding="16,8"
-                    AutomationProperties.Name="Apply the selected display mode"/>
+                    AutomationProperties.Name="Apply mode — the selected display mode"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -66,7 +66,7 @@
                             Style="{StaticResource SecondaryButton}" DockPanel.Dock="Right"
                             Padding="14,8" Margin="8,0,0,0"
                             IsEnabled="{Binding IsDnsApplying, Converter={StaticResource BoolInvert}}"
-                            AutomationProperties.Name="Reset DNS to DHCP (automatic)"/>
+                            AutomationProperties.Name="Reset to DHCP — DNS assigned automatically"/>
                     <Button Content="Apply" Command="{Binding ApplyDnsCommand}"
                             Style="{StaticResource PrimaryButton}" DockPanel.Dock="Right"
                             Padding="18,8" Margin="8,0,0,0"

--- a/SysManager/SysManager/Views/EdgeOneDriveView.xaml
+++ b/SysManager/SysManager/Views/EdgeOneDriveView.xaml
@@ -73,7 +73,7 @@
                         <WrapPanel Orientation="Horizontal" Margin="0,14,0,0">
                             <Button Content="Remove OneDrive…" Command="{Binding RemoveOneDriveCommand}"
                                     Style="{StaticResource DangerButton}" Margin="0,0,8,0"
-                                    AutomationProperties.Name="Remove OneDrive for the current user"
+                                    AutomationProperties.Name="Remove OneDrive… — for the current user"
                                     ToolTip="Uninstall OneDrive for your account (reversible via Restore)."/>
                             <Button Content="Restore OneDrive" Command="{Binding RestoreOneDriveCommand}"
                                     Style="{StaticResource SecondaryButton}"
@@ -94,11 +94,11 @@
                         <WrapPanel Orientation="Horizontal" Margin="0,14,0,0">
                             <Button Content="Disable &amp; de-integrate Edge…" Command="{Binding DisableEdgeCommand}"
                                     Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"
-                                    AutomationProperties.Name="Disable and de-integrate Microsoft Edge"
+                                    AutomationProperties.Name="Disable &amp; de-integrate Edge…"
                                     ToolTip="Turn off Edge background mode, startup boost, and auto-update tasks (reversible)."/>
                             <Button Content="Restore Edge" Command="{Binding RestoreEdgeCommand}"
                                     Style="{StaticResource SecondaryButton}"
-                                    AutomationProperties.Name="Restore Microsoft Edge to defaults"
+                                    AutomationProperties.Name="Restore Edge — to its defaults"
                                     ToolTip="Clear the policies and re-enable Edge's automatic-update tasks."/>
                         </WrapPanel>
                     </StackPanel>

--- a/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
+++ b/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
@@ -79,7 +79,7 @@
                             ToolTip="Re-read all variables from the registry."/>
                     <Button Content="Restore backup" Command="{Binding RestoreBackupCommand}"
                             IsEnabled="{Binding HasBackup}"
-                            AutomationProperties.Name="Restore the original environment from backup"
+                            AutomationProperties.Name="Restore backup — the original environment"
                             Style="{StaticResource GhostButton}" Margin="0,0,16,0"
                             ToolTip="Revert every variable to its value from before your first change (created on first Apply)."/>
 
@@ -104,7 +104,7 @@
                     <ComboBox ItemsSource="{Binding ScopeFilters}" SelectedItem="{Binding NewScope}"
                               AutomationProperties.Name="New variable scope" Width="100" Margin="0,0,8,0"/>
                     <Button Content="Add variable" Command="{Binding AddVariableCommand}"
-                            AutomationProperties.Name="Add new variable"
+                            AutomationProperties.Name="Add variable"
                             Style="{StaticResource SecondaryButton}"/>
                 </WrapPanel>
             </StackPanel>

--- a/SysManager/SysManager/Views/FileLockView.xaml
+++ b/SysManager/SysManager/Views/FileLockView.xaml
@@ -75,7 +75,7 @@
                          ToolTip="Enter or paste a full file/folder path"/>
                 <Button Grid.Column="1" Content="Browse…" Command="{Binding BrowseCommand}"
                         Style="{StaticResource SecondaryButton}" Margin="8,0,0,0" Padding="14,8"
-                        AutomationProperties.Name="Browse for a file"/>
+                        AutomationProperties.Name="Browse… — for a file"/>
                 <Button Grid.Column="2" Content="Scan" Command="{Binding ScanCommand}"
                         Style="{StaticResource PrimaryButton}" Margin="8,0,0,0" Padding="18,8"
                         AutomationProperties.Name="Scan for locking processes"/>
@@ -121,7 +121,7 @@
             </DockPanel>
             <Button Grid.Column="1" Content="End process" Command="{Binding KillSelectedCommand}"
                     Style="{StaticResource DangerButton}" Padding="14,8"
-                    AutomationProperties.Name="End the selected process"/>
+                    AutomationProperties.Name="End process — the selected process"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -42,7 +42,7 @@
                      The tooltip gives the full path so there is no ambiguity before clicking. -->
                 <Button Content="SysManager's own logs" AutomationProperties.AutomationId="btn-logs-open-folder" AutomationProperties.Name="SysManager's own logs — open SysManager's own log folder" Command="{Binding OpenLogFolderCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"
                         ToolTip="{Binding LogFolder, Mode=OneWay, StringFormat='Opens SysManager''s own diagnostic logs: {0}'}"/>
-                <Button Content="Export CSV" AutomationProperties.AutomationId="btn-logs-export-csv" AutomationProperties.Name="Export logs to CSV" Command="{Binding ExportCsvCommand}" Style="{StaticResource SecondaryButton}" Margin="6,0,0,0"/>
+                <Button Content="Export CSV" AutomationProperties.AutomationId="btn-logs-export-csv" AutomationProperties.Name="Export CSV — the event log" Command="{Binding ExportCsvCommand}" Style="{StaticResource SecondaryButton}" Margin="6,0,0,0"/>
             </StackPanel>
         </DockPanel>
 
@@ -439,8 +439,8 @@
                             </Border>
 
                             <StackPanel Orientation="Horizontal" Margin="0,14,0,0">
-                                <Button Content="Copy details" AutomationProperties.Name="Copy event details" Command="{Binding CopySelectedCommand}" Style="{StaticResource SecondaryButton}"/>
-                                <Button Content="Search online" AutomationProperties.Name="Search this event online" Command="{Binding SearchOnlineCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>
+                                <Button Content="Copy details" AutomationProperties.Name="Copy details — the selected event" Command="{Binding CopySelectedCommand}" Style="{StaticResource SecondaryButton}"/>
+                                <Button Content="Search online" AutomationProperties.Name="Search online — this event" Command="{Binding SearchOnlineCommand}" Style="{StaticResource GhostButton}" Margin="6,0,0,0"/>
                             </StackPanel>
 
                             <Expander Header="Full system message" Margin="0,16,0,0" Foreground="{DynamicResource TextSecondary}">

--- a/SysManager/SysManager/Views/PerformanceView.xaml
+++ b/SysManager/SysManager/Views/PerformanceView.xaml
@@ -227,7 +227,7 @@
                             <TextBlock Text="Create a Windows System Restore point before making changes. Requires admin."
                                        Style="{StaticResource Subtle}" FontSize="11" Margin="0,0,0,8"/>
                             <Button Content="Create Restore Point" Command="{Binding CreateRestorePointCommand}"
-                                    AutomationProperties.Name="Create system restore point"
+                                    AutomationProperties.Name="Create Restore Point"
                                     Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"/>
                         </StackPanel>
                     </Border>
@@ -244,7 +244,7 @@
                             <TextBlock Text="⚠ Apps may feel briefly slower on next access as pages are faulted back in."
                                        Foreground="{DynamicResource Warning}" FontSize="11" Margin="0,0,0,8"/>
                             <Button Content="Trim RAM Now" Command="{Binding TrimRamCommand}"
-                                    AutomationProperties.Name="Trim RAM working set now"
+                                    AutomationProperties.Name="Trim RAM Now — the working set"
                                     Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"/>
                         </StackPanel>
                     </Border>

--- a/SysManager/SysManager/Views/PrivacyMonitorView.xaml
+++ b/SysManager/SysManager/Views/PrivacyMonitorView.xaml
@@ -32,7 +32,7 @@
                         AutomationProperties.Name="Refresh access history"
                         Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
                 <Button Content="Open privacy settings" Command="{Binding OpenPrivacySettingsCommand}"
-                        AutomationProperties.Name="Open Windows privacy settings"
+                        AutomationProperties.Name="Open privacy settings — in Windows"
                         Style="{StaticResource GhostButton}"
                         ToolTip="Open Windows Settings to grant or revoke camera/microphone/location access."/>
             </WrapPanel>

--- a/SysManager/SysManager/Views/ProfileView.xaml
+++ b/SysManager/SysManager/Views/ProfileView.xaml
@@ -51,7 +51,7 @@
                 <WrapPanel>
                     <Button Content="Export profile…" Command="{Binding ExportCommand}"
                             IsEnabled="{Binding HasSections}"
-                            AutomationProperties.Name="Export profile to file"
+                            AutomationProperties.Name="Export profile… — to a file"
                             Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"/>
                     <Button Content="Refresh" Command="{Binding RefreshCommand}"
                             AutomationProperties.Name="Refresh section list"
@@ -67,7 +67,7 @@
                 <TextBlock Text="Load a profile exported from another PC. You'll see what it contains and confirm before anything is overwritten. Restart SysManager afterwards for all changes to take effect."
                            Style="{StaticResource Subtle}" Margin="0,2,0,10" TextWrapping="Wrap"/>
                 <Button Content="Import profile…" Command="{Binding ImportCommand}"
-                        AutomationProperties.Name="Import profile from file"
+                        AutomationProperties.Name="Import profile… — from a file"
                         Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"/>
             </StackPanel>
         </Border>

--- a/SysManager/SysManager/Views/ResourceHistoryView.xaml
+++ b/SysManager/SysManager/Views/ResourceHistoryView.xaml
@@ -52,7 +52,7 @@
                         AutomationProperties.Name="Refresh history"/>
                 <Button Content="Export CSV" Command="{Binding ExportCsvCommand}"
                         Style="{StaticResource SecondaryButton}" Margin="6,0,0,0"
-                        AutomationProperties.Name="Export history to CSV"/>
+                        AutomationProperties.Name="Export CSV — the resource history"/>
             </StackPanel>
         </DockPanel>
 

--- a/SysManager/SysManager/Views/RestorePointsView.xaml
+++ b/SysManager/SysManager/Views/RestorePointsView.xaml
@@ -74,7 +74,7 @@
                                Visibility="{Binding NewDescription, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                 </Grid>
                 <Button Content="Create restore point" Command="{Binding CreateCommand}"
-                        AutomationProperties.Name="Create a restore point"
+                        AutomationProperties.Name="Create restore point"
                         Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"
                         ToolTip="Create a new System Restore point (admin; once per 24h)."/>
                 <Button Content="Refresh" Command="{Binding RefreshCommand}"
@@ -87,7 +87,7 @@
                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
 
                 <Button Content="Restore selected…" Command="{Binding RestoreCommand}"
-                        AutomationProperties.Name="Restore the selected restore point"
+                        AutomationProperties.Name="Restore selected… — the selected restore point"
                         Style="{StaticResource DangerButton}"
                         ToolTip="Roll the system back to the selected restore point (restarts Windows)."/>
             </WrapPanel>

--- a/SysManager/SysManager/Views/ScheduledMaintenanceView.xaml
+++ b/SysManager/SysManager/Views/ScheduledMaintenanceView.xaml
@@ -101,10 +101,10 @@
                 <WrapPanel Orientation="Horizontal" Margin="0,4,0,0">
                     <Button Content="Save schedule" Command="{Binding SaveScheduleCommand}"
                             Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"
-                            AutomationProperties.Name="Save maintenance schedule"/>
+                            AutomationProperties.Name="Save schedule — the maintenance schedule"/>
                     <Button Content="Remove schedule" Command="{Binding RemoveScheduleCommand}"
                             Style="{StaticResource DangerButton}" Margin="0,0,8,0"
-                            AutomationProperties.Name="Remove maintenance schedule"/>
+                            AutomationProperties.Name="Remove schedule — the maintenance schedule"/>
                     <Button Content="Refresh" Command="{Binding RefreshCommand}"
                             Style="{StaticResource GhostButton}"
                             AutomationProperties.Name="Refresh schedule status"/>

--- a/SysManager/SysManager/Views/SettingsWatchdogView.xaml
+++ b/SysManager/SysManager/Views/SettingsWatchdogView.xaml
@@ -39,10 +39,10 @@
                         DockPanel.Dock="Right" VerticalAlignment="Center">
                 <Button Content="Save baseline" Command="{Binding SaveBaselineCommand}"
                         Style="{StaticResource PrimaryButton}"
-                        AutomationProperties.Name="Save settings baseline"/>
+                        AutomationProperties.Name="Save baseline — the settings baseline"/>
                 <Button Content="Check now" Command="{Binding RefreshCommand}"
                         Style="{StaticResource SecondaryButton}" Margin="6,0,0,0"
-                        AutomationProperties.Name="Check for setting changes now"/>
+                        AutomationProperties.Name="Check now — for setting changes"/>
                 <Button Content="Restore changed" Command="{Binding RestoreSelectedCommand}"
                         Style="{StaticResource SecondaryButton}" Margin="6,0,0,0"
                         AutomationProperties.Name="Restore changed settings to baseline"/>

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml
@@ -79,7 +79,7 @@
                         AutomationProperties.Name="Deselect all shortcuts"
                         Style="{StaticResource GhostButton}" Margin="0,0,16,0"/>
                 <CheckBox Content="Move to Recycle Bin" IsChecked="{Binding MoveToRecycleBin}"
-                          AutomationProperties.Name="Move deleted shortcuts to Recycle Bin"
+                          AutomationProperties.Name="Move to Recycle Bin — deleted shortcuts go there"
                           VerticalAlignment="Center" Foreground="{DynamicResource TextSecondary}"/>
             </WrapPanel>
         </Border>

--- a/SysManager/SysManager/Views/StandbyMemoryView.xaml
+++ b/SysManager/SysManager/Views/StandbyMemoryView.xaml
@@ -131,7 +131,7 @@
             </DockPanel>
             <Button Grid.Column="1" Content="Purge standby list" Command="{Binding PurgeCommand}"
                     Style="{StaticResource PrimaryButton}" Padding="16,8" IsEnabled="{Binding IsElevated}"
-                    AutomationProperties.Name="Purge the standby list now"/>
+                    AutomationProperties.Name="Purge standby list"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -163,7 +163,7 @@
                                     AutomationProperties.Name="Find BIOS update — open manufacturer support page for BIOS updates"
                                     Style="{StaticResource PrimaryButton}" Padding="14,8" Margin="0,0,8,0"/>
                             <Button Content="Copy info" Command="{Binding CopyBiosInfoCommand}"
-                                    AutomationProperties.Name="Copy BIOS and motherboard info"
+                                    AutomationProperties.Name="Copy info — BIOS and motherboard"
                                     Style="{StaticResource GhostButton}" Padding="14,8"/>
                         </StackPanel>
                     </Grid>
@@ -199,7 +199,7 @@
                             <TextBlock Text="Disk health (SMART)" Style="{StaticResource SectionTitle}"/>
                             <Button Content="Run SMART check" Command="{Binding CheckDiskHealthCommand}"
                                     AutomationProperties.AutomationId="btn-system-health-smart"
-                                    AutomationProperties.Name="Run SMART disk health check"
+                                    AutomationProperties.Name="Run SMART check — disk health"
                                     Style="{StaticResource PrimaryButton}"
                                     HorizontalAlignment="Right" DockPanel.Dock="Right"/>
                         </DockPanel>

--- a/SysManager/SysManager/Views/SystemReportView.xaml
+++ b/SysManager/SysManager/Views/SystemReportView.xaml
@@ -38,15 +38,15 @@
                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
 
                 <Button Content="Export HTML" Command="{Binding ExportHtmlCommand}"
-                        AutomationProperties.Name="Export report as HTML"
+                        AutomationProperties.Name="Export HTML — the system report"
                         Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"
                         ToolTip="Save a styled, self-contained HTML report."/>
                 <Button Content="Export JSON" Command="{Binding ExportJsonCommand}"
-                        AutomationProperties.Name="Export report as JSON"
+                        AutomationProperties.Name="Export JSON — the system report"
                         Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"
                         ToolTip="Save a structured JSON report."/>
                 <Button Content="Export text" Command="{Binding ExportTextCommand}"
-                        AutomationProperties.Name="Export report as text"
+                        AutomationProperties.Name="Export text — the system report"
                         Style="{StaticResource GhostButton}" Margin="0,0,8,0"
                         ToolTip="Save the plain-text report."/>
                 <Button Content="Copy" Command="{Binding CopyCommand}"

--- a/SysManager/SysManager/Views/TaskSchedulerView.xaml
+++ b/SysManager/SysManager/Views/TaskSchedulerView.xaml
@@ -187,7 +187,7 @@
             </DockPanel>
             <Button Grid.Column="1" Content="Enable / Disable" Command="{Binding ToggleEnabledCommand}"
                     Style="{StaticResource PrimaryButton}" Padding="16,8"
-                    AutomationProperties.Name="Enable or disable the selected task"/>
+                    AutomationProperties.Name="Enable / Disable — the selected task"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -118,7 +118,7 @@
                 <WrapPanel Orientation="Horizontal">
                     <Button Content="List updates" Command="{Binding ListUpdatesCommand}"
                             AutomationProperties.AutomationId="btn-windows-update-list"
-                            AutomationProperties.Name="List available Windows updates"
+                            AutomationProperties.Name="List updates — available Windows updates"
                             Style="{StaticResource PrimaryButton}" Margin="0,0,8,8"/>
                     <Button Content="History" Command="{Binding ShowHistoryCommand}"
                             AutomationProperties.AutomationId="btn-windows-update-history"
@@ -126,7 +126,7 @@
                             Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"/>
                     <Button Content="Pending reboot?" Command="{Binding CheckPendingRebootCommand}"
                             AutomationProperties.AutomationId="btn-windows-update-pending-reboot"
-                            AutomationProperties.Name="Check for a pending reboot"
+                            AutomationProperties.Name="Pending reboot? — check whether a reboot is pending"
                             Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"/>
                     <Button Content="Install selected" Command="{Binding InstallUpdatesCommand}" Style="{StaticResource PrimaryButton}" Margin="0,0,8,8"
                             AutomationProperties.AutomationId="btn-windows-update-install-selected"


### PR DESCRIPTION
## What does this PR do?

Windows Voice Access matches what the user *says* against a control's accessible name. On 41 controls
that name had been **reworded rather than extended**, so saying the printed label matched nothing:

| Printed | Announced |
|---|---|
| `Export CSV` | `Export logs to CSV` |
| `Clear History` | `Clear alert history` |
| `Empty Recycle Bin` | `Empty the Recycle Bin` |
| `Pending reboot?` | `Check for a pending reboot` |

The failure is silent and invisible to screen-reader testing, because a screen reader reads the
override out perfectly well.

Each name now **leads with the label verbatim** and adds context after an em-dash — or is simply the
label where the old name added only an article. That is the codebase's own shape, not an invention: of
the compliant controls **167 already lead with the label and 52 equal it**, and the two worst cases
from the original audit were repaired in exactly this form (`Content="Run"` with
`Name="Run — reset Windows Update"`, `SystemFixesView.xaml:76-77`).

Closes #1537.

## The more interesting half: the guard was already there, and passing

`UiAutomationContractTests.EveryLabelledControl_IsAnnouncedWithTheWordsPrintedOnIt` exists for exactly
this class and was **green**. `SpeaksTheLabel` asked only that the label's words appear **in order,
anywhere** in the name — and "Clear alert history" satisfies that. Its own summary already claimed the
stricter rule ("leading with the visible words and appending context"), so the implementation was
weaker than the documented intent.

It now requires the words as **one contiguous run**. I did **not** add a parallel guard — the existing
one is the single source of truth for this rule, so it was tightened in place. (I built a second guard
first, then deleted it on finding this one; the diff carries only the tightening.)

Contiguity is compared over the normalised **word lists**, not raw strings, keeping the existing case-
and punctuation-insensitivity so a name may re-case the label while continuing the sentence
(`Enable / Disable` ⊂ `Enable / Disable — the selected task`).

## Populations, derived not guessed

Parsed every view as XML rather than grepping, since `grep -A 3` conflates a column-level name with a
correct one on an inner element:

| | |
|---|---|
| labelled controls with a literal label **and** name | 250 |
| failed the **old** in-order rule | **0** (hence the green guard) |
| failed the **tightened** contiguous rule | **41** — 40 Button, 1 CheckBox |
| after this PR | 0 |

Widening the scan to `RepeatButton`, `MainWindow.xaml` and `App.xaml` adds nothing (still 250/41), so
the guard's existing scope is already complete. Glyph-only labels and `{Binding}` names stay exempt —
an icon carries no visible text, and a runtime-built name is not the literal in the XAML.

Five expectations in the automation-id contract map were updated to the new names.

## Type of change

- [x] Bug fix (`fix:`) — releases a patch

## Checklist

- [x] Branch created from `main`
- [x] Code compiles with 0 errors — all four projects, 0 warnings
- [x] `dotnet format --verify-no-changes` passes on both touched projects
- [x] Tests added/updated and passing locally — contract class 4/4 green; 50 green across
      `UiAutomationContractTests` + `ArchitectureTests`
- [x] Author headers on all modified files
- [x] Self-review completed
- [x] README updated (if features changed) — n/a: no feature, tab or count change; the only
      user-visible surface is what assistive tech announces, which the CHANGELOG covers
- [x] No AI/IDE tool references

### Releasing changes only

- [x] CHANGELOG.md updated in this same PR — `1.65.21`
- [x] csproj `Version` / `FileVersion` / `AssemblyVersion` bumped to 1.65.21

## How this was verified

Six mutations. The one that matters is **B**, the control that proves the tightening is load-bearing
rather than decorative:

| Mutation | Result |
|---|---|
| A — revert one repaired name, tightened rule | **RED** (label-in-name) |
| **B — same revert, with the OLD in-order helper restored** | **GREEN** ← the old rule could not see it |
| C — revert the CheckBox name | **RED** (so the guard covers more than Buttons) |
| D — break the guard's control-type list | **RED** (inspected-count floor) |
| E — change a name in XAML without updating the contract map | **RED** (contract map) |
| baseline | green |

All four files restored byte-for-byte. An earlier version of the proof raised on a bad anchor *after*
writing one file and left the tree mutated, so the next run snapshotted the mutation as its baseline —
the script now restores in a `finally`, and the tree was reset from git before the recorded run.