### PR TITLE
fix: make progress bars say what they report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.22] - 2026-08-24
+
+Progress bars now say what they are reporting. On four pages several appeared at once and all of them
+were announced as just "Progress", and two were not progress at all — a screen reader read out
+"Progress 78" for a battery that was 78% charged.
+
+### Fixed
+- **Ten progress bars were announced identically, or described the wrong thing.** Deep Cleanup shows
+  separate bars for the scan, the cleanup and the large-file search, and all three announced
+  "Progress", so there was no way to hear which one was moving. Disk Analyzer's drive-usage bar and
+  Battery Health's charge bar are not progress at all but gauges, and announcing them as progress said
+  something untrue — they now read "Drive space used" and "Battery charge level". Disk Analyzer's
+  per-folder bar names its folder, and Speed Test's two bars name their engine, matching the Cancel
+  buttons beside them. A test now fails the build if two bars on one page are announced the same way.
+
 ## [1.65.21] - 2026-08-24
 
 If you drive Windows by voice, 41 buttons and tick boxes could not be pressed by saying what is

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2447,6 +2447,95 @@ public partial class ArchitectureTests
             + $"instead:\n  " + string.Join("\n  ", sameOnEveryRow));
     }
 
+    /// <summary>
+    /// No two progress bars on the same page may be announced by the same name.
+    /// <para>Forty-four bars were announced as the bare word "Progress", and on four pages two or three
+    /// appeared at once: Deep Cleanup showed separate scan, cleanup and large-file bars, all three saying
+    /// "Progress". Worse, two were not progress at all — Disk Analyzer's drive-usage bar and Battery
+    /// Health's charge bar are GAUGES, so a screen reader announced "Progress 78" for a battery that is
+    /// 78% charged. Each now says what it reports.</para>
+    /// <para>The rule is uniqueness per view rather than "never call a bar Progress": on the 34 pages
+    /// with a single bar the bare word is uninformative but not ambiguous, and renaming those would mean
+    /// inventing 34 strings for no behavioural gain. Ambiguity is the defect; vagueness is polish.</para>
+    /// <para>Unnamed bars are ratcheted, not forbidden. Ten remain, and both kinds need a decision this
+    /// codebase has not made yet: five are decorative indeterminate strips (Bulk Installer, MainWindow,
+    /// two on the Dashboard) which arguably belong OUT of the accessibility tree rather than named, and no
+    /// convention for hiding an element exists yet; the other five are live value indicators (the
+    /// Dashboard's CPU, RAM and GPU gauges, its per-row share bar, and Volume Control's per-session peak
+    /// meter) where a per-row name is the right shape. The ratchet lets those counts fall but never rise,
+    /// so the debt is recorded in code rather than in a comment nobody runs.</para>
+    /// </summary>
+    [Fact]
+    public void NoTwoProgressBarsOnAPage_AreAnnouncedTheSame()
+    {
+        var appDir = FindAppProjectDir();
+        var files = Directory
+            .EnumerateFiles(appDir, "*.xaml", SearchOption.AllDirectories)
+            .Where(f => !Path.GetRelativePath(appDir, f)
+                .Split(Path.DirectorySeparatorChar)
+                .Any(segment => segment.Equals("obj", StringComparison.OrdinalIgnoreCase)
+                                || segment.Equals("bin", StringComparison.OrdinalIgnoreCase)))
+            .ToArray();
+
+        // Views that still hold a bar with no name at all, with the count each is allowed. Fewer is
+        // always fine; one more is a regression.
+        var unnamedAllowance = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["DashboardView.xaml"] = 7,
+            ["AudioMixerView.xaml"] = 1,
+            ["BulkInstallerView.xaml"] = 1,
+            ["MainWindow.xaml"] = 1,
+        };
+
+        var ambiguous = new List<string>();
+        var unnamedOverAllowance = new List<string>();
+        var barsSeen = 0;
+
+        foreach (var path in files)
+        {
+            var root = System.Xml.Linq.XDocument.Load(path).Root;
+            if (root is null) continue;
+            var file = Path.GetFileName(path);
+
+            var named = new List<string>();
+            var unnamed = 0;
+
+            foreach (var bar in root.DescendantsAndSelf()
+                         .Where(e => e.Name.LocalName == "ProgressBar"))
+            {
+                barsSeen++;
+                var name = bar.Attributes()
+                    .FirstOrDefault(a => a.Name.LocalName == "AutomationProperties.Name")?.Value;
+                if (string.IsNullOrWhiteSpace(name)) unnamed++;
+                else named.Add(name.Trim());
+            }
+
+            foreach (var group in named.GroupBy(n => n, StringComparer.Ordinal).Where(g => g.Count() > 1))
+                ambiguous.Add($"{file} — {group.Count()} bars all announced \"{group.Key}\"");
+
+            var allowed = unnamedAllowance.TryGetValue(file, out var cap) ? cap : 0;
+            if (unnamed > allowed)
+                unnamedOverAllowance.Add($"{file} — {unnamed} unnamed bar(s), {allowed} allowed");
+        }
+
+        // Vacuity floor: an absence check over a population the guard discovers itself.
+        Assert.True(barsSeen >= 50,
+            $"only {barsSeen} progress bars were found across {files.Length} XAML files — the element "
+            + "selector has stopped matching, so this guard is measuring nothing.");
+
+        Assert.True(ambiguous.Count == 0,
+            "these pages show more than one progress bar announced by the same name, so a screen-reader "
+            + "or voice user cannot tell which one is being reported. Name each bar for what it "
+            + $"reports:\n  " + string.Join("\n  ", ambiguous));
+
+        Assert.True(unnamedOverAllowance.Count == 0,
+            "a progress bar with no accessible name is announced with no identity at all. The remaining "
+            + "ones are ratcheted (see this test's summary); this list means a NEW one appeared, or one "
+            + "moved into a view that had none. Name it for what it reports, or settle the "
+            + $"hide-decorative-elements convention first:\n  "
+            + string.Join("\n  ", unnamedOverAllowance));
+    }
+
     /// <summary>A style that suppresses the focus indicator outright.</summary>
     [GeneratedRegex(@"FocusVisualStyle""\s*Value=""\{x:Null\}""", RegexOptions.Compiled)]
     private static partial Regex NulledFocusVisual();

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.21</Version>
-    <FileVersion>1.65.21.0</FileVersion>
-    <AssemblyVersion>1.65.21.0</AssemblyVersion>
+    <Version>1.65.22</Version>
+    <FileVersion>1.65.22.0</FileVersion>
+    <AssemblyVersion>1.65.22.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/BatteryHealthView.xaml
+++ b/SysManager/SysManager/Views/BatteryHealthView.xaml
@@ -64,7 +64,7 @@
                                                Margin="12,0,0,0" Style="{StaticResource Subtle}"/>
                                 </StackPanel>
 
-                                <ProgressBar AutomationProperties.Name="Progress"
+                                <ProgressBar AutomationProperties.Name="Battery charge level"
                                              Value="{Binding Battery.ChargePercent}" Maximum="100"
                                              Height="8" Margin="0,8,0,0"/>
                             </StackPanel>
@@ -177,7 +177,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="4" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Refresh progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/DeepCleanupView.xaml
+++ b/SysManager/SysManager/Views/DeepCleanupView.xaml
@@ -58,7 +58,7 @@
                                 <TextBlock Grid.Column="0" Text="{Binding ScanStatusLine}" Foreground="{DynamicResource Accent}" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                 <TextBlock Grid.Column="1" Text="{Binding ScanProgress, StringFormat={}{0}%}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center" Margin="12,0,0,0"/>
                             </Grid>
-                            <ProgressBar AutomationProperties.Name="Progress" Height="6" Minimum="0" Maximum="100" Value="{Binding ScanProgress}" Margin="0,6,0,0"/>
+                            <ProgressBar AutomationProperties.Name="Scan progress" Height="6" Minimum="0" Maximum="100" Value="{Binding ScanProgress}" Margin="0,6,0,0"/>
                             <!-- The VM already runs an EtaCalculator over ScanProgress; nothing bound the
                                  result, so the estimate for a scan that can take minutes was discarded. -->
                             <TextBlock Text="{Binding ScanEtaText}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="0,4,0,0"
@@ -130,7 +130,7 @@
                                 <TextBlock Grid.Column="0" Text="{Binding CleanStatusLine}" Foreground="{DynamicResource Success}" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                 <TextBlock Grid.Column="1" Text="{Binding CleanProgress, StringFormat={}{0}%}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center" Margin="12,0,0,0"/>
                             </Grid>
-                            <ProgressBar AutomationProperties.Name="Progress" Height="6" Minimum="0" Maximum="100" Value="{Binding CleanProgress}" Margin="0,6,0,0"/>
+                            <ProgressBar AutomationProperties.Name="Cleanup progress" Height="6" Minimum="0" Maximum="100" Value="{Binding CleanProgress}" Margin="0,6,0,0"/>
                             <!-- Same for the clean phase, which deletes real files — knowing how long is
                                  left is what stops someone killing the app mid-delete. -->
                             <TextBlock Text="{Binding CleanEtaText}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="0,4,0,0"
@@ -180,7 +180,7 @@
 
                         <!-- Large-files scan progress — indeterminate bar + live counters -->
                         <StackPanel Margin="0,0,0,10" Visibility="{Binding IsLargeScanning, Converter={StaticResource FlexVis}}">
-                            <ProgressBar AutomationProperties.Name="Progress" Height="6" IsIndeterminate="True"/>
+                            <ProgressBar AutomationProperties.Name="Large-file scan progress" Height="6" IsIndeterminate="True"/>
                             <Grid Margin="0,6,0,0">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto"/>

--- a/SysManager/SysManager/Views/DiskAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/DiskAnalyzerView.xaml
@@ -67,7 +67,7 @@
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <ProgressBar AutomationProperties.Name="Progress" Grid.Column="0" Height="8" Minimum="0" Maximum="100"
+                    <ProgressBar AutomationProperties.Name="Drive space used" Grid.Column="0" Height="8" Minimum="0" Maximum="100"
                                  Value="{Binding DriveUsedPercent, Mode=OneWay}"/>
                     <TextBlock Grid.Column="1" Margin="12,0,0,0" FontSize="12"
                                Foreground="{DynamicResource TextMuted}">
@@ -149,7 +149,7 @@
 
                             <!-- Size bar -->
                             <Grid Grid.Column="2" VerticalAlignment="Center" Margin="8,0">
-                                <ProgressBar AutomationProperties.Name="Progress" Height="6" Minimum="0" Maximum="100"
+                                <ProgressBar AutomationProperties.Name="{Binding Name, StringFormat='Share of scanned space: {0}'}" Height="6" Minimum="0" Maximum="100"
                                              Value="{Binding Percentage, Mode=OneWay}"/>
                             </Grid>
 
@@ -180,7 +180,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="4" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/SpeedTestView.xaml
+++ b/SysManager/SysManager/Views/SpeedTestView.xaml
@@ -90,7 +90,7 @@
                                         ContentTemplate="{StaticResource SpeedVerdictTemplate}"
                                         Visibility="{Binding OoklaVerdict, Converter={StaticResource FlexVis}}"/>
                         <TextBlock Text="{Binding OoklaResult.Server}" Style="{StaticResource Caption}" Margin="0,10,0,0" Visibility="{Binding OoklaResult, Converter={StaticResource FlexVis}}"/>
-                        <ProgressBar AutomationProperties.Name="Progress" Value="{Binding SpeedProgress}" Maximum="100" Height="4" Margin="0,14,0,0" Visibility="{Binding IsOoklaTesting, Converter={StaticResource FlexVis}}"/>
+                        <ProgressBar AutomationProperties.Name="Ookla speed test progress" Value="{Binding SpeedProgress}" Maximum="100" Height="4" Margin="0,14,0,0" Visibility="{Binding IsOoklaTesting, Converter={StaticResource FlexVis}}"/>
                         <TextBlock Text="{Binding OoklaStatus}" Style="{StaticResource Subtle}" Margin="0,6,0,0"/>
                         <!-- The VM already maintains an EtaCalculator and updates EstimatedTime on every
                              progress tick; nothing bound it, so the "time remaining" for a test that can
@@ -125,7 +125,7 @@
                         <ContentControl Content="{Binding HttpVerdict}"
                                         ContentTemplate="{StaticResource SpeedVerdictTemplate}"
                                         Visibility="{Binding HttpVerdict, Converter={StaticResource FlexVis}}"/>
-                        <ProgressBar AutomationProperties.Name="Progress" Value="{Binding SpeedProgress}" Maximum="100" Height="4" Margin="0,14,0,0" Visibility="{Binding IsHttpTesting, Converter={StaticResource FlexVis}}"/>
+                        <ProgressBar AutomationProperties.Name="HTTP speed test progress" Value="{Binding SpeedProgress}" Maximum="100" Height="4" Margin="0,14,0,0" Visibility="{Binding IsHttpTesting, Converter={StaticResource FlexVis}}"/>
                         <TextBlock Text="{Binding HttpStatus}" Style="{StaticResource Subtle}" Margin="0,6,0,0"/>
                         <!-- Shares the single EstimatedTime property with the Ookla card above; only one
                              engine runs at a time (both are gated on the shared SpeedProgress/CTS), so the


### PR DESCRIPTION
## What does this PR do?

44 progress bars are announced as the bare word **"Progress"**. On four pages two or three appear at
once, so the name identifies nothing — and two of them are not progress at all:

| View | Bars | Problem |
|---|---|---|
| `DeepCleanupView` | 3 | scan, cleanup and large-file search all announced "Progress" |
| `DiskAnalyzerView` | 3 | one is a **drive-usage gauge**, one repeats **per folder row**, one is the scan |
| `BatteryHealthView` | 2 | one is a **charge-level gauge** — a screen reader said "Progress 78" for a battery at 78% |
| `SpeedTestView` | 2 | two engines, same name |

Announcing a gauge as progress asserts something untrue, which is worse than being vague. Ten bars
renamed for what they report — `Drive space used`, `Battery charge level`, `Scan progress`,
`Cleanup progress`, `Large-file scan progress`, `Refresh progress`. Disk Analyzer's per-folder bar is
named **per row** (the rule pinned in #1931); Speed Test's two name their engine, matching the
`Cancel Ookla speed test` / `Cancel HTTP speed test` buttons beside them, so the wording comes from
what that view already establishes.

**The other 34 single-bar views are left alone deliberately.** With one bar on the page the bare word is
uninformative but not ambiguous, and renaming them would mean inventing 34 strings for no behavioural
gain. Ambiguity is the defect; vagueness is polish.

## Where this came from

Not the backlog — this came out of auditing the eleven batches shipped since `v1.65.16`. A
duplicate-accessible-name sweep over every view turned it up while confirming that my own 41 renames in
#1935 had not created a collision (they had not). Same ambiguous-announcement class as #1539/#1557 and
#1537.

## Type of change

- [x] Bug fix (`fix:`) — releases a patch

## Checklist

- [x] Branch created from `main`
- [x] Code compiles with 0 errors — all four projects, 0 warnings
- [x] `dotnet format --verify-no-changes` passes on both touched projects
- [x] Tests added/updated and passing locally — 51 green across `ArchitectureTests` +
      `UiAutomationContractTests`
- [x] Author headers on all modified files
- [x] Self-review completed
- [x] README updated (if features changed) — n/a: no feature or count change; the only user-visible
      surface is what assistive tech announces, covered by the CHANGELOG
- [x] No AI/IDE tool references

### Releasing changes only

- [x] CHANGELOG.md updated in this same PR — `1.65.22`
- [x] csproj `Version` / `FileVersion` / `AssemblyVersion` bumped to 1.65.22

## The guard, and the debt it records

`NoTwoProgressBarsOnAPage_AreAnnouncedTheSame` derives the population from the XAML, so the next bar is
covered without editing the test. It asserts uniqueness per view, floors the population at 50 bars
(60 exist), and **ratchets** the unnamed ones rather than forbidding them.

Ten bars still have no name, and both kinds need a decision this codebase has not made:

- **5 decorative indeterminate strips** (Bulk Installer, MainWindow, 2 on the Dashboard) — these
  arguably belong *out* of the accessibility tree rather than named, and there is **no convention for
  hiding an element** anywhere in the app yet (verified: no `AccessibilityView`, no
  `IsOffscreenBehavior`). Inventing one is a design decision, not a mechanical fix.
- **5 live value indicators** — the Dashboard's CPU, RAM and GPU gauges, its per-row share bar, and
  Volume Control's per-session peak meter — where a per-row name is the right shape.

The allowance is **per file and caps the count**, so it can fall but never rise. That keeps the debt in
code rather than in a comment nobody runs, and makes the follow-up explicit instead of silent.

## How this was verified

Five mutations, each expected to redden a **specific** assertion:

| Mutation | Assertion that fired |
|---|---|
| Deep Cleanup's cleanup bar reverted so it collides with the scan bar | ambiguous |
| Battery Health's charge gauge reverted to "Progress" | ambiguous |
| a bar stripped of its name in a view with **no** allowance | unnamed ratchet |
| an **eighth** unnamed bar added to the Dashboard, which is allowed seven | unnamed ratchet (so the allowance caps rather than exempts) |
| the guard's element selector broken | bars-seen floor |

All five files restored byte-for-byte.

**A limitation worth stating:** Speed Test's two bars are mutually exclusive by `Visibility`, so a shared
name there would not have been a real defect — the guard would flag it anyway, because static XAML
cannot know what is visible at runtime. They were renamed on their merits (each now says its engine), so
the rule holds without a special case.