### PR TITLE
fix: name the six progress indicators that report a value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.65.23] - 2026-08-24
+
+Six more indicators now say what they are measuring. The Dashboard's CPU, memory and GPU bars, its
+per-drive space bars and its quick-action bar carried no label at all, and neither did the level meter
+beside each app in Volume Control — a screen reader announced a number with nothing to attach it to.
+
+### Fixed
+- **Six progress indicators were announced with no name.** The Dashboard's three headline bars now read
+  "CPU usage", "Memory usage" and "GPU usage", matching the CPU / MEMORY / GPU headings printed above
+  them, and its quick-action bar reads "Quick action progress". The two that are drawn once per item
+  name that item: each STORAGE bar says which drive it measures, and Volume Control's meter says which
+  app it is listening to — previously a whole column of bars would have announced the same words. A test
+  now fails the build if an indicator that repeats per item announces a fixed label.
+
 ## [1.65.22] - 2026-08-24
 
 Progress bars now say what they are reporting. On four pages several appeared at once and all of them

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2457,13 +2457,17 @@ public partial class ArchitectureTests
     /// <para>The rule is uniqueness per view rather than "never call a bar Progress": on the 34 pages
     /// with a single bar the bare word is uninformative but not ambiguous, and renaming those would mean
     /// inventing 34 strings for no behavioural gain. Ambiguity is the defect; vagueness is polish.</para>
-    /// <para>Unnamed bars are ratcheted, not forbidden. Ten remain, and both kinds need a decision this
-    /// codebase has not made yet: five are decorative indeterminate strips (Bulk Installer, MainWindow,
-    /// two on the Dashboard) which arguably belong OUT of the accessibility tree rather than named, and no
-    /// convention for hiding an element exists yet; the other five are live value indicators (the
-    /// Dashboard's CPU, RAM and GPU gauges, its per-row share bar, and Volume Control's per-session peak
-    /// meter) where a per-row name is the right shape. The ratchet lets those counts fall but never rise,
-    /// so the debt is recorded in code rather than in a comment nobody runs.</para>
+    /// <para>Unnamed bars are ratcheted, not forbidden, and the allowance has since been tightened from
+    /// ten to FOUR. The six that carried a <c>Value</c> binding — the Dashboard's CPU, memory and GPU
+    /// gauges, its per-drive space bar, its quick-action bar, and Volume Control's per-session peak meter
+    /// — report a real reading, so they were named (#1939); the two per-row ones name their row, as the
+    /// guard above requires.</para>
+    /// <para>What remains is the four DECORATIVE strips: <c>IsIndeterminate="True"</c> with no
+    /// <c>Value</c> at all (Bulk Installer, MainWindow, two on the Dashboard). A spinner that only means
+    /// "working" arguably belongs OUT of the accessibility tree rather than named, and no convention for
+    /// hiding an element exists anywhere in this app yet — inventing one is a design decision, so it stays
+    /// on #1939. The ratchet lets these counts fall but never rise, so the debt is recorded in code rather
+    /// than in a comment nobody runs.</para>
     /// </summary>
     [Fact]
     public void NoTwoProgressBarsOnAPage_AreAnnouncedTheSame()
@@ -2479,17 +2483,20 @@ public partial class ArchitectureTests
 
         // Views that still hold a bar with no name at all, with the count each is allowed. Fewer is
         // always fine; one more is a regression.
+        // Only the decorative indeterminate strips are left. AudioMixerView is deliberately absent now:
+        // its peak meter was named, so a new unnamed bar there must fail.
         var unnamedAllowance = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
         {
-            ["DashboardView.xaml"] = 7,
-            ["AudioMixerView.xaml"] = 1,
+            ["DashboardView.xaml"] = 2,
             ["BulkInstallerView.xaml"] = 1,
             ["MainWindow.xaml"] = 1,
         };
 
         var ambiguous = new List<string>();
         var unnamedOverAllowance = new List<string>();
+        var sameOnEveryRow = new List<string>();
         var barsSeen = 0;
+        var repeatingBars = 0;
 
         foreach (var path in files)
         {
@@ -2508,6 +2515,20 @@ public partial class ArchitectureTests
                     .FirstOrDefault(a => a.Name.LocalName == "AutomationProperties.Name")?.Value;
                 if (string.IsNullOrWhiteSpace(name)) unnamed++;
                 else named.Add(name.Trim());
+
+                // A bar inside a DataTemplate is drawn once per item, so a CONSTANT name says the same
+                // thing on every row and identifies none of them. The row guard above cannot see these:
+                // it is scoped to the Button family inside a DataGrid column, and these sit in an
+                // ItemsControl. A mutation that replaced one of these bound names with a constant went
+                // green, which is how the gap was found.
+                var repeats = bar.Ancestors().Any(a => a.Name.LocalName == "DataTemplate");
+                if (!repeats) continue;
+                repeatingBars++;
+                if (!string.IsNullOrWhiteSpace(name)
+                    && !name.Contains("{Binding", StringComparison.Ordinal))
+                {
+                    sameOnEveryRow.Add($"{file} — repeating bar announced \"{name.Trim()}\" on every row");
+                }
             }
 
             foreach (var group in named.GroupBy(n => n, StringComparer.Ordinal).Where(g => g.Count() > 1))
@@ -2518,10 +2539,13 @@ public partial class ArchitectureTests
                 unnamedOverAllowance.Add($"{file} — {unnamed} unnamed bar(s), {allowed} allowed");
         }
 
-        // Vacuity floor: an absence check over a population the guard discovers itself.
+        // Vacuity floors: absence checks over populations the guard discovers itself.
         Assert.True(barsSeen >= 50,
             $"only {barsSeen} progress bars were found across {files.Length} XAML files — the element "
             + "selector has stopped matching, so this guard is measuring nothing.");
+        Assert.True(repeatingBars >= 4,
+            $"only {repeatingBars} progress bars were found inside a DataTemplate — the ancestor test has "
+            + "stopped matching, so the per-row rule below is measuring nothing.");
 
         Assert.True(ambiguous.Count == 0,
             "these pages show more than one progress bar announced by the same name, so a screen-reader "
@@ -2534,6 +2558,11 @@ public partial class ArchitectureTests
             + "moved into a view that had none. Name it for what it reports, or settle the "
             + $"hide-decorative-elements convention first:\n  "
             + string.Join("\n  ", unnamedOverAllowance));
+
+        Assert.True(sameOnEveryRow.Count == 0,
+            "these progress bars are drawn once per item but announce a constant, so every row reports "
+            + "the same words and none of them says which item it belongs to. Bind a property of the "
+            + $"row:\n  " + string.Join("\n  ", sameOnEveryRow));
     }
 
     /// <summary>A style that suppresses the focus indicator outright.</summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.22</Version>
-    <FileVersion>1.65.22.0</FileVersion>
-    <AssemblyVersion>1.65.22.0</AssemblyVersion>
+    <Version>1.65.23</Version>
+    <FileVersion>1.65.23.0</FileVersion>
+    <AssemblyVersion>1.65.23.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AudioMixerView.xaml
+++ b/SysManager/SysManager/Views/AudioMixerView.xaml
@@ -100,7 +100,8 @@
                                             <!-- Live peak meter (0..1 mapped onto the slider width). Decorative
                                                  and unnamed — the named Slider already conveys the level to screen
                                                  readers, matching the Dashboard's live meters (no AutomationProperties.Name). -->
-                                            <ProgressBar Height="3" Margin="0,4,0,0" Minimum="0" Maximum="1"
+                                            <ProgressBar AutomationProperties.Name="{Binding DisplayName, StringFormat='Audio level for {0}'}"
+                                                         Height="3" Margin="0,4,0,0" Minimum="0" Maximum="1"
                                                          Value="{Binding PeakLevel, Mode=OneWay}"
                                                          Foreground="{DynamicResource Accent}"
                                                          Background="Transparent" BorderThickness="0"

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -288,7 +288,7 @@
                         <TextBlock Text="{Binding CpuName}" FontSize="11" Foreground="{DynamicResource TextMuted}"
                                    TextTrimming="CharacterEllipsis" Margin="0,4,0,0"/>
                         <TextBlock Text="{Binding CpuCores}" FontSize="11" Foreground="{DynamicResource TextMuted}" Margin="0,2,0,0"/>
-                        <ProgressBar Height="4" Minimum="0" Maximum="100" Value="{Binding CpuPercent, Mode=OneWay}"
+                        <ProgressBar AutomationProperties.Name="CPU usage" Height="4" Minimum="0" Maximum="100" Value="{Binding CpuPercent, Mode=OneWay}"
                                      Foreground="{DynamicResource Success}" Background="{DynamicResource Surface3}" Margin="0,10,0,0"/>
                     </StackPanel>
                 </Border>
@@ -316,7 +316,7 @@
                             <Run Text=" · "/>
                             <Run Text="{Binding RamType, Mode=OneWay}"/>
                         </TextBlock>
-                        <ProgressBar Height="4" Minimum="0" Maximum="100" Value="{Binding RamPercent, Mode=OneWay}"
+                        <ProgressBar AutomationProperties.Name="Memory usage" Height="4" Minimum="0" Maximum="100" Value="{Binding RamPercent, Mode=OneWay}"
                                      Foreground="{DynamicResource MetricBlue}" Background="{DynamicResource Surface3}" Margin="0,10,0,0"/>
                     </StackPanel>
                 </Border>
@@ -335,7 +335,7 @@
                         <TextBlock Text="{Binding GpuName}" FontSize="11" Foreground="{DynamicResource TextMuted}"
                                    TextTrimming="CharacterEllipsis" Margin="0,4,0,0"/>
                         <TextBlock Text="{Binding GpuVram}" FontSize="11" Foreground="{DynamicResource TextMuted}" Margin="0,2,0,0"/>
-                        <ProgressBar Height="4" Minimum="0" Maximum="100" Value="{Binding GpuPercent, Mode=OneWay}"
+                        <ProgressBar AutomationProperties.Name="GPU usage" Height="4" Minimum="0" Maximum="100" Value="{Binding GpuPercent, Mode=OneWay}"
                                      Foreground="{DynamicResource MetricPurple}" Background="{DynamicResource Surface3}" Margin="0,10,0,0"/>
                     </StackPanel>
                 </Border>
@@ -422,7 +422,8 @@
                                     </Grid.ColumnDefinitions>
                                     <TextBlock Grid.Column="0" Text="{Binding Letter}" FontSize="13" FontWeight="SemiBold"
                                                VerticalAlignment="Center"/>
-                                    <ProgressBar Grid.Column="1" Height="8" Minimum="0" Maximum="100"
+                                    <ProgressBar AutomationProperties.Name="{Binding Letter, StringFormat='Space used on drive {0}'}"
+                                                 Grid.Column="1" Height="8" Minimum="0" Maximum="100"
                                                  Value="{Binding Percent, Mode=OneWay}"
                                                  Foreground="{Binding ColorHex, Converter={StaticResource HexBrush}}"
                                                  Background="{DynamicResource Surface3}"
@@ -501,7 +502,7 @@
                                                DockPanel.Dock="Right" HorizontalAlignment="Right" VerticalAlignment="Center"
                                                Foreground="{DynamicResource MetricBlue}"/>
                                 </DockPanel>
-                                <ProgressBar Height="4" Minimum="0" Maximum="100"
+                                <ProgressBar AutomationProperties.Name="Quick action progress" Height="4" Minimum="0" Maximum="100"
                                              Value="{Binding QuickActionProgress, Mode=OneWay}"
                                              Foreground="{DynamicResource MetricBlue}" Background="{DynamicResource Surface3}" Margin="0,0,0,6"/>
                                 <TextBlock Text="{Binding QuickActionDetail}" FontSize="11"


### PR DESCRIPTION
## What does this PR do?

Part of #1939. Ten progress bars carried **no accessible name**, so assistive technology announced a
reading with nothing to attach it to. Six of them carry a `Value` binding and report something real —
those are named here. The remaining four are decorative `IsIndeterminate` strips with no `Value` at all,
and taking those *out* of the accessibility tree needs a hide-an-element convention this repo does not
have, so they stay on #1939.

| Bar | Now announces |
|---|---|
| `CpuPercent` | `CPU usage` |
| `RamPercent` | `Memory usage` |
| `GpuPercent` | `GPU usage` |
| `QuickActionProgress` | `Quick action progress` |
| per-drive `Percent` (STORAGE list) | `Space used on drive {Letter}` |
| per-session `PeakLevel` (Volume Control) | `Audio level for {DisplayName}` |

Wording follows the **visible card headings** (`CPU`, `MEMORY`, `GPU`, `QUICK ACTIONS`) so the name agrees
with what is on screen, and the two bars drawn once per item name that item — `DriveUsageInfo.Letter`, and
the same `DisplayName` the output-device picker in that row already uses.

The unnamed ratchet tightens **10 → 4**, and `AudioMixerView` is removed from the allowance entirely
rather than left at 1, so a new unnamed bar there now fails.

## Related issues

Part of #1939 — the four decorative strips remain, and that issue now carries only that question.

## Type of change

- [x] Bug fix (`fix:`) — releases a patch

## Checklist

- [x] Branch created from `main`
- [x] Code compiles with 0 errors — all four projects, 0 warnings
- [x] `dotnet format --verify-no-changes` passes on both touched projects
- [x] Tests added/updated and passing locally — 51 green across `ArchitectureTests` +
      `UiAutomationContractTests`
- [x] Author headers on all modified files
- [x] Self-review completed
- [x] README updated (if features changed) — n/a: no feature or count change
- [x] No AI/IDE tool references

### Releasing changes only

- [x] CHANGELOG.md updated in this same PR — `1.65.23`
- [x] csproj bumped to 1.65.23

## The mutation proof found a real gap

Two of the five cases came back **green** when I expected red, and that was my expectation being wrong
rather than the code — replacing either per-row bound name with a **constant** was caught by nothing.
`EveryRowControl_AnnouncesTheRowItIsOn` cannot see these: it is scoped to the Button family inside a
**DataGrid column**, and both bars sit in an `ItemsControl`.

So the bars guard now also asserts that a `ProgressBar` inside a `DataTemplate`, *if* it has a name, binds
it — a constant on a repeating control says the same words on every row and identifies none of them. All
three repeating bars already comply (verified: 3 of 3 bound), so the rule is the established shape rather
than a new demand, and it carries its own vacuity floor (≥4 bars must be found inside a template, or the
ancestor test has stopped matching).

| Mutation | Assertion that fired |
|---|---|
| peak meter stripped of its name (AudioMixerView now has **no** allowance) | unnamed ratchet |
| CPU gauge stripped of its name (Dashboard allowed 2, would have 3) | unnamed ratchet |
| per-drive name replaced with a constant | **repeating constant** ← the new rule |
| peak-meter name replaced with a constant | **repeating constant** |
| allowance loosened back to the old numbers, nothing renamed | **green** — the control proving the two above are caught by the tightening |

All three files restored byte-for-byte.