### PR TITLE
feat: read the policy startup list Task Manager does not show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.66.0] - 2026-08-24
+
+Startup Manager now shows a hiding place it was missing. Windows has a "policy" startup list that Task
+Manager does not display at all, which is exactly why unwanted software likes it — you turn off
+everything you can see, restart, and the program starts anyway.
+
+### Added
+- **Startup Manager reads the policy startup list.** Programs registered under Windows'
+  `Policies\Explorer\Run` key, for your account and for the whole machine, now appear in the list like
+  any other startup item, with the folder they came from shown as usual. Windows gives no way to switch
+  these off from an app, so each one says "Set by a system policy — managed elsewhere" instead of
+  offering a switch that would do nothing: if you try anyway, it tells you plainly rather than reporting
+  success and leaving the program to start again next time. On a PC with no such entries — most PCs —
+  nothing changes.
+
 ## [1.65.23] - 2026-08-24
 
 Six more indicators now say what they are measuring. The Dashboard's CPU, memory and GPU bars, its

--- a/README.md
+++ b/README.md
@@ -423,6 +423,10 @@ a confirmation before it runs:
 - Lists every program that runs at Windows boot: the Run and RunOnce registry keys for both your
   account and the whole machine, **including the separate location 64-bit Windows uses for programs
   installed by a 32-bit installer**, plus both Startup folders and logon-triggered scheduled tasks
+- **Also reads the "policy" startup list that Task Manager does not show at all** — a favourite hiding
+  place for bundled software, since you can switch off everything visible, restart, and it still starts.
+  Windows gives an app no way to disable these, so each one is labelled "Set by a system policy —
+  managed elsewhere" instead of being offered a switch that would silently do nothing
 - Toggle on/off without deleting the original entry (same mechanism as Task Manager) — the disable
   flag is written to the location Windows actually reads for that kind of entry, so a disabled item
   really stays down

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.65.x   | :white_check_mark: |
-| < 1.65   | :x:                |
+| 1.66.x   | :white_check_mark: |
+| < 1.66   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2694,6 +2694,64 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// A startup source with NO <c>StartupApproved</c> state must be refused outright, never allowed to
+    /// fall through to the approved-key switch.
+    /// <para>The guard above pins the sources whose state lives in a DIFFERENT key. This pins the harder
+    /// case: the policy Run key (<c>…\CurrentVersion\Policies\Explorer\Run</c>) has no approved state
+    /// anywhere, because Windows never consults <c>StartupApproved</c> for a policy key. Letting such an
+    /// entry reach the switch writes a disable blob to <c>StartupApproved\Run</c>, which nothing reads —
+    /// the item keeps starting at every boot while the tab reports "Disabled". That failure has already
+    /// shipped twice in this service's history (the all-users folder, then the 32-bit view), and RunOnce is
+    /// refused for precisely this reason.</para>
+    /// <para>Asserted at source level for the same reason as the guard above: <c>SetEnabledAsync</c> writes
+    /// to the live registry, so the refusal cannot be exercised from a unit test without touching the
+    /// user's real machine.</para>
+    /// </summary>
+    [Fact]
+    public void EveryStartupSourceWithNoApprovedKey_IsRefusedInsteadOfFakingSuccess()
+    {
+        var source = File.ReadAllText(Path.Combine(FindAppProjectDir(), "Services", "StartupService.cs"));
+
+        // The key must actually be enumerated, or everything below would hold over a scan that never
+        // produces a policy entry — the pre-fix state, and a guard passing on the defect.
+        Assert.Contains("private const string PolicyRunKey =", source, StringComparison.Ordinal);
+        Assert.Contains(
+            @"@""SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer\Run""",
+            source, StringComparison.Ordinal);
+
+        // Both hives: the key exists under HKCU and HKLM, and bundleware writes whichever it can.
+        foreach (var hive in new[] { "Registry.CurrentUser", "Registry.LocalMachine" })
+        {
+            Assert.Contains(
+                $"ReadRunKey({hive}, PolicyRunKey, StartupSource.PolicyRun, results)",
+                source, StringComparison.Ordinal);
+        }
+
+        var writeAt = source.IndexOf("public static async Task<bool> SetEnabledAsync", StringComparison.Ordinal);
+        Assert.True(writeAt > 0, "SetEnabledAsync was not found — fix this guard, do not delete it.");
+        var writeBody = source[writeAt..];
+
+        // The refusal must come BEFORE the approved-key switch, so slice there and require it in the
+        // earlier half: a refusal placed after the switch would never run.
+        var switchAt = writeBody.IndexOf("var (root, approvedPath) = entry.Source switch", StringComparison.Ordinal);
+        Assert.True(switchAt > 0, "the approved-key switch was not found in SetEnabledAsync.");
+        var beforeSwitch = writeBody[..switchAt];
+
+        Assert.Contains("entry.Source == StartupSource.PolicyRun", beforeSwitch, StringComparison.Ordinal);
+
+        // And it must actually return false, not merely set a message and carry on into the switch.
+        var refusalAt = beforeSwitch.IndexOf("entry.Source == StartupSource.PolicyRun", StringComparison.Ordinal);
+        Assert.Contains("return false;", beforeSwitch[refusalAt..], StringComparison.Ordinal);
+
+        // The read path must not map the policy source to an approved dictionary either. Matched as the
+        // switch-ARM shape so the comments that name the source cannot satisfy it.
+        var readAt = source.IndexOf("private static void ApplyApprovedState", StringComparison.Ordinal);
+        Assert.True(readAt > 0 && readAt < writeAt,
+            "ApplyApprovedState was not found before SetEnabledAsync; the slice below assumes that order.");
+        Assert.DoesNotContain("StartupSource.PolicyRun =>", source[readAt..writeAt], StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// Everything the scheduled-task query pays to fetch must reach the screen.
     /// <para>The Task Scheduler tab queried <c>Author</c>, <c>Description</c> and <c>NextRunTime</c> from
     /// Windows on every scan, carried all three through <c>ScheduledTaskInfo</c>, and even defined a

--- a/SysManager/SysManager/Models/StartupEntry.cs
+++ b/SysManager/SysManager/Models/StartupEntry.cs
@@ -68,5 +68,19 @@ public enum StartupSource
     StartupFolder,
     /// <summary>All-users (Common) shell Startup folder (%ProgramData%\...\Startup) — approved-state in HKLM.</summary>
     CommonStartupFolder,
-    TaskScheduler
+    TaskScheduler,
+    /// <summary>
+    /// The policy Run key in either hive
+    /// (<c>SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer\Run</c>) — <b>no</b> approved-state
+    /// anywhere, so it can be shown but not toggled here.
+    /// <para>Task Manager's Startup tab does not list this key at all, which is why bundleware favours it:
+    /// the user disables everything visible, reboots, and the program still starts. Showing it is the
+    /// point; pretending it can be switched off from here would be the defect.</para>
+    /// <para>A distinct source for the same reason as <see cref="RegistryLocalMachine32"/> and
+    /// <see cref="CommonStartupFolder"/>: Windows never consults <c>StartupApproved</c> for a policy key,
+    /// so a disable blob written there would land where nothing reads it and the item would keep running
+    /// while the UI reported "Disabled". <c>SetEnabledAsync</c> therefore refuses this source outright and
+    /// says why, the same way it already refuses RunOnce.</para>
+    /// </summary>
+    PolicyRun
 }

--- a/SysManager/SysManager/Services/StartupService.cs
+++ b/SysManager/SysManager/Services/StartupService.cs
@@ -45,6 +45,20 @@ public sealed class StartupService
         (@"SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\RunOnce", StartupSource.RegistryLocalMachine32),
     };
 
+    // The policy Run key, read from BOTH hives. This is a real autostart location that Task Manager's
+    // Startup tab does not show at all, which is exactly why bundleware and adware favour it: the user
+    // disables everything visible, reboots, and the program is still there — so the tab that reported
+    // "nothing left to disable" is the one that looks broken.
+    //
+    // Deliberately NOT part of MachineRunKeys, and carrying its own source value. Windows never consults
+    // StartupApproved for a policy key, so there is no enable/disable state to read or write. Reusing
+    // RegistryLocalMachine would let SetEnabledAsync write a disable blob to StartupApproved\Run, where
+    // Windows would never look for it — the item would keep running while this tab reported "Disabled".
+    // That exact failure has shipped twice here (the all-users folder, then the 32-bit view), which is why
+    // every family with a different state location gets its own StartupSource.
+    private const string PolicyRunKey =
+        @"SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer\Run";
+
     // Approved key where Windows stores disabled startup items
     private const string ApprovedRunHKCU =
         @"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run";
@@ -69,6 +83,11 @@ public sealed class StartupService
         // HKLM Run keys
         foreach (var (keyPath, source) in MachineRunKeys)
             ReadRunKey(Registry.LocalMachine, keyPath, source, results);
+
+        // The policy Run key in both hives. Read last so a program registered in both a normal Run key
+        // and the policy key keeps its disableable entry first in the list.
+        ReadRunKey(Registry.CurrentUser, PolicyRunKey, StartupSource.PolicyRun, results);
+        ReadRunKey(Registry.LocalMachine, PolicyRunKey, StartupSource.PolicyRun, results);
 
         // Shell startup folders (user + common). The common (all-users) folder's enabled/disabled
         // state lives under HKLM, not HKCU — flag it so ApplyApprovedState/SetEnabledAsync target
@@ -376,7 +395,13 @@ public sealed class StartupService
                     ValueName = valueName,
                     IsEnabled = true, // will be refined by ApplyApprovedState
                     Publisher = ExtractPublisher(command),
-                    StatusText = "Enabled"
+                    // A policy item says so up front rather than only when a toggle is attempted: it does
+                    // run, so "Enabled" would be true but would imply a switch that this key does not
+                    // have. ApplyApprovedState leaves this alone — a policy source resolves to no
+                    // approved dictionary, so the StatusText it would overwrite is never reached.
+                    StatusText = source == StartupSource.PolicyRun
+                        ? "Set by a system policy — managed elsewhere"
+                        : "Enabled"
                 });
             }
         }
@@ -470,6 +495,16 @@ public sealed class StartupService
             if (entry.RegistryKey.EndsWith("RunOnce", StringComparison.OrdinalIgnoreCase))
             {
                 entry.StatusText = "Run-once item — runs next boot, then removes itself; cannot be disabled here.";
+                return false;
+            }
+
+            // Policy Run items have no StartupApproved state at all — Windows never consults it for a
+            // policy key. Falling through to the switch below would write the disable blob to
+            // StartupApproved\Run, which nothing reads: the item would keep starting while this tab
+            // reported "Disabled". Same reasoning as RunOnce above; say so instead of faking success.
+            if (entry.Source == StartupSource.PolicyRun)
+            {
+                entry.StatusText = "Set by a system policy — managed elsewhere; cannot be disabled here.";
                 return false;
             }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.65.23</Version>
-    <FileVersion>1.65.23.0</FileVersion>
-    <AssemblyVersion>1.65.23.0</AssemblyVersion>
+    <Version>1.66.0</Version>
+    <FileVersion>1.66.0.0</FileVersion>
+    <AssemblyVersion>1.66.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## What does this PR do?

Windows has an autostart location that **Task Manager's Startup tab omits entirely**:
`SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer\Run`, in both hives. That omission is
precisely why bundleware favours it — the user disables everything visible, reboots, and the program
starts anyway, so the tab that reported "nothing left to disable" is the one that looks broken.

The scan now reads it from HKCU and HKLM, **last**, so a program registered in both a normal Run key and
the policy key keeps its disableable entry first in the list.

Closes #1586.

## Why it gets its own `StartupSource`

Because this service has shipped the opposite mistake twice. Windows never consults `StartupApproved` for
a policy key, so there is **no** enable/disable state to read or write. Reusing a neighbouring source
would let `SetEnabledAsync` write a disable blob to `StartupApproved\Run`, where nothing reads it — the
item would keep starting at every boot while the tab reported "Disabled". That failure shipped once for
the all-users startup folder (hence `CommonStartupFolder`) and once for the 32-bit view (hence
`RegistryLocalMachine32`), so every family with a different state location gets its own value.

So the entry is **shown but not offered as switchable**:

- it reads `Set by a system policy — managed elsewhere` from the moment it is scanned, not only after a
  failed toggle;
- `SetEnabledAsync` refuses the source outright and says why, the same way it already refuses RunOnce;
- `ApplyApprovedState` needed no change — a policy source resolves to no dictionary through the existing
  `_ => null`.

**On #1586's other half:** it also asked for the 32-bit machine Run key. That had already landed, with
`RunOnce` alongside it, so only the policy half remained. Verified against current source rather than
taken from the issue.

## Type of change

- [x] New feature (`feat:`) — releases a minor

`feat:` because it adds a scanned location rather than repairing a broken one, and the issue is filed as
an Enhancement. Note that makes this a **minor** bump: csproj and the CHANGELOG say `1.66.0`, not
`1.65.24` — I had written the patch number first and corrected it after checking
`auto-release.yml`, which maps `feat:` to minor.

## Checklist

- [x] Branch created from `main`
- [x] Code compiles with 0 errors — all four projects, 0 warnings
- [x] `dotnet format --verify-no-changes` passes on both touched projects
- [x] Tests added/updated and passing locally — 31 green across the startup guards,
      `StartupServiceTests` and the docs guards
- [x] Author headers on all modified files
- [x] Self-review completed
- [x] README updated — **yes, required here**: the Startup Manager section enumerates exactly which
      locations are read, so it would otherwise have been wrong
- [x] No AI/IDE tool references

### Releasing changes only

- [x] CHANGELOG.md updated in this same PR — `1.66.0`, under `### Added`
- [x] csproj bumped to 1.66.0

## How this was verified

`EveryStartupSourceWithNoApprovedKey_IsRefusedInsteadOfFakingSuccess` is asserted at **source level**, for
the reason the sibling guard already documents: `SetEnabledAsync` writes to the live registry, so the
refusal cannot be exercised from a unit test without touching the user's real machine.

| Mutation | Result |
|---|---|
| the refusal deleted | **RED** |
| the refusal moved *after* the approved-key switch, where it can never run | **RED** — so the guard checks position, not just presence |
| only HKCU read, HKLM dropped | **RED** |
| `PolicyRun` mapped to the HKCU approved dictionary in `ApplyApprovedState` | **RED** — the read half of the same defect |
| the key constant renamed away consistently | **RED** |
| baseline | green |

Two of those needed correcting first, and the corrections are the interesting part: renaming *only* the
constant is a **compile error**, not a guard failure, and injecting a dummy statement to relocate the
refusal trips **CS0219-as-error**. Either would have "failed" without testing the guard at all, so both
mutations were rewritten to compile — a consistent rename, and re-inserting the real block after the
switch closes.

## Risk

Read-only enumeration of one extra key per hive. `OpenSubKey` returns `null` when the key is absent —
the case on most machines — and `ReadRunKey` already no-ops on null, so on a PC with no policy entries
nothing changes at all.