### PR TITLE
fix: say which scheduled tasks Startup Manager shows, and which it does not

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -223,8 +223,15 @@ Key services:
   `SocketsHttpHandler`, retry, and surfaced error messages.
 - `UpdateApplier` — runs on relaunch to swap the freshly-downloaded exe over the
   old one and restart, before any DI/UI is built (see the Updates flow below).
-- `StartupService` — enumerate and toggle startup programs via registry
-  Run / RunOnce keys. Enriches each entry from `ProcessDescriptionService`
+- `StartupService` — enumerate and toggle startup programs across seven kinds of
+  location, each a distinct `StartupSource` because the enable/disable state lives
+  in a different place per kind: the `Run`/`RunOnce` keys in both hives, the
+  `Wow6432Node` pair (approved-state in `StartupApproved\Run32`), both shell Startup
+  folders (per-user approved under HKCU, Common under HKLM), the
+  `Policies\Explorer\Run` key (no approved-state at all — shown, never toggled), and
+  third-party scheduled tasks read from the `TaskCache` registry (`\Microsoft\` and
+  `\Windows\` excluded; toggled through `schtasks /Change`, so the same task the
+  Task Scheduler tab owns). Enriches each entry from `ProcessDescriptionService`
   (plain-language description + `ProcessSafety`) keyed on the executable's base
   name; unrecognised programs are left blank so the UI never guesses a safety.
 - `DuplicateFileService` — three-pass duplicate finder (size grouping →

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.66.1] - 2026-08-24
+
+Two tabs list the same scheduled tasks, and now each one says so. Startup Manager deliberately leaves out
+Windows' own tasks to keep its list short and safe to touch, which is the right call — but it never told
+you, so a task you could not find looked like a task that was not there.
+
+### Fixed
+- **Startup Manager and Task Scheduler now explain how they overlap.** Startup Manager says that it lists
+  scheduled tasks belonging to programs you installed and that Windows' own are left out, and points at
+  Task Scheduler for the complete list. Task Scheduler says the reverse: a third-party task also appears
+  in Startup Manager, it is the same task in both places, and switching it in one tab shows up in the
+  other once that tab refreshes. Neither claims the two lists stay in step live, because they do not.
+- **Corrected a documented claim that was never true.** The README said Startup Manager lists
+  "logon-triggered scheduled tasks". The scan only requires that a task have some trigger — it never reads
+  which kind — so a task that runs daily or when the machine goes idle was always listed too. The README
+  now describes what the scan really does, and a test pins the wording to the code so the claim cannot
+  drift back: it becomes allowed only if the scan is one day taught to read the trigger type.
+
 ## [1.66.0] - 2026-08-24
 
 Startup Manager now shows a hiding place it was missing. Windows has a "policy" startup list that Task

--- a/README.md
+++ b/README.md
@@ -353,6 +353,10 @@ a confirmation before it runs:
   the task** — System tasks show an extra warning before you disable them
 - Filter by name or path, and optionally hide system tasks to focus on the rest
 - Changes need administrator and are verified by reading the task's state back
+- Overlaps [Startup Manager](#startup-manager) on purpose: that tab lists the third-party tasks among
+  these next to the programs that launch at boot, because that is all the shorter answer to "why is my
+  PC slow to start" needs. It is the same task in both places, so switching it in one tab applies in the
+  other as soon as that tab refreshes — the two lists are not kept in step live
 
 ### Windows Update (Windows Update Agent COM API)
 - Direct Windows Update Agent COM integration (`Microsoft.Update.Session`) —
@@ -420,9 +424,14 @@ a confirmation before it runs:
   is disabled by design so a mis-click can never hurt anything.
 
 ### Startup Manager
-- Lists every program that runs at Windows boot: the Run and RunOnce registry keys for both your
+- Lists the programs that run at Windows boot: the Run and RunOnce registry keys for both your
   account and the whole machine, **including the separate location 64-bit Windows uses for programs
-  installed by a 32-bit installer**, plus both Startup folders and logon-triggered scheduled tasks
+  installed by a 32-bit installer**, plus both Startup folders and scheduled tasks belonging to
+  programs you installed
+- **Windows' own scheduled tasks are deliberately left out**, so the list stays short enough to read
+  and nothing here is something you should not touch. [Task Scheduler](#task-scheduler) is the tab that
+  shows every task, Windows' included — a third-party task appears on both, and it is the same task in
+  both places
 - **Also reads the "policy" startup list that Task Manager does not show at all** — a favourite hiding
   place for bundled software, since you can switch off everything visible, restart, and it still starts.
   Windows gives an app no way to disable these, so each one is labelled "Set by a system policy —

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2752,6 +2752,144 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// The Startup Manager copy must describe the list its scan actually produces, and the two tabs that
+    /// read the same scheduled tasks must point at each other.
+    /// <para>README said the tab lists "logon-triggered scheduled tasks". <c>ReadScheduledTasks</c> requires
+    /// only a non-empty <c>Triggers</c> blob and never decodes the trigger TYPE, so a task that runs daily
+    /// or on idle is listed identically — the qualifier was simply untrue, and untrue in the way a reviewer
+    /// waves through, because it describes what the tab sounds like it ought to do. The issue asking for
+    /// this fix repeated the same phrase, so writing the copy from the issue text would have shipped the
+    /// error a second time.</para>
+    /// <para>The other half is scope. The scan drops <c>\Microsoft\</c> and <c>\Windows\</c> tasks on
+    /// purpose — the short list is the right answer to "why is my PC slow to start" — so the tab is
+    /// deliberately incomplete and has to say so, and to name the tab that is complete. Both directions are
+    /// asserted, because a third-party task appears on BOTH tabs and both toggle it through the same
+    /// <c>schtasks /Change</c> call: a user who disables it in one must not read the other list as a
+    /// different object.</para>
+    /// <para>Conditional rather than a blocklist, the same shape as
+    /// <see cref="NoPublicDocument_ClaimsAPublisherPinThatIsNotArmed"/>. The phrase becomes legal the day
+    /// the scan really decodes a logon trigger, and the disclosure becomes WRONG the day the exclusions are
+    /// dropped and the list turns complete. Either edit flips what the copy must say, and this fails until
+    /// the copy follows.</para>
+    /// </summary>
+    [Fact]
+    public void TheStartupTabCopy_DescribesTheTaskScanItActuallyRuns()
+    {
+        var appDir = FindAppProjectDir();
+        var service = File.ReadAllText(Path.Combine(appDir, "Services", "StartupService.cs"));
+
+        // Slice the scan itself, so a mention anywhere else in this 900-line service cannot stand in for it.
+        var scanAt = service.IndexOf("private static void ReadScheduledTasks", StringComparison.Ordinal);
+        Assert.True(scanAt > 0, "ReadScheduledTasks was not found in StartupService.cs — fix this guard "
+            + "rather than trusting its pass.");
+        var rest = service[scanAt..];
+        var nextMember = NextMemberDeclaration().Match(rest, 1);
+        var scan = nextMember.Success ? rest[..nextMember.Index] : rest;
+        Assert.True(scan.Length > 200,
+            $"the ReadScheduledTasks slice is {scan.Length} chars — too short to be the method, so every "
+            + "assertion below would be measuring nothing.");
+
+        // Does the scan decode the trigger TYPE, or merely require that SOME trigger exists? Positive
+        // signals only: indexing the blob, or naming a trigger kind. Counting occurrences of the local
+        // would go red on an unrelated rename.
+        var decodesTriggerType = scan.Contains("triggers[", StringComparison.Ordinal)
+            || scan.Contains("TriggerType", StringComparison.Ordinal)
+            || scan.Contains("LogonTrigger", StringComparison.Ordinal)
+            || scan.Contains("TASK_TRIGGER", StringComparison.Ordinal);
+
+        // Is the list deliberately incomplete? Matched as the real StartsWith arguments, so the comments
+        // that explain the exclusion cannot satisfy it.
+        var exclusions = new[] { @"@""\Microsoft\""", @"@""\Windows\""" }
+            .Count(marker => scan.Contains(marker, StringComparison.Ordinal));
+        Assert.Equal(2, exclusions);
+
+        var views = Path.Combine(appDir, "Views");
+        // Comments stripped: a comment naming the other tab must not count as telling the user about it.
+        // The neighbouring guard's first draft stayed green for exactly that reason.
+        var startupView = Collapse(XmlComment().Replace(
+            File.ReadAllText(Path.Combine(views, "StartupView.xaml")), string.Empty));
+        var taskView = Collapse(XmlComment().Replace(
+            File.ReadAllText(Path.Combine(views, "TaskSchedulerView.xaml")), string.Empty));
+
+        var root = FindRepoRoot();
+        var readme = Collapse(File.ReadAllText(Path.Combine(root, "README.md")));
+
+        // CHANGELOG is deliberately NOT scanned. It is the historical record, so the entry that documents
+        // this very fix has to be free to quote the wording being removed.
+        var offenders = new List<string>();
+
+        if (!decodesTriggerType)
+        {
+            foreach (var (surface, text) in new[]
+                     { ("README.md", readme), ("StartupView.xaml", startupView), ("TaskSchedulerView.xaml", taskView) })
+            {
+                var claim = LogonTriggerClaim().Match(text);
+                if (claim.Success)
+                    offenders.Add($"{surface} claims \"{claim.Value}\" but the scan only checks that a "
+                        + "trigger EXISTS — it never reads which kind");
+            }
+        }
+
+        if (exclusions == 2)
+        {
+            if (!startupView.Contains("Task Scheduler", StringComparison.Ordinal))
+                offenders.Add("StartupView.xaml never names Task Scheduler, so the tab hides Windows' own "
+                    + "tasks without telling the user where the complete list is");
+
+            if (!taskView.Contains("Startup Manager", StringComparison.Ordinal))
+                offenders.Add("TaskSchedulerView.xaml never names Startup Manager, so a user who disabled a "
+                    + "task there cannot tell it is the same task");
+
+            // Scoped to the tab's own README section: a mention under any other heading is not this
+            // tab explaining itself.
+            var sectionAt = readme.IndexOf("### Startup Manager", StringComparison.Ordinal);
+            Assert.True(sectionAt > 0, "README.md has no '### Startup Manager' section — the guard would "
+                + "pass vacuously.");
+            var after = readme[(sectionAt + 1)..];
+            var sectionEnd = after.IndexOf("### ", StringComparison.Ordinal);
+            var section = sectionEnd > 0 ? after[..sectionEnd] : after;
+            Assert.True(section.Length > 200,
+                $"the README Startup Manager section sliced to {section.Length} chars — not the section.");
+
+            if (!section.Contains("Task Scheduler", StringComparison.Ordinal))
+                offenders.Add("the README Startup Manager section does not point at Task Scheduler, though "
+                    + "the scan drops every Windows task");
+        }
+
+        // The ARCHITECTURE count is spelled out in prose, which is exactly what drifts: it was written when
+        // there were four sources and had to be re-derived twice since. Pin it to the enum.
+        var model = File.ReadAllText(Path.Combine(appDir, "Models", "StartupEntry.cs"));
+        var enumAt = model.IndexOf("public enum StartupSource", StringComparison.Ordinal);
+        Assert.True(enumAt > 0, "StartupSource was not found — the count below would be invented.");
+        // Comments come off BEFORE the braces are matched: a doc comment containing a brace would
+        // otherwise truncate the body and undercount the sources without failing anything.
+        var declaration = DocComment().Replace(model[enumAt..], string.Empty);
+        var enumBody = declaration[(declaration.IndexOf('{', StringComparison.Ordinal) + 1)..];
+        enumBody = enumBody[..enumBody.IndexOf('}', StringComparison.Ordinal)];
+        var sources = enumBody
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Count(v => v.Length > 0);
+        Assert.True(sources >= 5, $"only {sources} StartupSource values parsed — the parse is wrong.");
+
+        string[] spelled = ["zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"];
+        var architecture = Collapse(File.ReadAllText(Path.Combine(root, "ARCHITECTURE.md")));
+        var expected = $"{spelled[sources]} kinds of location";
+        if (!architecture.Contains(expected, StringComparison.Ordinal))
+            offenders.Add($"ARCHITECTURE.md does not say \"{expected}\" though StartupSource now has "
+                + $"{sources} values");
+
+        Assert.True(offenders.Count == 0,
+            "the Startup Manager copy no longer matches the scan behind it:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    [GeneratedRegex(@"logon[- ]triggered|triggered at logon", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    private static partial Regex LogonTriggerClaim();
+
+    [GeneratedRegex(@"///.*?$", RegexOptions.Compiled | RegexOptions.Multiline)]
+    private static partial Regex DocComment();
+
+    /// <summary>
     /// Everything the scheduled-task query pays to fetch must reach the screen.
     /// <para>The Task Scheduler tab queried <c>Author</c>, <c>Description</c> and <c>NextRunTime</c> from
     /// Windows on every scan, carried all three through <c>ScheduledTaskInfo</c>, and even defined a

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.66.0</Version>
-    <FileVersion>1.66.0.0</FileVersion>
-    <AssemblyVersion>1.66.0.0</AssemblyVersion>
+    <Version>1.66.1</Version>
+    <FileVersion>1.66.1.0</FileVersion>
+    <AssemblyVersion>1.66.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -21,8 +21,8 @@
         <!-- Header -->
         <StackPanel Grid.Row="0" Margin="0,0,0,16">
             <TextBlock Text="Startup Manager" Style="{StaticResource Display}"/>
-            <TextBlock Text="Programs that run when Windows starts. Disabling is non-destructive — you can re-enable anytime."
-                       Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+            <TextBlock Text="Programs that run when Windows starts. Disabling is non-destructive — you can re-enable anytime. Scheduled tasks from other programs are listed too; Windows' own tasks are left out, so System → Task Scheduler is where you see every task."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
         <!-- Elevation banner: not elevated -->

--- a/SysManager/SysManager/Views/TaskSchedulerView.xaml
+++ b/SysManager/SysManager/Views/TaskSchedulerView.xaml
@@ -25,7 +25,7 @@
         <!-- Header -->
         <StackPanel Grid.Row="1" Margin="0,0,0,16">
             <TextBlock Text="Task Scheduler" Style="{StaticResource Display}"/>
-            <TextBlock Text="Browse Windows scheduled tasks and turn them on or off. Tasks are color-coded by type; disabling is always reversible and never deletes a task."
+            <TextBlock Text="Browse Windows scheduled tasks and turn them on or off. Tasks are color-coded by type; disabling is always reversible and never deletes a task. Third-party tasks also appear on System → Startup Manager — the same task in both places, so switching it there is the same switch, and this list shows the new state after a refresh."
                        Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 


### PR DESCRIPTION
Closes #1503.

## Problem

`StartupService.ReadScheduledTasks` lists scheduled tasks alongside the Run keys and Startup folders, but filters to third-party only — `\Microsoft\` and `\Windows\` URIs are skipped, and a name already seen from the Run keys is skipped. That filter is the right call for this tab: the short list is the useful answer to "why is my PC slow to start", and nothing in it is something the target user should not touch.

Nothing told the user any of that. A task they could not find looked like a task that was not there, and there was no hint that the row is the same Windows object the Task Scheduler tab lists — both toggle it, so a user could disable it in one tab and read the other as a second, still-enabled thing.

## What changed

**Both tabs disclose the overlap.** Startup Manager now says it lists scheduled tasks belonging to installed programs, that Windows' own are left out, and that Task Scheduler is where every task is. Task Scheduler says the reverse. Neither promises the lists stay in step live, because they do not — `SetTaskSchedulerEnabledAsync` shells `schtasks /Change` and the other tab keeps its old rows until refreshed. The wording is explicit about that rather than silent.

**A README claim that was never true is corrected.** It said the tab lists "logon-triggered scheduled tasks". `ReadScheduledTasks` requires only a non-empty `Triggers` blob (`length >= 4`) and never decodes the trigger *type*, so a task with a daily or on-idle trigger has always been listed identically. Worth flagging: issue #1503 proposes the same "logon-triggered" phrasing, so writing the copy from the issue text would have shipped the error a second time. The wording was re-derived from the scan.

**ARCHITECTURE now matches the service.** It described `StartupService` as reading "registry Run / RunOnce keys", which has been incomplete for several releases — it omitted `Wow6432Node`, both Startup folders, scheduled tasks, and (as of v1.66.0) the policy key. It now lists all seven sources and why each has to be distinct.

## The guard

`TheStartupTabCopy_DescribesTheTaskScanItActuallyRuns` is conditional, not a blocklist — same shape as `NoPublicDocument_ClaimsAPublisherPinThatIsNotArmed`:

- while the scan cannot read a trigger type, the logon phrasing is forbidden in the README and both views;
- while the `\Microsoft\`/`\Windows\` exclusions are in place, both tabs must name each other and the README section must point at Task Scheduler;
- the source count spelled out in ARCHITECTURE must equal the `StartupSource` enum.

Either code edit flips what the copy must say, so the guard fails until the copy follows rather than freezing today's wording. XAML comments are stripped before matching, so a comment naming the other tab cannot satisfy it, and CHANGELOG is deliberately not scanned so this entry can quote the wording being removed.

## Verification

Seven mutations, each run against the real guard:

| Mutation | Result |
|---|---|
| baseline, unmutated | green |
| the false `logon-triggered` claim restored in README | **red** |
| StartupView stops naming Task Scheduler | **red** |
| TaskSchedulerView stops naming Startup Manager | **red** |
| pointer removed from the README *section* while another section still names the tab | **red** |
| ARCHITECTURE says "six kinds" while the enum has seven | **red** |
| the `\Windows\` exclusion deleted from the scan | **red** |
| the scan taught to really index the trigger blob (ban must lift) | green |

All five mutated files restored byte-for-byte afterwards.

Also: all four projects build 0 errors / 0 warnings; `dotnet format --verify-no-changes` clean; the three CI gates reproduced locally before pushing (version consistency, valid-bump, CHANGELOG lead) all exit 0; and a regression sweep of the eight guards this could disturb — including `EveryUiTextAssertion_QuotesCopyTheAppActuallyShips`, since two subtitles changed — is green. No UI test quotes either subtitle.