### PR TITLE
fix: stop Gaming Profile from overruling a notification change the user just made

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.66.2] - 2026-08-24
+
+Turning notifications back on while a Gaming Profile is running now sticks. Gaming Profile and the
+Notifications page are two switches wired to the same setting, and when the game exited the profile put
+its own version back — silencing notifications you had just deliberately switched on.
+
+### Fixed
+- **Gaming Profile no longer overrules a notification change you made yourself.** When a profile ends it
+  restores the notification setting only if it is still the one the profile applied. If you changed it
+  meanwhile — from Privacy & Security → Notifications, which is the very same switch — your choice is
+  kept and the profile leaves it alone. Everything else about the restore is unchanged, including putting
+  an explicitly-on setting back exactly as it was rather than merely "not off".
+- **The two features now share one definition of that setting.** The registry location was written out
+  twice, word for word, in two different services that both wrote to it, with neither aware of the other
+  — so a correction to one would silently not apply to the other. There is now a single owner, and a test
+  refuses any registry location that is spelled out in more than one place, which is the class of mistake
+  rather than this one instance of it.
+
 ## [1.66.1] - 2026-08-24
 
 Two tabs list the same scheduled tasks, and now each one says so. Startup Manager deliberately leaves out

--- a/README.md
+++ b/README.md
@@ -775,6 +775,9 @@ offers, "rate us" prompts:
 - **Fully reversible & snapshot-based** — the original state (power plan, visual
   effects, indexing, notifications) is captured before any change and restored exactly;
   SysManager also tries a System Restore point first (best-effort, needs administrator)
+- **Your own changes win** — if you switch notifications back on yourself while a profile is
+  running (from Privacy & Security → Notifications, which is the same switch), the restore leaves
+  your choice alone instead of silencing them again when the game exits
 - **Crash-safe** — the session is recorded on disk, so if SysManager closes mid-game the
   system-wide changes are offered for restore on next launch
 - **Honest about admin** — freeing standby memory and pausing indexing need

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2752,6 +2752,128 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// A registry path must be declared in ONE place. Two verbatim copies of the same key drift, and they
+    /// drift silently: nothing tells the compiler that two identical strings were meant to stay identical.
+    /// <para>The defect this generalises: <c>PushNotifications\ToastEnabled</c> was declared twice,
+    /// byte-identical, in <c>NotificationBlockerService</c> and in the Gaming Profile's
+    /// <c>NotificationsTweak</c> — and BOTH wrote it, so the Notifications tab and Gaming Profile were
+    /// fighting over one switch with neither aware of the other. The repo had already learned this lesson
+    /// and written it down: <c>Helpers/WingetId.cs</c> exists because the winget-ID allowlist had been
+    /// copy-pasted into three services "where three copies could drift apart".</para>
+    /// <para>Nine duplicate pairs predate this guard and are listed with the reason each is tolerated, so
+    /// the rule can be enforced now rather than after a cleanup that may never happen. The allowlist is
+    /// keyed to the EXACT set of files, not to a count and not to the literal alone: adding a THIRD copy of
+    /// an already-tolerated path fails, and so does fixing a pair without deleting its entry — a stale
+    /// exemption is a lie about the codebase that the next reader will trust.</para>
+    /// </summary>
+    [Fact]
+    public void NoRegistryPath_IsDeclaredInTwoPlaces()
+    {
+        // literal (lower-cased) -> the only files allowed to declare it, and why.
+        var tolerated = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // A Windows-defined device class GUID, not a SysManager convention. Both readers want the
+            // display-adapters class; neither owns it.
+            [@"system\currentcontrolset\control\class\{4d36e968-e325-11ce-bfc1-08002be10318}"] =
+                "Helpers/GpuVramHelper.cs,Services/PerformanceService.cs",
+
+            // The two Uninstall roots. AppAlertService watches them for newly installed apps;
+            // UninstallerService enumerates them to list programs. Same roots, different jobs.
+            [@"software\microsoft\windows\currentversion\uninstall"] =
+                "Services/AppAlertService.cs,Services/UninstallerService.cs",
+            [@"software\wow6432node\microsoft\windows\currentversion\uninstall"] =
+                "Services/AppAlertService.cs,Services/UninstallerService.cs",
+
+            // SettingsWatchdogService re-declares the policy keys PrivacyService writes, so it can notice
+            // when Windows silently reverts them. Watching your own writes needs the same path twice, but
+            // it is still duplication: correct one and not the other and the watchdog quietly stops
+            // watching the toggle it is named after.
+            [@"hklm\software\policies\microsoft\windows\datacollection"] =
+                "Services/PrivacyService.cs,Services/SettingsWatchdogService.cs",
+            [@"hklm\software\policies\microsoft\windows\system"] =
+                "Services/PrivacyService.cs,Services/SettingsWatchdogService.cs",
+            [@"hkcu\software\microsoft\windows\currentversion\advertisinginfo"] =
+                "Services/PrivacyService.cs,Services/SettingsWatchdogService.cs",
+            [@"hkcu\software\microsoft\windows\currentversion\contentdeliverymanager"] =
+                "Services/PrivacyService.cs,Services/SettingsWatchdogService.cs",
+            [@"hkcu\software\policies\microsoft\windows\explorer"] =
+                "Services/PrivacyService.cs,Services/SettingsWatchdogService.cs",
+            [@"hklm\software\policies\microsoft\dsh"] =
+                "Services/PrivacyService.cs,Services/SettingsWatchdogService.cs",
+        };
+
+        var appDir = FindAppProjectDir();
+        var sources = Directory
+            .EnumerateFiles(appDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                                    StringComparison.Ordinal)
+                        && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}",
+                                       StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.True(sources.Length >= 50,
+            $"only {sources.Length} app source files found under {appDir} — the scan is not seeing the "
+            + "codebase, so every assertion below would pass vacuously.");
+
+        var byLiteral = new Dictionary<string, SortedSet<string>>(StringComparer.Ordinal);
+        foreach (var file in sources)
+        {
+            var relative = Path.GetRelativePath(appDir, file).Replace(Path.DirectorySeparatorChar, '/');
+            foreach (var match in VerbatimLiteral().Matches(File.ReadAllText(file)).Cast<Match>())
+            {
+                var value = match.Groups[1].Value;
+                // Registry-shaped only: a separator plus a hive or a well-known registry segment. The
+                // length floor drops fragments like @"Software\" that are composed at the call site.
+                if (!value.Contains('\\', StringComparison.Ordinal) || value.Length < 12) continue;
+                if (!RegistryShaped().IsMatch(value)) continue;
+
+                var key = value.ToLowerInvariant();
+                if (!byLiteral.TryGetValue(key, out var files))
+                    byLiteral[key] = files = new SortedSet<string>(StringComparer.Ordinal);
+                files.Add(relative);
+            }
+        }
+
+        Assert.True(byLiteral.Count >= 30,
+            $"only {byLiteral.Count} registry-shaped literals matched — the extraction is broken, so a "
+            + "clean result would mean nothing.");
+
+        var offenders = new List<string>();
+
+        foreach (var (literal, files) in byLiteral.Where(kv => kv.Value.Count > 1))
+        {
+            var actual = string.Join(",", files);
+            if (!tolerated.TryGetValue(literal, out var allowed))
+            {
+                offenders.Add($"NEW duplicate: {literal} — declared in {actual}. Give it one owner and "
+                    + "reference it from there (see Helpers/WingetId.cs).");
+                continue;
+            }
+
+            if (!string.Equals(actual, allowed, StringComparison.Ordinal))
+                offenders.Add($"the tolerated pair {literal} moved: expected {allowed}, found {actual}. A "
+                    + "third copy is never acceptable; edit the entry only if the set genuinely changed.");
+        }
+
+        foreach (var (literal, allowed) in tolerated)
+        {
+            if (byLiteral.TryGetValue(literal, out var files) && files.Count > 1) continue;
+            offenders.Add($"{literal} is listed as a tolerated duplicate but is no longer declared twice "
+                + $"(expected {allowed}). Delete the entry — it now exempts nothing.");
+        }
+
+        Assert.True(offenders.Count == 0,
+            "registry paths must have exactly one declaration site:\n  - " + string.Join("\n  - ", offenders));
+    }
+
+    [GeneratedRegex(@"@""([^""]*)""", RegexOptions.Compiled)]
+    private static partial Regex VerbatimLiteral();
+
+    [GeneratedRegex(@"SOFTWARE|Software|SYSTEM|System|HKEY|HKCU|HKLM|CurrentVersion|Policies|Classes",
+                    RegexOptions.Compiled)]
+    private static partial Regex RegistryShaped();
+
+    /// <summary>
     /// The Startup Manager copy must describe the list its scan actually produces, and the two tabs that
     /// read the same scheduled tasks must point at each other.
     /// <para>README said the tab lists "logon-triggered scheduled tasks". <c>ReadScheduledTasks</c> requires

--- a/SysManager/SysManager.Tests/NotificationsTweakTests.cs
+++ b/SysManager/SysManager.Tests/NotificationsTweakTests.cs
@@ -1,0 +1,163 @@
+// SysManager · NotificationsTweakTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using Microsoft.Win32;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Round-trip tests for the Gaming Profile <c>NotificationsTweak</c>, which had none: the profile
+/// engine's own tests drive fake <see cref="IGamingTweak"/> steps, so nothing exercised the registry
+/// write this tweak really performs. The tweak now takes an injectable registry root, so the
+/// apply/revert round-trip runs against a disposable HKCU subkey instead of the machine's real
+/// notification settings (mirrors <see cref="NotificationBlockerServiceTests"/>).
+/// </summary>
+public sealed class NotificationsTweakTests : IDisposable
+{
+    private readonly string _rootName = @"Software\SysManagerTests\NotifTweak_" + Guid.NewGuid().ToString("N");
+    private readonly RegistryKey _root;
+
+    public NotificationsTweakTests()
+        => _root = Registry.CurrentUser.CreateSubKey(_rootName, writable: true)!;
+
+    public void Dispose()
+    {
+        _root.Dispose();
+        try { Registry.CurrentUser.DeleteSubKeyTree(_rootName, throwOnMissingSubKey: false); }
+        catch (System.Security.SecurityException) { /* best-effort cleanup */ }
+        catch (UnauthorizedAccessException) { /* best-effort cleanup */ }
+    }
+
+    /// <summary>The raw ToastEnabled value under the redirected root; null when absent.</summary>
+    private object? Current()
+    {
+        using var key = _root.OpenSubKey(NotificationBlockerService.PushKeyPath);
+        return key?.GetValue(NotificationBlockerService.ToastValueName);
+    }
+
+    private void Seed(int? value)
+    {
+        using var key = _root.CreateSubKey(NotificationBlockerService.PushKeyPath, writable: true)!;
+        if (value is { } v) key.SetValue(NotificationBlockerService.ToastValueName, v, RegistryValueKind.DWord);
+        else key.DeleteValue(NotificationBlockerService.ToastValueName, throwOnMissingValue: false);
+    }
+
+    [Fact]
+    public async Task Apply_WhenNotificationsWereOn_SuppressesThem()
+    {
+        Seed(null);
+
+        var result = await new NotificationsTweak(originalToastEnabled: null, _root).ApplyAsync(default);
+
+        Assert.Equal(GamingTweakResult.Applied, result);
+        Assert.Equal(0, Current());
+    }
+
+    [Fact]
+    public async Task Apply_WhenAlreadySuppressed_ReportsNoChangeAndWritesNothing()
+    {
+        // No key at all, so a stray write would be visible as the key coming into existence.
+        var result = await new NotificationsTweak(originalToastEnabled: 0, _root).ApplyAsync(default);
+
+        Assert.Equal(GamingTweakResult.NoChange, result);
+        using var key = _root.OpenSubKey(NotificationBlockerService.PushKeyPath);
+        Assert.Null(key);
+    }
+
+    [Fact]
+    public async Task Revert_WhenTheValueWasAbsent_RemovesItAgain()
+    {
+        Seed(null);
+        var tweak = new NotificationsTweak(originalToastEnabled: null, _root);
+        await tweak.ApplyAsync(default);
+        Assert.Equal(0, Current());
+
+        await tweak.RevertAsync(default);
+
+        Assert.Null(Current());
+    }
+
+    /// <summary>
+    /// An explicit 1 must come back as 1, not as "absent". Windows treats both as notifications-on,
+    /// so the two are easy to conflate — but the tweak documents an exact restore, and routing this
+    /// through a boolean set-enabled API would quietly turn the 1 into a deletion. This test is what
+    /// makes that difference observable.
+    /// </summary>
+    [Fact]
+    public async Task Revert_WhenTheValueWasExplicitlyOne_RestoresOneRatherThanDeletingIt()
+    {
+        Seed(1);
+        var tweak = new NotificationsTweak(originalToastEnabled: 1, _root);
+        await tweak.ApplyAsync(default);
+        Assert.Equal(0, Current());
+
+        await tweak.RevertAsync(default);
+
+        Assert.Equal(1, Current());
+    }
+
+    /// <summary>
+    /// Regression test for the reverting half of #1502. The Notifications tab writes the SAME value
+    /// this tweak writes, so a user can switch notifications back on while a profile is still active.
+    /// Revert used to restore the pre-game snapshot unconditionally, which overturned that newer
+    /// decision — notifications went silent again on their own when the game exited. Revert now only
+    /// undoes the 0 it wrote, so a value that is no longer 0 is left exactly as the user left it.
+    /// </summary>
+    [Fact]
+    public async Task Revert_WhenTheUserTurnedNotificationsBackOnMidSession_KeepsTheirChoice()
+    {
+        // The snapshot is an explicit 1 rather than "absent" on purpose: the Notifications tab
+        // re-enables by DELETING the value, so a snapshot of 1 is what makes the old unconditional
+        // restore observable. With a null snapshot both the bug and the fix leave the value absent,
+        // and the test would pass either way — proving nothing.
+        Seed(1);
+        var tweak = new NotificationsTweak(originalToastEnabled: 1, _root);
+        await tweak.ApplyAsync(default);
+        Assert.Equal(0, Current());
+
+        // The user re-enables notifications from the Notifications tab, mid-session.
+        new NotificationBlockerService(_root).SetGlobalToastEnabled(true);
+        Assert.Null(Current());
+
+        await tweak.RevertAsync(default);
+
+        Assert.Null(Current());
+    }
+
+    /// <summary>
+    /// Same rule when the user's mid-session value is an explicit 1 rather than a deletion: revert
+    /// must not overwrite it with the snapshot either.
+    /// </summary>
+    [Fact]
+    public async Task Revert_WhenTheUserSetAnExplicitOneMidSession_KeepsIt()
+    {
+        Seed(null);
+        var tweak = new NotificationsTweak(originalToastEnabled: null, _root);
+        await tweak.ApplyAsync(default);
+
+        Seed(1);
+
+        await tweak.RevertAsync(default);
+
+        Assert.Equal(1, Current());
+    }
+
+    [Fact]
+    public void ReadToastEnabled_WhenTheValueIsAbsent_IsNull()
+    {
+        Seed(null);
+
+        Assert.Null(NotificationsTweak.ReadToastEnabled(_root));
+    }
+
+    [Fact]
+    public void ReadToastEnabled_WhenSuppressed_IsZero()
+    {
+        Seed(0);
+
+        Assert.Equal(0, NotificationsTweak.ReadToastEnabled(_root));
+    }
+}

--- a/SysManager/SysManager/Services/GamingTweaks.cs
+++ b/SysManager/SysManager/Services/GamingTweaks.cs
@@ -175,25 +175,36 @@ internal sealed class SearchIndexingTweak(bool wasRunning) : IGamingTweak
 /// Silence toast notifications via the documented HKCU push-notifications key (reversible, no
 /// admin). This mutes toasts while gaming; it is NOT the Focus Assist / Do-Not-Disturb tile
 /// (no stable public API), which the UI copy states plainly. Restores the original DWORD on
-/// revert (deleting the value if it was absent, to restore the exact prior state).
+/// revert (deleting the value if it was absent, to restore the exact prior state) — but only
+/// while the value is still the 0 this tweak wrote. The key is shared with
+/// <see cref="NotificationBlockerService"/>, which owns the path and value name, so the user can
+/// move the same switch from the Notifications tab while a profile is active; if they have, revert
+/// keeps their choice rather than resurrecting the pre-game state.
 /// </summary>
-internal sealed class NotificationsTweak(int? originalToastEnabled) : IGamingTweak
+internal sealed class NotificationsTweak(int? originalToastEnabled, RegistryKey? baseKey = null) : IGamingTweak
 {
-    // Per-user master toggle for toast notifications (the same value the Settings > Notifications
-    // switch writes). ToastEnabled = 0 suppresses toasts; absent/1 = normal.
-    internal const string PushKeyPath = @"Software\Microsoft\Windows\CurrentVersion\PushNotifications";
-    internal const string ToastValueName = "ToastEnabled";
+    // The key path and value name are NOT redeclared here. They are owned by
+    // NotificationBlockerService, whose Notifications tab writes the same user-wide master toggle,
+    // and referenced from there so the two cannot drift — the situation Helpers/WingetId.cs exists
+    // to prevent, where the same rule lived in three services and could diverge in one of them.
+    // ToastEnabled = 0 suppresses toasts; absent/1 = normal.
+    //
+    // The registry root is injectable (defaulting to HKCU) for the same reason as
+    // NotificationBlockerService and AppBlockerService: it lets the apply/revert round-trip be
+    // tested against a redirected subkey instead of the machine's real notification settings.
+    private RegistryKey Root => baseKey ?? Registry.CurrentUser;
 
     public string Label => "Silence notifications";
     public bool RequiresAdmin => false;
 
     /// <summary>Reads the current ToastEnabled DWORD (null = value absent → notifications on).</summary>
-    internal static int? ReadToastEnabled()
+    internal static int? ReadToastEnabled(RegistryKey? baseKey = null)
     {
         try
         {
-            using var key = Registry.CurrentUser.OpenSubKey(PushKeyPath, writable: false);
-            return key?.GetValue(ToastValueName) is int i ? i : null;
+            using var key = (baseKey ?? Registry.CurrentUser)
+                .OpenSubKey(NotificationBlockerService.PushKeyPath, writable: false);
+            return key?.GetValue(NotificationBlockerService.ToastValueName) is int i ? i : null;
         }
         catch (System.Security.SecurityException) { return null; }
         catch (UnauthorizedAccessException) { return null; }
@@ -203,19 +214,35 @@ internal sealed class NotificationsTweak(int? originalToastEnabled) : IGamingTwe
     {
         // Toasts already suppressed (ToastEnabled == 0) → no-op; nothing to change or restore.
         if (originalToastEnabled == 0) return Task.FromResult(GamingTweakResult.NoChange);
-        using var key = Registry.CurrentUser.CreateSubKey(PushKeyPath, writable: true);
-        key.SetValue(ToastValueName, 0, RegistryValueKind.DWord);
+        using var key = Root.CreateSubKey(NotificationBlockerService.PushKeyPath, writable: true);
+        key.SetValue(NotificationBlockerService.ToastValueName, 0, RegistryValueKind.DWord);
         Log.Information("Gaming Profile: notifications silenced (ToastEnabled=0)");
         return Task.FromResult(GamingTweakResult.Applied);
     }
 
     public Task RevertAsync(CancellationToken ct)
     {
-        using var key = Registry.CurrentUser.CreateSubKey(PushKeyPath, writable: true);
+        // Undo only the value this tweak actually wrote. A NoChange apply is never tracked for
+        // revert, so reaching here means ToastEnabled was set to 0 by us; if it is no longer 0 the
+        // user has since changed the master toggle themselves — most likely on the Notifications
+        // tab, which writes this very value — and restoring the pre-game snapshot would silently
+        // overturn that newer decision. Leaving it alone is what "reversible" has to mean when the
+        // user has already moved the switch.
+        var current = ReadToastEnabled(baseKey);
+        if (current != 0)
+        {
+            Log.Information(
+                "Gaming Profile: notifications master toggle was changed while the profile was active "
+                + "(now {Current}); leaving the user's setting instead of restoring {Original}",
+                current, originalToastEnabled);
+            return Task.CompletedTask;
+        }
+
+        using var key = Root.CreateSubKey(NotificationBlockerService.PushKeyPath, writable: true);
         if (originalToastEnabled is { } v)
-            key.SetValue(ToastValueName, v, RegistryValueKind.DWord);
+            key.SetValue(NotificationBlockerService.ToastValueName, v, RegistryValueKind.DWord);
         else
-            key.DeleteValue(ToastValueName, throwOnMissingValue: false); // was absent → restore absent
+            key.DeleteValue(NotificationBlockerService.ToastValueName, throwOnMissingValue: false); // was absent → restore absent
         return Task.CompletedTask;
     }
 }

--- a/SysManager/SysManager/Services/NotificationBlockerService.cs
+++ b/SysManager/SysManager/Services/NotificationBlockerService.cs
@@ -32,7 +32,9 @@ public sealed class NotificationBlockerService : INotificationBlockerService
     internal const string SettingsPath = @"Software\Microsoft\Windows\CurrentVersion\Notifications\Settings";
     internal const string EnabledValueName = "Enabled";
 
-    // The user-wide master toggle (same values NotificationsTweak uses for Gaming Profile).
+    // The user-wide master toggle. This service OWNS these two strings: NotificationsTweak (Gaming
+    // Profile) writes the same value and references them from here rather than declaring its own
+    // copies, which is what let the two drift apart before.
     internal const string PushKeyPath = @"Software\Microsoft\Windows\CurrentVersion\PushNotifications";
     internal const string ToastValueName = "ToastEnabled";
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.66.1</Version>
-    <FileVersion>1.66.1.0</FileVersion>
-    <AssemblyVersion>1.66.1.0</AssemblyVersion>
+    <Version>1.66.2</Version>
+    <FileVersion>1.66.2.0</FileVersion>
+    <AssemblyVersion>1.66.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #1502.

## Problem

`PushNotifications\ToastEnabled` was declared **twice, byte-identical** — in `NotificationBlockerService` and in the Gaming Profile's `NotificationsTweak` — and both services WRITE it. Neither knew about the other.

The user-visible consequence: `RevertAsync` restored the pre-game snapshot unconditionally. Turn notifications back on mid-session from **Privacy & Security → Notifications** (the same switch), and when the game exits the profile silences them again. The switch appears not to stick, with no message explaining why.

## What changed

**One owner.** `NotificationBlockerService` owns `PushKeyPath` / `ToastValueName`; `NotificationsTweak` references them. No behaviour change in itself — it removes the drift risk, which is the defect in the issue title.

**Revert respects a newer decision.** `RevertAsync` now undoes only the `ToastEnabled = 0` it wrote:

```csharp
var current = ReadToastEnabled(baseKey);
if (current != 0) { /* the user moved the switch — leave it */ return Task.CompletedTask; }
```

A `NoChange` apply is never added to the engine's `applied` list (`GamingProfileService.cs`), so reaching this code means the tweak really did write the `0`. That is what makes the comparison meaningful rather than a guess.

**The tweak is testable and now tested.** It takes an injectable registry root, mirroring `NotificationBlockerService` and `AppBlockerService`. It previously had **no tests at all** — `GamingProfileServiceTests` drives fake `IGamingTweak` steps, so nothing ever exercised the registry write. Eight tests now run against a disposable HKCU subkey.

## Fixing the class, not the instance

`NoRegistryPath_IsDeclaredInTwoPlaces` refuses any registry literal declared in more than one file, in the spirit of `Helpers/WingetId.cs` (which exists because the winget-ID allowlist had been copy-pasted into three services "where three copies could drift apart").

Nine pairs predate the guard and are listed with the reason each is tolerated. The allowlist is keyed to the **exact set of files**, not to a count and not to the literal alone, so:

- a **third** copy of an already-tolerated path fails;
- **removing** a duplication without deleting its entry fails, because a stale exemption misdescribes the codebase and the next reader will trust it.

Measured before writing it: 49 registry-shaped literals in the app project, 9 duplicated across files. The tolerated list documents each — the two Uninstall roots (AppAlertService vs UninstallerService), a Windows device-class GUID (GpuVramHelper vs PerformanceService), and six policy paths that `SettingsWatchdogService` re-declares to watch what `PrivacyService` writes.

## Verification

| Mutation | Result |
|---|---|
| baseline, unmutated | green |
| the `ToastEnabled` constants re-declared in GamingTweaks (the original defect) | **red** — new duplicate |
| a third copy of an already-tolerated path | **red** |
| a tolerated pair broken so it is declared once, entry left behind | **red** — stale entry |
| the old unconditional `RevertAsync` restored | **red** — *both* mid-session tests |
| revert always deletes instead of restoring the captured value | **red** — the explicit-1 test |

Both mutated files restored byte-for-byte. Note the mid-session test deliberately snapshots an explicit `1` rather than "absent": the Notifications tab re-enables by DELETING the value, so with a null snapshot the bug and the fix both leave it absent and the test would pass either way, proving nothing.

Both projects build **0 errors / 0 warnings**; `dotnet format --verify-no-changes` clean on both; the three CI gates reproduced locally (version consistency, valid bump, CHANGELOG lead) all exit 0; regression sweep of 11 related tests green.

## Not fixed here — filed as #1948

The mirror-image ordering cannot be fixed by comparing values. If the user turns notifications **off** mid-session, the value is `0` — identical to what the tweak wrote — so revert still restores "on". The registry cannot say who wrote the `0`; that half needs shared intent state, and #1948 lays out the two options with a recommendation rather than leaving it implied by a closed issue.

## Docs

README's Gaming Profile section promised the original state is "restored exactly", which is now deliberately not true when the user has moved the switch themselves. A bullet states the exception in the user's own terms.