### PR TITLE
fix: make Gaming Profile take the system-modification lock before it snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.66.3] - 2026-08-24
+
+Gaming Profile and Performance Mode can no longer trip over each other. They change the same two
+settings — the power plan and the visual-effects switch — and each writes down "how you had it" before
+changing anything. Start one while the other is mid-change and the note it takes down is the other one's
+change, so restoring later put your PC somewhere you had never been.
+
+### Fixed
+- **Gaming Profile now waits for Performance Mode, and vice versa.** Starting a game profile while a
+  Performance Mode change is running says plainly which one is busy instead of starting anyway. It takes
+  that check **before** reading your current settings, not just before changing them — reading them at
+  the wrong moment is what recorded the wrong "original" and could leave your PC on a gaming power plan
+  after everything was supposedly restored.
+- **Undoing is never refused.** If a game exits while another change happens to be running, the
+  optimizations are still undone. Leaving your PC tweaked because something else was busy would be worse
+  than the clash being avoided, so the undo goes ahead and says so in the log. The same applies to the
+  leftover-session cleanup that runs after a crash.
+- **The README no longer overstates the protection.** It said the lock covers every tab that changes
+  system state and then omitted Gaming Profile, which was the one tab it did not cover. A test now keeps
+  that list honest in both directions.
+
 ## [1.66.2] - 2026-08-24
 
 Turning notifications back on while a Gaming Profile is running now sticks. Gaming Profile and the

--- a/README.md
+++ b/README.md
@@ -584,8 +584,15 @@ a confirmation before it runs:
   is blocking and refuses to start the new one
 - Integrated into every tab that mutates disk, network, or system state
   (Cleanup, Deep Cleanup, Disk Analyzer, Duplicate Finder, Speed Test, Traceroute,
-  Network Repair, Shortcut Cleaner, Performance Mode, Environment Variables, and the
-  Dashboard's quick actions)
+  Network Repair, Shortcut Cleaner, Performance Mode, Gaming Profile, Environment
+  Variables, and the Dashboard's quick actions)
+- **Gaming Profile takes the lock before it reads your current settings**, not just
+  around the changes — it and Performance Mode set the same power plan and the same
+  visual-effects switch, so whichever starts second would otherwise write down the
+  other one's change as "how you had it" and restore you to that later
+- Undoing is never refused. If a game exits while another change is running, the
+  optimizations are still reverted — leaving your PC on a gaming power plan because a
+  lock was busy would be worse than the clash the lock exists to avoid
 
 ### Shortcut Cleaner
 - Scans Desktop, Start Menu, Quick Launch, and Recent Items for broken .lnk

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2752,6 +2752,158 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// Gaming Profile must take the app-wide system-modification lock, and the two directions must stay
+    /// asymmetric: apply REFUSES when the lock is held, revert NEVER does.
+    /// <para>Gaming Profile and Performance Mode write the same power plan and the same visual-effects
+    /// flag, and each keeps its own record of the original — <c>gaming-profiles.json</c> versus
+    /// <c>performance-snapshot.json</c>. The service had its own <c>_gate</c>, which serialises it against
+    /// itself and says nothing about the other tab. The damage is done at SNAPSHOT time: a snapshot taken
+    /// while the other tab's change is live records that change as the baseline, and the later "restore"
+    /// strands the machine off the user's real power plan with both tabs believing they were correct. So
+    /// the acquire has to sit before <c>CaptureSnapshotAsync</c> — around the writes alone would leave the
+    /// hazard open — and position is asserted here, not just presence.</para>
+    /// <para>The opposite rule holds for undoing. <c>RevertAsync</c> runs from the game's
+    /// <c>Process.Exited</c> callback and <c>RecoverPendingAsync</c> from startup after a crash; refusing
+    /// either leaves tweaks live with nothing left to undo them, which is worse than the contention the
+    /// lock prevents. Neither captures a snapshot, so running unlocked cannot poison a baseline. A future
+    /// edit that "tidies" these into the same refuse-on-busy shape as apply would reintroduce exactly that,
+    /// so the null-lock branch is asserted to warn and continue rather than return.</para>
+    /// </summary>
+    [Fact]
+    public void GamingProfileMutations_TakeTheLockAndOnlyApplyRefuses()
+    {
+        var service = File.ReadAllText(
+            Path.Combine(FindAppProjectDir(), "Services", "GamingProfileService.cs"));
+
+        // Comments are stripped from every slice before anything is matched. The first draft of this
+        // guard went false-RED on its own explanatory comment: the paragraph above the acquire names
+        // CaptureSnapshotAsync, so the positional check compared the acquire against a MENTION of the
+        // snapshot rather than the call, and reported the ordering backwards. A source-text guard must
+        // read code, never prose — including its own.
+        var apply = WithoutComments(MemberSlice(service, "public async Task<GamingApplyResult> ApplyAsync"));
+        var revert = WithoutComments(MemberSlice(service, "public async Task RevertAsync"));
+        var recover = WithoutComments(MemberSlice(service, "public async Task RecoverPendingAsync"));
+        foreach (var (name, slice) in new[] { ("ApplyAsync", apply), ("RevertAsync", revert), ("RecoverPendingAsync", recover) })
+            Assert.True(slice.Length > 200,
+                $"the {name} slice is {slice.Length} chars — too short to be the method, so the assertions "
+                + "below would measure nothing.");
+
+        var offenders = new List<string>();
+
+        // ── Apply: the acquire must precede the snapshot, and refusal must be reported ──
+        var acquireAt = apply.IndexOf("OperationCategory.SystemModification", StringComparison.Ordinal);
+        var snapshotAt = apply.IndexOf("CaptureSnapshotAsync", StringComparison.Ordinal);
+        if (acquireAt < 0)
+            offenders.Add("ApplyAsync does not take the SystemModification lock at all");
+        else if (snapshotAt < 0)
+            offenders.Add("CaptureSnapshotAsync was not found in ApplyAsync — this guard cannot check the "
+                + "ordering it exists to check; fix the guard.");
+        else if (acquireAt > snapshotAt)
+            offenders.Add("ApplyAsync takes the lock AFTER CaptureSnapshotAsync, so the snapshot can still "
+                + "record Performance Mode's applied state as the baseline — the whole point of the lock");
+
+        // "BlockedBy:" — the named argument — not bare "BlockedBy", which the log template
+        // "{BlockedBy} already holds..." would satisfy on its own. Comments are stripped above but
+        // string literals are not, and a guard that a log message can satisfy proves nothing about
+        // what the method returns.
+        if (!apply.Contains("BlockedBy:", StringComparison.Ordinal))
+            offenders.Add("ApplyAsync never returns BlockedBy, so a refused start cannot be told apart "
+                + "from one that applied nothing");
+
+        // ── Revert paths: acquire, then warn and CONTINUE on a null lock ──
+        foreach (var (name, slice) in new[] { ("RevertAsync", revert), ("RecoverPendingAsync", recover) })
+        {
+            if (!slice.Contains("OperationCategory.SystemModification", StringComparison.Ordinal))
+            {
+                offenders.Add($"{name} does not take the SystemModification lock, so it does not serialise "
+                    + "with Performance Mode even when the lock is free");
+                continue;
+            }
+
+            var nullCheck = slice.IndexOf("opLock is null", StringComparison.Ordinal);
+            if (nullCheck < 0)
+            {
+                offenders.Add($"{name} never handles a null lock — TryAcquire returning null must be an "
+                    + "explicit, logged decision to continue, not an ignored value");
+                continue;
+            }
+
+            // The whole statement that follows the null check: it must log and fall through.
+            var statementEnd = slice.IndexOf(';', nullCheck);
+            var branch = statementEnd > nullCheck ? slice[nullCheck..statementEnd] : slice[nullCheck..];
+            if (branch.Contains("return", StringComparison.Ordinal))
+                offenders.Add($"{name} returns early when the lock is busy. Undoing must never be refused: "
+                    + "the game has already exited, so the tweaks would stay live with nothing to revert "
+                    + "them. Warn and continue.");
+            if (!branch.Contains("Log.Warning", StringComparison.Ordinal))
+                offenders.Add($"{name} continues without the lock but does not warn — a silent unlocked "
+                    + "system change is exactly what a maintainer needs to see in the log");
+        }
+
+        // ── The README claim must match the code, in both directions ──
+        var readme = Collapse(File.ReadAllText(Path.Combine(FindRepoRoot(), "README.md")));
+        var lockSectionAt = readme.IndexOf("### Operation Lock", StringComparison.Ordinal);
+        Assert.True(lockSectionAt > 0, "README.md has no '### Operation Lock' section — the guard would "
+            + "pass vacuously.");
+        var after = readme[(lockSectionAt + 1)..];
+        var end = after.IndexOf("### ", StringComparison.Ordinal);
+        var lockSection = end > 0 ? after[..end] : after;
+        Assert.True(lockSection.Length > 200,
+            $"the README Operation Lock section sliced to {lockSection.Length} chars — not the section.");
+
+        var takesLock = acquireAt >= 0;
+        var listed = lockSection.Contains("Gaming Profile", StringComparison.Ordinal);
+        if (takesLock && !listed)
+            offenders.Add("Gaming Profile takes the lock but the README Operation Lock section does not "
+                + "list it — the section claims the lock covers every tab that mutates system state");
+        if (!takesLock && listed)
+            offenders.Add("the README lists Gaming Profile under Operation Lock but the service no longer "
+                + "takes it — the claim is now false");
+
+        Assert.True(offenders.Count == 0,
+            "the Gaming Profile lock contract is broken:\n  - " + string.Join("\n  - ", offenders));
+    }
+
+    /// <summary>
+    /// C# source with comments removed, so a source-text assertion cannot be satisfied — or defeated —
+    /// by prose that merely names the construct. Quote-aware on the line scan so a <c>//</c> inside a
+    /// string literal (a URL, say) is left alone.
+    /// </summary>
+    private static string WithoutComments(string source)
+    {
+        var noBlocks = BlockComment().Replace(source, " ");
+        var kept = new List<string>();
+        foreach (var line in noBlocks.Split('\n'))
+        {
+            var inString = false;
+            var cut = -1;
+            for (var i = 0; i < line.Length - 1; i++)
+            {
+                if (line[i] == '"' && (i == 0 || line[i - 1] != '\\')) inString = !inString;
+                else if (!inString && line[i] == '/' && line[i + 1] == '/') { cut = i; break; }
+            }
+            kept.Add(cut >= 0 ? line[..cut] : line);
+        }
+        return string.Join("\n", kept);
+    }
+
+    [GeneratedRegex(@"/\*.*?\*/", RegexOptions.Compiled | RegexOptions.Singleline)]
+    private static partial Regex BlockComment();
+
+    /// <summary>
+    /// A member's text from its declaration up to the next member at the same indentation — enough to
+    /// assert what one method does without matching an identical call elsewhere in the file.
+    /// </summary>
+    private static string MemberSlice(string source, string declaration)
+    {
+        var start = source.IndexOf(declaration, StringComparison.Ordinal);
+        if (start < 0) return "";
+        var rest = source[start..];
+        var end = NextMemberDeclaration().Match(rest, 1);
+        return end.Success ? rest[..end.Index] : rest;
+    }
+
+    /// <summary>
     /// A registry path must be declared in ONE place. Two verbatim copies of the same key drift, and they
     /// drift silently: nothing tells the compiler that two identical strings were meant to stay identical.
     /// <para>The defect this generalises: <c>PushNotifications\ToastEnabled</c> was declared twice,

--- a/SysManager/SysManager.Tests/GamingProfileServiceTests.cs
+++ b/SysManager/SysManager.Tests/GamingProfileServiceTests.cs
@@ -19,7 +19,12 @@ namespace SysManager.Tests;
 /// The pure helpers (<c>PerformanceCoreMask</c>) and the persisted-store round-trip / schema
 /// guard are also covered here. The composed services themselves are already audited under
 /// their own tests; this file treats them as a contract at the seam.
+/// <para>In the serialized collection because the lock tests below take the process-wide
+/// <c>OperationLockService.Instance</c>; a class holding that static in parallel with another
+/// would make either one pass or fail for a foreign reason
+/// (<see cref="ArchitectureTests.ProcessWideStaticUsers_AreInTheSerializedCollection"/>).</para>
 /// </summary>
+[Collection("ProcessWideStatics")]
 public class GamingProfileServiceTests
 {
     /// <summary>A fake step that records apply/revert order into a shared log.</summary>
@@ -533,6 +538,72 @@ public class GamingProfileServiceTests
             // The leftover marker is cleared exactly once, under the gate.
             Assert.False(StoreOnlyService(path).HasPendingRecovery,
                 "the recovered session's ActiveSession marker should be cleared after recovery");
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    // ── The app-wide system-modification lock ──────────────────────────────────
+    // _gate above serialises this service against ITSELF. It says nothing about Performance Mode,
+    // which writes the same power plan and the same visual-effects flag through its own commands and
+    // keeps its own "original" snapshot. These two tests pin the asymmetry that makes that safe:
+    // APPLY refuses (nothing has changed yet, and a snapshot taken now would record the other tab's
+    // change as the baseline), REVERT never refuses (a game has exited and the machine must come
+    // back, even if something else holds the lock).
+
+    [Fact]
+    public async Task ApplyAsync_WhileAnotherSystemModificationRuns_IsRefusedAndChangesNothing()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"sm-gaming-lock-{Guid.NewGuid():N}.json");
+        try
+        {
+            var svc = StoreOnlyService(path);
+
+            using var held = OperationLockService.Instance.TryAcquire(
+                OperationCategory.SystemModification, "Apply power plan");
+            Assert.NotNull(held); // precondition: this test really is holding the lock
+
+            // A profile with the two colliding tweaks enabled, so the test is not passing merely
+            // because there was nothing to do.
+            var result = await svc.ApplyAsync(
+                new GamingProfile { UltimatePerformancePlan = true, DisableVisualEffects = true },
+                game: null);
+
+            Assert.Equal("Apply power plan", result.BlockedBy);
+            Assert.Empty(result.Steps);
+            Assert.False(result.RestorePointCreated);
+            Assert.False(svc.IsActive);
+
+            // The refusal happens BEFORE the snapshot and before the restore-point attempt, so no
+            // session marker can have been written. This is what makes the test safe to run on a real
+            // machine: no powercfg, no registry, no restore point.
+            Assert.False(StoreOnlyService(path).HasPendingRecovery,
+                "a refused apply must leave no crash-recovery marker behind");
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task RevertAsync_WhileAnotherSystemModificationRuns_StillRevertsInsteadOfStranding()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"sm-gaming-unlock-{Guid.NewGuid():N}.json");
+        try
+        {
+            var svc = StoreOnlyService(path);
+            var log = new List<string>();
+            var tweak = new FakeTweak("power plan", log);
+            svc.SeedAppliedStepForTest(tweak);
+            Assert.True(svc.IsActive, "precondition: a live session to revert");
+
+            using var held = OperationLockService.Instance.TryAcquire(
+                OperationCategory.SystemModification, "Apply visual effects");
+            Assert.NotNull(held);
+
+            await svc.RevertAsync();
+
+            Assert.True(tweak.Reverted,
+                "revert must run even when the lock is held: it is triggered by the game exiting, so "
+                + "deferring it strands the machine on the gaming power plan with nothing left to undo it");
+            Assert.False(svc.IsActive);
         }
         finally { if (File.Exists(path)) File.Delete(path); }
     }

--- a/SysManager/SysManager/Services/GamingProfileService.cs
+++ b/SysManager/SysManager/Services/GamingProfileService.cs
@@ -162,6 +162,29 @@ public sealed class GamingProfileService : IGamingProfileService, IDisposable
     {
         if (IsActive) await RevertAsync(ct).ConfigureAwait(false); // never stack sessions
 
+        // Acquired BEFORE the snapshot, not merely around the writes, because the snapshot IS the
+        // hazard. Gaming Profile and Performance Mode set the same power plan and the same
+        // visual-effects flag, and each keeps its own idea of the original (gaming-profiles.json vs
+        // performance-snapshot.json). If Performance Mode applies Ultimate Performance while this
+        // method sits between CaptureSnapshotAsync and its writes, this session records the OTHER
+        // tab's already-applied value as the baseline and later "restores" the machine to it — the
+        // user is stranded off their real power plan with both tabs believing they were right.
+        // PerformanceService.OriginalSnapshot carries the same warning for the same reason.
+        //
+        // Refusing is safe HERE precisely because nothing has changed yet. RevertAsync deliberately
+        // does not refuse — see the note there.
+        using var opLock = OperationLockService.Instance.TryAcquire(
+            OperationCategory.SystemModification, "Gaming Profile");
+        if (opLock is null)
+        {
+            var blockedBy = OperationLockService.Instance.GetActiveOperationName(
+                OperationCategory.SystemModification) ?? "another system change";
+            Log.Information(
+                "Gaming Profile apply refused: {BlockedBy} already holds the system-modification lock",
+                blockedBy);
+            return new GamingApplyResult([], RestorePointCreated: false, BlockedBy: blockedBy);
+        }
+
         bool restorePointCreated = await EnsureRestorePointAsync(ct).ConfigureAwait(true);
 
         // Capture the machine-wide baseline BEFORE any change.
@@ -203,6 +226,20 @@ public sealed class GamingProfileService : IGamingProfileService, IDisposable
 
     public async Task RevertAsync(CancellationToken ct = default)
     {
+        // Opportunistic, and it NEVER refuses. Revert runs from the game's Process.Exited callback,
+        // so a refusal would leave the machine on Ultimate Performance with visual effects off and
+        // nothing left to undo it — strictly worse than the contention the lock exists to prevent.
+        // Taking it when free still serialises the common case, and running without it cannot corrupt
+        // a baseline the way a concurrent APPLY can, because revert captures no snapshot: it only
+        // writes back values recorded before this session began.
+        using var opLock = OperationLockService.Instance.TryAcquire(
+            OperationCategory.SystemModification, "Gaming Profile revert");
+        if (opLock is null)
+            Log.Warning("Gaming Profile reverting while {Holder} holds the system-modification lock — "
+                + "not deferring, because a game has exited and the machine must come back",
+                OperationLockService.Instance.GetActiveOperationName(
+                    OperationCategory.SystemModification) ?? "another system change");
+
         // Serialize with ApplyAsync and the auto-revert path: manual Stop (UI thread) and
         // OnGameExited (thread-pool) both mutate _appliedSteps + _boundGame on this singleton.
         await _gate.WaitAsync(ct).ConfigureAwait(false);
@@ -239,6 +276,18 @@ public sealed class GamingProfileService : IGamingProfileService, IDisposable
 
     public async Task RecoverPendingAsync(CancellationToken ct = default)
     {
+        // Opportunistic and non-refusing, exactly as in RevertAsync: this is a revert of a session
+        // that outlived a crash, so declining it would leave the previous run's tweaks live with the
+        // marker still on disk. It writes back a recorded baseline and captures nothing, so it cannot
+        // poison a snapshot even when it runs unlocked.
+        using var opLock = OperationLockService.Instance.TryAcquire(
+            OperationCategory.SystemModification, "Gaming Profile recovery");
+        if (opLock is null)
+            Log.Warning("Gaming Profile recovering a leftover session while {Holder} holds the "
+                + "system-modification lock — not deferring, the previous run's tweaks are still live",
+                OperationLockService.Instance.GetActiveOperationName(
+                    OperationCategory.SystemModification) ?? "another system change");
+
         // Serialize with ApplyAsync / RevertAsync on _gate. Without this the startup recovery
         // sweep runs unguarded: after the user answers the "restore?" dialog, the UI is live
         // again and a Start click can launch ApplyAsync while this revert + store rewrite is

--- a/SysManager/SysManager/Services/IGamingProfileService.cs
+++ b/SysManager/SysManager/Services/IGamingProfileService.cs
@@ -91,7 +91,19 @@ public sealed record GamingStepOutcome(string Label, GamingStepStatus Status, st
 /// and whether a System Restore point was actually created (so the UI never over-promises a
 /// safety net that didn't materialize — mirrors <see cref="TweakApplyResult"/>).
 /// </summary>
-public sealed record GamingApplyResult(IReadOnlyList<GamingStepOutcome> Steps, bool RestorePointCreated)
+/// <param name="Steps">Per-step outcomes; empty when the batch never ran.</param>
+/// <param name="RestorePointCreated">Whether a restore point was actually created.</param>
+/// <param name="BlockedBy">
+/// Name of the operation that already held the system-modification lock, or <c>null</c> when the
+/// batch ran. Non-null means NOTHING was changed and no snapshot was taken — Gaming Profile and
+/// Performance Mode write the same power plan and visual-effects settings while each keeps its own
+/// idea of the original, so whichever starts second must not capture the other's applied state as a
+/// baseline it will later "restore".
+/// </param>
+public sealed record GamingApplyResult(
+    IReadOnlyList<GamingStepOutcome> Steps,
+    bool RestorePointCreated,
+    string? BlockedBy = null)
 {
     /// <summary>Count of steps that applied successfully.</summary>
     public int AppliedCount => Steps.Count(s => s.Status == GamingStepStatus.Applied);

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.66.2</Version>
-    <FileVersion>1.66.2.0</FileVersion>
-    <AssemblyVersion>1.66.2.0</AssemblyVersion>
+    <Version>1.66.3</Version>
+    <FileVersion>1.66.3.0</FileVersion>
+    <AssemblyVersion>1.66.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/GamingProfileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/GamingProfileViewModel.cs
@@ -168,6 +168,16 @@ public sealed partial class GamingProfileViewModel : ViewModelBase
         {
             _service.SaveLastConfig(profile);
             var result = await _service.ApplyAsync(profile, game);
+            if (result.BlockedBy is { } blocker)
+            {
+                // Nothing was applied and no snapshot was taken, so say so and stop — do not log an
+                // activity entry or flip IsSessionActive for a session that never began. Same wording
+                // Performance Mode uses when the lock is held, because these two tabs are the pair
+                // that collide: they write the same power plan and the same visual-effects flag.
+                StatusMessage = $"Cannot start — {blocker} is already running.";
+                return;
+            }
+
             IsSessionActive = _service.IsActive;
             StatusMessage = DescribeResult(result, game);
             ActivityLogService.Instance.Log("Gaming Profile",


### PR DESCRIPTION
Closes #1501.

## Problem

Gaming Profile and Performance Mode write the **same** power plan and the **same** visual-effects flag, and each keeps its own record of the original (`gaming-profiles.json` vs `performance-snapshot.json`). `GamingProfileViewModel` took no `OperationLock` at all — verified again on current source — while every one of Performance Mode's mutating commands takes `OperationCategory.SystemModification`. The service's `_gate` serialises it against *itself* and says nothing about the other tab.

The hazard is the **snapshot**, not the write. A snapshot captured while the other tab's change is live records that change as the baseline, and the later "restore" leaves the machine on a power plan the user never chose — with both tabs believing they were correct. `PerformanceService.OriginalSnapshot` already documents exactly this ("callers MUST invoke this BEFORE applying any change").

## What changed

`ApplyAsync` acquires the lock **before `CaptureSnapshotAsync`**, not around the writes, and refuses when it is held. Refusing is safe there precisely because nothing has changed yet.

```csharp
using var opLock = OperationLockService.Instance.TryAcquire(
    OperationCategory.SystemModification, "Gaming Profile");
if (opLock is null) { ...; return new GamingApplyResult([], RestorePointCreated: false, BlockedBy: blockedBy); }
```

## Where this departs from the issue

The issue proposes locking "Apply **and** Revert". Locking revert would be a new failure mode: `RevertAsync` runs from the game's `Process.Exited` callback and `RecoverPendingAsync` from startup after a crash. If Performance Mode holds the lock when a game exits, a refusal leaves the machine on Ultimate Performance with visual effects off and **nothing left to undo it** — strictly worse than the contention the lock exists to prevent.

So the two directions are deliberately asymmetric:

| Path | On a busy lock |
|---|---|
| `ApplyAsync` | **refuses** — nothing changed yet, and a snapshot now would be poisoned |
| `RevertAsync` | proceeds, logs a warning |
| `RecoverPendingAsync` | proceeds, logs a warning |

Neither revert path captures a snapshot — both write back a value recorded before the session — so running unlocked cannot poison a baseline. The guard asserts this asymmetry, because a later edit that "tidied" the revert paths into apply's refuse-on-busy shape would silently reintroduce the stranding.

## The guard

`GamingProfileMutations_TakeTheLockAndOnlyApplyRefuses` asserts:

- the acquire in `ApplyAsync` appears **before** `CaptureSnapshotAsync` (position, not presence);
- `ApplyAsync` returns `BlockedBy:` — the named argument, not bare `BlockedBy`, which the log template `{BlockedBy}` would have satisfied on its own;
- both revert paths take the lock and their null-lock branch **warns and continues** rather than returning;
- README's Operation Lock section names Gaming Profile while the service takes the lock, and does **not** if it stops.

Its first draft went **false-red on its own comment** — the paragraph above the acquire names `CaptureSnapshotAsync`, so the positional check compared the acquire against a mention rather than the call. Slices are now comment-stripped (quote-aware, so a `//` inside a string literal survives).

## Verification

| Mutation | Result |
|---|---|
| baseline | green |
| acquire moved AFTER `CaptureSnapshotAsync` | **red** — guard |
| `RevertAsync` stops taking the lock | **red** — guard |
| `RevertAsync` refuses on a busy lock | **red** — guard + revert test |
| README stops naming Gaming Profile | **red** — guard |
| refusal returns no `BlockedBy` | **red** — guard + apply test |

Both mutated files restored byte-for-byte. The last mutation deliberately keeps the early return: one that let `ApplyAsync` proceed would really have changed this machine's power plan, which is not an acceptable thing for a proof to do.

The two runtime tests are safe on a real machine by construction. The refusal happens before the restore-point attempt and before the snapshot, so the apply test issues no `powercfg`, no registry write and no restore point; the revert test drives the existing `FakeTweak`. `GamingProfileServiceTests` joins the serialized `ProcessWideStatics` collection because it now holds the process-wide `OperationLockService.Instance` — required by `ProcessWideStaticUsers_AreInTheSerializedCollection`, which exists precisely to stop that race.

Both projects build **0 errors / 0 warnings**; `dotnet format --verify-no-changes` clean on both (real exit codes, not through a pipe); all three CI gates reproduced locally after fetching tags — the first run reported a stale newest-tag of v1.66.1 because the worktree predated v1.66.2.

## Docs

README's Operation Lock section claimed the lock covers every tab that mutates system state and then omitted the one tab it did not cover. It now lists Gaming Profile and explains, in the user's terms, why the check happens before their settings are read and why undoing is never refused.