### PR TITLE
fix: give every tab one name in the sidebar and on the page

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -72,7 +72,7 @@ body:
         - Process Manager
         - Resource History
         - Camera/Mic/Location
-        - App Alerts
+        - New App Alerts
         - File Lock Detector
         - Settings Watchdog
         - Bandwidth Monitor
@@ -107,7 +107,7 @@ body:
         - System Report
         - Legacy Panels
         - About
-        - Profile Export/Import
+        - Profile Export / Import
         - CLI Interface
         - Environment Variables
         - Multiple / general UI

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -63,7 +63,7 @@ body:
         - Process Manager
         - Resource History
         - Camera/Mic/Location
-        - App Alerts
+        - New App Alerts
         - File Lock Detector
         - Settings Watchdog
         - Bandwidth Monitor
@@ -98,7 +98,7 @@ body:
         - System Report
         - Legacy Panels
         - About
-        - Profile Export/Import
+        - Profile Export / Import
         - CLI Interface
         - Environment Variables
         - Multiple / general UI

--- a/.github/ISSUE_TEMPLATE/general_issue.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue.yml
@@ -61,7 +61,7 @@ body:
         - Process Manager
         - Resource History
         - Camera/Mic/Location
-        - App Alerts
+        - New App Alerts
         - File Lock Detector
         - Settings Watchdog
         - Bandwidth Monitor
@@ -96,7 +96,7 @@ body:
         - System Report
         - Legacy Panels
         - About
-        - Profile Export/Import
+        - Profile Export / Import
         - CLI Interface
         - Environment Variables
         - Multiple / general UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.66.4] - 2026-08-24
+
+Two tabs were called one thing in the sidebar and another at the top of the page. Small, but it is the
+kind of thing that makes you wonder whether you clicked the right item.
+
+### Fixed
+- **"App Alerts" and its page are both called "New App Alerts" now.** The sidebar said "App Alerts"
+  while the page was headed "App Installation Alerts". The new name says what the tab is for — it tells
+  you when something new installed itself.
+- **"Profile Export / Import" is spelled the same in both places.** The sidebar wrote it without spaces
+  around the slash, the page with them.
+- Two tabs keep names that differ on purpose: **About** (the sidebar convention, with the usual longer
+  heading) and **Context Menu**, whose rename is still being decided. Both are recorded as deliberate,
+  so a future tab cannot quietly join them — a test now compares every tab's sidebar label against its
+  page heading, and the two names are edited in different files, which is why they drifted unnoticed.
+- The tab names offered in the GitHub issue forms were updated to match, so a bug report can name the
+  tab the way the app does.
+
 ## [1.66.3] - 2026-08-24
 
 Gaming Profile and Performance Mode can no longer trip over each other. They change the same two

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ row and every group header is also keyboard-operable with a visible focus cue. A
 | 🏠 Dashboard | Dashboard |
 | 🔧 System | System Health · Windows Update · Performance Mode · Services · Startup Manager · Windows Features · Restore Points · Task Scheduler · Boot Analyzer · System Fixes · Tweaks Hub 🔬 |
 | 🎮 Gaming & Profiles | Gaming Profile 🔬 · Standby List Cleaner · Timer Resolution · CPU Core Affinity · Display Profiles |
-| 📊 Monitor | Process Manager · Resource History 🔬 · Camera/Mic/Location · App Alerts · File Lock Detector · Settings Watchdog 🔬 · Bandwidth Monitor |
+| 📊 Monitor | Process Manager · Resource History 🔬 · Camera/Mic/Location · New App Alerts · File Lock Detector · Settings Watchdog 🔬 · Bandwidth Monitor |
 | 🧹 Cleanup | Quick Cleanup · Deep Cleanup · Shortcut Cleaner · Scheduled Maintenance 🔬 |
 | 💾 Storage | Disk Analyzer · Duplicate Finder |
 | 🌐 Network | Ping · Traceroute · Speed Test · Network Repair · DNS & Hosts |
@@ -135,7 +135,7 @@ row and every group header is also keyboard-operable with a visible focus cue. A
 | 🛡️ Privacy & Security | Privacy & Telemetry · File Shredder · App Blocker · Debloater & Ads · Browser Cleaner · Edge/OneDrive Remover · Defender Tweaks · Notification Blocker 🔬 |
 | 🎨 Customization | Context Menu · Dark Mode Scheduler · Volume Control |
 | ℹ️ Info | Drivers · Battery Health · System Logs · System Report · Legacy Panels · About |
-| ⚙️ Advanced | Profile Export/Import · CLI Interface 🔬 · Environment Variables |
+| ⚙️ Advanced | Profile Export / Import · CLI Interface 🔬 · Environment Variables |
 
 > 🔬 = Preview — fully implemented and usable, marked in-app while it settles in.
 
@@ -663,7 +663,7 @@ a confirmation before it runs:
 - Live console output showing winget progress
 - GroupedView with visual category headers
 
-### App Alerts
+### New App Alerts
 - Monitors Program Files, AppData\Programs, and registry uninstall keys for
   new application installations
 - FileSystemWatcher on install directories + 30-second registry poll cycle
@@ -1021,7 +1021,7 @@ offers, "rate us" prompts:
 </details>
 
 <details>
-<summary><strong>📊 Monitor</strong> — Resource History · App Alerts · File Lock · Settings Watchdog · Bandwidth</summary>
+<summary><strong>📊 Monitor</strong> — Resource History · New App Alerts · File Lock · Settings Watchdog · Bandwidth</summary>
 <br>
 <p>
 <a href="docs/screenshots/19-resource-history.png"><img src="docs/screenshots/19-resource-history.png" width="280" alt="Resource History"></a>&nbsp;
@@ -1116,10 +1116,10 @@ previous one showed the tab while it was a placeholder, which no longer reflects
 </details>
 
 <details>
-<summary><strong>⚙️ Advanced</strong> — Profile Export/Import · CLI Interface</summary>
+<summary><strong>⚙️ Advanced</strong> — Profile Export / Import · CLI Interface</summary>
 <br>
 <p>
-<a href="docs/screenshots/56-profile-export.png"><img src="docs/screenshots/56-profile-export.png" width="280" alt="Profile Export/Import"></a>&nbsp;
+<a href="docs/screenshots/56-profile-export.png"><img src="docs/screenshots/56-profile-export.png" width="280" alt="Profile Export / Import"></a>&nbsp;
 <a href="docs/screenshots/57-cli-interface.png"><img src="docs/screenshots/57-cli-interface.png" width="280" alt="CLI Interface"></a>
 </p>
 </details>

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2752,6 +2752,111 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// Every tab must have exactly ONE name: the label in the sidebar and the header on the page must
+    /// read the same.
+    /// <para>Five of 58 pairs disagreed — "App Alerts" under a page headed "App Installation Alerts",
+    /// "Profile Export/Import" under "Profile Export / Import". For the target persona a mismatch is a
+    /// small dose of doubt about having clicked the right thing, and it costs nothing to remove. The point
+    /// of asserting it is that the invariant survives the NEXT tab: a label and a header are edited in two
+    /// different files, so they drift silently, and nothing else in the build compares them.</para>
+    /// <para>Three pairs are deliberate and listed with the reason and the issue that owns them. An
+    /// exception must state the exact header it expects, so a tab in the list is still pinned — it just
+    /// pins a different value — and a tab whose mismatch is silently "fixed" fails until its entry is
+    /// removed.</para>
+    /// <para>Header text is HTML-decoded before comparison. Without that, <c>DNS &amp;amp; Hosts</c> in
+    /// XAML reads as a mismatch against the label <c>DNS &amp; Hosts</c>, which is the same text — a
+    /// first pass at this check reported 8 mismatches, and 3 of them were that artifact.</para>
+    /// </summary>
+    [Fact]
+    public void EveryTabsSidebarLabel_MatchesItsPageHeader()
+    {
+        // nav id -> (the header it is allowed to differ with, why).
+        var tolerated = new Dictionary<string, (string Header, string Why)>(StringComparer.Ordinal)
+        {
+            ["nav-about"] = ("About SysManager",
+                "\"About\" is the universal convention for the sidebar and the expanded header is standard; "
+                + "forcing parity here would be churn for its own sake (#1516 says so explicitly)"),
+            ["nav-context-menu"] = ("Context Menu Manager",
+                "the label is proposed to become \"Right-Click Menu\" in a separate rename issue; aligning "
+                + "it to \"Context Menu Manager\" now would have to be undone by that change"),
+            ["nav-privacy-monitor"] = ("Privacy Monitor",
+                "the Camera/Mic/Location naming is owned by its own issue, which decides both sides at once"),
+        };
+
+        var vm = File.ReadAllText(Path.Combine(FindAppProjectDir(), "ViewModels", "MainWindowViewModel.cs"));
+        var nav = MemberSlice(vm, "private NavGroup[] BuildNavGroups()");
+        Assert.True(nav.Length > 2000,
+            $"the BuildNavGroups slice is {nav.Length} chars — too short to hold 58 tabs, so this guard "
+            + "would compare almost nothing.");
+
+        var entries = NavEntry().Matches(nav).Cast<Match>().ToArray();
+        Assert.True(entries.Length >= 50,
+            $"only {entries.Length} nav entries parsed — the shape of BuildNavGroups changed and this "
+            + "guard is no longer reading the sidebar; fix the pattern rather than trusting the pass.");
+
+        var offenders = new List<string>();
+        var compared = 0;
+
+        foreach (var entry in entries)
+        {
+            var navId = entry.Groups[1].Value;
+            var label = entry.Groups[2].Value;
+            var view = entry.Groups[3].Value;
+
+            var path = Path.Combine(FindAppProjectDir(), "Views", view + ".xaml");
+            Assert.True(File.Exists(path), $"{view}.xaml is referenced by {navId} but does not exist");
+
+            // Comments stripped so a commented-out old header cannot be read as the live one.
+            var xaml = XmlComment().Replace(File.ReadAllText(path), string.Empty);
+            var displayAt = xaml.IndexOf("Style=\"{StaticResource Display}\"", StringComparison.Ordinal);
+            Assert.True(displayAt > 0,
+                $"{view}.xaml has no Display-styled header — every page carries one, so either the view "
+                + "regressed or this guard is looking for the wrong marker.");
+
+            // Bound the search to the element that carries the style, so Text= from a neighbouring
+            // control cannot be mistaken for the header. Attribute order is irrelevant this way.
+            var open = xaml.LastIndexOf('<', displayAt);
+            var close = xaml.IndexOf('>', displayAt);
+            Assert.True(open >= 0 && close > open, $"could not bound the header element in {view}.xaml");
+            var textMatch = TextAttribute().Match(xaml[open..close]);
+            Assert.True(textMatch.Success, $"the Display-styled element in {view}.xaml has no Text=");
+
+            var header = System.Net.WebUtility.HtmlDecode(textMatch.Groups[1].Value);
+            compared++;
+
+            if (tolerated.TryGetValue(navId, out var exception))
+            {
+                if (!string.Equals(header, exception.Header, StringComparison.Ordinal))
+                    offenders.Add($"{navId} is a documented exception expecting the header "
+                        + $"\"{exception.Header}\" but the page now says \"{header}\". Either restore it or "
+                        + $"remove the entry — the reason on file is: {exception.Why}");
+                else if (string.Equals(header, label, StringComparison.Ordinal))
+                    offenders.Add($"{navId} now matches its header (\"{header}\") but is still listed as an "
+                        + "exception. Delete the entry so the list keeps describing the app.");
+                continue;
+            }
+
+            if (!string.Equals(header, label, StringComparison.Ordinal))
+                offenders.Add($"{navId}: the sidebar says \"{label}\" but the page is headed \"{header}\" — "
+                    + "one tab, two names. Align them, or add a documented exception saying why not.");
+        }
+
+        Assert.True(compared >= 50,
+            $"only {compared} label/header pairs were actually compared out of {entries.Length} entries.");
+
+        Assert.True(offenders.Count == 0,
+            "every tab must have one name:\n  - " + string.Join("\n  - ", offenders));
+    }
+
+    // Tab<TVm>("nav-id", "Label", typeof(Views.SomeView)  /  EagerItem("nav-id", "Label", typeof(Views.SomeView)
+    [GeneratedRegex(@"(?:Tab<\w+>|EagerItem)\(\s*""([^""]+)""\s*,\s*""([^""]+)""\s*,\s*typeof\(Views\.(\w+)\)",
+                    RegexOptions.Compiled)]
+    private static partial Regex NavEntry();
+
+    [GeneratedRegex(@"Text=""([^""]*)""", RegexOptions.Compiled)]
+    private static partial Regex TextAttribute();
+
+    /// <summary>
     /// Gaming Profile must take the app-wide system-modification lock, and the two directions must stay
     /// asymmetric: apply REFUSES when the lock is held, revert NEVER does.
     /// <para>Gaming Profile and Performance Mode write the same power plan and the same visual-effects

--- a/SysManager/SysManager.UITests/AllTabsSmokeUiTests.cs
+++ b/SysManager/SysManager.UITests/AllTabsSmokeUiTests.cs
@@ -49,7 +49,7 @@ public class AllTabsSmokeUiTests
         new object[] { "nav-processes", "Process Manager" },
         new object[] { "nav-resource-history", "Resource History" },
         new object[] { "nav-privacy-monitor", "Privacy Monitor" },
-        new object[] { "nav-app-alerts", "App Installation Alerts" },
+        new object[] { "nav-app-alerts", "New App Alerts" },
         new object[] { "nav-file-lock", "File Lock Detector" },
         new object[] { "nav-settings-watchdog", "Settings Watchdog" },
         new object[] { "nav-bandwidth-monitor", "Bandwidth Monitor" },

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.66.3</Version>
-    <FileVersion>1.66.3.0</FileVersion>
-    <AssemblyVersion>1.66.3.0</AssemblyVersion>
+    <Version>1.66.4</Version>
+    <FileVersion>1.66.4.0</FileVersion>
+    <AssemblyVersion>1.66.4.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -207,7 +207,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Tab<ProcessManagerViewModel>("nav-processes",       "Process Manager",    typeof(Views.ProcessManagerView)),
             Tab<ResourceHistoryViewModel>("nav-resource-history", "Resource History", typeof(Views.ResourceHistoryView), inDevelopment: true),
             Tab<PrivacyMonitorViewModel>("nav-privacy-monitor", "Camera/Mic/Location", typeof(Views.PrivacyMonitorView)),
-            Tab<AppAlertsViewModel>("nav-app-alerts",           "App Alerts",         typeof(Views.AppAlertsView)),
+            Tab<AppAlertsViewModel>("nav-app-alerts",           "New App Alerts",     typeof(Views.AppAlertsView)),
             Tab<FileLockViewModel>("nav-file-lock",             "File Lock Detector", typeof(Views.FileLockView)),
             Tab<SettingsWatchdogViewModel>("nav-settings-watchdog", "Settings Watchdog", typeof(Views.SettingsWatchdogView), inDevelopment: true),
             Tab<BandwidthMonitorViewModel>("nav-bandwidth-monitor", "Bandwidth Monitor", typeof(Views.BandwidthMonitorView))),
@@ -261,7 +261,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             EagerItem("nav-about", "About", typeof(Views.AboutView), About)),
 
         Group("grp-advanced", "Advanced",
-            Tab<ProfileViewModel>("nav-profile-export", "Profile Export/Import", typeof(Views.ProfileView)),
+            Tab<ProfileViewModel>("nav-profile-export", "Profile Export / Import", typeof(Views.ProfileView)),
             Tab<CliInterfaceViewModel>("nav-cli-interface", "CLI Interface",     typeof(Views.CliInterfaceView), inDevelopment: true),
             Tab<EnvironmentVariablesViewModel>("nav-env-variables", "Environment Variables", typeof(Views.EnvironmentVariablesView))),
     ];

--- a/SysManager/SysManager/Views/AppAlertsView.xaml
+++ b/SysManager/SysManager/Views/AppAlertsView.xaml
@@ -20,7 +20,7 @@
 
         <!-- Header -->
         <StackPanel Grid.Row="0" Margin="0,0,0,16">
-            <TextBlock Text="App Installation Alerts" Style="{StaticResource Display}"/>
+            <TextBlock Text="New App Alerts" Style="{StaticResource Display}"/>
             <TextBlock Text="{Binding MonitorStatus}" Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
         </StackPanel>
 


### PR DESCRIPTION
Closes #1516.

## Measured first

A mechanical diff of all **58** nav labels in `BuildNavGroups()` against each view's `Display`-styled header. Five disagree — matching the issue's count exactly. My first pass reported 8; three of those were an artifact of my own parser, because `DNS &amp; Hosts` in XAML is the same text as the label `DNS & Hosts`. The guard HTML-decodes before comparing for that reason.

| Sidebar | Page header | Action |
|---|---|---|
| App Alerts | App Installation Alerts | both → **New App Alerts** |
| Profile Export/Import | Profile Export / Import | sidebar → **spaced** form |
| About | About SysManager | **kept** — documented exception |
| Context Menu | Context Menu Manager | **kept** — a rename is pending in its own issue |
| Camera/Mic/Location | Privacy Monitor | **kept** — owned by its own issue |

"Installation" is the informative word, but the full phrase is long for a sidebar; "New App Alerts" says what the tab is for. The spaced Profile form wins because the page heading and the README section already used it, so no anchor changed — checked for inbound `#app-alerts` / `#profile-export` links and ToC entries before renaming, and there are none.

## The guard

`EveryTabsSidebarLabel_MatchesItsPageHeader` exists for the *next* tab: a label and a header are edited in two different files and nothing else in the build compares them, which is exactly how five pairs drifted unnoticed. Each of the three exceptions states the **exact** header it expects, so:

- an exempt tab is still pinned — it just pins a different value;
- an exception whose mismatch has since been fixed **fails** until the entry is deleted, so the list cannot rot into a stale claim about the app.

The header is located by bounding the element that carries the `Display` style and reading its `Text=` from within those bounds, so attribute order does not matter and a neighbouring control's `Text=` cannot be mistaken for the heading. XAML comments are stripped, so a commented-out old header cannot be read as the live one.

## Propagate check — this is what it caught

`AllTabsSmokeUiTests.cs` asserted the **old** header text (`"App Installation Alerts"`). Leaving it would have failed the UI job *and* tripped the blocking `EveryUiTextAssertion_QuotesCopyTheAppActuallyShips` guard, because the quoted sentence would no longer exist anywhere in the app. It moves with the rename.

The three GitHub issue forms (`bug_report`, `feature_request`, `general_issue`) offered the old names in their tab dropdowns, so a reporter would have picked a tab name the app does not show. All six options updated.

## Verification

| Mutation | Result |
|---|---|
| baseline | green |
| the old header restored, sidebar keeps the new label | **red** |
| the Profile Export label un-spaced again | **red** |
| the `nav-about` exception deleted | **red** |
| the `nav-about` exception given the wrong expected header | **red** |
| an exempt tab aligned while its exception is left behind | **red** — stale entry |

All three mutated files restored byte-for-byte.

One correction worth recording: I predicted the first mutation would *also* turn `EveryUiTextAssertion_QuotesCopyTheAppActuallyShips` red. It does not, and that is correct — it asks whether the quoted string exists anywhere in the app, and `"New App Alerts"` still exists as the sidebar label. That is precisely the hole this new guard fills: no existing check compared the two surfaces to each other.

All three projects build **0 errors / 0 warnings** (app, tests, and UITests, since the UI test changed); `dotnet format --verify-no-changes` clean on all three with real exit codes; the three CI gates reproduced locally exit 0.