### PR TITLE
fix: stop Performance Mode recording a running game profile's settings as your own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.66.5] - 2026-08-24
+
+Performance Mode will no longer mistake a running game profile's settings for your own. Start a profile,
+then change something in Performance Mode for the first time, and it used to write down the profile's
+power plan as "how you had it" — so a later Restore All would put you back onto a gaming plan you had
+never chosen.
+
+### Fixed
+- **Performance Mode asks you to stop a game profile before it records your original settings.** While a
+  profile is running, the power plan and visual effects on the machine are the profile's, not yours. The
+  tab now says so and refuses to save them as your baseline, instead of silently keeping borrowed values
+  it would restore you to later. Nothing is changed when it refuses.
+- A baseline saved **before** a profile started is still loaded and used normally, so the protection does
+  not stop the tab working during a game — it only declines to invent a new baseline out of the profile's
+  own settings.
+
 ## [1.66.4] - 2026-08-24
 
 Two tabs were called one thing in the sidebar and another at the top of the page. Small, but it is the

--- a/README.md
+++ b/README.md
@@ -852,6 +852,10 @@ offers, "rate us" prompts:
   persists it locally, and reloads it when the tab opens so Restore All remains
   available after an app restart; persisted fields are validated before use and the
   confirmation shows when the baseline was captured
+- **It will not record your settings while a game profile is running** — those are the
+  profile's power plan and visual effects, not yours, and saving them as your baseline
+  would restore you to them later. It asks you to stop the profile first. A baseline
+  saved *before* the profile started is still used normally
 - Confirmation dialog before every change
 - **Restore point creation**: create a Windows System Restore point before
   making changes (requires admin)

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2752,6 +2752,75 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// Performance Mode must refuse to CAPTURE a recovery baseline while a game profile is live — and must
+    /// still be allowed to LOAD one that was persisted earlier.
+    /// <para>The lock added for #1501 stops the two tabs from snapshotting each other mid-change, but it is
+    /// held per operation and a gaming session outlives it: the profile applies, releases the lock, and its
+    /// power plan and visual-effects values stay live until the game exits. A capture in that window
+    /// records borrowed values as the user's own and persists them, so a later Restore All puts the machine
+    /// on a gaming plan it was never on.</para>
+    /// <para>Both halves are asserted because each can be broken on its own. Moving the check after
+    /// <c>TakeSnapshotAsync</c> would let the capture happen and merely refuse afterwards; moving it above
+    /// <c>LoadSnapshot</c> would block a legitimate load of a baseline that PREDATES the session, which
+    /// would turn a safety guard into "Performance Mode stops working while a game runs".</para>
+    /// </summary>
+    [Fact]
+    public void PerformanceMode_RefusesToCaptureABaselineDuringAGameSession()
+    {
+        var vm = File.ReadAllText(
+            Path.Combine(FindAppProjectDir(), "ViewModels", "PerformanceViewModel.cs"));
+
+        // Comment-stripped: the paragraph above the check names both TakeSnapshotAsync and the session,
+        // and a positional assertion that reads prose reports the ordering backwards (batch 106).
+        var slice = WithoutComments(MemberSlice(vm, "private async Task EnsureSnapshotAsync()"));
+        Assert.True(slice.Length > 300,
+            $"the EnsureSnapshotAsync slice is {slice.Length} chars — too short to be the method, so every "
+            + "assertion below would measure nothing.");
+
+        var checkAt = slice.IndexOf("_gaming.IsActive", StringComparison.Ordinal);
+        var loadAt = slice.IndexOf("LoadSnapshot", StringComparison.Ordinal);
+        var captureAt = slice.IndexOf("TakeSnapshotAsync", StringComparison.Ordinal);
+
+        var offenders = new List<string>();
+
+        if (checkAt < 0)
+            offenders.Add("EnsureSnapshotAsync does not consult the gaming session at all, so it can record "
+                + "a profile's power plan as the user's original");
+        Assert.True(loadAt >= 0 && captureAt >= 0,
+            "LoadSnapshot / TakeSnapshotAsync were not both found in EnsureSnapshotAsync — this guard "
+            + "cannot check the ordering it exists for; fix the guard.");
+
+        if (checkAt >= 0 && checkAt > captureAt)
+            offenders.Add("the gaming-session check sits AFTER TakeSnapshotAsync, so the borrowed settings "
+                + "are captured first and only then refused");
+
+        if (checkAt >= 0 && checkAt < loadAt)
+            offenders.Add("the gaming-session check sits BEFORE LoadSnapshot, which blocks loading a "
+                + "baseline persisted before the session began — that is not a safety win, it just stops "
+                + "Performance Mode working while a game runs");
+
+        // The refusal must carry an instruction, not just fail. Every Apply command surfaces
+        // InvalidOperationException.Message verbatim in StatusMessage.
+        if (!vm.Contains("Stop the game profile first", StringComparison.Ordinal))
+            offenders.Add("the refusal no longer tells the user what to do; the message is what reaches "
+                + "StatusMessage, so an empty or generic one leaves them stuck");
+
+        // One gaming service for the whole designer/test graph. Under DI both view-models resolve the
+        // same singleton, but the manual graph can silently hand Performance Mode its own copy — which
+        // would answer "no session" while the real one had a game running, i.e. exactly the state that
+        // must never be snapshotted, with the guard above still passing.
+        var shell = WithoutComments(File.ReadAllText(
+            Path.Combine(FindAppProjectDir(), "ViewModels", "MainWindowViewModel.cs")));
+        var built = shell.Split("new GamingProfileService(").Length - 1;
+        if (built != 1)
+            offenders.Add($"MainWindowViewModel constructs GamingProfileService {built} times; the designer "
+                + "graph must build exactly one and pass it to both Performance Mode and Gaming Profile");
+
+        Assert.True(offenders.Count == 0,
+            "the Performance Mode baseline contract is broken:\n  - " + string.Join("\n  - ", offenders));
+    }
+
+    /// <summary>
     /// Every tab must have exactly ONE name: the label in the sidebar and the header on the page must
     /// read the same.
     /// <para>Five of 58 pairs disagreed — "App Alerts" under a page headed "App Installation Alerts",

--- a/SysManager/SysManager.Tests/PerformanceSnapshotRestartTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceSnapshotRestartTests.cs
@@ -36,6 +36,18 @@ public sealed class PerformanceSnapshotRestartTests
         return new PerformanceService(runner, new RestorePointService(runner), configDir);
     }
 
+    /// <summary>
+    /// No game profile is running — the normal case for these tests. Performance Mode consults this
+    /// only to decide whether the settings on the machine right now are the user's own before it
+    /// records them as the recovery baseline.
+    /// </summary>
+    private static IGamingProfileService NoGamingSession()
+    {
+        var gaming = Substitute.For<IGamingProfileService>();
+        gaming.IsActive.Returns(false);
+        return gaming;
+    }
+
     private static PerformanceService.OriginalSnapshot ValidSnapshot(
         DateTimeOffset? capturedAtUtc = null) =>
         new(
@@ -80,7 +92,7 @@ public sealed class PerformanceSnapshotRestartTests
             using var service = NewService(dir);
             Assert.Equal(snapshot, service.LoadSnapshot());
 
-            using var vm = new PerformanceViewModel(service);
+            using var vm = new PerformanceViewModel(service, NoGamingSession());
             await vm.InitializationComplete;
 
             Assert.True(vm.HasSnapshot);
@@ -145,7 +157,7 @@ public sealed class PerformanceSnapshotRestartTests
                 });
 
             using var service = NewService(dir, runner);
-            using var vm = new PerformanceViewModel(service);
+            using var vm = new PerformanceViewModel(service, NoGamingSession());
             try
             {
                 await refreshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -211,7 +223,7 @@ public sealed class PerformanceSnapshotRestartTests
                 """);
 
             using var service = NewService(dir);
-            using var vm = new PerformanceViewModel(service);
+            using var vm = new PerformanceViewModel(service, NoGamingSession());
             await vm.InitializationComplete;
 
             Assert.True(vm.HasSnapshot);
@@ -255,7 +267,7 @@ public sealed class PerformanceSnapshotRestartTests
             using var service = NewService(dir, runner);
             Assert.True(service.SaveSnapshot(ValidSnapshot()));
 
-            using var vm = new PerformanceViewModel(service);
+            using var vm = new PerformanceViewModel(service, NoGamingSession());
             await vm.InitializationComplete;
             Assert.True(vm.HasSnapshot);
 
@@ -414,6 +426,58 @@ public sealed class PerformanceSnapshotRestartTests
 
             Assert.False(service.SaveSnapshot(invalid));
             Assert.False(File.Exists(Path.Combine(dir, "performance-snapshot.json")));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// A live Gaming Profile session must stop this tab from inventing a recovery baseline out of the
+    /// profile's settings.
+    /// </summary>
+    /// <remarks>
+    /// #1501 stopped the two tabs from snapshotting each other mid-change by taking the
+    /// system-modification lock before CaptureSnapshotAsync. That lock is held per OPERATION, but a
+    /// gaming SESSION outlives it: the profile applies, releases the lock, and its power plan and
+    /// visual-effects values stay live until the game exits. The first mutating command in this tab
+    /// during that window used to capture those borrowed values and PERSIST them as the user's
+    /// original, so a later Restore All would put the machine on a gaming plan it had never been on.
+    /// <para>The refusal is checked, not just the absence of a file: a test that only asserted
+    /// "no snapshot written" would also pass if the command failed for some unrelated reason.</para>
+    /// </remarks>
+    [Fact]
+    public async Task Apply_WhileAGameProfileIsRunning_RefusesInsteadOfRecordingTheProfilesSettings()
+    {
+        var dir = CreateTempDirectory();
+        try
+        {
+            using var service = NewService(dir);
+            var gaming = Substitute.For<IGamingProfileService>();
+            gaming.IsActive.Returns(true);
+
+            using var vm = new PerformanceViewModel(service, gaming);
+            await vm.InitializationComplete;
+            Assert.False(vm.HasSnapshot, "precondition: nothing is persisted, so a capture would happen");
+
+            var previousDialog = DialogService.Instance;
+            var dialog = Substitute.For<IDialogService>();
+            dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+            DialogService.Instance = dialog;
+            try
+            {
+                // Must DIFFER from the current plan, or the command returns at its "already set to
+                // the selected option" short-circuit and never reaches the snapshot step — which is
+                // what the first version of this test did, passing for the wrong reason.
+                vm.SelectedPlan = "high";
+                await vm.ApplyPowerPlanCommand.ExecuteAsync(null);
+            }
+            finally { DialogService.Instance = previousDialog; }
+
+            Assert.Contains("Stop the game profile first", vm.StatusMessage, StringComparison.Ordinal);
+            Assert.Null(service.LoadSnapshot());
+            Assert.False(vm.HasSnapshot);
         }
         finally
         {

--- a/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
@@ -46,7 +46,20 @@ public class PerformanceViewModelTests
             Path.GetTempPath(),
             "SysManagerPerformanceTests",
             Guid.NewGuid().ToString("N"));
-        return new(new PerformanceService(ps, new RestorePointService(ps), configDir));
+        return new(new PerformanceService(ps, new RestorePointService(ps), configDir),
+                   NoGamingSession());
+    }
+
+    /// <summary>
+    /// No game profile is running — the normal case for these tests. Performance Mode consults this
+    /// only to decide whether the settings on the machine right now are the user's own before it
+    /// records them as the recovery baseline.
+    /// </summary>
+    private static IGamingProfileService NoGamingSession()
+    {
+        var gaming = Substitute.For<IGamingProfileService>();
+        gaming.IsActive.Returns(false);
+        return gaming;
     }
 
     // ── Commands exist ──

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.66.4</Version>
-    <FileVersion>1.66.4.0</FileVersion>
-    <AssemblyVersion>1.66.4.0</AssemblyVersion>
+    <Version>1.66.5</Version>
+    <FileVersion>1.66.5.0</FileVersion>
+    <AssemblyVersion>1.66.5.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -402,6 +402,15 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         var networkShared = new NetworkSharedState(pinger, tracer, traceMonitor, speedTest, netRepair);
         var restorePoints = new RestorePointService(runner);
         var gamingCpu = new CpuAffinityService();
+        // ONE gaming service for the whole graph. Performance Mode asks it whether a profile is live
+        // before it records a recovery baseline, so a second copy would answer "no" while the first
+        // one had a session running — which is exactly the state that must never be snapshotted.
+        // Under DI both resolve the same singleton; this keeps the designer/test path honest.
+        var gamingProfiles = new GamingProfileService(
+            new PerformanceService(runner, restorePoints),
+            new TimerResolutionService(), gamingCpu,
+            new StandbyMemoryService(), restorePoints,
+            Helpers.AdminHelper.IsElevated());
 
         return new Dictionary<Type, object>
         {
@@ -416,7 +425,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             [typeof(ProcessManagerViewModel)] = new ProcessManagerViewModel(new ProcessManagerService()),
             [typeof(BatteryHealthViewModel)] = new BatteryHealthViewModel(battery),
             [typeof(UninstallerViewModel)] = new UninstallerViewModel(new UninstallerService(runner)),
-            [typeof(PerformanceViewModel)] = new PerformanceViewModel(new PerformanceService(runner, restorePoints)),
+            [typeof(PerformanceViewModel)] = new PerformanceViewModel(new PerformanceService(runner, restorePoints), gamingProfiles),
             [typeof(StartupViewModel)] = new StartupViewModel(new StartupService()),
             [typeof(NetworkSharedState)] = networkShared,
             [typeof(PingViewModel)] = new PingViewModel(networkShared),
@@ -463,13 +472,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             [typeof(TweaksHubViewModel)] = new TweaksHubViewModel(new TweaksHubService(new PrivacyService(), restorePoints)),
             [typeof(AudioMixerViewModel)] = new AudioMixerViewModel(new AudioMixerService(), new VolumePresetService()),
             [typeof(NotificationBlockerViewModel)] = new NotificationBlockerViewModel(new NotificationBlockerService()),
-            [typeof(GamingProfileViewModel)] = new GamingProfileViewModel(
-                new GamingProfileService(
-                    new PerformanceService(runner, restorePoints),
-                    new TimerResolutionService(), gamingCpu,
-                    new StandbyMemoryService(), restorePoints,
-                    Helpers.AdminHelper.IsElevated()),
-                gamingCpu),
+            [typeof(GamingProfileViewModel)] = new GamingProfileViewModel(gamingProfiles, gamingCpu),
         };
     }
 }

--- a/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
@@ -27,6 +27,10 @@ namespace SysManager.ViewModels;
 public sealed partial class PerformanceViewModel : ViewModelBase
 {
     private readonly PerformanceService _service;
+    // Consulted for ONE question: is a game profile live? While it is, the current power plan and
+    // visual-effects state belong to the profile, not to the user, so they must not be recorded as
+    // the recovery baseline. See EnsureSnapshotAsync.
+    private readonly IGamingProfileService _gaming;
     private PerformanceService.OriginalSnapshot? _snapshot;
     // Serializes the load-modify of _snapshot so two Apply commands running at once
     // can't both observe a null snapshot and race the capture/save.
@@ -57,9 +61,10 @@ public sealed partial class PerformanceViewModel : ViewModelBase
     [ObservableProperty] private bool _needsReboot;
     [ObservableProperty] private bool _hasSnapshot;
 
-    public PerformanceViewModel(PerformanceService service)
+    public PerformanceViewModel(PerformanceService service, IGamingProfileService gaming)
     {
         _service = service;
+        _gaming = gaming;
         IsElevated = AdminHelper.IsElevated();
         InitializeAsync(InitAsync);
     }
@@ -124,6 +129,15 @@ public sealed partial class PerformanceViewModel : ViewModelBase
                 }
                 else
                 {
+                    // Refuse to CAPTURE while a game profile is live. The lock that keeps this tab and
+                    // Gaming Profile from overlapping is held per operation, but a gaming SESSION
+                    // outlives it: the profile applies, releases the lock, and its power plan and
+                    // visual-effects values stay live until the game exits. A snapshot taken in that
+                    // window records the profile's state as the user's own and persists it, so a later
+                    // Restore All would put the machine on a gaming plan it was never on. Loading an
+                    // ALREADY-persisted snapshot above is fine — it predates the session.
+                    if (_gaming.IsActive) throw SnapshotDuringGamingSession();
+
                     var captured = await _service.TakeSnapshotAsync();
                     var saved = await Task.Run(() => _service.SaveSnapshot(captured));
                     if (!saved) throw SnapshotUnavailable();
@@ -142,6 +156,17 @@ public sealed partial class PerformanceViewModel : ViewModelBase
     /// </summary>
     private static InvalidOperationException SnapshotUnavailable() =>
         new("The recovery snapshot could not be saved, so no setting was changed.");
+
+    /// <summary>
+    /// The refusal for "a game profile is running, so the settings on this machine right now are the
+    /// profile's, not yours". Thrown only when there is no persisted snapshot to fall back on, i.e.
+    /// exactly when this tab would otherwise invent a baseline out of borrowed values. Every Apply
+    /// command catches <see cref="InvalidOperationException"/> and shows the message, so the user is
+    /// told what to do rather than just refused.
+    /// </summary>
+    private static InvalidOperationException SnapshotDuringGamingSession() =>
+        new("Stop the game profile first. While it is running, the power plan and visual effects are "
+            + "the profile's, so recording them as your original settings would restore you to them later.");
 
     /// <summary>
     /// Releases the snapshot gate unless disposal has already claimed it. Releasing a disposed


### PR DESCRIPTION
Closes #1954 — which I filed during the audit after #1501 shipped, by hunting the same defect class instead of stopping at the one instance.

## The window the lock cannot cover

#1501 made `GamingProfileService.ApplyAsync` take the `SystemModification` lock **before** `CaptureSnapshotAsync`, so the two tabs can no longer snapshot each other mid-change. Verified still true, and `PerformanceViewModel` has the same order everywhere (acquire at :236, `EnsureSnapshotAsync()` at :247, and the same pairing at :294/:306, :340/:352, :384/:396, :434/:446, :500/:512).

But the lock is held **per operation**, and a gaming session outlives it:

1. Start a profile → power plan becomes Ultimate Performance. Apply returns, **the lock is released**, the session stays active.
2. Still in-game, use any Performance Mode command for the first time. It acquires the free lock, finds no persisted snapshot, and captures the current state — the profile's values — persisting them as the user's original.
3. The game exits; Gaming Profile reverts correctly.
4. Later, **Restore All** applies the stale baseline, leaving the machine on a gaming plan it had never been on.

Step 2 is reachable more than once, because Restore All deletes the persisted snapshot.

## The fix, and the asymmetry that matters

`EnsureSnapshotAsync` refuses to **capture** while `IGamingProfileService.IsActive` — and still **loads** an already-persisted snapshot, because that one predates the session and really is the user's own baseline.

```csharp
if (_gaming.IsActive) throw SnapshotDuringGamingSession();
```

Both halves are asserted, because each breaks on its own:

- move the check **below** `TakeSnapshotAsync` → the borrowed values are captured and only then refused;
- move it **above** `LoadSnapshot` → a legitimate pre-session baseline is blocked, turning a safety guard into "Performance Mode stops working while a game runs".

The refusal carries an instruction rather than just failing. Every Apply command already surfaces `InvalidOperationException.Message` verbatim in `StatusMessage`, so the user reads *"Stop the game profile first…"* — the guard asserts that sentence still exists, since a generic message would leave them stuck.

## One gaming service in the manual graph

Under DI both view-models resolve the same singleton, but `BuildDesignerGraph` was constructing a second `GamingProfileService` inline. That copy would answer "no session" while the real one had a game running — the exact state that must never be snapshotted, with every other assertion still passing. The graph now builds one and passes it to both, and the guard asserts exactly one construction.

## Verification

| Mutation | Result |
|---|---|
| baseline | green |
| the session check deleted | **red** — guard + regression test |
| the check moved AFTER the capture | **red** — guard |
| the check moved ABOVE `LoadSnapshot` | **red** — guard |
| the instruction stripped out of the message | **red** — guard + regression test |
| the designer graph given a second gaming service | **red** — guard |

Both mutated files restored byte-for-byte.

**The regression test first passed for the wrong reason** and had to be fixed: it selected `"balanced"`, which matched the stubbed current plan, so `ApplyPowerPlanAsync` returned at its "already set to the selected option" short-circuit and never reached the snapshot step. It now selects a differing plan, and a comment records why. The test is safe on a real machine regardless — the refusal throws before any `powercfg` call, and the runner is a substitute.

Five existing test call sites needed the new constructor argument; they pass a `NoGamingSession()` substitute, which is the honest default for tests that are not about this behaviour.

Both projects build **0 errors / 0 warnings**; `dotnet format --verify-no-changes` clean on both with real exit codes; the three CI gates reproduced locally exit 0; a 9-test regression sweep is green, including `OnlyTheJustifiedTabs_AreBuiltAtStartup` since this changes DI wiring — the new dependency does not make any tab eager.

## Docs

README claimed the snapshot "captures the exact system state before the first change" without qualification. It now states the one case where it declines, and that a baseline saved before the profile started is still used.