### PR TITLE
feat: carry five more of the user's settings in an exported profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.67.0] - 2026-08-24
+
+Moving to a new PC now actually brings your setup with you. Profile Export carried your theme, your
+speed-test history and your update-check choice — and silently left behind the dark-mode schedule, the
+gaming profiles, the volume presets and two more preferences you had set. Eight sections travel now
+instead of three.
+
+### Added
+- **Profile Export carries five more of your settings**: the dark-mode schedule, your gaming profiles,
+  your volume presets, the close-button behaviour, and the standby-memory preference. Each is still
+  optional — tick the ones you want, as before.
+- **What it will not carry, on purpose.** Anything that describes *this* PC rather than your choices is
+  deliberately left out: the undo baselines behind Performance Mode and Environment Variables, the
+  Settings Watchdog's record of this machine's registry, the service-startup ledger and the local
+  activity log. Copying those to another computer would restore it to settings it had never been on, or
+  report differences that are only "a different PC". A test now keeps each of them out.
+- **A gaming profile arrives without the other PC's unfinished session.** That file also holds a
+  crash-recovery marker for a game running on the machine that exported it; imported as-is, this PC would
+  offer to undo tweaks it never applied for a game that never ran here. Your actual profiles come across;
+  that marker is dropped. If the section cannot be read at all it is skipped rather than written over a
+  working file.
+- The tab's empty-state message and the README section listed only the old three sections; both now
+  describe what really travels.
+
 ## [1.66.5] - 2026-08-24
 
 Performance Mode will no longer mistake a running game profile's settings for your own. Start a profile,

--- a/README.md
+++ b/README.md
@@ -945,11 +945,18 @@ offers, "rate us" prompts:
   a bug. Both are in the About tab; a browser tab opens only when you press them.
 
 ### Profile Export / Import
-- Export your SysManager settings — theme/appearance and speed-test history — to
-  a single portable JSON file, and import them on another PC
+- Export your SysManager settings to a single portable JSON file and import them on
+  another PC: **theme and appearance, dark-mode schedule, gaming profiles, volume
+  presets, close-button behaviour, standby-memory preference, update-check preference,
+  and speed-test history**
 - **Selective export** (tick which sections to include) and **selective import**
   (confirm what a profile contains before anything is overwritten)
 - **Version-aware** — refuses profiles created by a newer, incompatible build
+- **What it deliberately leaves out** — anything that describes *this* PC rather than
+  your choices: the undo baselines behind Performance Mode and Environment Variables,
+  the Settings Watchdog's record of this machine's registry, the service-startup ledger,
+  and the local activity log. Carrying those to another PC would restore it to settings
+  it was never on, or report differences that are only "a different computer"
 - Only SysManager's own config is ever touched (never system settings), so an
   import is fully reversible — just import a different profile
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.66.x   | :white_check_mark: |
-| < 1.66   | :x:                |
+| 1.67.x   | :white_check_mark: |
+| < 1.67   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ProfileServiceTests.cs
+++ b/SysManager/SysManager.Tests/ProfileServiceTests.cs
@@ -217,4 +217,87 @@ public class ProfileServiceTests : IDisposable
             denied.SetAccessControl(acl);
         }
     }
+
+    // ---------- The catalog carries the user's choices, and nothing machine-specific ----------
+
+    /// <summary>
+    /// Every catalog section must actually surface once its file exists. A section whose file name does
+    /// not match what the owning service writes exports NOTHING and fails silently — the profile just
+    /// comes out smaller, which is exactly how six of these went missing for months.
+    /// </summary>
+    [Fact]
+    public void AvailableSections_SurfacesEverySectionTheCatalogClaims()
+    {
+        // One file per section the catalog knows about, named as the owning services name them.
+        string[] files =
+        [
+            "theme.json", "speedtest-history.json", "update-check.json", "darkmode-schedule.json",
+            "gaming-profiles.json", "volume-presets.json", "close-preference.json",
+            "standby-preference.json",
+        ];
+        foreach (var f in files) WriteConfig(f, "{}");
+
+        var keys = _svc.AvailableSections().Select(x => x.Key).OrderBy(x => x, StringComparer.Ordinal).ToArray();
+
+        Assert.Equal(files.Length, keys.Length);
+        Assert.Equal(
+            new[] { "closebehaviour", "darkmode", "gaming", "speedtest", "standby", "theme", "updatecheck", "volume" },
+            keys);
+    }
+
+    /// <summary>
+    /// Machine-specific state must never be carried to another PC. Each of these files is written by the
+    /// app under the same config folder, so the ONLY thing keeping them out of a profile is their absence
+    /// from the catalog — which is a one-line edit away from being undone by someone adding "everything".
+    /// </summary>
+    [Theory]
+    [InlineData("performance-snapshot.json")]
+    [InlineData("environment-backup.json")]
+    [InlineData("settings-baseline.json")]
+    [InlineData("service-startup-ledger.json")]
+    [InlineData("last-crash.json")]
+    [InlineData("activity.json")]
+    [InlineData("resource-history-config.json")]
+    public void AvailableSections_NeverCarriesMachineSpecificState(string fileName)
+    {
+        WriteConfig(fileName, "{\"machine\":\"specific\"}");
+
+        Assert.Empty(_svc.AvailableSections());
+    }
+
+    /// <summary>
+    /// A gaming profile carries the user's tick-boxes, but ActiveSession is the crash-recovery marker for
+    /// a game running on the machine that exported it. Imported as-is, this PC would offer to restore
+    /// tweaks it never applied for a game that never ran here.
+    /// </summary>
+    [Fact]
+    public void ApplySections_GamingProfiles_KeepsTheProfilesAndDropsTheLiveSession()
+    {
+        var foreign = "{\"SchemaVersion\":1,\"LastConfig\":{\"FinestTimerResolution\":true},"
+            + "\"ActiveSession\":{\"Profile\":{},\"Snapshot\":{}}}";
+
+        var applied = _svc.ApplySections([new ConfigSection("gaming", "Gaming profiles", "gaming-profiles.json", foreign)]);
+
+        Assert.Equal(1, applied);
+        var written = File.ReadAllText(Path.Combine(_dir, "gaming-profiles.json"));
+        Assert.DoesNotContain("ActiveSession", written, StringComparison.Ordinal);
+        Assert.Contains("FinestTimerResolution", written, StringComparison.Ordinal);
+        Assert.Contains("SchemaVersion", written, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// An unreadable section is skipped, not written. Overwriting a working local file with content the
+    /// owning service cannot parse would turn a bad import into lost settings.
+    /// </summary>
+    [Fact]
+    public void ApplySections_GamingProfiles_UnparseableContentIsSkippedAndLeavesTheLocalFileAlone()
+    {
+        WriteConfig("gaming-profiles.json", "{\"SchemaVersion\":1,\"LastConfig\":{\"Mine\":true}}");
+
+        var applied = _svc.ApplySections([new ConfigSection("gaming", "Gaming profiles", "gaming-profiles.json", "{ not json ][")]);
+
+        Assert.Equal(0, applied);
+        Assert.Contains("Mine", File.ReadAllText(Path.Combine(_dir, "gaming-profiles.json")),
+            StringComparison.Ordinal);
+    }
 }

--- a/SysManager/SysManager/Services/ProfileService.cs
+++ b/SysManager/SysManager/Services/ProfileService.cs
@@ -42,16 +42,78 @@ public sealed class ProfileService
     private enum Base { Local, Roaming }
 
     /// <summary>
-    /// The set of config files a profile carries — logical key, label, file name, and which
-    /// AppData base it lives under. The base MUST match the owning service or export/import
-    /// silently reads/writes the wrong location.
+    /// The set of config files a profile carries — logical key, label, file name, which AppData base it
+    /// lives under, and an optional import sanitiser. The base MUST match the owning service or
+    /// export/import silently reads/writes the wrong location.
+    /// <para>What is DELIBERATELY absent matters as much as what is here. A profile is meant to move a
+    /// user's choices to another PC, so anything that describes THIS machine is excluded on purpose:</para>
+    /// <list type="bullet">
+    /// <item><c>performance-snapshot.json</c> and <c>environment-backup.json</c> — undo baselines of this
+    ///   machine's power plan and PATH. Importing another PC's baseline and later pressing Restore would
+    ///   apply settings this machine was never on; that is the same defect class as #1954.</item>
+    /// <item><c>settings-baseline.json</c> — the Settings Watchdog's record of this machine's registry.
+    ///   A foreign baseline makes the Watchdog report drift that is only "a different PC".</item>
+    /// <item><c>service-startup-ledger.json</c>, <c>last-crash.json</c> — undo/diagnostic state tied to
+    ///   this installation's history.</item>
+    /// <item><c>activity.json</c> — the local activity log. It is a record of what happened here, not a
+    ///   setting, and merging two machines' histories would make it a fiction.</item>
+    /// <item><c>ProcessDescriptions.json</c>, <c>icon-fetch.json</c> — bundled data and a cache.</item>
+    /// <item><c>resource-history-config.json</c> — a single retention number; a whole section and a
+    ///   checkbox for one integer costs the user more attention than it saves.</item>
+    /// </list>
     /// </summary>
-    private static readonly (string Key, string DisplayName, string FileName, Base Base)[] Catalog =
+    private static readonly (string Key, string DisplayName, string FileName, Base Base,
+        Func<string, string?>? OnImport)[] Catalog =
     [
-        ("theme", "Theme & appearance", "theme.json", Base.Roaming),        // ThemeService → Roaming
-        ("speedtest", "Speed-test history", "speedtest-history.json", Base.Local), // SpeedTestHistoryService → Local
-        ("updatecheck", "Update-check preference", "update-check.json", Base.Roaming), // UpdateCheckPreferenceService → Roaming
+        ("theme", "Theme & appearance", "theme.json", Base.Roaming, null),        // ThemeService → Roaming
+        ("speedtest", "Speed-test history", "speedtest-history.json", Base.Local, null), // SpeedTestHistoryService → Local
+        ("updatecheck", "Update-check preference", "update-check.json", Base.Roaming, null), // UpdateCheckPreferenceService → Roaming
+        ("darkmode", "Dark-mode schedule", "darkmode-schedule.json", Base.Roaming, null), // WindowsThemeService → Roaming
+        ("gaming", "Gaming profiles", "gaming-profiles.json", Base.Local, StripActiveSession), // GamingProfileService → Local
+        ("volume", "Volume presets", "volume-presets.json", Base.Local, null),   // VolumePresetService → Local
+        ("closebehaviour", "Close-button behaviour", "close-preference.json", Base.Local, null), // ClosePreferenceService → Local
+        ("standby", "Standby-memory preference", "standby-preference.json", Base.Local, null), // StandbyPreferenceService → Local
     ];
+
+    /// <summary>
+    /// Removes <c>ActiveSession</c> from an imported gaming-profiles file. That field is the crash-recovery
+    /// marker for a game session on the machine that exported it: carried over, this PC would offer to
+    /// "restore" tweaks it never applied, for a game that never ran here. The user's actual profiles — the
+    /// part they configured — are kept.
+    /// <para>Returns <c>null</c> to skip the section when the JSON cannot be parsed, rather than writing
+    /// something unreadable over a working file.</para>
+    /// </summary>
+    private static string? StripActiveSession(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object) return null;
+
+            var buffer = new System.Buffers.ArrayBufferWriter<byte>();
+            using (var writer = new Utf8JsonWriter(buffer, new JsonWriterOptions
+            {
+                Indented = true,
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+            }))
+            {
+                writer.WriteStartObject();
+                foreach (var property in doc.RootElement.EnumerateObject())
+                {
+                    if (string.Equals(property.Name, "ActiveSession", StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    property.WriteTo(writer);
+                }
+                writer.WriteEndObject();
+            }
+            return Encoding.UTF8.GetString(buffer.WrittenSpan);
+        }
+        catch (JsonException ex)
+        {
+            Log.Warning("Profile: gaming profiles section is not valid JSON, skipping it: {Error}", ex.Message);
+            return null;
+        }
+    }
 
     /// <summary>
     /// Creates the service. When <paramref name="configDir"/> is given (tests), BOTH bases
@@ -79,7 +141,9 @@ public sealed class ProfileService
     public IReadOnlyList<ConfigSection> AvailableSections()
     {
         List<ConfigSection> sections = [];
-        foreach (var (key, display, fileName, baseDir) in Catalog)
+        // The import sanitiser is irrelevant on the way out — a section is exported as the owning
+        // service wrote it, and only sanitised when it lands on another machine.
+        foreach (var (key, display, fileName, baseDir, _) in Catalog)
         {
             var path = Path.Combine(DirFor(baseDir), fileName);
             if (!File.Exists(path)) continue;
@@ -149,6 +213,21 @@ public sealed class ProfileService
                 Log.Warning("Profile: skipping unknown config section '{Key}'", section.Key);
                 continue;
             }
+            // Sections that carry machine-specific state are sanitised before they land. A sanitiser
+            // returning null means "this content is not safe or not readable" — skip rather than write
+            // something the owning service would choke on or act wrongly upon.
+            var content = section.Json;
+            if (known.OnImport is { } sanitize)
+            {
+                if (sanitize(content) is not { } cleaned)
+                {
+                    Log.Warning("Profile: skipping section '{Key}' — its content did not survive the "
+                        + "import check", section.Key);
+                    continue;
+                }
+                content = cleaned;
+            }
+
             // Always use the catalog's own file name + base — never a path from the
             // (untrusted) profile — and write to the SAME folder the owning service reads.
             var dir = DirFor(known.Base);
@@ -156,7 +235,7 @@ public sealed class ProfileService
             var path = Path.Combine(dir, known.FileName);
             try
             {
-                AtomicFile.WriteAllText(path, section.Json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                AtomicFile.WriteAllText(path, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
                 applied++;
             }
             catch (IOException ex) { Log.Warning("Profile: could not write {File}: {Error}", known.FileName, ex.Message); }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.66.5</Version>
-    <FileVersion>1.66.5.0</FileVersion>
-    <AssemblyVersion>1.66.5.0</AssemblyVersion>
+    <Version>1.67.0</Version>
+    <FileVersion>1.67.0.0</FileVersion>
+    <AssemblyVersion>1.67.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/ProfileView.xaml
+++ b/SysManager/SysManager/Views/ProfileView.xaml
@@ -44,7 +44,7 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
 
-                <TextBlock Text="No exportable settings found yet. Use the app a little (set a theme, run a speed test), then refresh."
+                <TextBlock Text="No exportable settings found yet. Change something you would want on another PC — pick a theme, set a dark-mode schedule, save a volume preset — then refresh."
                            Style="{StaticResource Subtle}" TextWrapping="Wrap" Margin="0,0,0,8"
                            Visibility="{Binding HasSections, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
 


### PR DESCRIPTION
Closes #1491.

## Problem

`ProfileService.Catalog` had **three** entries while the app writes **17** JSON files under AppData. `AvailableSections()` only ever surfaces catalog entries, so the omission was invisible — the export simply came out smaller. The migration story this feature exists for ("new laptop, bring my setup back") silently left behind the dark-mode schedule, the gaming profiles, the volume presets and two more preferences the user had deliberately set.

**Both numbers in the issue had moved**, so the set was re-derived from current source rather than taken from the report: the catalog already had three entries (`updatecheck` was added after the audit) and four of the config files did not exist then.

## Added

| Section | File | Base | Owner |
|---|---|---|---|
| Dark-mode schedule | `darkmode-schedule.json` | Roaming | `WindowsThemeService` |
| Gaming profiles | `gaming-profiles.json` | Local | `GamingProfileService` |
| Volume presets | `volume-presets.json` | Local | `VolumePresetService` |
| Close-button behaviour | `close-preference.json` | Local | `ClosePreferenceService` |
| Standby-memory preference | `standby-preference.json` | Local | `StandbyPreferenceService` |

Every base was re-derived from its owning service, because a wrong base makes export and import quietly read and write a folder nobody reads.

## The exclusions are the other half

Documented on the catalog itself, and each is now pinned **out** by a theory so "just add everything" fails:

- `performance-snapshot.json`, `environment-backup.json` — this machine's undo baselines. Importing a foreign one and later pressing Restore would apply settings the machine was never on. That is exactly the defect class of #1954, fixed one PR ago.
- `settings-baseline.json` — the Settings Watchdog's record of this machine's registry; a foreign baseline makes it report drift that is only "a different PC". The issue was undecided on this one; excluding it is the call, with the reason on file.
- `service-startup-ledger.json`, `last-crash.json` — undo/diagnostic state tied to this installation.
- `activity.json` — a log of what happened *here*, not a setting; merging two machines' histories would make it a fiction.
- `ProcessDescriptions.json`, `icon-fetch.json` — bundled data and a cache.
- `resource-history-config.json` — one retention integer; a section and a checkbox for it costs more attention than it saves.

## Sanitising, not just including

`gaming-profiles.json` also holds `ActiveSession`, the crash-recovery marker for a session on the **exporting** machine. Imported as-is, this PC would offer to undo tweaks it never applied, for a game that never ran here. The catalog entry now carries an import sanitiser:

- it drops `ActiveSession` and keeps the user's profiles;
- returning `null` means "skip this section", so unparseable content is never written over a working local file — a bad import must not become lost settings.

## Verification

| Mutation | Result |
|---|---|
| baseline | green |
| a section dropped from the catalog | **red** |
| `settings-baseline.json` added to the catalog | **red** — the exclusion theory |
| the gaming entry loses its sanitiser | **red** — *two* tests |
| unparseable content written instead of skipped | **red** |
| a catalog file name typoed | **red** |

The sanitiser mutation turning two tests red was a correction to my own prediction: without a sanitiser the unparseable case is also written verbatim, so that test pins the sanitiser's existence too. The file-name mutation is the important one for the future — a name that does not match what the owning service writes exports nothing, silently, which is how this feature came to carry three sections.

Both projects build **0 errors / 0 warnings**; `dotnet format --verify-no-changes` clean with real exit codes; all three CI gates reproduced locally exit 0; a 16-test regression sweep is green.

## Docs

`ProfileView.xaml`'s empty state told the user to "set a theme, run a speed test" — literally naming the only two sections that worked. It and the README section now describe what really travels, and the README states what is deliberately left behind and why. `SECURITY.md` moves to 1.67.x with the minor bump.