### PR TITLE
refactor: make four constructor-only fields readonly and trim in the projection

### DIFF
--- a/SysManager/SysManager/Services/AudioMixerService.cs
+++ b/SysManager/SysManager/Services/AudioMixerService.cs
@@ -641,7 +641,7 @@ public sealed class AudioMixerService : IAudioMixerService, IDisposable
     // ── Core Audio COM interop (documented interfaces, exact vtable order) ──
 
     private static readonly Guid CLSID_MMDeviceEnumerator = new("BCDE0395-E52F-467C-8E3D-C4579291692E");
-    private static Guid IID_IAudioSessionManager2 = new("77AA99A0-1BD6-484F-8BC7-2C654C9A9B6F");
+    private static readonly Guid IID_IAudioSessionManager2 = new("77AA99A0-1BD6-484F-8BC7-2C654C9A9B6F");
     private const uint CLSCTX_ALL = 0x17;
 
     private enum EDataFlow { Render = 0, Capture = 1, All = 2 }

--- a/SysManager/SysManager/Services/HostsFileService.cs
+++ b/SysManager/SysManager/Services/HostsFileService.cs
@@ -124,9 +124,10 @@ public sealed partial class HostsFileService
         catch (IOException) { return preserved; }
         catch (UnauthorizedAccessException) { return preserved; }
 
-        foreach (var raw in rawLines)
+        // Trim in the projection: the loop body never needs the untrimmed line, and rawLines is
+        // already a materialised array from ReadAllLines, so this is the same work in the same order.
+        foreach (var line in rawLines.Select(r => r.Trim()))
         {
-            var line = raw.Trim();
 
             if (line.Length == 0)
             {

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -30,7 +30,9 @@ public sealed partial class AboutViewModel : ViewModelBase
 
     // Suppresses saving while the constructor applies the loaded value, so restoring the
     // preference does not immediately rewrite the same file.
-    private bool _loadingPreference;
+    // Armed and disarmed inside the constructor only, so it is readonly: re-arming it later would
+    // leave the preference save permanently suppressed instead of just during the initial load.
+    private readonly bool _loadingPreference;
 
     [ObservableProperty] private IReadOnlyList<ReleaseNote> _releaseHistory = [];
 

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -379,7 +379,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     // ── Designer / test dependency graph ────────────────────────────────────
     // Built lazily (and only when there is no DI container) so the parameterless ctor keeps
     // working in the XAML designer and unit tests exactly as before — every VM eager, no DI.
-    private Dictionary<Type, object>? _designerVms;
+    private readonly Dictionary<Type, object>? _designerVms;
 
     private Dictionary<Type, object> BuildDesignerGraph()
     {

--- a/SysManager/SysManager/ViewModels/StandbyMemoryViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StandbyMemoryViewModel.cs
@@ -25,7 +25,8 @@ public sealed partial class StandbyMemoryViewModel : ViewModelBase
     private readonly DispatcherTimer? _timer;
     // Suppresses saving while the constructor applies the loaded values, so restoring a
     // preference does not immediately rewrite the same file.
-    private bool _loadingPreferences;
+    // Constructor-only, like AboutViewModel's equivalent flag — see the note there.
+    private readonly bool _loadingPreferences;
 
     [ObservableProperty] private string _totalDisplay = "—";
     [ObservableProperty] private string _availableDisplay = "—";


### PR DESCRIPTION
Refs #1946 — clears **5 of the 8** unowned code-scanning alerts. No behaviour change, so **no version bump and no release**: `auto-release.yml` maps anything other than `feat:`/`fix:` to `type=none`, verified in the workflow rather than assumed.

## The four `cs/missed-readonly-modifier` alerts

Each was re-derived against current source instead of trusted from the alert text, because that rule fires wrongly on a field assigned outside a constructor — and two of these looked exactly like that until I checked the enclosing member. All four are legal, and **the compiler is the proof**: it rejects any write outside a constructor, so a clean build is the check.

| Alert | Field | Why readonly is correct |
|---|---|---|
| #1714 | `AboutViewModel._loadingPreference` | armed *and* disarmed inside the constructor (`:149`/`:151`, ctor at `:135`) |
| #1712 | `StandbyMemoryViewModel._loadingPreferences` | same shape (`:58`/`:62`, ctor at `:49`) |
| #1699 | `MainWindowViewModel._designerVms` | assigned once, conditionally, in the constructor's no-DI path |
| #1697 | `AudioMixerService.IID_IAudioSessionManager2` | never reassigned, never passed by `ref` — its single use copies it into a local first |

The two flags are more than a nit: `readonly` documents that they cannot be re-armed later, and a load-suppression flag left true outside construction would **permanently** suppress the preference save it guards — the very bug the flag exists to prevent. `ConstructingTheViewModel_DoesNotTouchTheRealPreferenceFile` covers that behaviour and stays green.

The GUID is the one with a visible payoff: `CLSID_MMDeviceEnumerator`, declared one line above it in the same interop block, was already `static readonly`. That inconsistency is what made the alert worth acting on rather than dismissing.

## The one `cs/linq/missed-select` worth taking

`HostsFileService`'s parse loop mapped its iteration variable to a trimmed copy and never used the original — verified by grepping the whole loop body for `raw`, which appears only on the `foreach` line and the trim. The trim moves into the projection. `rawLines` is already a materialised array from `ReadAllLines`, so the work and its order are identical; laziness cannot defer anything here.

The parse path is covered by the round-trip, fixed-point, comment-preservation and no-temp-file-left-behind tests — **27 green**.

## The three I recommend NOT changing

Judged individually rather than churned to make a number go down:

- **`GpuVramHelper:59`** — the loop opens a `RegistryKey` per iteration under `using var`. Projecting it would either leak handles or dispose them at the wrong time. Deterministic disposal beats the idiom.
- **`UpdateApplier:199`** — a security-boundary check (is this path under a system root) whose `foreach` with an early return is the clearer form. Low value, non-zero risk.
- **`BootAnalyzerViewModel:68`** — both branches assign `StatusMessage`, but the empty-list branch is *itself* a ternary on `IsElevated`, so collapsing produces a ternary nested inside a ternary across four lines of message text.

Dismissing an alert with a reason is a legitimate outcome; I have left all three open rather than dismissing them, since changing the public alert list is a visible state change I would rather you approve.

The four `cs/constant-condition` alerts remain untouched on purpose — post-`await` dispose guards, whose removal reintroduces the use-after-dispose crashes fixed earlier.

## Verification

App and test projects both build **0 errors / 0 warnings**; `dotnet format --verify-no-changes` clean on both (exit captured into a variable — see below); the three CI gates reproduced locally, with the bump gate correctly reporting *"Version 1.67.0 equals the newest tag — no release expected from this PR"*.

Worth recording: my first format check reported a false pass. Writing `dotnet format …; echo "fmt $(basename $pj) REAL=$?"` measures **`basename`**, not `dotnet format`, because the command substitution resets `$?`. The real exit was 2 — three ENDOFLINE violations from comment lines I had inserted with LF endings. Fixed, and re-checked with `rc=$?` captured immediately.