### PR TITLE
feat: share one restore point across every tab that changes system settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.68.0] - 2026-08-25
+
+The automatic restore point now covers the tab where you would most want it. Turning a privacy switch
+off through Tweaks Hub took a Windows restore point first; making the identical change from another tab,
+or removing OneDrive, took none. Same risk, different answer depending on which page you happened to
+open — and the unpredictable version of a safety net is the worst kind.
+
+### Added
+- **Edge/OneDrive Remover now takes a restore point before its first change**, like Tweaks Hub already
+  did. It is attempted before the change rather than after, because a snapshot taken afterwards records
+  the state you are trying to get back from. The Restore buttons count too — putting Edge back is a
+  system change like any other.
+- **One restore point per session, not one per tab.** Windows allows roughly one a day, so two features
+  each making their own meant the first one used up the allowance and the second reported "no restore
+  point" while a perfectly good one existed. Tweaks Hub and Gaming Profile each had their own private
+  copy of that logic; there is now a single shared one, and a test refuses a second.
+
+### Changed
+- The restore point is still only ever mentioned when one was actually created. System Restore is
+  switched off on many PCs and needs administrator, so a silent "no" is normal — and claiming
+  protection that did not happen would be worse than not offering it.
+
 ## [1.67.0] - 2026-08-24
 
 Moving to a new PC now actually brings your setup with you. Profile Export carried your theme, your

--- a/README.md
+++ b/README.md
@@ -724,6 +724,10 @@ Get Microsoft Edge and OneDrive out of your way — reversibly:
   and guides you instead of pretending to change it
 - Every action confirms first with a plain-language impact summary; disabling Edge needs
   administrator (the tab explains why and what it unlocks), removing OneDrive does not
+- **A Windows restore point is attempted before the first change of the session** — shared with
+  the other tabs that change system settings, so at most one is made no matter how many tabs you
+  use. It is mentioned only when one was really created: System Restore is switched off on many
+  PCs and Windows allows roughly one point a day, so silence means "no snapshot", never a promise
 
 ### Defender Tweaks
 Manage Microsoft Defender without digging through Windows Security:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.67.x   | :white_check_mark: |
-| < 1.67   | :x:                |
+| 1.68.x   | :white_check_mark: |
+| < 1.68   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2752,6 +2752,98 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// The automatic "snapshot before the first change of the session" must have exactly ONE
+    /// implementation, and no tab may quietly grow its own.
+    /// <para>It had three. <c>TweaksHubService</c> and <c>GamingProfileService</c> each carried a private
+    /// <c>_restorePointAttemptedThisSession</c> bool with a byte-equivalent method beside it, and the six
+    /// other system-mutating services carried nothing at all — so flipping a privacy toggle through
+    /// Tweaks Hub took a snapshot while the identical registry write from the Privacy tab, or removing
+    /// Edge, took none. An unpredictable guarantee is the worst kind: it is the thing that makes the user
+    /// feel able to press the button.</para>
+    /// <para>Two copies were also worse than one in a way that is easy to miss: Windows rate-limits
+    /// restore points to roughly one per 24 hours, so whichever feature ran first consumed the window and
+    /// the second reported "no restore point" while a perfectly good one existed.</para>
+    /// <para>Naming <c>CreateAsync</c> directly is still legitimate in three places and no more: the two
+    /// wiring sites that hand the delegate to the seam, the manual button in Performance Mode, and the
+    /// Restore Points tab where creating one IS the feature. A fourth caller means an automatic snapshot
+    /// that bypasses the once-per-session rule, which is exactly the drift this guard exists to catch.</para>
+    /// </summary>
+    [Fact]
+    public void TheSessionRestorePoint_IsTheOnlyAutomaticSnapshot()
+    {
+        var appDir = FindAppProjectDir();
+        var sources = Directory
+            .EnumerateFiles(appDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                                    StringComparison.Ordinal)
+                        && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}",
+                                       StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.True(sources.Length >= 50,
+            $"only {sources.Length} app source files found — the scan is not seeing the codebase, so a "
+            + "clean result would mean nothing.");
+
+        // Files allowed to name CreateAsync on the restore service, and why.
+        var allowed = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["ServiceRegistration.cs"] = "hands the delegate to the single seam",
+            ["ViewModels/MainWindowViewModel.cs"] = "the designer/test graph's equivalent wiring",
+            ["Services/PerformanceService.cs"] = "the MANUAL 'create a restore point' button — the user asked",
+            ["ViewModels/RestorePointsViewModel.cs"] = "the Restore Points tab, where creating one is the feature",
+            ["Services/RestorePointService.cs"] = "declares it",
+        };
+
+        var offenders = new List<string>();
+        var implementations = new List<string>();
+        var callers = 0;
+
+        foreach (var file in sources)
+        {
+            var relative = Path.GetRelativePath(appDir, file).Replace(Path.DirectorySeparatorChar, '/');
+            // Comments stripped: the paragraphs explaining this contract name both the field and the
+            // method, and a guard that reads its own prose reports the opposite of the truth.
+            var code = WithoutComments(File.ReadAllText(file));
+
+            if (code.Contains(": ISessionRestorePoint", StringComparison.Ordinal))
+                implementations.Add(relative);
+
+            // The copied pattern: a per-feature "did I already try this session" flag.
+            if (RestorePointAttemptFlag().IsMatch(code) && relative != "Services/SessionRestorePoint.cs")
+                offenders.Add($"{relative} keeps its own once-per-session restore-point flag. Use "
+                    + "ISessionRestorePoint — a second copy means two features each burn the 24-hour "
+                    + "limit and the loser reports no snapshot while one exists.");
+
+            // Any DOTTED reference counts, with or without an argument list: the two wiring sites pass
+            // CreateAsync as a delegate, so requiring "CreateAsync(" missed exactly the callers that
+            // matter most and drove this guard below its own floor.
+            if (!RestorePointCreateCall().IsMatch(code)) continue;
+
+            callers++;
+            if (!allowed.ContainsKey(relative))
+                offenders.Add($"{relative} calls the restore service directly. Automatic snapshots go "
+                    + "through ISessionRestorePoint so the session takes at most one; add it to the "
+                    + "allowlist only if it is a user-initiated point like the Performance Mode button.");
+        }
+
+        Assert.True(callers >= 3,
+            $"only {callers} restore-point call sites matched — the pattern is not finding the real ones, "
+            + "so the allowlist above is not being enforced.");
+
+        Assert.Single(implementations);
+        Assert.Equal("Services/SessionRestorePoint.cs", implementations[0]);
+
+        Assert.True(offenders.Count == 0,
+            "the automatic restore point must have exactly one owner:\n  - " + string.Join("\n  - ", offenders));
+    }
+
+    [GeneratedRegex(@"bool\s+_restorePoint\w*Attempted\w*\s*;", RegexOptions.Compiled)]
+    private static partial Regex RestorePointAttemptFlag();
+
+    [GeneratedRegex(@"\.\s*CreateAsync", RegexOptions.Compiled)]
+    private static partial Regex RestorePointCreateCall();
+
+    /// <summary>
     /// Performance Mode must refuse to CAPTURE a recovery baseline while a game profile is live — and must
     /// still be allowed to LOAD one that was persisted earlier.
     /// <para>The lock added for #1501 stops the two tabs from snapshotting each other mid-change, but it is

--- a/SysManager/SysManager.Tests/EdgeOneDriveViewModelTests.cs
+++ b/SysManager/SysManager.Tests/EdgeOneDriveViewModelTests.cs
@@ -39,7 +39,8 @@ public sealed class EdgeOneDriveViewModelTests : IDisposable
         var ps = Substitute.For<IPowerShellRunner>();
         ps.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
           .Returns(new Collection<PSObject>());
-        var vm = new EdgeOneDriveViewModel(new EdgeOneDriveService(ps, hkcuRoot: _root, hklmRoot: _root));
+        var vm = new EdgeOneDriveViewModel(new EdgeOneDriveService(ps, hkcuRoot: _root, hklmRoot: _root),
+                                      NoRestorePoint());
         vm.InitializationComplete.GetAwaiter().GetResult();
         return vm;
     }
@@ -124,7 +125,8 @@ public sealed class EdgeOneDriveViewModelTests : IDisposable
             var ps = Substitute.For<IPowerShellRunner>();
             ps.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
               .Returns(new Collection<PSObject>());
-            var vm = new EdgeOneDriveViewModel(new EdgeOneDriveService(ps, hkcuRoot: _root, hklmRoot: _root));
+            var vm = new EdgeOneDriveViewModel(new EdgeOneDriveService(ps, hkcuRoot: _root, hklmRoot: _root),
+                                      NoRestorePoint());
             await vm.InitializationComplete;
             // Force the "installed" precondition so the guard reaches the confirm dialog.
             vm.OneDriveInstalled = true;
@@ -139,4 +141,15 @@ public sealed class EdgeOneDriveViewModelTests : IDisposable
         }
         finally { DialogService.Instance = prevDialog; }
     }
+    /// <summary>
+    /// A session restore point that never materialises — the honest default on a machine with System
+    /// Restore off, and what keeps these tests about Edge/OneDrive rather than about snapshots.
+    /// </summary>
+    private static ISessionRestorePoint NoRestorePoint()
+    {
+        var rp = Substitute.For<ISessionRestorePoint>();
+        rp.EnsureAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        return rp;
+    }
+
 }

--- a/SysManager/SysManager.Tests/GamingProfileServiceTests.cs
+++ b/SysManager/SysManager.Tests/GamingProfileServiceTests.cs
@@ -248,7 +248,9 @@ public class GamingProfileServiceTests
             new TimerResolutionService(),
             new CpuAffinityService(),
             new StandbyMemoryService(),
-            restore,
+            // Never creates a point: these tests are about the engine, and a real System Restore
+            // call needs admin, takes seconds and is rate-limited.
+            new SessionRestorePoint((_, _) => Task.FromResult(false)),
             isElevated: false,
             storePath: path);
     }

--- a/SysManager/SysManager.Tests/SessionRestorePointTests.cs
+++ b/SysManager/SysManager.Tests/SessionRestorePointTests.cs
@@ -1,0 +1,149 @@
+// SysManager · SessionRestorePointTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for the shared once-per-session restore point. The logic used to live privately inside
+/// <c>TweaksHubService</c>, where nothing exercised it directly and no other tab could reach it; the
+/// point of lifting it out was that every tab writing system state gets the same safety net, so the
+/// semantics now need pinning rather than assuming.
+/// <para>Driven through the injected create-delegate, so no test ever asks Windows for a real System
+/// Restore point — that needs administrator, takes seconds, and is rate-limited to roughly one per 24
+/// hours, which would make these tests slow, order-dependent, and machine-dependent. The delegate also
+/// counts its own calls, which is what makes "once per session" observable.</para>
+/// </summary>
+public class SessionRestorePointTests
+{
+    /// <summary>A create-delegate that records how often it ran and what it was asked to name the point.</summary>
+    private sealed class FakeCreator(bool result = true, Exception? throws = null)
+    {
+        public int Calls { get; private set; }
+        public List<string> Descriptions { get; } = [];
+
+        public Task<bool> CreateAsync(string description, CancellationToken ct)
+        {
+            Calls++;
+            Descriptions.Add(description);
+            return throws is not null ? Task.FromException<bool>(throws) : Task.FromResult(result);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureAsync_FirstCall_CreatesThePointAndReportsIt()
+    {
+        var creator = new FakeCreator(result: true);
+        var session = new SessionRestorePoint(creator.CreateAsync);
+
+        Assert.True(await session.EnsureAsync("SysManager Test"));
+
+        Assert.True(session.CreatedThisSession);
+        Assert.Equal(1, creator.Calls);
+        Assert.Equal("SysManager Test", Assert.Single(creator.Descriptions));
+    }
+
+    /// <summary>
+    /// One attempt per session, not one per click. Windows refuses a second point within 24 hours
+    /// anyway, and each attempt costs seconds of the user's time for nothing.
+    /// </summary>
+    [Fact]
+    public async Task EnsureAsync_SecondCall_DoesNotAskWindowsAgain()
+    {
+        var creator = new FakeCreator(result: true);
+        var session = new SessionRestorePoint(creator.CreateAsync);
+
+        await session.EnsureAsync("first");
+        var second = await session.EnsureAsync("second");
+
+        Assert.False(second);
+        Assert.Equal(1, creator.Calls);
+    }
+
+    /// <summary>
+    /// The split that keeps the UI honest: a later caller is told "I did not create one" — so it does
+    /// not claim to have just taken a snapshot — while still being able to learn that the session HAS
+    /// one. Reporting the per-call answer as the session fact is how a tab would end up saying "no
+    /// restore point" moments after another tab made one.
+    /// </summary>
+    [Fact]
+    public async Task EnsureAsync_SecondCall_StillReportsThatTheSessionHasAPoint()
+    {
+        var session = new SessionRestorePoint(new FakeCreator(result: true).CreateAsync);
+
+        await session.EnsureAsync("first");
+
+        Assert.False(await session.EnsureAsync("second"));
+        Assert.True(session.CreatedThisSession);
+    }
+
+    /// <summary>
+    /// A "no" is the normal outcome on much of consumer Windows — System Restore is often off, needs
+    /// administrator, and is rate-limited. It must surface as a plain false so no caller claims a
+    /// safety net that does not exist.
+    /// </summary>
+    [Fact]
+    public async Task EnsureAsync_WhenWindowsDeclines_ReportsFalseAndNeverClaimsASession()
+    {
+        var session = new SessionRestorePoint(new FakeCreator(result: false).CreateAsync);
+
+        Assert.False(await session.EnsureAsync("SysManager Test"));
+
+        Assert.False(session.CreatedThisSession);
+    }
+
+    /// <summary>
+    /// The failure the original code specifically swallowed: no administrator, or System Restore
+    /// disabled by policy. It must not propagate — a tab whose Apply threw because the OPTIONAL
+    /// snapshot failed would refuse the change the user actually asked for.
+    /// </summary>
+    [Theory]
+    [InlineData(typeof(UnauthorizedAccessException))]
+    [InlineData(typeof(InvalidOperationException))]
+    public async Task EnsureAsync_WhenCreationThrows_IsSwallowedAndReportsFalse(Type exceptionType)
+    {
+        var creator = new FakeCreator(throws: (Exception)Activator.CreateInstance(exceptionType)!);
+        var session = new SessionRestorePoint(creator.CreateAsync);
+
+        Assert.False(await session.EnsureAsync("SysManager Test"));
+
+        Assert.False(session.CreatedThisSession);
+        Assert.Equal(1, creator.Calls);
+    }
+
+    /// <summary>
+    /// A failed attempt still counts as the session's attempt. Retrying before every batch would make
+    /// each Apply pay the timeout again on exactly the machines where it can never succeed.
+    /// </summary>
+    [Fact]
+    public async Task EnsureAsync_AfterAFailedAttempt_DoesNotRetry()
+    {
+        var creator = new FakeCreator(result: false);
+        var session = new SessionRestorePoint(creator.CreateAsync);
+
+        await session.EnsureAsync("first");
+        await session.EnsureAsync("second");
+
+        Assert.Equal(1, creator.Calls);
+    }
+
+    /// <summary>
+    /// The attempt is claimed BEFORE the await, so two callers racing — a UI command and, say, a
+    /// thread-pool callback — cannot both get past the check and ask Windows twice.
+    /// </summary>
+    [Fact]
+    public async Task EnsureAsync_ConcurrentCallers_StillAskWindowsOnce()
+    {
+        var creator = new FakeCreator(result: true);
+        var session = new SessionRestorePoint(creator.CreateAsync);
+
+        var results = await Task.WhenAll(Enumerable.Range(0, 8)
+            .Select(i => Task.Run(() => session.EnsureAsync($"caller {i}"))));
+
+        Assert.Equal(1, creator.Calls);
+        Assert.Single(results, created => created);
+        Assert.True(session.CreatedThisSession);
+    }
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -63,6 +63,10 @@ public static class ServiceRegistration
         services.AddSingleton<ContextMenuService>();
         services.AddSingleton<EnvironmentVariableService>();
         services.AddSingleton<RestorePointService>();
+        // Singleton on purpose: "one restore point per session" has to mean the whole app, or two
+        // tabs each take their own and the second burns the 24-hour rate limit on a duplicate.
+        services.AddSingleton<ISessionRestorePoint>(sp =>
+            new SessionRestorePoint(sp.GetRequiredService<RestorePointService>().CreateAsync));
         services.AddSingleton<DebloaterService>();
         services.AddSingleton<EdgeOneDriveService>();
         services.AddSingleton<LegacyPanelService>();
@@ -100,7 +104,7 @@ public static class ServiceRegistration
             sp.GetRequiredService<ITimerResolutionService>(),
             sp.GetRequiredService<ICpuAffinityService>(),
             sp.GetRequiredService<StandbyMemoryService>(),
-            sp.GetRequiredService<RestorePointService>(),
+            sp.GetRequiredService<ISessionRestorePoint>(),
             Helpers.AdminHelper.IsElevated()));
 
         // ── ViewModels (Singleton — one instance per tab) ──────────────

--- a/SysManager/SysManager/Services/GamingProfileService.cs
+++ b/SysManager/SysManager/Services/GamingProfileService.cs
@@ -39,7 +39,7 @@ public sealed class GamingProfileService : IGamingProfileService, IDisposable
     private readonly ITimerResolutionService _timer;
     private readonly ICpuAffinityService _cpu;
     private readonly StandbyMemoryService _standby;
-    private readonly RestorePointService _restore;
+    private readonly ISessionRestorePoint _restorePoint;
     private readonly bool _isElevated;
     private readonly string _storePath;
 
@@ -50,7 +50,6 @@ public sealed class GamingProfileService : IGamingProfileService, IDisposable
     // _appliedSteps and _boundGame, so they must not overlap.
     private readonly SemaphoreSlim _gate = new(1, 1);
     private Process? _boundGame;
-    private bool _restorePointAttemptedThisSession;
     private bool _disposed;
 
     public GamingProfileService(
@@ -58,7 +57,7 @@ public sealed class GamingProfileService : IGamingProfileService, IDisposable
         ITimerResolutionService timer,
         ICpuAffinityService cpu,
         StandbyMemoryService standby,
-        RestorePointService restore,
+        ISessionRestorePoint restorePoint,
         bool isElevated,
         string? storePath = null)
     {
@@ -66,7 +65,7 @@ public sealed class GamingProfileService : IGamingProfileService, IDisposable
         _timer = timer;
         _cpu = cpu;
         _standby = standby;
-        _restore = restore;
+        _restorePoint = restorePoint;
         _isElevated = isElevated;
         _storePath = storePath ?? Path.Join(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
@@ -185,7 +184,12 @@ public sealed class GamingProfileService : IGamingProfileService, IDisposable
             return new GamingApplyResult([], RestorePointCreated: false, BlockedBy: blockedBy);
         }
 
-        bool restorePointCreated = await EnsureRestorePointAsync(ct).ConfigureAwait(true);
+        // Shared with every other tab that writes system state: one point per session, not one
+        // per feature. The private copy this replaced meant Tweaks Hub and Gaming Profile each
+        // attempted their own, so whichever ran first burned the 24-hour limit and the second
+        // reported "no restore point" while one actually existed.
+        bool restorePointCreated = await _restorePoint
+            .EnsureAsync("SysManager Gaming Profile", ct).ConfigureAwait(true);
 
         // Capture the machine-wide baseline BEFORE any change.
         var snapshot = await CaptureSnapshotAsync(profile, ct).ConfigureAwait(true);
@@ -411,21 +415,6 @@ public sealed class GamingProfileService : IGamingProfileService, IDisposable
         // No such service / access denied / not a Windows service host → treat as "not running".
         catch (InvalidOperationException) { return false; }
         catch (System.ComponentModel.Win32Exception) { return false; }
-    }
-
-    private async Task<bool> EnsureRestorePointAsync(CancellationToken ct)
-    {
-        if (_restorePointAttemptedThisSession) return false;
-        _restorePointAttemptedThisSession = true;
-        try
-        {
-            return await _restore.CreateAsync("SysManager Gaming Profile", ct).ConfigureAwait(true);
-        }
-        catch (Exception ex) when (ex is InvalidOperationException or UnauthorizedAccessException)
-        {
-            Log.Debug("Gaming Profile restore point skipped: {Error}", ex.Message);
-            return false;
-        }
     }
 
     // ── Auto-revert on game exit (Process.Exited, NOT a poll loop) ─────────────

--- a/SysManager/SysManager/Services/ISessionRestorePoint.cs
+++ b/SysManager/SysManager/Services/ISessionRestorePoint.cs
@@ -1,0 +1,39 @@
+// SysManager · ISessionRestorePoint
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Services;
+
+/// <summary>
+/// One System Restore point per app session, shared by every tab that changes system state, so the
+/// safety net does not depend on which door the user came through.
+/// <para>Before this existed, <c>TweaksHubService</c> owned a private copy of the logic and was the
+/// only place that had it: flipping a privacy toggle through Tweaks Hub took a snapshot, while the
+/// identical registry write from the Privacy tab, or removing Edge, took none. An unpredictable
+/// guarantee is the worst kind — it is the reason the user feels able to press the button at all.</para>
+/// <para><b>Deliberately best-effort.</b> System Restore is off by default on much of consumer
+/// Windows, needs administrator, and Windows rate-limits creation to roughly one point per 24 hours.
+/// A "no" is therefore normal and must never be presented as protection that exists. Callers report
+/// the snapshot ONLY when one was actually created.</para>
+/// </summary>
+public interface ISessionRestorePoint
+{
+    /// <summary>
+    /// Attempts a restore point the first time it is called in this app session, and does nothing on
+    /// every later call — one attempt per session, not one per click, because Windows would refuse the
+    /// rest anyway and each attempt costs seconds.
+    /// </summary>
+    /// <param name="description">What the user will see in the System Restore list.</param>
+    /// <returns>
+    /// <c>true</c> only when THIS call created the point. A later caller in the same session gets
+    /// <c>false</c> even though a point exists — ask <see cref="CreatedThisSession"/> for that. The
+    /// split keeps "we just took a snapshot for you" honest and separate from "this session has one".
+    /// </returns>
+    Task<bool> EnsureAsync(string description, CancellationToken ct = default);
+
+    /// <summary>
+    /// Whether a restore point was actually created at any point in this session, by any caller.
+    /// Never true when the attempt failed or was skipped.
+    /// </summary>
+    bool CreatedThisSession { get; }
+}

--- a/SysManager/SysManager/Services/SessionRestorePoint.cs
+++ b/SysManager/SysManager/Services/SessionRestorePoint.cs
@@ -1,0 +1,60 @@
+// SysManager · SessionRestorePoint
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using Serilog;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// The one implementation of <see cref="ISessionRestorePoint"/>. Registered as a singleton so
+/// "once per session" means once for the whole app, not once per tab: two tabs each taking their own
+/// snapshot would burn the 24-hour rate limit on a duplicate and leave the second user action
+/// unprotected for no benefit.
+/// </summary>
+/// <remarks>
+/// Takes the single capability it needs — "create a point, tell me whether it happened" — rather
+/// than <see cref="RestorePointService"/> itself, which is sealed and therefore unmockable. That
+/// would have forced either an interface across every existing consumer or unsealing production
+/// code for the benefit of a test; a delegate keeps the seam where it belongs and lets these tests
+/// run with no proxy framework at all.
+/// </remarks>
+public sealed class SessionRestorePoint(Func<string, CancellationToken, Task<bool>> createAsync)
+    : ISessionRestorePoint
+{
+    // Interlocked rather than a plain bool: mutating commands live on the UI thread today, but the
+    // Gaming Profile's auto-revert already runs from a thread-pool Process.Exited callback, so a
+    // future caller on that path must not be able to slip a second attempt through the check.
+    private int _attempted;
+    private volatile bool _created;
+
+    /// <inheritdoc />
+    public bool CreatedThisSession => _created;
+
+    /// <inheritdoc />
+    public async Task<bool> EnsureAsync(string description, CancellationToken ct = default)
+    {
+        // Claim the single attempt BEFORE awaiting, so a slow or failing snapshot is not retried
+        // ahead of every subsequent batch — the behaviour TweaksHubService established.
+        if (Interlocked.Exchange(ref _attempted, 1) == 1) return false;
+
+        try
+        {
+            // ConfigureAwait(true): callers are UI-thread commands whose post-await code mutates
+            // bound state. RestorePointService.CreateAsync hops to the thread pool internally, so
+            // without this the continuation would resume off the UI thread — a real cross-thread
+            // defect, and the reason the original TweaksHub call was written this way.
+            var created = await createAsync(description, ct).ConfigureAwait(true);
+            _created = created;
+            Log.Information("Session restore point for {Description}: created={Created}", description, created);
+            return created;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or UnauthorizedAccessException)
+        {
+            // Not an error path worth surfacing: no admin, System Restore disabled, or rate-limited.
+            // The caller reports nothing, which is the honest outcome.
+            Log.Debug("Session restore point skipped ({Description}): {Error}", description, ex.Message);
+            return false;
+        }
+    }
+}

--- a/SysManager/SysManager/Services/TweaksHubService.cs
+++ b/SysManager/SysManager/Services/TweaksHubService.cs
@@ -18,13 +18,15 @@ namespace SysManager.Services;
 public sealed class TweaksHubService : ITweaksHubService
 {
     private readonly PrivacyService _privacy;
-    private readonly RestorePointService _restore;
-    private bool _restorePointAttemptedThisSession;
+    // The once-per-session restore point used to live here as a private method plus a bool. It is
+    // now the shared ISessionRestorePoint, so the tabs that write the SAME settings get the same
+    // snapshot instead of only this one having it.
+    private readonly ISessionRestorePoint _restorePoint;
 
-    public TweaksHubService(PrivacyService privacy, RestorePointService restore)
+    public TweaksHubService(PrivacyService privacy, ISessionRestorePoint restorePoint)
     {
         _privacy = privacy;
-        _restore = restore;
+        _restorePoint = restorePoint;
     }
 
     /// <summary>Loads every tweak with its current applied state, classified into tiers.</summary>
@@ -46,7 +48,8 @@ public sealed class TweaksHubService : ITweaksHubService
         // CanExecute). Resuming on the captured UI context keeps those mutations on the UI
         // thread — RestorePointService.CreateAsync hops to the thread pool internally, so
         // without this the continuation would run off-thread (a real cross-thread defect).
-        bool restorePointCreated = await EnsureRestorePointAsync(ct).ConfigureAwait(true);
+        bool restorePointCreated = await _restorePoint
+            .EnsureAsync("SysManager Tweaks Hub", ct).ConfigureAwait(true);
 
         var failed = new List<TweakItem>();
         foreach (var item in tweaks)
@@ -58,27 +61,6 @@ public sealed class TweaksHubService : ITweaksHubService
                 failed.Add(item);
         }
         return new TweakApplyResult(failed, restorePointCreated);
-    }
-
-    /// <summary>
-    /// Attempts a restore point once per session. Returns true only if one was actually
-    /// created. Best-effort: System Restore needs admin and is rate-limited by Windows to one
-    /// per 24h, so a "no" is normal and must not be presented as a guaranteed safety net.
-    /// </summary>
-    private async Task<bool> EnsureRestorePointAsync(CancellationToken ct)
-    {
-        if (_restorePointAttemptedThisSession) return false;
-        // Mark attempted first so a slow/failed snapshot isn't retried before every batch.
-        _restorePointAttemptedThisSession = true;
-        try
-        {
-            return await _restore.CreateAsync("SysManager Tweaks Hub", ct).ConfigureAwait(true);
-        }
-        catch (Exception ex) when (ex is InvalidOperationException or UnauthorizedAccessException)
-        {
-            Log.Debug("Tweaks Hub restore point skipped: {Error}", ex.Message);
-            return false;
-        }
     }
 
     // ── Pure helpers (unit-testable) ───────────────────────────────────────

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.67.0</Version>
-    <FileVersion>1.67.0.0</FileVersion>
-    <AssemblyVersion>1.67.0.0</AssemblyVersion>
+    <Version>1.68.0</Version>
+    <FileVersion>1.68.0.0</FileVersion>
+    <AssemblyVersion>1.68.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/EdgeOneDriveViewModel.cs
+++ b/SysManager/SysManager/ViewModels/EdgeOneDriveViewModel.cs
@@ -23,6 +23,11 @@ namespace SysManager.ViewModels;
 public sealed partial class EdgeOneDriveViewModel : ViewModelBase
 {
     private readonly EdgeOneDriveService _service;
+    // Removing OneDrive or de-integrating Edge is among the scariest things in the app for the
+    // target user, and until now it was one of the tabs with NO snapshot while the identical
+    // registry writes made through Tweaks Hub did get one. Shared so the whole session takes at
+    // most one point.
+    private readonly ISessionRestorePoint _restorePoint;
 
     [ObservableProperty] private bool _isElevated;
 
@@ -52,9 +57,10 @@ public sealed partial class EdgeOneDriveViewModel : ViewModelBase
             ? "Edge is de-integrated (background mode and startup boost are off)."
             : "Edge is active (background mode / startup boost may be on).";
 
-    public EdgeOneDriveViewModel(EdgeOneDriveService service)
+    public EdgeOneDriveViewModel(EdgeOneDriveService service, ISessionRestorePoint restorePoint)
     {
         _service = service;
+        _restorePoint = restorePoint;
         IsElevated = AdminHelper.IsElevated();
         StatusMessage = "Reading Edge and OneDrive status…";
         PropertyChanged += OnVmPropertyChanged;
@@ -199,10 +205,18 @@ public sealed partial class EdgeOneDriveViewModel : ViewModelBase
         IsProgressIndeterminate = true;
         try
         {
+            // Before the change, never after: a snapshot taken afterwards would record the state
+            // the user is trying to get back FROM. Applies to the Restore commands too — putting
+            // Edge back is a system change like any other.
+            var snapshotTaken = await _restorePoint
+                .EnsureAsync("SysManager Edge/OneDrive", CancellationToken.None).ConfigureAwait(true);
+
             var outcome = await operation(CancellationToken.None).ConfigureAwait(true);
             StatusMessage = outcome switch
             {
-                EdgeOneDriveOutcome.Success => $"{component} {pastTense}.",
+                EdgeOneDriveOutcome.Success => snapshotTaken
+                    ? $"{component} {pastTense}. Restore point created."
+                    : $"{component} {pastTense}.",
                 EdgeOneDriveOutcome.NeedsAdmin => $"{component} was not changed — this needs administrator rights. Use \"Run as administrator\" above.",
                 EdgeOneDriveOutcome.NotApplicable => $"{component} is not installed — nothing to do.",
                 _ => $"{component} could not be {pastTense}.",

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -401,6 +401,9 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         // it (one tab's Start must disable the other's), so a second copy would silently split them.
         var networkShared = new NetworkSharedState(pinger, tracer, traceMonitor, speedTest, netRepair);
         var restorePoints = new RestorePointService(runner);
+        // ONE session restore point for the graph, as in DI: a second instance would let two
+        // tabs each attempt a snapshot, and Windows refuses the second within 24h anyway.
+        var sessionRestorePoint = new SessionRestorePoint(restorePoints.CreateAsync);
         var gamingCpu = new CpuAffinityService();
         // ONE gaming service for the whole graph. Performance Mode asks it whether a profile is live
         // before it records a recovery baseline, so a second copy would answer "no" while the first
@@ -409,7 +412,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         var gamingProfiles = new GamingProfileService(
             new PerformanceService(runner, restorePoints),
             new TimerResolutionService(), gamingCpu,
-            new StandbyMemoryService(), restorePoints,
+            new StandbyMemoryService(), sessionRestorePoint,
             Helpers.AdminHelper.IsElevated());
 
         return new Dictionary<Type, object>
@@ -449,7 +452,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             [typeof(EnvironmentVariablesViewModel)] = new EnvironmentVariablesViewModel(new EnvironmentVariableService()),
             [typeof(RestorePointsViewModel)] = new RestorePointsViewModel(restorePoints),
             [typeof(DebloaterViewModel)] = new DebloaterViewModel(new DebloaterService(new PowerShellRunner())),
-            [typeof(EdgeOneDriveViewModel)] = new EdgeOneDriveViewModel(new EdgeOneDriveService(new PowerShellRunner())),
+            [typeof(EdgeOneDriveViewModel)] = new EdgeOneDriveViewModel(new EdgeOneDriveService(new PowerShellRunner()), sessionRestorePoint),
             [typeof(LegacyPanelsViewModel)] = new LegacyPanelsViewModel(new LegacyPanelService()),
             [typeof(SystemFixesViewModel)] = new SystemFixesViewModel(new SystemFixService(new PowerShellRunner())),
             [typeof(ProfileViewModel)] = new ProfileViewModel(new ProfileService()),
@@ -469,7 +472,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             [typeof(SettingsWatchdogViewModel)] = new SettingsWatchdogViewModel(new SettingsWatchdogService()),
             [typeof(CliInterfaceViewModel)] = new CliInterfaceViewModel(),
             [typeof(ScheduledMaintenanceViewModel)] = new ScheduledMaintenanceViewModel(new MaintenanceSchedulerService(new PowerShellRunner())),
-            [typeof(TweaksHubViewModel)] = new TweaksHubViewModel(new TweaksHubService(new PrivacyService(), restorePoints)),
+            [typeof(TweaksHubViewModel)] = new TweaksHubViewModel(new TweaksHubService(new PrivacyService(), sessionRestorePoint)),
             [typeof(AudioMixerViewModel)] = new AudioMixerViewModel(new AudioMixerService(), new VolumePresetService()),
             [typeof(NotificationBlockerViewModel)] = new NotificationBlockerViewModel(new NotificationBlockerService()),
             [typeof(GamingProfileViewModel)] = new GamingProfileViewModel(gamingProfiles, gamingCpu),


### PR DESCRIPTION
Advances #1500. **Not** closing it — see the scope note at the end.

## The inconsistency

A fresh census confirms the report: `RestorePointService` had three consumers, and of the system-mutating services only `TweaksHubService` referenced it (6 hits). `DebloaterService`, `EdgeOneDriveService`, `DefenderService`, `PrivacyService`, `ContextMenuService`, `WindowsFeaturesService` — **zero each**.

So flipping a privacy toggle through Tweaks Hub took a Windows restore point, while the identical registry write from another tab, or removing OneDrive, took none.

## Two copies were worse than one

Centralising turned up a second, byte-equivalent private copy in `GamingProfileService` — the same `_restorePointAttemptedThisSession` bool and the same method. That is not merely duplication: Windows allows roughly **one restore point per 24 hours**, so whichever feature ran first consumed the allowance and the second reported "no restore point" while a perfectly good one existed. One shared owner fixes a real interaction, not just a style issue.

## The design

`ISessionRestorePoint` — one attempt per app **session**, best-effort, registered as a singleton so "once per session" means the whole app rather than once per tab.

The return value and the session fact are deliberately separate:

- `EnsureAsync` returns true **only when this call created the point**, so no tab claims to have just taken a snapshot when it did not;
- `CreatedThisSession` answers "does this session have one", so a later tab is not forced to report "no restore point" moments after another tab made one.

It depends on a **create-delegate**, not on `RestorePointService`, which is `sealed`. Depending on the class would have meant an interface across every existing consumer or unsealing production code for the benefit of a test — the delegate keeps the seam where it belongs and lets the tests run with no proxy framework at all.

## What changed per file

- `TweaksHubService`, `GamingProfileService` — private copies deleted, both now use the seam. No behaviour change for Tweaks Hub: its per-call semantics are preserved exactly.
- `EdgeOneDriveViewModel` — gains the protection, inside the single `RunOperationAsync` funnel every command already uses, so the **Restore** buttons are covered too. Taken **before** the change: a snapshot afterwards would record the state the user is trying to get back from.
- Honest reporting copied verbatim from `TweaksHubViewModel`: the sentence appears only when a point was really created.

## The guard

`TheSessionRestorePoint_IsTheOnlyAutomaticSnapshot` pins the class rather than this instance: exactly one implementation, no per-feature attempt flag anywhere else, and an exact allowlist of the four files permitted to reach the restore service directly — the two wiring sites, Performance Mode's **manual** button, and the Restore Points tab where creating one *is* the feature. A fifth caller means an automatic snapshot bypassing the once-per-session rule.

## Verification

| Mutation | Result |
|---|---|
| baseline | green |
| Tweaks Hub grows its own once-per-session flag again | **red** — guard |
| an allowlist entry removed | **red** — guard |
| the once-per-session claim removed | **red** — repeat + retry + concurrency tests |
| a creation failure allowed to propagate | **red** — the swallow test |
| a declined attempt recorded as protection | **red** — the "never claim a net you do not have" test |

All three mutated files restored byte-for-byte. Eight tests cover the seam, including a concurrency case (8 racing callers, exactly one attempt) because the attempt is claimed with `Interlocked` before the await.

Two process notes worth recording, both caught by floors rather than luck:

1. Three mutations initially **failed to compile** (unused field, possible null dereference — both errors here), so the compiler was rejecting them instead of the guard failing. Rewritten to compile; only then do they prove anything.
2. The guard itself went **silently vacuous** while being written: a heredoc collapsed `\b` into a literal backspace inside the regex, so it scanned 345 files and matched 0 call sites. Its own `callers >= 3` floor caught it — `grep` could not, because 0x08 is invisible.

Both projects build 0 errors / 0 warnings; `dotnet format --verify-no-changes` clean on both (exit captured into a variable, not read after a command substitution); all three CI gates reproduced locally; 13-test regression sweep green across Gaming Profile, Performance Mode, Profile Export and the accessibility guards.

## Scope

`Closes` is deliberately not claimed for the whole issue. Debloater (`Task<bool>`) and Defender (`Task<DefenderStatus>`) each need their own result plumbing and their own honest copy — and for Debloater the restore point is a *partial* net at best, since System Restore does not bring back removed Appx packages, so its wording needs care rather than a copy-paste. Those follow as separate changes.