### PR TITLE
feat: take a restore point before every Defender Tweaks change

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -128,7 +128,7 @@ QA-verified is marked with `IsInDevelopment` (surfaced as a PREVIEW badge) inste
 - `FileLockViewModel` — find which processes are holding a file/folder (Restart Manager) and optionally end a selected one after confirmation; critical processes are protected.
 - `DisplayProfileViewModel` — list displays and supported resolution/refresh modes and switch between them; applies for the session with a 15-second auto-revert safety net.
 - `CpuAffinityViewModel` — pin a running process to specific logical CPUs with P-core/E-core labels on hybrid CPUs; per-process and reverts on process exit.
-- `DefenderViewModel` — view Microsoft Defender status, toggle PUA / Controlled Folder Access, and manage scan-exclusion folders; every change is admin-gated, confirmed, and verified by read-back (Tamper Protection can silently reject).
+- `DefenderViewModel` — view Microsoft Defender status, toggle PUA / Controlled Folder Access, and manage scan-exclusion folders; every change is admin-gated, confirmed, and verified by read-back (Tamper Protection can silently reject). All four changes share one `RunOperationAsync` funnel that takes the shared `ISessionRestorePoint` snapshot before the first of them, so no command can skip it; each keeps its own failure wording, passed in.
 - `TaskSchedulerViewModel` — browse Windows scheduled tasks with a safety classification and enable/disable them (reversible, never deletes); system tasks warn before disabling, changes verified by read-back.
 - `DarkModeViewModel` — switch the Windows light/dark theme manually or on a fixed-time schedule (DispatcherTimer poll while the app runs); persists the schedule.
 - `AudioMixerViewModel` — per-app volume mixer (Volume Control tab): lists apps playing on the default render device with a volume slider, mute toggle, and a live peak meter. Two loops drive it, both idle while the tab is hidden (`IsActive`) and both sampling off the UI thread: membership reconciles on a ~1&#160;s cadence, and the meters refresh every 50&#160;ms via one batched `GetPeaks` call per tick. The peak loop *parks* on an activation gate while hidden rather than ticking and skipping — at 50&#160;ms a skip-check still queues 20 Dispatcher continuations a second. (Per-row `GetPeak` on the UI thread was the 1.65.11 stutter fix.) Rows reconcile in place by session id (a wholesale replace would drop a slider mid-drag). Adds per-app output-device routing (via the guarded `AudioPolicyConfigFactory`; falls back to guiding the user to Windows sound settings when the OS lacks the interface) and named volume presets (persisted by `VolumePresetService`, keyed by exe name so they re-apply across restarts). Row VMs (`AudioSessionRowViewModel`) propagate volume/mute/route to the service, with a re-entrancy guard so an external change surfaced by a refresh is not echoed back.
@@ -319,7 +319,7 @@ Key services:
   a delegate rather than the sealed service, which keeps it substitutable without unsealing
   production code. Returns true only when THIS call created a point, so no caller can claim one that
   Windows refused. Consumed by `TweaksHubService`, `GamingProfileService`, `EdgeOneDriveViewModel`,
-  `DebloaterViewModel` and `PrivacyViewModel`.
+  `DebloaterViewModel`, `PrivacyViewModel` and `DefenderViewModel`.
 - `DebloaterService` — lists (`Get-AppxPackage`) and removes (`Remove-AppxPackage`,
   per-user) Windows Store apps through the `IPowerShellRunner` seam. A hard-coded
   denylist of system-critical package families is enforced in code; the parser and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.70.0] - 2026-08-25
+
+Defender Tweaks now takes a Windows restore point before it changes anything, which was the last tab
+still without one. Every tab that changes system settings is now covered by the same single snapshot,
+so the answer no longer depends on which page you opened.
+
+### Added
+- **Defender Tweaks takes a restore point before the first change of the session.** Its four changes
+  — PUA protection, Controlled Folder Access, and adding or removing a scan exclusion — now run
+  through one shared path instead of four near-identical copies, so none of them can skip the
+  snapshot. Each keeps the exact wording it had when something goes wrong.
+
+### Changed
+- A change Defender rejected — Tamper Protection on, or no administrator — no longer mentions the
+  restore point. Nothing was changed, so there is nothing for a snapshot to reassure you about, and
+  saying otherwise read as though something had happened.
+
 ## [1.69.0] - 2026-08-25
 
 Two more of the tabs that change your PC now take a Windows restore point first: Debloater & Ads and

--- a/README.md
+++ b/README.md
@@ -750,6 +750,10 @@ Manage Microsoft Defender without digging through Windows Security:
   after reading it back and confirming Windows actually applied it
 - Changes need administrator and are confirmed first; lowering a protection is
   always an explicit, reversible choice
+- **A Windows restore point is attempted before the first change of the session**, shared with the
+  other tabs that change system settings. All four changes run through one path, so none of them can
+  quietly skip it, and it is mentioned only when Windows really made one — never on a change that
+  was rejected
 
 ### Notification Blocker
 Mute the apps that nag you with pop-up notifications — update reminders, trial

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.69.x   | :white_check_mark: |
-| < 1.69   | :x:                |
+| 1.70.x   | :white_check_mark: |
+| < 1.70   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2867,6 +2867,7 @@ public partial class ArchitectureTests
         var expected = new (string File, string Member, string Mutation)[]
         {
             ("DebloaterViewModel.cs", "private async Task RemoveSelectedAsync()", "_service.RemoveAsync("),
+            ("DefenderViewModel.cs", "private async Task RunOperationAsync(", "await change("),
             ("EdgeOneDriveViewModel.cs", "private async Task RunOperationAsync(", "await operation("),
             ("PrivacyViewModel.cs", "private async Task ApplyChanges()", "_service.ApplyAll("),
         };
@@ -2886,7 +2887,8 @@ public partial class ArchitectureTests
         {
             // Comments stripped: the note AT each call site explains the ordering rule and names both
             // sides of it, so a guard that reads prose would pass on code that has it backwards.
-            var slice = WithoutComments(MemberSlice(File.ReadAllText(Path.Combine(vmDir, file)), member));
+            var code = WithoutComments(File.ReadAllText(Path.Combine(vmDir, file)));
+            var slice = MemberSlice(code, member);
             Assert.False(string.IsNullOrWhiteSpace(slice),
                 $"{file}: '{member}' not found — the slice is empty, so every check below would pass "
                 + "without reading a line of code.");
@@ -2903,21 +2905,22 @@ public partial class ArchitectureTests
                 $"{file}: the restore point is taken AFTER {mutation}. A snapshot of the state the user "
                 + "is trying to escape is not a safety net.");
 
-            // Wherever the wording appears, the condition it sits under must be the snapshot result.
+            // Wherever the wording appears in this view model — the funnel or the helper that
+            // builds the message — the condition it sits under must be the snapshot result.
             var claims = 0;
-            for (var i = slice.IndexOf("estore point", StringComparison.Ordinal); i >= 0;
-                 i = slice.IndexOf("estore point", i + 1, StringComparison.Ordinal))
+            for (var i = code.IndexOf("estore point", StringComparison.Ordinal); i >= 0;
+                 i = code.IndexOf("estore point", i + 1, StringComparison.Ordinal))
             {
                 claims++;
-                var window = slice[Math.Max(0, i - 150)..i];
+                var window = code[Math.Max(0, i - 150)..i];
                 Assert.True(SnapshotGuardedClaim().IsMatch(window),
                     $"{file}: the restore-point wording at offset {i} is not conditional on the snapshot "
                     + "result. Only claim a point when EnsureAsync actually created one.");
             }
 
             Assert.True(claims >= 1,
-                $"{file}: {member} takes a restore point but never tells the user — either the slice is "
-                + "truncated and this guard is vacuous, or the reassurance was dropped.");
+                $"{file} takes a restore point but never tells the user it did — either the file is not "
+                + "being read and this guard is vacuous, or the reassurance was dropped.");
         }
     }
 

--- a/SysManager/SysManager.Tests/DefenderViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DefenderViewModelTests.cs
@@ -20,6 +20,24 @@ namespace SysManager.Tests;
 [Collection("ProcessWideStatics")]
 public class DefenderViewModelTests
 {
+    /// <summary>
+    /// A seam that answers "no point was created" — the common case, since System Restore ships
+    /// disabled on many consumer PCs and Windows grants roughly one point per 24 hours.
+    /// </summary>
+    private static ISessionRestorePoint NoRestorePoint()
+    {
+        var rp = Substitute.For<ISessionRestorePoint>();
+        rp.EnsureAsync(Arg.Any<string>(), Arg.Any<System.Threading.CancellationToken>()).Returns(false);
+        return rp;
+    }
+
+    private static ISessionRestorePoint RestorePointTaken()
+    {
+        var rp = Substitute.For<ISessionRestorePoint>();
+        rp.EnsureAsync(Arg.Any<string>(), Arg.Any<System.Threading.CancellationToken>()).Returns(true);
+        return rp;
+    }
+
     private static DefenderViewModel NewVm()
     {
         // Runner returns an empty result set, so GetStatusAsync produces a default
@@ -27,7 +45,7 @@ public class DefenderViewModelTests
         var ps = Substitute.For<IPowerShellRunner>();
         ps.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<System.Threading.CancellationToken>())
           .Returns(new Collection<PSObject>());
-        var vm = new DefenderViewModel(new DefenderService(ps));
+        var vm = new DefenderViewModel(new DefenderService(ps), NoRestorePoint());
         vm.InitializationComplete.GetAwaiter().GetResult();
         return vm;
     }
@@ -94,7 +112,7 @@ public class DefenderViewModelTests
         var ps = Substitute.For<IPowerShellRunner>();
         ps.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<System.Threading.CancellationToken>())
           .Returns(new Collection<PSObject>()); // empty -> DefenderStatus.Unavailable (all zeros)
-        var vm = new DefenderViewModel(new DefenderService(ps));
+        var vm = new DefenderViewModel(new DefenderService(ps), NoRestorePoint());
         await vm.InitializationComplete;
 
         // Pretend PUA was on so the toggle requests OFF (target 0), the dangerous case.
@@ -131,7 +149,7 @@ public class DefenderViewModelTests
           .Returns(_ => ++calls <= 1
               ? new Collection<PSObject>()
               : throw new System.InvalidOperationException("runspace is broken"));
-        var vm = new DefenderViewModel(new DefenderService(ps));
+        var vm = new DefenderViewModel(new DefenderService(ps), NoRestorePoint());
         await vm.InitializationComplete;
 
         var prevDialog = DialogService.Instance;
@@ -150,5 +168,116 @@ public class DefenderViewModelTests
 
         Assert.False(vm.IsBusy);
         Assert.Contains("could not change pua", vm.StatusMessage, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ---------- session restore point (#1500) ----------
+    // All four Defender changes run through one funnel, so the snapshot happens in exactly one
+    // place. These pin both halves: that it is taken before the change, and that it is only ever
+    // claimed when Windows actually made one.
+
+    /// <summary>
+    /// A runner whose Get-MpPreference projection is readable, so ParseStatus reports Available and
+    /// the read-back verification can succeed — the empty-collection runner above always yields the
+    /// all-zeros Unavailable status, which only exercises the failure path.
+    /// </summary>
+    private static IPowerShellRunner RunnerReportingPua(int pua)
+    {
+        var projection = new PSObject();
+        projection.Properties.Add(new PSNoteProperty("PUAProtection", pua));
+        var ps = Substitute.For<IPowerShellRunner>();
+        ps.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<System.Threading.CancellationToken>())
+          .Returns(new Collection<PSObject> { projection });
+        return ps;
+    }
+
+    [Fact]
+    public async Task TogglePua_TakesTheRestorePointBeforeChangingDefender()
+    {
+        var restorePoint = RestorePointTaken();
+        var vm = new DefenderViewModel(new DefenderService(RunnerReportingPua(1)), restorePoint);
+        await vm.InitializationComplete;
+        using var dialog = new DialogAnswer(confirm: true);
+
+        await vm.TogglePuaCommand.ExecuteAsync(null);
+
+        await restorePoint.Received(1).EnsureAsync("SysManager Defender Tweaks", Arg.Any<System.Threading.CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TogglePua_WhenTheUserDeclines_TakesNoRestorePoint()
+    {
+        // Declining changes nothing, so it must not spend the single point Windows grants per day.
+        var restorePoint = RestorePointTaken();
+        var vm = new DefenderViewModel(new DefenderService(RunnerReportingPua(1)), restorePoint);
+        await vm.InitializationComplete;
+        using var dialog = new DialogAnswer(confirm: false);
+
+        await vm.TogglePuaCommand.ExecuteAsync(null);
+
+        await restorePoint.DidNotReceive().EnsureAsync(Arg.Any<string>(), Arg.Any<System.Threading.CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EveryChange_GoesThroughTheOneFunnel()
+    {
+        // The reason for a funnel rather than four private calls: a command that skips it changes
+        // Defender with no snapshot, and nothing else would notice.
+        var restorePoint = RestorePointTaken();
+        var vm = new DefenderViewModel(new DefenderService(RunnerReportingPua(1)), restorePoint);
+        await vm.InitializationComplete;
+        using var dialog = new DialogAnswer(confirm: true);
+
+        await vm.TogglePuaCommand.ExecuteAsync(null);
+        await vm.ToggleCfaCommand.ExecuteAsync(null);
+
+        await restorePoint.Received(2).EnsureAsync("SysManager Defender Tweaks", Arg.Any<System.Threading.CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TogglePua_WhenAPointWasCreated_SaysSo()
+    {
+        var vm = new DefenderViewModel(new DefenderService(RunnerReportingPua(1)), RestorePointTaken());
+        await vm.InitializationComplete;
+        vm.PuaEnabled = false;   // so the toggle asks for ON (target 1), which the read-back confirms
+        using var dialog = new DialogAnswer(confirm: true);
+
+        await vm.TogglePuaCommand.ExecuteAsync(null);
+
+        Assert.Contains("updated", vm.StatusMessage, System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Restore point created.", vm.StatusMessage, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TogglePua_WhenNoPointWasCreated_ClaimsNone()
+    {
+        var vm = new DefenderViewModel(new DefenderService(RunnerReportingPua(1)), NoRestorePoint());
+        await vm.InitializationComplete;
+        vm.PuaEnabled = false;
+        using var dialog = new DialogAnswer(confirm: true);
+
+        await vm.TogglePuaCommand.ExecuteAsync(null);
+
+        Assert.Contains("updated", vm.StatusMessage, System.StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("restore point", vm.StatusMessage, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task TogglePua_WhenTheChangeFails_ClaimsNoRestorePointEvenThoughOneWasMade()
+    {
+        // A point really was created here, but Defender rejected the change (Tamper Protection or
+        // no admin). Mentioning the snapshot next to "was not changed" would read as though
+        // something happened and could be undone. Nothing changed, so nothing is claimed.
+        var ps = Substitute.For<IPowerShellRunner>();
+        ps.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<System.Threading.CancellationToken>())
+          .Returns(new Collection<PSObject>());   // empty -> DefenderStatus.Unavailable
+        var vm = new DefenderViewModel(new DefenderService(ps), RestorePointTaken());
+        await vm.InitializationComplete;
+        vm.PuaEnabled = true;    // asks for OFF (target 0), which the all-zeros status would fake
+        using var dialog = new DialogAnswer(confirm: true);
+
+        await vm.TogglePuaCommand.ExecuteAsync(null);
+
+        Assert.Contains("was not changed", vm.StatusMessage, System.StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("restore point", vm.StatusMessage, System.StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.69.0</Version>
-    <FileVersion>1.69.0.0</FileVersion>
-    <AssemblyVersion>1.69.0.0</AssemblyVersion>
+    <Version>1.70.0</Version>
+    <FileVersion>1.70.0.0</FileVersion>
+    <AssemblyVersion>1.70.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DefenderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DefenderViewModel.cs
@@ -16,11 +16,13 @@ namespace SysManager.ViewModels;
 /// ViewModel for the Defender Tweaks tab. Shows the current Microsoft Defender status,
 /// toggles PUA protection and Controlled Folder Access, and manages scan exclusion
 /// folders. Every change requires admin and is verified by reading the value back
-/// (Tamper Protection can silently reject it); changes are confirmed first.
+/// (Tamper Protection can silently reject it); changes are confirmed first. All four changes run
+/// through one funnel, which takes the shared session restore point before the first of them.
 /// </summary>
 public sealed partial class DefenderViewModel : ViewModelBase
 {
     private readonly DefenderService _service;
+    private readonly ISessionRestorePoint _restorePoint;
 
     public BulkObservableCollection<string> ExclusionPaths { get; } = new();
 
@@ -35,9 +37,10 @@ public sealed partial class DefenderViewModel : ViewModelBase
     [ObservableProperty] private bool _cfaEnabled;
     [ObservableProperty] private string? _selectedExclusion;
 
-    public DefenderViewModel(DefenderService service)
+    public DefenderViewModel(DefenderService service, ISessionRestorePoint restorePoint)
     {
         _service = service;
+        _restorePoint = restorePoint;
         IsElevated = AdminHelper.IsElevated();
         StatusMessage = "Reading Defender status…";
         PropertyChanged += OnVmPropertyChanged;
@@ -101,36 +104,20 @@ public sealed partial class DefenderViewModel : ViewModelBase
     private async Task TogglePuaAsync()
     {
         if (!Confirm($"{(PuaEnabled ? "Disable" : "Enable")} potentially-unwanted-app (PUA) protection?")) return;
-        IsBusy = true;
-        IsProgressIndeterminate = true;
-        try
-        {
-            int target = PuaEnabled ? 0 : 1;
-            var status = await _service.SetPuaProtectionAsync(target).ConfigureAwait(true);
-            Apply(status);
-            ReportVerified("PUA protection", status, status.PuaProtection == target);
-        }
-        catch (InvalidOperationException ex) { StatusMessage = $"Could not change PUA protection: {ex.Message}"; }
-        catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"Could not change PUA protection: {ex.Message}"; }
-        finally { IsBusy = false; IsProgressIndeterminate = false; }
+        // Read the target BEFORE the change runs — Apply overwrites PuaEnabled from the read-back.
+        int target = PuaEnabled ? 0 : 1;
+        await RunOperationAsync(() => _service.SetPuaProtectionAsync(target),
+            "PUA protection", "change PUA protection", s => s.PuaProtection == target);
     }
 
     [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task ToggleCfaAsync()
     {
         if (!Confirm($"{(CfaEnabled ? "Disable" : "Enable")} Controlled Folder Access (ransomware protection)?")) return;
-        IsBusy = true;
-        IsProgressIndeterminate = true;
-        try
-        {
-            int target = CfaEnabled ? 0 : 1;
-            var status = await _service.SetControlledFolderAccessAsync(target).ConfigureAwait(true);
-            Apply(status);
-            ReportVerified("Controlled Folder Access", status, status.ControlledFolderAccess == target);
-        }
-        catch (InvalidOperationException ex) { StatusMessage = $"Could not change Controlled Folder Access: {ex.Message}"; }
-        catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"Could not change Controlled Folder Access: {ex.Message}"; }
-        finally { IsBusy = false; IsProgressIndeterminate = false; }
+        int target = CfaEnabled ? 0 : 1;
+        await RunOperationAsync(() => _service.SetControlledFolderAccessAsync(target),
+            "Controlled Folder Access", "change Controlled Folder Access",
+            s => s.ControlledFolderAccess == target);
     }
 
     [RelayCommand(CanExecute = nameof(NotBusy))]
@@ -147,17 +134,9 @@ public sealed partial class DefenderViewModel : ViewModelBase
         }
         if (!Confirm($"Exclude \"{path}\" from Defender scanning?\n\nFiles in an excluded folder are not scanned for malware.")) return;
 
-        IsBusy = true;
-        IsProgressIndeterminate = true;
-        try
-        {
-            var status = await _service.AddExclusionPathAsync(path).ConfigureAwait(true);
-            Apply(status);
-            ReportVerified("Exclusion", status, status.ExclusionPaths.Any(p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase)));
-        }
-        catch (InvalidOperationException ex) { StatusMessage = $"Could not add the exclusion: {ex.Message}"; }
-        catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"Could not add the exclusion: {ex.Message}"; }
-        finally { IsBusy = false; IsProgressIndeterminate = false; }
+        await RunOperationAsync(() => _service.AddExclusionPathAsync(path),
+            "Exclusion", "add the exclusion",
+            s => s.ExclusionPaths.Any(p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase)));
     }
 
     [RelayCommand(CanExecute = nameof(CanRemoveExclusion))]
@@ -167,17 +146,9 @@ public sealed partial class DefenderViewModel : ViewModelBase
         if (path is null) return;
         if (!Confirm($"Stop excluding \"{path}\"?\n\nThe folder will be scanned for malware again.")) return;
 
-        IsBusy = true;
-        IsProgressIndeterminate = true;
-        try
-        {
-            var status = await _service.RemoveExclusionPathAsync(path).ConfigureAwait(true);
-            Apply(status);
-            ReportVerified("Exclusion removal", status, !status.ExclusionPaths.Any(p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase)));
-        }
-        catch (InvalidOperationException ex) { StatusMessage = $"Could not remove the exclusion: {ex.Message}"; }
-        catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"Could not remove the exclusion: {ex.Message}"; }
-        finally { IsBusy = false; IsProgressIndeterminate = false; }
+        await RunOperationAsync(() => _service.RemoveExclusionPathAsync(path),
+            "Exclusion removal", "remove the exclusion",
+            s => !s.ExclusionPaths.Any(p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase)));
     }
 
     private bool HasSelectedExclusion => SelectedExclusion is not null;
@@ -193,6 +164,39 @@ public sealed partial class DefenderViewModel : ViewModelBase
            && path.Length <= 260
            && Directory.Exists(path);
 
+    /// <summary>
+    /// The shape all four Defender changes share: gate the UI, take the session restore point before
+    /// the first change of the session, run the change, adopt the returned status and report it
+    /// against a read-back.
+    /// <para>One funnel rather than four copies because the restore point belongs in exactly one
+    /// place — four private calls is the duplication that made Tweaks Hub and Gaming Profile each
+    /// burn the 24-hour allowance, with the loser reporting no snapshot while a good one existed.
+    /// The failure wording is passed in so each command keeps the message it already had.</para>
+    /// </summary>
+    private async Task RunOperationAsync(
+        Func<Task<DefenderStatus>> change,
+        string what,
+        string failureVerb,
+        Func<DefenderStatus, bool> applied)
+    {
+        IsBusy = true;
+        IsProgressIndeterminate = true;
+        try
+        {
+            // Before the change, never after. Defender preferences are machine-wide, so a snapshot
+            // taken afterwards would record the settings the user is trying to be able to undo.
+            var snapshotTaken = await _restorePoint
+                .EnsureAsync("SysManager Defender Tweaks").ConfigureAwait(true);
+
+            var status = await change().ConfigureAwait(true);
+            Apply(status);
+            ReportVerified(what, status, applied(status), snapshotTaken);
+        }
+        catch (InvalidOperationException ex) { StatusMessage = $"Could not {failureVerb}: {ex.Message}"; }
+        catch (System.ComponentModel.Win32Exception ex) { StatusMessage = $"Could not {failureVerb}: {ex.Message}"; }
+        finally { IsBusy = false; IsProgressIndeterminate = false; }
+    }
+
     private void Apply(DefenderStatus status)
     {
         IsAvailable = status.Available;
@@ -207,7 +211,7 @@ public sealed partial class DefenderViewModel : ViewModelBase
         RemoveExclusionCommand.NotifyCanExecuteChanged();
     }
 
-    private void ReportVerified(string what, DefenderStatus status, bool applied)
+    private void ReportVerified(string what, DefenderStatus status, bool applied, bool snapshotTaken)
     {
         // A read-back only proves anything when the status is actually readable. When the
         // Set failed (needs admin / PowerShell host fault), the service returns the all-zeros
@@ -216,7 +220,12 @@ public sealed partial class DefenderViewModel : ViewModelBase
         // unavailable read-back as a failure, never a silent success.
         if (applied && status.Available)
         {
-            StatusMessage = $"{what} updated.";
+            // Mentioned only when Windows really made one — the rule Tweaks Hub set. System Restore
+            // is switched off on many PCs and rate-limited to about one point a day, so silence here
+            // means "no snapshot", never a promise. Not mentioned on the failure paths below: those
+            // changed nothing, so there is nothing for a snapshot to reassure the user about.
+            var rp = snapshotTaken ? " Restore point created." : "";
+            StatusMessage = $"{what} updated.{rp}";
             Log.Information("Defender: {What} change applied", what);
         }
         else

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -463,7 +463,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             [typeof(FileLockViewModel)] = new FileLockViewModel(new FileLockService()),
             [typeof(DisplayProfileViewModel)] = new DisplayProfileViewModel(new DisplayProfileService()),
             [typeof(CpuAffinityViewModel)] = new CpuAffinityViewModel(new CpuAffinityService()),
-            [typeof(DefenderViewModel)] = new DefenderViewModel(new DefenderService(new PowerShellRunner())),
+            [typeof(DefenderViewModel)] = new DefenderViewModel(new DefenderService(new PowerShellRunner()), sessionRestorePoint),
             [typeof(TaskSchedulerViewModel)] = new TaskSchedulerViewModel(new TaskSchedulerService(new PowerShellRunner())),
             [typeof(DarkModeViewModel)] = new DarkModeViewModel(new WindowsThemeService()),
             [typeof(StandbyMemoryViewModel)] = new StandbyMemoryViewModel(new StandbyMemoryService()),


### PR DESCRIPTION
The last tab that changed system settings without a snapshot. With this, every one of them shares the single session restore point from 1.68.0, so the protection no longer depends on which page the user opened. Closes #1500.

### Why this one needed a refactor first

Defender had **four** mutating commands — PUA protection, Controlled Folder Access, add exclusion, remove exclusion — each carrying its own copy of the same `IsBusy` / `try` / `Apply` / `ReportVerified` / two-catch / `finally` shape. Putting `EnsureAsync` in four places would be precisely the duplication this work exists to remove: it is what made Tweaks Hub and Gaming Profile each burn the 24-hour allowance, with the loser reporting "no restore point" while a perfectly good one existed.

So the four bodies now share one `RunOperationAsync` funnel — the name Edge/OneDrive already uses for its funnel, rather than a parallel one — which takes the point once, before the change. **No message changed:** the failure verb is passed in, so `"Could not add the exclusion: …"` and the other three read exactly as before. That is what the 68 deletions are.

### A rejected change says nothing about the snapshot

If Tamper Protection is on, or the user is not elevated, Defender silently ignores the change and the read-back reports "was not changed". A point may well have been created, but mentioning it there reads as though something happened that could be undone. Nothing happened, so nothing is claimed.

### Guard change

The claim half of `EveryAutomaticSnapshot_ComesBeforeItsChangeAndIsNeverOverClaimed` now scans the whole view model instead of the funnel's member slice, because Defender builds its message in `ReportVerified` rather than in the funnel. That is also **stricter**: an unguarded claim anywhere in the view model fails, not only one inside the funnel. The consumer list is still derived from the source, so this tab could not have been added without appearing in the table.

### Tests

6 new. Eight mutations, each verified red for the right reason, tree restored byte-for-byte:

| mutation | caught by |
|---|---|
| snapshot moved **after** the Defender change | guard — ordering |
| unconditional claim in `ReportVerified` | guard — claim (this is what proves the file-scope check) |
| funnel stops taking a point at all | guard — missing |
| Defender missing from the case table | guard — derived-list floor |
| the claim removed entirely | guard — vacuity floor |
| a command bypasses the funnel | `EveryChange_GoesThroughTheOneFunnel` |
| snapshot taken before the confirmation | `TogglePua_WhenTheUserDeclines_TakesNoRestorePoint` |
| a rejected change claims the snapshot | `TogglePua_WhenTheChangeFails_ClaimsNoRestorePointEvenThoughOneWasMade` |

The two pre-existing Defender tests (the read-back-must-require-`Available` regression and the runspace-fault catch) pass unchanged, which is the behaviour-preservation evidence for the funnel.

Local: all 4 projects build 0 warnings / 0 errors; 61 test names across the touched files run green (68 executions with name collisions); `dotnet format --verify-no-changes` clean; the three CI gate bodies extracted verbatim from `ci.yml` pass — version consistency, valid bump from v1.69.0, CHANGELOG lead.

One note for the record: a red appeared during the regression sweep and was **not** real — I had rebuilt the four projects but not the throwaway harness, so it ran the previous assembly still containing a mutation. Confirmed by grepping the restored source, rebuilding, and checking the DLL timestamps against the source.

### Docs

README Defender bullet; `ARCHITECTURE.md` gains the funnel description and `DefenderViewModel` joins the seam's consumer list; CHANGELOG 1.70.0; SECURITY.md supported line.
