### PR TITLE
fix: derive the Settings Watchdog drift list and watched list from one read

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -525,6 +525,10 @@ Key services:
   live registry against it and restores drifted values on request. `DetectChanges` is a
   pure, unit-tested diff; registry access reuses the validated HKCU/HKLM helper pattern
   from `PrivacyService`. Reads/writes only well-known values; nothing leaves the machine.
+  `DetectDrift` has two shapes: the no-argument one reads the live values itself, and the
+  overload takes a snapshot the caller already read. A caller that also DISPLAYS those values
+  must use the overload, so the drift verdict and the displayed value describe one moment —
+  two reads let a setting move in between and appear settled while it had changed.
 - `CliRunner` — the headless command-line entry point (dispatched from `App.OnStartup`
   before the single-instance mutex, attaching to the parent console). Exposes only
   read-only/safe verbs (`--health`, `--cleanup`, `--trim-ram`, `--version/--help/--list`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.70.1] - 2026-08-25
+
+Settings Watchdog could show a setting as unchanged while it had in fact changed. The page read your
+live settings twice — once to work out what had drifted, once to fill in the list of what it watches —
+and anything that moved between those two reads appeared in the list with its new value but without
+being flagged. Now both come from a single read, so the two halves of the page can no longer disagree.
+
+### Fixed
+- **Settings Watchdog: the drift list and the watched list now come from one read.** This was most
+  likely to bite in exactly the situation the tab exists for — the catalog watches settings that
+  Windows Update flips back underneath you, so a change arriving mid-refresh is the expected case,
+  not a rare one. The baseline file was also being loaded twice per refresh; now once.
+
 ## [1.70.0] - 2026-08-25
 
 Defender Tweaks now takes a Windows restore point before it changes anything, which was the last tab

--- a/SysManager/SysManager.Tests/SettingsWatchdogViewModelTests.cs
+++ b/SysManager/SysManager.Tests/SettingsWatchdogViewModelTests.cs
@@ -25,7 +25,11 @@ public class SettingsWatchdogViewModelTests
         var svc = Substitute.For<ISettingsWatchdogService>();
         svc.Catalog.Returns([]);
         svc.LoadBaseline().Returns(new BaselineSnapshot(new DateTime(2026, 1, 1), []));
+        // Both shapes stubbed: the view model uses the overload (one read for both lists), while
+        // other callers still use the no-argument one.
         svc.DetectDrift().Returns(drifts);
+        svc.DetectDrift(Arg.Any<BaselineSnapshot>(), Arg.Any<IReadOnlyDictionary<string, int?>>())
+           .Returns(drifts);
         return svc;
     }
 
@@ -164,7 +168,11 @@ public class SettingsWatchdogViewModelTests
         var svc = Substitute.For<ISettingsWatchdogService>();
         svc.Catalog.Returns([Setting("telemetry"), Setting("widgets"), Setting("web-search")]);
         svc.LoadBaseline().Returns(new BaselineSnapshot(new DateTime(2026, 1, 1), []));
+        // The view model hands its own read to the overload (one read for both lists, #1967); the
+        // no-argument shape stays stubbed for any caller that only wants drifts.
         svc.DetectDrift().Returns(drifts);
+        svc.DetectDrift(Arg.Any<BaselineSnapshot>(), Arg.Any<IReadOnlyDictionary<string, int?>>())
+           .Returns(drifts);
         svc.ReadCurrent().Returns(current);
         return svc;
     }
@@ -251,5 +259,105 @@ public class SettingsWatchdogViewModelTests
 
         Assert.Equal(@"HKLM\SOFTWARE\Test\telemetry\Val",
             vm.Watched.Single(w => w.Setting.Key == "telemetry").Location);
+    }
+
+    // ── one read per refresh (regression #1967) ────────────────────────────
+    // Refresh used to obtain the live values TWICE: DetectDrift() read them to compute drift, then
+    // Refresh read them again to build the watched list. A setting that changed between the two reads
+    // came out with its NEW value but no drift verdict — displayed as settled while having moved,
+    // which is the exact state this tab exists to surface. Both tests below fail on that version.
+
+    /// <summary>
+    /// The watched setting used by these two tests: telemetry, whose baseline is "Off (Security)" and
+    /// which Windows Update is known to raise back to "Full" — the scenario the tab is built for.
+    /// </summary>
+    private static WatchedSetting TelemetrySetting() => new(
+        "telemetry", "Diagnostic data (telemetry)", "Windows Update can raise it back to Full.",
+        "Privacy", @"HKLM\SOFTWARE\Policies\Microsoft\Windows\DataCollection", "AllowTelemetry",
+        new Dictionary<int, string> { [0] = "Off (Security)", [3] = "Full" });
+
+    /// <summary>
+    /// A service whose live read reports <paramref name="liveValue"/> while its baseline recorded 0,
+    /// and whose drift computation is the REAL pure function — so the verdict is honest for whatever
+    /// snapshot the view model actually passes in. The no-argument DetectDrift returns nothing, which
+    /// is what the old code path consulted.
+    /// </summary>
+    private static ISettingsWatchdogService ServiceWhereTelemetryReads(int liveValue)
+    {
+        var setting = TelemetrySetting();
+        var catalog = new[] { setting };
+        var baseline = new BaselineSnapshot(new DateTime(2026, 1, 1),
+            new Dictionary<string, int?> { ["telemetry"] = 0 });
+
+        var svc = Substitute.For<ISettingsWatchdogService>();
+        svc.Catalog.Returns(catalog);
+        svc.LoadBaseline().Returns(baseline);
+        // The FIRST read reports the live value; any further read in the same refresh reports the
+        // baseline instead. A refresh that reads twice therefore judges drift against a different
+        // snapshot than the one it displays, which is exactly the defect — and it now cannot pass
+        // unnoticed, because a fake returning the same value twice would hide it.
+        svc.ReadCurrent().Returns(
+            new Dictionary<string, int?> { ["telemetry"] = liveValue },
+            new Dictionary<string, int?> { ["telemetry"] = 0 });
+        svc.DetectDrift().Returns([]);
+        svc.DetectDrift(Arg.Any<BaselineSnapshot>(), Arg.Any<IReadOnlyDictionary<string, int?>>())
+           .Returns(ci => SettingsWatchdogService.DetectChanges(
+               catalog,
+               ((BaselineSnapshot)ci[0]!).Values,
+               (IReadOnlyDictionary<string, int?>)ci[1]!));
+        return svc;
+    }
+
+    [Fact]
+    public async Task Refresh_DerivesDriftFromItsOwnRead_NotASecondOneInsideTheService()
+    {
+        var svc = ServiceWhereTelemetryReads(3);
+
+        var vm = new SettingsWatchdogViewModel(svc);
+        await vm.InitializationComplete;
+
+        // The verdict must be computed against the snapshot this refresh read, so it has to be handed
+        // in. Calling the no-argument overload means the service reads again on its own, and the two
+        // lists then describe two different moments.
+        svc.Received().DetectDrift(Arg.Any<BaselineSnapshot>(), Arg.Any<IReadOnlyDictionary<string, int?>>());
+        svc.DidNotReceive().DetectDrift();
+    }
+
+    [Fact]
+    public async Task Refresh_NeverShowsAValueThatDisagreesWithItsOwnDriftFlag()
+    {
+        // Live telemetry reads "Full" while the baseline recorded "Off (Security)".
+        var svc = ServiceWhereTelemetryReads(3);
+
+        var vm = new SettingsWatchdogViewModel(svc);
+        await vm.InitializationComplete;
+
+        var row = Assert.Single(vm.Watched);
+        Assert.Equal("Full", row.CurrentLabel);
+
+        // The row shows a value that moved, so it must say so — and the drift list must contain it.
+        // The old code showed "Full" with HasDrifted false and an empty drift list, which is the
+        // WatchedRow doc comment ("the two views cannot disagree") being untrue.
+        Assert.True(row.HasDrifted,
+            $"the row shows \"{row.CurrentLabel}\" but is not marked as drifted — the value and the "
+            + "verdict came from different reads.");
+        Assert.Single(vm.Drifts);
+        Assert.Equal("telemetry", vm.Drifts[0].Drift.Setting.Key);
+    }
+
+    [Fact]
+    public async Task Refresh_WhenNothingMoved_MarksNoDrift()
+    {
+        // The settled case must stay settled: same seam, same single read, live value equals baseline.
+        var svc = ServiceWhereTelemetryReads(0);
+
+        var vm = new SettingsWatchdogViewModel(svc);
+        await vm.InitializationComplete;
+
+        var row = Assert.Single(vm.Watched);
+        Assert.Equal("Off (Security)", row.CurrentLabel);
+        Assert.False(row.HasDrifted);
+        Assert.Empty(vm.Drifts);
+        Assert.False(vm.HasDrift);
     }
 }

--- a/SysManager/SysManager/Services/ISettingsWatchdogService.cs
+++ b/SysManager/SysManager/Services/ISettingsWatchdogService.cs
@@ -35,8 +35,19 @@ public interface ISettingsWatchdogService
     /// <summary>
     /// The settings that have changed since the baseline. Returns an EMPTY list — never null — when
     /// there is no baseline or nothing drifted.
+    /// <para>Reads the baseline and the live values itself. A caller that is going to display those
+    /// live values as well must use the overload below and pass its own read in, or the two will come
+    /// from different moments.</para>
     /// </summary>
     IReadOnlyList<SettingDrift> DetectDrift();
+
+    /// <summary>
+    /// The settings that have changed, computed against an ALREADY-READ snapshot of the live values.
+    /// <para>Exists so a caller that shows both the drift list and the live values derives them from
+    /// ONE read. With two reads a setting that changes in between appears with its new value but no
+    /// drift verdict — which is precisely the state this tab exists to make visible.</para>
+    /// </summary>
+    IReadOnlyList<SettingDrift> DetectDrift(BaselineSnapshot baseline, IReadOnlyDictionary<string, int?> current);
 
     /// <summary>
     /// Writes one drifted setting back to its baseline value. Returns false when it cannot be

--- a/SysManager/SysManager/Services/SettingsWatchdogService.cs
+++ b/SysManager/SysManager/Services/SettingsWatchdogService.cs
@@ -95,8 +95,19 @@ public sealed class SettingsWatchdogService : ISettingsWatchdogService
     public IReadOnlyList<SettingDrift> DetectDrift()
     {
         var baseline = LoadBaseline();
-        if (baseline is null) return [];
-        return DetectChanges(Catalog, baseline.Values, ReadCurrent());
+        return baseline is null ? [] : DetectDrift(baseline, ReadCurrent());
+    }
+
+    /// <summary>
+    /// Drift against a snapshot the caller already read. The no-argument overload above is the
+    /// convenience path for callers that only want drifts and display nothing else.
+    /// </summary>
+    public IReadOnlyList<SettingDrift> DetectDrift(
+        BaselineSnapshot baseline, IReadOnlyDictionary<string, int?> current)
+    {
+        ArgumentNullException.ThrowIfNull(baseline);
+        ArgumentNullException.ThrowIfNull(current);
+        return DetectChanges(Catalog, baseline.Values, current);
     }
 
     /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.70.0</Version>
-    <FileVersion>1.70.0.0</FileVersion>
-    <AssemblyVersion>1.70.0.0</AssemblyVersion>
+    <Version>1.70.1</Version>
+    <FileVersion>1.70.1.0</FileVersion>
+    <AssemblyVersion>1.70.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/SettingsWatchdogViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SettingsWatchdogViewModel.cs
@@ -65,16 +65,19 @@ public sealed partial class SettingsWatchdogViewModel : ViewModelBase
         HasBaseline = baseline is not null;
         BaselineTaken = baseline is not null ? $"Baseline saved {baseline.TakenAt.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)}" : "";
 
-        var drifts = _service.DetectDrift();
+        // ONE read of the live values, feeding BOTH lists. It used to be two — DetectDrift() read
+        // them, then this method read them again for the watched list — and a setting that changed
+        // between the two reads came out with its NEW value but no drift verdict, so it displayed as
+        // settled while having moved. That is the exact state this tab exists to surface, and it is
+        // not hypothetical: the catalog watches settings whose whole point is that Windows Update
+        // flips them back underneath you.
+        // Still read per refresh, not per session: stale displayed values would be their own quiet lie.
+        var current = _service.ReadCurrent();
+        var drifts = baseline is null ? [] : _service.DetectDrift(baseline, current);
         Drifts.ReplaceWith(drifts.Select(d => new DriftRow(d)));
         HasDrift = Drifts.Count > 0;
         RestoreSelectedCommand.NotifyCanExecuteChanged();
 
-        // Rebuilt on every refresh rather than once in the constructor, so the values shown are the
-        // LIVE ones — a list of watched settings with stale values would be its own quiet lie, and this
-        // is the same read DetectDrift performs. Drifted settings are marked so the two lists agree:
-        // the same setting cannot read as settled here while the drift list flags it below.
-        var current = _service.ReadCurrent();
         var drifted = drifts.Select(d => d.Setting.Key).ToHashSet(StringComparer.Ordinal);
         Watched.ReplaceWith(_service.Catalog.Select(s =>
             new WatchedRow(s, current.TryGetValue(s.Key, out var v) ? v : null, drifted.Contains(s.Key))));


### PR DESCRIPTION
Fixes #1967, which I filed during the audit after batch 113.

### The defect

`Refresh()` read the live values **twice** — `DetectDrift()` read them to compute drift, then `Refresh` read them again to build the watched list. Each `WatchedRow` was built from the **second** read's value and the **first** read's verdict:

```
var drifts  = _service.DetectDrift();     // reads the live values internally  (read #1)
var current = _service.ReadCurrent();     //                                   (read #2)
var drifted = drifts.Select(d => d.Setting.Key).ToHashSet(...);          // from #1
Watched.ReplaceWith(Catalog.Select(s => new WatchedRow(s, current[...], drifted.Contains(...))));
```

A setting that changed between the two reads showed its **new value with no flag**, and was missing from the drift list. `LoadBaseline()` also ran twice per refresh, since `DetectDrift()` opens with its own call.

This is not a remote edge case in this tab specifically: the catalog watches settings whose entire premise is that Windows Update flips them back underneath you, so a change arriving mid-refresh is the expected case. And two comments asserted it could not happen — the one above the second read ("the two lists agree: the same setting cannot read as settled here while the drift list flags it below") and `WatchedRow.HasDrifted`'s own doc.

### The fix

`ISettingsWatchdogService` gains a `DetectDrift(baseline, current)` overload over the existing pure `DetectChanges`. `Refresh` loads the baseline once, reads the live values once, and derives both lists from that pair. The no-argument overload stays for callers that only want drifts and display nothing.

Still **one read per refresh, not one per session** — the displayed values must stay live, which is why the second read was added originally. That constraint is stated in the comment so it is not "optimised" into a cached read later.

### An existing test asserted this invariant and still passed on the bug

`ADriftedSetting_IsMarkedInTheWatchedList_SoTheTwoListsCannotDisagree` is a pre-existing test whose name is exactly this issue. It passed on the broken code because its fake fed drift through the stubbed no-argument `DetectDrift()`, so both lists effectively came from one source and the divergence was never exercised. Its intent was right; I tightened its fake to stub the shape the view model now calls rather than adding a parallel test, and the new tests cover what it could not reach.

### Tests

3 new. The fake is the important part: `ReadCurrent()` returns the **live** value on the first call and the **baseline** on any later one, so a refresh that reads twice necessarily judges drift against a different snapshot than it displays. A fake returning the same value twice would have hidden mutation B below.

| mutation | result |
|---|---|
| the literal original two-read `Refresh` | red in **both** `Refresh_DerivesDriftFromItsOwnRead_NotASecondOneInsideTheService` and `Refresh_NeverShowsAValueThatDisagreesWithItsOwnDriftFlag` |
| overload used, but handed a **fresh** read instead of the displayed one | red in `Refresh_NeverShowsAValueThatDisagreesWithItsOwnDriftFlag` |

Tree restored byte-for-byte after the proof.

One thing I deliberately did **not** ship: a test asserting "one `LoadBaseline` and one `ReadCurrent` per refresh". With the service substituted, one of the two reads happens inside the real implementation and is invisible to the mock, so that test would have passed on the unfixed code. `Refresh_DerivesDriftFromItsOwnRead_...` asserts the structural property instead — the overload is called, the no-argument one is not — which does discriminate.

Also, per the issue: this is **not** filed or fixed as a performance problem. The catalog is 8 settings, so the duplicated work is a few milliseconds; making `Refresh` async would have treated the wrong cause.

Local: all 4 projects build 0 warnings / 0 errors; 82 test names across the Watchdog suites and the architecture suite run green (86 executions with name collisions); `dotnet format --verify-no-changes` clean; the three CI gate bodies extracted verbatim from `ci.yml` pass — 1.70.1 consistent, valid patch bump from v1.70.0, CHANGELOG lead present.

`SECURITY.md` is untouched deliberately: a patch release does not change the supported MINOR line.
