### PR TITLE
feat: take a restore point before the first Windows Features toggle

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -104,7 +104,7 @@ QA-verified is marked with `IsInDevelopment` (surfaced as a PREVIEW badge) inste
 - `DriversViewModel` — driver inventory via Win32_PnPSignedDriver.
 - `LogsViewModel` — friendly Event Log viewer.
 - `AboutViewModel` — version info, auto-update, release history.
-- `WindowsFeaturesViewModel` — list, enable, disable Windows optional features.
+- `WindowsFeaturesViewModel` — list, enable, disable Windows optional features. Takes the shared `ISessionRestorePoint` snapshot before the first toggle of the session — after the confirmation and after the elevation refusal, so neither declining nor being unelevated spends the one point Windows grants per day.
 - `AppAlertsViewModel` — monitors new app installations via FileSystemWatcher + registry.
 - `ShortcutCleanerViewModel` — scans and removes broken desktop/Start Menu shortcuts.
 - `AppBlockerViewModel` — block/unblock apps via IFEO (Image File Execution Options) registry mechanism.
@@ -319,7 +319,7 @@ Key services:
   a delegate rather than the sealed service, which keeps it substitutable without unsealing
   production code. Returns true only when THIS call created a point, so no caller can claim one that
   Windows refused. Consumed by `TweaksHubService`, `GamingProfileService`, `EdgeOneDriveViewModel`,
-  `DebloaterViewModel`, `PrivacyViewModel` and `DefenderViewModel`.
+  `DebloaterViewModel`, `PrivacyViewModel`, `DefenderViewModel` and `WindowsFeaturesViewModel`.
 - `DebloaterService` — lists (`Get-AppxPackage`) and removes (`Remove-AppxPackage`,
   per-user) Windows Store apps through the `IPowerShellRunner` seam. A hard-coded
   denylist of system-critical package families is enforced in code; the parser and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.71.0] - 2026-08-25
+
+Windows Features now takes a restore point before it changes anything. It was the last tab making a
+servicing-level change to Windows without one, and the one where it matters most: turning a feature back
+on is a second operation that can itself fail, possibly with a reboot already pending. Unlike removing a
+Store app, a restore point genuinely does cover this kind of change.
+
+### Added
+- **Windows Features takes a restore point before the first toggle of the session.** Taken after the
+  confirmation and after the "needs administrator" refusal, so neither declining nor being unelevated
+  spends the single point Windows grants per day. Best-effort, and reported only when one was really
+  created — never on a toggle that DISM rejected, since nothing changed in that case.
+
 ## [1.70.1] - 2026-08-25
 
 Settings Watchdog could show a setting as unchanged while it had in fact changed. The page read your

--- a/README.md
+++ b/README.md
@@ -451,6 +451,11 @@ a confirmation before it runs:
 - Toggle enable/disable per feature with confirmation dialog
 - Categorized: Virtualization, Networking, Development, Media & Print, Legacy
 - Shows reboot-required status after toggling
+- **A Windows restore point is attempted before the first toggle of the session**, shared with the
+  other tabs that change system settings. This is the tab where it matters most: turning a feature
+  back on is a second servicing operation that can itself fail, and unlike removing a Store app,
+  a restore point really does cover this kind of change. Mentioned only when Windows actually made
+  one, and never on a toggle that failed
 - Search/filter across all features
 - Requires administrator privileges for modifications
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.70.x   | :white_check_mark: |
-| < 1.70   | :x:                |
+| 1.71.x   | :white_check_mark: |
+| < 1.71   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2870,6 +2870,7 @@ public partial class ArchitectureTests
             ("DefenderViewModel.cs", "private async Task RunOperationAsync(", "await change("),
             ("EdgeOneDriveViewModel.cs", "private async Task RunOperationAsync(", "await operation("),
             ("PrivacyViewModel.cs", "private async Task ApplyChanges()", "_service.ApplyAll("),
+            ("WindowsFeaturesViewModel.cs", "private async Task ToggleFeatureAsync(", "_service.DisableFeatureAsync("),
         };
 
         var consumers = Directory

--- a/SysManager/SysManager.Tests/WindowsFeaturesTests.cs
+++ b/SysManager/SysManager.Tests/WindowsFeaturesTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using NSubstitute;
 using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
@@ -12,6 +13,9 @@ namespace SysManager.Tests;
 /// <summary>
 /// Tests for <see cref="WindowsFeaturesService"/> and <see cref="WindowsFeaturesViewModel"/>.
 /// </summary>
+// Serialized: the restore-point tests swap the static DialogService.Instance via DialogAnswer,
+// which is process-wide shared state.
+[Collection("ProcessWideStatics")]
 public class WindowsFeaturesTests
 {
     // ── ParseFeatureList ──
@@ -126,7 +130,7 @@ public class WindowsFeaturesTests
     [Fact]
     public void ViewModel_InitialState_IsCorrect()
     {
-        var vm = new WindowsFeaturesViewModel(new WindowsFeaturesService(new PowerShellRunner()));
+        var vm = new WindowsFeaturesViewModel(new WindowsFeaturesService(new PowerShellRunner()), NoRestorePoint());
         Assert.Empty(vm.AllFeatures);
         Assert.Empty(vm.FilteredFeatures);
         Assert.Equal("", vm.FilterText);
@@ -142,7 +146,7 @@ public class WindowsFeaturesTests
         // Scan and ToggleFeature both drive the shared WindowsFeaturesService PowerShell
         // runner. Running them concurrently would let both LineReceived handlers capture
         // the same output. The NotBusy/CanToggle gates make them mutually exclusive.
-        var vm = new WindowsFeaturesViewModel(new WindowsFeaturesService(new PowerShellRunner()));
+        var vm = new WindowsFeaturesViewModel(new WindowsFeaturesService(new PowerShellRunner()), NoRestorePoint());
         var feature = new WindowsFeature { Name = "TelnetClient", DisplayName = "Telnet Client" };
 
         Assert.True(vm.ScanCommand.CanExecute(null));
@@ -155,5 +159,136 @@ public class WindowsFeaturesTests
         vm.IsBusy = false;
         Assert.True(vm.ScanCommand.CanExecute(null));
         Assert.True(vm.ToggleFeatureCommand.CanExecute(feature));
+    }
+
+    // ── session restore point (#1966) ──────────────────────────────────────
+    // The last tab making a servicing-level change with no snapshot. It matters more here than
+    // anywhere else covered so far: the app cannot undo a DISM toggle by flipping the same switch
+    // (re-enabling is a second servicing operation that can itself fail, possibly with a reboot
+    // pending), and unlike removing a Store app, a restore point genuinely DOES cover this state.
+
+    private static ISessionRestorePoint NoRestorePoint()
+    {
+        var rp = Substitute.For<ISessionRestorePoint>();
+        rp.EnsureAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        return rp;
+    }
+
+    private static ISessionRestorePoint RestorePointTaken()
+    {
+        var rp = Substitute.For<ISessionRestorePoint>();
+        rp.EnsureAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        return rp;
+    }
+
+    /// <summary>
+    /// A runner whose powershell.exe invocation reports success (exit 0) without launching anything,
+    /// so the toggle path can be exercised without a real DISM servicing operation.
+    /// </summary>
+    private static IPowerShellRunner RunnerThatSucceeds()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunProcessAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>(),
+                               Arg.Any<System.Text.Encoding?>())
+              .Returns(Task.FromResult(0));
+        return runner;
+    }
+
+    private static WindowsFeaturesViewModel ElevatedVm(IPowerShellRunner runner, ISessionRestorePoint rp)
+    {
+        var vm = new WindowsFeaturesViewModel(new WindowsFeaturesService(runner), rp);
+        vm.IsElevated = true;   // the command refuses outright without elevation
+        return vm;
+    }
+
+    [Fact]
+    public async Task ToggleFeature_TakesTheRestorePointBeforeTouchingTheFeature()
+    {
+        var rp = RestorePointTaken();
+        using var dialog = new DialogAnswer(confirm: true);
+        var vm = ElevatedVm(RunnerThatSucceeds(), rp);
+
+        await vm.ToggleFeatureCommand.ExecuteAsync(
+            new WindowsFeature { Name = "TelnetClient", DisplayName = "Telnet Client" });
+
+        await rp.Received(1).EnsureAsync("SysManager Windows Features", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ToggleFeature_WhenTheUserDeclines_TakesNoRestorePoint()
+    {
+        // Declining changes nothing, so it must not spend the one point Windows grants per day.
+        var rp = RestorePointTaken();
+        using var dialog = new DialogAnswer(confirm: false);
+        var vm = ElevatedVm(RunnerThatSucceeds(), rp);
+
+        await vm.ToggleFeatureCommand.ExecuteAsync(
+            new WindowsFeature { Name = "TelnetClient", DisplayName = "Telnet Client" });
+
+        await rp.DidNotReceive().EnsureAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ToggleFeature_WithoutElevation_TakesNoRestorePoint()
+    {
+        // The command refuses before the confirmation when not elevated. Creating a point there would
+        // burn the daily allowance on an operation that was never going to run.
+        var rp = RestorePointTaken();
+        using var dialog = new DialogAnswer(confirm: true);
+        var vm = new WindowsFeaturesViewModel(new WindowsFeaturesService(RunnerThatSucceeds()), rp);
+        vm.IsElevated = false;
+
+        await vm.ToggleFeatureCommand.ExecuteAsync(
+            new WindowsFeature { Name = "TelnetClient", DisplayName = "Telnet Client" });
+
+        await rp.DidNotReceive().EnsureAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        Assert.Contains("Administrator", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ToggleFeature_WhenAPointWasCreated_SaysSoAfterTheRebootNote()
+    {
+        using var dialog = new DialogAnswer(confirm: true);
+        var vm = ElevatedVm(RunnerThatSucceeds(), RestorePointTaken());
+
+        await vm.ToggleFeatureCommand.ExecuteAsync(
+            new WindowsFeature { Name = "TelnetClient", DisplayName = "Telnet Client" });
+
+        Assert.Contains("Telnet Client enabled", vm.StatusMessage, StringComparison.Ordinal);
+        Assert.Contains("Restore point created.", vm.StatusMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ToggleFeature_WhenNoPointWasCreated_ClaimsNone()
+    {
+        // System Restore is off on many consumer PCs, so this is the common case — and a safety net
+        // the user does not have is worse than none, because she toggles the feature believing in it.
+        using var dialog = new DialogAnswer(confirm: true);
+        var vm = ElevatedVm(RunnerThatSucceeds(), NoRestorePoint());
+
+        await vm.ToggleFeatureCommand.ExecuteAsync(
+            new WindowsFeature { Name = "TelnetClient", DisplayName = "Telnet Client" });
+
+        Assert.Contains("Telnet Client enabled", vm.StatusMessage, StringComparison.Ordinal);
+        Assert.DoesNotContain("restore point", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ToggleFeature_WhenTheToggleFails_ClaimsNoRestorePointEvenThoughOneWasMade()
+    {
+        // DISM refused (non-zero exit). A point really was created, but saying so beside "Failed to
+        // enable" reads as though something happened that could be rolled back. Nothing happened.
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunProcessAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>(),
+                               Arg.Any<System.Text.Encoding?>())
+              .Returns(Task.FromResult(1));
+        using var dialog = new DialogAnswer(confirm: true);
+        var vm = ElevatedVm(runner, RestorePointTaken());
+
+        await vm.ToggleFeatureCommand.ExecuteAsync(
+            new WindowsFeature { Name = "TelnetClient", DisplayName = "Telnet Client" });
+
+        Assert.Contains("Failed to enable", vm.StatusMessage, StringComparison.Ordinal);
+        Assert.DoesNotContain("restore point", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.70.1</Version>
-    <FileVersion>1.70.1.0</FileVersion>
-    <AssemblyVersion>1.70.1.0</AssemblyVersion>
+    <Version>1.71.0</Version>
+    <FileVersion>1.71.0.0</FileVersion>
+    <AssemblyVersion>1.71.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -445,7 +445,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             [typeof(BulkInstallerViewModel)] = new BulkInstallerViewModel(new BulkInstallerService(new PowerShellRunner()), new AppIconService()),
             [typeof(FileShredderViewModel)] = new FileShredderViewModel(new FileShredderService()),
             [typeof(DnsHostsViewModel)] = new DnsHostsViewModel(new DnsService(new PowerShellRunner()), new HostsFileService()),
-            [typeof(WindowsFeaturesViewModel)] = new WindowsFeaturesViewModel(new WindowsFeaturesService(runner)),
+            [typeof(WindowsFeaturesViewModel)] = new WindowsFeaturesViewModel(new WindowsFeaturesService(runner), sessionRestorePoint),
             [typeof(PrivacyViewModel)] = new PrivacyViewModel(new PrivacyService(), sessionRestorePoint),
             [typeof(ContextMenuViewModel)] = new ContextMenuViewModel(new ContextMenuService()),
             [typeof(SystemReportViewModel)] = new SystemReportViewModel(new SystemReportService(sysInfo, diskHealth)),

--- a/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
@@ -18,6 +18,7 @@ namespace SysManager.ViewModels;
 public sealed partial class WindowsFeaturesViewModel : ViewModelBase
 {
     private readonly WindowsFeaturesService _service;
+    private readonly ISessionRestorePoint _restorePoint;
     private CancellationTokenSource? _scanCts;
     private CancellationTokenSource? _toggleCts;
 
@@ -33,9 +34,10 @@ public sealed partial class WindowsFeaturesViewModel : ViewModelBase
 
     partial void OnFilterTextChanged(string value) => ApplyFilter();
 
-    public WindowsFeaturesViewModel(WindowsFeaturesService service)
+    public WindowsFeaturesViewModel(WindowsFeaturesService service, ISessionRestorePoint restorePoint)
     {
         _service = service;
+        _restorePoint = restorePoint;
         // Scan and ToggleFeature both drive the shared WindowsFeaturesService PowerShell
         // runner (each subscribes its own LineReceived handler). Running them concurrently
         // would cross-contaminate the captured output (the SFC/DISM bug class). Re-evaluate
@@ -121,6 +123,15 @@ public sealed partial class WindowsFeaturesViewModel : ViewModelBase
 
         try
         {
+            // Before the change, never after. This is the tab where the snapshot matters most and is
+            // also genuinely useful: unlike removing a Store app, an optional feature is registry and
+            // system-file state, which is exactly what System Restore captures. Taken after the
+            // confirmation above, so declining costs the user nothing. Best-effort — the toggle is
+            // never gated on it, because Windows refuses a second point within 24h and System Restore
+            // is switched off entirely on many consumer machines.
+            var snapshotTaken = await _restorePoint
+                .EnsureAsync("SysManager Windows Features", _toggleCts.Token).ConfigureAwait(true);
+
             var (success, reboot) = feature.IsEnabled
                 ? await _service.DisableFeatureAsync(feature.Name, _toggleCts.Token)
                 : await _service.EnableFeatureAsync(feature.Name, _toggleCts.Token);
@@ -134,8 +145,11 @@ public sealed partial class WindowsFeaturesViewModel : ViewModelBase
 
                 if (reboot) PendingReboot = true;
 
+                // Only when Windows really made one. Not mentioned on the failure path below: that
+                // toggle changed nothing, so there is nothing for a snapshot to reassure anyone about.
+                var rp = snapshotTaken ? " Restore point created." : "";
                 StatusMessage = $"{feature.DisplayName} {(feature.IsEnabled ? "enabled" : "disabled")}" +
-                    (reboot ? " — reboot required." : ".");
+                    (reboot ? " — reboot required." : ".") + rp;
                 Log.Information("Feature {Feature} toggled to {State}, reboot={Reboot}",
                     feature.Name, feature.IsEnabled ? "Enabled" : "Disabled", reboot);
             }


### PR DESCRIPTION
Closes #1966, which I filed while auditing the remaining mutating services after #1500 closed. This is the last tab making a servicing-level change to Windows without a snapshot.

### Why this tab and not the others

The audit census in #1966 lists every mutating service with a per-service judgement. Windows Features is different from the ones I deliberately left alone in two ways:

1. **The app cannot undo it by flipping the same switch.** Context menu entries, DNS presets, privacy toggles — every one of those is a one-click reversal in its own tab. Re-enabling an optional feature is a second DISM servicing operation that can itself fail, and the machine may already be reboot-pending when the user discovers the problem.
2. **A restore point actually covers it**, unlike Debloater. Optional features are registry and system-file state, which is what System Restore captures — so here the reassurance is plainly true rather than carefully hedged.

The features people toggle in this tab are the ones that break things when they guess wrong: .NET Framework 3.5, Hyper-V, SMB1, WSL.

### Placement

After **both** early exits, not just the confirmation:

```
if (!IsElevated) { … return; }                     // ← snapshot must not happen before this
if (!Confirm(…)) return;                           // ← nor before this
try { var snapshotTaken = await _restorePoint.EnsureAsync("SysManager Windows Features", …);
      var (success, reboot) = … DisableFeatureAsync / EnableFeatureAsync …
```

Windows grants roughly one point per 24 hours, so spending it on an operation that never ran would deny it to the one that does. Both placements have their own test.

The completion message appends the sentence after the existing reboot note, and only when a point was really created. A toggle DISM rejected says nothing about it — nothing changed, so there is nothing to reassure anyone about.

### Tests

6 new. The service already takes `IPowerShellRunner` and `IsElevated` is an `[ObservableProperty]`, so the whole toggle path is exercisable with a substituted runner returning an exit code — no real DISM servicing operation runs.

| mutation | caught by |
|---|---|
| snapshot moved **after** the DISM toggle | guard — ordering |
| the claim stops being conditional | guard — over-claim |
| no snapshot taken at all | guard — missing, **and** `ToggleFeature_TakesTheRestorePointBeforeTouchingTheFeature` |
| the tab missing from the case table | guard — derived-list floor |
| snapshot before the confirmation | `ToggleFeature_WhenTheUserDeclines_TakesNoRestorePoint` |
| snapshot before the elevation refusal | `ToggleFeature_WithoutElevation_TakesNoRestorePoint` |
| a failed toggle claims the snapshot | `ToggleFeature_WhenTheToggleFails_ClaimsNoRestorePointEvenThoughOneWasMade` |

That last row closed a gap I could see while writing the proof: nothing asserted the failure path stayed silent, and a conditional claim added there would have passed the guard. I added the test first, then the mutation for it.

`WindowsFeaturesTests` also joins `[Collection("ProcessWideStatics")]`, since the new tests swap the static `DialogService.Instance` via `DialogAnswer` — which `ProcessWideStaticUsers_AreInTheSerializedCollection` enforces anyway.

Tree restored byte-for-byte after the proof. Local: all 4 projects build 0 warnings / 0 errors; 65 test names across the touched suites run green (88 executions with name collisions); `dotnet format --verify-no-changes` clean; the three CI gate bodies extracted verbatim from `ci.yml` pass — 1.71.0 consistent, valid minor bump from v1.70.1, CHANGELOG lead present.

### Docs

README bullet with the honest framing of what the point covers here; `ARCHITECTURE.md` VM entry plus the seam's consumer list; CHANGELOG 1.71.0; SECURITY.md supported line.
