### PR TITLE
fix: stop the Dashboard inventing a "~10s remaining" countdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.72.1] - 2026-08-25
+
+The Dashboard no longer tells you "~10s remaining" for a check it is not timing. When one of the
+five startup checks took more than five seconds, the card showed a fixed "~10s remaining" that was
+never measured — it read the same whether the check finished in a moment or stalled. It now says
+"still checking…", which promises no time it cannot keep.
+
+### Fixed
+- **Dashboard: the slow-check hint no longer invents a countdown.** The five health checks are
+  pass/fail probes with no progress to measure, so there is no honest number to show; the app's real
+  time estimator stays where it belongs, on the operations that report progress (App Updates, Bulk
+  Installer, Cleanup). The hint is also dropped the moment its check finishes, so it stops leaving
+  five idle timers per refresh waiting to fire after the work is already done.
+
 ## [1.72.0] - 2026-08-25
 
 The Task Scheduler scan can be stopped. On a PC with a full task tree, listing every scheduled task

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2929,6 +2929,96 @@ public partial class ArchitectureTests
     private static partial Regex SnapshotGuardedClaim();
 
     /// <summary>
+    /// No remaining-time text is a hardcoded duration.
+    /// <para>This is a different invariant from
+    /// <see cref="EveryEtaTextProperty_IsClearedWhenItsOperationEnds"/>: that one asks whether the text
+    /// is taken DOWN when the work ends, this one asks whether it was ever TRUE. Both can fail
+    /// independently, and the Dashboard failed only the second — it dutifully cleared a number it had
+    /// invented.</para>
+    /// <para>The defect: <c>DashboardViewModel</c> assigned <c>alert.Eta = "~10s remaining"</c> as a
+    /// literal, fired five times per dashboard load, five seconds into checks whose duration nothing
+    /// measured — so it read the same whether a check took 300&#160;ms or a minute. The app owns a real
+    /// estimator (<c>Helpers/EtaCalculator.cs</c>, an exponential rate smoother) which App Updates and
+    /// Bulk Installer feed with observed progress; the Dashboard's probes have no progress signal to
+    /// feed it, which is why a literal was reached for instead.</para>
+    /// <para>Models are scanned as well as view models, because that site was invisible to the older
+    /// guard on both axes: the property is <c>_eta</c> (not <c>_etaText</c>) and it lives on
+    /// <c>Models/DashboardAlert.cs</c> rather than a <c>*ViewModel.cs</c>.</para>
+    /// </summary>
+    [Fact]
+    public void NoRemainingTimeText_IsAHardcodedDuration()
+    {
+        var appDir = FindAppProjectDir();
+        var files = Directory
+            .EnumerateFiles(appDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                                    StringComparison.Ordinal)
+                        && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}",
+                                       StringComparison.Ordinal))
+            .ToArray();
+
+        var assignments = 0;
+        var fabricated = new List<string>();
+
+        foreach (var file in files)
+        {
+            // Comments stripped: the paragraphs above quote the exact defect string, and a guard that
+            // reads its own prose reports a violation that is not in the code.
+            var code = WithoutComments(File.ReadAllText(file));
+            var name = Path.GetFileName(file);
+
+            foreach (Match m in EtaAssignment().Matches(code))
+            {
+                var target = m.Groups["target"].Value;
+                // ShowEta and friends are visibility booleans, not the text that makes the claim.
+                if (target.Contains("Show", StringComparison.Ordinal)) continue;
+
+                assignments++;
+
+                // Only a literal can be a fabricated claim. EtaCalculator.Update(...) and
+                // string.Empty are the shapes this rule WANTS, so they are skipped here — the
+                // floor above is what proves they were actually seen.
+                var rhs = m.Groups["rhs"].Value.Trim();
+                if (rhs.StartsWith("$\"", StringComparison.Ordinal)) rhs = rhs[1..];
+                if (rhs.Length < 2 || rhs[0] != '"' || rhs[^1] != '"') continue;
+
+                var literal = rhs[1..^1];
+                if (HardcodedDuration().IsMatch(literal))
+                    fabricated.Add($"{name} — {target} = '{literal}'");
+            }
+        }
+
+        // Floor derived from the real population: 38 ETA assignments across six view models at the time
+        // this was written, all of them EtaCalculator.Update(...) or a clear. Set well below that so
+        // ordinary edits do not trip it, but high enough that a pattern which stops matching cannot
+        // report a clean codebase. The FIRST version of this guard required 4 and found 1, because it
+        // demanded a word boundary before "Eta" and so missed every UpgradeEtaText-shaped name.
+        Assert.True(assignments >= 30,
+            $"only {assignments} ETA assignments matched, so this guard is not finding the real ones and "
+            + "a clean result would mean nothing — the pattern has drifted from the code.");
+
+        Assert.True(fabricated.Count == 0,
+            "remaining-time text must be MEASURED, not asserted. Feed EtaCalculator with observed "
+            + "progress, or say something that promises no duration ('still checking…'). A number the "
+            + "code cannot back up is the same defect as promising a restore point that was never "
+            + "created:\n  - " + string.Join("\n  - ", fabricated));
+    }
+
+    // EVERY assignment to a name ending in Eta / EtaText, whatever the right-hand side, on a view model
+    // or a model. Matching all of them is what lets the floor above prove the guard can see the code;
+    // the literal test happens in C# so EtaCalculator.Update(...) and clears are counted, not flagged.
+    // No \b before "Eta": the names in this codebase are UpgradeEtaText / InstallEtaText, where the
+    // preceding character is a word character, so a boundary there matches nothing that matters.
+    [GeneratedRegex(@"(?<target>[\w.]*Eta(?:Text)?)\s*=\s*(?<rhs>[^;]*);", RegexOptions.Compiled)]
+    private static partial Regex EtaAssignment();
+
+    // A duration claim: a number next to a time unit ("~10s remaining", "2 min left", "about 30
+    // seconds"). An empty string, or wording that names no duration, carries no claim and passes.
+    [GeneratedRegex(@"\d\s*(ms|s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hour|hours)\b",
+                    RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    private static partial Regex HardcodedDuration();
+
+    /// <summary>
     /// Performance Mode must refuse to CAPTURE a recovery baseline while a game profile is live — and must
     /// still be allowed to LOAD one that was persisted earlier.
     /// <para>The lock added for #1501 stops the two tabs from snapshotting each other mid-change, but it is

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.72.0</Version>
-    <FileVersion>1.72.0.0</FileVersion>
-    <AssemblyVersion>1.72.0.0</AssemblyVersion>
+    <Version>1.72.1</Version>
+    <FileVersion>1.72.1.0</FileVersion>
+    <AssemblyVersion>1.72.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -415,24 +415,48 @@ public sealed partial class DashboardViewModel : ViewModelBase
         _ = RunAlertScanAsync(featuresAlert, ScanWindowsFeaturesAsync);
     }
 
+    /// <summary>
+    /// Says "this is taking a moment" after five seconds, and deliberately does NOT say how much
+    /// longer.
+    /// <para>It used to read "~10s remaining", which was a string literal — nothing measured it, and it
+    /// said the same thing whether the check finished in 300&#160;ms or stalled for a minute. These five
+    /// checks are pass/fail probes with no progress signal, so there is nothing for
+    /// <see cref="Helpers.EtaCalculator"/> to smooth; the tabs that DO report progress (App Updates,
+    /// Bulk Installer) feed it real samples. Inventing a number where none exists is the same mistake as
+    /// promising a restore point that was never created.</para>
+    /// <para>The mutation must run on the UI thread — <paramref name="alert"/> is a bound
+    /// ObservableObject, so raising PropertyChanged off the thread-pool thread can throw or fail to
+    /// update. Marshal onto the dispatcher exactly like the scanner bodies do.</para>
+    /// </summary>
+    private static async Task AcknowledgeSlowScanAsync(DashboardAlert alert, CancellationToken ct)
+    {
+        try
+        {
+            await Task.Delay(TimeSpan.FromSeconds(5), ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return;   // the scan finished first, so there is nothing to acknowledge
+        }
+
+        System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
+        {
+            // Re-checked on the UI thread: the scan can complete between the delay ending and this
+            // running, and a hint that appears after the result has landed would be nonsense.
+            if (alert.State == AlertLoadingState.Loading)
+            {
+                alert.ShowEta = true;
+                alert.Eta = "still checking…";
+            }
+        });
+    }
+
     private static async Task RunAlertScanAsync(DashboardAlert alert, Func<DashboardAlert, Task> scanner)
     {
-        // Fire-and-forget ETA hint: after 5s of loading, surface a "remaining" note.
-        // The mutation must run on the UI thread — `alert` is a bound ObservableObject,
-        // so raising PropertyChanged off the thread-pool thread can throw or fail to
-        // update. Marshal onto the dispatcher exactly like the scanner bodies do.
-        _ = Task.Run(async () =>
-        {
-            await Task.Delay(5000);
-            System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
-            {
-                if (alert.State == AlertLoadingState.Loading)
-                {
-                    alert.ShowEta = true;
-                    alert.Eta = "~10s remaining";
-                }
-            });
-        });
+        // After 5s the wait is worth acknowledging — but WITHOUT naming a duration. Cancelled as
+        // soon as the scan ends, so a fast check leaves nothing waiting to wake up.
+        using var hintCts = new CancellationTokenSource();
+        _ = AcknowledgeSlowScanAsync(alert, hintCts.Token);
 
         try
         {
@@ -446,6 +470,9 @@ public sealed partial class DashboardViewModel : ViewModelBase
         }
         finally
         {
+            // Before the flags below: once the scan is done the hint has nothing left to say, and
+            // this is what stops five delays per dashboard load outliving the work they described.
+            hintCts.Cancel();
             alert.State = AlertLoadingState.Complete;
             alert.ShowEta = false;
         }


### PR DESCRIPTION
Closes #1975, which I filed while auditing fire-and-forget call sites.

### The defect

`DashboardViewModel` set `alert.Eta = "~10s remaining"` as a **string literal**, fired once per alert (five times per dashboard load) five seconds into checks whose duration nothing measured. It read the same whether a check finished in 300 ms or stalled for a minute — a remaining-time claim the code never computed. `grep` for assignments to `.Eta` returned exactly this one hit.

The app already owns the right mechanism: `Helpers/EtaCalculator.cs`, an exponential rate smoother that **six** view models feed with observed progress (App Updates, Bulk Installer, Cleanup, Deep Cleanup, Uninstaller). The Dashboard's five checks are pass/fail probes with no progress signal, which is why a literal was reached for. Same class of defect as the restore-point wording across 1.68.0–1.71.0: a claim the code cannot honour is worse than none, because the user acts on it.

### The fix

The hint now reads **"still checking…"** — it acknowledges the wait (5 seconds of silence on a card is worth marking) without naming a duration it cannot keep. The 5-second timer moved into a named `AcknowledgeSlowScanAsync` driven by a `CancellationTokenSource` the scan cancels on completion, so a fast check no longer leaves five detached `Task.Delay` timers waiting to wake up after the work is done (the secondary observation in the issue). The UI-thread re-check (`State == Loading`) is kept, since the scan can still complete between the delay elapsing and the dispatcher callback running.

### Guard

`NoRemainingTimeText_IsAHardcodedDuration` scans view models **and** models — that site was invisible to the existing ETA guard on both axes (`_eta`, not `_etaText`; `Models/`, not `*ViewModel.cs`). It flags any `Eta`/`EtaText` assignment whose literal is a duration (a number beside a time unit). It is a **distinct invariant** from `EveryEtaTextProperty_IsClearedWhenItsOperationEnds`: that one asks whether the text is taken *down*, this asks whether it was ever *true*. The Dashboard passed the first and failed only the second.

The floor (`>= 30 assignments seen`) is set from the real population of 38. Worth noting: my **first** version of the guard required a `\b` before `Eta`, matched only 1 assignment, and its own floor caught that — exactly the near-vacuous guard the floor exists to stop. I corrected the pattern rather than lowering the floor.

### Tests

Four mutations, each confirmed red for the right reason, tree restored byte-for-byte:

| mutation | result |
|---|---|
| the exact `"~10s remaining"` literal returns | red |
| a slower-burning `"about 30 seconds left"` | red |
| interpolated, number still hardcoded (`$"~10s remaining for {…}"`) | red |
| the pattern drifts and stops matching `UpgradeEtaText`-shaped names | red (the floor) |

One case I checked and did **not** turn into a test: removing `hintCts.Cancel()`. The `using` disposes the CTS at scope exit regardless, and the detached delay's `catch (OperationCanceledException)` handles the token either way, so it costs a wasted 5-second wake-up but breaks nothing. No existing guard covers it because the token drives an internal `Task.Delay`, not a service call. Asserting it as correctness would be a test that pins a courtesy, so I left it out and kept the cancel for the reason the issue gave.

Local: all 4 projects build 0 warnings / 0 errors; 76 test names across the touched suites run green (160 executions with name collisions across the full architecture suite); `dotnet format --verify-no-changes` clean; all three extracted CI gate bodies pass — 1.72.1 consistent, valid patch bump from v1.72.0, CHANGELOG lead present.

### Docs

CHANGELOG 1.72.1. README is untouched — it never documented the ETA hint, so there is nothing user-facing to correct. SECURITY.md untouched: a patch release does not move the supported MINOR line.
