### PR TITLE
feat: Disk Analyzer remembers each folder's last scan and shows what changed

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -84,7 +84,7 @@ QA-verified is marked with `IsInDevelopment` (surfaced as a PREVIEW badge) inste
 - `DeepCleanupViewModel` — scan-first deep cleanup + large-files finder.
 - `StartupViewModel` — startup program management (enable/disable via registry).
 - `DuplicateFileViewModel` — duplicate file finder with partial-hash pre-filter.
-- `DiskAnalyzerViewModel` — disk space breakdown by folder with drill-down.
+- `DiskAnalyzerViewModel` — disk space breakdown by folder with drill-down. Remembers the last scan of each root via `DiskScanHistoryService` and shows a "since last scan" delta; the read-and-remember is best-effort, so a history failure degrades to no delta rather than breaking a completed scan.
 - `ProcessManagerViewModel` — running processes with kill, filter, sort. The kill path has three
   tiers, because one message cannot be true for all of them: `BootCriticalProcesses` (13 names) is
   refused outright, `HighConsequenceProcesses` (Defender's engine, Windows Installer and the servicing
@@ -279,6 +279,11 @@ Key services:
   descriptions from file version info and known-process database.
 - `SpeedTestHistoryService` — persists speed test results to JSON for
   historical charting and trend analysis.
+- `DiskScanHistoryService` — remembers the last Disk Analyzer scan per root (one snapshot each,
+  capped roots and capped folders-per-root) in `disk-scan-history.json`, so the tab can show what
+  changed since last time. Same never-throw-on-IO contract and `configDir` test seam as
+  `SpeedTestHistoryService`. Machine-specific by nature (absolute paths + sizes on this disk), so it
+  is deliberately absent from `ProfileService.Catalog` and pinned OUT by a test.
 - `ShortcutCleanerService` — scans Start Menu and Desktop for broken
   shortcuts (dead targets) and offers safe removal.
 - `BulkInstallerService` — installs apps via winget in batch with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.73.0] - 2026-08-25
+
+Disk Analyzer now remembers your last scan of each folder and tells you what changed. Until now every
+reopen started blank, even though the rest of the app remembers things; now, after you re-scan a folder,
+a line reads e.g. "3.2 GB larger than your last scan on 12 Jul" - turning a one-off number into an
+answer to "why is my disk filling up?".
+
+### Added
+- **Disk Analyzer: a "since last scan" delta per folder.** The last scan of each root is saved locally
+  (disk-scan-history.json), and on the next scan of that folder the tab shows how much it grew or
+  shrank and when it was last measured. It is always phrased as "since your last scan", never as
+  continuous monitoring, because scanning is something you trigger. The history is bounded (a capped
+  number of folders, a capped number of roots) and follows the same never-lose-the-tab-on-a-bad-file
+  rule as the Speed Test history it is modelled on.
+
+### Notes
+- The scan history stays on this PC and is **not** part of Profile Export - folder paths and sizes are
+  specific to one machine, so a delta from another PC's disk would be meaningless here.
+
 ## [1.72.1] - 2026-08-25
 
 The Dashboard no longer tells you "~10s remaining" for a check it is not timing. When one of the

--- a/README.md
+++ b/README.md
@@ -489,6 +489,10 @@ a confirmation before it runs:
   reports, and names the exact folders on hover
 - Folders Windows wouldn't let it fully read are marked, so a partial figure never looks
   like a complete one
+- **Remembers your last scan of each folder** and shows what changed — "3.2 GB larger than your
+  last scan on 12 Jul" — so a one-off number becomes an answer to "why did my disk fill up?". It is
+  always phrased as *since your last scan*, never as live monitoring, because you choose when to
+  scan. Stored only on this PC and never carried to another (folder sizes here mean nothing there)
 
 ### Process Manager
 - Lists running Windows processes with PID, memory, threads, and status

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.72.x   | :white_check_mark: |
-| < 1.72   | :x:                |
+| 1.73.x   | :white_check_mark: |
+| < 1.73   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/DiskAnalyzerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DiskAnalyzerViewModelTests.cs
@@ -3,6 +3,8 @@
 // License: MIT
 
 using System.IO;
+using SysManager.Models;
+using SysManager.Services;
 using SysManager.ViewModels;
 
 namespace SysManager.Tests;
@@ -18,7 +20,9 @@ public class DiskAnalyzerViewModelTests
     // observe the populated collection instead of racing the background load.
     private static DiskAnalyzerViewModel NewVm()
     {
-        var vm = new DiskAnalyzerViewModel(new Services.DiskAnalyzerService());
+        var vm = new DiskAnalyzerViewModel(new DiskAnalyzerService(),
+            new DiskScanHistoryService(Path.Combine(Path.GetTempPath(),
+                "SysManagerDiskHistVm_" + Guid.NewGuid().ToString("N"))));
         vm.InitializationComplete.GetAwaiter().GetResult();
         return vm;
     }
@@ -251,5 +255,60 @@ public class DiskAnalyzerViewModelTests
         var path = Path.Combine(dir!.FullName, "SysManager", "Views", fileName);
         Assert.True(File.Exists(path), $"{fileName} not found at {path}");
         return path;
+    }
+
+    // ---------- the "since last scan" delta wording (#1591) ----------
+    // DescribeTrend is the whole value of the feature: turning a one-off number into "what changed?".
+    // Tested at the source, so the branches are deterministic — no disk, no wall-clock.
+
+    private static DiskScanSnapshot Prior(long total, DateTime at) =>
+        new() { RootPath = @"C:\Data", TotalSize = total, CapturedAt = at };
+
+    [Fact]
+    public void Trend_WithNoPriorScan_IsEmpty()
+    {
+        // A first-ever scan of a root must show nothing, not "0 bytes larger".
+        Assert.Equal("", DiskAnalyzerViewModel.DescribeTrend(null, 5_000_000_000));
+    }
+
+    [Fact]
+    public void Trend_WhenLarger_SaysLargerAndNamesTheDate()
+    {
+        var prior = Prior(2_000_000_000, new DateTime(2026, 7, 12));
+        var text = DiskAnalyzerViewModel.DescribeTrend(prior, 5_200_000_000);
+
+        Assert.Contains("larger", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("smaller", text, StringComparison.Ordinal);
+        Assert.Contains("12 Jul 2026", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Trend_WhenSmaller_SaysSmaller()
+    {
+        var prior = Prior(5_000_000_000, new DateTime(2026, 7, 12));
+        var text = DiskAnalyzerViewModel.DescribeTrend(prior, 1_000_000_000);
+
+        Assert.Contains("smaller", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("larger", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Trend_WhenNegligiblyChanged_ReadsAsAboutTheSame()
+    {
+        // A few kilobytes on a multi-gigabyte folder is churn, not growth — it must not read as either.
+        var prior = Prior(5_000_000_000, new DateTime(2026, 7, 12));
+        var text = DiskAnalyzerViewModel.DescribeTrend(prior, 5_000_064_000);
+
+        Assert.Contains("About the same", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("larger", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("smaller", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Trend_ExactlyUnchanged_ReadsAsAboutTheSame()
+    {
+        var prior = Prior(5_000_000_000, new DateTime(2026, 7, 12));
+        Assert.Contains("About the same",
+            DiskAnalyzerViewModel.DescribeTrend(prior, 5_000_000_000), StringComparison.Ordinal);
     }
 }

--- a/SysManager/SysManager.Tests/DiskScanHistoryServiceTests.cs
+++ b/SysManager/SysManager.Tests/DiskScanHistoryServiceTests.cs
@@ -1,0 +1,142 @@
+// SysManager · DiskScanHistoryServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="DiskScanHistoryService"/> — the per-root persistence behind the Disk Analyzer's
+/// "since last scan" line. Everything runs against a temp directory via the <c>configDir</c> seam, so the
+/// real save/load/upsert/trim paths are exercised without touching the user's own history file.
+/// </summary>
+public sealed class DiskScanHistoryServiceTests : IDisposable
+{
+    private readonly string _dir;
+
+    public DiskScanHistoryServiceTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "SysManagerDiskHist_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true);
+    }
+
+    private DiskScanHistoryService NewService() => new(_dir);
+
+    private static DiskScanSnapshot Snap(string root, long total, DateTime at, params (string Name, long Size)[] folders)
+        => new()
+        {
+            RootPath = root,
+            TotalSize = total,
+            CapturedAt = at,
+            TopFolders = folders.Select(f => new FolderUsage { Name = f.Name, SizeBytes = f.Size }).ToList(),
+        };
+
+    [Fact]
+    public async Task Find_BeforeAnyScan_IsNull()
+    {
+        using var svc = NewService();
+        Assert.Null(await svc.FindAsync(@"C:\Data"));
+    }
+
+    [Fact]
+    public async Task Save_ThenFind_RoundTripsTheSnapshot()
+    {
+        using var svc = NewService();
+        var at = new DateTime(2026, 7, 12, 9, 0, 0);
+
+        Assert.True(await svc.SaveAsync(Snap(@"C:\Data", 5_000, at, ("Sub", 4_000))));
+
+        var found = await svc.FindAsync(@"C:\Data");
+        Assert.NotNull(found);
+        Assert.Equal(5_000, found!.TotalSize);
+        Assert.Equal(at, found.CapturedAt);
+        Assert.Equal("Sub", Assert.Single(found.TopFolders).Name);
+    }
+
+    [Fact]
+    public async Task Save_SameRootTwice_KeepsOnlyTheNewer()
+    {
+        using var svc = NewService();
+        await svc.SaveAsync(Snap(@"C:\Data", 100, new DateTime(2026, 1, 1)));
+        await svc.SaveAsync(Snap(@"C:\Data", 999, new DateTime(2026, 2, 1)));
+
+        var all = await svc.LoadAsync();
+        Assert.Single(all);
+        Assert.Equal(999, all[0].TotalSize);   // the upsert replaced, it did not accumulate
+    }
+
+    [Theory]
+    [InlineData(@"C:\Data", @"C:\Data\")]      // trailing separator
+    [InlineData(@"C:\Data", @"c:\data")]        // case
+    public async Task Save_TreatsEquivalentPathsAsOneRoot(string first, string second)
+    {
+        using var svc = NewService();
+        await svc.SaveAsync(Snap(first, 1, new DateTime(2026, 1, 1)));
+        await svc.SaveAsync(Snap(second, 2, new DateTime(2026, 2, 1)));
+
+        Assert.Single(await svc.LoadAsync());
+        Assert.Equal(2, (await svc.FindAsync(first))!.TotalSize);
+    }
+
+    [Fact]
+    public async Task Save_BoundsRootsToTheCap_DroppingTheOldest()
+    {
+        using var svc = NewService();
+        // One more than the cap; the oldest by capture time must fall off.
+        for (var i = 0; i <= DiskScanHistoryService.MaxRoots; i++)
+            await svc.SaveAsync(Snap($@"C:\Root{i}", i, new DateTime(2026, 1, 1).AddDays(i)));
+
+        var all = await svc.LoadAsync();
+        Assert.Equal(DiskScanHistoryService.MaxRoots, all.Count);
+        Assert.Null(await svc.FindAsync(@"C:\Root0"));                    // oldest dropped
+        Assert.NotNull(await svc.FindAsync($@"C:\Root{DiskScanHistoryService.MaxRoots}")); // newest kept
+    }
+
+    [Fact]
+    public async Task Save_BoundsFoldersPerRoot_KeepingTheLargest()
+    {
+        using var svc = NewService();
+        var folders = Enumerable.Range(1, DiskScanHistoryService.MaxFoldersPerRoot + 5)
+            .Select(i => ($"F{i}", (long)i * 100))
+            .ToArray();
+        await svc.SaveAsync(Snap(@"C:\Data", 9_999, new DateTime(2026, 1, 1), folders));
+
+        var found = await svc.FindAsync(@"C:\Data");
+        Assert.Equal(DiskScanHistoryService.MaxFoldersPerRoot, found!.TopFolders.Count);
+        // Largest kept, smallest dropped.
+        Assert.Contains(found.TopFolders, f => f.Name == $"F{DiskScanHistoryService.MaxFoldersPerRoot + 5}");
+        Assert.DoesNotContain(found.TopFolders, f => f.Name == "F1");
+    }
+
+    [Fact]
+    public async Task Load_OnCorruptFile_DegradesToEmpty_DoesNotThrow()
+    {
+        File.WriteAllText(Path.Combine(_dir, "disk-scan-history.json"), "{ this is not valid json ]");
+        using var svc = NewService();
+
+        Assert.Empty(await svc.LoadAsync());
+        Assert.Null(await svc.FindAsync(@"C:\Data"));
+        // And a save over the corrupt file recovers rather than throwing.
+        Assert.True(await svc.SaveAsync(Snap(@"C:\Data", 1, new DateTime(2026, 1, 1))));
+        Assert.Single(await svc.LoadAsync());
+    }
+
+    [Fact]
+    public async Task Clear_RemovesEverything()
+    {
+        using var svc = NewService();
+        await svc.SaveAsync(Snap(@"C:\Data", 1, new DateTime(2026, 1, 1)));
+
+        Assert.True(await svc.ClearAsync());
+        Assert.Empty(await svc.LoadAsync());
+        Assert.True(await svc.ClearAsync());   // idempotent — clearing an already-empty history is fine
+    }
+}

--- a/SysManager/SysManager.Tests/ProfileServiceTests.cs
+++ b/SysManager/SysManager.Tests/ProfileServiceTests.cs
@@ -258,6 +258,7 @@ public class ProfileServiceTests : IDisposable
     [InlineData("last-crash.json")]
     [InlineData("activity.json")]
     [InlineData("resource-history-config.json")]
+    [InlineData("disk-scan-history.json")]   // folder paths + sizes on THIS disk; meaningless on another PC
     public void AvailableSections_NeverCarriesMachineSpecificState(string fileName)
     {
         WriteConfig(fileName, "{\"machine\":\"specific\"}");

--- a/SysManager/SysManager/Models/DiskScanSnapshot.cs
+++ b/SysManager/SysManager/Models/DiskScanSnapshot.cs
@@ -1,0 +1,37 @@
+// SysManager · DiskScanSnapshot — a remembered disk-analysis result for one scanned root
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// One remembered Disk Analyzer scan, keyed by the root that was scanned. Persisted so the tab can
+/// answer the question a one-off number cannot — "what changed since last time?" — with a delta line.
+/// <para>Deliberately small: the measured total plus the top folders by size, not the full tree. The
+/// payload is bounded on write (a capped number of roots, a capped number of folders each) so a user
+/// who drills into many folders cannot grow the file without limit.</para>
+/// <para>This is a serialization DTO — plain settable properties so <c>System.Text.Json</c> can
+/// round-trip it. It is machine-specific by nature (absolute paths and sizes on THIS disk), which is
+/// why it is NOT part of Profile Export: a delta from another PC's disk would be meaningless here.</para>
+/// </summary>
+public sealed class DiskScanSnapshot
+{
+    /// <summary>The scanned root, e.g. <c>C:\Users\me\Downloads</c>. The lookup key.</summary>
+    public string RootPath { get; set; } = "";
+
+    /// <summary>When this scan was taken. Shown to the user as the "since" date in the delta line.</summary>
+    public DateTime CapturedAt { get; set; }
+
+    /// <summary>Sum of the measured folders — the same partial total the tab shows, by the same rules.</summary>
+    public long TotalSize { get; set; }
+
+    /// <summary>The largest folders under the root at capture time, most recent scan wins.</summary>
+    public List<FolderUsage> TopFolders { get; set; } = [];
+}
+
+/// <summary>One folder's measured size within a <see cref="DiskScanSnapshot"/>.</summary>
+public sealed class FolderUsage
+{
+    public string Name { get; set; } = "";
+    public long SizeBytes { get; set; }
+}

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -39,6 +39,7 @@ public static class ServiceRegistration
         services.AddSingleton<IAppBlockerService, AppBlockerService>();
         services.AddSingleton<DeepCleanupService>();
         services.AddSingleton<DiskAnalyzerService>();
+        services.AddSingleton<DiskScanHistoryService>();
         services.AddSingleton<DuplicateFileService>();
         services.AddSingleton<EventLogService>();
         services.AddSingleton<FixedDriveService>();

--- a/SysManager/SysManager/Services/DiskScanHistoryService.cs
+++ b/SysManager/SysManager/Services/DiskScanHistoryService.cs
@@ -1,0 +1,226 @@
+// SysManager · DiskScanHistoryService — remembers the last Disk Analyzer scan per root
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Text.Json;
+using Serilog;
+using SysManager.Helpers;
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Persists the last Disk Analyzer scan for each root to a local JSON file, so reopening the tab can
+/// show what changed since last time instead of starting blank. One snapshot per root (the newest wins),
+/// capped at <see cref="MaxRoots"/> roots so drilling into many folders cannot grow the file without
+/// bound.
+/// <para>Modelled on <see cref="SpeedTestHistoryService"/>, down to the contract: a
+/// <see cref="SemaphoreSlim"/> serialises the non-atomic load-modify-write, IO failures degrade to
+/// "no history" rather than throwing to the tab, and the <c>configDir</c> seam lets tests run against a
+/// temp directory instead of the user's real file.</para>
+/// </summary>
+public sealed class DiskScanHistoryService : IDisposable
+{
+    /// <summary>How many distinct roots are remembered. Oldest-by-capture are trimmed on save.</summary>
+    public const int MaxRoots = 20;
+
+    /// <summary>How many folders each snapshot keeps, largest first. Bounds the per-root payload.</summary>
+    public const int MaxFoldersPerRoot = 10;
+
+    private readonly string _historyPath;
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    // Serialise all file operations: load-modify-save is not atomic, so two concurrent saves would race.
+    private readonly SemaphoreSlim _fileLock = new(1, 1);
+
+    // Paired with the guarded release below: a DI singleton disposed at process exit could otherwise
+    // release a disposed gate from a finally block and log an error on a clean shutdown.
+    private bool _disposed;
+
+    /// <summary>
+    /// Creates the service. <paramref name="configDir"/> is overridable so tests exercise the real
+    /// save/load paths against a temp directory — the same seam as <see cref="SpeedTestHistoryService"/>.
+    /// A <c>static readonly</c> path could not be redirected, because
+    /// <see cref="Environment.SpecialFolder.LocalApplicationData"/> resolves through the Win32
+    /// known-folder API and ignores the <c>LOCALAPPDATA</c> environment variable.
+    /// </summary>
+    public DiskScanHistoryService(string? configDir = null)
+    {
+        var dir = configDir ?? Path.Join(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager");
+        _historyPath = Path.Join(dir, "disk-scan-history.json");
+    }
+
+    private void ReleaseFileLock()
+    {
+        if (_disposed) return;
+        try { _fileLock.Release(); }
+        catch (ObjectDisposedException) { /* disposed mid-request at shutdown */ }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _fileLock.Dispose();
+    }
+
+    /// <summary>Every remembered snapshot, newest first. Empty on any error.</summary>
+    public async Task<IReadOnlyList<DiskScanSnapshot>> LoadAsync(CancellationToken ct = default)
+    {
+        await _fileLock.WaitAsync(ct).ConfigureAwait(false);
+        try { return await LoadCoreAsync(ct).ConfigureAwait(false); }
+        finally { ReleaseFileLock(); }
+    }
+
+    /// <summary>
+    /// The remembered snapshot for one root, or <c>null</c> if that root has never been scanned. Path
+    /// comparison is normalised so a trailing separator does not create a second entry for the same
+    /// folder.
+    /// </summary>
+    public async Task<DiskScanSnapshot?> FindAsync(string rootPath, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(rootPath)) return null;
+        var key = Normalize(rootPath);
+        await _fileLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var all = await LoadCoreAsync(ct).ConfigureAwait(false);
+            return all.FirstOrDefault(s => Normalize(s.RootPath) == key);
+        }
+        finally { ReleaseFileLock(); }
+    }
+
+    /// <summary>
+    /// Remembers <paramref name="snapshot"/> as the latest scan of its root, replacing any earlier one
+    /// for the same root and trimming to <see cref="MaxRoots"/>. Returns <c>true</c> when it reached
+    /// disk. Never throws to the caller — a failed write must not take the tab down — but reports the
+    /// outcome so a caller need not pretend it succeeded, the same contract
+    /// <see cref="SpeedTestHistoryService.SaveAsync"/> learned the hard way.
+    /// </summary>
+    public async Task<bool> SaveAsync(DiskScanSnapshot snapshot, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        var key = Normalize(snapshot.RootPath);
+
+        await _fileLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var all = (await LoadCoreAsync(ct).ConfigureAwait(false)).ToList();
+
+            // Upsert by root: the newest scan of a folder replaces the old one rather than accumulating.
+            all.RemoveAll(s => Normalize(s.RootPath) == key);
+
+            // Bound the payload: keep only the largest folders, and only their name + size.
+            snapshot.TopFolders = snapshot.TopFolders
+                .OrderByDescending(f => f.SizeBytes)
+                .Take(MaxFoldersPerRoot)
+                .ToList();
+            all.Add(snapshot);
+
+            var trimmed = all
+                .OrderByDescending(s => s.CapturedAt)
+                .Take(MaxRoots)
+                .ToList();
+
+            Directory.CreateDirectory(Path.GetDirectoryName(_historyPath)!);
+            var json = JsonSerializer.Serialize(trimmed, JsonOpts);
+            await AtomicFile.WriteAllTextAsync(_historyPath, json, ct).ConfigureAwait(false);
+            return true;
+        }
+        catch (IOException ex)
+        {
+            Log.Warning(ex, "Failed to save disk-scan history");
+            return false;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Log.Warning(ex, "Access denied saving disk-scan history");
+            return false;
+        }
+        finally
+        {
+            ReleaseFileLock();
+        }
+    }
+
+    /// <summary>Forgets all remembered scans. Returns <c>true</c> when the file is gone afterwards.</summary>
+    public async Task<bool> ClearAsync(CancellationToken ct = default)
+    {
+        await _fileLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (File.Exists(_historyPath))
+                File.Delete(_historyPath);
+            return true;
+        }
+        catch (IOException ex)
+        {
+            Log.Warning(ex, "Failed to clear disk-scan history");
+            return false;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Log.Warning(ex, "Access denied clearing disk-scan history");
+            return false;
+        }
+        finally
+        {
+            ReleaseFileLock();
+        }
+    }
+
+    /// <summary>Load without locking — called only from inside a locked section.</summary>
+    private async Task<IReadOnlyList<DiskScanSnapshot>> LoadCoreAsync(CancellationToken ct)
+    {
+        try
+        {
+            if (!File.Exists(_historyPath)) return [];
+
+            var json = await File.ReadAllTextAsync(_historyPath, ct).ConfigureAwait(false);
+            var entries = JsonSerializer.Deserialize<List<DiskScanSnapshot>>(json, JsonOpts);
+            if (entries is null) return [];
+
+            // A file that parses but omits TopFolders leaves that list null on the DTO; normalise so no
+            // caller has to null-check a collection that is documented as never-null.
+            foreach (var e in entries)
+                e.TopFolders ??= [];
+
+            return entries;
+        }
+        catch (IOException ex)
+        {
+            Log.Warning(ex, "Failed to load disk-scan history");
+            return [];
+        }
+        catch (JsonException ex)
+        {
+            Log.Warning(ex, "Failed to parse disk-scan history JSON");
+            return [];
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Log.Warning(ex, "Access denied loading disk-scan history");
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Case-insensitive path key with any trailing separator removed, so <c>C:\Data</c> and
+    /// <c>C:\Data\</c> are one root. Falls back to the raw trimmed string if the path is malformed —
+    /// a bad key still matches itself, which is all the lookup needs.
+    /// </summary>
+    private static string Normalize(string path)
+    {
+        var trimmed = path.Trim();
+        try { trimmed = Path.TrimEndingDirectorySeparator(Path.GetFullPath(trimmed)); }
+        catch (ArgumentException) { /* malformed path — key it by its raw text */ }
+        return trimmed.ToLowerInvariant();
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.72.1</Version>
-    <FileVersion>1.72.1.0</FileVersion>
-    <AssemblyVersion>1.72.1.0</AssemblyVersion>
+    <Version>1.73.0</Version>
+    <FileVersion>1.73.0.0</FileVersion>
+    <AssemblyVersion>1.73.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
@@ -21,6 +21,7 @@ namespace SysManager.ViewModels;
 public sealed partial class DiskAnalyzerViewModel : ViewModelBase
 {
     private readonly DiskAnalyzerService _service;
+    private readonly DiskScanHistoryService _history;
     private CancellationTokenSource? _cts;
 
     public BulkObservableCollection<DiskUsageEntry> Entries { get; } = new();
@@ -28,6 +29,15 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
 
     [ObservableProperty] private string _selectedPath = "";
     [ObservableProperty] private string _scanSummary = "Select a drive or folder and click Analyze.";
+
+    // The delta line: "3.2 GB larger than your last scan on 12 Jul", or empty when this root has no
+    // remembered scan yet. Explicitly "since last scan", never framed as continuous monitoring — the
+    // sampling is user-triggered and irregular. Empty string keeps the row collapsed (see the view).
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasTrend))]
+    private string _trendSummary = "";
+
+    public bool HasTrend => !string.IsNullOrEmpty(TrendSummary);
     [ObservableProperty] private long _totalSize;
     [ObservableProperty] private int _totalFiles;
     [ObservableProperty] private int _totalFolders;
@@ -75,9 +85,10 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
         ", plus any junction or symbolic link (following one would double-count, or lead outside the " +
         "folder you asked about).";
 
-    public DiskAnalyzerViewModel(DiskAnalyzerService service)
+    public DiskAnalyzerViewModel(DiskAnalyzerService service, DiskScanHistoryService history)
     {
         _service = service;
+        _history = history;
         // Probe drives off the UI thread: DriveInfo.IsReady can stall on a disconnected
         // mapped/removable volume. This tab is LAZY — NavItem.ContentFactory builds it on first open,
         // not at startup (the eager set is Dashboard, DarkMode and About; see the list above
@@ -134,6 +145,7 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
         IsBusy = true;
         IsProgressIndeterminate = true;
         StatusMessage = "Analyzing…";
+        TrendSummary = "";
         Entries.Clear();
         TotalSize = 0;
         TotalFiles = 0;
@@ -163,6 +175,7 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
                 ? "No subfolders found."
                 : string.Create(CultureInfo.InvariantCulture, $"{EntryCount} folders · {FormatSize(TotalSize)} total · {TotalFiles:N0} files");
             HasScanned = true;
+            await UpdateTrendAndRememberAsync(SelectedPath, ct).ConfigureAwait(true);
             StatusMessage = "Analysis complete.";
             ToastService.Instance.Show("Disk Analysis complete", $"{EntryCount} folders, {FormatSize(TotalSize)} total");
             Log.Information("Disk analysis completed: {Folders} folders, {Size} total",
@@ -186,6 +199,60 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
             IsProgressIndeterminate = false;
             CurrentFolder = "";
         }
+    }
+
+    /// <summary>
+    /// Reads the remembered scan of <paramref name="root"/> to show what changed, then remembers this
+    /// scan in its place. Deliberately swallows its own failures: the scan has already completed and its
+    /// results are on screen, so a history read/write problem must degrade to "no trend line", never to a
+    /// broken tab. That is the same never-throw-to-the-caller contract the history service keeps
+    /// internally; this is the second half of it, at the call site.
+    /// </summary>
+    private async Task UpdateTrendAndRememberAsync(string root, CancellationToken ct)
+    {
+        try
+        {
+            var previous = await _history.FindAsync(root, ct).ConfigureAwait(true);
+            TrendSummary = DescribeTrend(previous, TotalSize);
+
+            var snapshot = new DiskScanSnapshot
+            {
+                RootPath = root,
+                CapturedAt = DateTime.Now,
+                TotalSize = TotalSize,
+                TopFolders = Entries
+                    .Select(e => new FolderUsage { Name = e.Name, SizeBytes = e.SizeBytes })
+                    .ToList(),
+            };
+            await _history.SaveAsync(snapshot, ct).ConfigureAwait(true);
+        }
+        catch (OperationCanceledException)
+        {
+            // The tab closed between the scan finishing and this running — nothing to record.
+        }
+    }
+
+    /// <summary>
+    /// The one-line "since last scan" delta. Returns empty when this root has never been scanned, so a
+    /// first-ever scan shows no trend rather than a misleading "0 bytes larger". A change smaller than a
+    /// tenth of a percent reads as "about the same" rather than a spurious few-kilobyte delta.
+    /// </summary>
+    internal static string DescribeTrend(DiskScanSnapshot? previous, long currentTotal)
+    {
+        if (previous is null) return "";
+
+        var on = previous.CapturedAt.ToString("d MMM yyyy", CultureInfo.CurrentCulture);
+        var delta = currentTotal - previous.TotalSize;
+        var magnitude = Math.Abs(delta);
+
+        // Below 0.1% of the previous total (and at least a token 1 MB) counts as unchanged, so ordinary
+        // churn does not read as growth.
+        var threshold = Math.Max(1L * 1024 * 1024, previous.TotalSize / 1000);
+        if (magnitude < threshold)
+            return $"About the same as your last scan on {on}.";
+
+        var direction = delta > 0 ? "larger" : "smaller";
+        return $"{FormatSize(magnitude)} {direction} than your last scan on {on}.";
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -424,7 +424,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             [typeof(CleanupViewModel)] = new CleanupViewModel(runner),
             [typeof(DeepCleanupViewModel)] = new DeepCleanupViewModel(new DeepCleanupService(), new LargeFileScanner(), fixedDrives),
             [typeof(DuplicateFileViewModel)] = new DuplicateFileViewModel(new DuplicateFileService()),
-            [typeof(DiskAnalyzerViewModel)] = new DiskAnalyzerViewModel(new DiskAnalyzerService()),
+            [typeof(DiskAnalyzerViewModel)] = new DiskAnalyzerViewModel(new DiskAnalyzerService(), new DiskScanHistoryService()),
             [typeof(ProcessManagerViewModel)] = new ProcessManagerViewModel(new ProcessManagerService()),
             [typeof(BatteryHealthViewModel)] = new BatteryHealthViewModel(battery),
             [typeof(UninstallerViewModel)] = new UninstallerViewModel(new UninstallerService(runner)),

--- a/SysManager/SysManager/Views/DiskAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/DiskAnalyzerView.xaml
@@ -51,6 +51,12 @@
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
             <StackPanel>
                 <TextBlock Text="{Binding ScanSummary}" FontWeight="SemiBold" FontSize="13" Margin="0,0,0,6"/>
+                <!-- What changed since the last scan of this folder. Collapsed until there is a prior
+                     scan to compare against, so a first-ever scan shows nothing rather than a zero. -->
+                <TextBlock Text="{Binding TrendSummary}" FontSize="12" Margin="0,0,0,6"
+                           Foreground="{DynamicResource TextSecondary}"
+                           AutomationProperties.Name="Change since last scan"
+                           Visibility="{Binding HasTrend, Converter={StaticResource BoolToVis}}"/>
                 <!-- The total is partial BY DESIGN: four Windows system subtrees are skipped because they
                      are slow or unreadable, and junctions are never followed (following one would
                      double-count, or walk outside the folder that was asked about). WinSxS alone is


### PR DESCRIPTION
Closes #1591. The two storage tabs were the only features in the app that forgot everything on close, while eleven other JSON files under `%LocalAppData%\SysManager` remember theme, speed-test history, volume presets and more. Disk Analyzer is where that amnesia costs the most: a one-off "Downloads is 12 GB" answers nothing, but "3.2 GB larger than your last scan on 12 Jul" answers the persona's real question — "why is my disk filling up?".

### What's new

`DiskScanHistoryService`, modelled line-for-line on `SpeedTestHistoryService`: a `SemaphoreSlim` serialises the non-atomic load-modify-write, IO failures degrade to "no history" instead of throwing to the tab, and a `string? configDir` seam lets tests run against a temp directory. One snapshot per root (newest wins), capped at `MaxRoots` roots and `MaxFoldersPerRoot` folders each so drilling into many folders can't grow the file unbounded. Paths are normalised (case + trailing separator), so `C:\Data` and `C:\Data\` are one root.

`DiskAnalyzerViewModel` reads the remembered scan of the selected root to compute a delta, then remembers the new one. Both are best-effort — a history failure degrades to no delta, never a broken scan that already completed. The line reads "larger"/"smaller" with the date, "about the same" when the change is under 0.1% of the previous total (churn ≠ growth), or nothing for a first-ever scan (no "0 bytes larger").

### Two scope decisions, both defended

**Disk Analyzer only, not the Duplicate File tab.** The issue mentions both, but a duplicate-scan has no meaningful "delta" — a saved list of duplicate groups may name files the user already deleted, so persisting it would show *stale results*, not history. The trend value is entirely folder-size-over-time.

**Not added to Profile Export**, despite the issue proposing it. Folder paths and sizes are machine-specific; "Downloads is 3.2 GB bigger" carried to a fresh PC is meaningless. #1491 established that machine-specific state stays out of export, and I pinned this OUT by **extending that existing theory** — `disk-scan-history.json` is now an `InlineData` row in `AvailableSections_NeverCarriesMachineSpecificState` — rather than adding a parallel guard.

### Tests

The history service (round-trip, upsert-not-accumulate, path equivalence, root cap, folder cap, corrupt-file-degrades, clear-is-idempotent) and the delta wording (no-prior → empty, larger, smaller, negligible → "about the same", exact → "about the same"). `DescribeTrend` is `internal` so the branches are tested with no filesystem and no clock.

Nine mutations, each confirmed red for the right reason, tree restored byte-for-byte:

| mutation | caught by |
|---|---|
| first-ever scan invents a delta | `Trend_WithNoPriorScan_IsEmpty` |
| the "about the same" band collapses | both negligible/exact trend tests |
| the direction word is inverted | both larger/smaller trend tests |
| upsert accumulates instead of replacing | `Save_SameRootTwice_KeepsOnlyTheNewer` |
| path normalisation dropped | `Save_TreatsEquivalentPathsAsOneRoot` |
| root cap removed | `Save_BoundsRootsToTheCap_DroppingTheOldest` |
| per-root folder cap removed | `Save_BoundsFoldersPerRoot_KeepingTheLargest` |
| corrupt file allowed to throw | `Load_OnCorruptFile_DegradesToEmpty_DoesNotThrow` |
| file added to Profile Export | `AvailableSections_NeverCarriesMachineSpecificState` |

Local: all 4 projects build 0 warnings / 0 errors; 99 test names across the storage/profile/architecture suites run green (115 executions with name collisions); `dotnet format --verify-no-changes` clean; all three extracted CI gate bodies pass — 1.73.0 consistent, valid minor bump from v1.72.1, CHANGELOG lead present.

One process note: this branch was cut from v1.72.0 while the 1.72.1 fix (#1976) was still an open PR. I merged that first, then merged the new `main` into this branch and re-resolved the version to 1.73.0 above the 1.72.1 CHANGELOG entry — the serial-PR discipline, so the two don't collide on CHANGELOG/csproj at merge.

### Docs

README bullet (with the "since your last scan, stays on this PC" framing); `ARCHITECTURE.md` gains the service entry and the note that it's deliberately out of Profile Export; CHANGELOG 1.73.0; SECURITY.md supported line.
