### PR TITLE
feat: clear Firefox cookies and sessions, not just cache

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -332,7 +332,11 @@ Key services:
 - `BrowserCleanerService` — scans + cleans per-browser data (Chromium family +
   Firefox) under injectable LOCALAPPDATA/APPDATA roots. Scan is read-only (sizes);
   Clean deletes only discovered files, skips locked files, and never follows
-  reparse points. Cookies/sessions are flagged sensitive.
+  reparse points. Cookies/sessions are flagged sensitive. Firefox cache lives under
+  Local and its cookies/sessions under Roaming (like Opera's split); each targets
+  specific named files under the profile, never the profile root (logins.json, key4.db,
+  prefs.js, places.sqlite). Firefox History is intentionally NOT offered — places.sqlite
+  holds bookmarks as well as history.
 - `EdgeOneDriveService` — reversibly de-integrates Edge and OneDrive through the
   `IPowerShellRunner` seam plus injectable HKCU/HKLM roots. OneDrive is fully removed
   per-user (`OneDriveSetup.exe /uninstall` + nav-pane unpin, no elevation); Edge is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.0] - 2026-08-25
+
+Browser Cleaner now clears Firefox cookies and open-tab sessions, not just its cache. A Firefox user who
+opened this tab to clear browsing traces was, until now, only ever clearing cache — while the tab's own
+description promised the same categories it offers the other browsers.
+
+### Added
+- **Firefox: Cookies and Sessions can now be cleared**, alongside the cache it already handled. Both are
+  unticked by default and flagged "signs you out", the same as the Chrome/Edge/Brave/Opera cookie rows,
+  and each Firefox profile gets its own rows.
+
+### Notes
+- **Firefox History is deliberately not offered.** Firefox stores your history and your bookmarks in the
+  same file (`places.sqlite`), so a "clear history" would delete bookmarks too. Rather than do that
+  silently, the tab omits History for Firefox. Its cookies/sessions target only their own named files —
+  saved logins, keys, bookmarks and preferences are never touched.
+
 ## [1.74.0] - 2026-08-25
 
 The CPU Core Affinity process list is now filterable, and shows which processes are already pinned.

--- a/README.md
+++ b/README.md
@@ -724,6 +724,11 @@ Reclaim space and clear browsing traces, per browser:
 - **Per-category** with size shown: Cache, History, Cookies, Sessions
 - **Cookies/sessions are flagged and left unticked** by default — cleaning them
   signs you out, so it's always an explicit choice; cache and history are pre-selected
+- **Firefox gets cache, cookies and sessions — but not history, on purpose.** Firefox
+  keeps history and your bookmarks in the same file (`places.sqlite`), so clearing
+  "history" would delete your bookmarks with it. Rather than do that quietly, the tab
+  simply doesn't offer History for Firefox. Its cookies and sessions target only their
+  own named files — never saved logins, keys or bookmarks
 - **Confirmation with an impact summary** before anything is deleted
 - Per-user (no admin); locked files (browser open) are skipped, not forced, and
   symlinks/junctions are never followed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.74.x   | :white_check_mark: |
-| < 1.74   | :x:                |
+| 1.75.x   | :white_check_mark: |
+| < 1.75   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/BrowserCleanerServiceTests.cs
+++ b/SysManager/SysManager.Tests/BrowserCleanerServiceTests.cs
@@ -405,4 +405,98 @@ public sealed class BrowserCleanerServiceTests : IDisposable
         var cache = items.Single(i => i.Category == "Cache");
         Assert.True(cache.IsSelected);
     }
+
+    // ---------- Firefox parity: Cookies + Sessions, never credentials or bookmarks (#1590) ----------
+    // Firefox stores cookies/sessions in the ROAMING profile; cache is under Local. History is
+    // intentionally NOT offered because places.sqlite holds bookmarks too.
+
+    [Fact]
+    public async Task Scan_FirefoxCookies_TargetsTheSqliteFiles_NeverTheProfileRoot()
+    {
+        // A roaming profile with cookies + the credential/bookmark files that must never be touched.
+        WriteRoamingFile(@"Mozilla\Firefox\Profiles\abc.default-release\cookies.sqlite", 4096);
+        WriteRoamingFile(@"Mozilla\Firefox\Profiles\abc.default-release\cookies.sqlite-wal", 512);
+        WriteRoamingFile(@"Mozilla\Firefox\Profiles\abc.default-release\logins.json", 256);
+        WriteRoamingFile(@"Mozilla\Firefox\Profiles\abc.default-release\key4.db", 256);
+        WriteRoamingFile(@"Mozilla\Firefox\Profiles\abc.default-release\places.sqlite", 8192);
+        WriteRoamingFile(@"Mozilla\Firefox\Profiles\abc.default-release\prefs.js", 128);
+
+        var items = await _svc.ScanAsync();
+        var cookies = items.FirstOrDefault(i => i.Browser == "Firefox" && i.Category == "Cookies");
+
+        Assert.NotNull(cookies);
+        // Only the two cookie files that exist are sized (4096 + 512); the -shm is absent.
+        Assert.Equal(4096 + 512, cookies!.SizeBytes);
+        // The credential store, the key database, bookmarks/history and prefs are NEVER in the paths.
+        Assert.All(cookies.Paths, p =>
+        {
+            Assert.DoesNotContain("logins.json", p, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("key4.db", p, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("places.sqlite", p, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("prefs.js", p, StringComparison.OrdinalIgnoreCase);
+        });
+        // Sensitive -> unticked by default (opt-in), like the Chromium cookie rows.
+        Assert.True(cookies.IsSensitive);
+        Assert.False(cookies.IsSelected);
+    }
+
+    [Fact]
+    public async Task Scan_FirefoxSessions_TargetsSessionFilesOnly()
+    {
+        WriteRoamingFile(@"Mozilla\Firefox\Profiles\abc.default-release\sessionstore.jsonlz4", 2048);
+        WriteRoamingFile(@"Mozilla\Firefox\Profiles\abc.default-release\sessionstore-backups\recovery.jsonlz4", 1024);
+        WriteRoamingFile(@"Mozilla\Firefox\Profiles\abc.default-release\logins.json", 256);
+
+        var items = await _svc.ScanAsync();
+        var sessions = items.FirstOrDefault(i => i.Browser == "Firefox" && i.Category == "Sessions");
+
+        Assert.NotNull(sessions);
+        Assert.Equal(2048 + 1024, sessions!.SizeBytes);
+        Assert.All(sessions.Paths, p => Assert.DoesNotContain("logins.json", p, StringComparison.OrdinalIgnoreCase));
+        Assert.True(sessions.IsSensitive);
+    }
+
+    [Fact]
+    public async Task Scan_Firefox_NeverOffersHistory_BecausePlacesSqliteHoldsBookmarks()
+    {
+        // places.sqlite present, but there must be no History row for Firefox — deleting it would
+        // drop the user's bookmarks along with history.
+        WriteRoamingFile(@"Mozilla\Firefox\Profiles\abc.default-release\places.sqlite", 8192);
+        WriteRoamingFile(@"Mozilla\Firefox\Profiles\abc.default-release\cookies.sqlite", 1024);
+
+        var items = await _svc.ScanAsync();
+
+        Assert.DoesNotContain(items, i => i.Browser == "Firefox" && i.Category == "History");
+    }
+
+    [Fact]
+    public async Task Clean_FirefoxCookies_RemovesCookiesButLeavesCredentialsAndBookmarks()
+    {
+        WriteRoamingFile(@"Mozilla\Firefox\Profiles\abc.default-release\cookies.sqlite", 4096);
+        WriteRoamingFile(@"Mozilla\Firefox\Profiles\abc.default-release\logins.json", 256);
+        WriteRoamingFile(@"Mozilla\Firefox\Profiles\abc.default-release\key4.db", 256);
+        WriteRoamingFile(@"Mozilla\Firefox\Profiles\abc.default-release\places.sqlite", 8192);
+
+        var items = await _svc.ScanAsync();
+        var cookies = items.First(i => i.Browser == "Firefox" && i.Category == "Cookies");
+        await _svc.CleanAsync([cookies]);
+
+        var profile = Path.Combine(_roaming, @"Mozilla\Firefox\Profiles\abc.default-release");
+        Assert.False(File.Exists(Path.Combine(profile, "cookies.sqlite")));   // cleaned
+        Assert.True(File.Exists(Path.Combine(profile, "logins.json")));       // saved logins untouched
+        Assert.True(File.Exists(Path.Combine(profile, "key4.db")));           // key database untouched
+        Assert.True(File.Exists(Path.Combine(profile, "places.sqlite")));     // history + bookmarks untouched
+    }
+
+    [Fact]
+    public async Task Scan_FirefoxMultipleProfiles_EachGetsCookiesAndSessions()
+    {
+        WriteRoamingFile(@"Mozilla\Firefox\Profiles\aaa.default-release\cookies.sqlite", 1024);
+        WriteRoamingFile(@"Mozilla\Firefox\Profiles\bbb.dev-edition\cookies.sqlite", 2048);
+
+        var items = await _svc.ScanAsync();
+        var cookieRows = items.Where(i => i.Browser == "Firefox" && i.Category == "Cookies").ToList();
+
+        Assert.Equal(2, cookieRows.Count);   // one per profile, like the Chromium per-profile expansion
+    }
 }

--- a/SysManager/SysManager/Services/BrowserCleanerService.cs
+++ b/SysManager/SysManager/Services/BrowserCleanerService.cs
@@ -152,7 +152,54 @@ public sealed class BrowserCleanerService
         // are expanded at scan time (see ExpandFirefoxCachePaths).
         foreach (var cachePath in ExpandFirefoxCachePaths())
             defs.Add(new("Firefox", "Cache", "Cached images and files.", false, [cachePath]));
+        // Cookies and Sessions live under the ROAMING profile. Until now Firefox got a Cache row and
+        // nothing else, so a Firefox user clearing "browsing traces" cleared none of them, while the
+        // tab's header promised parity with the Chromium browsers. History is deliberately NOT offered:
+        // Firefox stores history and BOOKMARKS in the same places.sqlite, so a "clear history" that
+        // silently dropped bookmarks would be worse than the gap it fills. Chromium keeps them separate,
+        // which is why History is safe there and not here.
+        defs.AddRange(ExpandFirefoxDataDefs());
         return defs;
+    }
+
+    /// <summary>
+    /// One Cookies def and one Sessions def per Firefox profile, targeting SPECIFIC named files under
+    /// the roaming profile — never the profile root, which holds <c>logins.json</c>, <c>key4.db</c>,
+    /// <c>prefs.js</c> and <c>places.sqlite</c> (history AND bookmarks). Same safety invariant as
+    /// <see cref="ExpandFirefoxCachePaths"/>, and the same roaming split Opera already uses.
+    /// <para>Sensitive on both, so they are unticked by default and carry the "signs you out" badge, the
+    /// same treatment the Chromium Cookies/Sessions rows get. History is intentionally absent — see
+    /// <see cref="BuildDefs"/>.</para>
+    /// </summary>
+    private IEnumerable<Def> ExpandFirefoxDataDefs()
+    {
+        const string profilesRel = @"Mozilla\Firefox\Profiles";
+        var profilesAbs = Path.Combine(_roamingAppData, profilesRel);
+        if (!Directory.Exists(profilesAbs) || IsReparsePoint(profilesAbs)) yield break;
+
+        string[] profileDirs;
+        try { profileDirs = Directory.GetDirectories(profilesAbs); }
+        catch (IOException) { yield break; }
+        catch (UnauthorizedAccessException) { yield break; }
+
+        foreach (var dir in profileDirs)
+        {
+            var profileRel = Path.Combine(profilesRel, Path.GetFileName(dir));
+
+            // Cookies: the sqlite database and its write-ahead/shared-memory sidecars. Named files
+            // only — the profile root is never a target.
+            yield return new("Firefox", "Cookies",
+                "Cookies — clearing these signs you out of websites.", true,
+                [Path.Combine(profileRel, "cookies.sqlite"),
+                 Path.Combine(profileRel, "cookies.sqlite-wal"),
+                 Path.Combine(profileRel, "cookies.sqlite-shm")], Roaming: true);
+
+            // Sessions: the current session file and the backups folder that restores open tabs.
+            yield return new("Firefox", "Sessions",
+                "Open tabs / session restore data.", true,
+                [Path.Combine(profileRel, "sessionstore.jsonlz4"),
+                 Path.Combine(profileRel, "sessionstore-backups")], Roaming: true);
+        }
     }
 
     /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.74.0</Version>
-    <FileVersion>1.74.0.0</FileVersion>
-    <AssemblyVersion>1.74.0.0</AssemblyVersion>
+    <Version>1.75.0</Version>
+    <FileVersion>1.75.0.0</FileVersion>
+    <AssemblyVersion>1.75.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #1590. Every Chromium browser got four categories and Opera four, but Firefox got exactly one — **Cache**. A Firefox user who opened Browser Cleaner to clear browsing traces cleared none of them, while the tab header and README promised the same categories offered to the others.

### What changed

Firefox cookies and sessions live under the **roaming** profile (its cache is under Local) — the same local/roaming split Opera already models. `ExpandFirefoxDataDefs` enumerates roaming profiles and yields, per profile:

- **Cookies** — `cookies.sqlite` (+ `-wal`, `-shm`), sensitive.
- **Sessions** — `sessionstore.jsonlz4` + the `sessionstore-backups` folder, sensitive.

Both target only their own named files — **never the profile root** (`logins.json`, `key4.db`, `prefs.js`, `places.sqlite`) — the same safety invariant `ExpandFirefoxCachePaths` already keeps. Sensitive on both, so unticked by default with the "signs you out" badge, exactly like the Chromium rows. Each Firefox profile gets its own rows.

### History is deliberately omitted for Firefox

Firefox stores history **and bookmarks** in one file (`places.sqlite`), so a "clear history" would delete bookmarks with it. Chromium keeps them separate, which is why History is safe there and omitted here. Rather than quietly drop bookmarks, the tab doesn't offer Firefox History at all — and the README/ARCHITECTURE now say so instead of the blanket "History, Cookies, Sessions" claim that didn't hold for Firefox.

I scoped this to Cookies + Sessions (the issue's safe recommendation) rather than shipping a flagged History row, because the persona-safest outcome is that a maintenance tool never has a path to delete bookmarks, even a confirmed one.

### Tests

5 new + the existing cache test still green. Five mutations, each confirmed red for the right reason, tree restored byte-for-byte:

| mutation | caught by |
|---|---|
| data defs never wired in (the cache-only bug) | cookies + sessions scan tests |
| cookies point at the profile ROOT (credential/bookmark leak) | `..._NeverTheProfileRoot` |
| History offered for Firefox | `..._NeverOffersHistory_BecausePlacesSqliteHoldsBookmarks` |
| cookies read from Local not Roaming (finds nothing) | `..._NeverTheProfileRoot` |
| cookies not flagged sensitive (pre-selected) | `..._NeverTheProfileRoot` |

The Clean test is the load-bearing one: it removes `cookies.sqlite` and asserts `logins.json`, `key4.db` and `places.sqlite` all survive.

Local: all 4 projects build 0 warnings / 0 errors; 75 test names across the browser + architecture suites run green (80 executions); `dotnet format --verify-no-changes` clean; all three extracted CI gate bodies pass — 1.75.0 consistent, valid minor bump from v1.74.0, CHANGELOG lead present.

### Deliberately not in scope

The issue also floated a per-item sensitive-badge (a bespoke "clearing this also removes your bookmarks" message). Since History is omitted, that wording has nothing to attach to, and the existing shared "signs you out" badge already fits cookies/sessions exactly as it does for the other browsers. Left as-is to keep this a clean parity change rather than a badge refactor.

### Docs

README Firefox bullet + ARCHITECTURE service entry (the local/roaming split and the no-History rationale); CHANGELOG 1.75.0; SECURITY.md supported line.
