### PR TITLE
refactor: project Firefox profile paths with Select to satisfy missed-select

### DIFF
--- a/SysManager/SysManager/Services/BrowserCleanerService.cs
+++ b/SysManager/SysManager/Services/BrowserCleanerService.cs
@@ -182,10 +182,10 @@ public sealed class BrowserCleanerService
         catch (IOException) { yield break; }
         catch (UnauthorizedAccessException) { yield break; }
 
-        foreach (var dir in profileDirs)
+        // Project each profile dir to its relative path up front, so the loop body just yields the
+        // two defs it builds from that path (and CodeQL's missed-select does not flag the map).
+        foreach (var profileRel in profileDirs.Select(d => Path.Combine(profilesRel, Path.GetFileName(d))))
         {
-            var profileRel = Path.Combine(profilesRel, Path.GetFileName(dir));
-
             // Cookies: the sqlite database and its write-ahead/shared-memory sidecars. Named files
             // only — the profile root is never a target.
             yield return new("Firefox", "Cookies",


### PR DESCRIPTION
No behavior change. `ExpandFirefoxDataDefs` (added in 1.75.0, #1590) opened its loop with an intermediate `var profileRel = Path.Combine(...)` as the first statement, which CodeQL's `cs/linq/missed-select` flagged (alert #1725, introduced by that PR — the sibling `ExpandFirefoxCachePaths`, a direct yield with no intermediate variable, was never flagged).

The loop yields **two** defs per profile, so a literal `.Select()` mapping doesn't apply — but moving the map into the loop's source, `foreach (var profileRel in profileDirs.Select(d => Path.Combine(profilesRel, Path.GetFileName(d))))`, removes the flagged intermediate and reads more directly. The two `yield return`s are unchanged.

Behaviour-identical guarantee: same defs, same order — all five #1590 Firefox tests stay green (cookies / sessions / history-omitted / clean-keeps-credentials-and-bookmarks / multi-profile). `refactor:`, so no version bump, no CHANGELOG, no release.

Fixing it because I introduced the alert in this run — keeping CodeQL from creeping up on my own watch (it had ticked 40 → 41).