### PR TITLE
fix: capture each process's original CPU affinity once so Restore really reverts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.1] - 2026-08-26
+
+"Restore original cores" on the CPU Core Affinity tab could report success while putting nothing back.
+If you pinned a process and then refreshed the list, Restore quietly re-applied the cores you had just
+pinned instead of the ones the process started with — and still said it had restored them.
+
+### Fixed
+- **CPU Core Affinity: Restore now really returns a process to the cores it started on.** The tab
+  remembered "original cores" in a single slot that was re-read every time a process was selected, so
+  refreshing the list after pinning overwrote the remembered value with the pinned one. Restore then
+  wrote that same mask back — a no-op reported as a success. Each process's starting affinity is now
+  captured once, the first time the tab sees it, and kept for the rest of the session. Two related
+  edges are covered as well: the remembered value survives a refresh (so the button no longer
+  disappears), and Restore is not offered at all for a process whose affinity could not be read,
+  rather than being offered for a restore that would do nothing.
+
 ## [1.75.0] - 2026-08-25
 
 Browser Cleaner now clears Firefox cookies and open-tab sessions, not just its cache. A Firefox user who

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -4276,4 +4276,80 @@ public partial class ArchitectureTests
         throw new DirectoryNotFoundException(
             "Could not locate the SysManager app project from " + AppContext.BaseDirectory);
     }
+
+    /// <summary>
+    /// A revert baseline may not be captured inside a selection-changed handler with a plain
+    /// assignment. That is precisely how "Restore original cores" became a no-op that reported
+    /// success: <c>OnSelectedProcessChanged</c> re-read the live affinity into a single
+    /// <c>_originalMask</c> field, so refreshing the list after a pin overwrote the remembered value
+    /// with the pinned one — and the refresh re-selects the same process on purpose, to preserve the
+    /// selection. The two safe shapes are a keyed capture-once (<c>TryAdd</c> into a dictionary) or a
+    /// capture taken in the command that performs the change, immediately before it.
+    /// <para>Assignments that CLEAR the baseline are fine — forgetting is not re-baselining — as is
+    /// any assignment outside a change handler.</para>
+    /// </summary>
+    [Fact]
+    public void NoRevertBaseline_IsRecapturedInASelectionChangedHandler()
+    {
+        var vmDir = Path.Combine(FindAppProjectDir(), "ViewModels");
+        var handlersScanned = 0;
+
+        foreach (var path in Directory.EnumerateFiles(vmDir, "*ViewModel.cs").OrderBy(p => p, StringComparer.Ordinal))
+        {
+            // Comments stripped: the field this rule exists for documents the rule at its declaration,
+            // so a guard reading prose would pass on code that does the wrong thing.
+            var code = WithoutComments(File.ReadAllText(path));
+            var file = Path.GetFileName(path);
+
+            foreach (var handler in ChangeHandler().Matches(code).Cast<Match>())
+            {
+                var slice = MemberSlice(code, handler.Value);
+                if (string.IsNullOrWhiteSpace(slice)) continue;
+
+                // MemberSlice ends at the next private/public/internal/protected/doc-comment line, and
+                // `partial void` is none of those — so a run of consecutive change handlers would slice
+                // as one block and attribute a later handler's assignment to the first. Cut at the next
+                // handler declaration inside the slice.
+                var next = ChangeHandler().Match(slice, handler.Value.Length);
+                if (next.Success) slice = slice[..next.Index];
+                handlersScanned++;
+
+                foreach (var write in BaselineAssignment().Matches(slice).Cast<Match>())
+                {
+                    var rhs = write.Groups["rhs"].Value.Trim();
+
+                    // Clearing is allowed; so is assigning from another field of the same kind
+                    // (moving a baseline around, not re-reading the world).
+                    if (rhs is "null" or "default") continue;
+
+                    Assert.Fail(
+                        $"{file}: {handler.Value.Trim()} assigns the revert baseline "
+                        + $"'{write.Groups["target"].Value}' from '{rhs}'. A change handler runs again when the "
+                        + "list is refreshed and the same item is re-selected, so this overwrites the value a "
+                        + "Restore/Revert is supposed to return to — the command then re-applies the state the "
+                        + "user wanted to leave and reports success. Capture it once per item (TryAdd into a "
+                        + "dictionary keyed by identity) or capture it in the command that makes the change.");
+                }
+            }
+        }
+
+        // Vacuity floor: this guard is worthless if the patterns match nothing. The view models carry
+        // dozens of generated change handlers, so a collapse to zero means the shape drifted.
+        Assert.True(handlersScanned >= 40,
+            $"only {handlersScanned} change handlers were sliced — the handler pattern no longer matches "
+            + "the generated shape, so this guard is passing without reading any of them.");
+    }
+
+    /// <summary>Matches a generated <c>partial void On…Changed</c> declaration.</summary>
+    [GeneratedRegex(@"partial void On\w+Changed\([^)]*\)")]
+    private static partial Regex ChangeHandler();
+
+    /// <summary>
+    /// Matches an assignment to a field whose name marks it as a revert baseline. Deliberately
+    /// name-based: what makes a field a baseline is that a Restore/Revert reads it, which no
+    /// structural pattern can see from the assignment alone.
+    /// </summary>
+    [GeneratedRegex(@"(?<target>_(?:original|previous|baseline|before|prior)\w*)\s*=\s*(?<rhs>[^;]+);")]
+    private static partial Regex BaselineAssignment();
+
 }

--- a/SysManager/SysManager.Tests/CpuAffinityViewModelTests.cs
+++ b/SysManager/SysManager.Tests/CpuAffinityViewModelTests.cs
@@ -450,4 +450,130 @@ public class CpuAffinityViewModelTests
         var all = new RunningProcess(7, "proc", CpuAffinityService.AllCoresMask(Environment.ProcessorCount));
         Assert.Equal("proc (7)", all.PinnedDisplay);
     }
+
+    // ---------- Restore must target the TRUE original, not a re-baselined one ----------
+    // OnSelectedProcessChanged used to read the live mask into a single _originalMask field, so a
+    // Refresh after Apply re-baselined "original" to the mask the user had just pinned. Restore then
+    // wrote that same value back and still reported "Restored … to its original cores" — the button
+    // did nothing and said it worked. Before the selection-preserving Refresh, a refresh nulled the
+    // selection and Restore went disabled, which hid the defect rather than fixing it.
+
+    /// <summary>
+    /// A fake whose <c>GetAffinity</c> and <c>GetProcesses</c> reflect whatever <c>TrySetAffinity</c>
+    /// last wrote, so "the live mask changed because we pinned it" is modelled instead of assumed.
+    /// <paramref name="live"/> is a one-element box holding the current mask; <paramref name="writes"/>
+    /// records every applied mask in order.
+    /// </summary>
+    private static ICpuAffinityService LiveMaskService(int pid, string name, long[] live, List<long> writes)
+    {
+        var service = Substitute.For<ICpuAffinityService>();
+        service.LogicalProcessorCount.Returns(4);
+        service.GetCores().Returns(new List<CpuCore>
+        {
+            new(0, 0, "Standard"), new(1, 0, "Standard"),
+            new(2, 0, "Standard"), new(3, 0, "Standard"),
+        });
+        service.GetProcesses().Returns(_ => new List<RunningProcess> { new(pid, name, live[0]) });
+        service.GetAffinity(pid).Returns(_ => live[0]);
+        service.TrySetAffinity(pid, Arg.Any<long>(), out Arg.Any<string>())
+               .Returns(ci =>
+               {
+                   live[0] = (long)ci[1];
+                   writes.Add(live[0]);
+                   ci[2] = string.Empty;
+                   return true;
+               });
+        return service;
+    }
+
+    [Fact]
+    public async Task Restore_AfterApplyThenRefresh_WritesTheTrueOriginal_NotThePinnedMask()
+    {
+        const long allFour = 0b1111;
+        long[] live = [allFour];
+        var writes = new List<long>();
+        var vm = NewVm(LiveMaskService(4242, "game", live, writes));
+        vm.SelectedProcess = vm.Processes.First(p => p.ProcessId == 4242);
+
+        foreach (var c in vm.Cores) c.IsSelected = c.Index == 0;
+        vm.ApplyCommand.Execute(null);
+        Assert.Equal(0b0001, writes[^1]);
+
+        // The refresh that preserves the selection — this is what re-baselined "original".
+        await vm.RefreshProcessesCommand.ExecuteAsync(null);
+
+        Assert.True(vm.RestoreCommand.CanExecute(null));
+        vm.RestoreCommand.Execute(null);
+
+        // All four cores must come back. Before the fix this wrote 0b0001 — the pinned mask — so
+        // Restore was a no-op that still claimed success.
+        Assert.Equal(allFour, writes[^1]);
+        Assert.Equal(allFour, live[0]);
+        Assert.Contains("original cores", vm.StatusMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Restore_StaysAvailableAcrossARefresh()
+    {
+        // Companion to the above: the captured original must survive a refresh, so the button is
+        // still offered rather than silently disappearing.
+        long[] live = [0b1111];
+        var vm = NewVm(LiveMaskService(4242, "game", live, new List<long>()));
+        vm.SelectedProcess = vm.Processes.First(p => p.ProcessId == 4242);
+        Assert.True(vm.RestoreCommand.CanExecute(null));
+
+        await vm.RefreshProcessesCommand.ExecuteAsync(null);
+
+        Assert.True(vm.RestoreCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void Restore_WhenTheAffinityCouldNotBeRead_IsNotOffered()
+    {
+        // A protected or exiting process returns no mask, so nothing gets captured. The button must
+        // stay disabled rather than being offered for a restore that would silently do nothing —
+        // "selected" is not the same as "we know what to put back".
+        var service = Substitute.For<ICpuAffinityService>();
+        service.LogicalProcessorCount.Returns(4);
+        service.GetCores().Returns(new List<CpuCore>
+        {
+            new(0, 0, "Standard"), new(1, 0, "Standard"),
+            new(2, 0, "Standard"), new(3, 0, "Standard"),
+        });
+        service.GetProcesses().Returns(new List<RunningProcess> { new(4242, "protected", 0) });
+        service.GetAffinity(4242).Returns((long?)null);
+
+        var vm = NewVm(service);
+        vm.SelectedProcess = vm.Processes.Single(p => p.ProcessId == 4242);
+
+        Assert.NotNull(vm.SelectedProcess);
+        Assert.True(vm.ApplyCommand.CanExecute(null));    // pinning is still allowed
+        Assert.False(vm.RestoreCommand.CanExecute(null)); // restoring is not
+    }
+
+    [Fact]
+    public void Restore_WhenAPidIsReused_UsesTheNewProcessOwnOriginal()
+    {
+        // Windows reuses pids, so the captured original is keyed on pid AND name. A different
+        // process that lands on a pid SysManager already pinned must be restored to what IT had,
+        // never to the previous tenant's affinity.
+        const long allFour = 0b1111;
+        long[] live = [allFour];
+        var writes = new List<long>();
+        var vm = NewVm(LiveMaskService(4242, "game", live, writes));
+
+        vm.SelectedProcess = vm.Processes.First(p => p.ProcessId == 4242);
+        foreach (var c in vm.Cores) c.IsSelected = c.Index == 0;
+        vm.ApplyCommand.Execute(null);
+        Assert.Equal(0b0001, live[0]);
+
+        // "game" exits; an unrelated process is handed the same pid, inheriting the live mask.
+        vm.SelectedProcess = new RunningProcess(4242, "other.exe", live[0]);
+        Assert.True(vm.RestoreCommand.CanExecute(null));
+        vm.RestoreCommand.Execute(null);
+
+        // Its own original is 0b0001, the mask it was seen with. Keyed on the pid alone this would
+        // have written 0b1111 and handed a stranger the old process's cores.
+        Assert.Equal(0b0001, writes[^1]);
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.0</Version>
-    <FileVersion>1.75.0.0</FileVersion>
-    <AssemblyVersion>1.75.0.0</AssemblyVersion>
+    <Version>1.75.1</Version>
+    <FileVersion>1.75.1.0</FileVersion>
+    <AssemblyVersion>1.75.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/CpuAffinityViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CpuAffinityViewModel.cs
@@ -30,8 +30,18 @@ public sealed partial class CoreToggle : ObservableObject
 public sealed partial class CpuAffinityViewModel : ViewModelBase
 {
     private readonly ICpuAffinityService _service;
-    private long _originalMask;
-    private bool _hasOriginal;
+
+    /// <summary>
+    /// The affinity each process had when SysManager FIRST saw it this session, keyed by pid+name.
+    /// Captured once and never overwritten, which is the entire point: this used to be a single field
+    /// re-read on every selection change, so a Refresh after Apply re-baselined "original" to the mask
+    /// the user had just pinned — Restore then wrote the pinned value back and still reported
+    /// "Restored … to its original cores". Keyed on the name as well as the pid because Windows reuses
+    /// pids: a recycled pid is a different process and must not inherit the old one's original mask.
+    /// <para>One entry per process the user actually selects, so it is bounded by clicks rather than by
+    /// the process list; a refresh re-selecting the same process adds nothing.</para>
+    /// </summary>
+    private readonly Dictionary<(int Pid, string Name), long> _originalMasks = [];
 
     // The full list; Processes is the filtered view the picker binds. Kept separate so typing in the
     // filter never loses a process, exactly as ServicesViewModel keeps _allServices behind Services.
@@ -120,19 +130,30 @@ public sealed partial class CpuAffinityViewModel : ViewModelBase
 
     partial void OnSelectedProcessChanged(RunningProcess? value)
     {
-        _hasOriginal = false;
-        if (value is null) return;
+        if (value is null)
+        {
+            ApplyCommand.NotifyCanExecuteChanged();
+            RestoreCommand.NotifyCanExecuteChanged();
+            return;
+        }
 
         long? mask = _service.GetAffinity(value.ProcessId);
         if (mask is { } m)
         {
-            _originalMask = m;
-            _hasOriginal = true;
+            // Capture the original ONCE per process. TryAdd, not an assignment: re-selecting a process
+            // — which a Refresh now does automatically to preserve the selection — must not treat the
+            // mask SysManager itself just applied as the value to restore to.
+            _originalMasks.TryAdd(OriginalKey(value), m);
+
+            // The checkboxes always mirror the LIVE mask, so the grid shows what is true right now.
+            // Only the restore target is remembered.
             foreach (var c in Cores) c.IsSelected = CpuAffinityService.IsCoreInMask(m, c.Index);
         }
         ApplyCommand.NotifyCanExecuteChanged();
         RestoreCommand.NotifyCanExecuteChanged();
     }
+
+    private static (int Pid, string Name) OriginalKey(RunningProcess p) => (p.ProcessId, p.Name);
 
     private bool HasSelection => SelectedProcess is not null;
 
@@ -154,16 +175,19 @@ public sealed partial class CpuAffinityViewModel : ViewModelBase
         }
     }
 
-    private bool CanRestore => SelectedProcess is not null && _hasOriginal;
+    private bool CanRestore =>
+        SelectedProcess is not null && _originalMasks.ContainsKey(OriginalKey(SelectedProcess));
 
     [RelayCommand(CanExecute = nameof(CanRestore))]
     private void Restore()
     {
         var proc = SelectedProcess;
-        if (proc is null || !_hasOriginal) return;
-        if (_service.TrySetAffinity(proc.ProcessId, _originalMask, out string error))
+        if (proc is null) return;
+        if (!_originalMasks.TryGetValue(OriginalKey(proc), out long original)) return;
+
+        if (_service.TrySetAffinity(proc.ProcessId, original, out string error))
         {
-            foreach (var c in Cores) c.IsSelected = CpuAffinityService.IsCoreInMask(_originalMask, c.Index);
+            foreach (var c in Cores) c.IsSelected = CpuAffinityService.IsCoreInMask(original, c.Index);
             StatusMessage = $"Restored {proc.Name} to its original cores.";
         }
         else


### PR DESCRIPTION
## Problem

Found by an audit of the CPU Core Affinity tab. "Restore original cores" could report success while
putting nothing back.

`OnSelectedProcessChanged` read the process's live affinity into a single `_originalMask` field, so
"original" was re-derived every time a process was selected. The process list's Refresh deliberately
re-selects the same process to preserve the user's selection (added in v1.74.0), which fires that
handler — so refreshing after a pin overwrote the remembered original with the mask that had just
been applied. `Restore` then wrote that same value back and still reported
`"Restored {Name} to its original cores."`

The wrong capture predates the selection-preserving refresh; before it, a refresh nulled the
selection so `CanRestore` went false and the button was merely *disabled*. That hid the defect
rather than fixing it — and preserving the selection turned a disabled button into a confidently
wrong one.

## Fix

`_originalMask`/`_hasOriginal` are replaced by a `Dictionary<(int Pid, string Name), long>` filled
with `TryAdd`, so a process's starting affinity is captured **once**, the first time the tab sees it,
and never overwritten. The key carries the name as well as the pid because Windows reuses pids: a
recycled pid is a different process and must not inherit the previous tenant's affinity. The
checkboxes still mirror the **live** mask, so the grid keeps showing what is true right now; only the
restore target is remembered. `CanRestore` now asks whether an original was actually captured, which
also closes the case where the affinity could not be read at all.

One entry per process the user actually selects, so the dictionary is bounded by clicks rather than
by the process list; a refresh re-selecting the same process adds nothing.

## Regression test — red before, green after

Four tests in `CpuAffinityViewModelTests`, driven by a fake whose `GetAffinity` reflects whatever
`TrySetAffinity` last wrote, so "the live mask changed because we pinned it" is modelled instead of
assumed. Each mutation below **compiled** and flipped exactly its target test:

| Mutation | Test that went red | Failure |
|---|---|---|
| `TryAdd` → indexer assignment (re-baseline every selection) | `Restore_AfterApplyThenRefresh_WritesTheTrueOriginal_NotThePinnedMask` | `Expected: 15, Actual: 1` — the pinned mask written back |
| Key on the pid alone, ignoring the name | `Restore_WhenAPidIsReused_UsesTheNewProcessOwnOriginal` | `Expected: 1, Actual: 15` — the old tenant's cores |
| Drop the captured-original check from `CanRestore` | `Restore_WhenTheAffinityCouldNotBeRead_IsNotOffered` | `Assert.False() Expected: False, Actual: True` |

`Restore_StaysAvailableAcrossARefresh` is a companion assertion (the button must not vanish); no
mutation here removes it, so it is stated as coverage rather than as an independently killed case.

## Guard against the class

`ArchitectureTests.NoRevertBaseline_IsRecapturedInASelectionChangedHandler` fails any view model that
assigns a `_original*` / `_previous*` / `_baseline*` / `_before*` / `_prior*` field inside a generated
`On…Changed` handler from anything other than `null`/`default`. Proven the same way: reintroducing the
exact pre-fix shape makes it red, naming the field and the handler, and breaking its vacuity floor
makes it red too (84 change handlers are really sliced against a floor of 40). It trims each slice at
the next handler declaration locally, because the shared `NextMemberDeclaration` helper does not break
on `partial void`.

## Propagate check

Every view model with a Restore/Revert/Undo command was read. `DisplayProfileViewModel` captures
`_previousMode` inside `ApplyAsync`, immediately before the change, and clears it on Keep/Revert — the
safe shape. `EnvironmentVariablesViewModel` already keys `_baseline`/`_originals` per variable. No other
single-slot re-read capture exists, which is what the new guard now enforces.

## Verification

- All four projects build Release with 0 warnings / 0 errors.
- `dotnet format --verify-no-changes` clean on all four.
- 94 green across `ArchitectureTests` + `CpuAffinityViewModelTests`; the only reds are the throwaway
  runner's own artifacts (its source-locator needs the assembly under `SysManager.Tests/bin`, and the
  header guard flags the runner file itself), never committed.
- Version consistency, valid-bump (v1.75.0 → 1.75.1, patch) and CHANGELOG plain-English lead gates run
  locally and pass.

Closes #1987


