### PR TITLE
test: replace four section comments that cited an internal review codename

### DIFF
--- a/SysManager/SysManager.Tests/AppBlockerServiceRegistryTests.cs
+++ b/SysManager/SysManager.Tests/AppBlockerServiceRegistryTests.cs
@@ -110,7 +110,7 @@ public sealed class AppBlockerServiceRegistryTests : IDisposable
         Assert.Equal(@"C:\Tools\dbg.exe", ReadDebugger("external.exe"));
     }
 
-    // ── Ultra-audit fix: never let App Blocker block SysManager itself ─────────
+    // ── Never let App Blocker block SysManager itself ──────────────────────────
     //
     // An IFEO block on our own exe is unrecoverable in-app (UnblockApp needs the app running,
     // but the next launch is redirected to the non-existent blocker path and fails) — the same

--- a/SysManager/SysManager.Tests/GamingProfileServiceTests.cs
+++ b/SysManager/SysManager.Tests/GamingProfileServiceTests.cs
@@ -485,7 +485,7 @@ public class GamingProfileServiceTests
         finally { if (File.Exists(path)) File.Delete(path); }
     }
 
-    // ── Ultra-audit fix: RecoverPendingAsync must serialize on _gate ───────────
+    // ── RecoverPendingAsync must serialize on _gate ────────────────────────────
     //
     // The startup crash-recovery sweep used to revert the leftover session and rewrite the store
     // WITHOUT holding _gate. After the user answers the "restore?" dialog the UI is live again, so a

--- a/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
@@ -244,7 +244,7 @@ public class PerformanceViewModelTests
         Assert.IsAssignableFrom<CommunityToolkit.Mvvm.Input.IAsyncRelayCommand>(vm.TrimRamCommand);
     }
 
-    // ── System-modification lock (ultra-audit #46) ──
+    // ── System-modification lock ──
     //
     // Every mutating command (Apply* / Restore All / Trim RAM / Create restore point /
     // Toggle hibernation) must serialize through OperationLockService before touching the

--- a/SysManager/SysManager.Tests/SystemPathsTests.cs
+++ b/SysManager/SysManager.Tests/SystemPathsTests.cs
@@ -109,7 +109,7 @@ public class SystemPathsTests
         Assert.Null(SystemPaths.ResolveSystemTool(null!));
     }
 
-    // ── winget resolution (ultra-audit P1: bare-name binary-planting LPE) ──
+    // ── winget resolution (bare-name binary-planting LPE) ──────────────────
     //
     // winget is an MSIX execution alias, not a System32 tool, so the System32 probes never match.
     // Before ResolveWinget, ResolveSystemTool("winget") fell through and returned the UNROOTED bare


### PR DESCRIPTION
## Problem

Four test files carried section headers referring to a private review process and one of its
internal finding numbers. To a reader of this repository those are dangling pointers — someone
who wants to know what "#46" was has no way to find out.

The four headers are in `AppBlockerServiceRegistryTests`, `GamingProfileServiceTests`,
`PerformanceViewModelTests` and `SystemPathsTests`.

## Change

Each header now states the invariant its section pins:

- App Blocker must never block SysManager's own executable
- `RecoverPendingAsync` must serialize on `_gate`
- Every mutating Performance command goes through the system-modification lock
- `winget` must resolve to a rooted path, never a bare name

The comment **bodies** below each header were already self-contained and are untouched, so nothing
explanatory is lost — only the pointer to a process a reader cannot see.

`PerformanceViewModelTests` already has a neighbouring header citing a **public** issue number
(`// ── Processor state lock (issue #103) ──`), which is the right precedent: reference something a
reader can actually open. Its new header is also shortened to match the 26–47 character range the
rest of that file's headers use, instead of being the one 77-character outlier.

## Scope

Comment text only — 4 lines changed across 4 files. No assertion, no test logic, no production
code. `test:` does not trigger a release.

## Verification

- `SysManager.Tests` builds Release with 0 warnings / 0 errors.
- `dotnet format --verify-no-changes` clean.
- Tree-wide re-scan after the change finds no remaining reference.

Closes #1988
