### PR TITLE
fix: read NtQueryTimerResolution's range in the order the call actually returns it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.2] - 2026-08-26
+
+Timer Resolution had the two ends of its range the wrong way round, so "Enable" asked Windows for the
+slowest timer instead of the fastest one. The tab reported a 15.6 ms best case and a 0.5 ms worst
+case — exactly backwards — and Gaming Profile's "Finest timer resolution" switch had the same
+problem, promising 0.5 ms while requesting the 15.6 ms default.
+
+### Fixed
+- **Timer Resolution now really requests the fastest timer your hardware supports.** The Windows call
+  that reports the achievable range returns the slowest value first and the fastest second; its
+  parameter names say the opposite ("Minimum" means minimum precision, i.e. the longest interval), and
+  SysManager had trusted the names. Measured on real hardware the call returns 15.625 ms, then
+  0.5 ms, then the value in effect. The two are now read in the order the call actually uses, so the
+  tab shows the right numbers, Enable asks for the fast end, and the Gaming Profile switch does what
+  its label says. If you had used either one for lower input latency, it was not doing anything —
+  it now does.
+
 ## [1.75.1] - 2026-08-26
 
 "Restore original cores" on the CPU Core Affinity tab could report success while putting nothing back.

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -4352,4 +4352,71 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"(?<target>_(?:original|previous|baseline|before|prior)\w*)\s*=\s*(?<rhs>[^;]+);")]
     private static partial Regex BaselineAssignment();
 
+
+    /// <summary>
+    /// <c>NtQueryTimerResolution</c>'s out-parameters must be bound (coarsest, finest, current), at
+    /// the declaration AND the call site, and <c>Enable</c> must target the finest of the two.
+    /// <para>The NT signature's names are the trap: <c>MinimumResolution</c> comes FIRST and means
+    /// minimum PRECISION — the LARGEST interval. Measured on real hardware the call returns 156250
+    /// (15.6 ms), then 5000 (0.5 ms), then the current value. Bound the other way round,
+    /// <c>finest</c> held the coarse Windows default, so <c>Enable</c> requested 15.6 ms while the
+    /// tab and Gaming Profile's "Finest timer resolution (~0.5 ms)" toggle both reported that
+    /// 0.5 ms had been asked for.</para>
+    /// <para>Nothing else can catch this. The model, its display helpers and their tests all encode
+    /// the right convention already — only the marshalling disagreed, and a P/Invoke cannot be
+    /// mocked, so no unit test can observe which end of the range each field received.</para>
+    /// </summary>
+    [Fact]
+    public void TheTimerResolutionQuery_BindsItsOutParametersCoarsestFinestCurrent()
+    {
+        // Comments stripped: the declaration documents this exact ordering right above itself, so a
+        // guard that read prose would pass on code that has the binding backwards.
+        var code = WithoutComments(File.ReadAllText(
+            Path.Combine(FindAppProjectDir(), "Services", "TimerResolutionService.cs")));
+
+        string[] expected = ["coarsest", "finest", "current"];
+
+        foreach (var (label, regex) in new (string, Regex)[]
+        {
+            ("declaration", TimerQueryDeclaration()),
+            ("call site", TimerQueryCall()),
+        })
+        {
+            var m = regex.Match(code);
+            Assert.True(m.Success,
+                $"the NtQueryTimerResolution {label} no longer matches the shape this guard reads, so "
+                + "its ordering check proves nothing. Re-derive the pattern before trusting a pass.");
+
+            string[] actual = [m.Groups["p1"].Value, m.Groups["p2"].Value, m.Groups["p3"].Value];
+            Assert.Equal(expected, actual);
+        }
+
+        // The consumer half: requesting the coarse end is what made the feature inert. Asserted on
+        // the TARGET assignment specifically, not on the name appearing somewhere in the member —
+        // Enable() also reads FinestHundredNs in its query-failed guard, so a "does the slice
+        // mention it" check stayed green while the target was switched to the coarse end.
+        var enable = MemberSlice(code, "public TimerResolutionStatus Enable()");
+        Assert.False(string.IsNullOrWhiteSpace(enable),
+            "Enable() was not found — the slice is empty, so the check below would pass without "
+            + "reading a line of code.");
+
+        var target = EnableTarget().Match(enable);
+        Assert.True(target.Success,
+            "Enable() no longer assigns its requested resolution to a local this guard can read, so "
+            + "nothing here verifies which end of the range it asks for.");
+        Assert.Equal("FinestHundredNs", target.Groups["end"].Value);
+    }
+
+    /// <summary>Captures which end of the range Enable() requests.</summary>
+    [GeneratedRegex(@"uint target = status\.(?<end>\w+);")]
+    private static partial Regex EnableTarget();
+
+    /// <summary>Matches the ntdll import declaration and captures its three out-parameter names.</summary>
+    [GeneratedRegex(@"partial int NtQueryTimerResolution\(\s*out uint (?<p1>\w+),\s*out uint (?<p2>\w+),\s*out uint (?<p3>\w+)\s*\)")]
+    private static partial Regex TimerQueryDeclaration();
+
+    /// <summary>Matches the single call to that import and captures the order it binds.</summary>
+    [GeneratedRegex(@"NativeMethods\.NtQueryTimerResolution\(\s*out uint (?<p1>\w+),\s*out uint (?<p2>\w+),\s*out uint (?<p3>\w+)\s*\)")]
+    private static partial Regex TimerQueryCall();
+
 }

--- a/SysManager/SysManager/Services/TimerResolutionService.cs
+++ b/SysManager/SysManager/Services/TimerResolutionService.cs
@@ -32,7 +32,7 @@ public sealed partial class TimerResolutionService : ITimerResolutionService
     {
         try
         {
-            int status = NativeMethods.NtQueryTimerResolution(out uint finest, out uint coarsest, out uint current);
+            int status = NativeMethods.NtQueryTimerResolution(out uint coarsest, out uint finest, out uint current);
             if (status != NativeMethods.StatusSuccess)
             {
                 Log.Debug("NtQueryTimerResolution failed: NTSTATUS 0x{Status:X8}", status);
@@ -104,10 +104,17 @@ public sealed partial class TimerResolutionService : ITimerResolutionService
         /// <summary>STATUS_SUCCESS.</summary>
         public const int StatusSuccess = 0;
 
-        // NTSTATUS NtQueryTimerResolution(PULONG MaximumTime, PULONG MinimumTime, PULONG CurrentTime)
-        // Param order is (finest, coarsest, current) — "Maximum" (finest) comes FIRST.
+        // NTSTATUS NtQueryTimerResolution(PULONG MinimumResolution, PULONG MaximumResolution,
+        //                                 PULONG CurrentResolution)
+        //
+        // The order is (coarsest, finest, current), and the names are the trap: "Minimum" means
+        // minimum PRECISION, which is the LARGEST interval. Measured on real hardware, the call
+        // returns 156250 (15.6 ms) first, then 5000 (0.5 ms), then the current value — so the
+        // first out-param is the coarse Windows default, not the fine one. Binding these the other
+        // way round made Enable request the 15.6 ms default while the UI (and Gaming Profile's
+        // "Finest timer resolution (~0.5 ms)" toggle) claimed it had asked for 0.5 ms.
         [LibraryImport("ntdll.dll")]
-        internal static partial int NtQueryTimerResolution(out uint finest, out uint coarsest, out uint current);
+        internal static partial int NtQueryTimerResolution(out uint coarsest, out uint finest, out uint current);
 
         // NTSTATUS NtSetTimerResolution(ULONG DesiredTime, BOOLEAN SetResolution, PULONG ActualTime)
         // BOOLEAN is a 1-byte type → marshal bool as U1.

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.1</Version>
-    <FileVersion>1.75.1.0</FileVersion>
-    <AssemblyVersion>1.75.1.0</AssemblyVersion>
+    <Version>1.75.2</Version>
+    <FileVersion>1.75.2.0</FileVersion>
+    <AssemblyVersion>1.75.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem

`NtQueryTimerResolution`'s three out-parameters were bound `(finest, coarsest, current)`, but the
call returns the **coarsest** first. Two user-facing features therefore did the opposite of what
they said:

- The **Timer Resolution** tab reported the range with its two ends swapped — a 15.6 ms "finest"
  and a 0.5 ms "coarsest".
- **Enable** computed `uint target = status.FinestHundredNs`, which held the coarse value, so it
  requested ~15.6 ms — the Windows default — and improved nothing.
- **Gaming Profile** ships the same call behind a toggle labelled *"Finest timer resolution
  (~0.5 ms)"*, a promise the code could not keep.

## Evidence

Measured on real hardware with a standalone probe that calls the query and nothing else:

```
NTSTATUS = 0x00000000
param1 =   156250  (15.6250 ms)   <- coarsest
param2 =     5000  ( 0.5000 ms)   <- finest
param3 =    10000  ( 1.0000 ms)   <- current
```

The first out-parameter is the larger number. That matches the documented signature, whose first
parameter is `MinimumResolution` — and the names are exactly the trap: "Minimum" means minimum
*precision*, i.e. the longest interval. The previous comment asserted the opposite in prose, so the
declaration read as if it were deliberate.

## Fix

Bind `(coarsest, finest, current)` at the declaration and the call site. `Enable` then targets
`FinestHundredNs` = 5000 and requests 0.5 ms; `Disable` is unaffected, because `SetResolution=false`
ignores the interval argument and only releases this process's prior request.

## Why no unit test could have caught this

`TimerResolutionStatus`, its display helpers and their tests already encode the correct convention —
`TimerResolutionStatusTests` constructs `new TimerResolutionStatus(5000, 156250, …)` and asserts
`FinestDisplay == "0.5 ms"`. The model was right; only the marshalling disagreed. A P/Invoke cannot
be substituted, so no test can observe which end of the range each field received.

So the pin is a source guard: `ArchitectureTests.TheTimerResolutionQuery_BindsItsOutParametersCoarsestFinestCurrent`
asserts the binding order at **both** the declaration and the call site, and asserts which end
`Enable` targets. It reads the file with comments stripped, so it cannot pass on the prose that
described the wrong order.

### Red/green proof

Three mutations, each compiled, each expected to trip the guard:

| Mutation | Result |
|---|---|
| Reverse the declaration (the original defect) | RED — `Expected: ["coarsest","finest","current"], Actual: ["finest","coarsest","current"]` |
| Reverse only the call site, declaration left right | RED — same assertion, so a half-fix is caught |
| `Enable` targets `CoarsestHundredNs` | RED — `Expected: "FinestHundredNs", Actual: "CoarsestHundredNs"` |

The third mutation initially passed: the first version of that check asked whether
`status.FinestHundredNs` appeared anywhere in `Enable()`, and it also appears in the query-failed
guard, so the assertion could not fail. It now reads the target assignment specifically.

## Propagate check

`NtQueryTimerResolution` is the only P/Invoke in the codebase declaring two or more `out`
parameters, so there is no second instance of this class to fix.

## Verification

- All four projects build Release with 0 warnings / 0 errors.
- `dotnet format --verify-no-changes` clean on all four.
- Version consistency, valid-bump (v1.75.1 → 1.75.2, patch) and CHANGELOG plain-English lead gates
  run locally and pass.

Closes #1990
