### PR TITLE
fix: let Windows' disk verdict cap the health score instead of being ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.3] - 2026-08-26
+
+A drive that Windows itself reports as failing could still show a green 100% health score. Disk Health
+would say "Drive is failing — back up now and replace it." on one line and 100% on the next, and the
+Dashboard health score agreed with the 100%. If you have ever seen those two disagree, believe the
+warning.
+
+### Fixed
+- **A failing drive can no longer report a healthy score.** The percentage was worked out from wear,
+  temperature and error counts, and it only looked at Windows' own verdict when there were no such
+  readings at all. So a drive with normal wear and temperature scored 100 even when Windows had
+  flagged it as failing — which it does for problems those readings do not cover, such as
+  reallocated sectors or a predictive-failure warning from the drive itself. Windows' verdict is now a
+  ceiling: a drive it calls failing cannot score above 20, one it warns about cannot score above 60,
+  and a drive already scoring worse than that keeps the worse number. The Dashboard health score
+  follows the same rule, so the two tabs can no longer contradict each other.
+- **A drive we know nothing about no longer counts as perfect** in the Dashboard score. It counts as
+  80, because no readings and no verdict is not the same as a clean bill of health.
+
 ## [1.75.2] - 2026-08-26
 
 Timer Resolution had the two ends of its range the wrong way round, so "Enable" asked Windows for the

--- a/SysManager/SysManager.Tests/DiskHealthReportTests.cs
+++ b/SysManager/SysManager.Tests/DiskHealthReportTests.cs
@@ -194,4 +194,72 @@ public class DiskHealthReportTests
         var r = new DiskHealthReport { PowerOnHours = hours };
         Assert.Equal(expected, r.PowerOnDisplay);
     }
+
+    // ---------- Windows' verdict caps the score ----------
+    // A drive Windows reports as Unhealthy used to score 100 whenever ANY SMART field was present,
+    // because HealthStatus was consulted only in the no-data branch. The same report object then
+    // said "Drive is failing - back up now and replace it." next to a green 100% gauge.
+
+    [Fact]
+    public void HealthPercent_UnhealthyDiskWithCleanSmartData_IsCappedNotPerfect()
+    {
+        // Every SMART counter is pristine, so the arithmetic alone gives 100.
+        var r = new DiskHealthReport
+        {
+            HealthStatus = "Unhealthy",
+            WearPercent = 0,
+            TemperatureC = 35,
+            ReadErrors = 0,
+            WriteErrors = 0,
+        };
+
+        Assert.Equal(20, r.HealthPercent);
+    }
+
+    [Fact]
+    public void HealthPercent_WarningDiskWithCleanSmartData_IsCappedAt60()
+    {
+        var r = new DiskHealthReport { HealthStatus = "Warning", WearPercent = 0, TemperatureC = 35 };
+
+        Assert.Equal(60, r.HealthPercent);
+    }
+
+    [Fact]
+    public void HealthPercent_UnhealthyDiskAlreadyBelowTheCeiling_KeepsTheWorseScore()
+    {
+        // The ceiling only ever lowers. A drive that scores 5 on wear must not be lifted to 20.
+        var r = new DiskHealthReport { HealthStatus = "Unhealthy", WearPercent = 95 };
+
+        Assert.Equal(5, r.HealthPercent);
+    }
+
+    [Fact]
+    public void HealthPercent_HealthyDisk_IsNotCapped()
+    {
+        // "Healthy" maps to 100, so it must constrain nothing.
+        var r = new DiskHealthReport { HealthStatus = "Healthy", WearPercent = 0, TemperatureC = 35 };
+
+        Assert.Equal(100, r.HealthPercent);
+    }
+
+    [Fact]
+    public void HealthPercent_UnrecognisedStatusWithSmartData_IsNotCapped()
+    {
+        // An empty or unknown status is not evidence of anything, so the SMART arithmetic stands.
+        var r = new DiskHealthReport { HealthStatus = "", WearPercent = 10 };
+
+        Assert.Equal(90, r.HealthPercent);
+    }
+
+    [Theory]
+    [InlineData("Healthy", 100)]
+    [InlineData("Warning", 60)]
+    [InlineData("Unhealthy", 20)]
+    [InlineData("", null)]
+    [InlineData("Something else", null)]
+    [InlineData(null, null)]
+    public void StatusCeiling_IsTheSingleMappingBothCallersUse(string? status, int? expected)
+    {
+        Assert.Equal(expected, DiskHealthReport.StatusCeiling(status));
+    }
 }

--- a/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
+++ b/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
@@ -261,4 +261,30 @@ public class HealthScoreServiceTests
             new List<DiskInfo>(),
             DateTime.Now);
     }
+
+    // ---------- The disk score honours the Windows verdict ----------
+
+    [Fact]
+    public void ComputeDiskScore_UnhealthyDiskWithCleanSmartData_IsNot100()
+    {
+        // The Dashboard used to report a perfect disk score for a drive the Disk Health tab was
+        // telling the user to replace.
+        var disks = new List<DiskHealthReport>
+        {
+            new() { HealthStatus = "Healthy", WearPercent = 0 },
+            new() { HealthStatus = "Unhealthy", WearPercent = 0, TemperatureC = 35 },
+        };
+
+        Assert.Equal(20, HealthScoreService.ComputeDiskScore(disks));
+    }
+
+    [Fact]
+    public void ComputeDiskScore_DiskWithNoDataAtAll_ScoresTheUnknownValue()
+    {
+        // HealthPercent is null only when there is neither SMART data nor a recognised status.
+        // Absent evidence is not a clean bill of health, so it scores 80 rather than 100.
+        var disks = new List<DiskHealthReport> { new() { HealthStatus = "Unknown to us" } };
+
+        Assert.Equal(80, HealthScoreService.ComputeDiskScore(disks));
+    }
 }

--- a/SysManager/SysManager/Models/DiskHealthReport.cs
+++ b/SysManager/SysManager/Models/DiskHealthReport.cs
@@ -79,20 +79,34 @@ public sealed partial class DiskHealthReport : ObservableObject
             if (ReadErrors is > 0) score -= (int)Math.Min(ReadErrors.Value * 5L, 20L);
             if (WriteErrors is > 0) score -= (int)Math.Min(WriteErrors.Value * 5L, 20L);
 
-            if (!WearPercent.HasValue && !TemperatureC.HasValue && ReadErrors is null && WriteErrors is null)
-            {
-                return HealthStatus switch
-                {
-                    "Healthy" => 100,
-                    "Warning" => 60,
-                    "Unhealthy" => 20,
-                    _ => null
-                };
-            }
+            // Windows' own verdict is a CEILING, not a tie-break. A drive it has flagged as failing
+            // cannot report a healthy score just because wear and temperature happen to look fine —
+            // HealthStatus covers conditions SMART counters do not (predictive-failure flags,
+            // reallocated-sector thresholds, driver-reported media errors). Before this, the gauge
+            // showed 100% on a drive whose own verdict line read "Drive is failing".
+            int? ceiling = StatusCeiling(HealthStatus);
 
-            return Math.Clamp(score, 0, 100);
+            if (!WearPercent.HasValue && !TemperatureC.HasValue && ReadErrors is null && WriteErrors is null)
+                return ceiling;
+
+            return Math.Clamp(ceiling is { } cap ? Math.Min(score, cap) : score, 0, 100);
         }
     }
+
+    /// <summary>
+    /// The highest score a drive may report given Windows' own <c>HealthStatus</c>, or null when the
+    /// status is absent or unrecognised (in which case it constrains nothing).
+    /// <para>Declared once and used for both the no-SMART fallback and the cap above.
+    /// <c>HealthScoreService</c> used to carry a second copy of this table that disagreed on
+    /// <c>Warning</c> (50 there, 60 here), which is how a duplicated mapping drifts.</para>
+    /// </summary>
+    internal static int? StatusCeiling(string? status) => status switch
+    {
+        "Healthy" => 100,
+        "Warning" => 60,
+        "Unhealthy" => 20,
+        _ => null,
+    };
 
     /// <summary>Color hex for the health percentage gauge.</summary>
     public string HealthPercentColorHex => HealthPercent switch

--- a/SysManager/SysManager/Services/HealthScoreService.cs
+++ b/SysManager/SysManager/Services/HealthScoreService.cs
@@ -108,14 +108,19 @@ public sealed class HealthScoreService
     {
         if (disks is null || disks.Count == 0) return 100;
 
-        // Use the worst disk's health percentage, or map status string
-        int worstScore = disks.Select(d => d.HealthPercent ?? d.HealthStatus switch
-        {
-            "Healthy" => 100,
-            "Warning" => 50,
-            "Unhealthy" => 20,
-            _ => 80
-        }).Min();
+        // The worst disk decides. HealthPercent already folds in Windows' own verdict as a ceiling,
+        // so there is nothing left to map here.
+        //
+        // This used to be `?? d.HealthStatus switch { "Healthy" => 100, "Warning" => 50,
+        // "Unhealthy" => 20, _ => 80 }`, whose three named arms were unreachable: HealthPercent
+        // returns null ONLY when there is no SMART data AND the status is none of those three, so
+        // the fallback could only ever hit `_`. It read as if the Windows verdict were handled here
+        // while the percentage was quietly ignoring it, and its Warning value (50) disagreed with
+        // the real mapping (60).
+        //
+        // 80, not 100, for a drive we know nothing about: absent evidence is not a clean bill of
+        // health, and this is the only case that reaches it.
+        int worstScore = disks.Select(d => d.HealthPercent ?? 80).Min();
         return Math.Clamp(worstScore, 0, 100);
     }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.2</Version>
-    <FileVersion>1.75.2.0</FileVersion>
-    <AssemblyVersion>1.75.2.0</AssemblyVersion>
+    <Version>1.75.3</Version>
+    <FileVersion>1.75.3.0</FileVersion>
+    <AssemblyVersion>1.75.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem

A drive Windows reports as failing could score **100/100**. The same `DiskHealthReport` said two
opposite things at once:

- `Verdict` → *"Drive is failing — back up now and replace it."* (red)
- `HealthPercent` → `100` (green gauge, and a Dashboard disk score of 100)

`HealthPercent` worked out a score from wear, temperature and error counts, and looked at
`HealthStatus` **only** when none of those readings existed. Windows sets that verdict for problems
SMART counters do not carry: predictive-failure flags, reallocated-sector thresholds, driver-reported
media errors. So "SMART looks fine but Windows says failing" is a real state, and it scored 100.

`DiskHealthService.ApplyVerdict` gets this right and says so in its own comment ("Base on HealthStatus
first — Windows already knows about failures"). Only the percentage disagreed.

## Second defect: unreachable code that read as if it handled this

`HealthScoreService.ComputeDiskScore` looked like it covered the status case:

```csharp
int worstScore = disks.Select(d => d.HealthPercent ?? d.HealthStatus switch
{
    "Healthy" => 100, "Warning" => 50, "Unhealthy" => 20, _ => 80
}).Min();
```

Those three named arms are unreachable. `HealthPercent` returns null only when there is no SMART data
**and** the status is none of `Healthy`/`Warning`/`Unhealthy`, so whenever the fallback runs the status
is by definition unrecognised and only `_ => 80` can execute. The existing test
`ComputeDiskScore_OneWarning_Returns60` proves it: it expects **60**, which is the model's mapping, not
this one's **50**. Two copies of one table, already drifted.

## Fix

`StatusCeiling` is declared once on the model and used for both the no-SMART fallback and as a cap:

```csharp
int? ceiling = StatusCeiling(HealthStatus);
if (no SMART readings at all) return ceiling;
return Math.Clamp(ceiling is { } cap ? Math.Min(score, cap) : score, 0, 100);
```

`Math.Min`, so the ceiling only ever lowers: a drive already scoring 5 on wear is not lifted to 20. An
absent or unrecognised status yields `null` and constrains nothing. `ComputeDiskScore` becomes
`d.HealthPercent ?? 80` — 80 rather than 100, because no readings and no verdict is not a clean bill of
health, and that is now the only case reaching it.

## Red/green proof

Six mutations, each of which compiled, each killing exactly the predicted set:

| Mutation | Tests that went red |
|---|---|
| Ignore the ceiling (the original defect) | the two capping tests + the Dashboard score test |
| Let the ceiling *raise* a worse score | `…AlreadyBelowTheCeiling_KeepsTheWorseScore` |
| Drift `Warning` 60 → 50 | 4, including the pre-existing `ComputeDiskScore_OneWarning_Returns60` |
| Drift `Healthy` 100 → 90 | 4, including `ComputeDiskScore_AllHealthy_Returns100` |
| Cap an unrecognised status at 80 | 4, including `HealthPercent_PerfectDisk_Returns100` |
| Treat an unknown disk as perfect | `…DiskWithNoDataAtAll_ScoresTheUnknownValue` |

Every one of the 8 new tests is killed by at least one mutation. Two of my initial predictions were
wrong and the proof caught both: mutation B cannot reach the null-ceiling path, and the 80-ceiling
mutation leaves the Dashboard test green because the no-SMART branch then returns 80 by a different
route. Correcting them exposed one test (`HealthPercent_HealthyDisk_IsNotCapped`) that no mutation
killed, which is why the `Healthy` drift mutation exists.

## Propagate check

Every other `"Unhealthy"` site in the codebase was read. `DiskHealthService.ApplyVerdict` maps the
status to a verdict *string*, `DiskHealthService`/`SystemInfoService` map the raw WMI code to the
status string, and `TrayIconService` answers "is there a problem" as a bool. None of them scores, so
the table I removed was the only duplicate.

## Verification

- All four projects build Release with 0 warnings / 0 errors; `dotnet format --verify-no-changes` clean.
- 275 green / 0 red across `DiskHealthReport`, `DiskHealthReportEdgeCase`, `DiskHealthService`,
  `HealthScoreService` and `DashboardViewModel` tests.
- Version consistency, valid-bump (v1.75.2 → 1.75.3, patch) and CHANGELOG lead gates pass locally.

Closes #1993
