### PR TITLE
fix: identify the updater's target by product resource so Install works, and keep the rollback checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.4] - 2026-08-27
+
+The in-app updater could not actually install an update: clicking Install closed SysManager and
+nothing came back, and Roll back could quietly stop being offered. Both are fixed, so the updater
+works end to end.
+
+### Fixed
+- **"Install update" now replaces the running build instead of doing nothing.** The updater only
+  agreed to write over a file whose name matched the running program's, but the program doing the
+  writing is the freshly downloaded `SysManager-<newversion>.exe` while the file being replaced is the
+  older build — two different names, so the check could never pass and every update was silently
+  refused after the app had already closed. It now identifies a SysManager build by the product stamp
+  Windows keeps inside the file, which is the same across versions and survives you renaming the
+  portable .exe. Downloading and installing an update now completes and relaunches.
+- **Roll back no longer loses its safety copy when you download a newer update.** Cleaning up old
+  downloads deleted the checksum file that Roll back needs to confirm the saved build is intact.
+  Because that confirmation refuses to proceed without the checksum, Roll back would stop being
+  offered after the next download. The checksum is now kept alongside the saved build.
+
 ## [1.75.3] - 2026-08-26
 
 A drive that Windows itself reports as failing could still show a green 100% health score. Disk Health

--- a/SysManager/SysManager.Tests/UpdateApplierTests.cs
+++ b/SysManager/SysManager.Tests/UpdateApplierTests.cs
@@ -363,20 +363,29 @@ public class UpdateApplierTests
     // validation which is the sole defense must be explicitly tested.
 
     /// <summary>
-    /// The name the applier will accept, derived the same way production does. In the test host this is
-    /// the runner's own executable, which is the point: the rule is "my own name", not a literal.
+    /// A valid target is a COPY of the running test host: identity is the Win32 product resource, and
+    /// the only way to get a file that genuinely carries this process's product is to copy this
+    /// process's own binary. A plain text file has no resource at all, which is why the earlier
+    /// write-some-bytes fixture no longer models an acceptable target.
     /// </summary>
-    private static string OwnExeName() => Path.GetFileName(Environment.ProcessPath)!;
+    private static string CopyOfThisBuild(DirectoryInfo dir, string name = "SysManager-vX.Y.Z.exe")
+    {
+        var target = Path.Combine(dir.FullName, name);
+        File.Copy(Environment.ProcessPath!, target);
+        return target;
+    }
 
     [Fact]
-    public void ApplyTarget_AcceptsAnExistingCopyOfThisExecutable()
+    public void ApplyTarget_AcceptsAnExistingBuildCarryingThisProduct_UnderAnyName()
     {
-        // The legitimate case, so the negative tests below cannot pass by refusing everything.
+        // The legitimate case, and it deliberately uses a DIFFERENT file name from the running process:
+        // in production the applier is SysManager-<new>.exe and the target is the older build, so a rule
+        // keyed on name equality could never accept a real update. Identity is the product resource.
         var dir = Directory.CreateTempSubdirectory("ApplierTarget_");
         try
         {
-            var target = Path.Combine(dir.FullName, OwnExeName());
-            File.WriteAllText(target, "the installed build");
+            var target = CopyOfThisBuild(dir);
+            Assert.NotEqual(Path.GetFileName(target), Path.GetFileName(Environment.ProcessPath!));
 
             Assert.True(UpdateApplier.IsValidApplyTarget(target, out var reason), reason);
             Assert.Equal("", reason);
@@ -386,20 +395,20 @@ public class UpdateApplierTests
 
     [Theory]
     [InlineData("hosts")]                 // the file an attacker would aim at first
-    [InlineData("evil.exe")]
-    [InlineData("SysManager.dll")]        // right stem, wrong extension
-    [InlineData("notepad.exe")]
-    public void ApplyTarget_RefusesAFileThatIsNotThisExecutable(string fileName)
+    [InlineData("SysManager.exe")]        // even OUR canonical name cannot smuggle a foreign file in
+    [InlineData("SysManager-v9.9.9.exe")] // shaped exactly like a downloaded asset
+    public void ApplyTarget_RefusesAFileThatDoesNotCarryOurProduct(string fileName)
     {
         var dir = Directory.CreateTempSubdirectory("ApplierTarget_");
         try
         {
-            // Existing and writable — the ONLY thing wrong with it is that it is not our own binary.
+            // Existing and writable, but no version resource, so it is not one of our builds — and the
+            // name, even our own, cannot make it one.
             var target = Path.Combine(dir.FullName, fileName);
             File.WriteAllText(target, "someone else's file");
 
             Assert.False(UpdateApplier.IsValidApplyTarget(target, out var reason));
-            Assert.Contains("not named", reason);
+            Assert.Contains("build", reason);
         }
         finally { dir.Delete(recursive: true); }
     }
@@ -413,7 +422,7 @@ public class UpdateApplierTests
         var dir = Directory.CreateTempSubdirectory("ApplierTarget_");
         try
         {
-            var target = Path.Combine(dir.FullName, OwnExeName());   // correct name, never created
+            var target = Path.Combine(dir.FullName, "SysManager-vX.Y.Z.exe");   // never created
 
             Assert.False(UpdateApplier.IsValidApplyTarget(target, out var reason));
             Assert.Contains("does not exist", reason);
@@ -427,7 +436,7 @@ public class UpdateApplierTests
         // Belt-and-braces for a file legitimately named like ours inside a system root: an elevated
         // SysManager must not be steerable into writing there, whatever the file is called.
         var windows = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
-        var target = Path.Combine(windows, "System32", OwnExeName());
+        var target = Path.Combine(windows, "System32", "SysManager-vX.Y.Z.exe");
 
         Assert.False(UpdateApplier.IsValidApplyTarget(target, out var reason));
         // Specifically for BEING in a system root — the location check runs before the existence check,
@@ -436,17 +445,25 @@ public class UpdateApplierTests
     }
 
     [Fact]
-    public void ApplyTarget_RefusesARealExistingSystemBinary()
+    public void ApplyTarget_RefusesARealBinaryCarryingADifferentProduct()
     {
-        // A file that genuinely exists, so this cannot pass via the existence check — the only thing
-        // that can refuse it is the name rule. Together with the test above (a system-root path bearing
-        // OUR name, refused for its location) this pins both branches as reachable rather than dead.
-        var existing = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.System), "notepad.exe");
-        Assert.True(File.Exists(existing), "probe file missing — this test needs a real System32 file");
+        // A genuine, signed Windows binary carries a real product resource ("Microsoft ... Operating
+        // System"), which is NOT ours. Copied out of System32 into a temp dir so the system-root check
+        // cannot be what refuses it: the ONLY thing left to reject it is the product mismatch, which is
+        // the branch a plain text file (no resource at all) never exercises.
+        var source = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "notepad.exe");
+        Assert.True(File.Exists(source), "probe file missing — this test needs a real System32 binary");
 
-        Assert.False(UpdateApplier.IsValidApplyTarget(existing, out var reason));
-        Assert.Contains("not named", reason);
+        var dir = Directory.CreateTempSubdirectory("ApplierForeign_");
+        try
+        {
+            var target = Path.Combine(dir.FullName, "SysManager-vX.Y.Z.exe");
+            File.Copy(source, target);
+
+            Assert.False(UpdateApplier.IsValidApplyTarget(target, out var reason));
+            Assert.Contains("build", reason);
+        }
+        finally { dir.Delete(recursive: true); }
     }
 
     [Fact]
@@ -464,7 +481,9 @@ public class UpdateApplierTests
             var traversal = Path.Combine(sub.FullName, "..", "hosts");
 
             Assert.False(UpdateApplier.IsValidApplyTarget(traversal, out var reason));
-            Assert.Contains("not named", reason);
+            // Refused because "hosts" is not one of our builds; the point here is that canonicalisation
+            // happened at all, so ".." was resolved before the decision rather than compared literally.
+            Assert.Contains("build", reason);
         }
         finally { dir.Delete(recursive: true); }
     }

--- a/SysManager/SysManager.Tests/UpdateServicePruneTests.cs
+++ b/SysManager/SysManager.Tests/UpdateServicePruneTests.cs
@@ -164,4 +164,45 @@ public class UpdateServicePruneTests : IDisposable
         Assert.Equal(0, UpdateService.PruneOldDownloads(_dir, keep));
         Assert.Equal(["SysManager-1.56.8.exe"], Remaining());
     }
+
+    [Fact]
+    public void Prune_KeepsTheRetainedPreviousBuildAndItsChecksum()
+    {
+        // #1998: the previous build's .sha256 matches the SysManager-*.exe* sweep pattern, and the
+        // guard used to exempt only the bare .exe. Losing the sidecar disabled rollback permanently,
+        // because TryOpenVerifiedPreviousBuild fails CLOSED on a missing hash and nothing rewrites it
+        // except another successful apply. Both files must survive a prune triggered by a new download.
+        var keep = Touch("SysManager-1.56.8.exe");
+        Touch("SysManager-1.56.8.exe.sha256");
+        Touch(UpdateApplier.PreviousBuildFileName);                 // SysManager-previous.exe
+        Touch(UpdateApplier.PreviousBuildFileName + ".sha256");
+
+        UpdateService.PruneOldDownloads(_dir, keep);
+
+        Assert.Contains(UpdateApplier.PreviousBuildFileName, Remaining());
+        Assert.Contains(UpdateApplier.PreviousBuildFileName + ".sha256", Remaining());
+    }
+
+    [Fact]
+    public void Prune_StillRemovesASupersededBuildWhileKeepingThePreviousPair()
+    {
+        // The exemption is narrow: an ordinary older download is still swept, so keeping the rollback
+        // pair does not turn the prune into a no-op.
+        Touch("SysManager-1.56.6.exe");
+        Touch("SysManager-1.56.6.exe.sha256");
+        var keep = Touch("SysManager-1.56.8.exe");
+        Touch(UpdateApplier.PreviousBuildFileName);
+        Touch(UpdateApplier.PreviousBuildFileName + ".sha256");
+
+        var removed = UpdateService.PruneOldDownloads(_dir, keep);
+
+        Assert.Equal(2, removed);   // the 1.56.6 exe and its hash
+        // Ordinal order: '1' (0x31) sorts before 'p' (0x70), so the versioned kept build comes first.
+        Assert.Equal(
+        [
+            "SysManager-1.56.8.exe",
+            UpdateApplier.PreviousBuildFileName,
+            UpdateApplier.PreviousBuildFileName + ".sha256",
+        ], Remaining());
+    }
 }

--- a/SysManager/SysManager/Services/UpdateApplier.cs
+++ b/SysManager/SysManager/Services/UpdateApplier.cs
@@ -36,13 +36,6 @@ internal static class UpdateApplier
     internal const string PreviousBuildFileName = "SysManager-previous.exe";
 
     /// <summary>
-    /// The one file name the applier is allowed to write. Derived from the running assembly rather
-    /// than hardcoded, so a rename of the produced executable cannot silently disable the check.
-    /// </summary>
-    private static string OwnExecutableName =>
-        Path.GetFileName(Environment.ProcessPath) is { Length: > 0 } name ? name : "SysManager.exe";
-
-    /// <summary>
     /// Where the outgoing executable is kept so a bad update can be undone.
     /// </summary>
     /// <remarks>
@@ -121,11 +114,15 @@ internal static class UpdateApplier
     /// 85 MB executable over that path and then launches it — and because the app's documented
     /// workflow is "Run as administrator", the writable set can be every file on the machine.</para>
     /// <para>The rule is deliberately narrow: an update replaces SysManager with SysManager, so the
-    /// target must be an EXISTING file (never a creation) whose name is this executable's own name.
-    /// Requiring existence matters as much as the name: a first install has nothing to update, and it
-    /// stops the applier being used to plant a new file where none was. Rejecting a target under a
-    /// system root is belt-and-braces for the case where someone has legitimately named a file
-    /// SysManager.exe inside Windows.</para>
+    /// target must be an EXISTING file (never a creation) carrying the same product resource as this
+    /// executable. Requiring existence matters as much as the identity: a first install has nothing to
+    /// update, and it stops the applier being used to plant a new file where none was. Rejecting a
+    /// target under a system root is belt-and-braces for the case where someone has legitimately put a
+    /// SysManager build inside Windows.</para>
+    /// <para>The identity is the PRODUCT resource, never the file name. The applier is the freshly
+    /// downloaded <c>SysManager-&lt;newVersion&gt;.exe</c> and the target is the older build it
+    /// replaces, so a name-equality rule can never be satisfied by a real update — it refused every
+    /// one, logged the refusal at Error, and returned after the old process had already exited.</para>
     /// <para>Returns a reason rather than a bare bool so the refusal can be logged specifically —
     /// a silent no-op here would look identical to a successful update.</para>
     /// </remarks>
@@ -163,12 +160,6 @@ internal static class UpdateApplier
             return false;
         }
 
-        if (!Path.GetFileName(full).Equals(OwnExecutableName, StringComparison.OrdinalIgnoreCase))
-        {
-            reason = $"the target is not named {OwnExecutableName}";
-            return false;
-        }
-
         // Location before existence: whether a path is protected is a property of the path, not of
         // whether a file happens to be sitting there. Checking it first also keeps this branch
         // deterministically reachable instead of being shadowed by the existence check below.
@@ -186,7 +177,59 @@ internal static class UpdateApplier
             return false;
         }
 
+        // "An update replaces SysManager with SysManager" — verified on the product resource, which
+        // needs the file to exist, hence last. Compared against THIS executable's own product rather
+        // than a hardcoded literal, keeping the original intent that a rename of what we ship cannot
+        // silently disable the check.
+        if (!TryReadProductName(Environment.ProcessPath, out var ownProduct))
+        {
+            // Fail closed: unable to establish what we are, so unable to establish what the target is.
+            reason = "this build's product name could not be read, so the target cannot be verified";
+            return false;
+        }
+
+        if (!TryReadProductName(full, out var targetProduct) ||
+            !string.Equals(targetProduct, ownProduct, StringComparison.Ordinal))
+        {
+            reason = $"the target is not a {ownProduct} build";
+            return false;
+        }
+
         return true;
+    }
+
+    /// <summary>
+    /// Reads a file's Win32 <c>ProductName</c>, trimmed. False when there is none or it cannot be read.
+    /// </summary>
+    /// <remarks>
+    /// The product resource, not the file NAME, is what identifies one of our builds. The name cannot
+    /// do the job: the applier is the freshly downloaded <c>SysManager-&lt;newVersion&gt;.exe</c> while
+    /// its target is the build being replaced, so requiring the two to match refused every real update.
+    /// The product string is identical across versions and survives a user renaming the portable file,
+    /// which is a documented thing to do with a single-file app.
+    /// </remarks>
+    private static bool TryReadProductName(string? path, out string product)
+    {
+        product = "";
+        if (string.IsNullOrWhiteSpace(path)) return false;
+
+        try
+        {
+            product = FileVersionInfo.GetVersionInfo(path).ProductName?.Trim() ?? "";
+            return product.Length > 0;
+        }
+        catch (FileNotFoundException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
     }
 
     /// <summary>

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -543,10 +543,16 @@ public sealed class UpdateService
                     continue;
                 }
 
-                // Never prune the retained previous build. It matches the SysManager-*.exe pattern,
-                // so without this the very next update download would delete the one copy that makes
-                // rollback possible — silently, since pruning is best-effort and logs at Debug.
-                if (name.Equals(UpdateApplier.PreviousBuildFileName, StringComparison.OrdinalIgnoreCase))
+                // Never prune the retained previous build OR its checksum. Both match the
+                // SysManager-*.exe* pattern (the trailing * catches the sidecar), so without this the
+                // very next update download would delete the one copy that makes rollback possible —
+                // silently, since pruning is best-effort and logs at Debug.
+                //
+                // The sidecar is not optional: TryOpenVerifiedPreviousBuild fails CLOSED on a missing
+                // hash, and nothing rewrites it except another successful apply, so losing it disabled
+                // rollback permanently while the button stayed enabled.
+                if (name.Equals(UpdateApplier.PreviousBuildFileName, StringComparison.OrdinalIgnoreCase) ||
+                    name.Equals(UpdateApplier.PreviousBuildFileName + ".sha256", StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.3</Version>
-    <FileVersion>1.75.3.0</FileVersion>
-    <AssemblyVersion>1.75.3.0</AssemblyVersion>
+    <Version>1.75.4</Version>
+    <FileVersion>1.75.4.0</FileVersion>
+    <AssemblyVersion>1.75.4.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Two defects on the in-app update path

Both found by audit, both confirmed against current source, both on the same code path so they ship
together.

### #1994 — the updater refused every real update

`UpdateApplier`'s sole write gate required the target's **file name** to equal the running process's:

```csharp
if (!Path.GetFileName(full).Equals(OwnExecutableName, ...)) { reason = "the target is not named ..."; return false; }
```

But the applier process **is** the freshly downloaded `SysManager-<newVersion>.exe`, launched via
`FileName = DownloadedPath`, and the target is the older build being replaced. Those names can never
be equal, so `Run` logged the refusal at Error and returned — **after** the old process had already
called `Application.Current.Shutdown()`. Clicking Install closed the app and nothing came back.

Proven earlier by a probe renamed to the real asset name: `the target is not named SysManager-1.75.2.exe`.

**Fix:** identity is the Win32 **product resource**, read via `FileVersionInfo`. It is identical
across versions and survives a user renaming the portable .exe (a documented thing to do with a
single-file app). Fails closed if either the running build's or the target's product cannot be read.
The existence and system-root checks are unchanged and still run first, so a non-existent path or a
system-directory target is still refused for those reasons.

### #1998 — downloading an update dropped the rollback checksum

`PruneOldDownloads` enumerates `SysManager-*.exe*` and exempted only `SysManager-previous.exe`, not
its `.sha256`. The trailing `*` matches the sidecar, so it was deleted. `TryOpenVerifiedPreviousBuild`
**fails closed** on a missing hash and nothing rewrites it except another successful apply, so the
next download silently withdrew the rollback offer. The guard now exempts the checksum too.

Correction to the filed issue: it also claimed the Rollback button stayed enabled. That was wrong and
I withdrew it on the issue — `RefreshRollbackAvailability` already requires **both** files, so the
control is hidden, not offered-and-failing. The prune defect is real; the severity is lower than
filed (a capability that quietly stops being offered, not a misleading control).

## Tests

The five `IsValidApplyTarget` tests keyed to the old name rule are rebuilt around the product
resource, verified empirically first (a .NET exe's product defaults to its assembly name; notepad is
"Microsoft® Windows® Operating System"; a text file has none):

- **valid target** = a copy of the test host, under a *different* file name, so a name-equality rule
  could not accept it — which is the whole point
- **foreign binary** = notepad copied out of System32 into a temp dir, so location cannot be what
  refuses it; only the product mismatch can
- **no resource** = a plain text file, pinning the unreadable-product branch

Two prune tests assert the rollback pair survives a sweep while an ordinary older build is still
removed (with the ordinal-order note, since `'1' < 'p'`).

### Red/green proof

| Mutation | Result |
|---|---|
| Revert to matching on file name (the original defect) | RED — accepts-a-real-update test fails |
| Remove the identity check entirely | RED — an existing foreign file passes: 4 tests, incl. the end-to-end `Run` hostile-target test |
| Exempt only the previous `.exe`, not its `.sha256` | RED — both prune tests fail |

Baseline all green; every mutation compiled. One baseline failure and one under-prediction surfaced
during the proof (an ordinal-order slip in my own test, and the fact that removing the check has
broader reach than I first listed); both corrected, which is the proof doing its job.

## Verification

- All four projects build Release, 0 warnings / 0 errors; `dotnet format --verify-no-changes` clean.
- 119 green across `UpdateApplier`, `UpdateServicePrune`, `UpdateService`, `AboutViewModel` tests.
- Version consistency, valid-bump (v1.75.3 → 1.75.4, patch) and CHANGELOG-lead gates pass locally.

Closes #1994
Closes #1998
