### PR TITLE
fix: stop both temp cleanups deleting the running build's own extracted files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.5] - 2026-08-27
+
+Tune-Up's temp cleanup was reaching into SysManager's own working files. That could make a perfectly
+clean run report errors, and in the worst case stop a feature working until you restarted the app.
+
+### Fixed
+- **Cleanups no longer sweep the folder SysManager is running out of.** Because the app ships as a
+  single file, Windows unpacks part of it into your temp folder while it runs, and both temp cleanups
+  — Tune-Up's and Deep Cleanup's "Temporary files" — walked temp without knowing to leave that
+  alone. Files the app had open refused to delete and were counted as errors, so a cleanup could report
+  failures it caused itself. Files it had unpacked but not opened yet were deleted for real, which
+  could break a feature later in the same session — the per-app bandwidth view was the most likely
+  one, since it loads its extra components only when you start it. Both cleanups now skip that one
+  folder and nothing else, so everything they used to remove is still removed.
+
 ## [1.75.4] - 2026-08-27
 
 The in-app updater could not actually install an update: clicking Install closed SysManager and

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -4419,4 +4419,59 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"NativeMethods\.NtQueryTimerResolution\(\s*out uint (?<p1>\w+),\s*out uint (?<p2>\w+),\s*out uint (?<p3>\w+)\s*\)")]
     private static partial Regex TimerQueryCall();
 
+
+    /// <summary>
+    /// Every call into a temp-tree walker must pass the own-extraction exclusion.
+    /// </summary>
+    /// <remarks>
+    /// Both cleanups sweep all of <c>%TEMP%</c> — Tune-Up's temp cleanup and Deep Cleanup's
+    /// "Temporary files" definition — and for a single-file build that is where this process unpacked
+    /// its own native libraries. Deleting them made a clean run report errors (files the app holds open
+    /// refuse to delete) and broke a later lazy load for anything unpacked but not yet opened.
+    /// <para>The exclusion is a call-site argument with a <c>null</c> default, so nothing in the type
+    /// system stops a future edit from dropping it. No unit test can see it either: Deep Cleanup's
+    /// walkers are private, and the test host's <c>AppContext.BaseDirectory</c> never intersects a temp
+    /// fixture, so the real static cannot be exercised. A source guard is the only thing that pins
+    /// this, which a mutation proof confirmed by removing one call site's argument and watching every
+    /// test stay green.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryTempTreeWalkerCall_PassesTheOwnExtractionExclusion()
+    {
+        var servicesDir = Path.Combine(FindAppProjectDir(), "Services");
+        string[] sweepers = ["TuneUpService.cs", "DeepCleanupService.cs"];
+        var callsChecked = 0;
+
+        foreach (var file in sweepers)
+        {
+            // Comments stripped: both files explain this rule in prose right beside the calls, so a
+            // guard that read comments would pass on code that had dropped the argument.
+            var code = WithoutComments(File.ReadAllText(Path.Combine(servicesDir, file)));
+
+            foreach (var call in TempWalkerCall().Matches(code).Cast<Match>())
+            {
+                var args = call.Groups["args"].Value;
+
+                // Skip the declarations: their parameter list names the type, a call site never does.
+                if (args.Contains("CancellationToken", StringComparison.Ordinal)) continue;
+
+                callsChecked++;
+                Assert.Contains("SystemPaths.OwnExtractionDirectory", args, StringComparison.Ordinal);
+            }
+        }
+
+        // Vacuity floor: five call sites exist today across the two services. A collapse means the
+        // pattern stopped matching, and this guard would then pass without reading a single call.
+        Assert.True(callsChecked >= 5,
+            $"only {callsChecked} walker calls were matched — the pattern no longer matches the call "
+            + "shape, so this guard proves nothing. Re-derive it before trusting a pass.");
+    }
+
+    /// <summary>
+    /// Matches a call to one of the temp-tree walkers and captures its argument list. Bounded to
+    /// argument lists without nested parentheses, which every current call site and declaration is.
+    /// </summary>
+    [GeneratedRegex(@"(?<!Directory\.)\bEnumerate(?:Files|Directories)\w*\((?<args>[^()]*)\)")]
+    private static partial Regex TempWalkerCall();
+
 }

--- a/SysManager/SysManager.Tests/SystemPathsTests.cs
+++ b/SysManager/SysManager.Tests/SystemPathsTests.cs
@@ -183,4 +183,49 @@ public class SystemPathsTests
         var bad = SystemPaths.ParsePackageVersion(@"C:\Program Files\WindowsApps\SomethingElse");
         Assert.Equal(new Version(0, 0), bad);
     }
+
+    // ---------- the running build's own extraction directory (#1999) ----------
+    //
+    // The shipped exe is single-file with IncludeNativeLibrariesForSelfExtract, so the host unpacks
+    // native libraries into %TEMP%\.net\<app>\<hash> and AppContext.BaseDirectory points there. Both
+    // wholesale %TEMP% sweeps (Tune-Up's temp cleanup and Deep Cleanup's "Temporary files") must skip
+    // that tree, so the rule lives here rather than being copied into each service.
+
+    [Theory]
+    // A sibling whose name merely STARTS with the excluded path must not be swallowed: this is the
+    // boundary bug a bare StartsWith would introduce.
+    [InlineData(@"C:\Temp\.net\SysManagerX\lib.dll", @"C:\Temp\.net\SysManager", false)]
+    [InlineData(@"C:\Temp\.net\SysManager\lib.dll", @"C:\Temp\.net\SysManager", true)]
+    [InlineData(@"C:\Temp\.net\SysManager", @"C:\Temp\.net\SysManager", true)]
+    [InlineData(@"C:\Temp\.net\SysManager\", @"C:\Temp\.net\SysManager", true)]
+    [InlineData(@"C:\Temp\other\lib.dll", @"C:\Temp\.net\SysManager", false)]
+    [InlineData(@"C:\Temp\.net\sysmanager\lib.dll", @"C:\Temp\.net\SysManager", true)]  // case-insensitive
+    public void IsInsideSubtree_ComparesOnADirectoryBoundary(string candidate, string subtree, bool expected)
+    {
+        Assert.Equal(expected, SystemPaths.IsInsideSubtree(candidate, subtree));
+    }
+
+    [Fact]
+    public void IsInsideSubtree_WithNoSubtree_ExcludesNothing()
+    {
+        // Null must exclude NOTHING, not everything: the walkers pass this straight through, so
+        // getting it backwards would silently turn both cleanups into no-ops.
+        Assert.False(SystemPaths.IsInsideSubtree(@"C:\Temp\anything.txt", null));
+        Assert.False(SystemPaths.IsInsideSubtree(@"C:\Temp\anything.txt", ""));
+        Assert.False(SystemPaths.IsInsideSubtree(@"C:\Temp\anything.txt", "   "));
+    }
+
+    [Fact]
+    public void OwnExtractionDirectory_IsResolvedAndAbsolute()
+    {
+        // Under the test host this is the output folder rather than a temp extraction directory, which
+        // is the point: outside a single-file run the exclusion is inert. It must still resolve to an
+        // absolute path with no trailing separator, or the boundary comparison cannot work.
+        var own = SystemPaths.OwnExtractionDirectory;
+
+        Assert.False(string.IsNullOrWhiteSpace(own));
+        Assert.True(Path.IsPathFullyQualified(own!));
+        Assert.Equal(Path.TrimEndingDirectorySeparator(own!), own);
+        Assert.True(SystemPaths.IsInsideSubtree(own!, own));
+    }
 }

--- a/SysManager/SysManager.Tests/TuneUpServiceTests.cs
+++ b/SysManager/SysManager.Tests/TuneUpServiceTests.cs
@@ -483,4 +483,75 @@ public class TuneUpServiceTests
             try { System.IO.Directory.Delete(baseDir, recursive: true); } catch { /* best effort */ }
         }
     }
+
+    // ---------- the app must not sweep its own extraction directory (#1999) ----------
+    //
+    // The shipped exe is single-file with IncludeNativeLibrariesForSelfExtract, so the host unpacks
+    // native libraries into %TEMP%\.net\<app>\<hash> and AppContext.BaseDirectory points there.
+    // Sweeping all of %TEMP% therefore targeted the running build's own runtime: loaded libraries
+    // refuse to delete and were counted as errors, and anything not yet loaded was deleted for real.
+
+    [Fact]
+    public void EnumerateFiles_SkipsTheExcludedSubtree_AndKeepsEverythingElse()
+    {
+        // Layout: temp/ordinary.txt          -> must be enumerated
+        //         temp/.net/app/native.dll   -> must NOT be enumerated (the excluded subtree)
+        var root = Path.Combine(Path.GetTempPath(), "smtu_" + Guid.NewGuid().ToString("N"));
+        var extraction = Path.Combine(root, ".net", "app");
+        Directory.CreateDirectory(extraction);
+        var ordinary = Path.Combine(root, "ordinary.txt");
+        var mine = Path.Combine(extraction, "native.dll");
+        File.WriteAllText(ordinary, "an unrelated temp file");
+        File.WriteAllText(mine, "a native library this process needs");
+
+        try
+        {
+            var found = TuneUpService
+                .EnumerateFilesSkippingReparsePoints(root, CancellationToken.None, extraction)
+                .ToList();
+
+            Assert.Contains(found, f => f.EndsWith("ordinary.txt", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(found, f => f.EndsWith("native.dll", StringComparison.OrdinalIgnoreCase));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Fact]
+    public void EnumerateFiles_WithNoExclusion_StillYieldsEverything()
+    {
+        // The exclusion must be opt-in: passing null (what every other caller does) changes nothing,
+        // so this cannot pass by the traversal having quietly become more restrictive for everyone.
+        var root = Path.Combine(Path.GetTempPath(), "smtu_" + Guid.NewGuid().ToString("N"));
+        var sub = Path.Combine(root, ".net", "app");
+        Directory.CreateDirectory(sub);
+        File.WriteAllText(Path.Combine(root, "ordinary.txt"), "x");
+        File.WriteAllText(Path.Combine(sub, "native.dll"), "x");
+
+        try
+        {
+            var found = TuneUpService
+                .EnumerateFilesSkippingReparsePoints(root, CancellationToken.None, null)
+                .ToList();
+
+            Assert.Contains(found, f => f.EndsWith("ordinary.txt", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(found, f => f.EndsWith("native.dll", StringComparison.OrdinalIgnoreCase));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Fact]
+    public void EnumerateFiles_WhenTheRootItselfIsExcluded_YieldsNothing()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "smtu_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        File.WriteAllText(Path.Combine(root, "native.dll"), "x");
+
+        try
+        {
+            Assert.Empty(TuneUpService
+                .EnumerateFilesSkippingReparsePoints(root, CancellationToken.None, root));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
 }

--- a/SysManager/SysManager/Helpers/SystemPaths.cs
+++ b/SysManager/SysManager/Helpers/SystemPaths.cs
@@ -142,4 +142,49 @@ internal static class SystemPaths
             return version;
         return new Version(0, 0);
     }
+
+    /// <summary>
+    /// The directory this build extracted itself into, resolved once because the sweep visits
+    /// thousands of paths.
+    /// </summary>
+    /// <remarks>
+    /// The shipped exe is published with <c>PublishSingleFile</c> and
+    /// <c>IncludeNativeLibrariesForSelfExtract</c>, so the .NET host unpacks its native libraries to
+    /// <c>%TEMP%\.net\&lt;app&gt;\&lt;hash&gt;</c> at startup and <see cref="AppContext.BaseDirectory"/>
+    /// points there. Sweeping that tree meant the app deleting its own runtime: loaded libraries refuse
+    /// to delete and were counted as errors, so a clean machine still reported failures, and anything
+    /// extracted but not yet loaded was removed for real, breaking a later lazy load (TraceEvent's
+    /// native components, which load when ETW starts for the Bandwidth Monitor, are exactly that shape).
+    /// <para>For a normal build <c>BaseDirectory</c> is the output folder, which no temp root contains,
+    /// so the exclusion is inert outside a single-file run.</para>
+    /// </remarks>
+    internal static string? OwnExtractionDirectory { get; } = Normalise(AppContext.BaseDirectory);
+
+    /// <summary>
+    /// True when <paramref name="candidate"/> IS <paramref name="subtree"/> or sits inside it.
+    /// Compared on a directory boundary, so a sibling such as <c>…\SysManagerX</c> is never mistaken
+    /// for <c>…\SysManager</c> — the same boundary rule the system-root checks use elsewhere.
+    /// Null or unusable input excludes nothing.
+    /// </summary>
+    internal static bool IsInsideSubtree(string candidate, string? subtree)
+    {
+        if (Normalise(subtree) is not { Length: > 0 } root) return false;
+        if (Normalise(candidate) is not { Length: > 0 } full) return false;
+
+        return full.Equals(root, StringComparison.OrdinalIgnoreCase)
+            || full.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Absolute path with any trailing separator removed, or null when it cannot be formed.</summary>
+    private static string? Normalise(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return null;
+        try
+        {
+            return Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+        }
+        catch (ArgumentException) { return null; }
+        catch (NotSupportedException) { return null; }
+        catch (PathTooLongException) { return null; }
+    }
 }

--- a/SysManager/SysManager/Services/DeepCleanupService.cs
+++ b/SysManager/SysManager/Services/DeepCleanupService.cs
@@ -202,7 +202,7 @@ public sealed class DeepCleanupService
             foreach (var p in existing)
             {
                 if (ct.IsCancellationRequested) break;
-                foreach (var file in EnumerateFiles(p, ct))
+                foreach (var file in EnumerateFiles(p, ct, SystemPaths.OwnExtractionDirectory))
                 {
                     if (ct.IsCancellationRequested) break;
                     try
@@ -359,7 +359,7 @@ public sealed class DeepCleanupService
 
                 try
                 {
-                    foreach (var file in EnumerateFiles(path, ct))
+                    foreach (var file in EnumerateFiles(path, ct, SystemPaths.OwnExtractionDirectory))
                     {
                         if (ct.IsCancellationRequested) break;
                         try
@@ -381,7 +381,7 @@ public sealed class DeepCleanupService
                             Log.Debug(ex, "Deep cleanup: failed to delete file {File}", file);
                         }
                     }
-                    foreach (var dir in EnumerateDirectoriesDepthFirst(path, ct))
+                    foreach (var dir in EnumerateDirectoriesDepthFirst(path, ct, SystemPaths.OwnExtractionDirectory))
                     {
                         try { Directory.Delete(dir, recursive: false); }
                         catch (IOException ex) { Log.Debug(ex, "Deep cleanup: failed to delete directory {Dir}", dir); }
@@ -411,14 +411,22 @@ public sealed class DeepCleanupService
     private static long SafeLength(string path)
     { try { return new FileInfo(path).Length; } catch (IOException) { return 0; } catch (UnauthorizedAccessException) { return 0; } }
 
-    private static IEnumerable<string> EnumerateFiles(string root, CancellationToken ct)
+    /// <param name="excludeSubtree">
+    /// A directory tree to skip entirely, or null for none. Callers pass
+    /// <see cref="SystemPaths.OwnExtractionDirectory"/>: the "Temporary files" definition covers all of
+    /// %TEMP%, which for a single-file build is where this process unpacked its own native libraries.
+    /// Deleting those made a clean run report errors (loaded files refuse to delete) and broke a later
+    /// lazy load for anything unpacked but not yet opened.
+    /// </param>
+    private static IEnumerable<string> EnumerateFiles(
+        string root, CancellationToken ct, string? excludeSubtree = null)
     {
         // Guard the traversal ROOT itself, not just its children: if a cleanup-root
         // cache path is replaced by a junction/symlink (writable without admin, e.g.
         // %LOCALAPPDATA%\NVIDIA\GLCache), EnumerateFiles(root) would yield the LINK
         // TARGET's files and the caller would delete them — data loss outside the
         // target tree. IsReparsePoint fails safe (returns true on access error).
-        if (IsReparsePoint(root)) yield break;
+        if (IsReparsePoint(root) || SystemPaths.IsInsideSubtree(root, excludeSubtree)) yield break;
         var stack = new Stack<string>();
         stack.Push(root);
         while (stack.Count > 0 && !ct.IsCancellationRequested)
@@ -446,17 +454,18 @@ public sealed class DeepCleanupService
             // files that live outside the cleanup target tree (data-loss risk).
             foreach (var d in dirs)
             {
-                if (!IsReparsePoint(d)) stack.Push(d);
+                if (!IsReparsePoint(d) && !SystemPaths.IsInsideSubtree(d, excludeSubtree)) stack.Push(d);
             }
         }
     }
 
-    private static IEnumerable<string> EnumerateDirectoriesDepthFirst(string root, CancellationToken ct)
+    private static IEnumerable<string> EnumerateDirectoriesDepthFirst(
+        string root, CancellationToken ct, string? excludeSubtree = null)
     {
         List<string> all = [];
         // Guard the root (see EnumerateFiles): a junction at the root must not be
         // traversed, or its target's subdirectories could be reached for deletion.
-        if (IsReparsePoint(root)) return all;
+        if (IsReparsePoint(root) || SystemPaths.IsInsideSubtree(root, excludeSubtree)) return all;
         var stack = new Stack<string>();
         stack.Push(root);
         while (stack.Count > 0 && !ct.IsCancellationRequested)
@@ -468,7 +477,7 @@ public sealed class DeepCleanupService
             // link recursively) could reach outside the cleanup tree.
             foreach (var d in dirs)
             {
-                if (!IsReparsePoint(d)) stack.Push(d);
+                if (!IsReparsePoint(d) && !SystemPaths.IsInsideSubtree(d, excludeSubtree)) stack.Push(d);
             }
             if (!string.Equals(cur, root, StringComparison.OrdinalIgnoreCase)) all.Add(cur);
         }

--- a/SysManager/SysManager/Services/TuneUpService.cs
+++ b/SysManager/SysManager/Services/TuneUpService.cs
@@ -185,7 +185,7 @@ public sealed class TuneUpService
                 // symbolic links). SearchOption.AllDirectories follows them, so a
                 // junction inside %TEMP% pointing elsewhere would let this delete real
                 // user data outside TEMP. Mirrors DeepCleanupService's safe traversal.
-                foreach (var file in EnumerateFilesSkippingReparsePoints(dir, ct))
+                foreach (var file in EnumerateFilesSkippingReparsePoints(dir, ct, SystemPaths.OwnExtractionDirectory))
                 {
                     ct.ThrowIfCancellationRequested();
                     try
@@ -203,7 +203,7 @@ public sealed class TuneUpService
                 // Try to remove empty subdirectories, deepest first. Reparse points are
                 // excluded so a junction is never deleted/recursed as if it were a real
                 // directory. Depth = separator count (a deeper path can be shorter).
-                foreach (var sub in EnumerateDirectoriesSkippingReparsePoints(dir, ct)
+                foreach (var sub in EnumerateDirectoriesSkippingReparsePoints(dir, ct, SystemPaths.OwnExtractionDirectory)
                              .OrderByDescending(d => d.Count(c => c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar)))
                 {
                     ct.ThrowIfCancellationRequested();
@@ -234,13 +234,19 @@ public sealed class TuneUpService
     /// reparse points (junctions / symbolic links), so cleanup can never follow a
     /// link out of the temp tree and delete unrelated user data. Internal for testing.
     /// </summary>
-    internal static IEnumerable<string> EnumerateFilesSkippingReparsePoints(string root, CancellationToken ct)
+    /// <param name="excludeSubtree">
+    /// A directory tree to skip entirely, or null for none. The temp sweep passes
+    /// <see cref="SystemPaths.OwnExtractionDirectory"/> so it cannot delete the running build's own
+    /// files.
+    /// </param>
+    internal static IEnumerable<string> EnumerateFilesSkippingReparsePoints(
+        string root, CancellationToken ct, string? excludeSubtree = null)
     {
         // Guard the traversal ROOT too: if the root itself is a junction/symlink,
         // descending into it would follow the link out of the temp tree and yield
         // (then delete) unrelated files — amplified when running elevated. Child dirs
         // are already filtered below; the root needs the same check.
-        if (IsReparsePoint(root)) yield break;
+        if (IsReparsePoint(root) || SystemPaths.IsInsideSubtree(root, excludeSubtree)) yield break;
         var stack = new Stack<string>();
         stack.Push(root);
         while (stack.Count > 0 && !ct.IsCancellationRequested)
@@ -255,7 +261,7 @@ public sealed class TuneUpService
                 yield return file;
 
             foreach (var d in dirs)
-                if (!IsReparsePoint(d)) stack.Push(d);
+                if (!IsReparsePoint(d) && !SystemPaths.IsInsideSubtree(d, excludeSubtree)) stack.Push(d);
         }
     }
 
@@ -263,12 +269,13 @@ public sealed class TuneUpService
     /// Enumerates sub-directories under <paramref name="root"/> (excluding the root),
     /// skipping reparse points so a junction is never deleted or recursed as a real dir.
     /// </summary>
-    private static IEnumerable<string> EnumerateDirectoriesSkippingReparsePoints(string root, CancellationToken ct)
+    private static IEnumerable<string> EnumerateDirectoriesSkippingReparsePoints(
+        string root, CancellationToken ct, string? excludeSubtree = null)
     {
         List<string> all = [];
         // Same root guard as EnumerateFilesSkippingReparsePoints: never recurse a
         // junction/symlink root out of the temp tree.
-        if (IsReparsePoint(root)) return all;
+        if (IsReparsePoint(root) || SystemPaths.IsInsideSubtree(root, excludeSubtree)) return all;
         var stack = new Stack<string>();
         stack.Push(root);
         while (stack.Count > 0 && !ct.IsCancellationRequested)
@@ -277,10 +284,11 @@ public sealed class TuneUpService
             IEnumerable<string> dirs;
             try { dirs = Directory.EnumerateDirectories(cur); } catch (IOException) { continue; } catch (UnauthorizedAccessException) { continue; }
             foreach (var d in dirs)
-                if (!IsReparsePoint(d)) { stack.Push(d); all.Add(d); }
+                if (!IsReparsePoint(d) && !SystemPaths.IsInsideSubtree(d, excludeSubtree)) { stack.Push(d); all.Add(d); }
         }
         return all;
     }
+
 
     /// <summary>True when the directory is a reparse point (junction or symbolic link).</summary>
     private static bool IsReparsePoint(string path)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.4</Version>
-    <FileVersion>1.75.4.0</FileVersion>
-    <AssemblyVersion>1.75.4.0</AssemblyVersion>
+    <Version>1.75.5</Version>
+    <FileVersion>1.75.5.0</FileVersion>
+    <AssemblyVersion>1.75.5.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem

The shipped exe is published with `PublishSingleFile` and `IncludeNativeLibrariesForSelfExtract`
(`publish.ps1`), so the .NET host unpacks its native libraries into `%TEMP%\.net\<app>\<hash>` at
startup and `AppContext.BaseDirectory` points there. Nothing in the codebase knew that directory
existed, and two features walk all of `%TEMP%` deleting what they find.

Two real consequences:

- A library the process holds open **refuses to delete**, and the handler counts it as an error. A
  cleanup on a healthy machine reported failures it had caused itself, with nothing indicating the app
  had tripped over its own files.
- Anything extracted but **not yet loaded** was deleted for real, and the host does not re-extract
  mid-process. A later lazy load then fails for the rest of the session. TraceEvent's native
  components, which load when ETW starts for the Bandwidth Monitor's admin mode, are exactly that
  shape.

## Fixed in both sweeps, not just the reported one

The audit named Tune-Up. `DeepCleanupService` ships a **"Temporary files"** definition over
`[Path.GetTempPath(), Windows\Temp]` with its own walker and the identical blind spot, so fixing only
Tune-Up would have left half a migration.

The rule therefore lives **once**, in `SystemPaths`:

- `OwnExtractionDirectory` — `AppContext.BaseDirectory`, normalised, resolved once because the sweeps
  visit thousands of paths.
- `IsInsideSubtree(candidate, subtree)` — boundary-aware containment.

Both services take the same optional `excludeSubtree` parameter and both pass
`SystemPaths.OwnExtractionDirectory` **at the call site**, so neither hides the rule inside a static
and the two cannot drift. Five call sites across the two services.

Two details that matter:

- **Directory boundary, not `StartsWith`.** A sibling like `…\SysManagerX` must not be swallowed by an
  exclusion of `…\SysManager`, the same boundary rule the system-root checks already use.
- **A null subtree excludes NOTHING.** Getting that backwards would turn both cleanups into silent
  no-ops, which is why it has a test of its own.

The exclusion is **inert outside a single-file run**: for a normal build `BaseDirectory` is the output
folder, which no temp root contains. So this changes nothing for a dev build, and removes nothing the
cleanups used to remove other than the app's own live files.

## Red/green proof — five mutations, each compiled

| Mutation | Result |
|---|---|
| Shared helper excludes everything when given null | RED ×3, across both services' tests |
| Shared helper uses a bare `StartsWith` | RED — the sibling-boundary theory |
| Tune-Up stops filtering child directories (the original defect) | RED |
| Tune-Up drops its root guard | RED |
| DeepCleanup stops passing the exclusion at a call site | **initially green — a real gap** |

That last row is the useful one. Removing the argument from one of DeepCleanup's call sites went
**unnoticed by every test**: its walkers are private, and the test host's `BaseDirectory` never
intersects a temp fixture, so no unit test can observe it. Rather than leave DeepCleanup's half
unpinned, `ArchitectureTests.EveryTempTreeWalkerCall_PassesTheOwnExtractionExclusion` asserts every
walker call passes the exclusion, with a vacuity floor of 5 calls. It turns that mutation red.

Building that guard also took a correction: the first pattern matched the BCL's own
`Directory.EnumerateFiles(cur)` inside the walkers and went red for the wrong reason. It now excludes
the framework prefix.

## Verification

- All four projects build Release, 0 warnings / 0 errors; `dotnet format --verify-no-changes` clean.
- Baseline all green including the two pre-existing reparse-point safety tests, which must not regress.
- Version consistency, valid-bump (v1.75.4 → 1.75.5, patch) and CHANGELOG-lead gates pass locally.

## Note on scope

Only **our own** extraction directory is excluded. `%TEMP%\.net` also holds other single-file apps'
extractions; those are left as they are, because a running app's files fail to delete safely and a
stale directory is real space worth reclaiming. Widening the exclusion to the whole `.net` root would
trade that away, so it is deliberately not done here.

Closes #1999
