### PR TITLE
fix: name every progress bar for what it reports, so a screen reader says something useful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.6] - 2026-08-28
+
+If you use a screen reader, SysManager's progress bars now tell you what they are doing. Before, 33
+tabs all announced the same word, "Progress", and four bars announced nothing at all.
+
+### Fixed
+- **Every progress bar now says what it reports.** A screen reader announced the bare word "Progress"
+  on 33 different tabs, so it told you something was happening but never what — and four bars had no
+  announcement at all, including the strip under each sidebar entry and the spinner beside each
+  Dashboard alert. All 60 bars are now named for the thing they track: "Cleanup progress", "Driver scan
+  progress", "Update download progress", and so on. The bar under a sidebar entry names the tab it
+  belongs to, and the spinner beside a Dashboard alert names the check it is waiting on. Five more that
+  said only "Working", "Loading" or "Monitoring" got the same treatment.
+- Nothing changed visually. A name is read out, never drawn.
+
 ## [1.75.5] - 2026-08-27
 
 Tune-Up's temp cleanup was reaching into SysManager's own working files. That could make a perfectly

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2448,26 +2448,24 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
-    /// No two progress bars on the same page may be announced by the same name.
-    /// <para>Forty-four bars were announced as the bare word "Progress", and on four pages two or three
-    /// appeared at once: Deep Cleanup showed separate scan, cleanup and large-file bars, all three saying
-    /// "Progress". Worse, two were not progress at all — Disk Analyzer's drive-usage bar and Battery
-    /// Health's charge bar are GAUGES, so a screen reader announced "Progress 78" for a battery that is
-    /// 78% charged. Each now says what it reports.</para>
-    /// <para>The rule is uniqueness per view rather than "never call a bar Progress": on the 34 pages
-    /// with a single bar the bare word is uninformative but not ambiguous, and renaming those would mean
-    /// inventing 34 strings for no behavioural gain. Ambiguity is the defect; vagueness is polish.</para>
-    /// <para>Unnamed bars are ratcheted, not forbidden, and the allowance has since been tightened from
-    /// ten to FOUR. The six that carried a <c>Value</c> binding — the Dashboard's CPU, memory and GPU
-    /// gauges, its per-drive space bar, its quick-action bar, and Volume Control's per-session peak meter
-    /// — report a real reading, so they were named (#1939); the two per-row ones name their row, as the
-    /// guard above requires.</para>
-    /// <para>What remains is the four DECORATIVE strips: <c>IsIndeterminate="True"</c> with no
-    /// <c>Value</c> at all (Bulk Installer, MainWindow, two on the Dashboard). A spinner that only means
-    /// "working" arguably belongs OUT of the accessibility tree rather than named, and no convention for
-    /// hiding an element exists anywhere in this app yet — inventing one is a design decision, so it stays
-    /// on #1939. The ratchet lets these counts fall but never rise, so the debt is recorded in code rather
-    /// than in a comment nobody runs.</para>
+    /// Every progress bar carries a name, that name says what the bar reports, and no two bars on one
+    /// page share it. Four rules, all enforced below.
+    /// <para>The history: forty-four bars announced the bare word "Progress". On four pages two or three
+    /// appeared at once — Deep Cleanup showed separate scan, cleanup and large-file bars, all three
+    /// saying "Progress" — and two were not progress at all, since Disk Analyzer's drive-usage bar and
+    /// Battery Health's charge bar are GAUGES, so a screen reader announced "Progress 78" for a battery
+    /// at 78%.</para>
+    /// <para>Uniqueness alone was fixed first, on the reasoning that a single bar per page is
+    /// uninformative but not ambiguous. That reasoning was wrong in practice: it left 33 tabs where the
+    /// only announcement was "Progress", which tells a screen-reader user that something is happening
+    /// and nothing about what. All 60 bars now name their operation, gauge or row, so
+    /// <c>tooVagueToIdentify</c> rejects the bare words outright rather than tolerating them.</para>
+    /// <para><c>unnamedAllowance</c> is now EMPTY. The last four holdouts were decorative indeterminate
+    /// strips, and the open question was whether a "working" spinner belongs out of the accessibility
+    /// tree instead of being named. WPF has no declarative way to remove an element from the UIA tree
+    /// (<c>AutomationProperties.AccessibilityView</c> is UWP-only and fails to compile here), so hiding
+    /// them would have meant a custom style with real visual risk. Naming carries none, and the two that
+    /// sit inside item templates bind their row as the rule above requires.</para>
     /// </summary>
     [Fact]
     public void NoTwoProgressBarsOnAPage_AreAnnouncedTheSame()
@@ -2481,20 +2479,27 @@ public partial class ArchitectureTests
                                 || segment.Equals("bin", StringComparison.OrdinalIgnoreCase)))
             .ToArray();
 
-        // Views that still hold a bar with no name at all, with the count each is allowed. Fewer is
-        // always fine; one more is a regression.
-        // Only the decorative indeterminate strips are left. AudioMixerView is deliberately absent now:
-        // its peak meter was named, so a new unnamed bar there must fail.
-        var unnamedAllowance = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
-        {
-            ["DashboardView.xaml"] = 2,
-            ["BulkInstallerView.xaml"] = 1,
-            ["MainWindow.xaml"] = 1,
-        };
+        // EMPTY on purpose. Every bar in the app now carries a name, so there is nothing left to
+        // ratchet and any unnamed bar is a new one. The four this used to exempt were the sidebar's
+        // per-tab strip, Bulk Installer's search strip, the Dashboard's health-score strip and its
+        // per-alert spinner; the first and last are inside item templates and are bound to the row, as
+        // the repeating-bar rule below requires. Adding an entry here again means accepting a bar that
+        // announces no identity at all — settle the hide-decorative-elements convention instead.
+        var unnamedAllowance = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        // A name that could sit on any bar in any app identifies none of them. "Progress" was on 33
+        // bars across 33 tabs, so a screen reader said the same word everywhere and conveyed only that
+        // something was happening. Compared whole-string, so "Scan progress" is fine and "Progress" is
+        // not.
+        string[] tooVagueToIdentify =
+        [
+            "progress", "progress bar", "loading", "working", "busy", "please wait", "monitoring",
+        ];
 
         var ambiguous = new List<string>();
         var unnamedOverAllowance = new List<string>();
         var sameOnEveryRow = new List<string>();
+        var vague = new List<string>();
         var barsSeen = 0;
         var repeatingBars = 0;
 
@@ -2513,8 +2518,16 @@ public partial class ArchitectureTests
                 barsSeen++;
                 var name = bar.Attributes()
                     .FirstOrDefault(a => a.Name.LocalName == "AutomationProperties.Name")?.Value;
-                if (string.IsNullOrWhiteSpace(name)) unnamed++;
-                else named.Add(name.Trim());
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    unnamed++;
+                }
+                else
+                {
+                    named.Add(name.Trim());
+                    if (tooVagueToIdentify.Contains(name.Trim(), StringComparer.OrdinalIgnoreCase))
+                        vague.Add($"{file} — bar announced \"{name.Trim()}\"");
+                }
 
                 // A bar inside a DataTemplate is drawn once per item, so a CONSTANT name says the same
                 // thing on every row and identifies none of them. The row guard above cannot see these:
@@ -2558,6 +2571,12 @@ public partial class ArchitectureTests
             + "moved into a view that had none. Name it for what it reports, or settle the "
             + $"hide-decorative-elements convention first:\n  "
             + string.Join("\n  ", unnamedOverAllowance));
+
+        Assert.True(vague.Count == 0,
+            "these progress bars are named something that would fit any bar in any application, so the "
+            + "announcement says only that something is happening. Name each one for the operation it "
+            + $"reports, e.g. \"Cleanup progress\" rather than \"Progress\":\n  "
+            + string.Join("\n  ", vague));
 
         Assert.True(sameOnEveryRow.Count == 0,
             "these progress bars are drawn once per item but announce a constant, so every row reports "

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -318,7 +318,7 @@
                                                                                        Foreground="{DynamicResource Info}"/>
                                                                         </Border>
                                                                     </Grid>
-                                                                    <ProgressBar Height="2" Margin="0,3,0,0"
+                                                                    <ProgressBar AutomationProperties.Name="{Binding Label, StringFormat='Working on {0}'}" Height="2" Margin="0,3,0,0"
                                                                                  IsIndeterminate="True"
                                                                                  Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
                                                                 </StackPanel>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.5</Version>
-    <FileVersion>1.75.5.0</FileVersion>
-    <AssemblyVersion>1.75.5.0</AssemblyVersion>
+    <Version>1.75.6</Version>
+    <FileVersion>1.75.6.0</FileVersion>
+    <AssemblyVersion>1.75.6.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AboutView.xaml
+++ b/SysManager/SysManager/Views/AboutView.xaml
@@ -169,7 +169,7 @@
                         <!-- Download progress -->
                         <StackPanel Margin="0,14,0,0"
                                     Visibility="{Binding IsDownloading, Converter={StaticResource FlexVis}}">
-                            <ProgressBar AutomationProperties.Name="Progress" Height="6" Minimum="0" Maximum="100" Value="{Binding DownloadPercent}"/>
+                            <ProgressBar AutomationProperties.Name="Update download progress" Height="6" Minimum="0" Maximum="100" Value="{Binding DownloadPercent}"/>
                             <TextBlock Text="{Binding DownloadStatus}" Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
                         </StackPanel>
 

--- a/SysManager/SysManager/Views/AppAlertsView.xaml
+++ b/SysManager/SysManager/Views/AppAlertsView.xaml
@@ -130,7 +130,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="3" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="App alert scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml
@@ -115,7 +115,7 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <ProgressBar AutomationProperties.Name="Progress" Grid.Column="0" Height="6" Minimum="0" Maximum="100"
+            <ProgressBar AutomationProperties.Name="App update progress" Grid.Column="0" Height="6" Minimum="0" Maximum="100"
                          Value="{Binding Progress}"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"/>
             <TextBlock Grid.Column="1" Text="{Binding UpgradeEtaText}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="8,0,0,0" VerticalAlignment="Center"

--- a/SysManager/SysManager/Views/AudioMixerView.xaml
+++ b/SysManager/SysManager/Views/AudioMixerView.xaml
@@ -178,7 +178,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="3" Margin="28,12,28,24">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Audio device refresh progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/BandwidthMonitorView.xaml
+++ b/SysManager/SysManager/Views/BandwidthMonitorView.xaml
@@ -227,7 +227,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="5" Margin="28,12,28,24">
-            <ProgressBar AutomationProperties.Name="Monitoring" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Bandwidth monitoring progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="True"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding ModeDescription}" Style="{StaticResource Caption}" DockPanel.Dock="Right"

--- a/SysManager/SysManager/Views/BootAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/BootAnalyzerView.xaml
@@ -149,7 +149,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="4" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Boot analysis progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <Button DockPanel.Dock="Right" Content="Refresh" Command="{Binding RefreshCommand}"

--- a/SysManager/SysManager/Views/BrowserCleanerView.xaml
+++ b/SysManager/SysManager/Views/BrowserCleanerView.xaml
@@ -99,7 +99,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="3" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Browser cleanup progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -126,7 +126,7 @@
                 </DockPanel>
 
                 <!-- Searching indicator -->
-                <ProgressBar IsIndeterminate="True" Height="2" Margin="0,8,0,0"
+                <ProgressBar AutomationProperties.Name="Searching for apps" IsIndeterminate="True" Height="2" Margin="0,8,0,0"
                              Visibility="{Binding IsSearching, Converter={StaticResource BoolToVis}}"/>
 
                 <!-- Search results -->
@@ -279,7 +279,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="5" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="App install progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Value="{Binding Progress}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -157,7 +157,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="4" Margin="28,12,28,24">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Cleanup progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Value="{Binding Progress}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>

--- a/SysManager/SysManager/Views/ContextMenuView.xaml
+++ b/SysManager/SysManager/Views/ContextMenuView.xaml
@@ -256,7 +256,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="5" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Context menu scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/CpuAffinityView.xaml
+++ b/SysManager/SysManager/Views/CpuAffinityView.xaml
@@ -113,7 +113,7 @@
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
             <DockPanel Grid.Column="0" VerticalAlignment="Center">
-                <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+                <ProgressBar AutomationProperties.Name="Process list progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                              IsIndeterminate="{Binding IsProgressIndeterminate}"
                              Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
                 <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -259,7 +259,7 @@
             <Border Grid.Row="4" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="14"
                     Visibility="{Binding IsHealthScoreLoading, Converter={StaticResource BoolToVis}}">
                 <StackPanel Orientation="Horizontal">
-                    <ProgressBar IsIndeterminate="True" Width="80" Height="4" Margin="0,0,10,0" VerticalAlignment="Center"/>
+                    <ProgressBar AutomationProperties.Name="Computing health score" IsIndeterminate="True" Width="80" Height="4" Margin="0,0,10,0" VerticalAlignment="Center"/>
                     <TextBlock Text="Computing health score…" Foreground="{DynamicResource TextSecondary}" FontSize="12"/>
                 </StackPanel>
             </Border>
@@ -529,7 +529,7 @@
                                     <StackPanel Margin="0,0,0,8">
                                         <StackPanel Orientation="Horizontal">
                                             <!-- Loading spinner -->
-                                            <ProgressBar IsIndeterminate="True" Width="14" Height="14" Margin="0,0,8,0"
+                                            <ProgressBar AutomationProperties.Name="{Binding Title, StringFormat='Checking {0}'}" IsIndeterminate="True" Width="14" Height="14" Margin="0,0,8,0"
                                                          VerticalAlignment="Center">
                                                 <ProgressBar.Style>
                                                     <Style TargetType="ProgressBar" BasedOn="{StaticResource {x:Type ProgressBar}}">

--- a/SysManager/SysManager/Views/DebloaterView.xaml
+++ b/SysManager/SysManager/Views/DebloaterView.xaml
@@ -126,7 +126,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="3" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="App removal progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Value="{Binding Progress}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>

--- a/SysManager/SysManager/Views/DefenderView.xaml
+++ b/SysManager/SysManager/Views/DefenderView.xaml
@@ -161,7 +161,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="6" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Defender operation progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/DisplayProfileView.xaml
+++ b/SysManager/SysManager/Views/DisplayProfileView.xaml
@@ -110,7 +110,7 @@
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
             <DockPanel Grid.Column="0" VerticalAlignment="Center">
-                <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+                <ProgressBar AutomationProperties.Name="Display mode progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                              IsIndeterminate="{Binding IsProgressIndeterminate}"
                              Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
                 <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>

--- a/SysManager/SysManager/Views/DriversView.xaml
+++ b/SysManager/SysManager/Views/DriversView.xaml
@@ -121,7 +121,7 @@
 
             <!-- Status bar -->
             <DockPanel Grid.Row="4" Margin="0,8,0,0">
-                <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+                <ProgressBar AutomationProperties.Name="Driver scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                              IsIndeterminate="{Binding IsProgressIndeterminate}"
                              Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
                 <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/DuplicateFileView.xaml
+++ b/SysManager/SysManager/Views/DuplicateFileView.xaml
@@ -180,7 +180,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="4" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Duplicate file scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <!-- The status text now carries the file being read, so it can be long; trim it rather than

--- a/SysManager/SysManager/Views/EdgeOneDriveView.xaml
+++ b/SysManager/SysManager/Views/EdgeOneDriveView.xaml
@@ -121,7 +121,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="3" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Edge and OneDrive operation progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/FileLockView.xaml
+++ b/SysManager/SysManager/Views/FileLockView.xaml
@@ -114,7 +114,7 @@
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
             <DockPanel Grid.Column="0" VerticalAlignment="Center">
-                <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+                <ProgressBar AutomationProperties.Name="File lock scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                              IsIndeterminate="{Binding IsProgressIndeterminate}"
                              Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
                 <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>

--- a/SysManager/SysManager/Views/GamingProfileView.xaml
+++ b/SysManager/SysManager/Views/GamingProfileView.xaml
@@ -142,7 +142,7 @@
         <!-- Action bar -->
         <Border Grid.Row="4" Style="{StaticResource Card}" Margin="28,12,28,24" Padding="12">
             <DockPanel>
-                <ProgressBar AutomationProperties.Name="Working" DockPanel.Dock="Left" Width="100" Height="4"
+                <ProgressBar AutomationProperties.Name="Gaming profile progress" DockPanel.Dock="Left" Width="100" Height="4"
                              VerticalAlignment="Center" Margin="0,0,12,0"
                              IsIndeterminate="{Binding IsProgressIndeterminate}"
                              Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -479,7 +479,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="4" Margin="28,12,28,24">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Log loading progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/NotificationBlockerView.xaml
+++ b/SysManager/SysManager/Views/NotificationBlockerView.xaml
@@ -136,7 +136,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="5" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Notification setting progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/PerformanceView.xaml
+++ b/SysManager/SysManager/Views/PerformanceView.xaml
@@ -336,7 +336,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="5" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Performance tweak progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -135,7 +135,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="4" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Privacy setting progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -294,7 +294,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="5" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Process list progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/ProfileView.xaml
+++ b/SysManager/SysManager/Views/ProfileView.xaml
@@ -74,7 +74,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="4" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Profile import and export progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/ResourceHistoryView.xaml
+++ b/SysManager/SysManager/Views/ResourceHistoryView.xaml
@@ -117,7 +117,7 @@
 
         <!-- Status -->
         <DockPanel Grid.Row="4" Margin="28,12,28,24">
-            <ProgressBar AutomationProperties.Name="Loading" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Resource history loading progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="True"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>

--- a/SysManager/SysManager/Views/RestorePointsView.xaml
+++ b/SysManager/SysManager/Views/RestorePointsView.xaml
@@ -123,7 +123,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="4" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Restore point progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/ScheduledMaintenanceView.xaml
+++ b/SysManager/SysManager/Views/ScheduledMaintenanceView.xaml
@@ -114,7 +114,7 @@
 
         <!-- Status -->
         <DockPanel Grid.Row="5" Margin="28,12,28,24">
-            <ProgressBar AutomationProperties.Name="Working" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Scheduled maintenance progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="True"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -310,7 +310,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="4" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Service list progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/StandbyMemoryView.xaml
+++ b/SysManager/SysManager/Views/StandbyMemoryView.xaml
@@ -124,7 +124,7 @@
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
             <DockPanel Grid.Column="0" VerticalAlignment="Center">
-                <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+                <ProgressBar AutomationProperties.Name="Standby memory progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                              IsIndeterminate="{Binding IsProgressIndeterminate}"
                              Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
                 <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -269,7 +269,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="4" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Startup item scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/SystemFixesView.xaml
+++ b/SysManager/SysManager/Views/SystemFixesView.xaml
@@ -120,7 +120,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="4" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="System repair progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <Button DockPanel.Dock="Right" Content="Cancel" Command="{Binding CancelCommand}"

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -383,7 +383,7 @@
 
                 <!-- Status bar -->
                 <DockPanel Margin="0,16,0,0">
-                    <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+                    <ProgressBar AutomationProperties.Name="System health check progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                                  IsIndeterminate="{Binding IsProgressIndeterminate}"
                                  Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
                     <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/SystemReportView.xaml
+++ b/SysManager/SysManager/Views/SystemReportView.xaml
@@ -79,7 +79,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="3" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Report generation progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/TweaksHubView.xaml
+++ b/SysManager/SysManager/Views/TweaksHubView.xaml
@@ -137,7 +137,7 @@
         <!-- Action bar -->
         <Border Grid.Row="4" Style="{StaticResource Card}" Margin="28,12,28,24" Padding="12">
             <DockPanel>
-                <ProgressBar AutomationProperties.Name="Working" DockPanel.Dock="Left" Width="100" Height="4"
+                <ProgressBar AutomationProperties.Name="Tweak progress" DockPanel.Dock="Left" Width="100" Height="4"
                              VerticalAlignment="Center" Margin="0,0,12,0" IsIndeterminate="True"
                              Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
                 <TextBlock DockPanel.Dock="Left" VerticalAlignment="Center"

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -273,7 +273,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="5" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Uninstall progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Value="{Binding Progress}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -276,7 +276,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="5" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Windows feature progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -375,7 +375,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="7" Margin="28,12,28,24">
-            <ProgressBar AutomationProperties.Name="Progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+            <ProgressBar AutomationProperties.Name="Windows update progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Value="{Binding Progress}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>


### PR DESCRIPTION
## Problem

33 progress bars announced the bare word **"Progress"**. Across 33 different tabs that is the same
announcement, so a screen reader told you something was happening and never what. Four more announced
nothing at all, and five said only "Working", "Loading" or "Monitoring" — the same defect in different
words.

| | before | after |
|---|---|---|
| ProgressBar elements | 60 | 60 |
| no accessible name | 4 | **0** |
| named "Progress" | 33 | **0** |
| vague ("Working"/"Loading"/"Monitoring") | 5 | **0** |
| descriptive | 18 | **60** |

## What each one is called now

Each name comes from what that bar actually reports, read from its bindings and surrounding markup
rather than guessed from the view name: "Cleanup progress", "Driver scan progress", "Update download
progress", "Searching for apps", "Computing health score", and so on. The 23 bars that were already
descriptive set the convention.

Two are inside item templates and bind a property of the row:

- the strip under each sidebar entry → `{Binding Label, StringFormat='Working on {0}'}` (`NavItem.Label`)
- the spinner beside each Dashboard alert → `{Binding Title, StringFormat='Checking {0}'}` (`DashboardAlert.Title`)

A constant in either place would say identical words on every row, which the guard's existing
repeating-bar rule already forbids. Both bound properties were verified to exist.

## The guard is tightened, not duplicated

`NoTwoProgressBarsOnAPage_AreAnnouncedTheSame` enforced only per-page **uniqueness**, on the explicit
reasoning that a single bar per page is "uninformative but not ambiguous — ambiguity is the defect;
vagueness is polish". That reasoning is exactly what left 33 tabs saying one word, so it is retired:

- `unnamedAllowance`, which exempted precisely the four nameless bars, is now **empty**. A stale
  exemption is a lie about the codebase the next reader trusts.
- A new `tooVagueToIdentify` list rejects the bare words whole-string, so "Scan progress" passes and
  "Progress" does not.
- The summary described the old debt as the current state; it now describes the rule as it stands.

## Why naming rather than hiding

The open question on #1939 was whether a decorative "working" spinner belongs **out** of the
accessibility tree instead of being named. It cannot be done cleanly here:
`AutomationProperties.AccessibilityView` is UWP-only and does not compile in WPF (verified earlier by
compiler error `MC3072`). Hiding would have meant a custom style with real visual risk; a name carries
none, and it is strictly more useful than silence.

## Red/green proof

Five mutations, each compiled, each turning the guard red:

| Mutation | Catches |
|---|---|
| Revert a name to `"Progress"` | the 33-bar defect returning |
| Revert a name to `"Working"` | the vague variant, previously accepted |
| Remove a name outright | that the retired allowance no longer forgives it |
| Replace a bound per-row name with a constant | same words on every alert |
| Give two bars on one page the same name | the original uniqueness rule still works |

## Verification

- All four projects build Release, 0 warnings / 0 errors; `dotnet format --verify-no-changes` clean.
- The XAML diff is **attribute-only** across 41 views — every changed line is a `ProgressBar` line, and
  the author header on each file is untouched.
- Re-scan after the change: 60 bars, 0 unnamed, 0 vague, no duplicate name within any single view.
- Version consistency, valid-bump (v1.75.5 → 1.75.6, patch) and CHANGELOG-lead gates pass locally.

## Note on scope

#1939 also covers the earlier count of "10 unnamed and 34 generic". Those numbers were already stale
when I re-derived them: the real figures were 4 and 33, and my first scan said 5 because the pattern
`<ProgressBar\b` also matched the property-element tag `<ProgressBar.Style>`. The corrected count is
60 elements, not 61. I will post the accurate figures on the issue.

Refs #1939
