### PR TITLE
fix: make dashboard metrics, slider focus and sidebar hover readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.7] - 2026-08-28
+
+Five things you could see, or could not see, in the interface. On any light theme the Dashboard's
+MEMORY and GPU figures were washed out; sliders gave no sign of which one the keyboard was on; the
+per-drive checkboxes in System Health all sounded identical to a screen reader; Shortcut Cleaner's
+delete button looked like an ordinary one; and pointing at a sidebar group made it look already open.
+
+### Fixed
+- **The Dashboard's MEMORY and GPU figures are legible on light themes.** Every other colour in the
+  app is chosen per theme, but these two were fixed at the shades picked for the dark theme, so on a
+  light preset the MEMORY bar and its dot sat at 2.42:1 against their own track — visible if you knew
+  where to look, easy to miss otherwise — while the CPU card beside them, which uses a theme-aware
+  colour, stayed crisp. The same blue also tints the Quick action status line and its bar, so that was
+  washed out too. Both colours now darken on light themes to the same step already used by the badges
+  elsewhere in the app, which clears the 3:1 contrast that applies to a bar or a dot. Dark themes are
+  byte-for-byte unchanged.
+- **Sliders show which one has keyboard focus.** Sliders are keyboard controls by definition, since the
+  arrow keys change their value, but SysManager's slider draws its own track and thumb and that
+  replaced the outline Windows normally puts around a focused control. Tabbing through Audio Mixer or
+  Display Profiles moved focus invisibly. The slider now uses the same focus ring as every other
+  control in the app.
+- **Each drive's CHKDSK checkbox says which drive it is.** System Health lists one checkbox per drive,
+  and a screen reader announced only the control type for all of them, so you could hear that there
+  were six checkboxes but not which one was C:. Each now announces its own drive letter.
+- **Shortcut Cleaner's "Delete Selected" is styled as the destructive action it is.** It deletes files
+  from disk but wore the ordinary secondary style, so the three buttons in that row looked
+  interchangeable and the one that removes files was the least conspicuous of them. It now carries the
+  same red treatment the rest of the app uses for irreversible actions.
+- **Hovering a sidebar group no longer looks like opening it.** The group headers tinted themselves on
+  hover with the exact colour this window uses to mark the page you are on, so running the mouse down
+  the sidebar made each group in turn look like the open one. They now use the hover tint the nav rows
+  and table rows already use, which keeps the two meanings distinct.
+
 ## [1.75.6] - 2026-08-28
 
 If you use a screen reader, SysManager's progress bars now tell you what they are doing. Before, 33

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2320,13 +2320,17 @@ public partial class ArchitectureTests
     /// <summary>
     /// Every control inside a DataGrid row must announce WHICH ROW it belongs to, and the name must be
     /// somewhere an automation peer can actually read it.
-    /// <para>Two distinct defects, both of which look correct in the markup. App Blocker set
+    /// <para>Three distinct defects, all of which look correct in the markup. App Blocker set
     /// <c>AutomationProperties.Name="Select application"</c> on the <c>DataGridCheckBoxColumn</c> itself —
     /// but a column is a definition, not a visual, so it has no automation peer and the generated
     /// CheckBox in every cell stayed unlabelled. Startup Manager's per-row "Open" button had no name at
     /// all, so all of its rows announced the single word "Open" with nothing to say which program would
     /// be opened. A row control that announces the same thing on every row is barely better than one
-    /// that announces nothing: the user can hear it but cannot tell the rows apart.</para>
+    /// that announces nothing: the user can hear it but cannot tell the rows apart. The third arrived
+    /// later and from the other direction: System Health's per-drive CHKDSK checkbox sits in an
+    /// ItemsControl item template rather than a DataGrid column, so both filters below missed it and it
+    /// announced the bare control type on every drive. Found by mutation — deleting its name left every
+    /// test green.</para>
     /// <para>Both populations are derived from the XAML tree rather than from a known list, so the next
     /// column or the next row button is caught without editing this test. Attribute lookup is by local
     /// name: <c>AutomationProperties.Name</c> is written unprefixed in XAML, so it arrives as a single
@@ -2351,12 +2355,18 @@ public partial class ArchitectureTests
         static bool IsInsideAColumn(System.Xml.Linq.XElement e) =>
             e.Ancestors().Any(a => a.Name.LocalName.EndsWith("Column", StringComparison.Ordinal));
 
+        // A row of an ItemsControl/ListBox/DataGrid cell: the DataContext is one item, so a name written
+        // here is re-evaluated per row and CAN identify it — which is exactly why leaving it off hurts.
+        static bool IsInsideAnItemTemplate(System.Xml.Linq.XElement e) =>
+            e.Ancestors().Any(a => a.Name.LocalName == "DataTemplate");
+
         var namedOnTheColumn = new List<string>();
         var unnamedRowControls = new List<string>();
         var sameOnEveryRow = new List<string>();
         var columnsSeen = 0;
         var namedRowControls = 0;
         var rowNameSetters = 0;
+        var itemTemplateSelectors = 0;
 
         foreach (var path in files)
         {
@@ -2388,6 +2398,26 @@ public partial class ArchitectureTests
                     var value = (string?)element.Attribute("Value") ?? "";
                     if (!value.Contains("{Binding", StringComparison.Ordinal))
                         sameOnEveryRow.Add($"{file} — <Setter> value \"{value}\"");
+                    continue;
+                }
+
+                // A selection control living in an item template. Same rule, different container:
+                // "CheckBox" on all six drives is as useless as "Open" on all forty rows.
+                if (name is ("CheckBox" or "RadioButton") && IsInsideAnItemTemplate(element))
+                {
+                    var boxName = element.Attributes()
+                        .FirstOrDefault(a => a.Name.LocalName == "AutomationProperties.Name")?.Value;
+                    if (boxName is null)
+                    {
+                        unnamedRowControls.Add($"{file} — <{name}> in an item template carries no name");
+                    }
+                    else
+                    {
+                        itemTemplateSelectors++;
+                        if (!boxName.Contains("{Binding", StringComparison.Ordinal))
+                            sameOnEveryRow.Add($"{file} — <{name}> name \"{boxName}\"");
+                    }
+
                     continue;
                 }
 
@@ -2424,6 +2454,9 @@ public partial class ArchitectureTests
         Assert.True(rowNameSetters >= 10,
             $"only {rowNameSetters} ElementStyle name setters were found — six checkbox columns carry a "
             + "pair each, so a lower count means the Setter selector has stopped matching.");
+        Assert.True(itemTemplateSelectors >= 6,
+            $"only {itemTemplateSelectors} named item-template checkboxes were found — eight views carry "
+            + "one each, so a lower count means the DataTemplate ancestor test has stopped matching.");
 
         Assert.True(namedOnTheColumn.Count == 0,
             "AutomationProperties.Name is set on a DataGrid COLUMN, which is a definition rather than a "
@@ -2433,10 +2466,10 @@ public partial class ArchitectureTests
             + "it:\n  " + string.Join("\n  ", namedOnTheColumn));
 
         Assert.True(unnamedRowControls.Count == 0,
-            "these controls sit in a DataGrid cell template with no accessible name, so every row "
-            + "announces the same word — or nothing — and a screen-reader user cannot tell which row "
-            + "the control belongs to. Bind the name to a property of the row, as the sibling columns "
-            + $"do:\n  " + string.Join("\n  ", unnamedRowControls));
+            "these controls sit in a per-row template — a DataGrid cell or an ItemsControl item — with no "
+            + "accessible name, so every row announces the same word, or nothing, and a screen-reader user "
+            + "cannot tell which row the control belongs to. Bind the name to a property of the row, as "
+            + $"every sibling already does:\n  " + string.Join("\n  ", unnamedRowControls));
 
         // A constant name is the same defect one step later: present, readable, and identical on all
         // forty rows, so it still cannot tell them apart. Every one of the existing names binds a row
@@ -4492,5 +4525,108 @@ public partial class ArchitectureTests
     /// </summary>
     [GeneratedRegex(@"(?<!Directory\.)\bEnumerate(?:Files|Directories)\w*\((?<args>[^()]*)\)")]
     private static partial Regex TempWalkerCall();
+
+
+    /// <summary>
+    /// A style that replaces a keyboard-operable control's template must still provide a focus visual.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="NoStyle_SuppressesTheKeyboardFocusIndicator"/> catches only an explicit
+    /// <c>FocusVisualStyle="{x:Null}"</c>. Replacing the whole <c>ControlTemplate</c> removes the default
+    /// adorner just as effectively while leaving nothing for that guard to match, which is how the Slider
+    /// shipped with no keyboard cue at all: arrow keys change its value, and nothing showed which slider
+    /// had focus. Found by mutation — deleting the Slider's <c>FocusVisualStyle</c> setter left every test
+    /// green.
+    /// <para>Satisfied by either route the app already uses: the shared <c>FocusRing</c> adorner, or an
+    /// <c>IsKeyboardFocused</c> trigger drawing a ring inside the template.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryTemplatedKeyboardControl_ProvidesAFocusVisual()
+    {
+        // Controls a keyboard user drives directly. Deliberately not every control: a Border or a
+        // TextBlock is not focusable, and a Button family style is already covered above.
+        string[] keyboardDriven = ["Slider", "CheckBox", "RadioButton", "ToggleButton", "ComboBox"];
+
+        var appXaml = File.ReadAllText(Path.Combine(FindAppProjectDir(), "App.xaml"));
+        var offenders = new List<string>();
+        var stylesChecked = 0;
+
+        foreach (var type in keyboardDriven)
+        {
+            foreach (var style in TypedStyle(type).Matches(appXaml).Cast<Match>())
+            {
+                var body = style.Value;
+
+                // Only styles that take over the rendering can lose the default adorner.
+                if (!body.Contains("<ControlTemplate", StringComparison.Ordinal)) continue;
+                stylesChecked++;
+
+                // A control that cannot take focus needs no focus visual — ComboBox's internal toggle
+                // is Focusable="False" because the ComboBox itself is what the user tabs to.
+                if (NotFocusable().IsMatch(body)) continue;
+
+                var hasRing = body.Contains("FocusVisualStyle", StringComparison.Ordinal)
+                              && body.Contains("FocusRing", StringComparison.Ordinal);
+                var hasTrigger = body.Contains("IsKeyboardFocused", StringComparison.Ordinal)
+                                 || body.Contains("IsKeyboardFocusWithin", StringComparison.Ordinal);
+
+                // Style inheritance carries the setter: FilterChipCaution and FilterChipCritical are
+                // BasedOn FilterChip, which sets the ring, so they are covered without repeating it.
+                var basedOn = StyleBasedOn().Match(body);
+                if (!hasRing && !hasTrigger && basedOn.Success)
+                {
+                    var parent = TypedStyleWithKey(basedOn.Groups["key"].Value).Match(appXaml);
+                    if (parent.Success
+                        && parent.Value.Contains("FocusRing", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+                }
+
+                var key = StyleKey().Match(body);
+                if (!hasRing && !hasTrigger)
+                    offenders.Add($"{type} style '{(key.Success ? key.Groups["key"].Value : "implicit")}' "
+                                  + "replaces its template with no focus visual");
+            }
+        }
+
+        // Vacuity floor: several templated styles for these types exist today. A collapse means the
+        // pattern stopped matching and this guard is reading nothing.
+        Assert.True(stylesChecked >= 3,
+            $"only {stylesChecked} templated styles were found for {string.Join("/", keyboardDriven)} — "
+            + "the style pattern no longer matches, so this guard proves nothing.");
+
+        Assert.True(offenders.Count == 0,
+            "these styles replace a keyboard-operable control's template and provide no focus visual, so "
+            + "a keyboard user cannot see what has focus. Set FocusVisualStyle to the shared FocusRing, or "
+            + $"add an IsKeyboardFocused trigger inside the template:\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// A style that opts its own control out of focus entirely. Deliberately the SETTER form only:
+    /// matching the attribute form too made this skip the Slider, whose template children are
+    /// <c>Focusable="False"</c> while the Slider itself is exactly what the user tabs to — the guard
+    /// then went green on the very defect it was written for.
+    /// </summary>
+    [GeneratedRegex(@"<Setter\s+Property=""Focusable""\s+Value=""False""")]
+    private static partial Regex NotFocusable();
+
+    /// <summary>
+    /// Captures the key a style inherits from. Anchored to the style's own opening tag so a nested
+    /// style inside a ControlTemplate cannot donate its ring-bearing parent to the outer style.
+    /// </summary>
+    [GeneratedRegex(@"\A<Style[^>]*BasedOn=""\{StaticResource (?<key>\w+)\}""")]
+    private static partial Regex StyleBasedOn();
+
+    /// <summary>Captures a style's own key, anchored for the same reason as <see cref="StyleBasedOn"/>.</summary>
+    [GeneratedRegex(@"\A<Style[^>]*x:Key=""(?<key>\w+)""")]
+    private static partial Regex StyleKey();
+
+    private static Regex TypedStyleWithKey(string key) =>
+        new(@"<Style[^>]*x:Key=""" + Regex.Escape(key) + @"""(?:(?!</Style>).)*</Style>",
+            RegexOptions.Singleline);
+    private static Regex TypedStyle(string targetType) =>
+        new(@"<Style[^>]*TargetType=""" + Regex.Escape(targetType) + @"""(?:(?!</Style>).)*</Style>",
+            RegexOptions.Singleline);
 
 }

--- a/SysManager/SysManager.Tests/SidebarSelectionContractTests.cs
+++ b/SysManager/SysManager.Tests/SidebarSelectionContractTests.cs
@@ -169,6 +169,59 @@ public class SidebarSelectionContractTests
         Assert.Equal("{Binding Label}", (string?)liveExpander.Attribute("AutomationProperties.Name"));
     }
 
+    /// <summary>
+    /// No hover state in the sidebar may paint itself with the SELECTION brush.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="LiveRows_ShareSelectedVisualTreatment"/> pins the two brushes on the
+    /// <c>SidebarNavRow</c> style itself. It cannot see the group-header <c>Border</c>, which carries its
+    /// own inline style, and that header hovered in <c>AccentSoft</c> — the very brush this window uses to
+    /// mark the selected page. Two different meanings, one colour, in one control: moving the mouse down
+    /// the sidebar made each group look momentarily like the open one.
+    /// <para>Deliberately scoped to this window. Nine views elsewhere tint a hovered row with
+    /// <c>AccentSoft</c> and none of them use it for selection, so there is nothing to confuse; the rule
+    /// is not "AccentSoft is never a hover colour" but "not where it already means selected".</para>
+    /// </remarks>
+    [Fact]
+    public void NoSidebarHover_BorrowsTheSelectionBrush()
+    {
+        var document = LoadProjectXaml("MainWindow.xaml");
+
+        // Any trigger shape, including a MultiTrigger whose condition list mentions the property, so a
+        // future rewrite into conditions cannot slip past this.
+        var hoverTriggers = document
+            .Descendants()
+            .Where(element => element.Name.LocalName.EndsWith("Trigger", StringComparison.Ordinal))
+            .Where(element =>
+                (string?)element.Attribute("Property") == "IsMouseOver"
+                || element.Descendants(Presentation + "Condition")
+                    .Any(condition => (string?)condition.Attribute("Property") == "IsMouseOver"))
+            .ToList();
+
+        // Vacuity floor: three exist today (two row hovers and the keyboard-focus border's sibling).
+        Assert.True(
+            hoverTriggers.Count >= 3,
+            $"only {hoverTriggers.Count} hover triggers were found in MainWindow.xaml — the trigger "
+            + "selector has stopped matching, so this guard is reading nothing.");
+
+        var borrowed = hoverTriggers
+            .SelectMany(trigger => trigger.Descendants(Presentation + "Setter"))
+            .Where(setter =>
+                ((string?)setter.Attribute("Property"))?.EndsWith("Background", StringComparison.Ordinal)
+                    == true
+                && ((string?)setter.Attribute("Value"))?.Contains("AccentSoft", StringComparison.Ordinal)
+                    == true)
+            .Select(setter => (string?)setter.Attribute("Value") ?? "")
+            .ToList();
+
+        Assert.True(
+            borrowed.Count == 0,
+            "a sidebar hover state paints itself with AccentSoft, which is what this window uses to mark "
+            + "the SELECTED page: hovering a group then looks identical to having opened it. Use RowHover, "
+            + $"as the nav rows and DataGridRow already do. Found {borrowed.Count} occurrence(s): "
+            + string.Join(", ", borrowed));
+    }
+
     [Fact]
     public void LegacyTabItemStyle_IsNotKeptAsASecondSourceOfTruth()
     {

--- a/SysManager/SysManager.Tests/ThemeStatusBrushTests.cs
+++ b/SysManager/SysManager.Tests/ThemeStatusBrushTests.cs
@@ -142,6 +142,58 @@ public class ThemeStatusBrushTests
             $"Light-theme '{key}' must meet WCAG AA (4.5:1) as small badge text on the most-tinted light surface; got {ratio:F2}:1.");
     }
 
+    /// <summary>
+    /// Mirrors <c>ThemeService.Lerp</c> so the track colour under a metric fill is derived with the
+    /// same maths the app uses, rather than an approximation of it.
+    /// </summary>
+    private static Color Lerp(Color a, Color b, double t) => Color.FromArgb(
+        255,
+        (byte)(a.R + (b.R - a.R) * t),
+        (byte)(a.G + (b.G - a.G) * t),
+        (byte)(a.B + (b.B - a.B) * t));
+
+    // Dashboard metric accents (#1623). Deliberately NOT folded into the theories above: both real
+    // usages are non-text — the ProgressBar fill and the 6px status dot — so the applicable bar is
+    // WCAG 1.4.11's 3:1 for graphical objects, not 4.5:1 for small text. Asserting 4.5 here would be
+    // over-strict for a fill and would reject a legitimate future value; asserting nothing would leave
+    // the defect free to return. The 26px bold percentage is large text, which 3:1 also covers.
+    //
+    // The surface is the fill's OWN track (Surface3), derived the way ThemeService derives it, because
+    // that is what the fill is measured against — not the card behind it.
+    [Theory]
+    [InlineData("MetricBlue")]
+    [InlineData("MetricPurple")]
+    public void LightPalette_MetricAccents_MeetNonTextContrastOnTheirTrack(string key)
+    {
+        var track = Lerp(LightTintedSurface, C("#0F172A"), 0.05);   // Surface3 = Lerp(Surface2, TextPrimary, 0.05)
+        var ratio = ContrastRatio(Lookup(ThemeService.StatusPalette(false), key), track);
+        Assert.True(ratio >= 3.0,
+            $"Light-theme '{key}' is a ProgressBar fill and a status dot, so it must meet WCAG 1.4.11 "
+            + $"(3:1) against its own Surface3 track; got {ratio:F2}:1.");
+    }
+
+    [Theory]
+    [InlineData("MetricBlue")]
+    [InlineData("MetricPurple")]
+    public void DarkPalette_MetricAccents_AreByteIdenticalToTheAppXamlDefaults(string key)
+    {
+        // The dark branch must be a no-op: these tints already worked there, and a shift would
+        // invalidate every dark-theme screenshot for no benefit.
+        var expected = key == "MetricBlue" ? C("#3B82F6") : C("#A855F7");
+        Assert.Equal(expected, Lookup(ThemeService.StatusPalette(true), key));
+    }
+
+    [Theory]
+    [InlineData("MetricBlue")]
+    [InlineData("MetricPurple")]
+    public void MetricAccents_PresentInBothModes_AndDiverge(string key)
+    {
+        // If the light rows were dropped, Lookup would throw rather than silently fall back, and the
+        // divergence assertion states the intent that light is NOT simply the dark value.
+        Assert.NotEqual(Lookup(ThemeService.StatusPalette(true), key),
+                        Lookup(ThemeService.StatusPalette(false), key));
+    }
+
     [Theory]
     [InlineData("CriticalText")]
     [InlineData("BadgeIndigoText")]

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -890,6 +890,11 @@
             <!-- names so snapping + value binding still work.                   -->
             <!-- ============================================================ -->
             <Style TargetType="Slider">
+                <!-- The template below replaces the whole control, which drops the default focus
+                     adorner, and a slider is keyboard-operated by definition (arrow keys change the
+                     value). The shared FocusRing adorner draws outside the control, so it needs no
+                     room inside the 4px track. -->
+                <Setter Property="FocusVisualStyle" Value="{StaticResource FocusRing}"/>
                 <Setter Property="Foreground" Value="{DynamicResource Accent}"/>
                 <Setter Property="Background" Value="{DynamicResource Border2}"/>
                 <Setter Property="MinHeight" Value="22"/>

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -183,8 +183,12 @@
                                                 <Style TargetType="Border">
                                                     <Setter Property="Background" Value="Transparent"/>
                                                     <Style.Triggers>
+                                                        <!-- RowHover, not AccentSoft: AccentSoft is what marks the
+                                                             SELECTED item elsewhere in this same sidebar, so using it
+                                                             for hover made pointing at a group look identical to
+                                                             having opened it. -->
                                                         <Trigger Property="IsMouseOver" Value="True">
-                                                            <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
+                                                            <Setter Property="Background" Value="{DynamicResource RowHover}"/>
                                                         </Trigger>
                                                     </Style.Triggers>
                                                 </Style>

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -296,6 +296,12 @@ public sealed class ThemeService
             ("OutOutputBrush", C("#E6E6E6")), ("OutVerboseBrush", C("#9AA0A6")),
             ("OutInfoBrush", C("#38BDF8")), ("OutWarnBrush", C("#FBBF24")), ("OutErrorBrush", C("#F87171")),
             ("OutDebugBrush", C("#B388FF")), ("OutProgressBrush", C("#4ADE80")),
+
+            // Dashboard metric accents. The last two App.xaml brushes that were never re-themed, so a
+            // light preset kept these dark-theme mid-tones while the sibling CPU card used the
+            // mode-aware Success brush — one crisp card beside two washed-out ones. Dark values mirror
+            // App.xaml exactly (no visual change on dark).
+            ("MetricBlue", C("#3B82F6")), ("MetricPurple", C("#A855F7")),
         ]
         :
         [
@@ -318,6 +324,13 @@ public sealed class ThemeService
             // Danger #B91C1C already did. (Earlier values passed on #FFFFFF but dipped to ~3.6-4.3 on
             // the pastel presets — see ThemeStatusBrushTests, which now asserts against the tinted surface.)
             ("Info", C("#075985")), ("Success", C("#166534")), ("Warning", C("#9A3412")), ("Danger", C("#B91C1C")),
+
+            // Dashboard metric accents on light: blue-700 / purple-700, the same step already used for
+            // BadgeIndigoText / BadgePurpleText above. These are NON-TEXT marks — a ProgressBar fill and
+            // a 6px dot — so the bar is WCAG 1.4.11's 3:1 against their own Surface3 track, which the
+            // frozen dark tints missed badly (MetricBlue read 2.42:1 on soft-blossom). -700 rather than
+            // -800 keeps the hue identity: the 26px number must still read as "a blue metric", not black.
+            ("MetricBlue", C("#1D4ED8")), ("MetricPurple", C("#7E22CE")),
 
             // Console on light: dark-on-white body/verbose text; semantic lines reuse the AA light tones.
             ("OutOutputBrush", C("#1E1B4B")), ("OutVerboseBrush", C("#475569")),

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.6</Version>
-    <FileVersion>1.75.6.0</FileVersion>
-    <AssemblyVersion>1.75.6.0</AssemblyVersion>
+    <Version>1.75.7</Version>
+    <FileVersion>1.75.7.0</FileVersion>
+    <AssemblyVersion>1.75.7.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml
@@ -65,9 +65,12 @@
                 <Button Content="Scan" Command="{Binding ScanCommand}"
                         AutomationProperties.Name="Scan for broken shortcuts"
                         Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"/>
+                <!-- DangerButton, not Secondary: this deletes files off the disk. The style carries the
+                     colour the rest of the app uses for irreversible actions, so the row of buttons
+                     tells the user which one is the dangerous one before they read the label. -->
                 <Button Content="Delete Selected" Command="{Binding DeleteSelectedCommand}"
                         AutomationProperties.Name="Delete selected shortcuts"
-                        Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
+                        Style="{StaticResource DangerButton}" Margin="0,0,8,0"/>
                 <Button Content="Cancel" Command="{Binding CancelCommand}"
                         AutomationProperties.Name="Cancel scan"
                         Style="{StaticResource GhostButton}" Margin="0,0,16,0"

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -345,7 +345,11 @@
                                                 <ColumnDefinition Width="Auto"/>
                                                 <ColumnDefinition Width="Auto"/>
                                             </Grid.ColumnDefinitions>
-                                            <CheckBox Grid.Column="0" IsChecked="{Binding IsSelected, Mode=TwoWay}" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                                            <!-- Named for its row: one checkbox per drive, so a bare "check box"
+                                                 announcement identifies none of them. -->
+                                            <CheckBox Grid.Column="0" IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                                                      AutomationProperties.Name="{Binding Letter, StringFormat='Check drive {0}'}"
+                                                      VerticalAlignment="Center" Margin="0,0,12,0"/>
                                             <StackPanel Grid.Column="1" VerticalAlignment="Center">
                                                 <StackPanel Orientation="Horizontal">
                                                     <TextBlock Text="{Binding Letter}" FontWeight="Bold" FontSize="15" Foreground="{DynamicResource TextPrimary}"/>


### PR DESCRIPTION
Five interface defects, each re-verified against current source and each pinned by a guard that was
seen to fail on the defect and pass on the fix.

## What changed

**#1623 — Dashboard MEMORY and GPU accents were never re-themed.** `MetricBlue` and `MetricPurple` were
the last two `App.xaml` brushes that `ThemeService.StatusPalette` never overrode, so every light preset
kept the shades chosen for the dark theme. The MEMORY bar measured **2.42:1** against its own `Surface3`
track on soft-blossom, while the CPU card beside it — which uses the mode-aware `Success` brush — stayed
crisp. The same blue also tints the Quick action status line and bar. Both now take the blue-700 /
purple-700 step already used by `BadgeIndigoText` / `BadgePurpleText` above them in the same palette.
Dark values mirror `App.xaml` byte for byte, so no dark screenshot changes.

Fixed through the existing `StatusPalette` seam rather than with a bespoke darken in `ApplyTheme`: that
is where every other semantic colour already flows, and it is what makes the values testable.

**#1940 — Slider had no keyboard focus cue.** The style replaces the whole `ControlTemplate`, which drops
the default adorner, and a slider is keyboard-operated by definition. It now sets the shared `FocusRing`.

**#1553 — System Health's per-drive CHKDSK checkbox had no accessible name.** Six checkboxes, all
announcing the bare control type. It now binds its drive letter.

**#1615 — Shortcut Cleaner's "Delete Selected" used `SecondaryButton`.** It deletes files off the disk,
so it was the least conspicuous of the three buttons in its row. Now `DangerButton`.

**#1624 — The sidebar group header hovered in `AccentSoft`.** That is the brush this window uses to mark
the SELECTED page, so pointing at a group looked like having opened it. Now `RowHover`, matching
`SidebarNavRow` and `DataGridRow`.

## Guards, and why each is trustworthy

| Guard | Status | Proven by |
|---|---|---|
| `LightPalette_MetricAccents_MeetNonTextContrastOnTheirTrack` | new | reverting the light values to the dark tints |
| `DarkPalette_MetricAccents_AreByteIdenticalToTheAppXamlDefaults` | new | shifting a dark channel |
| `MetricAccents_PresentInBothModes_AndDiverge` | new | reverting the light values |
| `EveryTemplatedKeyboardControl_ProvidesAFocusVisual` | new | deleting the Slider setter |
| `EveryRowControl_AnnouncesTheRowItIsOn` | widened | deleting the checkbox name, and replacing it with a constant |
| `NoSidebarHover_BorrowsTheSelectionBrush` | new | restoring `AccentSoft` on the header hover |

The metric tests assert **3:1**, not 4.5:1: both usages are non-text (a `ProgressBar` fill and a 6px
dot), so WCAG 1.4.11 is the applicable bar, and the surface is the fill's own `Surface3` track derived
the way `ThemeService` derives it — not the card behind it.

Two of the five fixes had **no guard at all** when first written, and the mutation run recorded that
rather than glossing it. Closing those gaps is most of this diff:

- `EveryTemplatedKeyboardControl_ProvidesAFocusVisual` is new because the existing
  `NoStyle_SuppressesTheKeyboardFocusIndicator` only matches an explicit `FocusVisualStyle="{x:Null}"`.
  Replacing a template removes the adorner just as effectively and leaves that guard nothing to match.
- `EveryRowControl_AnnouncesTheRowItIsOn` was scoped to the Button family inside DataGrid columns, so a
  CheckBox in an `ItemsControl` item template fell outside both filters. Widened in place rather than
  duplicated, since it is the same rule about the same kind of control.

The focus-visual guard needed two exemptions (a `Focusable="False"` control needs no visual; a `BasedOn`
child inherits its parent's ring). Both are **proven load-bearing** by their own mutations, so neither is
a blanket skip. The first draft of that exemption also matched `Focusable="False"` on template *children*
— which made the guard pass on the very Slider defect it exists for. It reads the style's own setter now.

`#1615` is deliberately **not** guarded. Which buttons deserve `DangerButton` is a judgement about what
each command does, not something a label regex can decide: an 18-button sweep matched "Deselect All" and
"Save current as preset" alongside the real ones. The inconsistency is real but narrower than a first sweep suggests, and it is
filed as #2008 with the evidence: exactly two buttons act irreversibly while looking ordinary (Audio
Mixer's Delete preset and Environment Variables' Delete variable), and the other nine label matches are
staged list edits that correctly stay neutral. That issue also records the two mechanical rules I tried
and refuted, so nobody re-derives them.

## Verification

- All four projects build Release: **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes`: clean on all four.
- 95 XAML-contract tests via the local runner: **137 green, 2 red**, both artifacts of the runner itself
  (one resolves a source path from the runner's bin directory, the other flags the runner's own file).
- CI's version-consistency, valid-bump and CHANGELOG-lead gates extracted from `ci.yml` and run locally:
  all pass. `1.75.7` is a valid patch bump from `v1.75.6`.
- Leak scan: all 43 patterns from the enforced list against 324 added lines, 0 hits.

Visual confirmation of the light-theme rendering is deferred to an actual run of the app, as always.

Closes #1623
Closes #1940
Closes #1553
Closes #1615
Closes #1624

