### PR TITLE
fix: resolve the indirect resource reference behind a service description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.8] - 2026-08-28
+
+The Services tab now explains what each service does. Most of those descriptions were showing as a
+file path like `@%SystemRoot%\system32\spoolsv.exe,-2` instead of a sentence, which also meant
+searching for a word in a description could not find it.
+
+### Fixed
+- **Service descriptions read as sentences instead of file paths.** Windows almost never stores a
+  service's description as text. It stores a pointer into the program that owns the service, and the
+  sentence lives inside that file so one copy of Windows can show it in any language. SysManager was
+  showing the pointer. On a standard Windows 11 install that is 404 of the 461 services that have a
+  description at all, so the column that is supposed to tell you whether something is safe to turn off
+  was showing you `@%SystemRoot%\system32\spoolsv.exe,-2`. It now follows the pointer and shows what
+  Windows itself shows: "This service spools print jobs and handles interaction with the printer."
+  Search improved with it, since the search box looks at the description too — typing "print" could
+  never match the Print Spooler while its description was a path. The few descriptions Windows already
+  stores as plain text are untouched, and the handful that cannot be resolved now show nothing rather
+  than the raw pointer.
+
 ## [1.75.7] - 2026-08-28
 
 Five things you could see, or could not see, in the interface. On any light theme the Dashboard's

--- a/SysManager/SysManager.Tests/ServiceManagerServiceTests.cs
+++ b/SysManager/SysManager.Tests/ServiceManagerServiceTests.cs
@@ -141,4 +141,80 @@ public class ServiceManagerServiceTests
         await Assert.ThrowsAsync<ArgumentException>(
             () => ServiceManagerService.SetStartupTypeAsync("Winmgmt", startType, ps));
     }
+    // ── Description resolution (#1582) ─────────────────────────────────────────
+
+    [Fact]
+    public void ResolveDescription_IndirectReference_ReturnsTheResolvedText()
+    {
+        var resolved = ServiceManagerService.ResolveDescription(
+            @"@%SystemRoot%\system32\spoolsv.exe,-2",
+            _ => "This service spools print jobs.");
+
+        Assert.Equal("This service spools print jobs.", resolved);
+    }
+
+    [Theory]
+    [InlineData("Transfers files in the background using idle network bandwidth.")]
+    [InlineData("Provides user experience theme management.")]
+    public void ResolveDescription_PlainText_IsReturnedUnchanged(string description)
+    {
+        // 57 services on a stock install store real text here, and it must survive byte-for-byte.
+        Assert.Equal(
+            description,
+            ServiceManagerService.ResolveDescription(description, _ => "SHOULD NOT BE CALLED"));
+    }
+
+    [Fact]
+    public void ResolveDescription_PlainText_NeverReachesTheNativeResolver()
+    {
+        // Not merely a performance point: handing arbitrary description text to a resource loader is
+        // work that can only fail, and a resolver that returned something for plain text would
+        // silently replace a real sentence.
+        var calls = 0;
+        ServiceManagerService.ResolveDescription(
+            "Enables the detection of updates.",
+            _ => { calls++; return "replaced"; });
+
+        Assert.Equal(0, calls);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveDescription_NoValue_IsEmpty(string? raw)
+    {
+        // 365 services carry no Description at all, so this is the most common input of the three.
+        Assert.Equal("", ServiceManagerService.ResolveDescription(raw, _ => "SHOULD NOT BE CALLED"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void ResolveDescription_FailedResolve_YieldsEmptyRatherThanTheRawReference(string? nativeResult)
+    {
+        // The defect this fix exists for was showing "@%SystemRoot%\system32\wuaueng.dll,-105" to the
+        // user. Falling back to the raw value on failure would reintroduce exactly that string for the
+        // 19 services whose binary or resource id cannot be resolved, and it would also put a DLL path
+        // back into what the tab's free-text filter searches.
+        var resolved = ServiceManagerService.ResolveDescription(
+            @"@%SystemRoot%\system32\wuaueng.dll,-105",
+            _ => nativeResult);
+
+        Assert.Equal("", resolved);
+    }
+
+    [Fact]
+    public void ResolveDescription_PassesTheWholeReferenceToTheResolver()
+    {
+        // The '@' is part of the indirect-string syntax the native API parses; stripping it would make
+        // every resolution fail while still looking plausible at the call site.
+        string? seen = null;
+        const string reference = @"@%SystemRoot%\system32\spoolsv.exe,-2";
+
+        ServiceManagerService.ResolveDescription(reference, source => { seen = source; return "text"; });
+
+        Assert.Equal(reference, seen);
+    }
 }

--- a/SysManager/SysManager/Services/ServiceManagerService.cs
+++ b/SysManager/SysManager/Services/ServiceManagerService.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Collections.Frozen;
+using System.Runtime.InteropServices;
 using System.ServiceProcess;
 using SysManager.Models;
 
@@ -216,10 +217,74 @@ public sealed partial class ServiceManagerService
 
             using var key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(
                 $@"SYSTEM\CurrentControlSet\Services\{name}");
-            return key?.GetValue("Description")?.ToString() ?? "";
+            return ResolveDescription(
+                key?.GetValue("Description")?.ToString(),
+                NativeMethods.LoadIndirectString);
         }
         catch (System.Security.SecurityException) { return ""; }
         catch (UnauthorizedAccessException) { return ""; }
+    }
+
+    /// <summary>
+    /// Turns a raw registry <c>Description</c> value into readable text.
+    /// </summary>
+    /// <remarks>
+    /// Windows rarely stores a service description as text. For most in-box services the value is an
+    /// indirect resource reference — <c>@%SystemRoot%\system32\spoolsv.exe,-2</c> — and the sentence
+    /// lives in that binary's resource table, which is how one binary serves every display language.
+    /// Reading the value verbatim put the DLL path in the Description column and, worse, made it what
+    /// the tab's free-text filter searched: typing "print" could not match the Print Spooler because
+    /// its description was a path. This is not a non-English-only problem; English Windows stores the
+    /// reference too, and <c>services.msc</c> resolves it at display time exactly like this.
+    /// <para>The native call is a parameter so the decision table above it is unit-testable without
+    /// depending on which binaries a given machine has. A failed resolve yields empty rather than the
+    /// raw reference: the reference is noise to a reader and pollutes the filter, and an empty cell is
+    /// already the normal case for the 365 services that ship no description at all.</para>
+    /// </remarks>
+    internal static string ResolveDescription(string? raw, Func<string, string?> resolveIndirect)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return "";
+
+        // '@' is the only marker of an indirect reference. Anything else is already a sentence and is
+        // passed through untouched — 57 services on a stock install store real text here.
+        if (raw[0] != '@') return raw;
+
+        var resolved = resolveIndirect(raw);
+        return string.IsNullOrWhiteSpace(resolved) ? "" : resolved;
+    }
+
+    private static partial class NativeMethods
+    {
+        /// <summary>Longest description observed is ~700 chars; 2048 leaves generous headroom.</summary>
+        private const int IndirectStringBuffer = 2048;
+
+        /// <summary>
+        /// Resolves an indirect string of the form <c>@[path\]file,-resourceId</c>, expanding
+        /// environment variables on the way, or returns null when it cannot.
+        /// </summary>
+        internal static string? LoadIndirectString(string source)
+        {
+            var buffer = new char[IndirectStringBuffer];
+
+            // A missing binary, a missing resource id and a malformed reference all return E_FAIL with
+            // the buffer untouched, so a non-zero HRESULT is the whole error story — there is no
+            // partial-write case to defend against.
+            if (SHLoadIndirectString(source, buffer, IndirectStringBuffer, IntPtr.Zero) != 0)
+                return null;
+
+            // The API null-terminates rather than returning a length.
+            var end = Array.IndexOf(buffer, '\0');
+            return new string(buffer, 0, end < 0 ? buffer.Length : end);
+        }
+
+        // Unicode-only: shlwapi exports no A/W pair for this one, so it correctly carries no EntryPoint
+        // suffix. Verified against the live export table — the W-suffixed name does not resolve.
+        [LibraryImport("shlwapi.dll", StringMarshalling = StringMarshalling.Utf16)]
+        private static partial int SHLoadIndirectString(
+            string pszSource,
+            [Out] char[] pszOutBuf,
+            int cchOutBuf,
+            IntPtr ppvReserved);
     }
 
     // \A…\z (absolute anchors): ^…$ would accept a trailing newline in the service

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.7</Version>
-    <FileVersion>1.75.7.0</FileVersion>
-    <AssemblyVersion>1.75.7.0</AssemblyVersion>
+    <Version>1.75.8</Version>
+    <FileVersion>1.75.8.0</FileVersion>
+    <AssemblyVersion>1.75.8.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Windows almost never stores a service description as text. It stores an indirect resource reference and
the sentence lives inside the referenced binary, which is how one copy of Windows serves every display
language. `GetServiceDescription` read the registry value verbatim, so the Services tab printed the
reference.

## Scale, measured before writing anything

On this machine (stock Windows 11), across all 826 keys under `SYSTEM\CurrentControlSet\Services`:

| | count |
|---|---|
| carry a `Description` that is an indirect reference | **404** |
| carry a `Description` that is already plain text | 57 |
| carry no `Description` at all | 365 |

So 404 of the 461 described services were showing something like
`@%SystemRoot%\system32\spoolsv.exe,-2` in the column meant to tell a non-technical user whether a
service is safe to turn off. It also degraded search: `ServicesViewModel` filters on `Description`, so
typing "print" could not match the Print Spooler while its description was a path.

**This is not the non-English-only problem the issue assumed.** English Windows stores the reference too;
`services.msc` resolves it at display time. So it was visible on every install, including the
maintainer's.

## Why `SHLoadIndirectString`, decided by probe rather than recollection

I probed the live registry before committing to an API:

- `SHLoadIndirectString` resolved `@%systemroot%\system32\spoolsv.exe,-2` to *"This service spools print
  jobs and handles interaction with the printer…"* with `S_OK`.
- `SHLoadIndirectStringW` **does not exist** — the export is Unicode-only with no A/W pair. So per the
  interop convention it correctly carries no `EntryPoint` suffix, and TEST-PROTOCOL Phase 5's rule
  ("functions without A/W variants are OK without EntryPoint") is satisfied rather than violated.
- Every failure mode — missing binary, out-of-range resource id, malformed reference — returns `E_FAIL`
  with the buffer untouched. So a non-zero HRESULT is the whole error story and there is no
  partial-write case to guard.

`RegLoadMUIString` was the alternative named in the issue. It needs the open key's handle plus the
`ERROR_MORE_DATA` buffer-resize dance, and buys nothing here: the value is a self-contained indirect
string, which is exactly what `SHLoadIndirectString` takes.

## Design

`ResolveDescription(string? raw, Func<string, string?> resolveIndirect)` is pure, with the native call
injected. That is the only way the decision table can be tested without depending on which binaries a
given machine has — and the native half is covered by a runtime pass instead (below).

A failed resolve yields **empty**, not the raw reference. Falling back would put `@dll,-105` back on
screen for the 19 services that cannot resolve, and back into what the filter searches. An empty cell is
already the normal case for the 365 services that ship no description.

## `DisplayName` needs no equivalent fix

The issue suggested the same treatment for `DisplayName`. Checked: the registry does hold
`@%systemroot%\system32\spoolsv.exe,-1`, but `DisplayName` is read through `ServiceController`, and the
SCM resolves it before returning — `ServiceController.DisplayName` reports `Print Spooler`. Verified for
Spooler, wuauserv, Dnscache and BITS. Adding resolution there would be dead code.

## Verification

**6 unit tests, 11 rows**, every branch pinned by a mutation that compiles:

| mutation | goes red |
|---|---|
| fall back to the raw reference on a failed resolve | `FailedResolve_YieldsEmptyRatherThanTheRawReference` |
| strip the leading `@` before resolving | `PassesTheWholeReferenceToTheResolver` |
| delete the plain-text fast path | `PlainText_IsReturnedUnchanged`, `PlainText_NeverReachesTheNativeResolver` |
| return the raw value for an absent description | `NoValue_IsEmpty` |

A fifth mutation (`if (false) return raw;`) was discarded because it trips CS0162 under
warnings-as-errors, and a mutation that does not compile proves nothing — the fast path is deleted
outright instead.

**Runtime pass over all 826 real service keys**, which is the part no unit test can cover:

```
indirect references                 : 404
  resolved to readable text         : 385
  still unresolved (yield empty)    : 19
plain text, passed through unchanged: 57
no Description value at all         : 365
```

Samples: `AFD: Ancillary Function Driver for Winsock`, `ahcache: Cache Compatibility Data and Attributes
for Individual PE File`. The pass also asserts plain text is never altered, and fails loudly if it is.

Four projects build Release with 0 warnings / 0 errors; `dotnet format --verify-no-changes` clean; the
version-consistency, valid-bump and CHANGELOG-lead gates extracted from `ci.yml` all pass locally; leak
scan over all 43 enforced patterns against 168 added lines, 0 hits.

Closes #1582
