### PR TITLE
fix: pick the on-fill foreground from the theme instead of hardcoding white

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.9] - 2026-08-28
+
+Text on the coloured buttons is readable on every theme now. On most of the twelve themes the white
+label on a purple, orange or green button was too faint against its own background, worst of all on
+Warm Ember where it was barely there. Those labels switch to dark text where dark reads better.
+
+### Changed
+- **Labels on coloured buttons now pick black or white, whichever you can actually read.** The main
+  action button on every tab takes its colour from the theme, and that colour ranges from a deep indigo
+  to a bright amber, but the label on it was always white. On Warm Ember that put white text on orange,
+  which measures as barely-there rather than merely low contrast; on ten of the twelve themes it was
+  below the readable-text standard. The label now switches to dark text on the themes where dark reads
+  better, which is eight of them. Ten themes look different as a result, and that is the fix: Lavender
+  and Soft Blossom keep white text because white is genuinely better there.
+- **The same applies to the red buttons and the checkbox tick.** "Delete", "Remove" and the other red
+  buttons had the identical problem in reverse — their white label was too faint on the dark theme and
+  fine on the light one — so they now follow the same rule per theme. The tick inside a ticked checkbox
+  sits on the same theme colour and was likewise always white, so it follows too.
+
 ## [1.75.8] - 2026-08-28
 
 The Services tab now explains what each service does. Most of those descriptions were showing as a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -4629,4 +4629,94 @@ public partial class ArchitectureTests
         new(@"<Style[^>]*TargetType=""" + Regex.Escape(targetType) + @"""(?:(?!</Style>).)*</Style>",
             RegexOptions.Singleline);
 
+    /// <summary>
+    /// A control filled with a theme brush must take its foreground from the paired theme token, never a
+    /// literal <c>White</c>.
+    /// </summary>
+    /// <remarks>
+    /// The accent swings from indigo <c>#6366F1</c> to amber <c>#F59E0B</c> across the twelve presets, so a
+    /// hardcoded white label measured 2.15:1 on warm-ember and cleared AA on only two of them —
+    /// <c>PrimaryButton</c>, the checked <c>ModePill</c> and the checkbox tick all sat on that fill. The
+    /// same defect existed one brush over: <c>DangerButton</c>'s white label is 3.76:1 on the dark-mode
+    /// <c>#EF4444</c>.
+    /// <para>Guarded as a class because the four known instances are not the interesting ones — the fifth
+    /// is. It is also invisible on the dark default a maintainer looks at most, and only appears after
+    /// switching presets, so review will not catch it.</para>
+    /// <para>The <c>ToggleSwitch</c> thumb is a KNOWN exception, listed below with its reason: it is the
+    /// one filled element whose backdrop changes with its own state, so no single colour can serve it.</para>
+    /// </remarks>
+    [Fact]
+    public void NoThemedFill_CarriesAHardcodedWhiteForeground()
+    {
+        // The fills whose colour is decided by the theme rather than fixed in the XAML.
+        string[] themedFills = ["Accent", "Danger"];
+
+        // The thumb sits on Surface4 when off and on Accent when on. Measured across all twelve presets,
+        // no single colour clears 3:1 against both: a mid-dark thumb reads 1.06-1.34:1 on the Accent track
+        // of the six light presets, which is worse than the white it would replace. Fixing it needs a
+        // state-dependent thumb, which is a visual change rather than a token swap, so it is tracked
+        // separately rather than silently tolerated.
+        string[] knownExceptions = ["ToggleSwitch"];
+
+        var appXaml = File.ReadAllText(Path.Combine(FindAppProjectDir(), "App.xaml"));
+        var offenders = new List<string>();
+        var themedFillStyles = 0;
+
+        foreach (var style in AnyStyle().Matches(appXaml).Cast<Match>())
+        {
+            var body = style.Value;
+            var key = StyleKey().Match(body) is { Success: true } m ? m.Groups["key"].Value : "(implicit)";
+
+            var fill = themedFills.FirstOrDefault(
+                f => body.Contains($"Property=\"Background\" Value=\"{{DynamicResource {f}}}\"",
+                                   StringComparison.Ordinal));
+            if (fill is null) continue;
+
+            themedFillStyles++;
+            if (knownExceptions.Contains(key, StringComparer.Ordinal)) continue;
+
+            // Foreground on the control, or Stroke on a glyph drawn inside it (the checkbox tick).
+            foreach (var literal in new[] { "Property=\"Foreground\" Value=\"White\"", "Stroke=\"White\"" })
+            {
+                if (body.Contains(literal, StringComparison.Ordinal))
+                    offenders.Add($"{key} fills with {fill} but sets a literal White ({literal})");
+            }
+        }
+
+        // Vacuity floor: four styles fill with a themed brush today. A collapse means the pattern stopped
+        // matching and this guard is reading nothing.
+        Assert.True(themedFillStyles >= 4,
+            $"only {themedFillStyles} styles were found filling with {string.Join("/", themedFills)} — the "
+            + "pattern no longer matches, so this guard proves nothing.");
+
+        Assert.True(offenders.Count == 0,
+            "these styles fill with a theme brush but hardcode a white foreground, so the label's contrast "
+            + "depends on which preset is active — it measured 2.15:1 on warm-ember. Bind the paired token "
+            + $"instead (TextOnAccent, TextOnDanger):\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// The paired foreground tokens must actually be bound by the XAML.
+    /// </summary>
+    /// <remarks>
+    /// A brush computed in <c>ThemeService</c> that nothing references is this codebase's most persistent
+    /// defect shape: implemented, unit-tested, and reaching no pixel. Asserting the reference is what makes
+    /// the contrast tests meaningful rather than merely true.
+    /// </remarks>
+    [Theory]
+    [InlineData("TextOnAccent")]
+    [InlineData("TextOnDanger")]
+    public void EveryPairedForegroundToken_IsBoundBySomeStyle(string token)
+    {
+        var appDir = FindAppProjectDir();
+        var appXaml = File.ReadAllText(Path.Combine(appDir, "App.xaml"));
+        var service = File.ReadAllText(Path.Combine(appDir, "Services", "ThemeService.cs"));
+
+        Assert.Contains($"\"{token}\"", service, StringComparison.Ordinal);
+        Assert.Contains($"{{DynamicResource {token}}}", appXaml, StringComparison.Ordinal);
+    }
+
+    /// <summary>Matches any Style block, keyed or implicit, up to its closing tag.</summary>
+    [GeneratedRegex(@"<Style\b(?:(?!</Style>).)*</Style>", RegexOptions.Singleline)]
+    private static partial Regex AnyStyle();
 }

--- a/SysManager/SysManager.Tests/ThemeStatusBrushTests.cs
+++ b/SysManager/SysManager.Tests/ThemeStatusBrushTests.cs
@@ -392,4 +392,93 @@ public class ThemeStatusBrushTests
         }
         return 0.2126 * Ch(c.R) + 0.7152 * Ch(c.G) + 0.0722 * Ch(c.B);
     }
+    // ── Foregrounds on a filled surface (#1621, #1534) ─────────────────────────
+
+    /// <summary>
+    /// Every preset's accent must carry a label that clears AA. PrimaryButton is 13px SemiBold, which is
+    /// normal text under WCAG — large text needs 18.66px bold or 24px — so the bar is 4.5:1, and the
+    /// issue's suggestion of raising the font to 14px Bold to qualify for 3:1 would not have worked.
+    /// </summary>
+    [Fact]
+    public void TextOnAccent_ClearsAaAgainstEveryPresetAccent()
+    {
+        var offenders = new List<string>();
+
+        foreach (var preset in ThemePreset.Defaults.Values)
+        {
+            var ratio = ContrastRatio(ThemeService.OnColor(preset.Accent), preset.Accent);
+            if (ratio < 4.5)
+                offenders.Add($"{preset.Id} (accent #{preset.Accent.R:X2}{preset.Accent.G:X2}"
+                              + $"{preset.Accent.B:X2}) = {ratio:F2}:1");
+        }
+
+        // Vacuity floor: twelve presets ship today, so an empty loop would report a clean sweep of nothing.
+        Assert.True(ThemePreset.Defaults.Count >= 12,
+            $"only {ThemePreset.Defaults.Count} presets were found — this sweep proves nothing.");
+
+        Assert.True(offenders.Count == 0,
+            "these presets give their on-accent label less than the 4.5:1 a 13px SemiBold label needs. "
+            + "PrimaryButton, the checked ModePill and the checkbox tick all sit on this fill:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// The choice must actually vary with the accent. A constant would pass the sweep above on most
+    /// presets while quietly failing whichever half it does not suit.
+    /// </summary>
+    [Fact]
+    public void TextOnAccent_IsNotOneConstantForEveryPreset()
+    {
+        var picks = ThemePreset.Defaults.Values
+            .Select(preset => ThemeService.OnColor(preset.Accent))
+            .Distinct()
+            .ToList();
+
+        Assert.Equal(2, picks.Count);
+    }
+
+    /// <summary>
+    /// Pinned because it was the deciding measurement. A softened near-black (#1A1A1A) reads better on a
+    /// saturated fill and was the first choice, but it does NOT clear the bar: against the default accent
+    /// #6366F1 it is 3.90:1 while white is 4.47:1, so neither reaches 4.5 and the app's own signature
+    /// colour would still fail. Only pure black does, which is why the helper returns Colors.Black rather
+    /// than a friendlier tone — and why a future "soften that harsh black" edit must not be made blindly.
+    /// </summary>
+    [Fact]
+    public void TextOnAccent_NeedsPureBlack_BecauseNearBlackMissesTheDefaultAccent()
+    {
+        var defaultAccent = ThemePreset.Defaults["midnight-indigo"].Accent;
+
+        Assert.True(ContrastRatio(Colors.White, defaultAccent) < 4.5,
+            "white was expected to fail against the default accent — if it now passes, re-derive this.");
+        Assert.True(ContrastRatio(C("#1A1A1A"), defaultAccent) < 4.5,
+            "#1A1A1A was expected to fail too; that is the reason pure black is used.");
+        Assert.True(ContrastRatio(Colors.Black, defaultAccent) >= 4.5);
+        Assert.Equal(Colors.Black, ThemeService.OnColor(defaultAccent));
+    }
+
+    /// <summary>
+    /// DangerButton's label had the same defect and needs the opposite answer per mode: white on the
+    /// dark-mode #EF4444 is 3.76:1, while white on the light-mode #B91C1C is 6.47:1 and correct.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void TextOnDanger_ClearsAaAgainstTheDangerFill(bool isDark)
+    {
+        var danger = Lookup(ThemeService.StatusPalette(isDark), "Danger");
+        var ratio = ContrastRatio(ThemeService.TextOnDanger(isDark), danger);
+
+        Assert.True(ratio >= 4.5,
+            $"{(isDark ? "Dark" : "Light")}-mode DangerButton label is {ratio:F2}:1 against its own fill; "
+            + "the label is 13px SemiBold, so it needs 4.5:1.");
+    }
+
+    /// <summary>
+    /// The two modes must not land on the same answer — that is the whole reason this is derived per mode
+    /// instead of written once.
+    /// </summary>
+    [Fact]
+    public void TextOnDanger_DiffersBetweenModes()
+        => Assert.NotEqual(ThemeService.TextOnDanger(true), ThemeService.TextOnDanger(false));
 }

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -312,7 +312,7 @@
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsChecked" Value="True">
                                     <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Accent}"/>
-                                    <Setter TargetName="Txt" Property="Foreground" Value="White"/>
+                                    <Setter TargetName="Txt" Property="Foreground" Value="{DynamicResource TextOnAccent}"/>
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>
@@ -429,7 +429,7 @@
             <Style x:Key="PrimaryButton" TargetType="Button" BasedOn="{StaticResource ButtonBase}">
                 <Setter Property="Background" Value="{DynamicResource Accent}"/>
                 <Setter Property="BorderThickness" Value="0"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextOnAccent}"/>
             </Style>
 
             <!-- Secondary: subtle surface with border -->
@@ -677,7 +677,7 @@
             <Style x:Key="DangerButton" TargetType="Button" BasedOn="{StaticResource ButtonBase}">
                 <Setter Property="Background" Value="{DynamicResource Danger}"/>
                 <Setter Property="BorderThickness" Value="0"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextOnDanger}"/>
                 <!-- Own template so the DISABLED state greys out to a neutral surface instead of
                      fading white-on-red to ~1.2:1 (illegible, esp. on light themes). Enabled/hover/
                      pressed/focus mirror ButtonBase. -->
@@ -1054,7 +1054,7 @@
                                         VerticalAlignment="Center">
                                     <Path x:Name="Check"
                                           Data="M 3 9 L 7 13 L 15 5"
-                                          Stroke="White" StrokeThickness="2"
+                                          Stroke="{DynamicResource TextOnAccent}" StrokeThickness="2"
                                           StrokeStartLineCap="Round" StrokeEndLineCap="Round"
                                           Visibility="Collapsed"
                                           SnapsToDevicePixels="True"/>

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -192,6 +192,12 @@ public sealed class ThemeService
         SetBrush(res, "AccentPressed", Darken(theme.Accent, 0.12));
         SetBrush(res, "AccentSoft", Color.FromArgb(24, theme.Accent.R, theme.Accent.G, theme.Accent.B));
 
+        // The foreground for anything drawn ON the accent fill: the primary button's label, the checked
+        // mode pill's label, the checkbox tick. Those were hardcoded White, and the accent swings from
+        // indigo #6366F1 to amber #F59E0B across the presets, so white measured 2.15:1 on warm-ember and
+        // cleared AA on only two of the twelve.
+        SetBrush(res, "TextOnAccent", OnColor(theme.Accent));
+
         SetColor(res, "Surface0Color", theme.Background);
         SetColor(res, "Surface1Color", theme.Surface);
         SetColor(res, "Surface2Color", theme.Surface2);
@@ -258,6 +264,58 @@ public sealed class ThemeService
     {
         foreach (var (key, color) in StatusPalette(isDark))
             SetBrush(res, key, color);
+
+        SetBrush(res, "TextOnDanger", TextOnDanger(isDark));
+    }
+
+    /// <summary>
+    /// The legible foreground for the Danger fill in the given mode, for <c>DangerButton</c>'s label.
+    /// </summary>
+    /// <remarks>
+    /// Derived from the palette rather than listed beside it, so retuning Danger carries its paired
+    /// foreground along instead of silently stranding it at a choice made for the old value.
+    /// <para>It has to be per-mode: white on the dark-mode <c>#EF4444</c> is 3.76:1 — below the 4.5:1 a
+    /// 13px SemiBold label needs — while white on the light-mode <c>#B91C1C</c> is 6.47:1 and correct.
+    /// One constant cannot serve both.</para>
+    /// </remarks>
+    internal static Color TextOnDanger(bool isDark) =>
+        OnColor(StatusPalette(isDark).First(entry => entry.Key == "Danger").Color);
+
+    /// <summary>
+    /// Black or white, whichever contrasts more against <paramref name="background"/> — the standard
+    /// WCAG-driven "on colour" rule for text or a mark drawn on a filled surface.
+    /// </summary>
+    /// <remarks>
+    /// Pure black, not a softened near-black. #1A1A1A was the first choice, because pure black can read
+    /// as harsh on a saturated fill, but it does not clear the bar: against the default accent #6366F1 it
+    /// measures 3.90:1 while white measures 4.47:1, so NEITHER reaches 4.5 and the app's own signature
+    /// colour would still fail. With pure black every preset clears it, the worst case being 4.60:1.
+    /// <para>Deliberately a local contrast implementation rather than one shared with the tests.
+    /// <c>ThemeStatusBrushTests</c> and <c>ThemeTextContrastTests</c> keep their own, so a mistake in this
+    /// formula shows up as a failing assertion instead of being cancelled out by a shared bug. The other
+    /// copy, <c>ChartTheme.Contrast</c>, is typed for SkiaSharp's SKColor and belongs to the chart stack.</para>
+    /// </remarks>
+    internal static Color OnColor(Color background) =>
+        ContrastAgainst(Colors.White, background) >= ContrastAgainst(Colors.Black, background)
+            ? Colors.White
+            : Colors.Black;
+
+    /// <summary>WCAG 2.x relative-luminance contrast ratio between two opaque colours.</summary>
+    private static double ContrastAgainst(Color a, Color b)
+    {
+        var (la, lb) = (RelativeLuminance(a), RelativeLuminance(b));
+        return (Math.Max(la, lb) + 0.05) / (Math.Min(la, lb) + 0.05);
+    }
+
+    private static double RelativeLuminance(Color c)
+    {
+        static double Channel(byte v)
+        {
+            var s = v / 255.0;
+            return s <= 0.03928 ? s / 12.92 : Math.Pow((s + 0.055) / 1.055, 2.4);
+        }
+
+        return (0.2126 * Channel(c.R)) + (0.7152 * Channel(c.G)) + (0.0722 * Channel(c.B));
     }
 
     /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.8</Version>
-    <FileVersion>1.75.8.0</FileVersion>
-    <AssemblyVersion>1.75.8.0</AssemblyVersion>
+    <Version>1.75.9</Version>
+    <FileVersion>1.75.9.0</FileVersion>
+    <AssemblyVersion>1.75.9.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
`PrimaryButton` set `Foreground="White"` over an `Accent` fill that ranges from indigo `#6366F1` to amber
`#F59E0B` across the twelve presets. At 13px SemiBold the label is normal text under WCAG, so the bar is
4.5:1 — and white cleared it on **2 of 12**.

## Measured before writing anything

| preset | accent | white | black | picked |
|---|---|---|---|---|
| warm-ember | `#F59E0B` | **2.15** | 8.10 | black |
| dark-forest | `#10B981` | **2.54** | 6.86 | black |
| sky-breeze | `#0EA5E9` | **2.77** | 6.28 | black |
| warm-sand | `#D97706` | **3.19** | 5.46 | black |
| mint-fresh | `#16A34A` | **3.30** | 5.28 | black |
| neon-rose | `#EC4899` | **3.53** | 4.93 | black |
| deep-ocean | `#3B82F6` | **3.68** | 4.73 | black |
| violet-night | `#A855F7` | **3.96** | 4.40 → 5.31 with pure black | black |
| midnight-indigo | `#6366F1` | **4.47** | 4.70 | black |
| clean-indigo | `#6366F1` | **4.47** | 4.70 | black |
| soft-blossom | `#DB2777` | 4.60 | 4.57 | white |
| lavender | `#7C3AED` | 5.70 | 3.69 | white |

Eight presets switch to dark text. The checked `ModePill` label and the checkbox tick sit on the same fill
and had the same defect, so they follow the same token.

## Pure black, not the `#1A1A1A` the issue proposed

This is the one place I deviated from #1621's plan, and it is the deciding measurement. A softened
near-black reads better on a saturated fill, so it was the obvious choice — but against the **default**
accent `#6366F1` it measures **3.90:1** while white measures **4.47:1**. Neither reaches 4.5, so the app's
own signature colour would still have failed. Only pure black clears every preset, worst case **4.60:1**.

`TextOnAccent_NeedsPureBlack_BecauseNearBlackMissesTheDefaultAccent` asserts all three of those facts, so a
future "soften that harsh black" edit goes red with the reason attached rather than silently reintroducing
a sub-AA label.

## A second instance of the same class, found while measuring

`DangerButton`'s white label over the **dark-mode** `Danger` fill `#EF4444` is **3.76:1**; black is 5.58.
Light mode already passed (white on `#B91C1C` is 6.47:1), so one constant cannot serve both — `TextOnDanger`
is derived per mode **from the palette itself**, so retuning `Danger` carries its paired foreground along
instead of stranding it at a choice made for the old value.

## Guarded as a class

Fixing four call sites leaves nothing stopping the fifth, and this defect is invisible on the dark default a
maintainer looks at most — it only appears after switching presets, so review will not catch it.

- `NoThemedFill_CarriesAHardcodedWhiteForeground` fails any style that fills with a theme brush and
  hardcodes a white `Foreground` or `Stroke`.
- `EveryPairedForegroundToken_IsBoundBySomeStyle` asserts both tokens are actually referenced by the XAML.
  A brush computed in `ThemeService` that reaches no pixel is this codebase's most persistent defect shape,
  so the contrast tests are only meaningful alongside this one.

## Deliberately NOT fixed: the ToggleSwitch thumb

It is the third hardcoded white and #1621 proposes a formula for it. **That formula fails on 8 of 12
presets**, which I only found by measuring: the thumb sits on `Surface4` when off and on `Accent` when on,
and `Lerp(Surface, TextPrimary, 0.55)` measures **1.06–1.34:1** against the Accent track on the six light
presets — worse than the white it would replace. Two dark presets fail on the ON track with white too
(dark-forest 2.54, warm-ember 2.15).

No single colour clears 3:1 against both tracks, so it needs a state-dependent thumb, which is a visual
change rather than a token swap. It is the guard's one listed exception with that reasoning recorded in the
test, and the numbers are posted on #1621.

## Verification

**7 mutations, all red on the expected tests** — the XAML call sites and the token derivation:

| mutation | goes red |
|---|---|
| PrimaryButton label back to literal White | class guard |
| DangerButton label back to literal White | class guard + unbound-token guard |
| checkbox tick `Stroke` back to White | class guard |
| soften `OnColor` to `#1A1A1A` | per-preset sweep + the pure-black test |
| `OnColor` always returns White | sweep, not-a-constant, pure-black, and both danger tests |
| `TextOnDanger` ignores the mode | both danger tests |
| stop publishing the `TextOnAccent` brush | unbound-token guard |

Two of my own predictions were wrong and are corrected in the proof rather than accommodated: reverting
DangerButton also trips the unbound-token guard because it removes the only `TextOnDanger` reference, and
breaking `OnColor` also breaks `TextOnDanger` because they share the helper. Both are the tests being more
sensitive than I expected.

Regression sweep: **265 green** across every test that reads `App.xaml` or `ThemeService` (the 2 reds are
the local runner's own artifacts — a source-path resolution and the runner's own file lacking an author
header). Four projects build Release 0 warnings / 0 errors; `dotnet format` clean; version-consistency,
valid-bump and CHANGELOG-lead gates extracted from `ci.yml` all pass; leak scan over all 43 enforced
patterns against 269 added lines, 0 hits.

Ten presets change appearance on the app's most-used control, so this is a deliberate visual change and is
logged under `### Changed`. Approved in advance — the alternative was darkening the accent seeds, which
would have shifted the identity colour on the toggle, progress bars, chart lines and the sidebar mark too.

Visual confirmation on the light presets is deferred to an actual run of the app, as usual.

Closes #1534

#1621 stays open on purpose: its ToggleSwitch-thumb half is deliberately unfixed, for the measured reason
above. It is narrowed to the thumb so the remaining work stays tracked.

(Worded without the word "close" next to that number: GitHub matches a closing keyword adjacent to an
issue reference regardless of any negation around it, so the first version of this line auto-closed the
issue it was explaining would stay open.)


