### PR TITLE
fix: keep a notification mute the user made while a Gaming Profile was active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.10] - 2026-08-28
+
+If you turn notifications off yourself while a Gaming Profile is running, ending the profile no longer
+turns them back on. Before, it quietly undid your change, so the switch looked like it did not stick.
+
+### Fixed
+- **Muting notifications during a game now sticks after the profile ends.** A Gaming Profile with "Silence
+  notifications" turns them off while you play and turns them back on afterwards. If you got interrupted
+  mid-game, went to Privacy & Security and turned notifications off yourself, ending the profile put them
+  back on — because Windows records both changes identically, so SysManager could not tell your change
+  from its own and assumed the switch was still its to undo. It now keeps a note of when the
+  Notifications page writes that setting, so it can recognise your change and leave it alone. The note is
+  saved to disk, so this still works if the app closes mid-game and cleans up on the next launch. The
+  ordinary case is unchanged: if you do not touch the switch, ending the profile restores notifications
+  exactly as before.
+
 ## [1.75.9] - 2026-08-28
 
 Text on the coloured buttons is readable on every theme now. On most of the twelve themes the white

--- a/SysManager/SysManager.Tests/NotificationsTweakTests.cs
+++ b/SysManager/SysManager.Tests/NotificationsTweakTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using Microsoft.Win32;
 using SysManager.Models;
 using SysManager.Services;
@@ -159,5 +160,145 @@ public sealed class NotificationsTweakTests : IDisposable
         Seed(0);
 
         Assert.Equal(0, NotificationsTweak.ReadToastEnabled(_root));
+    }
+    // ── Who wrote the 0 (#1948) ────────────────────────────────────────────────
+
+    /// <summary>A disposable config directory, so the ledger never touches the real LocalAppData copy.</summary>
+    private sealed class TempConfig : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "SysManagerTests_Ledger_" + Guid.NewGuid().ToString("N"));
+
+        public void Dispose()
+        {
+            try { if (Directory.Exists(Path)) Directory.Delete(Path, recursive: true); }
+            catch (IOException) { /* best-effort cleanup */ }
+            catch (UnauthorizedAccessException) { /* best-effort cleanup */ }
+        }
+    }
+
+    /// <summary>
+    /// The sequence this fix exists for: notifications on, profile applied, then the user mutes them
+    /// HERSELF mid-session, then the profile reverts.
+    /// </summary>
+    /// <remarks>
+    /// The registry cannot answer this on its own — the user's 0 and the tweak's 0 are byte-identical — so
+    /// the value-comparison guard cannot help and revert used to restore "absent", silently re-enabling
+    /// notifications the user had just deliberately turned off.
+    /// <para>Driven through the real <see cref="NotificationBlockerService"/> rather than by seeding the
+    /// registry directly. Writing the value by hand would exercise the comparison while proving nothing
+    /// about whether the Notifications tab actually records its write, which is the half that can rot.</para>
+    /// </remarks>
+    [Fact]
+    public async Task Revert_WhenTheUserMutedNotificationsMidSession_LeavesThemMuted()
+    {
+        using var config = new TempConfig();
+        Seed(null);                                     // notifications on: value absent
+
+        var atApply = NotificationBlockerService.ReadMasterToggleWriteCount(config.Path);
+        var tweak = new NotificationsTweak(
+            originalToastEnabled: null, baseKey: _root, writeCountAtApply: atApply, configDir: config.Path);
+        await tweak.ApplyAsync(CancellationToken.None);
+        Assert.Equal(0, Current());                     // the profile silenced them
+
+        // The user opens Privacy & Security -> Notifications and turns the master toggle off herself.
+        new NotificationBlockerService(_root, config.Path).SetGlobalToastEnabled(false);
+
+        await tweak.RevertAsync(CancellationToken.None);
+
+        Assert.Equal(0, Current());
+    }
+
+    /// <summary>
+    /// The ordinary case must still revert. Without this, "never restore when the value is 0" would pass the
+    /// test above while making the tweak permanent.
+    /// </summary>
+    [Fact]
+    public async Task Revert_WhenNobodyElseTouchedTheToggle_RestoresTheSnapshot()
+    {
+        using var config = new TempConfig();
+        Seed(null);
+
+        var atApply = NotificationBlockerService.ReadMasterToggleWriteCount(config.Path);
+        var tweak = new NotificationsTweak(
+            originalToastEnabled: null, baseKey: _root, writeCountAtApply: atApply, configDir: config.Path);
+        await tweak.ApplyAsync(CancellationToken.None);
+        Assert.Equal(0, Current());
+
+        await tweak.RevertAsync(CancellationToken.None);
+
+        Assert.Null(Current());                         // back to absent = notifications on
+    }
+
+    /// <summary>
+    /// A snapshot written by a build from before this field existed has no count, and must revert exactly as
+    /// it did then rather than refusing to.
+    /// </summary>
+    /// <remarks>
+    /// This is the upgrade path: a session left active by an older build is reverted by the new one, and the
+    /// safe failure is "behave like before", not "never restore".
+    /// </remarks>
+    [Fact]
+    public async Task Revert_WithNoCapturedCount_FallsBackToTheOldBehaviour()
+    {
+        using var config = new TempConfig();
+        Seed(null);
+
+        var tweak = new NotificationsTweak(
+            originalToastEnabled: null, baseKey: _root, writeCountAtApply: null, configDir: config.Path);
+        await tweak.ApplyAsync(CancellationToken.None);
+
+        // Even a user write cannot be detected without a captured baseline, so the snapshot is restored.
+        new NotificationBlockerService(_root, config.Path).SetGlobalToastEnabled(false);
+
+        await tweak.RevertAsync(CancellationToken.None);
+
+        Assert.Null(Current());
+    }
+
+    /// <summary>
+    /// The ledger has to survive the process, because revert can run in a later one: an ActiveSession left
+    /// behind by a run that closed mid-game is reverted on the next launch.
+    /// </summary>
+    /// <remarks>
+    /// Simulated by reading the count through a fresh service instance over the same directory, which is
+    /// what a second process would do. An in-memory marker would pass every test above and fail here.
+    /// </remarks>
+    [Fact]
+    public void TheWriteLedger_SurvivesTheProcessThatWroteIt()
+    {
+        using var config = new TempConfig();
+
+        var before = NotificationBlockerService.ReadMasterToggleWriteCount(config.Path);
+        new NotificationBlockerService(_root, config.Path).SetGlobalToastEnabled(false);
+        var after = NotificationBlockerService.ReadMasterToggleWriteCount(config.Path);
+
+        Assert.Equal(before + 1, after);
+    }
+
+    /// <summary>Every user write moves the count, so two writes cannot look like none.</summary>
+    [Fact]
+    public void TheWriteLedger_CountsEveryWrite()
+    {
+        using var config = new TempConfig();
+        var service = new NotificationBlockerService(_root, config.Path);
+
+        service.SetGlobalToastEnabled(false);
+        service.SetGlobalToastEnabled(true);
+        service.SetGlobalToastEnabled(false);
+
+        Assert.Equal(3, NotificationBlockerService.ReadMasterToggleWriteCount(config.Path));
+    }
+
+    /// <summary>
+    /// A missing or unreadable ledger reads as 0 rather than throwing, and 0 equals the captured 0, so a lost
+    /// file degrades to the behaviour that shipped before the ledger existed instead of to never reverting.
+    /// </summary>
+    [Fact]
+    public void AMissingLedger_ReadsAsZeroRatherThanThrowing()
+    {
+        using var config = new TempConfig();
+
+        Assert.Equal(0, NotificationBlockerService.ReadMasterToggleWriteCount(config.Path));
     }
 }

--- a/SysManager/SysManager/Models/GamingProfile.cs
+++ b/SysManager/SysManager/Models/GamingProfile.cs
@@ -84,6 +84,18 @@ public sealed record GamingSnapshot
 
     /// <summary>The HKCU ToastEnabled DWORD before apply (null = value was absent → default on).</summary>
     public int? OriginalToastEnabled { get; init; }
+
+    /// <summary>
+    /// The Notifications tab's master-toggle write count at apply time (null = not captured).
+    /// </summary>
+    /// <remarks>
+    /// Revert compares this against the current count to tell a <c>ToastEnabled = 0</c> the profile wrote
+    /// from one the user wrote on the Notifications tab, which are byte-identical in the registry.
+    /// <para>Null means a snapshot taken before this field existed, or a profile that does not silence
+    /// notifications. Revert then skips the comparison and behaves exactly as it did before, so an
+    /// in-flight session written by an older build still reverts rather than refusing to.</para>
+    /// </remarks>
+    public int? ToastWriteCountAtApply { get; init; }
 }
 
 /// <summary>A profile + the snapshot taken when it was applied — the on-disk record of a live session.</summary>

--- a/SysManager/SysManager/Services/GamingProfileService.cs
+++ b/SysManager/SysManager/Services/GamingProfileService.cs
@@ -335,6 +335,11 @@ public sealed class GamingProfileService : IGamingProfileService, IDisposable
             OriginalUiEffectsEnabled = profile.DisableVisualEffects && PerformanceService.GetUiEffectsEnabled(),
             SearchWasRunning = profile.PauseSearchIndexing ? IsSearchRunning() : null,
             OriginalToastEnabled = profile.SilenceNotifications ? NotificationsTweak.ReadToastEnabled() : null,
+            // Captured alongside the value it qualifies: on its own, a ToastEnabled of 0 at revert cannot
+            // say whether this profile wrote it or the user did.
+            ToastWriteCountAtApply = profile.SilenceNotifications
+                ? NotificationBlockerService.ReadMasterToggleWriteCount()
+                : null,
         };
     }
 
@@ -392,7 +397,9 @@ public sealed class GamingProfileService : IGamingProfileService, IDisposable
         if (profile.FinestTimerResolution) steps.Add(new TimerResolutionTweak(_timer));
         if (profile.PurgeStandbyMemory) steps.Add(new StandbyPurgeTweak(_standby));
         if (profile.PauseSearchIndexing) steps.Add(new SearchIndexingTweak(snapshot.SearchWasRunning ?? false));
-        if (profile.SilenceNotifications) steps.Add(new NotificationsTweak(snapshot.OriginalToastEnabled));
+        if (profile.SilenceNotifications)
+            steps.Add(new NotificationsTweak(
+                snapshot.OriginalToastEnabled, writeCountAtApply: snapshot.ToastWriteCountAtApply));
         return steps;
     }
 

--- a/SysManager/SysManager/Services/GamingTweaks.cs
+++ b/SysManager/SysManager/Services/GamingTweaks.cs
@@ -181,7 +181,11 @@ internal sealed class SearchIndexingTweak(bool wasRunning) : IGamingTweak
 /// move the same switch from the Notifications tab while a profile is active; if they have, revert
 /// keeps their choice rather than resurrecting the pre-game state.
 /// </summary>
-internal sealed class NotificationsTweak(int? originalToastEnabled, RegistryKey? baseKey = null) : IGamingTweak
+internal sealed class NotificationsTweak(
+    int? originalToastEnabled,
+    RegistryKey? baseKey = null,
+    int? writeCountAtApply = null,
+    string? configDir = null) : IGamingTweak
 {
     // The key path and value name are NOT redeclared here. They are owned by
     // NotificationBlockerService, whose Notifications tab writes the same user-wide master toggle,
@@ -235,6 +239,22 @@ internal sealed class NotificationsTweak(int? originalToastEnabled, RegistryKey?
                 "Gaming Profile: notifications master toggle was changed while the profile was active "
                 + "(now {Current}); leaving the user's setting instead of restoring {Original}",
                 current, originalToastEnabled);
+            return Task.CompletedTask;
+        }
+
+        // The value IS 0 — but the guard above can only catch the user switching notifications back ON.
+        // The opposite order is invisible to it: if the user muted notifications themselves while the
+        // profile was active, the registry holds a 0 that is byte-identical to the one this tweak wrote, so
+        // restoring the snapshot would silently re-enable notifications they had just deliberately turned
+        // off. Nothing in the registry can attribute the write, which is why the Notifications tab keeps a
+        // write ledger and this compares against the count captured at apply.
+        var writesNow = NotificationBlockerService.ReadMasterToggleWriteCount(configDir);
+        if (writeCountAtApply is { } atApply && writesNow != atApply)
+        {
+            Log.Information(
+                "Gaming Profile: the user set the notifications master toggle themselves while the profile "
+                + "was active (ledger {AtApply} -> {Now}); leaving it muted instead of restoring {Original}",
+                atApply, writesNow, originalToastEnabled);
             return Task.CompletedTask;
         }
 

--- a/SysManager/SysManager/Services/NotificationBlockerService.cs
+++ b/SysManager/SysManager/Services/NotificationBlockerService.cs
@@ -2,8 +2,11 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
+using System.Text.Json;
 using Microsoft.Win32;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -47,15 +50,101 @@ public sealed class NotificationBlockerService : INotificationBlockerService
         "Microsoft.Explorer.Notification", // legacy shell bucket, not a user-facing sender
     };
 
+    // The write ledger. A profile writes ToastEnabled=0 and so does the Notifications tab, and the two
+    // are byte-identical, so the registry cannot say which one produced the 0 that Gaming Profile finds at
+    // revert. This counter is the discriminator: the Notifications tab increments it, Gaming Profile records
+    // it at apply, and a changed value at revert means the user has since moved the switch themselves.
+    //
+    // On disk rather than in memory because revert can run in a LATER PROCESS: an ActiveSession left behind
+    // by a run that closed mid-game is reverted on the next launch, and that is precisely when the marker
+    // must still exist. One file per feature is the established shape here (close-preference.json,
+    // darkmode-schedule.json, ...).
+    //
+    // Deliberately NOT in ProfileService.Catalog: the number only means something next to a snapshot taken
+    // on the same machine, so exporting it to another PC and importing it there would make revert compare
+    // against a count that never applied to it.
+    internal const string WriteLedgerFileName = "notification-master-writes.json";
+
     private readonly RegistryKey _baseKey;
+    private readonly string _ledgerPath;
 
     /// <summary>
     /// Creates the service over a registry root. Defaults to <see cref="Registry.CurrentUser"/>
     /// (the real per-user notification settings); tests pass a redirected root (a disposable
     /// HKCU subkey) so reads/writes never touch the machine's real configuration.
     /// </summary>
-    public NotificationBlockerService(RegistryKey? baseKey = null)
-        => _baseKey = baseKey ?? Registry.CurrentUser;
+    public NotificationBlockerService(RegistryKey? baseKey = null, string? configDir = null)
+    {
+        _baseKey = baseKey ?? Registry.CurrentUser;
+        _ledgerPath = LedgerPath(configDir);
+    }
+
+    /// <summary>Resolves the ledger file, overridable for tests exactly as the registry root is.</summary>
+    private static string LedgerPath(string? configDir) => Path.Combine(
+        configDir ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager"),
+        WriteLedgerFileName);
+
+    /// <summary>The stored shape. A record so the JSON stays explicit.</summary>
+    private sealed record Ledger(int Writes);
+
+    /// <summary>
+    /// How many times the Notifications tab has written the master toggle on this machine.
+    /// </summary>
+    /// <remarks>
+    /// Static so <see cref="NotificationsTweak"/> can read it without taking a dependency on this service,
+    /// mirroring how it already reads <see cref="PushKeyPath"/> and <see cref="ToastValueName"/> from here.
+    /// <para>Returns 0 when the file is missing or unreadable. That is the safe direction: a count that
+    /// looks unchanged makes Gaming Profile restore its snapshot, which is the behaviour that shipped before
+    /// this ledger existed — a lost file degrades to the old semantics rather than to never reverting.</para>
+    /// </remarks>
+    internal static int ReadMasterToggleWriteCount(string? configDir = null)
+    {
+        var path = LedgerPath(configDir);
+        try
+        {
+            if (!File.Exists(path)) return 0;
+            return JsonSerializer.Deserialize<Ledger>(File.ReadAllText(path))?.Writes ?? 0;
+        }
+        catch (IOException ex) { Log.Debug("Toast write-ledger read failed: {Error}", ex.Message); return 0; }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Toast write-ledger denied: {Error}", ex.Message); return 0; }
+        catch (JsonException ex) { Log.Debug("Toast write-ledger malformed: {Error}", ex.Message); return 0; }
+    }
+
+    /// <summary>
+    /// Records that the user-facing path just wrote the master toggle.
+    /// </summary>
+    /// <remarks>
+    /// A failure here is logged and swallowed: the toggle itself already succeeded, and refusing the user's
+    /// change because bookkeeping failed would be a worse outcome than a revert that restores when it could
+    /// have held back.
+    /// </remarks>
+    private void RecordMasterToggleWrite()
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_ledgerPath)!);
+            var next = ReadMasterToggleWriteCountAt(_ledgerPath) + 1;
+            // AtomicFile, like every other store here: a torn write would read back as a malformed
+            // ledger, which degrades to 0 and makes revert restore when it should have held back.
+            AtomicFile.WriteAllText(_ledgerPath, JsonSerializer.Serialize(new Ledger(next)));
+        }
+        catch (IOException ex) { Log.Debug("Toast write-ledger update failed: {Error}", ex.Message); }
+        catch (UnauthorizedAccessException ex) { Log.Debug("Toast write-ledger update denied: {Error}", ex.Message); }
+    }
+
+    /// <summary>Reads the ledger at an explicit path, so the instance uses its own injected location.</summary>
+    private static int ReadMasterToggleWriteCountAt(string path)
+    {
+        try
+        {
+            if (!File.Exists(path)) return 0;
+            return JsonSerializer.Deserialize<Ledger>(File.ReadAllText(path))?.Writes ?? 0;
+        }
+        catch (IOException) { return 0; }
+        catch (UnauthorizedAccessException) { return 0; }
+        catch (JsonException) { return 0; }
+    }
 
     /// <inheritdoc />
     public bool IsGlobalToastEnabled()
@@ -80,6 +169,7 @@ public sealed class NotificationBlockerService : INotificationBlockerService
                 key.DeleteValue(ToastValueName, throwOnMissingValue: false); // absent = default = on
             else
                 key.SetValue(ToastValueName, 0, RegistryValueKind.DWord);
+            RecordMasterToggleWrite();
             Log.Information("Notifications: master toggle set to {Enabled}", enabled);
             return true;
         }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.9</Version>
-    <FileVersion>1.75.9.0</FileVersion>
-    <AssemblyVersion>1.75.9.0</AssemblyVersion>
+    <Version>1.75.10</Version>
+    <FileVersion>1.75.10.0</FileVersion>
+    <AssemblyVersion>1.75.10.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
A Gaming Profile with "Silence notifications" writes `ToastEnabled = 0` and restores the snapshot on revert.
The existing guard catches the user switching notifications **back on** mid-session. It cannot catch the
opposite order, which is the more likely one:

1. Notifications are on. The profile is applied → writes `0`, snapshots "was absent".
2. The user gets interrupted, opens Privacy & Security → Notifications, and turns them **off** herself.
   `SetGlobalToastEnabled(false)` writes `0` — the same value.
3. The profile reverts. The value is `0`, so it still looks like the tweak's own write → restores "absent"
   → **silently re-enables notifications the user had just deliberately turned off.**

The registry cannot attribute the write, so the discriminator has to live out of band. This is Option A from
the issue, with two refinements.

## No `TimeProvider`, and no timestamps

The issue proposes recording *when* each side wrote and comparing. A monotonic **write counter** answers the
same question — did the other writer act after we did — without a clock. So there is no time seam to inject
and the tests cannot go flaky on ordering.

## It has to be persisted, which the issue did not consider

`GamingProfileStore.ActiveSession` exists precisely so a run that closed mid-game is reverted on the next
launch. So **revert can execute in a later process than apply**, and an in-memory marker would be gone
exactly when crash recovery needs it. `TheWriteLedger_SurvivesTheProcessThatWroteIt` pins that: an
in-memory implementation passes every other test here and fails only that one.

## The dependency direction stays right

That was the objection to the issue's Option B. `NotificationsTweak` already reaches into
`NotificationBlockerService` for `PushKeyPath` and `ToastValueName`; the ledger is read the same way, via a
static, so there is **no new DI wiring** and `GamingProfileService` keeps its current constructor. The
notification service learns nothing about Gaming Profile — it only counts its own writes.

## Failure modes, all in the safe direction

| situation | behaviour |
|---|---|
| ledger missing or malformed | reads as 0, equals a captured 0 → restores, i.e. exactly the behaviour that shipped before the ledger existed |
| snapshot has no captured count (older build) | comparison skipped → reverts as it did before, so an upgrade mid-session is not stranded |
| ledger write fails | logged and swallowed — the user's toggle already succeeded, and refusing her change because bookkeeping failed is the worse outcome |

Deliberately **not** added to `ProfileService.Catalog`: the count only means something next to a snapshot
taken on the same machine, so exporting it to another PC and importing it there would make revert compare
against a count that never applied.

## The atomic-write guard caught my own mistake

Worth recording, because it is the mechanism working as intended. My first version used
`File.WriteAllText`, and `EveryServiceThatPersistsUserData_WritesItAtomically` failed with
`NotificationBlockerService.cs:127 writes _ledgerPath in place`. It uses `AtomicFile` now, like every other
store here — and the reason matters here specifically: a torn write reads back as malformed, degrades to 0,
and makes revert restore when it should have held back.

## Verification

**6 tests.** The headline one replays the issue's exact sequence, and drives step 2 through the **real**
`NotificationBlockerService` rather than seeding the registry by hand — otherwise it would prove the
comparison works while saying nothing about whether the Notifications tab actually feeds the ledger, which
is the half that can rot.

**4 mutations, all red on the expected tests:**

| mutation | goes red |
|---|---|
| remove the ledger guard (**reproduces the shipped code**) | the headline test |
| stop recording the user write | headline + both ledger tests |
| read the ledger as always 0 | headline + both ledger tests |
| treat a missing captured count as a difference | the upgrade test **and** the pre-existing explicit-one test |

Two things the mutations revealed that I had not predicted:

- Removing the guard **does not compile** without a discard, because `writeCountAtApply` and `configDir`
  become unread primary-constructor parameters (CS9113). That independently proves those parameters are used
  by nothing except this guard.
- The last mutation also reddens the pre-existing `Revert_WhenTheValueWasExplicitlyOne...` test, correctly:
  it also constructs the tweak without a captured count, so the null fallback protects both.

The two pre-existing mid-session tests stay green throughout, so the direction that was already fixed is not
regressed.

Regression sweep: **179 green** across the notification, gaming-profile, profile-export, atomic-file and
architecture suites (the 2 reds are the local runner's own artifacts). Four projects build Release 0
warnings / 0 errors; `dotnet format` clean; version-consistency, valid-bump and CHANGELOG-lead gates
extracted from `ci.yml` all pass; leak scan over all 43 enforced patterns against 300 added lines, 0 hits.

Closes #1948
