### PR TITLE
fix: keep the text ramp legible at every background-shade position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.11] - 2026-08-28
+
+The background-shade slider in Appearance can no longer make text hard to read. Dragging it to either
+end used to fade the writing into the background, with nothing telling you that was what happened.
+
+### Fixed
+- **The background slider keeps text readable at every position.** Appearance has a slider that makes the
+  app's background lighter or darker to taste. It moved the backgrounds but left the text colours where
+  they were, so at the far ends the writing and the panel behind it drifted close enough together to be a
+  strain — and since the slider is presented as harmless personalisation, nothing connected the cause to
+  the effect. Grey label text fell below the readable-text standard at a quarter of the positions the
+  slider can reach. The text now adjusts just enough to stay readable, and only when it otherwise would
+  not: if you have never moved the slider, nothing about your theme changes.
+
 ## [1.75.10] - 2026-08-28
 
 If you turn notifications off yourself while a Gaming Profile is running, ending the profile no longer

--- a/SysManager/SysManager.Tests/ThemeTextContrastTests.cs
+++ b/SysManager/SysManager.Tests/ThemeTextContrastTests.cs
@@ -114,4 +114,95 @@ public class ThemeTextContrastTests
         }
         return 0.2126 * Ch(c.R) + 0.7152 * Ch(c.G) + 0.0722 * Ch(c.B);
     }
+    // ── The shade slider's whole range (#1558) ─────────────────────────────────
+
+    /// <summary>
+    /// Every position the background-shade slider can reach keeps the text ramp at its floor.
+    /// </summary>
+    /// <remarks>
+    /// The theories above read <c>ThemePreset.Defaults[presetId]</c>, which is the seeded preset — shade
+    /// 0.5. The slider moves the surfaces by up to ±6% lightness while the ramp is seeded once, so the
+    /// entire shifted range was untested, and measured before the fix it put <c>TextMuted</c> below 4.5:1 in
+    /// 12 of 60 preset × position combinations (worst 3.94:1, midnight-indigo at 1.0).
+    /// <para>Swept at 0.05 rather than at a handful of points: the failures cluster at the ends, and a
+    /// five-point sweep would step over a preset whose floor is breached in between.</para>
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(AllPresets))]
+    public void EveryShadePosition_KeepsTheTextRampLegible(string presetId)
+    {
+        var seeded = ThemePreset.Defaults[presetId];
+        var offenders = new List<string>();
+        var positionsChecked = 0;
+
+        for (var step = 0; step <= 20; step++)
+        {
+            var position = step * 0.05;
+            var shaded = ThemeService.Shade(seeded, position);
+            positionsChecked++;
+
+            foreach (var (label, surface) in new[]
+                     {
+                         ("Background", shaded.Background),
+                         ("Surface", shaded.Surface),
+                         ("Surface2", shaded.Surface2),
+                     })
+            {
+                var muted = ContrastRatio(shaded.TextMuted, surface);
+                if (muted < 4.5)
+                    offenders.Add($"shade {position:F2}: TextMuted on {label} = {muted:F2}:1");
+            }
+
+            var secondary = ContrastRatio(shaded.TextSecondary, shaded.Surface2);
+            if (secondary < 4.5)
+                offenders.Add($"shade {position:F2}: TextSecondary on Surface2 = {secondary:F2}:1");
+
+            var primary = ContrastRatio(shaded.TextPrimary, shaded.Background);
+            if (primary < 7.0)
+                offenders.Add($"shade {position:F2}: TextPrimary on Background = {primary:F2}:1 (AAA)");
+        }
+
+        // Vacuity floor: a loop that stopped running would report a clean sweep of nothing.
+        Assert.Equal(21, positionsChecked);
+
+        Assert.True(offenders.Count == 0,
+            $"Preset '{presetId}' drops below its contrast floor at some slider positions. The shade slider "
+            + "is presented as harmless personalisation, so an unreadable outcome must be unreachable rather "
+            + $"than merely unlikely:\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// At the default position the correction must be a no-op, so shipping it changes nothing for anyone who
+    /// has not touched the slider.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(AllPresets))]
+    public void TheDefaultShadePosition_LeavesTheSeededRampUntouched(string presetId)
+    {
+        var seeded = ThemePreset.Defaults[presetId];
+        var shaded = ThemeService.Shade(seeded, 0.5);
+
+        Assert.Equal(seeded.TextPrimary, shaded.TextPrimary);
+        Assert.Equal(seeded.TextSecondary, shaded.TextSecondary);
+        Assert.Equal(seeded.TextMuted, shaded.TextMuted);
+        Assert.Equal(seeded.Background, shaded.Background);
+    }
+
+    /// <summary>
+    /// The correction has to actually engage somewhere, or the sweep above would pass simply because nothing
+    /// ever breaches a floor and the whole mechanism could be deleted unnoticed.
+    /// </summary>
+    [Fact]
+    public void TheCorrection_EngagesWhereTheSliderWouldOtherwiseBreachTheFloor()
+    {
+        // midnight-indigo at the top of the range is the worst measured case: 3.94:1 before the fix.
+        var seeded = ThemePreset.Defaults["midnight-indigo"];
+        var shaded = ThemeService.Shade(seeded, 1.0);
+
+        Assert.NotEqual(seeded.TextMuted, shaded.TextMuted);
+        Assert.True(ContrastRatio(shaded.TextMuted, shaded.Surface2) >= 4.5);
+        Assert.True(ContrastRatio(seeded.TextMuted, shaded.Surface2) < 4.5,
+            "the uncorrected ramp was expected to fail against the shifted surface — if it now passes, "
+            + "this test no longer proves the correction does anything.");
+    }
 }

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -153,17 +153,76 @@ public sealed class ThemeService
 
     private void ApplyShade()
     {
-        var t = _baseTheme;
-        var offset = (ShadePosition - 0.5) * 0.12;
-
-        CurrentTheme = t with
-        {
-            Background = ShiftLightness(t.Background, offset),
-            Surface = ShiftLightness(t.Surface, offset),
-            Surface2 = ShiftLightness(t.Surface2, offset),
-            Border = ShiftLightness(t.Border, offset)
-        };
+        CurrentTheme = Shade(_baseTheme, ShadePosition);
         Apply(CurrentTheme);
+    }
+
+    /// <summary>
+    /// Applies the background-shade position to a preset: shifts the surfaces, then keeps the text ramp
+    /// legible against them.
+    /// </summary>
+    /// <remarks>
+    /// The slider moves <c>Background</c>, <c>Surface</c>, <c>Surface2</c> and <c>Border</c> by up to ±6%
+    /// lightness. The text ramp is seeded once, so shifting the surfaces alone narrows every text/background
+    /// pairing in the app: measured across the whole slider range, <c>TextMuted</c> fell below 4.5:1 in 12
+    /// of 60 preset × position combinations, worst 3.94:1. The popup presents the slider as harmless
+    /// personalisation, so the outcome has to be unreachable rather than merely discouraged.
+    /// <para>Two simpler fixes were measured and rejected. Shifting the ramp by <c>-offset</c> makes it
+    /// worse (13 of 60, worst 3.49) because it assumes the text is darker than its surface, which is only
+    /// true on a light preset — on a dark one the text is the lighter of the two, so darkening it closes the
+    /// gap it was meant to open. Clamping the slider cannot work either: the safe range is the lower half
+    /// for dark presets and the upper half for light ones, so the intersection across all twelve is
+    /// 0.50-0.55 and the feature would be gone.</para>
+    /// <para>Pure and static so the whole reachable range can be swept in a unit test — the instance path
+    /// writes into <c>Application.Current.Resources</c>, which a test has no business doing.</para>
+    /// </remarks>
+    internal static ThemePreset Shade(ThemePreset baseTheme, double position)
+    {
+        var offset = (position - 0.5) * 0.12;
+
+        var shaded = baseTheme with
+        {
+            Background = ShiftLightness(baseTheme.Background, offset),
+            Surface = ShiftLightness(baseTheme.Surface, offset),
+            Surface2 = ShiftLightness(baseTheme.Surface2, offset),
+            Border = ShiftLightness(baseTheme.Border, offset)
+        };
+
+        // The floors and the surfaces each one is measured against mirror ThemeTextContrastTests exactly:
+        // this correction enforces the same contract those assertions check, rather than a second opinion
+        // about what "legible" means.
+        return shaded with
+        {
+            TextPrimary = Legible(shaded.TextPrimary, baseTheme.IsDark, 7.0, shaded.Background),
+            TextSecondary = Legible(shaded.TextSecondary, baseTheme.IsDark, 4.5, shaded.Surface2),
+            TextMuted = Legible(shaded.TextMuted, baseTheme.IsDark, 4.5,
+                                shaded.Background, shaded.Surface, shaded.Surface2)
+        };
+    }
+
+    /// <summary>
+    /// Returns <paramref name="text"/> unchanged when it already clears <paramref name="minimum"/> against
+    /// every surface, otherwise walks it away from them until it does.
+    /// </summary>
+    /// <remarks>
+    /// "Away" is toward white on a dark theme and toward black on a light one, decided from the preset's own
+    /// mode rather than by comparing luminances, so a surface shifted close to the text cannot flip the
+    /// direction mid-walk. 2% steps to a 80% ceiling, matching <c>ChartTheme.ReadableAgainst</c>; every real
+    /// preset clears its floor far earlier, and the ceiling exists so a pathological custom theme terminates
+    /// rather than looping.
+    /// </remarks>
+    private static Color Legible(Color text, bool isDark, double minimum, params Color[] surfaces)
+    {
+        var target = isDark ? Colors.White : Colors.Black;
+
+        for (var step = 0; step <= 40; step++)
+        {
+            var candidate = Lerp(text, target, step * 0.02);
+            if (surfaces.All(surface => ContrastAgainst(candidate, surface) >= minimum))
+                return candidate;
+        }
+
+        return Lerp(text, target, 0.8);
     }
 
     public void Apply(ThemePreset theme)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.10</Version>
-    <FileVersion>1.75.10.0</FileVersion>
-    <AssemblyVersion>1.75.10.0</AssemblyVersion>
+    <Version>1.75.11</Version>
+    <FileVersion>1.75.11.0</FileVersion>
+    <AssemblyVersion>1.75.11.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
`ApplyShade` shifts `Background`, `Surface`, `Surface2` and `Border` by up to ±6% lightness and leaves the
text ramp seeded, so dragging the Appearance slider narrows every text/background pairing in the app.

## Measured, and the measurement rejected the proposed fix

Swept `ShadePosition` across the range for all twelve presets. `TextMuted` fell below 4.5:1 in **12 of 60**
preset × position combinations, worst **3.94:1** (midnight-indigo at 1.0) — the issue's figures reproduce
exactly.

| variant | sub-AA combinations | worst |
|---|---|---|
| as shipped | 12 / 60 | 3.94 |
| **the issue's proposal** (`-offset` on the ramp) | **13 / 60** | **3.49** |
| mode-aware (`+offset` dark, `-offset` light) | 19 / 60 | 3.57 |
| **this fix** (conditional correction) | **0 / 60** | — |

The proposal makes it worse because it assumes the text is darker than its surface. That holds only on a
light preset — on a dark one the text is the *lighter* of the two, so darkening it closes the gap it was
meant to open. The mode-aware variant flattens the curve but degrades presets the slider happened to help.

**Clamping cannot work either.** The safe range is the lower half for dark presets and the upper half for
light ones, because surfaces may move *away* from the text freely and only slightly toward it:

| preset | safe positions |
|---|---|
| midnight-indigo | 0.00 – 0.55 |
| violet-night | 0.00 – 0.55 |
| deep-ocean | 0.00 – 0.60 |
| clean-indigo | 0.50 – 1.00 |
| sky-breeze | 0.50 – 1.00 |
| mint-fresh | 0.45 – 1.00 |

The intersection across all twelve is **0.50–0.55**, so a global clamp would delete the feature.

## The fix

Conditional: leave the ramp alone unless the shift would breach the floor, then walk the text away from the
surfaces just far enough. Same technique as `ChartTheme.ReadableAgainst`, for the same reasons — it is
arithmetic, so a thirteenth preset needs no hand-picked value, and only lightness moves so the hue survives.

The floors and the surfaces each member is measured against **mirror `ThemeTextContrastTests` exactly**
(4.5:1 for `TextMuted` on Background/Surface/Surface2, 4.5:1 for `TextSecondary` on Surface2, 7.0:1 AAA for
`TextPrimary` on Background). This enforces the contract those assertions already check rather than
introducing a second opinion about what legible means.

**At the default position it is a no-op.** Every preset already clears its floor at 0.5, so nobody who has
not moved the slider sees any change — pinned by its own test, because an unconditional correction would
silently restyle all twelve themes.

`ApplyShade` now delegates to a pure static `Shade(preset, position)`, so the whole reachable range can be
swept in a unit test. The instance path writes into `Application.Current.Resources`, which a test has no
business doing — the same reason `StatusPalette` is split out.

## Verification

**25 rows** — 12 presets × 21 positions at 0.05 steps. Swept finely rather than at five points because the
failures cluster at the ends and a coarse sweep would step over a preset whose floor is breached in between.

**4 mutations:**

| mutation | goes red |
|---|---|
| drop the correction (**reproduces the shipped defect**) | the sweep + the engages-somewhere test |
| **install the issue's own proposal** | the sweep + the engages test — this is the evidence for not taking it |
| walk the text *toward* the surface | the sweep + the engages test |
| correct unconditionally | the default-position no-op test |

One prediction of mine was wrong and is corrected in the proof rather than accommodated: the `-offset`
variant does **not** break the default-position test, because the offset is zero at the centre.

The pre-existing seeded-preset theories stay green throughout, so shade 0.5 behaviour is provably unchanged.

Regression sweep: **265 green** across every test that reads `App.xaml` or `ThemeService` (the 2 reds are the
local runner's own artifacts). Four projects build Release 0 warnings / 0 errors; `dotnet format` clean;
version-consistency, valid-bump and CHANGELOG-lead gates extracted from `ci.yml` all pass; leak scan over
all 43 enforced patterns against 179 added lines, 0 hits.

Visual confirmation of the slider extremes is deferred to an actual run of the app, as usual.

Closes #1558
