### PR TITLE
fix: stop non-safety filter chips borrowing the green Safe style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.12] - 2026-08-28
+
+Green now means "safe" again. The filter buttons on Services and System Logs were all green, including
+"Stopped" and the time ranges, so the colour that marks a safe service was also on buttons that say
+nothing about safety.
+
+### Changed
+- **Filter buttons that say nothing about safety are no longer green.** Services marks a service Safe,
+  Caution or Critical in green, amber and red — that part is intentional. But nine other filter buttons
+  borrowed the green one: "Running", "Stopped", "Advanced" and "All" in Services, and the 1h / 24h / 7d /
+  30d / All time ranges in System Logs. So a green "Stopped" sat one row under a green "Safe" in the same
+  row of buttons, and "last 24 hours" carried the same colour as "this service is safe". Those nine are
+  now plain grey, and turn purple when selected, which is the colour the rest of the app uses to show what
+  you have picked. Safe, "Safe to disable" and "Keep enabled" stay green, because each of those really is
+  a statement about safety.
+
 ## [1.75.11] - 2026-08-28
 
 The background-shade slider in Appearance can no longer make text hard to read. Dragging it to either

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -4719,4 +4719,58 @@ public partial class ArchitectureTests
     /// <summary>Matches any Style block, keyed or implicit, up to its closing tag.</summary>
     [GeneratedRegex(@"<Style\b(?:(?!</Style>).)*</Style>", RegexOptions.Singleline)]
     private static partial Regex AnyStyle();
+    /// <summary>
+    /// The neutral filter chip must not borrow the Success palette, and System Logs must use only it.
+    /// </summary>
+    /// <remarks>
+    /// <c>FilterChip</c> is the green member of a three-way safety family — <c>SuccessBgSubtle</c>
+    /// background, a <c>Success</c> dot, <c>SuccessText</c> label — with <c>FilterChipCaution</c> and
+    /// <c>FilterChipCritical</c> as its siblings. Services uses all three as intended for Safe / Caution /
+    /// Critical. Nine other chips borrowed the green one while stating no safety level, so a green
+    /// "Stopped (n)" sat one row under a green "Safe (n)" in the same radio group: two meanings, one colour.
+    /// <para>Guarded because the trap has been re-entered three times already — Running, Keep enabled and
+    /// Advanced were all added to the green style after the defect was first written up. The System Logs
+    /// assertion is the load-bearing half: that view filters by time only, so any safety colour there is
+    /// wrong by construction, and a new time range added to the wrong style fails here rather than shipping.</para>
+    /// </remarks>
+    [Fact]
+    public void TheNeutralFilterChip_StaysNeutral_AndSystemLogsUsesOnlyIt()
+    {
+        var appDir = FindAppProjectDir();
+        var appXaml = File.ReadAllText(Path.Combine(appDir, "App.xaml"));
+
+        var neutral = TypedStyleWithKey("FilterChipNeutral").Match(appXaml);
+        Assert.True(neutral.Success,
+            "FilterChipNeutral is missing. Services and System Logs need a chip that states a fact rather "
+            + "than a safety level; without it the green Safe chip's style gets borrowed again.");
+
+        foreach (var green in new[] { "Success", "SuccessText", "SuccessBgSubtle", "SuccessBorder" })
+        {
+            Assert.DoesNotContain($"{{DynamicResource {green}}}", neutral.Value, StringComparison.Ordinal);
+        }
+
+        // Selection reads as the app's identity colour, which is what the contract reserves purple for.
+        Assert.Contains("{DynamicResource Accent}", neutral.Value, StringComparison.Ordinal);
+
+        // System Logs filters by time range and by nothing else, so no chip there may carry a safety colour.
+        var logs = File.ReadAllText(Path.Combine(appDir, "Views", "LogsView.xaml"));
+        var chips = FilterChipUsage().Matches(logs).Cast<Match>()
+            .Select(m => m.Groups["style"].Value)
+            .ToList();
+
+        // Vacuity floor: five time-range chips ship today.
+        Assert.True(chips.Count >= 5,
+            $"only {chips.Count} filter chips were found in LogsView.xaml — the usage pattern has stopped "
+            + "matching, so this guard is reading nothing.");
+
+        var wrong = chips.Where(style => style != "FilterChipNeutral").Distinct().ToList();
+        Assert.True(wrong.Count == 0,
+            "System Logs filters by time range, which carries no safety meaning, so its chips must use "
+            + "FilterChipNeutral. These styles claim a severity colour instead: "
+            + string.Join(", ", wrong));
+    }
+
+    /// <summary>Captures the FilterChip-family style a chip is bound to.</summary>
+    [GeneratedRegex(@"StaticResource (?<style>FilterChip\w*)\}")]
+    private static partial Regex FilterChipUsage();
 }

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -573,6 +573,38 @@
                 <Setter Property="FontWeight" Value="Medium"/>
             </Style>
 
+            <!-- The neutral member of the FilterChip family. The other three state a safety level
+                 (Safe / Caution / Critical) and colour themselves accordingly; a time range or a
+                 run-state states a fact, and borrowing the green one made "Stopped" and "24h" claim
+                 the colour that means "this service is safe" one row above them.
+                 No status dot: a neutral filter has no status to signal. Checked is purple, which is
+                 what the colour contract already reserves for selection, so this reuses the app's
+                 existing meaning instead of introducing another one. -->
+            <Style x:Key="FilterChipNeutral" TargetType="RadioButton" BasedOn="{StaticResource FilterChip}">
+                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="RadioButton">
+                            <Border x:Name="Bd" CornerRadius="{StaticResource RadiusPill}" Padding="8,4"
+                                    Background="{DynamicResource Surface3}" BorderBrush="{DynamicResource Border2}" BorderThickness="1"
+                                    Cursor="Hand">
+                                <ContentPresenter VerticalAlignment="Center"/>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsChecked" Value="True">
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource AccentSoft}"/>
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Accent}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
+                                </Trigger>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource AccentSoft}"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
             <Style x:Key="FilterChipCaution" TargetType="RadioButton" BasedOn="{StaticResource FilterChip}">
                 <Setter Property="Foreground" Value="{DynamicResource WarningText}"/>
                 <Setter Property="Template">

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.11</Version>
-    <FileVersion>1.75.11.0</FileVersion>
-    <AssemblyVersion>1.75.11.0</AssemblyVersion>
+    <Version>1.75.12</Version>
+    <FileVersion>1.75.12.0</FileVersion>
+    <AssemblyVersion>1.75.12.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -151,23 +151,23 @@
                         <RadioButton Content="1h" GroupName="TimeRange" Margin="0,0,4,0"
                                      AutomationProperties.Name="1h — time range: last hour"
                                      IsChecked="{Binding SelectedTimeRange, Converter={StaticResource IsEqual}, ConverterParameter='Last hour'}"
-                                     Style="{StaticResource FilterChip}"/>
+                                     Style="{StaticResource FilterChipNeutral}"/>
                         <RadioButton Content="24h" GroupName="TimeRange" Margin="0,0,4,0"
                                      AutomationProperties.Name="24h — time range: last 24 hours"
                                      IsChecked="{Binding SelectedTimeRange, Converter={StaticResource IsEqual}, ConverterParameter='Last 24 hours'}"
-                                     Style="{StaticResource FilterChip}"/>
+                                     Style="{StaticResource FilterChipNeutral}"/>
                         <RadioButton Content="7d" GroupName="TimeRange" Margin="0,0,4,0"
                                      AutomationProperties.Name="7d — time range: last 7 days"
                                      IsChecked="{Binding SelectedTimeRange, Converter={StaticResource IsEqual}, ConverterParameter='Last 7 days'}"
-                                     Style="{StaticResource FilterChip}"/>
+                                     Style="{StaticResource FilterChipNeutral}"/>
                         <RadioButton Content="30d" GroupName="TimeRange" Margin="0,0,4,0"
                                      AutomationProperties.Name="30d — time range: last 30 days"
                                      IsChecked="{Binding SelectedTimeRange, Converter={StaticResource IsEqual}, ConverterParameter='Last 30 days'}"
-                                     Style="{StaticResource FilterChip}"/>
+                                     Style="{StaticResource FilterChipNeutral}"/>
                         <RadioButton Content="All" GroupName="TimeRange"
                                      AutomationProperties.Name="Time range: all time"
                                      IsChecked="{Binding SelectedTimeRange, Converter={StaticResource IsEqual}, ConverterParameter='All'}"
-                                     Style="{StaticResource FilterChip}"/>
+                                     Style="{StaticResource FilterChipNeutral}"/>
                     </StackPanel>
 
                     <TextBlock Text="Max results" Style="{StaticResource Subtle}" VerticalAlignment="Center"/>

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -117,12 +117,12 @@
                     <RadioButton Content="{Binding RunningCount, StringFormat='Running ({0})'}"
                                  GroupName="SafetyFilter" Margin="0,0,6,4"
                                  IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=Running}"
-                                 Style="{StaticResource FilterChip}"
+                                 Style="{StaticResource FilterChipNeutral}"
                                  AutomationProperties.Name="Filter running services"/>
                     <RadioButton Content="{Binding StoppedCount, StringFormat='Stopped ({0})'}"
                                  GroupName="SafetyFilter" Margin="0,0,6,4"
                                  IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=Stopped}"
-                                 Style="{StaticResource FilterChip}"
+                                 Style="{StaticResource FilterChipNeutral}"
                                  AutomationProperties.Name="Filter stopped services"/>
 
                     <!-- Gaming recommendation: a different dataset from the safety level on the left.
@@ -146,13 +146,13 @@
                     <RadioButton Content="{Binding AdvancedCount, StringFormat='Advanced ({0})'}"
                                  GroupName="SafetyFilter" Margin="0,0,6,4"
                                  IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=Advanced}"
-                                 Style="{StaticResource FilterChip}"
+                                 Style="{StaticResource FilterChipNeutral}"
                                  ToolTip="Only worth changing if you know what the service does"
                                  AutomationProperties.Name="Filter advanced services"/>
 
                     <RadioButton Content="All" GroupName="SafetyFilter" Margin="10,0,6,4"
                                  IsChecked="{Binding SelectedFilter, Converter={StaticResource IsEqual}, ConverterParameter=All}"
-                                 Style="{StaticResource FilterChip}"
+                                 Style="{StaticResource FilterChipNeutral}"
                                  AutomationProperties.Name="Show all services"/>
                 </WrapPanel>
             </StackPanel>


### PR DESCRIPTION
`FilterChip` is not a neutral chip. It is the **Success** member of a three-way safety-severity family —
`SuccessBgSubtle` fill, a `Success` dot, `SuccessText` label — with `FilterChipCaution` (amber) and
`FilterChipCritical` (red) as its siblings. Services uses all three as intended for Safe / Caution /
Critical.

Nine chips borrowed the green one while stating no safety level at all. All nine Services chips share one
radio group (`SafetyFilter`), so a green **"Stopped (n)"** sat one row under a green **"Safe (n)"** — two
meanings, one colour, in one group.

## Re-derived rather than trusting the issue

**11 usages now, not the 6 reported.** `Running`, `Keep enabled` and `Advanced` were all added to the green
style *after* the defect was written up, so the trap has been re-entered three times. That is the argument
for a guard rather than a note.

| chip | verdict |
|---|---|
| Services `Safe (n)` | **stays green** — states a safety level |
| Services `Safe to disable (n)` | **stays green** — states a safety judgement |
| Services `Keep enabled (n)` | **stays green** — states a safety judgement |
| Services `Caution` / `Critical` | unchanged, already on their own styles |
| Services `Running` `Stopped` `Advanced` `All` | → neutral |
| System Logs `1h` `24h` `7d` `30d` `All` | → neutral |

Only the chips stating a *fact* moved. The ones stating a *judgement* kept the colour that matches it.

## The new style

`FilterChipNeutral` is additive, `BasedOn="{StaticResource FilterChip}"` in the same shape the Caution and
Critical variants already use — so it inherits the focus ring rather than repeating it, which the regression
sweep confirms. `Surface3` fill, `Border2` edge, `TextSecondary` label, and **no status dot**, because a
neutral filter has no status to signal.

Checked is **purple**, which the colour contract already reserves for selection. So selection now reads as
selection everywhere instead of borrowing "safe" on two tabs — this replaces an invented meaning with the
app's existing one rather than picking a new colour.

## Guarded as semantics, not as a list of known chips

- the neutral style must carry **no** `Success` brush, or it stops being neutral
- **System Logs must use only it** — that view filters by time and nothing else, so any safety colour there
  is wrong by construction, and a sixth time range added to the wrong style fails here instead of shipping

Plus a vacuity floor, so a selector that stops matching cannot report a clean sweep of nothing.

## Verification

**4 mutations:** revert one System Logs chip to green, give the neutral style a `Success` brush, drop the
purple checked state, rename the style so nothing defines it. All red.

**Mutation C initially passed, and that was my error rather than a weak guard.** The single
`<Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Accent}"/>` line appears **five
times** in `App.xaml` at identical indentation — ButtonBase, DangerButton, TextBox, ComboBox and this chip —
so replacing the first occurrence removed ButtonBase's focus border instead of the chip's checked state. The
guard was right to stay green about ButtonBase; the run simply proved nothing. Re-anchored on a two-line span
unique to the chip, and it goes red.

Regression sweep: **265 green** across every test that reads `App.xaml` (the 2 reds are the local runner's
own artifacts). Four projects build Release 0 warnings / 0 errors; `dotnet format` clean;
version-consistency, valid-bump and CHANGELOG-lead gates extracted from `ci.yml` all pass; leak scan over
all 43 enforced patterns against 120 added lines, 0 hits.

Two tabs change appearance, so this is logged under `### Changed`. Visual confirmation is deferred to the
machine that runs the application as usual.

Closes #1628
