### PR TITLE
fix: opt the hosted PowerShell engine out of its own telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.13] - 2026-08-28
+
+SysManager runs PowerShell behind the scenes for some features, and that engine has its own usage
+reporting built in by Microsoft. It is now switched off. SysManager itself never sent anything, but the
+engine it borrows could have.
+
+### Fixed
+- **The PowerShell engine SysManager uses no longer has its usage reporting enabled.** Several features
+  work by running PowerShell, and rather than launching a separate window SysManager loads the PowerShell
+  engine inside itself. That engine ships with Microsoft's own usage-reporting component, which is turned
+  off by a single switch — and SysManager was not setting it. Nothing of yours was being collected by
+  SysManager, which has never had anything to send it to, but the borrowed engine could have reported its
+  own activity. The switch is now set before any PowerShell session starts, for this program only, so your
+  saved Windows settings are untouched. A test checks it stays set, and the privacy section of SECURITY.md
+  now names the dependency instead of only speaking for code written here.
+
 ## [1.75.12] - 2026-08-28
 
 Green now means "safe" again. The filter buttons on Services and System Logs were all green, including

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -165,6 +165,15 @@ machine, or your usage is transmitted anywhere — there is no server side to
 transmit it to. The application is a single portable executable that reads and
 writes only on the machine it runs on.
 
+That covers code written here. It does not automatically cover code SysManager
+hosts, so one dependency is worth naming: several features run PowerShell, and
+SysManager hosts the PowerShell 7 engine in-process. That engine has telemetry of
+its own, independent of ours, which Microsoft gates on a single environment
+variable. SysManager sets `POWERSHELL_TELEMETRY_OPTOUT=1` for its own process
+before any PowerShell session is created, so the hosted engine stays silent too.
+The variable is set for the running process only — your saved environment is never
+modified — and a test asserts it, so the opt-out cannot be dropped unnoticed.
+
 ### What the app stores, and where
 
 All of it stays on your PC, inside your own user profile. None of it is

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -4773,4 +4773,56 @@ public partial class ArchitectureTests
     /// <summary>Captures the FilterChip-family style a chip is bound to.</summary>
     [GeneratedRegex(@"StaticResource (?<style>FilterChip\w*)\}")]
     private static partial Regex FilterChipUsage();
+    /// <summary>
+    /// The hosted PowerShell's telemetry opt-out must stay in the source, and stay early.
+    /// </summary>
+    /// <remarks>
+    /// <c>PowerShellRunnerTelemetryTests</c> proves the variable is set, but it would keep passing if the
+    /// assignment moved somewhere that runs after a runspace already exists. This pins the shape: the
+    /// opt-out lives in a static constructor, so it cannot be reduced to a call some future entry point
+    /// forgets to make.
+    /// <para>Also pins that nothing else in the app writes the same variable, since a second writer could
+    /// set it to "0" and re-enable the subsystem while both the test and this guard stayed green.</para>
+    /// </remarks>
+    [Fact]
+    public void TheHostedPowerShell_OptsOutOfTelemetryInAStaticConstructor()
+    {
+        var runner = File.ReadAllText(
+            Path.Combine(FindAppProjectDir(), "Services", "PowerShellRunner.cs"));
+
+        Assert.Contains("static PowerShellRunner()", runner, StringComparison.Ordinal);
+        Assert.Contains("POWERSHELL_TELEMETRY_OPTOUT", runner, StringComparison.Ordinal);
+        Assert.Contains("EnvironmentVariableTarget.Process", runner, StringComparison.Ordinal);
+
+        // The assignment must sit inside the static constructor, not merely somewhere in the file.
+        // Both callers must remain: the static constructor for earliness, and CreateRunspace for the
+        // unconditional guarantee at the one place a runspace is born. Losing either leaves the opt-out
+        // dependent on type-initialisation order, which is what the first attempt at this got wrong.
+        Assert.Contains("static PowerShellRunner() => OptOutOfPowerShellTelemetry();", runner, StringComparison.Ordinal);
+
+        var createRunspace = runner.IndexOf(
+            "private (Runspace Runspace, IDisposable? ProcessInstance, IDisposable? Process) CreateRunspace()",
+            StringComparison.Ordinal);
+        Assert.True(createRunspace > 0, "CreateRunspace was renamed — re-derive this guard.");
+        var callInside = runner.IndexOf("OptOutOfPowerShellTelemetry();", createRunspace, StringComparison.Ordinal);
+        Assert.True(callInside > createRunspace && callInside - createRunspace < 400,
+            "CreateRunspace no longer calls OptOutOfPowerShellTelemetry before building a runspace, so the "
+            + "opt-out depends on when the runtime initialises the type.");
+
+        // No second writer anywhere in the app: one could set it back to "0".
+        var appDir = FindAppProjectDir();
+        var otherWriters = Directory
+            .EnumerateFiles(appDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !Path.GetRelativePath(appDir, f)
+                .Split(Path.DirectorySeparatorChar)
+                .Any(segment => segment is "obj" or "bin"))
+            .Where(f => Path.GetFileName(f) != "PowerShellRunner.cs")
+            .Where(f => File.ReadAllText(f).Contains("POWERSHELL_TELEMETRY_OPTOUT", StringComparison.Ordinal))
+            .Select(f => Path.GetFileName(f))
+            .ToList();
+
+        Assert.True(otherWriters.Count == 0,
+            "another file also references the PowerShell telemetry opt-out variable; a second writer could "
+            + $"set it back to \"0\". Keep it owned by PowerShellRunner alone: {string.Join(", ", otherWriters)}");
+    }
 }

--- a/SysManager/SysManager.Tests/PowerShellRunnerTelemetryTests.cs
+++ b/SysManager/SysManager.Tests/PowerShellRunnerTelemetryTests.cs
@@ -1,0 +1,54 @@
+// SysManager · PowerShellRunnerTelemetryTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// The hosted PowerShell must not be able to report anything anywhere.
+/// </summary>
+/// <remarks>
+/// The in-process runspace is the PowerShell 7 SDK, and <c>System.Management.Automation</c> ships
+/// <c>Microsoft.ApplicationInsights</c> for its telemetry subsystem — resolved in the dependency graph and
+/// bundled into the self-contained single-file .exe. PowerShell gates that subsystem on one environment
+/// variable and nothing else, so the opt-out is the whole defence and deserves a test rather than trust.
+/// </remarks>
+public class PowerShellRunnerTelemetryTests
+{
+    [Fact]
+    public void TouchingTheRunner_OptsPowerShellOutOfTelemetry()
+    {
+        // Calls the opt-out the way CreateRunspace does. Deliberately NOT by reading
+        // TelemetryOptOutVariable: it is a const, so C# inlines the literal and initialises nothing — the
+        // first version of this test did exactly that and was red for a real reason.
+        PowerShellRunner.OptOutOfPowerShellTelemetry();
+
+        // Read back through the LITERAL name, not through PowerShellRunner.TelemetryOptOutVariable.
+        // Using the constant on both sides makes the test self-consistent: rename it and the setter and the
+        // assertion move together, agreeing on a variable PowerShell does not read. Found by mutation —
+        // this test stayed green when the constant was typoed.
+        Assert.Equal(
+            "1",
+            Environment.GetEnvironmentVariable(
+                "POWERSHELL_TELEMETRY_OPTOUT", EnvironmentVariableTarget.Process));
+    }
+
+    [Fact]
+    public void TheOptOut_NamesTheVariablePowerShellActuallyReads()
+    {
+        // Pinned as a literal: a typo here would leave telemetry on while every other test stayed green,
+        // because nothing else in the app consults this name.
+        Assert.Equal("POWERSHELL_TELEMETRY_OPTOUT", PowerShellRunner.TelemetryOptOutVariable);
+    }
+
+    [Fact]
+    public void TheOptOut_DoesNotWriteTheUsersStoredEnvironment()
+    {
+        // Process scope only. Writing the user or machine scope would be a side effect nobody asked for,
+        // and those scopes are what EnvironmentVariableService edits on the user's behalf.
+        Assert.Null(Environment.GetEnvironmentVariable(
+            "POWERSHELL_TELEMETRY_OPTOUT", EnvironmentVariableTarget.User));
+    }
+}

--- a/SysManager/SysManager/Services/PowerShellRunner.cs
+++ b/SysManager/SysManager/Services/PowerShellRunner.cs
@@ -478,8 +478,54 @@ public sealed class PowerShellRunner : IPowerShellRunner
         return $"$env:PSModulePath='{escapedPath}';";
     }
 
+    /// <summary>
+    /// The single environment variable PowerShell 7 consults before sending telemetry.
+    /// </summary>
+    internal const string TelemetryOptOutVariable = "POWERSHELL_TELEMETRY_OPTOUT";
+
+    /// <summary>
+    /// Opts the hosted PowerShell out of telemetry before any runspace exists.
+    /// </summary>
+    /// <remarks>
+    /// The in-process runspace is the PowerShell 7 SDK, and <c>System.Management.Automation</c> pulls in
+    /// <c>Microsoft.ApplicationInsights</c> for one reason: its telemetry subsystem. That DLL is not
+    /// theoretical here — it resolves in the dependency graph and ships inside the self-contained
+    /// single-file .exe. PowerShell gates the whole subsystem on this one variable and nothing else.
+    /// <para>SysManager's standing promise, repeated on every release page, is that it transfers nothing
+    /// anywhere unless the user asks. Hosting a runspace that could report module loads to a third party
+    /// would contradict the only claim the product makes about itself, so the opt-out is set here rather
+    /// than trusted to a default.</para>
+    /// <para>A static constructor, not <c>App.OnStartup</c>: this runs before the first instance method
+    /// touches an SMA type, and it covers every host — the app, the test suite, and any future entry
+    /// point — instead of only the one that remembers to call it.</para>
+    /// <para><see cref="EnvironmentVariableTarget.Process"/> deliberately. This changes nothing the user
+    /// can see or keep; the machine and user scopes are what <c>EnvironmentVariableService</c> edits on
+    /// their behalf, and writing there would be a side effect nobody asked for. The elevated path starts
+    /// Windows PowerShell 5.1 as a child process, which inherits this, so one assignment covers both.</para>
+    /// </remarks>
+    static PowerShellRunner() => OptOutOfPowerShellTelemetry();
+
+    /// <summary>
+    /// Sets the opt-out. Idempotent, and called from both the static constructor and
+    /// <see cref="CreateRunspace"/>.
+    /// </summary>
+    /// <remarks>
+    /// Belt and braces on purpose. The static constructor alone would be enough in practice, but a
+    /// no-telemetry guarantee should not rest on when the runtime decides to initialise a type — and the
+    /// first version of this proved the hazard is real: exposing the name as a <c>const</c> meant reading it
+    /// inlined the literal and initialised nothing, so the accompanying test was red for a genuine reason.
+    /// Calling it again at the one place a runspace is born makes the ordering unconditional.
+    /// </remarks>
+    internal static void OptOutOfPowerShellTelemetry()
+        => Environment.SetEnvironmentVariable(
+            TelemetryOptOutVariable, "1", EnvironmentVariableTarget.Process);
+
     private (Runspace Runspace, IDisposable? ProcessInstance, IDisposable? Process) CreateRunspace()
     {
+        // Unconditional, immediately before the only runspace creation in the app, so the opt-out cannot
+        // depend on type-initialisation order. Idempotent, so calling it per runspace costs nothing.
+        OptOutOfPowerShellTelemetry();
+
         if (!_isElevated)
         {
             var initialSessionState = InitialSessionState.CreateDefault2();

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.12</Version>
-    <FileVersion>1.75.12.0</FileVersion>
-    <AssemblyVersion>1.75.12.0</AssemblyVersion>
+    <Version>1.75.13</Version>
+    <FileVersion>1.75.13.0</FileVersion>
+    <AssemblyVersion>1.75.13.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
The product's one standing promise, in `SECURITY.md` and on every release page, is that nothing is
transmitted anywhere. That covered code written here. It did not cover the engine hosted inside it.

## Verified by hand before writing anything, all three legs

| claim | check |
|---|---|
| the opt-out is never set | `POWERSHELL_TELEMETRY_OPTOUT` appears **nowhere** in the repository |
| the telemetry component is pulled in | `obj/project.assets.json` resolves `Microsoft.ApplicationInsights/2.23.0` through `System.Management.Automation`, whose only use for it is telemetry |
| it really ships | `bin/Release/net10.0-windows/win-x64/Microsoft.ApplicationInsights.dll` exists, so it is bundled into the self-contained single-file `.exe` |

Non-elevated sessions host the PowerShell 7 SDK in-process, and PowerShell gates its entire telemetry
subsystem on that one environment variable and nothing else.

## Scope

`PowerShellRunner.cs` is the **only** file in the app referencing `RunspaceFactory`, `PowerShell.Create` or
`PowerShellProcessInstance`, so gating there covers every path. `EnvironmentVariableTarget.Process` only —
the user's stored environment, which `EnvironmentVariableService` edits on their behalf, is untouched. The
elevated path starts Windows PowerShell 5.1 as a child process, which inherits it, so one assignment covers
both.

## Two mistakes of mine, both caught by the checks rather than by reading

**A `const` read does not run a static constructor.** The first version exposed the variable name as a
`const` and relied on `static PowerShellRunner()`. The test went red and was right to: C# inlines a const at
the call site, so reading it initialises nothing. The *shipped* behaviour was still correct — the static
constructor runs before any instance method — but resting a no-telemetry guarantee on when the runtime
initialises a type is the wrong shape for it. It is now an idempotent method called from **both** the static
constructor and the top of `CreateRunspace`, so the ordering is unconditional.

**The set-check asserted through the same constant it was verifying.** Renaming the constant left it green:
the setter and the assertion moved together and agreed on a variable PowerShell does not read.
Self-consistent and worthless. Found by mutating that name; both reads now use the hardcoded string.

There was also a stale-binary moment worth naming: a mangled escape put a real newline inside a C# string
literal, the build failed with CS1010, and the runner silently executed the **previous** assembly — so the
test output was about old code for one round. Repaired by line index, and `git diff --ignore-all-space`
confirms the file has no CRLF churn beyond the added lines.

## Verification

3 tests plus an architecture guard. The guard pins **both** call sites — losing either returns the opt-out to
depending on type-initialisation order — and asserts no second file writes the same variable, since one could
set it back to `"0"`.

| mutation | goes red |
|---|---|
| remove the call from `CreateRunspace` | the guard |
| remove the static constructor | the guard |
| typo the variable name | all three |
| set the opt-out to `"0"` | the set-check |

Deliberately **not** mutated: switching to `EnvironmentVariableTarget.User`. That assertion is real and worth
having, but the mutation would write to the machine's actual user environment, and a proof should not leave
side effects on the box to make a point.

Four projects build Release 0 warnings / 0 errors; regression sweep **265 green**; `dotnet format` clean;
version-consistency, valid-bump and CHANGELOG-lead gates all pass locally; leak scan over all 43 enforced
patterns, **including the new untracked test file** (invisible to `git diff`, which is how a leak slipped
through once before), 0 hits.

`SECURITY.md`'s privacy section now names the dependency rather than only speaking for code written here —
the claim was accurate about our code and incomplete about the whole binary.
