### PR TITLE
ci: stop dependabot proposing a Xunit.StaFact major that cannot build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,17 @@ updates:
     commit-message:
       prefix: "deps(tests)"
       include: "scope"
+    ignore:
+      # Xunit.StaFact majors target xUnit v3. Verified on 4.0.23 (dependabot PR #2025): it pulls
+      # xunit.v3.core alongside this suite's xunit.core 2.9.3, and the "Build tests" step fails with
+      # hundreds of CS0433 — "the type 'FactAttribute' exists in both" — because every [Fact] and
+      # [Collection] becomes ambiguous.
+      #
+      # Adopting it is an xUnit v2 -> v3 migration of the whole suite, not a version bump, so it is
+      # tracked separately. Without this rule dependabot reopens the same unbuildable PR every Monday.
+      # Minor and patch updates inside 1.x are still wanted, which is why this is major-only.
+      - dependency-name: "Xunit.StaFact"
+        update-types: ["version-update:semver-major"]
     groups:
       nuget-minor-patch:
         update-types:


### PR DESCRIPTION
#2025 bumped `Xunit.StaFact` 1.2.69 → 4.0.23 and failed the **Build tests** step with hundreds of:

```
error CS0433: The type 'FactAttribute' exists in both
  'xunit.core, Version=2.9.3.0, ...' and
  'xunit.v3.core, Version=4.0.0.0, ...'
```

StaFact majors target **xUnit v3**. This suite is **xUnit v2** (`xunit 2.9.3`), and referencing both makes
every `[Fact]` and `[Collection]` ambiguous. Only `Build tests` failed — the app itself compiled with 0
errors, and `Analyze`/`CodeQL` passed, which is what makes the cause unambiguous.

So this is not a bump to fix. Adopting StaFact 4.x means migrating the whole test suite from xUnit v2 to v3,
which is its own piece of work with its own risk.

## Why a config rule rather than just closing the PR

Closing it leaves dependabot free to reopen the identical unbuildable change next Monday, and the Monday
after. The rule belongs where it holds without anyone remembering it.

Scoped to **major only** — minor and patch updates inside 1.x are still wanted, so this does not freeze the
package, just the incompatible line.

## Verified

- `dependabot.yml` still parses (`yaml.safe_load`), 5 update entries, and the `ignore` rule lands on the
  `SysManager.Tests` entry
- `SysManager.Tests` is the only project referencing `Xunit.StaFact`; the version itself lives in
  `Directory.Packages.props` under central package management, which is why the PR arrived labelled
  `deps(tests)`

`ci:` — no release, no version bump.
