### PR TITLE
fix: refuse to block consent.exe, which would end elevation permanently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.14] - 2026-09-01
+
+App Blocker refuses to block one more Windows file. Blocking it was possible, and it would have stopped
+Windows ever asking you for permission again — including the permission needed to undo it.
+
+### Fixed
+- **App Blocker will no longer block the Windows permission prompt.** App Blocker stops a chosen program
+  from starting, and it already refuses the handful of Windows files that the computer needs in order to
+  start at all. Missing from that list was the small Windows program that draws the "Do you want to allow
+  this app to make changes?" box. Nothing stopped you picking it — the file browser accepts it like any
+  other program — and blocking it would have meant Windows could never ask for permission again. Undoing
+  the block needs permission, so there would have been no way back from inside SysManager, or from anywhere
+  else on the running computer. It is now refused like the others.
+- **The refusal message says what is actually true.** That message read "is required for Windows to start …
+  could leave the computer unable to boot", which was right for the files already on the list and wrong for
+  this one: Windows starts perfectly well without the permission prompt, and the damage only shows up the
+  first time something needs it. The message now covers both cases without claiming the wrong one.
+
 ## [1.75.13] - 2026-08-28
 
 SysManager runs PowerShell behind the scenes for some features, and that engine has its own usage

--- a/SysManager/SysManager.Tests/AppBlockerServiceRegistryTests.cs
+++ b/SysManager/SysManager.Tests/AppBlockerServiceRegistryTests.cs
@@ -175,6 +175,11 @@ public sealed class AppBlockerServiceRegistryTests : IDisposable
     [InlineData("lsass.exe")]
     [InlineData("explorer.exe")]
     [InlineData("csrss")]        // bare name; .exe is appended before the check
+    // Elevation-critical rather than boot-critical: Windows starts fine without the consent UI, but
+    // blocking it means no administrator prompt can ever appear again — including the one UnblockApp
+    // needs. Same circular hazard, different moment.
+    [InlineData("consent.exe")]
+    [InlineData("CONSENT")]      // case-insensitive + bare name
     public void TryBlockApp_BootCritical_ReportsBootCritical(string name)
     {
         // The distinction that mattered most: this previously told the user to check their admin

--- a/SysManager/SysManager.Tests/AppBlockerServiceValidationTests.cs
+++ b/SysManager/SysManager.Tests/AppBlockerServiceValidationTests.cs
@@ -63,6 +63,10 @@ public class AppBlockerServiceValidationTests
     // case-insensitive + bare-name (the service appends .exe before the denylist check)
     [InlineData("WinLogon.exe")]
     [InlineData("lsass")]
+    // consent.exe is the UAC consent UI. Blocking it leaves no way to elevate, and unblocking writes to
+    // HKLM, which needs elevation — so the refusal must happen before any registry write, exactly as for
+    // the boot-critical set.
+    [InlineData("consent.exe")]
     public void BlockApp_BootCriticalExecutable_IsRefused(string exeName)
     {
         // Blocking a boot/logon-critical process via IFEO would render Windows

--- a/SysManager/SysManager.Tests/AppBlockerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppBlockerViewModelTests.cs
@@ -164,7 +164,7 @@ public class AppBlockerViewModelTests
     }
 
     [Theory]
-    [InlineData(AppBlockerService.BlockResult.BootCritical, "required for Windows to start")]
+    [InlineData(AppBlockerService.BlockResult.BootCritical, "part of Windows that has to keep working")]
     [InlineData(AppBlockerService.BlockResult.OwnExecutable, "SysManager itself")]
     [InlineData(AppBlockerService.BlockResult.ExternalDebuggerPresent, "already registered a debugger")]
     [InlineData(AppBlockerService.BlockResult.InvalidName, "not a valid executable name")]

--- a/SysManager/SysManager/Services/AppBlockerService.cs
+++ b/SysManager/SysManager/Services/AppBlockerService.cs
@@ -34,18 +34,31 @@ public sealed partial class AppBlockerService : IAppBlockerService
         Path.Combine(Environment.SystemDirectory, "SysManager_Blocked.exe");
 
     /// <summary>
-    /// Boot- and logon-critical executables that must never be blocked. An IFEO
-    /// Debugger redirection on these is applied by the kernel/session manager during
-    /// boot and login; blocking one (e.g. winlogon.exe or lsass.exe) causes a fatal
-    /// boot/login failure that this app can no longer launch to undo. Mirrors the
-    /// system-process set in <see cref="IconExtractorService"/>, restricted to the
-    /// processes whose absence breaks startup.
+    /// Executables that must never be blocked, because the block cannot be undone.
     /// </summary>
+    /// <remarks>
+    /// Two distinct hazards, both ending in the same place — a machine the user cannot repair from inside
+    /// this app.
+    /// <para><b>Boot and logon critical.</b> An IFEO Debugger redirection on these is honoured by the
+    /// kernel/session manager during boot and login, so blocking one (winlogon.exe, lsass.exe) causes a
+    /// fatal boot/login failure and the app can never launch again to undo it. Mirrors the system-process
+    /// set in <see cref="IconExtractorService"/>, restricted to the processes whose absence breaks startup.</para>
+    /// <para><b>Elevation critical.</b> <c>consent.exe</c> is the UAC consent UI that the AppInfo service
+    /// launches for every elevation request. Blocking it means no elevation prompt can ever appear again —
+    /// and <see cref="UnblockApp"/> writes to HKLM, which requires elevation, which requires consent.exe.
+    /// The undo depends on the thing it disabled, so recovery means editing the registry offline. Windows
+    /// still boots and logs in fine, which is exactly why this one does not look dangerous and is worth
+    /// naming separately: the machine appears healthy right up to the first time something needs admin.</para>
+    /// <para>The same circular shape is what the self-block guard below exists for. A candidate belongs
+    /// here if blocking it removes the means of unblocking it, whether that happens at boot or at the first
+    /// elevation.</para>
+    /// </remarks>
     private static readonly HashSet<string> BootCriticalExecutables = new(StringComparer.OrdinalIgnoreCase)
     {
         "winlogon.exe", "wininit.exe", "csrss.exe", "smss.exe", "services.exe",
         "lsass.exe", "lsaiso.exe", "fontdrvhost.exe", "dwm.exe", "logonui.exe",
-        "explorer.exe", "svchost.exe", "ctfmon.exe", "userinit.exe", "spoolsv.exe"
+        "explorer.exe", "svchost.exe", "ctfmon.exe", "userinit.exe", "spoolsv.exe",
+        "consent.exe"
     };
 
     private readonly RegistryKey _baseKey;

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.13</Version>
-    <FileVersion>1.75.13.0</FileVersion>
-    <AssemblyVersion>1.75.13.0</AssemblyVersion>
+    <Version>1.75.14</Version>
+    <FileVersion>1.75.14.0</FileVersion>
+    <AssemblyVersion>1.75.14.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AppBlockerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppBlockerViewModel.cs
@@ -105,9 +105,14 @@ public sealed partial class AppBlockerViewModel : ViewModelBase
         // elevated — where the same guard refuses again, still without explaining itself.
         BlockStatus = result switch
         {
+            // Covers both denylist classes without claiming the wrong one. "Required to start" was true of
+            // winlogon.exe and false of consent.exe: Windows boots fine without the consent UI, and the
+            // damage only shows up the first time something asks for administrator rights. What both share
+            // is that blocking them removes the means of unblocking them.
             AppBlockerService.BlockResult.BootCritical =>
-                $"{exeName} is required for Windows to start, so SysManager will not block it. "
-                + "Blocking it could leave the computer unable to boot, with no way to undo it from here.",
+                $"{exeName} is a part of Windows that has to keep working, so SysManager will not block it. "
+                + "Blocking it could stop the computer starting, or stop Windows being able to ask for "
+                + "permission — and neither could be undone from here.",
             AppBlockerService.BlockResult.OwnExecutable =>
                 $"{exeName} is SysManager itself. Blocking it would stop SysManager from launching, "
                 + "and unblocking has to be done from inside the app — so this one is refused.",


### PR DESCRIPTION
`App Blocker` writes an IFEO `Debugger` redirection to stop a chosen program launching, and it already
refuses a denylist of executables whose block cannot be undone. `consent.exe` — the UAC consent UI that
AppInfo launches for **every** elevation — was not on it.

## Verified on all four legs before writing anything

| # | claim | check |
|---|---|---|
| 1 | it is not on the denylist | `BootCriticalExecutables` holds 15 entries; `consent.exe` is not among them |
| 2 | the UI hands over exactly that name | `BrowseForExe` sets `NewExeName = Path.GetFileName(dialog.FileName)` |
| 3 | validation accepts it | `ExeNamePattern` is `\A[A-Za-z0-9_\-. ]+\.exe\z` — `consent.exe` matches |
| 4 | so it reaches the registry | passes validation, passes the denylist, gets written |

**The consequence is circular.** With its `Debugger` pointed at `System32\SysManager_Blocked.exe`, no
elevation prompt can appear again. `UnblockApp` writes to HKLM, which requires elevation, which requires
`consent.exe`. So the block is unrecoverable from inside the app *and* from anywhere else on the running
system; recovery means editing the registry offline.

## Why it was missed, and what the comment now says

The list documents itself as "processes whose absence breaks startup", and `consent.exe` genuinely is not
one — Windows boots and logs in perfectly without it. That is exactly what makes it dangerous: the machine
looks healthy right up to the first time something asks for admin.

The doc comment now names **two** classes, boot-critical and elevation-critical, with the shared test spelled
out: a candidate belongs here if blocking it removes the means of unblocking it. That is the same reasoning
the self-block guard below already uses.

## The refusal message had to be reworded, not just extended

It read *"is required for Windows to start … could leave the computer unable to boot"*. Both sentences are
false for `consent.exe`. It now covers either outcome without claiming the wrong one.

**An existing test caught my first attempt at that wording.**
`BlockApp_SafetyRefusal_DoesNotBlameAdminRights` forbids the word "administrator" in a refusal — because
that reads as "you need admin rights" and sends the user off to relaunch elevated, where the same guard
refuses again. My draft said "stop administrator prompts appearing" and went red. Reworded to "stop Windows
being able to ask for **permission**", which is both allowed and closer to how the target user experiences
UAC.

## Verification

Both existing denylist theories were **extended rather than duplicated**, including case-insensitive and
bare-name rows since `.exe` is appended before the check.

| mutation | goes red |
|---|---|
| remove `consent.exe` from the list | **both** denylist theories |
| revert the message to the boot-only claim | the quoted-fragment test |
| put "administrator" back in the message | the don't-blame-admin-rights guard |

The first mutation reddening *both* theories is the point: the refusal must happen in the service before any
registry write, not merely be reported nicely afterwards.

Four projects build Release 0 warnings / 0 errors; regression sweep **265 green**; `dotnet format` clean;
version-consistency, valid-bump and CHANGELOG-lead gates all pass locally; leak scan over all 43 enforced
patterns, 0 hits.
