### PR TITLE
ci: send Codecov the JUnit XML its test analytics can actually read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,7 @@ jobs:
           dotnet test SysManager/SysManager.Tests/SysManager.Tests.csproj
           -c Release --no-build
           --logger "trx;LogFileName=unit-results.trx"
+          --logger "junit;LogFileName=unit-results.junit.xml"
           --collect:"XPlat Code Coverage"
           --results-directory TestResults
 
@@ -323,13 +324,45 @@ jobs:
           flags: unittests
           fail_ci_if_error: false
 
+      # Codecov's test-analytics parser reads JUnit XML and nothing else. A TRX is accepted by the CLI,
+      # uploaded, and discarded server-side without a word, which is how the upload step below stayed
+      # green for months while the Tests tab held zero tests (the test-analytics API returned
+      # `{"count":0,"results":[]}`). Nothing checked what was being handed over, so now this does.
+      #
+      # The case floor is the part that matters. Existence and a well-formed root would both pass on an
+      # empty report, so a logger that silently stops recording would look identical to a healthy run.
+      #
+      # Sits after the coverage upload on purpose: a failing step skips the ones that follow, and a
+      # malformed test report is no reason to lose the coverage number too.
+      - name: Verify the JUnit report before uploading it
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          report=TestResults/unit-results.junit.xml
+          if [ ! -s "$report" ]; then
+            echo "::error::$report is missing or empty, so there is nothing Codecov can parse. Written instead:"
+            ls -la TestResults || true
+            exit 1
+          fi
+          if ! grep -q "<testsuites" "$report"; then
+            echo "::error::$report has no <testsuites> root, so Codecov will drop it silently. First 400 bytes:"
+            head -c 400 "$report"
+            exit 1
+          fi
+          cases=$({ grep -o "<testcase " "$report" || true; } | wc -l)
+          echo "JUnit report: $(wc -c < "$report") bytes, $cases test cases."
+          if [ "$cases" -lt 4000 ]; then
+            echo "::error::the JUnit report holds only $cases test cases, under the floor of 4000. Either the run was truncated or the junit logger stopped recording; a report this small would upload cleanly and tell Codecov nothing."
+            exit 1
+          fi
+
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
-          files: TestResults/**/unit-results.trx
+          files: TestResults/unit-results.junit.xml
 
       - name: Upload test results
         if: always()

--- a/SysManager/Directory.Packages.props
+++ b/SysManager/Directory.Packages.props
@@ -37,6 +37,7 @@
   <!-- Test dependencies -->
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="JunitXml.TestLogger" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />

--- a/SysManager/SysManager.Tests/SysManager.Tests.csproj
+++ b/SysManager/SysManager.Tests/SysManager.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="JunitXml.TestLogger" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="NetArchTest.Rules" />

--- a/TESTING.md
+++ b/TESTING.md
@@ -69,6 +69,13 @@ Coverage is collected automatically on CI via `coverlet` and uploaded to
 [Codecov](https://codecov.io/gh/laurentiu021/SystemManager). The badge in
 `README.md` reflects the latest `main` branch result.
 
+The same CI job uploads test results to Codecov's test analytics, which reads JUnit XML
+and no other format. `dotnet test` therefore runs two loggers: `trx` for the CI artifact
+and the `Passed! - Failed: N` diagnostic line, and `junit` for the upload. A guard step
+checks the JUnit report exists, has a `<testsuites>` root, and holds at least 4000 test
+cases before the upload runs, because the CLI uploads an unreadable report just as
+happily as a readable one and Codecov never reports the rejection back.
+
 ## Test infrastructure
 
 ### Frameworks
@@ -79,6 +86,7 @@ Coverage is collected automatically on CI via `coverlet` and uploaded to
 | NSubstitute 6.1 | Mocking/substitution for interface-based testing |
 | NetArchTest.Rules 1.3 | Architecture fitness functions — MVVM dependency direction, and guards that pin recurring defect classes |
 | coverlet | Code coverage collection |
+| JunitXml.TestLogger | JUnit XML test report — the only format Codecov's test analytics parses |
 | Xunit.StaFact | STA thread support for WPF-dependent tests |
 
 Package versions are managed centrally in `SysManager/Directory.Packages.props`


### PR DESCRIPTION
## Problem

The `Upload test results to Codecov` step has been green on every CI run since it was added, and it has never delivered a single test result.

Evidence, both re-derived today:

- Run `33478596901`, job `99763003117`. The CLI ran `./codecov.exe upload-coverage ... --file TestResults/**/unit-results.trx --report-type test_results`, logged `Found 1 test_results files to report`, `Sending upload (1641072 bytes) to storage`, `Upload queued for processing complete`, outcome `success`. Nothing in that log looks wrong.
- `api.codecov.io/api/v2/github/laurentiu021/repos/SystemManager/test-analytics/?branch=main` returns `{"count":0,"next":null,"previous":null,"results":[],"total_pages":1}`.

Codecov's documentation states the cause plainly, in a warning box on the test-analytics page:

> Only JUnit XML test result files are supported at the moment.

We upload a TRX. The CLI accepts it, forwards it, and the server discards it. Neither side reports the rejection, which is why the Tests tab shows the `JUnit XML file not found` onboarding message while CI stays green.

Coverage was never affected and is working properly: `56.08%`, 392 files, refreshed today. Codecov is genuinely in use, so it stays. It just needed the one format it can parse.

## Change

- `JunitXml.TestLogger` 8.0.0 added, pinned centrally in `Directory.Packages.props` and referenced from `SysManager.Tests.csproj`. `dotnet test` has no built-in JUnit logger, and this is the package Codecov's own .NET instructions point at.
- A second `--logger "junit;LogFileName=unit-results.junit.xml"` on the unit-test command. `LogFileName` rather than `LogFilePath` is deliberate: `LoggerConfiguration` does `Path.Combine(TestRunDirectory, LogFileName)` when the former is used, so the report lands inside `--results-directory` next to the TRX; `LogFilePath` bypasses the results directory and resolves against the working directory instead.
- The TRX stays. It is what the `test-results` artifact carries and what the `Passed! - Failed: N` diagnostic note in this workflow tells a reader to consult.
- The Codecov `files:` input now points at `TestResults/unit-results.junit.xml`.
- A guard step between the two uploads. It requires the report to exist, to have a `<testsuites>` root, and to hold at least 4000 test cases.

The guard sits *after* the coverage upload on purpose. A failing step skips the ones that follow it, and a malformed test report is no reason to also lose the coverage number.

## Why the case floor is the load-bearing check

Existence and a well-formed root would both wave through a well-formed *empty* report, which is precisely what a silently regressed logger produces. Without the floor the guard would report exactly the same thing the old step did: success, on nothing.

## Verification

`dotnet restore` and `dotnet build -c Release` on the test project: exit 0, **0 warnings, 0 errors**. The logger extension lands in the test output directory, which is how vstest discovers it:

```
SysManager.Tests/bin/Release/net10.0-windows/Microsoft.VisualStudio.TestPlatform.Extension.JUnit.Xml.TestLogger.dll
SysManager.Tests/bin/Release/net10.0-windows/Spekt.TestLogger.dll
```

The `junit` friendly name and the `logger://` URI are both present in that assembly's metadata, and `LogFileName` is handled by `Spekt.TestLogger.dll` beside it.

The workflow parses (`yaml.safe_load`, 3 jobs), and the guard's script was extracted verbatim from the parsed YAML and run under `bash -e -o pipefail` against five report shapes:

| Report | Expected | Result |
|---|---|---|
| well-formed, 4907 cases | pass | pass, reports `380686 bytes, 4907 test cases` |
| file missing | fail | fail, names the missing path and lists `TestResults` |
| zero-byte file | fail | fail, same check |
| TRX content (the shipped bug) | fail | fail, `has no <testsuites> root` |
| well-formed but 12 cases | fail | fail, `only 12 test cases, under the floor of 4000` |

Note the fourth row: the guard rejects exactly what this repo has been uploading.

`TESTING.md` documents the two-logger arrangement and lists the package in the frameworks table.

This PR cannot prove the logger's runtime output locally, because the unit suite does not run on this machine. Its own guard step is the proof, and it runs on this PR: if the report does not appear at `TestResults/unit-results.junit.xml` with the expected shape, this check goes red rather than uploading something unreadable.
