### PR TITLE
fix: keep hosts lines SysManager cannot parse instead of deleting them on save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.15] - 2026-09-01
+
+If your hosts file had a line with a typo in it, saving from the Hosts tab used to delete that line
+without saying so. Those lines are now kept exactly as you wrote them.
+
+### Fixed
+- **A hosts line SysManager cannot read is no longer deleted when you save.** The Hosts tab rebuilds the
+  whole file every time you save, from the entries it managed to read plus your comments. A line it could
+  not read belonged to neither group, so it vanished — and only after you changed something else entirely,
+  which made the two look unrelated. The kinds of line this affected are all small mistakes: a semicolon
+  where a space belonged, an address with no website name after it, a fourth number above 255, a word on
+  its own. Every one of them is a line somebody typed deliberately and got slightly wrong, so it is the
+  best record of what they meant — and the mistake is exactly why the tab could not read it back. Those
+  lines now survive a save untouched, alongside the comments that were already being kept. They still do
+  not appear in the list of entries, because SysManager cannot tell what address they were meant to point
+  at and will not guess.
+
 ## [1.75.14] - 2026-09-01
 
 App Blocker refuses to block one more Windows file. Blocking it was possible, and it would have stopped

--- a/SysManager/SysManager.Tests/HostsFileServiceTests.cs
+++ b/SysManager/SysManager.Tests/HostsFileServiceTests.cs
@@ -532,4 +532,98 @@ public class HostsFileServiceTests
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { } }
     }
+
+    // ---------- unparseable non-comment lines ----------
+
+    [Theory]
+    [InlineData("127.0.0.1;localhost")]          // separator typo — one token, no whitespace
+    [InlineData("10.0.0.1")]                     // an IP with no hostname
+    [InlineData("192.168.1.300\tprinter.local")] // fourth octet out of range
+    [InlineData("localhost")]                    // a bare word
+    [InlineData("not-an-ip  some.host")]         // two tokens, first is not an IP
+    public async Task SaveHosts_UnparseableNonCommentLine_PreservedNotDeleted(string badLine)
+    {
+        // The line has no '#', so the preserved-comment capture used to reject it on the assumption
+        // that anything without a '#' is carried by `entries`. ReadHostsAsync never parsed it, so
+        // nothing carried it, and SaveHosts rewrites the whole file — the line was deleted the first
+        // time the user touched any unrelated entry in the UI.
+        //
+        // Each InlineData is a different reason to fail parsing (token count, IP validity, both), so a
+        // fix that only handled one shape stays red on the others.
+        var content = $"{badLine}\n127.0.0.1 localhost\n";
+        var (svc, hosts, dir) = NewServiceWithTempHosts(content);
+        try
+        {
+            var entries = await svc.ReadHostsAsync();
+            svc.SaveHosts(entries);
+
+            var saved = File.ReadAllText(hosts);
+            Assert.Contains(badLine, saved);
+            Assert.Contains("127.0.0.1\tlocalhost", saved);   // the good entry is untouched
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    [Fact]
+    public async Task SaveHosts_ParseableLine_EmittedOnceNotAlsoPreserved()
+    {
+        // The negative half of the fix. Preserving "everything without a '#'" would re-emit a normal
+        // entry as a raw line as well as an entry, duplicating every mapping in the file. The capture
+        // and ReadHostsAsync therefore have to agree on what counts as an entry, which is why they
+        // share one predicate rather than each having their own.
+        const string content = "0.0.0.0\tads.example.com\n127.0.0.1 localhost\n";
+        var (svc, hosts, dir) = NewServiceWithTempHosts(content);
+        try
+        {
+            var entries = await svc.ReadHostsAsync();
+            svc.SaveHosts(entries);
+
+            var saved = File.ReadAllText(hosts);
+            Assert.Equal(1, saved.Split("ads.example.com").Length - 1);
+            Assert.Equal(1, saved.Split("localhost").Length - 1);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    [Fact]
+    public async Task SaveHosts_WithUnparseableLine_IsStillFixedPoint()
+    {
+        // A preserved line is re-read on the next save and must be preserved again in the identical
+        // form, or the service — a singleton doing a whole-file rewrite — grows the file on every save.
+        // Preserving a line is the easy part; preserving it idempotently is the part worth pinning.
+        const string content =
+            "# Section A\n" +
+            "192.168.1.300\tprinter.local\n" +
+            "127.0.0.1\tlocalhost\n";
+        var (svc, hosts, dir) = NewServiceWithTempHosts(content);
+        try
+        {
+            svc.SaveHosts(await svc.ReadHostsAsync());
+            var afterFirst = File.ReadAllText(hosts);
+
+            svc.SaveHosts(await svc.ReadHostsAsync());
+            var afterSecond = File.ReadAllText(hosts);
+
+            Assert.Equal(afterFirst, afterSecond);
+            Assert.Equal(1, afterSecond.Split("192.168.1.300").Length - 1);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    [Fact]
+    public async Task ReadHostsAsync_UnparseableLine_StillNotAnEntry()
+    {
+        // Preserving the text must not become "accept it as an entry". An unparseable line has no
+        // usable IP, so turning it into a HostsEntry would put a broken mapping in the UI and write it
+        // back as if SysManager had authored it.
+        const string content = "192.168.1.300\tprinter.local\n127.0.0.1\tlocalhost\n";
+        var (svc, _, dir) = NewServiceWithTempHosts(content);
+        try
+        {
+            var entries = await svc.ReadHostsAsync();
+            Assert.DoesNotContain(entries, e => e.Hostname == "printer.local");
+            Assert.Contains(entries, e => e.Hostname == "localhost" && e.IpAddress == "127.0.0.1");
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
 }

--- a/SysManager/SysManager/Services/HostsFileService.cs
+++ b/SysManager/SysManager/Services/HostsFileService.cs
@@ -69,7 +69,7 @@ public sealed partial class HostsFileService
             {
                 workLine = line[1..].TrimStart();
                 // If the remainder isn't a valid disabled entry (IP + hostname), skip it
-                if (!IsDisabledEntryLine(workLine)) continue;
+                if (!IsEntryLine(workLine)) continue;
                 isDisabled = true;
             }
 
@@ -105,16 +105,29 @@ public sealed partial class HostsFileService
     }
 
     /// <summary>
-    /// Extracts the user's standalone comment and blank lines from the current hosts file so
-    /// <see cref="SaveHosts"/> can re-emit them. A line is preserved when it is a pure comment
-    /// (starts with '#') that is NOT a commented-out IP entry (those round-trip as disabled
-    /// <see cref="HostsEntry"/> objects) and NOT one of SysManager's managed-header lines
-    /// (excluding them keeps repeated saves from accumulating duplicate headers). Interior blank
-    /// lines are kept for readability; leading/trailing blanks are trimmed so the block is a fixed
-    /// point. Returns an empty list when the file is absent — so a file with no comments produces
-    /// output byte-identical to the previous behaviour.
+    /// Extracts every line of the current hosts file that <see cref="SaveHosts"/> would otherwise
+    /// lose, so it can re-emit them.
     /// </summary>
-    private List<string> ReadStandaloneCommentLines()
+    /// <remarks>
+    /// SaveHosts rewrites the whole file from header + these lines + <see cref="HostsEntry"/> objects,
+    /// so anything neither emitted as an entry nor captured here is deleted. Three kinds are captured:
+    /// <list type="bullet">
+    /// <item>Pure comments — a '#' line that is not a commented-out IP entry (those round-trip as
+    /// disabled entries) and not one of SysManager's own managed-header lines (excluding those keeps
+    /// repeated saves from accumulating duplicate headers).</item>
+    /// <item>Lines that are not comments and do not parse as an entry: a typo'd IP, an IP with no
+    /// hostname, a stray word. <see cref="ReadHostsAsync"/> skips them, so nothing else carries them.
+    /// They are usually a line the user meant to work, which makes them worth keeping rather than
+    /// quietly discarding — the malformed text is the record of the intent.</item>
+    /// <item>Interior blank lines, for readability. Leading and trailing blanks are trimmed.</item>
+    /// </list>
+    /// The keep-or-skip decision uses <see cref="IsEntryLine"/>, the same predicate ReadHostsAsync
+    /// uses to accept a line. That shared test is what keeps the two in step: a line this method keeps
+    /// is exactly a line ReadHostsAsync did not turn into an entry, so nothing is duplicated and
+    /// nothing is dropped. Returns an empty list when the file is absent, so a file of plain entries
+    /// produces output byte-identical to the earlier behaviour.
+    /// </remarks>
+    private List<string> ReadPreservedLines()
     {
         List<string> preserved = [];
         if (!File.Exists(HostsPath)) return preserved;
@@ -137,12 +150,20 @@ public sealed partial class HostsFileService
                 continue;
             }
 
-            if (!line.StartsWith('#')) continue;                       // an IP entry — carried by `entries`
+            if (!line.StartsWith('#'))
+            {
+                // Carried by `entries` only if ReadHostsAsync could actually parse it. When it could
+                // not, this is the last chance to keep the line, so keep it verbatim.
+                if (IsEntryLine(line)) continue;
+                preserved.Add(line);
+                continue;
+            }
+
             if (line == ManagedHeaderLine1 || line == ManagedHeaderLine2) continue; // our own header
 
             // A '#' followed by a valid disabled entry (IP + hostname) is already represented as a
             // HostsEntry with IsEnabled=false — skip it here so it isn't duplicated.
-            if (IsDisabledEntryLine(line[1..].TrimStart())) continue;
+            if (IsEntryLine(line[1..].TrimStart())) continue;
 
             preserved.Add(line);
         }
@@ -167,10 +188,12 @@ public sealed partial class HostsFileService
     /// already contained SysManager's own output — losing the pristine original and
     /// defeating <see cref="RestoreBackup"/>.
     ///
-    /// Standalone comments and blank lines the user wrote (documentation, section headers)
-    /// are preserved verbatim above the entries, so an edit through the UI no longer strips
-    /// them. SysManager's own managed-header lines are excluded from that capture, making the
-    /// rewrite a fixed point — repeated saves don't accumulate duplicate headers or blanks.
+    /// Anything the user wrote that the parser does not turn into an entry is preserved verbatim
+    /// above the entries: standalone comments, blank lines, and lines that fail to parse at all
+    /// (a typo'd IP, an IP with no hostname). Without that, editing one entry through the UI
+    /// silently deleted the rest of the file's hand-written content. SysManager's own managed-header
+    /// lines are excluded from the capture, making the rewrite a fixed point — repeated saves don't
+    /// accumulate duplicate headers or blanks. See <see cref="ReadPreservedLines"/>.
     /// </remarks>
     public void SaveHosts(List<HostsEntry> entries)
     {
@@ -188,7 +211,7 @@ public sealed partial class HostsFileService
         // Re-emit the user's own standalone comments/blank lines (not IP mappings — those are
         // carried by `entries`). Without this, editing one entry through the UI silently deleted
         // every hand-written comment on the next save.
-        var preserved = ReadStandaloneCommentLines();
+        var preserved = ReadPreservedLines();
         if (preserved.Count > 0)
         {
             lines.AddRange(preserved);
@@ -297,20 +320,28 @@ public sealed partial class HostsFileService
     }
 
     /// <summary>
-    /// Determines whether a '#'-stripped remainder represents a disabled hosts entry
-    /// (IP + hostname), using the SAME acceptance test as <see cref="ReadHostsAsync"/>:
-    /// strip an optional inline comment, split on whitespace, require at least two
-    /// tokens, and validate the first as an IP address. This replaces the old
-    /// <c>LooksLikeIpStart</c> heuristic that only checked the leading character — which
-    /// missed IPv6 addresses starting with hex letters (e.g. <c>fe80::</c>) and
-    /// falsely matched digit-leading comments (e.g. <c># 5G adapter notes</c>).
+    /// Determines whether <paramref name="candidate"/> is a hosts entry (IP + at least one hostname):
+    /// strip an optional inline comment, split on whitespace, require at least two tokens, and
+    /// validate the first as an IP address.
     /// </summary>
-    private static bool IsDisabledEntryLine(string afterHash)
+    /// <remarks>
+    /// This is the single acceptance test for "would ReadHostsAsync turn this into a HostsEntry", and
+    /// all three callers depend on that being one definition rather than three lookalikes:
+    /// ReadHostsAsync itself, to decide whether a '#' line is a disabled entry; and
+    /// <see cref="ReadPreservedLines"/> twice, to avoid re-emitting a line that is already carried as
+    /// an entry. If this drifted from what ReadHostsAsync accepts, lines would be silently duplicated
+    /// or silently dropped depending on which way it drifted.
+    /// <para>Named for what it computes rather than for one caller. It replaced a
+    /// <c>LooksLikeIpStart</c> heuristic that only inspected the leading character, which missed IPv6
+    /// addresses starting with hex letters (<c>fe80::</c>) and falsely matched digit-leading comments
+    /// (<c># 5G adapter notes</c>).</para>
+    /// </remarks>
+    private static bool IsEntryLine(string candidate)
     {
-        if (afterHash.Length == 0) return false;
+        if (candidate.Length == 0) return false;
 
         // Mirror ReadHostsAsync: strip inline comment, then tokenize.
-        string[] parts = afterHash.Split(['#'], 2);
+        string[] parts = candidate.Split(['#'], 2);
         string entryPart = parts[0].Trim();
         string[] tokens = entryPart.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries);
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.14</Version>
-    <FileVersion>1.75.14.0</FileVersion>
-    <AssemblyVersion>1.75.14.0</AssemblyVersion>
+    <Version>1.75.15</Version>
+    <FileVersion>1.75.15.0</FileVersion>
+    <AssemblyVersion>1.75.15.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem

`SaveHosts` rewrites the whole hosts file from header + preserved lines + parsed entries, so anything in neither group is deleted. Traced through current source:

- `ReadHostsAsync` skips a non-comment line at `HostsFileService.cs:82` (fewer than two tokens) or `:87` (first token is not an IP), so it never becomes a `HostsEntry`.
- The preserved-line capture then rejected the same line at `:140` — `if (!line.StartsWith('#')) continue;` — on the assumption that anything without a `#` is carried by `entries`. That holds for a line that parses. It does not hold for one that doesn't.

A file containing

```
127.0.0.1;localhost
10.0.0.1
192.168.1.300  printer.local
```

lost all three the first time the user toggled any unrelated entry in the UI. The delay between cause and effect is what made it hard to attribute: nothing happens when the bad line is written, only later, when the user was doing something else.

Every one of those is a line somebody typed deliberately and got slightly wrong, which makes it the most useful line in the file to keep. It is the record of the intent. The typo is also exactly why the parser rejects it, so "it was invalid anyway" argues for keeping it rather than deleting it.

This is the same defect the comment-preservation fix addressed, one case short: `SaveHosts` rewriting from a lossy parse. The fix reuses that mechanism instead of adding a parallel one.

## Change

The capture is widened to keep any non-comment line that does not parse as an entry, and renamed `ReadPreservedLines` since it no longer captures only comments.

The keep-or-skip test has to be byte-identical to the one `ReadHostsAsync` uses to accept a line. If it were looser, a line would be preserved *and* emitted as an entry; if tighter, it would still be lost. `IsDisabledEntryLine` already computed precisely that test, so it is reused as the shared predicate and renamed `IsEntryLine` — it describes what it computes rather than one of what are now three callers, and the remark spells out why all three must share one definition.

Preserved lines still never become entries. SysManager cannot tell what address a malformed line was meant to point at, so it does not guess.

## Regression tests

Four, each covering a different way the fix could be wrong rather than four phrasings of one check:

| Test | What it pins |
|---|---|
| `SaveHosts_UnparseableNonCommentLine_PreservedNotDeleted` | 5 shapes: separator typo, IP with no host, out-of-range octet, bare word, non-IP first token |
| `SaveHosts_ParseableLine_EmittedOnceNotAlsoPreserved` | the negative half — a normal entry is not duplicated |
| `SaveHosts_WithUnparseableLine_IsStillFixedPoint` | two saves produce identical output |
| `ReadHostsAsync_UnparseableLine_StillNotAnEntry` | preserving the text is not the same as accepting it |

The theory carries five rows on purpose: a fix that handled only one failure reason would stay red on the others.

## Red before, green after

Proven under three mutations against the harness. **Baseline: all 11 green** (4 new + 7 pre-existing hosts tests).

| Mutation | Expected red | Actual red |
|---|---|---|
| **A** — restore the shipped code (`if (!line.StartsWith('#')) continue;`) | preservation + fixed-point | matched |
| **B** — the obvious wrong fix: preserve *every* non-comment line | 4, incl. 2 pre-existing | matched |
| **C** — predicate drift: `tokens.Length >= 1` | 2, from both sides of the shared contract | matched |

Mutation A is the one that matters: it reproduces the real defect exactly, so the new tests are reacting to the bug rather than to arbitrary damage.

B and C each turned *more* tests red than I first predicted, and both surpluses are correct consequences. Preserving every non-comment line also re-preserves the entries this service emits, so the file grows on every save (`SaveHosts_IsFixedPoint_RepeatedSavesDoNotAccumulate`) and canonical output stops matching byte-for-byte (`SaveHosts_NoComments_OutputUnchangedFromCanonicalForm`). Loosening the predicate reclassifies `# 192.168.1.1` as an entry, so it is carried by nobody and deleted (`SaveHosts_CommentWithOnlyIpNoHostname_PreservedAsComment`). Worth stating plainly: the pre-existing suite already blocked the naive fix from both directions.

The service file was restored byte-for-byte after each mutation and rebuilt from the restored source.

## Regression sweep

- `dotnet build -c Release`: app **0 warnings, 0 errors**; tests **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes` on both projects: exit 0.
- All 61 architecture guards run (67 cases): 65 green, 2 red — both artefacts of the throwaway runner, not the diff. `EverySourceFile_CarriesTheAuthorHeader` flags the runner's own `h/Program.cs`, which is excluded via `.git/info/exclude:25` and invisible to git; `ProcessWideStaticUsers_AreInTheSerializedCollection` calls `FindTestSourceDirectory`, which walks up from `AppContext.BaseDirectory` looking for `SysManager.Tests.csproj` and cannot find it from the runner's `bin`. Both pass under CI's real `dotnet test`.
- Downstream: `DnsHostsViewModel` is the only consumer. It reads entries and saves a snapshot; `HostEntries.Count` is unaffected because preserved lines never become entries.
- Local CI gates re-run from the extracted workflow bodies: version consistency (1.75.15 across csproj, CHANGELOG, SECURITY.md), valid bump (v1.75.14 → 1.75.15), CHANGELOG plain-English lead. All pass.

## Propagate

`HostsFileService` is the only service that rewrites a file it did not author from its own parse. The other 20 file-writing services persist JSON stores SysManager owns, which the user never hand-edits, so an unparseable line there would be SysManager's own bug rather than lost user content. The defect class has exactly one instance and it is this one.

CHANGELOG entry and version bump to 1.75.15 are in this PR.
