### PR TITLE
fix: tell the user what the shredder actually did instead of claiming success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.16] - 2026-09-01
+
+File Shredder now tells you what it actually did. Before, a folder containing a shortcut to somewhere else
+was reported as fully destroyed while it was still sitting on the disk, and when a file could not be shredded
+the only thing shown was the word "Failed".
+
+### Fixed
+- **A folder holding a shortcut is no longer reported as destroyed.** File Shredder deliberately refuses to
+  follow a shortcut that points somewhere outside the folder you picked, because overwriting through one
+  would destroy files you never selected. That refusal is right and has not changed. What was wrong is that
+  nothing said so: the folder was reported as shredded, no note was written anywhere, and the folder stayed
+  on the disk because the shortcut was still inside it. So you were told your files were gone while looking
+  at the folder holding them. The shredder now says how many shortcuts it left alone and that the folder is
+  still there. A folder with no shortcuts in it reads exactly as before, with nothing extra added.
+- **When a file cannot be shredded, the reason is now shown.** The shredder already worked out a clear
+  explanation for every file it had to leave behind — which ones they were, and why, whether locked by
+  another program or sharing its contents with a file elsewhere on the disk. That explanation went only into
+  the log file. On screen the file was marked "Failed" and nothing more, which for a tool whose entire job is
+  destroying data beyond recovery leaves out the only part that matters: those files are still on your
+  computer and still readable. The explanation now appears beside the summary at the bottom of the tab.
+
 ## [1.75.15] - 2026-09-01
 
 If your hosts file had a line with a typo in it, saving from the Hosts tab used to delete that line

--- a/SysManager/SysManager.Tests/FileShredderServiceTests.cs
+++ b/SysManager/SysManager.Tests/FileShredderServiceTests.cs
@@ -2,8 +2,10 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using System.IO;
 using System.Security;
+using SysManager.Models;
 using SysManager.Services;
 
 namespace SysManager.Tests;
@@ -587,5 +589,157 @@ public class FileShredderServiceTests
             expanded.Equals(progFiles, StringComparison.OrdinalIgnoreCase) ||
             expanded.Equals(shortForm, StringComparison.OrdinalIgnoreCase),
             $"Unexpected expansion: {expanded}");
+    }
+    // ---------- a deliberately skipped link must be reported, not passed off as success ----------
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(3, true)]
+    public void ShredFolderReport_Notice_AppearsOnlyWhenSomethingWasSkipped(int skipped, bool expectNotice)
+    {
+        // The report is what stops a skipped junction being reported as a completed shred. With nothing
+        // skipped it must stay silent, or every ordinary folder shred would grow a warning nobody needs.
+        var report = new ShredFolderReport
+        {
+            FilesShredded = 5,
+            SkippedLinks = Enumerable.Range(0, skipped).Select(i => $@"C:\temp\link{i}").ToList()
+        };
+
+        Assert.Equal(expectNotice, report.Notice is not null);
+        if (expectNotice)
+        {
+            Assert.Contains(skipped.ToString(CultureInfo.InvariantCulture), report.Notice);
+            // Singular and plural both have to read correctly — this text is shown to someone who does
+            // not know what a reparse point is, and "1 shortcuts were left alone" undermines the rest.
+            Assert.Contains(skipped == 1 ? "shortcut inside was" : "shortcuts inside were", report.Notice);
+            Assert.Contains("still on the computer", report.Notice);
+        }
+    }
+
+    [Fact]
+    public async Task ShredFolderAsync_FolderWithoutLinks_ReportsNoNotice()
+    {
+        // The ordinary case, and the one that keeps the notice honest: two real files, both shredded,
+        // nothing skipped, nothing to tell the user.
+        var svc = NewService();
+        var dir = Path.Combine(Path.GetTempPath(), "smtest_shredplain_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(dir, "a.dat"), "aaa");
+            await File.WriteAllTextAsync(Path.Combine(dir, "b.dat"), "bbb");
+
+            var report = await svc.ShredFolderAsync(dir, ShredMethod.Quick, null, CancellationToken.None);
+
+            Assert.Equal(2, report.FilesShredded);
+            Assert.Empty(report.SkippedLinks);
+            Assert.Null(report.Notice);
+            Assert.False(Directory.Exists(dir), "an empty folder should have been removed after the shred");
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* ignore */ } }
+    }
+
+    [Fact]
+    public async Task ShredFolderAsync_JunctionInside_IsReportedNotSilentlySkipped()
+    {
+        // The walk correctly refuses to follow a junction — shredding through one would destroy data at
+        // its target, outside the selected folder. But the refusal used to be recorded nowhere, not even
+        // at Debug level, and the method then logged "Folder shredded successfully" while the folder was
+        // still on disk (TryRemoveIfEmpty cannot remove a directory that still holds the junction, and
+        // that failure is swallowed too). So the user was told their data was destroyed while looking at
+        // the folder containing it.
+        var svc = NewService();
+        var dir = Path.Combine(Path.GetTempPath(), "smtest_shredjunc_" + Guid.NewGuid().ToString("N"));
+        var outside = Path.Combine(Path.GetTempPath(), "smtest_shredtarget_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        Directory.CreateDirectory(outside);
+        var keep = Path.Combine(outside, "must-survive.dat");
+        await File.WriteAllTextAsync(keep, "data outside the selected folder");
+        var link = Path.Combine(dir, "junction");
+
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(dir, "real.dat"), "shred me");
+
+            // mklink /J creates a directory junction and needs no admin rights — the same approach the
+            // mid-path junction test above uses.
+            var psi = new System.Diagnostics.ProcessStartInfo("cmd.exe", $"/c mklink /J \"{link}\" \"{outside}\"")
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+            using (var proc = System.Diagnostics.Process.Start(psi)!)
+            {
+                proc.WaitForExit(10_000);
+                if (proc.ExitCode != 0 || (File.GetAttributes(link) & FileAttributes.ReparsePoint) == 0)
+                    return; // environment can't create junctions (rare) — nothing to assert
+            }
+
+            var report = await svc.ShredFolderAsync(dir, ShredMethod.Quick, null, CancellationToken.None);
+
+            Assert.Contains(link, report.SkippedLinks);
+            Assert.NotNull(report.Notice);
+            // The safety behaviour itself must be unchanged: the file behind the junction is untouched.
+            Assert.True(File.Exists(keep), "the shred followed the junction and destroyed data outside the folder");
+        }
+        finally
+        {
+            try { Directory.Delete(link); } catch { /* ignore */ }
+            try { Directory.Delete(dir, recursive: true); } catch { /* ignore */ }
+            try { Directory.Delete(outside, recursive: true); } catch { /* ignore */ }
+        }
+    }
+    [Fact]
+    public async Task ShredFolderAsync_ReparsePointRoot_IsRefusedAndTargetSurvives()
+    {
+        // The root guard had no test. Handing the shredder a junction AS the folder to shred used to walk
+        // straight into the link's target: the reparse-point skip inside EnumerateFilesSafe only inspects
+        // child entries, never the root it starts from, so everything at the target — outside the selected
+        // location entirely — would have been overwritten.
+        //
+        // Asserts the target's contents survive as well as the exception type. A SecurityException raised
+        // after the data was already destroyed would satisfy a type-only assertion and be worthless.
+        var svc = NewService();
+        var outside = Path.Combine(Path.GetTempPath(), "smtest_rootjunctarget_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outside);
+        var keep = Path.Combine(outside, "must-survive.dat");
+        const string content = "data at the junction target";
+        await File.WriteAllTextAsync(keep, content);
+
+        var baseDir = Path.Combine(Path.GetTempPath(), "smtest_rootjunc_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(baseDir);
+        var link = Path.Combine(baseDir, "asjunction");
+
+        try
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo("cmd.exe", $"/c mklink /J \"{link}\" \"{outside}\"")
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+            using (var proc = System.Diagnostics.Process.Start(psi)!)
+            {
+                proc.WaitForExit(10_000);
+                if (proc.ExitCode != 0 || (File.GetAttributes(link) & FileAttributes.ReparsePoint) == 0)
+                    return; // environment can't create junctions (rare) — nothing to assert
+            }
+
+            await Assert.ThrowsAsync<SecurityException>(
+                () => svc.ShredFolderAsync(link, ShredMethod.Quick, null, CancellationToken.None));
+
+            Assert.True(File.Exists(keep), "the shred followed the root junction and destroyed its target");
+            Assert.Equal(content, await File.ReadAllTextAsync(keep));
+        }
+        finally
+        {
+            try { Directory.Delete(link); } catch { /* ignore */ }
+            try { Directory.Delete(baseDir, recursive: true); } catch { /* ignore */ }
+            try { Directory.Delete(outside, recursive: true); } catch { /* ignore */ }
+        }
     }
 }

--- a/SysManager/SysManager.Tests/FileShredderViewModelTests.cs
+++ b/SysManager/SysManager.Tests/FileShredderViewModelTests.cs
@@ -263,4 +263,99 @@ public class FileShredderViewModelTests
 
         throw new FileNotFoundException("Could not locate FileShredderViewModel.cs from the test output.");
     }
+    // ---------- the reason a shred failed has to reach the screen ----------
+
+    [Fact]
+    public async Task ShredAll_WhenAFileCannotBeShredded_TheReasonReachesTheStatusLine()
+    {
+        // The service words its failures for the user — which files were left in place and why. The view
+        // model caught the exception, set Status to "Failed", logged a warning, and dropped the message:
+        // it contained no ex.Message anywhere. On screen the user saw the single word "Failed" for an
+        // operation whose whole point is knowing whether data is gone or still recoverable on disk.
+        //
+        // An open handle is the deterministic way to provoke it: the shredder opens with FileShare.None,
+        // so any other handle makes that open fail. No privileges, no reparse points, no timing.
+        var file = Path.Combine(Path.GetTempPath(), "smtest_shredlock_" + Guid.NewGuid().ToString("N") + ".dat");
+        await File.WriteAllTextAsync(file, "locked by the test");
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            using var hold = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+            var vm = NewVm();
+            vm.Items.Add(new ShredItem
+            {
+                Path = file,
+                Name = Path.GetFileName(file),
+                SizeBytes = 1,
+                IsFolder = false
+            });
+
+            await vm.ShredAllCommand.ExecuteAsync(null);
+
+            // Asserted on the item name rather than the operating system's wording, which is localised.
+            Assert.Contains(Path.GetFileName(file), vm.StatusMessage);
+            Assert.NotEqual("Complete — 0 shredded, 1 failed.", vm.StatusMessage);
+            Assert.StartsWith("Complete — 0 shredded, 1 failed.", vm.StatusMessage);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+            if (File.Exists(file)) File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ShredAll_WhenEverythingSucceeds_TheStatusLineStaysShort()
+    {
+        // The negative half. Appending explanations unconditionally would put noise on every clean run,
+        // so a shred with nothing to report must produce exactly the summary and not a character more.
+        //
+        // Queues a FOLDER as well as a file, deliberately. An earlier version used a file only, which
+        // meant ShredFolderAsync — and therefore the notice — was never reached, and a mutation making the
+        // notice fire unconditionally left this test green. The folder is what exercises the path that can
+        // produce noise.
+        var file = Path.Combine(Path.GetTempPath(), "smtest_shredclean_" + Guid.NewGuid().ToString("N") + ".dat");
+        await File.WriteAllTextAsync(file, "shred me");
+        var dir = Path.Combine(Path.GetTempPath(), "smtest_shredcleandir_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        await File.WriteAllTextAsync(Path.Combine(dir, "inner.dat"), "shred me too");
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            var vm = NewVm();
+            vm.Items.Add(new ShredItem
+            {
+                Path = file,
+                Name = Path.GetFileName(file),
+                SizeBytes = 1,
+                IsFolder = false
+            });
+            vm.Items.Add(new ShredItem
+            {
+                Path = dir,
+                Name = Path.GetFileName(dir),
+                SizeBytes = 1,
+                IsFolder = true
+            });
+
+            await vm.ShredAllCommand.ExecuteAsync(null);
+
+            Assert.Equal("Complete — 2 shredded, 0 failed.", vm.StatusMessage);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+            if (File.Exists(file)) File.Delete(file);
+            try { Directory.Delete(dir, recursive: true); } catch { /* ignore */ }
+        }
+    }
 }

--- a/SysManager/SysManager/Models/ShredItem.cs
+++ b/SysManager/SysManager/Models/ShredItem.cs
@@ -21,3 +21,38 @@ public sealed partial class ShredItem : ObservableObject
 
     public string SizeDisplay => FormatHelper.FormatSize(SizeBytes);
 }
+
+/// <summary>
+/// What a folder shred did, beyond the fact that it finished.
+/// </summary>
+/// <remarks>
+/// Exists so a deliberate skip can be reported without being reported as a failure. The shredder never
+/// follows a junction or symlink inside a selected folder, because overwriting through one would destroy
+/// data at the link's target outside the selection. That refusal is correct, so it must not surface as an
+/// error — but it does mean the folder was not emptied, and the user asked for it to be destroyed. Saying
+/// nothing leaves them believing data is gone when it is not, which is the one thing a shredder cannot
+/// afford to get wrong.
+/// </remarks>
+public sealed record ShredFolderReport
+{
+    /// <summary>Files that were securely overwritten and deleted.</summary>
+    public int FilesShredded { get; init; }
+
+    /// <summary>
+    /// Full paths of junctions, symlinks and link files found inside the folder and deliberately left
+    /// alone. Empty on the ordinary case, which is why <see cref="Notice"/> is null then.
+    /// </summary>
+    public IReadOnlyList<string> SkippedLinks { get; init; } = [];
+
+    /// <summary>
+    /// A plain-English sentence for the user, or null when there is nothing they need to know. Names the
+    /// consequence (the folder is still there) rather than the mechanism (reparse points), and says why
+    /// the skip was the safe choice.
+    /// </summary>
+    public string? Notice => SkippedLinks.Count == 0
+        ? null
+        : $"{SkippedLinks.Count} shortcut{(SkippedLinks.Count == 1 ? "" : "s")} inside "
+          + $"{(SkippedLinks.Count == 1 ? "was" : "were")} left alone because "
+          + $"{(SkippedLinks.Count == 1 ? "it points" : "they point")} to files outside the folder, "
+          + "so the folder itself is still on the computer.";
+}

--- a/SysManager/SysManager/Services/FileShredderService.cs
+++ b/SysManager/SysManager/Services/FileShredderService.cs
@@ -8,6 +8,7 @@ using System.Security;
 using System.Security.Cryptography;
 using Microsoft.Win32.SafeHandles;
 using Serilog;
+using SysManager.Models;
 
 namespace SysManager.Services;
 
@@ -177,7 +178,7 @@ public sealed partial class FileShredderService
     /// Securely shreds all files in a folder recursively, then removes the folder.
     /// Skips junctions and symlinks to prevent shredding outside the target directory.
     /// </summary>
-    public async Task ShredFolderAsync(string folderPath, ShredMethod method, IProgress<int>? progress, CancellationToken ct)
+    public async Task<ShredFolderReport> ShredFolderAsync(string folderPath, ShredMethod method, IProgress<int>? progress, CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(folderPath);
         ValidatePath(folderPath);
@@ -195,7 +196,9 @@ public sealed partial class FileShredderService
             throw new SecurityException(
                 $"The selected folder is a junction or symlink; shredding it would destroy data at its target outside the selected location: {folderPath}");
 
-        var files = EnumerateFilesSafe(folderPath);
+        // Links the walk refuses to follow. Collected rather than silently dropped: see ShredFolderReport.
+        List<string> skippedLinks = [];
+        var files = EnumerateFilesSafe(folderPath, skippedLinks);
         var totalFiles = files.Count;
 
         // Files whose secure overwrite did NOT complete (denied, locked, hard-linked, …). We
@@ -245,7 +248,7 @@ public sealed partial class FileShredderService
         // Directory.Delete remove an empty directory OUTSIDE the selected folder. Sharing the
         // file walk's reparse boundary confines cleanup to the real tree; a folder that contains
         // a child junction is intentionally left in place rather than descended into.
-        foreach (var dir in EnumerateDirectoriesSafe(folderPath)
+        foreach (var dir in EnumerateDirectoriesSafe(folderPath, [])
                      .OrderByDescending(d => d.Count(c => c == Path.DirectorySeparatorChar)))
         {
             TryRemoveIfEmpty(dir);
@@ -263,7 +266,19 @@ public sealed partial class FileShredderService
                 $"{failedFiles.Count} of {totalFiles} file(s) could not be securely shredded and were left in place (not deleted): {sample}{more}.");
         }
 
-        Log.Information("Folder shredded successfully: {Path} ({Method})", folderPath, method);
+        // A skipped link is NOT a failure — refusing to follow it is the correct behaviour — so it is
+        // returned rather than thrown. It still has to reach the user: the folder was not emptied, and
+        // they asked for it to be destroyed. Reporting "shredded successfully" while the folder is still
+        // sitting there is the one mistake a shredder cannot make.
+        var report = new ShredFolderReport { FilesShredded = totalFiles, SkippedLinks = skippedLinks };
+
+        if (skippedLinks.Count > 0)
+            Log.Information("Folder shredded, {Skipped} link(s) left alone: {Path} ({Method})",
+                skippedLinks.Count, folderPath, method);
+        else
+            Log.Information("Folder shredded successfully: {Path} ({Method})", folderPath, method);
+
+        return report;
     }
 
     /// <summary>
@@ -283,10 +298,17 @@ public sealed partial class FileShredderService
     }
 
     /// <summary>
-    /// Recursively enumerates files while skipping directories that are
-    /// junctions or symlinks (reparse points) to prevent traversal attacks.
+    /// Recursively enumerates files while skipping directories that are junctions or symlinks
+    /// (reparse points) to prevent traversal attacks.
     /// </summary>
-    private static List<string> EnumerateFilesSafe(string rootPath)
+    /// <param name="rootPath">Folder to walk. Its own reparse-point status is checked by the caller.</param>
+    /// <param name="skippedLinks">
+    /// Receives every link this walk refused to follow. The skip is the safe behaviour, but the caller has
+    /// to be able to tell the user about it: a folder holding a skipped link is not emptied, so reporting
+    /// the shred as complete without mentioning it would leave the user believing data was destroyed when
+    /// it is still there. Previously these skips were recorded nowhere at all, not even at Debug level.
+    /// </param>
+    private static List<string> EnumerateFilesSafe(string rootPath, List<string> skippedLinks)
     {
         List<string> results = [];
         Stack<DirectoryInfo> stack = [];
@@ -304,8 +326,13 @@ public sealed partial class FileShredderService
             // Skip symlink/hardlink files: shredding would overwrite the LINK TARGET
             // (which may live outside the selected folder), so only real files in the
             // tree are collected — mirrors the reparse-point skip on directories below.
-            foreach (var file in files.Where(f => (f.Attributes & FileAttributes.ReparsePoint) == 0))
-                results.Add(file.FullName);
+            foreach (var file in files)
+            {
+                if ((file.Attributes & FileAttributes.ReparsePoint) == 0)
+                    results.Add(file.FullName);
+                else
+                    skippedLinks.Add(file.FullName);
+            }
 
             DirectoryInfo[] subDirs;
             try { subDirs = dir.GetDirectories(); }
@@ -313,9 +340,12 @@ public sealed partial class FileShredderService
             catch (IOException) { continue; }
 
             // Skip junctions/symlinks to avoid following reparse points out of the tree.
-            foreach (var sub in subDirs.Where(s => (s.Attributes & FileAttributes.ReparsePoint) == 0))
+            foreach (var sub in subDirs)
             {
-                stack.Push(sub);
+                if ((sub.Attributes & FileAttributes.ReparsePoint) == 0)
+                    stack.Push(sub);
+                else
+                    skippedLinks.Add(sub.FullName);
             }
         }
 
@@ -330,7 +360,13 @@ public sealed partial class FileShredderService
     /// <see cref="TryRemoveIfEmpty"/> pass can never reach — and delete — an empty directory
     /// at the link's target, outside the selected folder.
     /// </summary>
-    private static List<string> EnumerateDirectoriesSafe(string rootPath)
+    /// <param name="rootPath">Folder to walk.</param>
+    /// <param name="skippedLinks">
+    /// Present so both walks share one signature and one boundary. The cleanup pass discards it: this
+    /// walk skips a subset of what <see cref="EnumerateFilesSafe"/> skips (directories only, not link
+    /// files), so reporting from here as well would under-count and double-count at the same time.
+    /// </param>
+    private static List<string> EnumerateDirectoriesSafe(string rootPath, List<string> skippedLinks)
     {
         List<string> results = [];
         Stack<DirectoryInfo> stack = [];
@@ -347,10 +383,17 @@ public sealed partial class FileShredderService
 
             // Skip junctions/symlinks — never descend through a reparse point (identical
             // boundary to EnumerateFilesSafe, so cleanup honors the exact scope that was shredded).
-            foreach (var sub in subDirs.Where(s => (s.Attributes & FileAttributes.ReparsePoint) == 0))
+            foreach (var sub in subDirs)
             {
-                results.Add(sub.FullName);
-                stack.Push(sub);
+                if ((sub.Attributes & FileAttributes.ReparsePoint) == 0)
+                {
+                    results.Add(sub.FullName);
+                    stack.Push(sub);
+                }
+                else
+                {
+                    skippedLinks.Add(sub.FullName);
+                }
             }
         }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.15</Version>
-    <FileVersion>1.75.15.0</FileVersion>
-    <AssemblyVersion>1.75.15.0</AssemblyVersion>
+    <Version>1.75.16</Version>
+    <FileVersion>1.75.16.0</FileVersion>
+    <AssemblyVersion>1.75.16.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/FileShredderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/FileShredderViewModel.cs
@@ -168,6 +168,13 @@ public sealed partial class FileShredderViewModel : ViewModelBase
         var completed = 0;
         var failed = 0;
 
+        // Everything the user needs to be told, in the order it happened. Previously the service built a
+        // careful explanation of what it could not shred and the catch below dropped it on the floor:
+        // item.Status showed the word "Failed" and ex.Message went only to the log file. For an operation
+        // whose entire purpose is destroying data, "it did not work" without "and these files are still
+        // on your disk" is the wrong half of the sentence.
+        List<string> notices = [];
+
         try
         {
             // Shred a SNAPSHOT of the queue, not the live collection: indexing Items across the
@@ -195,7 +202,9 @@ public sealed partial class FileShredderViewModel : ViewModelBase
                         // mutates the bound Items collection (RemoveAt in finally) and item.Status,
                         // which throw if run off the UI thread. The service's internal awaits keep
                         // ConfigureAwait(false).
-                        await _service.ShredFolderAsync(item.Path, SelectedMethod, itemProgress, ct);
+                        var report = await _service.ShredFolderAsync(item.Path, SelectedMethod, itemProgress, ct);
+                        if (report.Notice is { } notice)
+                            notices.Add($"{item.Name}: {notice}");
                     }
                     else
                     {
@@ -216,10 +225,18 @@ public sealed partial class FileShredderViewModel : ViewModelBase
                     item.Status = "Failed";
                     failed++;
                     Log.Warning(ex, "Failed to shred: {Path}", item.Path);
+
+                    // The service words these for the user — which files were left in place, why a hard-
+                    // linked file cannot be shredded, that a junction would have destroyed data
+                    // elsewhere. Show it. The Status column is 160px and would truncate it, so it goes to
+                    // the wrapping caption at the bottom of the view instead.
+                    notices.Add($"{item.Name}: {ex.Message}");
                 }
             }
 
-            StatusMessage = $"Complete — {completed} shredded, {failed} failed.";
+            StatusMessage = notices.Count == 0
+                ? $"Complete — {completed} shredded, {failed} failed."
+                : $"Complete — {completed} shredded, {failed} failed. " + string.Join(" ", notices);
             ToastService.Instance.Show("File Shredder complete", $"{completed} shredded, {failed} failed");
 
             // COUNT ONLY — never a file name or path. activity.json is plain text under


### PR DESCRIPTION
## Problem

Two defects in the same family: after asking SysManager to destroy data beyond recovery, the user is not told what actually happened to it. For a shredder that is the entire feature — the difference between "gone" and "still on the disk and readable" is the only thing the tab exists to communicate.

### Folder side: a deliberate skip reported as a completed shred

`EnumerateFilesSafe` does not follow reparse points, which is correct — shredding through a junction would overwrite data outside the selected folder. But the skip was recorded **nowhere**, not even at Debug level, and `ShredFolderAsync` then logged `Folder shredded successfully`. The folder also stayed on disk, because `TryRemoveIfEmpty` cannot remove a directory that still holds the skipped link, and it swallows that failure too.

So the user was told their files were destroyed while looking at the folder containing them.

Five lines further down, the same method builds a careful `IOException` for files it could not overwrite, with the rationale written out in a comment: *"the caller believes a shredded file was securely overwritten"*. That rationale applies identically to a skipped link and was never applied to one.

### View-model side: the honest message was thrown away

`FileShredderViewModel` caught `IOException` / `UnauthorizedAccessException` / `SecurityException`, set `item.Status = "Failed"`, logged a warning, and dropped `ex.Message`. Grepped the whole view model: it contained no `ex.Message` anywhere.

So the service's `3 of 12 file(s) could not be securely shredded and were left in place (not deleted): a.txt, b.txt` existed only in a log file the target user will never open. On screen: the word **Failed**.

## Change

A skipped link is **not** a failure — refusing to follow it is the correct behaviour — so `ShredFolderAsync` returns a `ShredFolderReport` rather than throwing. Shaped like the existing `CleanupResult` in `Models`: `init` properties plus a computed `Notice` that is `null` when there is nothing to say.

Both the notice and the failure reasons go to `StatusMessage`, the caption `TextBlock` already at the bottom of the view with `TextWrapping="Wrap"` that already shows `Complete — N shredded, M failed.` No new control, no new model property, no XAML change, so no UI design decision is involved. The `Status` column is 160px wide and would truncate them.

Also adds the missing test for the **reparse-point root refusal**. That guard sits in the method this PR changes, refuses a junction handed in as the folder to shred, and had nothing pinning it. It asserts the target's contents survive rather than only the exception type: a `SecurityException` raised after the data was already destroyed would satisfy a type-only assertion and be worthless.

## Regression tests

| Test | What it pins |
|---|---|
| `ShredFolderReport_Notice_AppearsOnlyWhenSomethingWasSkipped` | 3 rows: silent at zero, correct singular, correct plural |
| `ShredFolderAsync_FolderWithoutLinks_ReportsNoNotice` | the ordinary case stays silent, folder removed |
| `ShredFolderAsync_JunctionInside_IsReportedNotSilentlySkipped` | the link is reported **and** its target survives |
| `ShredFolderAsync_ReparsePointRoot_IsRefusedAndTargetSurvives` | the previously untested root guard |
| `ShredAll_WhenAFileCannotBeShredded_TheReasonReachesTheStatusLine` | the reason reaches the screen |
| `ShredAll_WhenEverythingSucceeds_TheStatusLineStaysShort` | the negative case: no noise on a clean run |

Three of these need no privileges and no reparse point, so they cannot go vacuous. The locked-file test provokes a deterministic failure with an open handle (the shredder opens `FileShare.None`) and asserts on the **item name** rather than the operating system's wording, which is localised.

## Red before, green after

**Baseline: all 13 green** (5 new + the root-guard test + 7 pre-existing shredder tests).

| Mutation | Expected red | Actual red |
|---|---|---|
| **A** — stop recording skipped junctions | junction test | matched |
| **B** — drop `ex.Message` again | reason test | matched |
| **C** — `Notice` fires with nothing skipped | 3 tests | matched |
| **D** — hardcode the plural wording | the theory | matched |

Two notes on the honesty of that table. Mutation A originally targeted the *file* branch of the walk and correctly changed nothing — a junction is a directory, so the directory arm is what records it; retargeted. And `ShredAll_WhenEverythingSucceeds_TheStatusLineStaysShort` originally queued only a file, so `ShredFolderAsync` was never reached and mutation C left it green; it now queues a folder as well, which is what makes it able to catch over-reporting at the view-model layer.

The junction tests bail out when the environment cannot create a reparse point, matching this test file's existing idiom. Verified independently that `mklink /J` works here (attributes `0x410`, reparse bit set), so they really ran rather than passing on nothing.

All three source files were restored byte-for-byte after each mutation and rebuilt from the restored source.

## Regression sweep

- `dotnet build -c Release`: app **0 warnings, 0 errors**; tests **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes`: both projects exit 0. It caught three bare LFs my test-splicing left behind, which CI's format check would have failed on; repaired.
- Local CI gates re-run from the extracted workflow bodies: version consistency (1.75.16 across csproj, CHANGELOG, SECURITY.md), valid bump (v1.75.15 → 1.75.16), CHANGELOG plain-English lead. All pass.
- `ShredFolderAsync`'s signature changed from `Task` to `Task<ShredFolderReport>`. Every caller `await`s it and the pre-existing tests that ignore the value still compile unchanged, so this is source-compatible rather than breaking.

## Propagate

Scanned all **65** view models: **405** catch clauses, **278** binding a variable. Fourteen discard `ex.Message` while setting user-visible text. Thirteen do it deliberately, replacing a framework or OS message with something better — `EnvironmentVariablesViewModel`'s purpose-written backup wording, `BulkInstallerViewModel`'s winget guidance, `WindowsUpdateViewModel`'s `HResult`, which is the actionable part of a WUA `COMException`. The fourteenth is the one fixed here.

`DebloaterViewModel` is a near-miss of a different shape: `DebloaterService` returns a `bool` and composes no explanation, so there is nothing for its view model to discard. Giving it a reason to report is a separate change and is not in this PR.

CHANGELOG entry and version bump to 1.75.16 are in this PR.
