### PR TITLE
ci: hash the props files that decide which NuGet packages get restored

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,23 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      # The key must hash every file that decides WHICH packages get restored. Under central package
+      # management a .csproj carries no versions at all — they are all in Directory.Packages.props, and
+      # Directory.Build.props adds a PackageReference of its own (Microsoft.SourceLink.GitHub). Hashing
+      # only .csproj therefore misses every version change.
+      #
+      # The failure is quiet rather than wrong: an unchanged key is an exact hit, actions/cache skips the
+      # save, and restore downloads the new version anyway. But it is never cached, so it is re-downloaded
+      # on every run until some unrelated .csproj edit rotates the key. Dependabot's grouped version bumps
+      # are precisely this shape, so it accumulates.
+      #
+      # global.json is intentionally absent: it pins the SDK, not the package set, and actions/setup-dotnet
+      # already governs that in the step above.
       - name: Cache NuGet packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props') }}
           restore-keys: |
             ${{ runner.os }}-nuget-
 


### PR DESCRIPTION
## Problem

`hashFiles('**/*.csproj')` predates central package management. Since CPM was adopted, a `.csproj` carries only `<PackageReference Include="..." />` with no version attribute — all 22 versions live in `SysManager/Directory.Packages.props`, and `SysManager/Directory.Build.props` adds a `PackageReference` of its own (`Microsoft.SourceLink.GitHub`). Neither file was hashed, so the cache key could not see a single version change.

The failure is quiet rather than wrong:

1. A version-only bump leaves the key unchanged, so `actions/cache` reports an **exact hit**.
2. An exact hit means the post-run save is skipped.
3. `dotnet restore` still resolves correctly — it downloads whatever the cache lacks — so nothing builds wrong.
4. But the newly bumped package never enters the cache, so it is re-downloaded on **every subsequent run** until some unrelated `.csproj` edit finally rotates the key.

Dependabot's grouped minor/patch bumps land in exactly that shape, so the effect accumulates rather than being a one-off.

## Verification

Reproduced instead of assumed. Hashing the matched files the way `actions/cache` does (SHA-256 over each file's SHA-256, in glob order), with a one-digit `NSubstitute` version bump as the only change:

| Key | Current tree | NSubstitute 6.2.1 | Moves? |
|---|---|---|---|
| old (`**/*.csproj`) | `b5d54c9d18ae7ad2` | `b5d54c9d18ae7ad2` | **no** — the defect |
| new (+ both props) | `8303395907ab11ac` | `37f83e6835bd4473` | yes |

Also verified each glob actually matches, since a glob that matched nothing would look fixed and stay blind: 4 `.csproj`, 1 `Directory.Packages.props`, 1 `Directory.Build.props`. And the workflow still parses (`yaml.safe_load`, 3 jobs) — a malformed `with:` block would make every job vanish rather than fail loudly.

## Scope

`global.json` is deliberately excluded. It pins the SDK version, not the package set, and `actions/setup-dotnet` already governs that a step earlier; hashing it would discard the entire package cache on an SDK bump for no benefit.

This is the only `actions/cache` step and the only `hashFiles` call in any workflow, so there is no second instance to migrate.

No CHANGELOG entry or version bump: `ci:` does not release.
