### PR TITLE
fix: pin the Ookla CLI so the verified binary is the one that gets executed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.17] - 2026-09-01
+
+The speed test uses a small program from Ookla, downloaded the first time you run it. SysManager already
+checked that program's signature before running it; now it also locks the file while it does so, closing a
+gap where the file could have been switched for another one in between.
+
+### Fixed
+- **The Ookla speed-test program is locked from the moment it is checked to the moment it finishes.** The
+  program is kept in your own user folder, which anything running under your account can write to. SysManager
+  checked its digital signature every time before running it — that part was already right — but it checked
+  the file by name and then started it by name, and in the gap between those two steps the file could have
+  been replaced. The checked file and the started file would not have been the same one, which is the only
+  thing a signature check is for. SysManager now holds the file open with changes and deletion blocked from
+  before the check until after the speed test ends, so the program that was approved is the program that
+  runs. This matters most when SysManager is running as administrator, where anything it starts inherits
+  those rights.
+- **A program that fails the signature check is now actually removed.** SysManager refuses to run it either
+  way, so nothing unsafe was ever started. But the removal was attempted while the file was still locked, so
+  it quietly failed and the rejected file stayed in the folder, to be rejected again on every later run. The
+  lock is now released first, so the file really goes.
+
 ## [1.75.16] - 2026-09-01
 
 File Shredder now tells you what it actually did. Before, a folder containing a shortcut to somewhere else

--- a/SysManager/SysManager.Tests/SpeedTestServiceTests.cs
+++ b/SysManager/SysManager.Tests/SpeedTestServiceTests.cs
@@ -65,5 +65,77 @@ public class SpeedTestServiceTests
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => svc.RunOoklaAsync(progress: null, cts.Token));
+    }    // ---------- the Ookla CLI pin: verified object == executed object ----------
+
+    [Fact]
+    public void Pin_WhileHeld_RefusesOverwriteAndRename()
+    {
+        // The whole point of the pin. The CLI lives in a user-writable directory, so without this a path
+        // verified a moment ago can name different bytes by the time Process.Start reads it — and when
+        // SysManager is elevated, those bytes run at high integrity.
+        var dir = Path.Combine(Path.GetTempPath(), "smtest_pin_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var file = Path.Combine(dir, "pinned.bin");
+        File.WriteAllBytes(file, [1, 2, 3, 4]);
+
+        try
+        {
+            using var pin = SpeedTestService.Pin(file);
+
+            Assert.ThrowsAny<IOException>(() => File.WriteAllBytes(file, [9, 9, 9, 9]));
+            Assert.ThrowsAny<IOException>(() => File.Move(file, Path.Combine(dir, "swapped.bin")));
+            Assert.ThrowsAny<IOException>(() => File.Delete(file));
+
+            // And the original bytes are intact, not merely un-renamed.
+            Assert.Equal(new byte[] { 1, 2, 3, 4 }, File.ReadAllBytes(file));
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* ignore */ } }
+    }
+
+    [Fact]
+    public void Pin_WhileHeld_StillAllowsReading()
+    {
+        // The opposite failure, and the reason this is FileShare.Read rather than FileShare.None: a pin
+        // that denied reading would stop the Windows loader mapping the image, so the speed test could
+        // never run. Reading is what the loader needs, so reading must stay possible.
+        var dir = Path.Combine(Path.GetTempPath(), "smtest_pinread_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var file = Path.Combine(dir, "pinned.bin");
+        File.WriteAllBytes(file, [7, 7, 7]);
+
+        try
+        {
+            using var pin = SpeedTestService.Pin(file);
+
+            using var reader = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read);
+            Assert.Equal(3, reader.Length);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* ignore */ } }
+    }
+
+    [Fact]
+    public void PinAndVerify_UnsignedBinary_ThrowsAndDeletesIt()
+    {
+        // Regression for a defect the pin itself introduced and that had to be designed out.
+        //
+        // VerifyOoklaSignature is fail-closed and used to delete the rejected binary itself, through
+        // TryDeleteExe — which swallows IOException at Debug level. Pinning the file against deletion
+        // during verification made every one of those deletes fail silently: the exception still said
+        // "Binary deleted for security" while the rejected file stayed in the cache indefinitely.
+        //
+        // The delete now happens in PinAndVerify's finally, after the pin is released. Reverse that order
+        // and this test goes red.
+        var dir = Path.Combine(Path.GetTempPath(), "smtest_pinverify_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var file = Path.Combine(dir, "speedtest.exe");
+        File.WriteAllBytes(file, [0x4D, 0x5A, 0x00, 0x01, 0x02, 0x03]);   // "MZ" and nothing else: no signature
+
+        try
+        {
+            Assert.Throws<InvalidOperationException>(() => SpeedTestService.PinAndVerify(file));
+            Assert.False(File.Exists(file),
+                "verification rejected the binary but it is still on disk — the pin was not released before the delete");
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* ignore */ } }
     }
 }

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -186,13 +186,80 @@ public sealed class SpeedTestService
 
     // ---------------- Ookla ----------------
 
+    /// <summary>
+    /// A verified Ookla CLI, held open so the bytes that were verified are the bytes that get executed.
+    /// </summary>
+    /// <remarks>
+    /// The CLI is cached under <c>%LocalAppData%\SysManager\tools</c>, which the user — and therefore any
+    /// process running as the user — can write to. Verifying a path and then launching that same path
+    /// leaves a window in which the file can be replaced, and when SysManager is elevated that window is a
+    /// way to get arbitrary code executed at high integrity by a caller who could not reach it otherwise.
+    /// Signature verification cannot close it, because the bytes checked are not the bytes mapped.
+    /// <para>Holding the file with <see cref="FileShare.Read"/> denies both writing and deleting for the
+    /// lifetime of this object, so the path cannot come to mean a different file. Measured that this does
+    /// not prevent execution: a pinned image still loads and runs, while an overwrite and a rename are both
+    /// refused. The same "act on the object you validated, not on the string" reasoning is written out at
+    /// length in <see cref="FileShredderService"/>.</para>
+    /// </remarks>
+    internal sealed class PinnedCli(string path, FileStream pin) : IDisposable
+    {
+        /// <summary>Full path of the pinned executable. Only meaningful while this object is alive.</summary>
+        public string Path { get; } = path;
+
+        public void Dispose() => pin.Dispose();
+    }
+
+    /// <summary>
+    /// Pins <paramref name="exe"/> against modification and deletion, then verifies it. On success the
+    /// caller owns the pin and must keep it alive until the process has exited.
+    /// </summary>
+    /// <remarks>
+    /// Pin first, verify second. The other order would leave the same gap, only narrower.
+    /// <para>On failure the pin is released BEFORE the rejected binary is deleted. That order is not
+    /// incidental: the pin denies deletion, and <see cref="TryDeleteExe"/> swallows the resulting
+    /// IOException at Debug level, so deleting while pinned would silently leave a binary that failed
+    /// verification sitting in the cache. Verification decides; this method cleans up.</para>
+    /// </remarks>
+    internal static PinnedCli PinAndVerify(string exe)
+    {
+        var pin = Pin(exe);
+        var verified = false;
+        try
+        {
+            VerifyOoklaSignature(exe);
+            verified = true;
+            return new PinnedCli(exe, pin);
+        }
+        finally
+        {
+            if (!verified)
+            {
+                pin.Dispose();
+                TryDeleteExe(exe);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Opens <paramref name="exe"/> for reading with writing and deleting denied to everyone else.
+    /// </summary>
+    /// <remarks>
+    /// Internal rather than private so the sharing mode can be unit-tested directly. Getting it wrong in
+    /// either direction is silent: too permissive and the swap this exists to prevent is still possible,
+    /// too restrictive and the image can no longer be executed at all.
+    /// </remarks>
+    internal static FileStream Pin(string exe) =>
+        new(exe, FileMode.Open, FileAccess.Read, FileShare.Read);
+
     public async Task<SpeedTestResult> RunOoklaAsync(
         IProgress<(int Percent, string Message)>? progress, CancellationToken ct, int? serverId = null)
     {
-        string exe;
+        // Held for the whole run, not only the preparation: the pin is what makes the verified binary and
+        // the executed binary the same object. Scoped by the `using` below, after the process has exited.
+        PinnedCli cli;
         try
         {
-            exe = await EnsureOoklaAsync(progress, ct).ConfigureAwait(false);
+            cli = await EnsureOoklaAsync(progress, ct).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -215,6 +282,9 @@ public sealed class SpeedTestService
             // OCE branches above are ever restructured.
             throw new InvalidOperationException($"Could not prepare Ookla CLI: {ex.Message}", ex);
         }
+
+        using var pinnedCli = cli;
+        var exe = pinnedCli.Path;
 
         progress?.Report((20, "Running Ookla speedtest…"));
         var args = "--accept-license --accept-gdpr --format=json --progress=no";
@@ -326,7 +396,7 @@ public sealed class SpeedTestService
         }
     }
 
-    private static async Task<string> EnsureOoklaAsync(
+    private static async Task<PinnedCli> EnsureOoklaAsync(
         IProgress<(int, string)>? progress, CancellationToken ct)
     {
         var toolsDir = Path.Join(
@@ -354,8 +424,9 @@ public sealed class SpeedTestService
             // TOCTOU guard: the cached exe lives in a user-writable dir, so an attacker
             // could swap it between runs. Re-verify its Authenticode signature every
             // time before we hand it back to be executed — not only right after download.
-            await Task.Run(() => VerifyOoklaSignature(exe), ct).ConfigureAwait(false);
-            return exe;
+            // The pin travels back with it, so the path cannot change meaning between here
+            // and Process.Start.
+            return await Task.Run(() => PinAndVerify(exe), ct).ConfigureAwait(false);
         }
 
         progress?.Report((5, "Downloading Ookla CLI…"));
@@ -428,18 +499,26 @@ public sealed class SpeedTestService
         if (!File.Exists(exe))
             throw new FileNotFoundException("speedtest.exe not found after extraction");
 
-        // Verify Authenticode signature on the freshly-extracted binary — fail-closed.
-        await Task.Run(() => VerifyOoklaSignature(exe), ct).ConfigureAwait(false);
-
-        return exe;
+        // Verify Authenticode signature on the freshly-extracted binary — fail-closed, and pinned first
+        // for the same reason as the cached branch above. Extraction has just written this file into a
+        // directory the user can write to, so the gap between verifying it and executing it is exactly as
+        // exploitable on the first run as on every later one.
+        return await Task.Run(() => PinAndVerify(exe), ct).ConfigureAwait(false);
     }
 
     /// <summary>
-    /// Verifies that <paramref name="exe"/> carries a valid Authenticode signature whose
-    /// subject is Ookla's — fail-closed (deletes the binary and throws on any mismatch or
-    /// missing signature). Runs both right after download AND on every cached-exe reuse,
-    /// since the cache lives in a user-writable directory (TOCTOU).
+    /// Verifies that <paramref name="exe"/> carries a valid Authenticode signature whose subject is
+    /// Ookla's — fail-closed, throwing on any mismatch or missing signature.
     /// </summary>
+    /// <remarks>
+    /// Deleting the rejected binary is <see cref="PinAndVerify"/>'s job, not this method's. It used to
+    /// delete here, which stopped working the moment the file was pinned against deletion during
+    /// verification: <see cref="TryDeleteExe"/> swallows the resulting IOException at Debug level, so a
+    /// binary that failed verification would have stayed in the cache while the exception still claimed it
+    /// had been removed. The caller releases the pin and then deletes.
+    /// <para>Called on every cached reuse as well as right after download, since the cache lives in a
+    /// user-writable directory.</para>
+    /// </remarks>
     private static void VerifyOoklaSignature(string exe)
     {
         try
@@ -452,7 +531,6 @@ public sealed class SpeedTestService
             if (!cert.Subject.Contains("Ookla", StringComparison.OrdinalIgnoreCase))
             {
                 Log.Warning("Ookla speedtest.exe Authenticode subject mismatch: {Subject}", cert.Subject);
-                TryDeleteExe(exe);
                 throw new InvalidOperationException(
                     $"Ookla speedtest.exe failed Authenticode verification (subject: {cert.Subject}). Binary deleted for security.");
             }
@@ -468,7 +546,6 @@ public sealed class SpeedTestService
             {
                 var statuses = string.Join(", ", chain.ChainStatus.Select(s => s.Status.ToString()));
                 Log.Warning("Ookla speedtest.exe certificate chain did not validate: {Status}", statuses);
-                TryDeleteExe(exe);
                 throw new InvalidOperationException(
                     $"Ookla speedtest.exe certificate chain failed validation ({statuses}). Binary deleted for security.");
             }
@@ -477,7 +554,6 @@ public sealed class SpeedTestService
         catch (System.Security.Cryptography.CryptographicException ex)
         {
             Log.Warning(ex, "Ookla speedtest.exe has no valid Authenticode signature");
-            TryDeleteExe(exe);
             throw new InvalidOperationException(
                 "Ookla speedtest.exe has no valid Authenticode signature. Binary deleted for security.", ex);
         }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.16</Version>
-    <FileVersion>1.75.16.0</FileVersion>
-    <AssemblyVersion>1.75.16.0</AssemblyVersion>
+    <Version>1.75.17</Version>
+    <FileVersion>1.75.17.0</FileVersion>
+    <AssemblyVersion>1.75.17.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem

`EnsureOoklaAsync` verifies `speedtest.exe`'s Authenticode signature and returns a **path string**. `RunOoklaAsync` then builds a `ProcessStartInfo` from that string and starts it.

Between those two moments the file at that path can be replaced. The CLI is cached under `%LocalAppData%\SysManager\tools`, which the user — and therefore any process running as the user — can write to. When SysManager runs elevated, which it does for a great many of its tabs, a non-elevated process at the same user can swap the binary in that window and have it executed at high integrity.

Signature verification cannot close this. The bytes that were checked are not the bytes that get mapped, which is the only thing a signature check is for.

**Already correct, and unchanged by this PR:** the cached-reuse site deliberately re-verifies on *every* run rather than only after download, and its comment already names TOCTOU as the reason. DLL search order via the working directory is handled too (`WorkingDirectory = System32`, SEC-M4).

## Change

The fix is the one `ShredFileAsync` already uses and writes out at length in its own comments: stop validating a path string and start acting on the object you validated.

The binary is opened with write and delete denied **before** it is verified, and the handle is held until the process has exited. Verification moves *under* the pin rather than being repeated after it — repeating it would have put a second `X509Chain` build with `RevocationMode.Online` into a security path, where one transient network failure aborts the whole speed test.

`Pin` and `PinAndVerify` are `internal` so the sharing mode can be unit-tested directly. It is wrong in two opposite directions and both are silent: too permissive and the swap this exists to prevent is still possible, too strict and the image can no longer be executed at all.

## Measured, not reasoned

`FILE_SHARE_READ` versus `FILE_EXECUTE` is not obvious, so it was measured before the code was written. With a copy of an inert system executable pinned via `CreateFileW(GENERIC_READ, FILE_SHARE_READ)`:

- the loader still started it — exit 0, real output;
- overwriting raised `PermissionError`;
- renaming raised `PermissionError`.

So the image loads and the swap is impossible.

## A consequence that had to be designed out

`VerifyOoklaSignature` is fail-closed and called `TryDeleteExe` at three points, and `TryDeleteExe` swallows `IOException` at Debug level.

A pin that denies deletion would have made every one of those deletes **fail silently**. A binary that *failed* verification would have stayed in the cache indefinitely — never executed, since the exception still propagates, but the exception's own text says `Binary deleted for security`, and that would have become untrue.

Deleting therefore moves to the single place that owns the pin, which releases it first. Verification decides; the pin owner cleans up. `TryDeleteExe` now has exactly one call site.

## Regression tests

| Test | What it pins |
|---|---|
| `Pin_WhileHeld_RefusesOverwriteAndRename` | overwrite, rename and delete all refused; original bytes intact |
| `Pin_WhileHeld_StillAllowsReading` | the opposite failure — `FileShare.None` would stop the image loading |
| `PinAndVerify_UnsignedBinary_ThrowsAndDeletesIt` | the consequence above: a rejected binary is really gone |

All three are deterministic, need no privileges and no network.

## Red before, green after

**Baseline: all 8 green** (3 new + 5 pre-existing `SpeedTestService` tests).

| Mutation | Expected red | Actual red |
|---|---|---|
| **A** — restore the bare-path shape | **none** — stated limit | none |
| **B** — delete before releasing the pin | the deletion test | matched, with its own message |
| **C** — `FileShare.ReadWrite \| Delete` | the swap test | matched |
| **D** — `FileShare.None` | 2 tests | matched |

Mutation A is included deliberately and expected to change nothing. No unit suite can lose a real race, and saying so is more useful than quietly omitting it: what the tests pin is the mechanism the fix depends on (C and D) plus the regression B, which is a behavioural change a test can catch. That is the honest statement of the suite's coverage.

`SpeedTestService.cs` was restored byte-for-byte after each mutation and rebuilt from the restored source.

## Regression sweep

- `dotnet build -c Release`: app **0 warnings, 0 errors**; tests **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes`: both projects exit 0.
- Local CI gates re-run from the extracted workflow bodies: version consistency (1.75.17 across csproj, CHANGELOG, SECURITY.md), valid bump (v1.75.16 → 1.75.17), CHANGELOG plain-English lead. All pass.
- `EnsureOoklaAsync` is private and both of its call paths were updated; `RunOoklaAsync` is the only consumer.

## Known residual, not fixed here

The tools directory itself is still user-writable, and an executable's **own directory** is first in the DLL search order regardless of the working directory. `WorkingDirectory = System32` closes the CWD entry in that order but not the app-directory entry, so a planted DLL beside a pinned `speedtest.exe` remains a theoretical path. Ookla's zip ships no DLLs, so there is nothing to shadow today. Hardening the directory's ACL is the real answer and is a separate change from this one — flagging it rather than silently widening this PR.

CHANGELOG entry and version bump to 1.75.17 are in this PR.
