### PR TITLE
fix: name every launched Windows program by its full path, not by filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.18] - 2026-09-01
+
+Several tabs open a built-in Windows program for you: File Explorer to show a file, Control Panel, Device
+Manager, Event Viewer. SysManager now always opens the real one from the Windows folder, instead of asking
+Windows to look up the name and trusting whatever it finds.
+
+### Fixed
+- **The built-in Windows programs SysManager opens are now named by their full location.** Ten places asked
+  Windows to find a program by name alone — File Explorer when you use "Show in folder" in Disk Analyzer,
+  Duplicate Finder, Deep Cleanup, Startup, Logs and the update screen; Control Panel, Sound, Power Options,
+  Device Manager and the rest of the Legacy Panels tab; and Event Viewer from Logs. Looking a name up is not
+  the same as finding the right program: Windows checks places that any program running as you can add
+  entries to, so the name could have been pointed at something else entirely. It never was, and none of this
+  needed fixing urgently, but SysManager is often run as administrator, and anything it opens then starts
+  with those same rights. Every one of these now names the actual file in the Windows folder, so there is
+  nothing to look up. Nothing changes in what you see or click.
+- **A check now stops this being reintroduced.** These ten were only found by searching for them, and nothing
+  would have stopped an eleventh being added later. The build now refuses any new code that opens a program
+  by name alone.
+
 ## [1.75.17] - 2026-09-01
 
 The speed test uses a small program from Ookla, downloaded the first time you run it. SysManager already

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -4825,4 +4825,97 @@ public partial class ArchitectureTests
             "another file also references the PowerShell telemetry opt-out variable; a second writer could "
             + $"set it back to \"0\". Keep it owned by PowerShellRunner alone: {string.Join(", ", otherWriters)}");
     }
+
+    [Fact]
+    public void EveryProcessLaunch_NamesItsExecutableByFullPath()
+    {
+        // An unrooted executable name is resolved by the operating system, and both mechanisms this app
+        // uses consult somewhere the user can write. UseShellExecute=false sends CreateProcess through the
+        // calling process's OWN directory first — and SysManager ships as a portable .exe people run from
+        // Downloads. UseShellExecute=true sends ShellExecuteEx through
+        // HKCU\Software\Microsoft\Windows\CurrentVersion\App Paths and then PATH, neither of which needs
+        // elevation to modify. When SysManager is running as administrator, whatever answers that lookup
+        // runs as administrator.
+        //
+        // SystemPaths.ResolveSystemTool exists for this and documents it at length. Nine launches were
+        // written without it anyway, across services and view models, and were only found by scanning. This
+        // is the scan, kept.
+        var sourceDir = Path.Combine(FindRepoRoot(), "SysManager", "SysManager");
+        var files = Directory.GetFiles(sourceDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")
+                        && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
+            .ToArray();
+        Assert.NotEmpty(files);
+
+        List<string> offenders = [];
+        var constructs = 0;
+
+        foreach (var file in files)
+        {
+            // Comments are stripped BEFORE matching. A guard that can match its own explanation goes red on
+            // correct code, and the text above contains every shape this looks for.
+            var code = string.Join('\n', File.ReadAllLines(file)
+                .Select(line => CommentTail().Replace(line, string.Empty)));
+
+            // The floor population: every launch construct, whatever it is handed, with resolver calls left
+            // in place because a resolved site is still a site. Counted separately from what gets judged —
+            // an earlier version counted only literals and set the floor above what a literal-only count
+            // could ever reach, so it went red on a clean tree.
+            constructs += LaunchSite().Matches(code).Count;
+
+            // Resolved launches are the fix, so remove the resolver call before looking for a bare literal;
+            // otherwise every site this test exists to protect would still read as an offender.
+            var judged = ResolverCall().Replace(code, "RESOLVED");
+
+            foreach (var match in LaunchTarget().Matches(judged).Cast<Match>())
+            {
+                var literal = match.Groups["exe"].Value;
+
+                // A rooted path, or anything with a separator, is not resolved by the OS search order.
+                if (literal.Contains('\\') || literal.Contains('/') || literal.Contains(':')) continue;
+
+                // Only executable-ish names are launched through the search order. A ms-settings: URI or a
+                // web address is handled by the shell as a protocol, not a file lookup, and is caught by the
+                // ':' test above anyway.
+                if (!literal.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+                    && !literal.EndsWith(".msc", StringComparison.OrdinalIgnoreCase)
+                    && !literal.EndsWith(".cpl", StringComparison.OrdinalIgnoreCase)
+                    && !literal.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase)
+                    && !literal.EndsWith(".bat", StringComparison.OrdinalIgnoreCase)) continue;
+
+                offenders.Add($"{Path.GetFileName(file)}: \"{literal}\"");
+            }
+        }
+
+        // The vacuity floor. The offender check passes trivially on an empty match set, so a pattern that
+        // silently stopped matching would report a clean codebase. Measured at 33 launch constructs when
+        // this was written; 25 leaves room for refactoring without being satisfiable by nothing.
+        Assert.True(constructs >= 25,
+            $"the launch scan found only {constructs} ProcessStartInfo sites, so it is no longer looking at "
+            + "anything — fix the pattern rather than trusting the pass");
+
+        Assert.True(offenders.Count == 0,
+            "these launches name their executable by a bare filename, which the OS resolves through the "
+            + "calling process's directory, HKCU's App Paths key, or PATH — all writable without elevation. "
+            + "Wrap the name in SystemPaths.ResolveSystemTool, which pins it to System32 or the Windows "
+            + "directory:\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>Any launch construct, whatever it is handed. The vacuity floor counts these.</summary>
+    [GeneratedRegex(@"new ProcessStartInfo\(|(?<![A-Za-z0-9_])FileName\s*=")]
+    private static partial Regex LaunchSite();
+
+    // The executable argument when it IS a literal: `new ProcessStartInfo("x"` or `FileName = "x"`. Anchored
+    // on `=` with a preceding boundary so a longer identifier such as `exeFileName` or
+    // `PreviousBuildFileName` cannot match — both did when this scan was first written by hand.
+    [GeneratedRegex(@"new ProcessStartInfo\(\s*""(?<exe>[^""]*)""|(?<![A-Za-z0-9_])FileName\s*=\s*""(?<exe>[^""]*)""")]
+    private static partial Regex LaunchTarget();
+
+    /// <summary>A `//` comment tail, so the scan never reads its own prose as code.</summary>
+    [GeneratedRegex(@"//.*$")]
+    private static partial Regex CommentTail();
+
+    /// <summary>A ResolveSystemTool call, removed so a fixed site is not reported as a bare literal.</summary>
+    [GeneratedRegex(@"(SysManager\.Helpers\.)?SystemPaths\.ResolveSystemTool\(\s*""[^""]*""\s*\)")]
+    private static partial Regex ResolverCall();
 }

--- a/SysManager/SysManager.Tests/LegacyPanelServiceTests.cs
+++ b/SysManager/SysManager.Tests/LegacyPanelServiceTests.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -59,5 +61,60 @@ public class LegacyPanelServiceTests
     {
         var svc = new LegacyPanelService();
         Assert.Throws<ArgumentNullException>(() => svc.Launch(null!));
+    }
+
+    // ---------- the catalog is launched by path, not by name ----------
+
+    [Fact]
+    public void EveryPanel_ResolvesToARootedExistingProgram()
+    {
+        // The catalog is hard-coded, which is not the same as the program being fixed. With
+        // UseShellExecute=true an unrooted name is resolved through HKCU's App Paths key and then PATH,
+        // neither of which needs elevation to modify, so "control.exe" means whatever those lookups answer —
+        // and when SysManager is elevated, that answer runs elevated.
+        //
+        // Behavioural rather than textual on purpose: the architecture guard scans for a bare literal handed
+        // to a launch, and this service hands it a property, so the guard cannot see this service at all.
+        foreach (var panel in LegacyPanelService.Panels)
+        {
+            var resolved = SystemPaths.ResolveSystemTool(panel.FileName);
+
+            Assert.True(Path.IsPathRooted(resolved),
+                $"'{panel.Name}' launches '{panel.FileName}', which does not resolve to a rooted path");
+            Assert.True(File.Exists(resolved),
+                $"'{panel.Name}' resolves to '{resolved}', which does not exist");
+        }
+    }
+
+    [Fact]
+    public void Launch_PassesTheCatalogNameThroughTheResolver()
+    {
+        // The other half. The test above proves every catalog entry CAN be pinned; this proves Launch
+        // actually pins it. Without both, a correct catalog could still be launched by bare name — which is
+        // exactly the state this service shipped in.
+        //
+        // Source text because the alternative is starting Control Panel from a unit test. Matches the code
+        // shape rather than a comment, and asserts the un-resolved form is gone, so deleting the call cannot
+        // leave this green.
+        var source = File.ReadAllText(Path.Combine(
+            FindRepoRoot(), "SysManager", "SysManager", "Services", "LegacyPanelService.cs"));
+
+        Assert.Contains("FileName = SystemPaths.ResolveSystemTool(panel.FileName),", source);
+        Assert.DoesNotContain("FileName = panel.FileName,", source);
+    }
+
+    /// <summary>The repository root — the source this test reads is not copied to the test output.</summary>
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "SUPPORT.md"))
+                && File.Exists(Path.Combine(dir.FullName, "README.md")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException(
+            "Could not locate the repository root from " + AppContext.BaseDirectory);
     }
 }

--- a/SysManager/SysManager.Tests/SystemPathsTests.cs
+++ b/SysManager/SysManager.Tests/SystemPathsTests.cs
@@ -228,4 +228,21 @@ public class SystemPathsTests
         Assert.Equal(Path.TrimEndingDirectorySeparator(own!), own);
         Assert.True(SystemPaths.IsInsideSubtree(own!, own));
     }
+
+    [Fact]
+    public void ResolveSystemTool_WindowsDirectoryTool_ResolvesToRootedExistingPath()
+    {
+        // explorer.exe is the reason the Windows-directory fallback exists. It is NOT in System32, so a
+        // System32-only probe returned the bare name unchanged — which reads as resolution and pins nothing.
+        // Eight launches were routed through this helper on the strength of that fallback, so without this
+        // test the whole change could regress to a no-op that still looks like a fix.
+        var resolved = SystemPaths.ResolveSystemTool("explorer.exe");
+
+        Assert.True(Path.IsPathRooted(resolved), $"explorer.exe must resolve to a rooted path, got '{resolved}'");
+        Assert.True(File.Exists(resolved), $"resolved explorer.exe must exist, got '{resolved}'");
+        Assert.Equal(
+            Path.Combine(Path.GetDirectoryName(Environment.SystemDirectory)!, "explorer.exe"),
+            resolved,
+            ignoreCase: true);
+    }
 }

--- a/SysManager/SysManager/Helpers/SystemPaths.cs
+++ b/SysManager/SysManager/Helpers/SystemPaths.cs
@@ -9,7 +9,8 @@ namespace SysManager.Helpers;
 
 /// <summary>
 /// Resolves bare Windows tool names (sfc.exe, netsh.exe, reg.exe, schtasks.exe, powercfg.exe,
-/// powershell.exe, …) to their full trusted paths under %SystemRoot%\System32.
+/// powershell.exe, explorer.exe, …) to their full trusted paths under %SystemRoot%\System32 or
+/// %SystemRoot% itself.
 /// <para>
 /// Launching a system tool by bare filename with <c>UseShellExecute=false</c> lets the Win32
 /// <c>CreateProcess</c> search order look in the CALLING process's own directory FIRST. SysManager
@@ -17,6 +18,14 @@ namespace SysManager.Helpers;
 /// sometimes elevated — so an attacker-planted <c>netsh.exe</c> / <c>reg.exe</c> next to it would be
 /// executed with administrator rights (binary-planting / local privilege escalation). Pinning the
 /// full System32 path closes that vector while leaving behaviour otherwise identical.
+/// </para>
+/// <para>
+/// <c>UseShellExecute=true</c> needs the same pinning for a different reason. <c>ShellExecuteEx</c>
+/// resolves an unrooted name through <c>HKCU\Software\Microsoft\Windows\CurrentVersion\App Paths</c>
+/// and then PATH. HKCU needs no elevation to write, and per-user tool installs routinely prepend
+/// user-writable directories to PATH, so a bare name is whatever those lookups answer. Every launch in
+/// this app therefore goes through here regardless of which mechanism starts the process; a test
+/// enforces it.
 /// </para>
 /// </summary>
 internal static class SystemPaths
@@ -70,6 +79,23 @@ internal static class SystemPaths
         foreach (var direct in candidates.Select(name => Path.Combine(systemDirectory, name)))
         {
             if (fileExists(direct)) return direct;
+        }
+
+        // Then the Windows directory itself. explorer.exe lives there rather than in System32, so a
+        // System32-only probe returned the bare name unchanged — which looks like resolution and provides
+        // no protection whatsoever. %WINDIR% carries the same trust as System32: writable by
+        // administrators and TrustedInstaller only.
+        //
+        // Derived as the parent of systemDirectory rather than taken as another parameter, so the existing
+        // injection seam and every test written against it keep working unchanged. %WINDIR%\System32's
+        // parent is %WINDIR% on every supported Windows, and for an injected fake directory the parent is
+        // that fake's parent, which is the consistent answer.
+        if (Path.GetDirectoryName(systemDirectory) is { Length: > 0 } windowsDirectory)
+        {
+            foreach (var direct in candidates.Select(name => Path.Combine(windowsDirectory, name)))
+            {
+                if (fileExists(direct)) return direct;
+            }
         }
 
         return fileName;

--- a/SysManager/SysManager/Services/ContextMenuService.cs
+++ b/SysManager/SysManager/Services/ContextMenuService.cs
@@ -420,7 +420,7 @@ public sealed partial class ContextMenuService
 
         try
         {
-            Process.Start(new ProcessStartInfo("explorer.exe") { UseShellExecute = true })?.Dispose();
+            Process.Start(new ProcessStartInfo(SysManager.Helpers.SystemPaths.ResolveSystemTool("explorer.exe")) { UseShellExecute = true })?.Dispose();
             Log.Information("Explorer restarted to apply context menu changes");
         }
         catch (System.ComponentModel.Win32Exception ex)

--- a/SysManager/SysManager/Services/LegacyPanelService.cs
+++ b/SysManager/SysManager/Services/LegacyPanelService.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -17,6 +18,12 @@ namespace SysManager.Services;
 /// and re-validates membership before launching. These are pure launchers; none modify the
 /// system, so no elevation or confirmation is needed (the applets themselves prompt for UAC
 /// when an action inside them requires it).
+/// <para>
+/// A hard-coded name is not the same as a hard-coded program. Every entry launches through
+/// <see cref="SysManager.Helpers.SystemPaths.ResolveSystemTool"/>, because <c>UseShellExecute=true</c>
+/// resolves an unrooted name through <c>HKCU</c>'s App Paths key and then PATH — both writable without
+/// elevation — so <c>"control.exe"</c> alone means whatever those lookups answer.
+/// </para>
 /// </summary>
 public sealed class LegacyPanelService
 {
@@ -56,7 +63,7 @@ public sealed class LegacyPanelService
         {
             var psi = new ProcessStartInfo
             {
-                FileName = panel.FileName,
+                FileName = SystemPaths.ResolveSystemTool(panel.FileName),
                 Arguments = panel.Arguments,
                 UseShellExecute = true
             };

--- a/SysManager/SysManager/Services/ProcessManagerService.cs
+++ b/SysManager/SysManager/Services/ProcessManagerService.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.IO;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -142,7 +143,7 @@ public sealed class ProcessManagerService
             // Dispose the returned Process handle — we don't track the launched explorer.
             Process.Start(new ProcessStartInfo
             {
-                FileName = "explorer.exe",
+                FileName = SystemPaths.ResolveSystemTool("explorer.exe"),
                 Arguments = $"/select,\"{filePath}\"",
                 UseShellExecute = true
             })?.Dispose();

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.17</Version>
-    <FileVersion>1.75.17.0</FileVersion>
-    <AssemblyVersion>1.75.17.0</AssemblyVersion>
+    <Version>1.75.18</Version>
+    <FileVersion>1.75.18.0</FileVersion>
+    <AssemblyVersion>1.75.18.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -894,7 +894,7 @@ public sealed partial class AboutViewModel : ViewModelBase
         var dir = Path.GetDirectoryName(DownloadedPath);
         if (!string.IsNullOrEmpty(dir) && Directory.Exists(dir))
         {
-            try { Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{DownloadedPath}\"") { UseShellExecute = true })?.Dispose(); }
+            try { Process.Start(new ProcessStartInfo(SysManager.Helpers.SystemPaths.ResolveSystemTool("explorer.exe"), $"/select,\"{DownloadedPath}\"") { UseShellExecute = true })?.Dispose(); }
             catch (InvalidOperationException) { /* explorer launch is best-effort */ }
             catch (System.ComponentModel.Win32Exception) { /* explorer launch is best-effort */ }
         }

--- a/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
@@ -362,7 +362,7 @@ public sealed partial class DeepCleanupViewModel : ViewModelBase
     private void ShowInExplorer(string? path)
     {
         if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) return;
-        try { Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{path}\"") { UseShellExecute = true })?.Dispose(); }
+        try { Process.Start(new ProcessStartInfo(SysManager.Helpers.SystemPaths.ResolveSystemTool("explorer.exe"), $"/select,\"{path}\"") { UseShellExecute = true })?.Dispose(); }
         catch (InvalidOperationException) { /* best-effort */ }
         catch (System.ComponentModel.Win32Exception) { /* best-effort */ }
     }

--- a/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
@@ -276,7 +276,7 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
         {
             System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
             {
-                FileName = "explorer.exe",
+                FileName = SysManager.Helpers.SystemPaths.ResolveSystemTool("explorer.exe"),
                 Arguments = $"\"{entry.FullPath}\"",
                 UseShellExecute = true
             })?.Dispose();

--- a/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
@@ -243,7 +243,7 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
         {
             System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
             {
-                FileName = "explorer.exe",
+                FileName = SysManager.Helpers.SystemPaths.ResolveSystemTool("explorer.exe"),
                 Arguments = $"/select,\"{entry.Path}\"",
                 UseShellExecute = true
             })?.Dispose();

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -249,7 +249,7 @@ public sealed partial class LogsViewModel : ViewModelBase
         try
         {
             Directory.CreateDirectory(LogFolder);
-            Process.Start(new ProcessStartInfo("explorer.exe", LogFolder) { UseShellExecute = true })?.Dispose();
+            Process.Start(new ProcessStartInfo(SysManager.Helpers.SystemPaths.ResolveSystemTool("explorer.exe"), LogFolder) { UseShellExecute = true })?.Dispose();
         }
         catch (IOException ex) { StatusMessage = ex.Message; }
         catch (UnauthorizedAccessException ex) { StatusMessage = ex.Message; }
@@ -262,7 +262,7 @@ public sealed partial class LogsViewModel : ViewModelBase
     {
         try
         {
-            Process.Start(new ProcessStartInfo("eventvwr.msc") { UseShellExecute = true })?.Dispose();
+            Process.Start(new ProcessStartInfo(SysManager.Helpers.SystemPaths.ResolveSystemTool("eventvwr.msc")) { UseShellExecute = true })?.Dispose();
         }
         catch (InvalidOperationException ex) { StatusMessage = ex.Message; }
         catch (System.ComponentModel.Win32Exception ex) { StatusMessage = ex.Message; }

--- a/SysManager/SysManager/ViewModels/StartupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StartupViewModel.cs
@@ -217,7 +217,7 @@ public sealed partial class StartupViewModel : ViewModelBase
             {
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
                 {
-                    FileName = "explorer.exe",
+                    FileName = SysManager.Helpers.SystemPaths.ResolveSystemTool("explorer.exe"),
                     Arguments = $"/select,\"{path}\"",
                     UseShellExecute = true
                 })?.Dispose();


### PR DESCRIPTION
## Problem

Ten launches asked the operating system to find their executable by name. Both mechanisms this app uses resolve an unrooted name somewhere the user can write:

- `UseShellExecute=false` → `CreateProcess` searches the **calling process's own directory first**.
- `UseShellExecute=true` → `ShellExecuteEx` searches `HKCU\Software\Microsoft\Windows\CurrentVersion\App Paths`, then `PATH`.

HKCU needs no elevation to write, and per-user tool installs routinely prepend user-writable directories to `PATH`. SysManager ships as a portable `.exe` people run from Downloads and often run as administrator, so whatever answers that lookup runs elevated.

**The repository already had the answer.** `SystemPaths.ResolveSystemTool` exists for exactly this, documents it at length, and was already used at six sites. `SystemFixesViewModel` even resolves `netplwiz.exe` — which `LegacyPanelService` lists as a bare name in the same catalog. This was an oversight, not a design decision.

## Scope: the audit named one site, scanning found ten

| Where | What |
|---|---|
| `LegacyPanelService` | the 12-entry catalog: `control.exe`, `mmc.exe`, `netplwiz.exe`, `SystemPropertiesAdvanced.exe` |
| `ContextMenuService`, `ProcessManagerService` | `explorer.exe` |
| `AboutViewModel`, `DeepCleanupViewModel`, `DiskAnalyzerViewModel`, `DuplicateFileViewModel`, `LogsViewModel`, `StartupViewModel` | `explorer.exe` |
| `LogsViewModel` | `eventvwr.msc` |

Two scan hits were **false positives**, read and left alone: `UninstallerService`'s `exeFileName` and `UpdateApplier`'s `PreviousBuildFileName` matched a `FileName=` pattern inside a longer identifier. `UninstallerService` already resolves trusted binaries to an absolute System32 path, and `UpdateApplier`'s constant is a filename used to build a path, not to launch anything.

## One gap had to be closed first, or the fix would have been theatre

`ResolveSystemTool` probed **System32 only**, and `explorer.exe` lives in `%WINDIR%`. Routing it through the helper would have looked exactly like a fix while returning the bare name unchanged.

The helper now falls back to the Windows directory, derived as the **parent of the system directory** rather than through a new parameter — so the existing injection seam and all 17 of its tests keep working untouched. `%WINDIR%` carries the same trust as System32: writable by administrators and TrustedInstaller only.

## A guard, so an eleventh cannot be written

These ten were only found by searching for them. `EveryProcessLaunch_NamesItsExecutableByFullPath` scans the shipped source and refuses any launch naming a bare executable.

Three things it gets right, each learned the hard way:

- **Comments are stripped before matching**, so the guard cannot go red on its own explanation — its comment block contains every shape it looks for.
- **Resolver calls are stripped before judging**, so a fixed site is not reported as an offender.
- **A vacuity floor of 25** against a measured 33 launch constructs. That floor earned its place immediately: my first version counted only string literals and set the floor above what a literal-only population could ever reach, so it went red on a clean tree. The floor caught my mistake before CI did, which is the entire reason for having one.

The guard **cannot see `LegacyPanelService`**, which hands a property rather than a literal, and that is stated rather than glossed over. Two tests cover it from the sides the guard cannot reach: `EveryPanel_ResolvesToARootedExistingProgram` (behavioural, over the real catalog) and `Launch_PassesTheCatalogNameThroughTheResolver` (source shape, asserting both that the resolved form is present and that the bare form is gone).

## Red before, green after

**Baseline: all 10 green** (4 new + 6 pre-existing `SystemPaths` tests).

| Mutation | Expected red | Actual red |
|---|---|---|
| **A** — `LegacyPanelService` launches the bare catalog name | the source-shape test | matched |
| **B** — a resolved `explorer.exe` reverts to the bare name | the guard | matched |
| **C** — a brand-new bare-name launch is planted | the guard | matched |
| **D** — the guard's own pattern is broken | the guard, **via its floor** (`found only 0 sites`) | matched |
| **E** — the Windows-directory probe is removed | the `explorer.exe` test (`got 'explorer.exe'`) | matched |

Mutation E is the one that would otherwise have shipped silently. D is the one that proves the guard can fail.

All four touched files were restored byte-for-byte after each mutation and rebuilt from the restored source.

## Regression sweep

- `dotnet build -c Release`: app **0 warnings, 0 errors**; tests **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes`: both projects exit 0. It initially reported four violations, including two at line 590 that looked pre-existing; a line-by-line comparison against `main` found the real cause at line 4827 — a splice had glued an appended member onto a closing brace. Repaired; the resulting diff to the test files is **insertions only**, 0 deletions, so no pre-existing code moved.
- Local CI gates re-run from the extracted workflow bodies: version consistency (1.75.18 across csproj, CHANGELOG, SECURITY.md), valid bump (v1.75.17 → 1.75.18), CHANGELOG plain-English lead. All pass.

## Known residual, not fixed here

`ResolveSystemTool` returns the bare name unchanged when a name is found in neither trusted directory. That is deliberate (its doc says so, and non-system executables must not be rewritten) but it means the guard, not the helper, is what keeps a genuinely unresolvable name out. `ResolveWinget` already fails closed to a rooted path for the one case where that mattered; extending fail-closed behaviour to the general helper would change callers of non-system executables and is a separate change.

CHANGELOG entry and version bump to 1.75.18 are in this PR.
