### PR TITLE
fix: end the Logs read loop on a reader fault, and fetch event XML on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.19] - 2026-09-01
+
+The Logs tab could get stuck loading forever, with one processor core pinned at full speed and the Refresh
+button greyed out. It also loads faster now, and pressing Cancel says "Cancelled" instead of pretending the
+list finished.
+
+### Fixed
+- **The Logs tab can no longer get stuck loading with a core at 100%.** Windows event logs are a rolling
+  buffer, so a busy log can move underneath a read that is already in progress. When that happened, SysManager
+  retried the same failed read over and over with nothing in between: the tab stayed on "Loading events…"
+  forever, Refresh stayed greyed out because it is disabled while loading, and one processor core sat at full
+  speed until the tab was closed or Cancel was pressed. Retrying could never have worked — Windows does not
+  move on to the next entry after that kind of failure — so SysManager now stops, keeps the events it already
+  read, and says the list is incomplete.
+- **Pressing Cancel now says "Cancelled" instead of reporting a finished list.** A cancelled load was
+  reported as a completed one, so a list stopped halfway through was described as "Loaded 137 events" with
+  nothing to indicate it was cut short. The same wrong message appeared when switching away from the tab
+  mid-load.
+- **A partly-read log now says so.** If a read stops early, the message under the list says how many events
+  arrived and that the rest are missing, rather than presenting the shortened list as everything there was.
+
+### Changed
+- **The Logs tab loads faster and uses less memory, especially at the larger row counts.** SysManager was
+  building the raw technical XML for every single event as it loaded, although that panel only ever shows the
+  one row you click. With the list set to 5000 rows that was 5000 pieces of work and 5000 stored blocks of
+  text nobody looked at. It is now produced for the row you select, when you select it. The panel behaves
+  exactly as before.
+
 ## [1.75.18] - 2026-09-01
 
 Several tabs open a built-in Windows program for you: File Explorer to show a file, Control Panel, Device

--- a/SysManager/SysManager.Tests/EventLogServiceTests.cs
+++ b/SysManager/SysManager.Tests/EventLogServiceTests.cs
@@ -2,8 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.Reflection;
 using System.Diagnostics.Eventing.Reader;
+using System.Reflection;
 using SysManager.Models;
 using SysManager.Services;
 

--- a/SysManager/SysManager.Tests/EventLogServiceTests.cs
+++ b/SysManager/SysManager.Tests/EventLogServiceTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Reflection;
+using System.Diagnostics.Eventing.Reader;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -175,22 +176,21 @@ public class EventLogServiceTests
     public void MapLevel_UnknownValue_ReturnsInfo()
         => Assert.Equal(EventSeverity.Info, InvokeMapLevel((byte)99));
 
-    // ---------- SeverityToLevel ----------
-
-    private static byte InvokeSeverityToLevel(EventSeverity s)
-    {
-        var m = typeof(EventLogService).GetMethod("SeverityToLevel", BindingFlags.NonPublic | BindingFlags.Static)!;
-        return (byte)m.Invoke(null, new object[] { s })!;
-    }
+    // ---------- SeverityToLevels (the live inverse of MapLevel) ----------
 
     [Theory]
-    [InlineData(EventSeverity.Critical, (byte)1)]
-    [InlineData(EventSeverity.Error, (byte)2)]
-    [InlineData(EventSeverity.Warning, (byte)3)]
-    [InlineData(EventSeverity.Info, (byte)4)]
-    [InlineData(EventSeverity.Verbose, (byte)5)]
-    public void SeverityToLevel_RoundTrips(EventSeverity severity, byte expected)
-        => Assert.Equal(expected, InvokeSeverityToLevel(severity));
+    [InlineData(EventSeverity.Critical, new[] { 1 })]
+    [InlineData(EventSeverity.Error, new[] { 2 })]
+    [InlineData(EventSeverity.Warning, new[] { 3 })]
+    [InlineData(EventSeverity.Verbose, new[] { 5 })]
+    // Info is the case that matters and the reason the old test was wrong. MapLevel folds Level 0
+    // (LogAlways) into Info, so the XPath must ask for BOTH 0 and 4 or every LogAlways event silently
+    // disappears from an Info-filtered view. A dead twin of this method encoded `Info => 4` and a reflection
+    // test certified it; both are gone.
+    [InlineData(EventSeverity.Info, new[] { 0, 4 })]
+    public void SeverityToLevels_IsTheExactInverseOfMapLevel(EventSeverity severity, int[] expected)
+        => Assert.Equal(expected, EventLogService.SeverityToLevels(severity));
+
 
     // ---------- P2 #32 regression: Info filter must include Level 0 (LogAlways) ----------
 
@@ -302,5 +302,111 @@ public class EventLogServiceTests
         await foreach (var _ in svc.ReadAsync(
             new EventLogQueryOptions { LogName = "SysManagerAlsoMissing" }, CancellationToken.None)) { }
         Assert.Equal(EventLogService.ReadOutcome.LogNotFound, svc.LastOutcome);
+    }
+    // ---------- the read loop: a fault must end it, a cancel must surface as one ----------
+
+    private static EventLogQueryOptions Options(int maxResults = 500) =>
+        new() { LogName = "System", MaxResults = maxResults };
+
+    [Fact]
+    public async Task Enumerate_ReaderAlwaysFaults_EndsInsteadOfSpinning()
+    {
+        // The P1. The loop's only progress variable is the emitted count, which a failure never increments,
+        // so `catch (EventLogException) { continue; }` spun with no delay — one Task.Run per iteration, one
+        // core at 100%, the tab stuck loading with Refresh disabled because it is gated on not-busy. This
+        // test simply cannot finish against that code.
+        var svc = new EventLogService();
+        var reads = 0;
+
+        var entries = new List<FriendlyEventEntry>();
+        await foreach (var e in svc.Enumerate(Options(), () =>
+        {
+            reads++;
+            throw new EventLogException("reader is stale");
+        }, CancellationToken.None))
+        {
+            entries.Add(e);
+        }
+
+        Assert.Empty(entries);
+        // Ended on the first fault rather than retrying: EvtNext does not advance its cursor on these
+        // failures, so a retry re-throws the identical error and a budget would only postpone the exit.
+        Assert.Equal(1, reads);
+        Assert.Equal(EventLogService.ReadOutcome.Unavailable, svc.LastOutcome);
+    }
+
+    [Fact]
+    public async Task Enumerate_CancelledMidRead_ThrowsInsteadOfCompleting()
+    {
+        // The P2. `catch (OperationCanceledException) { yield break; }` made Cancel look like a finished
+        // load, so the caller reported "Loaded N events" for a truncated list and LogsViewModel's cancel
+        // branch was dead code. Two sibling scanners already throw after their loop for this exact reason.
+        var svc = new EventLogService();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (var _ in svc.Enumerate(Options(), () => null, cts.Token))
+            {
+                // The loop body never runs on an already-cancelled token; the throw is the assertion.
+            }
+        });
+    }
+
+    [Fact]
+    public async Task Enumerate_ReaderReturnsNull_CompletesCleanly()
+    {
+        // The ordinary end-of-results path, so the fault handling above cannot be satisfied by a loop that
+        // simply always stops. A null record means the result set is exhausted and the outcome stays Ok.
+        var svc = new EventLogService();
+
+        var entries = new List<FriendlyEventEntry>();
+        await foreach (var e in svc.Enumerate(Options(), () => null, CancellationToken.None))
+            entries.Add(e);
+
+        Assert.Empty(entries);
+        Assert.Equal(EventLogService.ReadOutcome.Ok, svc.LastOutcome);
+    }
+
+    [Fact]
+    public async Task GetXmlAsync_UnknownRecordId_ReturnsEmptyRatherThanThrowing()
+    {
+        // An event log is a ring buffer, so a row visible in the list can genuinely have rolled off by the
+        // time it is clicked. That is not an error worth surfacing — the detail pane just shows nothing.
+        var svc = new EventLogService();
+
+        var xml = await svc.GetXmlAsync("System", long.MaxValue);
+
+        Assert.Equal("", xml);
+    }
+
+    [Fact]
+    public async Task GetXmlAsync_NonPositiveRecordId_ShortCircuits()
+    {
+        // Project leaves RecordId at 0 when the record carries none, and querying EventRecordID=0 is a
+        // pointless round-trip.
+        var svc = new EventLogService();
+
+        Assert.Equal("", await svc.GetXmlAsync("System", 0));
+        Assert.Equal("", await svc.GetXmlAsync("System", -1));
+    }
+    [Fact]
+    public async Task Enumerate_ReadRaisesCancellation_NeverLooksLikeCompletion()
+    {
+        // The one route where swallowing OperationCanceledException inside the loop is observable: the read
+        // raises it while the token itself is NOT cancelled, so the post-loop guard has nothing to fire on.
+        // `catch (OperationCanceledException) { yield break; }` turned that into a clean finish, which is
+        // exactly the conversion LargeFileScanner and DuplicateFileService both throw to avoid.
+        var svc = new EventLogService();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (var _ in svc.Enumerate(
+                Options(), () => throw new OperationCanceledException(), CancellationToken.None))
+            {
+                // Reaching the body would mean the read succeeded; the throw is the assertion.
+            }
+        });
     }
 }

--- a/SysManager/SysManager.Tests/LogsViewModelTests.cs
+++ b/SysManager/SysManager.Tests/LogsViewModelTests.cs
@@ -4,6 +4,7 @@
 
 using System.Reflection;
 using SysManager.Models;
+using SysManager.Services;
 using SysManager.ViewModels;
 
 namespace SysManager.Tests;
@@ -254,5 +255,43 @@ public class LogsViewModelTests
             .Invoke(vm, null);
 
         Assert.Equal(0, vm.HighlightedCount);
+    }
+    // ---------- the status sentence ----------
+
+    [Fact]
+    public void DescribeLoad_PartialReadAfterAFault_SaysTheListIsIncomplete()
+    {
+        // A read that ends early because the reader faulted keeps the records it already emitted, and the
+        // count-only wording announced those as a finished load — "Loaded 137 events from System" about a
+        // list that stopped halfway. Same mistake as calling a cancelled scan complete.
+        var message = LogsViewModel.DescribeLoad(137, EventLogService.ReadOutcome.Unavailable, "System");
+
+        Assert.Contains("137", message);
+        Assert.Contains("incomplete", message);
+        Assert.DoesNotContain("could not be opened", message);
+    }
+
+    [Theory]
+    [InlineData(EventLogService.ReadOutcome.AccessDenied, "administrator rights")]
+    [InlineData(EventLogService.ReadOutcome.LogNotFound, "does not exist")]
+    [InlineData(EventLogService.ReadOutcome.Unavailable, "could not be opened")]
+    public void DescribeLoad_EmptyResult_ExplainsWhyRatherThanSayingZero(
+        EventLogService.ReadOutcome outcome, string expected)
+    {
+        // "Loaded 0 events" followed by "No events match your filters" told a standard user selecting
+        // Security that their filters matched nothing, when in fact the log was never read.
+        var message = LogsViewModel.DescribeLoad(0, outcome, "Security");
+
+        Assert.Contains(expected, message);
+        Assert.DoesNotContain("Loaded 0", message);
+    }
+
+    [Fact]
+    public void DescribeLoad_CleanRead_StaysShort()
+    {
+        // The negative case: a healthy load must not grow a caveat.
+        var message = LogsViewModel.DescribeLoad(42, EventLogService.ReadOutcome.Ok, "Application");
+
+        Assert.Equal("Loaded 42 events from Application", message);
     }
 }

--- a/SysManager/SysManager/Services/EventLogService.cs
+++ b/SysManager/SysManager/Services/EventLogService.cs
@@ -5,6 +5,7 @@
 using System.Buffers;
 using System.Diagnostics.Eventing.Reader;
 using System.Text.RegularExpressions;
+using Serilog;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -77,35 +78,90 @@ public sealed partial class EventLogService
         catch (EventLogNotFoundException) { LastOutcome = ReadOutcome.LogNotFound; yield break; }
         catch (EventLogException) { LastOutcome = ReadOutcome.Unavailable; yield break; }
 
-        int emitted = 0;
         using (reader)
         {
             var localReader = reader;
-            while (!ct.IsCancellationRequested && emitted < opt.MaxResults)
-            {
-                // ReadEvent() is a blocking COM/IO call. Run it on a thread-pool
-                // thread so enumerating large logs never blocks the UI thread the
-                // caller awaits on. (await Task.Yield() alone did not move the work
-                // off the UI thread — it only released it momentarily per 200 rows.)
-                EventRecord? rec;
-                try { rec = await Task.Run(() => localReader.ReadEvent(), ct).ConfigureAwait(false); }
-                catch (EventLogException) { continue; }
-                catch (OperationCanceledException) { yield break; }
-                if (rec is null) yield break;
-
-                FriendlyEventEntry? entry = null;
-                try { entry = Project(rec, opt.LogName); }
-                catch (EventLogException) { /* skip malformed record */ }
-                catch (InvalidOperationException) { /* skip malformed record */ }
-                finally { rec.Dispose(); }
-
-                if (entry is null) continue;
-                EventExplainer.Enrich(entry);
-
-                emitted++;
+            await foreach (var entry in Enumerate(opt, () => localReader.ReadEvent(), ct).ConfigureAwait(false))
                 yield return entry;
-            }
         }
+    }
+
+    /// <summary>
+    /// The read loop, over a caller-supplied record source.
+    /// </summary>
+    /// <param name="opt">Query options; only <see cref="EventLogQueryOptions.MaxResults"/> and the log name are used here.</param>
+    /// <param name="readNext">
+    /// Produces the next record, or null at the end of the result set. Separated from
+    /// <see cref="EventLogReader"/> so the failure and cancellation paths can be tested: there is no way to
+    /// make a real reader fault on demand, and those two paths held the two worst defects in this file.
+    /// </param>
+    /// <param name="ct">Cancellation token; observed between records and inside the thread-pool hop.</param>
+    /// <remarks>
+    /// A reader fault ENDS the enumeration rather than retrying it. The previous code did
+    /// <c>catch (EventLogException) { continue; }</c>, and since the loop's only progress variable is the
+    /// emitted count — which a failure never increments — a persistent fault spun with no delay, queueing one
+    /// <see cref="Task.Run(Action)"/> per iteration: the tab never finished loading, Refresh stayed disabled
+    /// because it is gated on not-busy, and a core sat at 100%.
+    /// <para>Terminating is not merely the simpler choice. <c>EvtNext</c> does not advance its cursor on a
+    /// stale result set or a lost Event Log service, so a retry re-throws the identical error; a retry budget
+    /// would postpone the same exit and add a number nobody can tune. It also matches
+    /// <c>MemoryTestService.CheckErrorLogsAsync</c>, whose catch already terminates its scan.</para>
+    /// </remarks>
+    internal async IAsyncEnumerable<FriendlyEventEntry> Enumerate(
+        EventLogQueryOptions opt,
+        Func<EventRecord?> readNext,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+    {
+        var emitted = 0;
+        while (!ct.IsCancellationRequested && emitted < opt.MaxResults)
+        {
+            // readNext() is a blocking COM/IO call. Run it on a thread-pool thread so enumerating large
+            // logs never blocks the UI thread the caller awaits on. (await Task.Yield() alone did not move
+            // the work off the UI thread — it only released it momentarily per 200 rows.)
+            //
+            // Cancellation is deliberately NOT caught: the TaskCanceledException from Task.Run must reach
+            // the caller, or Cancel reads as a completed load.
+            EventRecord? rec = null;
+            var faulted = false;
+            try { rec = await Task.Run(readNext, ct).ConfigureAwait(false); }
+            catch (EventLogException ex)
+            {
+                // Debug rather than Warning: a log rolling over mid-enumeration is routine, and the outcome
+                // below is what the user is actually told.
+                Log.Debug(ex, "EventLog: read faulted on {Log}, ending the enumeration", opt.LogName);
+                faulted = true;
+            }
+
+            if (faulted)
+            {
+                LastOutcome = ReadOutcome.Unavailable;
+                yield break;
+            }
+
+            if (rec is null) yield break;
+
+            FriendlyEventEntry? entry = null;
+            try { entry = Project(rec, opt.LogName); }
+            catch (EventLogException) { /* skip malformed record */ }
+            catch (InvalidOperationException) { /* skip malformed record */ }
+            finally { rec.Dispose(); }
+
+            if (entry is null) continue;
+            EventExplainer.Enrich(entry);
+
+            emitted++;
+            yield return entry;
+        }
+
+        // A cancelled read exits the loop above with partial results; reporting them as a finished load
+        // would mislead the user. Throw so the caller's cancel branch handles it — the same finalize
+        // LargeFileScanner and DuplicateFileService use, and the reason LogsViewModel's
+        // catch (OperationCanceledException) branch exists at all.
+        //
+        // Here rather than in ReadInternal: this is the loop whose condition exits on cancellation, so this
+        // is where a cancelled read otherwise looks like a completed one. The throw propagates outward
+        // through ReadInternal's await foreach.
+        ct.ThrowIfCancellationRequested();
     }
 
     private static FriendlyEventEntry Project(EventRecord rec, string logName)
@@ -123,11 +179,44 @@ public sealed partial class EventLogService
             SeverityLabel = severity.ToString(),
             Message = firstLine,
             FullMessage = fullMessage,
-            Xml = rec.ToXml(),
+            // Xml is deliberately NOT rendered here. Its only consumer is the detail pane's
+            // SelectedEntry.Xml binding — one row at a time — while the largest MaxResults option is 5000,
+            // so projecting it eagerly cost up to 5000 extra EvtRender round-trips per refresh and retained
+            // 5000 strings for the lifetime of the tab. LogsViewModel fills it on selection via
+            // GetXmlAsync. Unlike FullMessage, nothing filters on it.
             MachineName = rec.MachineName,
             UserName = rec.UserId?.Value,
             RecordId = rec.RecordId ?? 0
         };
+    }
+
+    /// <summary>
+    /// Renders the raw XML of a single event, for the detail pane.
+    /// </summary>
+    /// <remarks>
+    /// Looked up by record id rather than carried on every entry. See the note in <see cref="Project"/>:
+    /// rendering XML for a whole result set paid thousands of COM round-trips and held thousands of strings
+    /// to fill a field only the selected row shows. Returns an empty string when the record can no longer be
+    /// found — an event log is a ring buffer, so a row visible in the list can genuinely have rolled off by
+    /// the time it is clicked, and that is not an error worth a dialog.
+    /// </remarks>
+    public async Task<string> GetXmlAsync(string logName, long recordId, CancellationToken ct = default)
+    {
+        if (recordId <= 0) return "";
+
+        return await Task.Run(() =>
+        {
+            try
+            {
+                var query = new EventLogQuery(logName, PathType.LogName,
+                    $"*[System[EventRecordID={recordId}]]");
+                using var reader = new EventLogReader(query);
+                using var rec = reader.ReadEvent();
+                return rec?.ToXml() ?? "";
+            }
+            catch (EventLogException) { return ""; }
+            catch (UnauthorizedAccessException) { return ""; }
+        }, ct).ConfigureAwait(false);
     }
 
     private static string SafeFormatMessage(EventRecord rec)
@@ -215,23 +304,13 @@ public sealed partial class EventLogService
         return "*[System[" + string.Join(" and ", clauses) + "]]";
     }
 
-    private static byte SeverityToLevel(EventSeverity s) => s switch
-    {
-        EventSeverity.Critical => 1,
-        EventSeverity.Error => 2,
-        EventSeverity.Warning => 3,
-        EventSeverity.Info => 4,
-        EventSeverity.Verbose => 5,
-        _ => 4
-    };
-
     /// <summary>
     /// Maps a severity back to ALL event levels that <see cref="MapLevel"/> folds into it.
     /// Used by <see cref="BuildXPath"/> so the XPath Level clause is the exact inverse of
     /// the read-side classification. In particular, Level 0 (LogAlways) is classified as
     /// Info by MapLevel, so Info must query BOTH Level=0 and Level=4.
     /// </summary>
-    private static IEnumerable<int> SeverityToLevels(EventSeverity s) => s switch
+    internal static IEnumerable<int> SeverityToLevels(EventSeverity s) => s switch
     {
         EventSeverity.Critical => [1],
         EventSeverity.Error => [2],

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.18</Version>
-    <FileVersion>1.75.18.0</FileVersion>
-    <AssemblyVersion>1.75.18.0</AssemblyVersion>
+    <Version>1.75.19</Version>
+    <FileVersion>1.75.19.0</FileVersion>
+    <AssemblyVersion>1.75.19.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -55,6 +55,32 @@ public sealed partial class LogsViewModel : ViewModelBase
     [ObservableProperty] private string _filterText = "";
     [ObservableProperty] private FriendlyEventEntry? _selectedEntry;
 
+    /// <summary>
+    /// Fills the detail pane's XML when a row is selected.
+    /// </summary>
+    /// <remarks>
+    /// The reader no longer renders XML for every record — it used to, for up to 5000 rows per refresh, to
+    /// populate a field only the selected row displays. Fetched here instead, once per row: the guard on
+    /// IsNullOrEmpty makes re-selecting a row free, and a row whose event has since rolled out of the log
+    /// simply gets an empty pane rather than an error, which is the honest answer for a ring buffer.
+    /// <para>Fire-and-forget because this hook is void and runs on the UI thread. The await resumes on the
+    /// captured context, so assigning to the bound property is safe, and the captured entry is re-checked
+    /// against the current selection so a fast click-through cannot write one row's XML onto another.</para>
+    /// </remarks>
+    partial void OnSelectedEntryChanged(FriendlyEventEntry? value)
+    {
+        if (value is null || !string.IsNullOrEmpty(value.Xml)) return;
+
+        _ = FillXmlAsync(value);
+    }
+
+    private async Task FillXmlAsync(FriendlyEventEntry entry)
+    {
+        var xml = await _eventLogs.GetXmlAsync(entry.LogName, entry.RecordId).ConfigureAwait(true);
+        if (ReferenceEquals(SelectedEntry, entry))
+            entry.Xml = xml;
+    }
+
     [ObservableProperty] private int _criticalCount;
     [ObservableProperty] private int _errorCount;
     [ObservableProperty] private int _warningCount;
@@ -139,6 +165,37 @@ public sealed partial class LogsViewModel : ViewModelBase
 
     // ---------- Commands ----------
 
+    /// <summary>
+    /// The sentence shown under the list once a load finishes.
+    /// </summary>
+    /// <remarks>
+    /// Distinguishes "nothing matched" from "not allowed to look". The Security log is readable only by an
+    /// elevated process, and the reader used to swallow that refusal and return an empty sequence — so a
+    /// standard user selecting Security saw "Loaded 0 events", then the empty-state's "No events match your
+    /// filters", with no way to know the filters were never applied to anything.
+    /// <para>The partial case is the newer one. A read that ends early because the reader faulted keeps the
+    /// records it already emitted, and the count-only wording announced those as a finished load. Saying
+    /// "Loaded 137 events" about a list that stopped halfway is the same mistake as calling a cancelled scan
+    /// complete, so it now says the list may be incomplete.</para>
+    /// <para>Pure and internal so it can be tested directly: forcing an outcome through the real service is
+    /// not possible from a test, and this is the sentence the user actually reads.</para>
+    /// </remarks>
+    internal static string DescribeLoad(int count, EventLogService.ReadOutcome outcome, string logName)
+        => (count, outcome) switch
+        {
+            (0, EventLogService.ReadOutcome.AccessDenied) =>
+                $"Windows would not let SysManager read the {logName} log. This log requires "
+                + "administrator rights — restart SysManager as administrator to view it.",
+            (0, EventLogService.ReadOutcome.LogNotFound) =>
+                $"The {logName} log does not exist on this machine.",
+            (0, EventLogService.ReadOutcome.Unavailable) =>
+                $"The {logName} log could not be opened. It may be disabled or in use.",
+            (> 0, EventLogService.ReadOutcome.Unavailable) =>
+                $"Loaded {count} events from {logName}, then the log stopped responding — this list is "
+                + "incomplete. Try again to see the rest.",
+            _ => $"Loaded {count} events from {logName}"
+        };
+
     [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task RefreshAsync()
     {
@@ -199,22 +256,7 @@ public sealed partial class LogsViewModel : ViewModelBase
                 });
             }
 
-            // Distinguish "nothing matched" from "not allowed to look". The Security log is
-            // readable only by an elevated process, and the reader used to swallow that refusal
-            // and return an empty sequence — so a standard user selecting Security saw
-            // "Loaded 0 events", then the empty-state's "No events match your filters", and had
-            // no way to know the filters were never applied to anything.
-            StatusMessage = (Entries.Count, _eventLogs.LastOutcome) switch
-            {
-                (0, EventLogService.ReadOutcome.AccessDenied) =>
-                    $"Windows would not let SysManager read the {SelectedLog} log. This log requires "
-                    + "administrator rights — restart SysManager as administrator to view it.",
-                (0, EventLogService.ReadOutcome.LogNotFound) =>
-                    $"The {SelectedLog} log does not exist on this machine.",
-                (0, EventLogService.ReadOutcome.Unavailable) =>
-                    $"The {SelectedLog} log could not be opened. It may be disabled or in use.",
-                _ => $"Loaded {Entries.Count} events from {SelectedLog}"
-            };
+            StatusMessage = DescribeLoad(Entries.Count, _eventLogs.LastOutcome, SelectedLog);
             LoadWasRefused = Entries.Count == 0 && _eventLogs.LastOutcome != EventLogService.ReadOutcome.Ok;
             UpdateVisibleCount();
         }

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -190,7 +190,7 @@ public sealed partial class LogsViewModel : ViewModelBase
                 $"The {logName} log does not exist on this machine.",
             (0, EventLogService.ReadOutcome.Unavailable) =>
                 $"The {logName} log could not be opened. It may be disabled or in use.",
-            (> 0, EventLogService.ReadOutcome.Unavailable) =>
+            ( > 0, EventLogService.ReadOutcome.Unavailable) =>
                 $"Loaded {count} events from {logName}, then the log stopped responding — this list is "
                 + "incomplete. Try again to see the rest.",
             _ => $"Loaded {count} events from {logName}"


### PR DESCRIPTION
Four defects in `EventLogService`, all re-derived from current source before writing anything.

## P1 — the read loop can spin forever with a core at 100%

`catch (EventLogException) { continue; }` is a no-progress retry. The loop's only progress variable is the emitted count, which the failure path never increments. So a persistent reader fault — a stale result set when the log rolls over mid-enumeration (routine on a busy System log), an Event Log service restart, an invalidated query handle — spins with **no delay**, queueing one `Task.Run` per iteration.

What the user sees: the tab stays on "Loading events…" forever, Refresh stays greyed out because it is gated on `NotBusy`, and one core sits at full speed until the tab is closed or Cancel is pressed.

`MemoryTestService.CheckErrorLogsAsync` lets the same exception terminate its scan, so this was a one-off asymmetry rather than a house pattern.

**Terminating rather than retrying is deliberate.** `EvtNext` does not advance its cursor on these failures, so every retry re-throws the identical error. A retry budget would only postpone the same exit while adding a number nobody can tune.

## P2 — Cancel was reported as a finished load

`catch (OperationCanceledException) { yield break; }`, plus a `while` condition that exits normally on cancellation, meant the caller's `await foreach` completed *successfully*. So a cancelled load reported `"Loaded 137 events from System"` for a truncated list, and `LogsViewModel`'s `catch (OperationCanceledException) { StatusMessage = "Cancelled"; }` was dead code. The same wrong message appeared on tab teardown, where `Dispose` cancels.

`LargeFileScanner.cs:143-145` and `DuplicateFileService.cs:193-199` both `ct.ThrowIfCancellationRequested()` after their loop, with the reasoning written out — *"surfacing them as Done would mislead the user"*. Same finalize adopted here, placed in `Enumerate` rather than `ReadInternal` because that is the loop whose condition exits early. **A test caught that**: my first attempt put the throw one level up, where an already-cancelled token never reaches it.

## P2 — XML rendered for every event to fill a one-row pane

`Project` rendered each record's full XML. The only consumer is `LogsView.xaml:463`, `Text="{Binding SelectedEntry.Xml}"` — one row at a time — while `MaxResultOptions` offers `"5000"`. So a refresh paid up to 5000 extra `EvtRender` round-trips and retained up to 5000 strings for the lifetime of the tab. Unlike `FullMessage`, nothing filters on it.

Now fetched by record id on selection, guarded on `IsNullOrEmpty` so re-selecting is free. An event log is a ring buffer, so a row whose event has since rolled off gets an empty pane rather than an error — the honest answer.

## P3 — a dead twin that encoded the bug its sibling documents

`SeverityToLevel` (singular) had **no production call sites**; `BuildXPath` uses `SeverityToLevels` (plural). It encoded `Info => 4`, which is precisely what the live method's own doc says must not happen: *"Level 0 (LogAlways) is classified as Info by MapLevel, so Info must query BOTH Level=0 and Level=4."* Its only reference in the repo was a reflection test **certifying the wrong mapping** — the classic trap for whoever greps for "severity to level" next.

Both deleted. The replacement tests the live method and asserts `Info => [0, 4]`.

## Also: a partly-read log now says so

A read that ends early keeps the records it already emitted, and the count-only wording announced those as finished — the same dishonesty as the cancellation bug, one branch over. The status switch moved into a pure `DescribeLoad` so the partial case could be added **and tested at all**: `LogsViewModel` takes the concrete service, so an outcome cannot be forced from a test.

## Seam

The loop is extracted behind a `Func<EventRecord?>`. Without it there is no way to make a reader fault on demand, and the two worst defects here lived on exactly that path.

## Red before, green after

**Baseline: all 14 green** (8 new + 6 pre-existing).

| Mutation | Expected red | Actual |
|---|---|---|
| **A** — restore the retry | the fault test | **the harness HANGS** — the defect's own signature, recorded via a bounded run |
| **B** — restore the inner `OperationCanceledException` catch | the observable-route test only | matched |
| **C** — remove the cancellation throw | the cancel test | matched |
| **D** — restore eager XML | **none** — stated limit | none |
| **E** — `Info => [4]` | 3 tests | matched |

Two things worth stating plainly rather than glossing.

**B was not what I first predicted.** I expected re-adding the inner catch to turn the main cancel test red; it changed nothing, because the post-loop throw covers an already-cancelled token regardless. There is exactly one route where that catch is observable — the read raising `OperationCanceledException` while the token is *not* cancelled, so the post-loop guard has nothing to fire on — and a test was added for it. Without that test, removing the catch would have been an untested clarity change presented as a fix.

**D changes nothing on purpose.** Eager XML is a cost defect, not a behavioural one. No unit test can see thousands of extra COM round-trips, and claiming one does would be worse than saying so.

`EventLogService.cs` was restored byte-for-byte after each mutation and rebuilt from the restored source.

## Regression sweep

- `dotnet build -c Release`: app **0 warnings, 0 errors**; tests **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes`: both projects exit 0. It reordered two usings and adjusted the spacing of a relational pattern in a tuple; the affected tests were re-run green afterwards.
- Leak scan over the whole branch diff against `main` (not just the last commit — the code was committed before the version bump, so a `HEAD`-only scan would have seen 33 lines instead of 372): 43 patterns, **0 hits**, non-vacuous.
- Local CI gates re-run from the extracted workflow bodies: version consistency (1.75.19 across csproj, CHANGELOG, SECURITY.md), valid bump (v1.75.18 → 1.75.19), CHANGELOG plain-English lead. All pass.
- `SeverityToLevels` and `Enumerate` became `internal` for testing; `GetXmlAsync` is `public` because the view model calls it.

CHANGELOG entry and version bump to 1.75.19 are in this PR.
