### PR TITLE
fix: stop the Dashboard stating disk and memory verdicts it never measured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.20] - 2026-09-01
+
+Two Dashboard tiles were telling you things SysManager had not actually checked. If your drive health could
+not be read, the tile still said your drives were healthy. And the "No memory errors" tile was not looking at
+memory errors at all — it was looking at how much memory was in use.
+
+### Fixed
+- **"All SMART indicators healthy" no longer appears when your drives could not be read.** Reading drive
+  health needs a part of Windows that is sometimes broken, switched off, or blocked without administrator
+  rights. When that happened SysManager got nothing back — and treated nothing back as a perfect result, so
+  the tile reported your drives were in good health without having looked at them. It now says the health
+  could not be read and points at the System Health tab. A drive that genuinely reports a problem is
+  unaffected: those wordings and thresholds are unchanged.
+- **The "No memory errors (30 days)" tile now actually looks for memory errors.** It was deciding based on how
+  much memory was currently in use, which has nothing to do with whether your memory has faulted. So a
+  computer with real memory hardware errors was told there were none as long as memory use was low, and a
+  perfectly healthy computer running a lot of programs was warned about "memory issues" that the System Health
+  tab then said did not exist. The tile now reads the same 30-day Windows error record the System Health tab
+  reads, and words the result the same way, so the two can no longer disagree. If that check itself cannot
+  run, it says so rather than reporting good news.
+- **The overall health score no longer counts unread information as perfect.** Drive health, memory and uptime
+  each scored full marks when their source returned nothing, so a computer where all three failed showed a
+  perfect score with no advice at all. An unread component is now scored as unknown, which is what a single
+  unreadable drive was already scored — the code said so in a comment while doing the opposite one screen
+  above.
+
 ## [1.75.19] - 2026-09-01
 
 The Logs tab could get stuck loading forever, with one processor core pinned at full speed and the Refresh

--- a/SysManager/SysManager.IntegrationTests/AllViewModelsSweepTests.cs
+++ b/SysManager/SysManager.IntegrationTests/AllViewModelsSweepTests.cs
@@ -32,7 +32,7 @@ public class AllViewModelsSweepTests
     private static CrashMarkerService TempCrashMarkers()
         => new(Path.Combine(Path.GetTempPath(), "SysManagerTests", "sweep-crash"));
 
-    [Fact] public void Dashboard_Constructs() => Assert.NotNull(new DashboardViewModel(new SystemInfoService(), new TuneUpService(new ShortcutCleanerService(), new DiskHealthService(), new SystemInfoService()), new HealthScoreService(new SystemInfoService(), new DiskHealthService(), new BatteryService()), new TemperatureService(new DiskHealthService(), skipHardwareInit: true), new WingetService(new PowerShellRunner()), TempCrashMarkers()));
+    [Fact] public void Dashboard_Constructs() => Assert.NotNull(new DashboardViewModel(new SystemInfoService(), new TuneUpService(new ShortcutCleanerService(), new DiskHealthService(), new SystemInfoService()), new HealthScoreService(new SystemInfoService(), new DiskHealthService(), new BatteryService()), new TemperatureService(new DiskHealthService(), skipHardwareInit: true), new WingetService(new PowerShellRunner()), TempCrashMarkers(), new MemoryTestService()));
     [Fact] public void AppUpdates_Constructs() => Assert.NotNull(new AppUpdatesViewModel(new WingetService(new PowerShellRunner())));
     [Fact] public void WindowsUpdate_Constructs() => Assert.NotNull(new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService(), new WindowsUpdatePolicyService()));
     [Fact] public void SystemHealth_Constructs() => Assert.NotNull(new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService()));
@@ -45,7 +45,7 @@ public class AllViewModelsSweepTests
 
     [Fact]
     public void Dashboard_HasNonEmptySummaryOrEmpty()
-        => Assert.NotNull(new DashboardViewModel(new SystemInfoService(), new TuneUpService(new ShortcutCleanerService(), new DiskHealthService(), new SystemInfoService()), new HealthScoreService(new SystemInfoService(), new DiskHealthService(), new BatteryService()), new TemperatureService(new DiskHealthService(), skipHardwareInit: true), new WingetService(new PowerShellRunner()), TempCrashMarkers()));
+        => Assert.NotNull(new DashboardViewModel(new SystemInfoService(), new TuneUpService(new ShortcutCleanerService(), new DiskHealthService(), new SystemInfoService()), new HealthScoreService(new SystemInfoService(), new DiskHealthService(), new BatteryService()), new TemperatureService(new DiskHealthService(), skipHardwareInit: true), new WingetService(new PowerShellRunner()), TempCrashMarkers(), new MemoryTestService()));
 
     [Fact]
     public void AppUpdates_HasCollections()

--- a/SysManager/SysManager.IntegrationTests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DashboardViewModelTests.cs
@@ -23,7 +23,8 @@ public class DashboardViewModelTests
             new WingetService(new PowerShellRunner()),
             // Redirected on purpose: reading a crash marker CONSUMES it, so pointing this at the real
             // profile would delete a genuine crash report before the user saw it (#1772).
-            new CrashMarkerService(Path.Combine(Path.GetTempPath(), "SysManagerTests", "dash-crash")));
+            new CrashMarkerService(Path.Combine(Path.GetTempPath(), "SysManagerTests", "dash-crash")),
+            new MemoryTestService());
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DashboardViewModelTests.cs
@@ -32,7 +32,8 @@ public class DashboardViewModelTests
             // CONSUMES it — pointed at the real profile (which is what the old optional parameter
             // defaulted to) these tests would delete a genuine crash report before the user was ever
             // told about it (#1772).
-            new CrashMarkerService(Path.Combine(Path.GetTempPath(), "SysManagerTests", "dash-crash")));
+            new CrashMarkerService(Path.Combine(Path.GetTempPath(), "SysManagerTests", "dash-crash")),
+            new MemoryTestService());
     }
 
     // ---------- construction & defaults ----------
@@ -361,5 +362,96 @@ public class DashboardViewModelTests
 
         Assert.False(vm.HasTuneUpResult);
         Assert.Null(vm.TuneUpResult);
+    }
+    // ---------- the two alerts that stated things the app did not know ----------
+
+    [Fact]
+    public void ClassifySmartHealth_Unavailable_SaysSoInsteadOfClaimingHealth()
+    {
+        // The P1, from the user's side. An unreadable Storage namespace scored 100 and landed in the green
+        // branch, so "All SMART indicators healthy" appeared for a machine whose disks were never read.
+        // Unknown is also not "degrading" — nothing is degrading, nothing was measured — so it gets its own
+        // wording rather than borrowing the middle branch's.
+        var (title, severity) = DashboardViewModel.ClassifySmartHealth(
+            HealthScoreService.UnknownComponentScore, unavailable: true);
+
+        Assert.Contains("could not be read", title);
+        Assert.Equal(AlertSeverity.Yellow, severity);
+        Assert.DoesNotContain("healthy", title);
+        Assert.DoesNotContain("degrading", title);
+    }
+
+    [Theory]
+    [InlineData(100, "All SMART indicators healthy", AlertSeverity.Green)]
+    [InlineData(90, "All SMART indicators healthy", AlertSeverity.Green)]
+    [InlineData(75, "Disk health degrading", AlertSeverity.Yellow)]
+    [InlineData(30, "Disk health critical", AlertSeverity.Red)]
+    public void ClassifySmartHealth_WithData_KeepsTheExistingThresholds(
+        int diskScore, string expectedFragment, AlertSeverity expectedSeverity)
+    {
+        // The measured cases must be untouched by the fix — the thresholds are what the System Health tab
+        // agrees with.
+        var (title, severity) = DashboardViewModel.ClassifySmartHealth(diskScore, unavailable: false);
+
+        Assert.Contains(expectedFragment, title);
+        Assert.Equal(expectedSeverity, severity);
+    }
+
+    [Fact]
+    public void ClassifyMemoryHealth_WheaErrors_IsRedAndCountsThem()
+    {
+        // The alert is titled after a 30-day hardware-error verdict and used to classify on memory USAGE, so
+        // a machine with real WHEA errors at 40% usage was told "No memory errors (30 days)".
+        var (title, severity) = DashboardViewModel.ClassifyMemoryHealth(
+            new MemoryTestService.MemoryErrorSummary(3, 0, DateTime.Now));
+
+        Assert.Contains("3", title);
+        Assert.Equal(AlertSeverity.Red, severity);
+        Assert.DoesNotContain("No memory errors", title);
+    }
+
+    [Fact]
+    public void ClassifyMemoryHealth_DiagnosticRan_IsYellow()
+    {
+        var (title, severity) = DashboardViewModel.ClassifyMemoryHealth(
+            new MemoryTestService.MemoryErrorSummary(0, 2, null));
+
+        Assert.Contains("2", title);
+        Assert.Equal(AlertSeverity.Yellow, severity);
+    }
+
+    [Fact]
+    public void ClassifyMemoryHealth_NoErrors_IsGreen()
+    {
+        // The genuine good-news case, which is the only one allowed to say this.
+        var (title, severity) = DashboardViewModel.ClassifyMemoryHealth(
+            new MemoryTestService.MemoryErrorSummary(0, 0, null));
+
+        Assert.Equal("No memory errors (30 days)", title);
+        Assert.Equal(AlertSeverity.Green, severity);
+    }
+
+    [Fact]
+    public void ClassifyMemoryHealth_ScanFailed_IsNotGoodNews()
+    {
+        // A failed scan is not the same as a clean one, and the previous code had no way to tell them apart
+        // because it never ran a scan.
+        var (title, severity) = DashboardViewModel.ClassifyMemoryHealth(null);
+
+        Assert.Contains("could not be checked", title);
+        Assert.Equal(AlertSeverity.Yellow, severity);
+    }
+
+    [Fact]
+    public void ClassifyMemoryHealth_SingularAndPlural_BothRead()
+    {
+        // Shown to someone who does not know what WHEA is; "1 memory hardware errors" undermines the rest.
+        var one = DashboardViewModel.ClassifyMemoryHealth(
+            new MemoryTestService.MemoryErrorSummary(1, 0, null)).Title;
+        var two = DashboardViewModel.ClassifyMemoryHealth(
+            new MemoryTestService.MemoryErrorSummary(2, 0, null)).Title;
+
+        Assert.Contains("1 memory hardware error ", one);
+        Assert.Contains("2 memory hardware errors ", two);
     }
 }

--- a/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
+++ b/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
@@ -124,9 +124,12 @@ public class HealthScoreServiceTests
     // ---------- ComputeUptimeScore ----------
 
     [Fact]
-    public void ComputeUptimeScore_NullSnapshot_Returns100()
+    public void ComputeUptimeScore_NullSnapshot_ScoresUnknownNotPerfect()
     {
-        Assert.Equal(100, HealthScoreService.ComputeUptimeScore(null));
+        // Rewritten with its three siblings. This test required the defect: a snapshot that never arrived is
+        // not evidence of a freshly-rebooted machine, and scoring it perfect is how a machine whose reads all
+        // failed reported full health with no advice.
+        Assert.Equal(HealthScoreService.UnknownComponentScore, HealthScoreService.ComputeUptimeScore(null));
     }
 
     [Fact]
@@ -294,13 +297,6 @@ public class HealthScoreServiceTests
         var disks = new List<DiskHealthReport> { new() { HealthStatus = "Unknown to us" } };
 
         Assert.Equal(80, HealthScoreService.ComputeDiskScore(disks));
-    }
-    [Fact]
-    public void ComputeUptimeScore_NullSnapshot_ScoresUnknownNotPerfect()
-    {
-        // The third arm with the same bug and the only one that had no test at all, which is presumably why
-        // it survived two rewrites of the other two.
-        Assert.Equal(HealthScoreService.UnknownComponentScore, HealthScoreService.ComputeUptimeScore(null));
     }
     [Fact]
     public void UnknownComponentScore_StaysBelowEveryGreenBranch()

--- a/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
+++ b/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
@@ -27,15 +27,22 @@ public class HealthScoreServiceTests
     // ---------- ComputeDiskScore ----------
 
     [Fact]
-    public void ComputeDiskScore_NullDisks_Returns100()
+    public void ComputeDiskScore_NullDisks_ScoresUnknownNotPerfect()
     {
-        Assert.Equal(100, HealthScoreService.ComputeDiskScore(null));
+        // This test used to require 100. That requirement WAS the defect: DiskHealthService swallows WMI
+        // failures and returns its partially-filled list, so a Storage namespace that is broken or
+        // access-denied arrives here as nothing at all — and the Dashboard's green branch is `>= 90`, so a
+        // machine whose disks were never read was told "All SMART indicators healthy".
+        Assert.Equal(HealthScoreService.UnknownComponentScore, HealthScoreService.ComputeDiskScore(null));
     }
 
     [Fact]
-    public void ComputeDiskScore_EmptyList_Returns100()
+    public void ComputeDiskScore_EmptyList_ScoresUnknownNotPerfect()
     {
-        Assert.Equal(100, HealthScoreService.ComputeDiskScore([]));
+        // The empty list is the case that actually happens in the field, and it used to be scored MORE
+        // generously than a single unreadable drive (100 versus 80) despite being a stronger absence of
+        // evidence. The service's own comment claimed the per-drive case was "the only case that reaches it".
+        Assert.Equal(HealthScoreService.UnknownComponentScore, HealthScoreService.ComputeDiskScore([]));
     }
 
     [Fact]
@@ -73,9 +80,10 @@ public class HealthScoreServiceTests
     // ---------- ComputeRamScore ----------
 
     [Fact]
-    public void ComputeRamScore_NullSnapshot_Returns100()
+    public void ComputeRamScore_NullSnapshot_ScoresUnknownNotPerfect()
     {
-        Assert.Equal(100, HealthScoreService.ComputeRamScore(null));
+        // Same rule as the disk arm: a snapshot that never arrived is not evidence of healthy memory.
+        Assert.Equal(HealthScoreService.UnknownComponentScore, HealthScoreService.ComputeRamScore(null));
     }
 
     [Fact]
@@ -286,5 +294,29 @@ public class HealthScoreServiceTests
         var disks = new List<DiskHealthReport> { new() { HealthStatus = "Unknown to us" } };
 
         Assert.Equal(80, HealthScoreService.ComputeDiskScore(disks));
+    }
+    [Fact]
+    public void ComputeUptimeScore_NullSnapshot_ScoresUnknownNotPerfect()
+    {
+        // The third arm with the same bug and the only one that had no test at all, which is presumably why
+        // it survived two rewrites of the other two.
+        Assert.Equal(HealthScoreService.UnknownComponentScore, HealthScoreService.ComputeUptimeScore(null));
+    }
+    [Fact]
+    public void UnknownComponentScore_StaysBelowEveryGreenBranch()
+    {
+        // The whole fix hangs on this one number, and the tests for the individual arms cannot pin it: they
+        // compare the constant to itself, so raising it moves both sides of their assertion at once. Raising
+        // it to 90 or above puts every unread component straight back into the Dashboard's green branch —
+        // "All SMART indicators healthy" for a machine whose disks were never read — with no other code
+        // changing anywhere.
+        Assert.Equal(80, HealthScoreService.UnknownComponentScore);
+
+        // Stated as the relationship as well as the value, because 90 is the Dashboard's green threshold and
+        // that is the constraint that actually matters if either number is ever revisited.
+        Assert.True(HealthScoreService.UnknownComponentScore < 90,
+            "an unknown component must never reach a green verdict");
+        Assert.True(HealthScoreService.UnknownComponentScore >= 60,
+            "and must not read as degrading either — nothing was measured");
     }
 }

--- a/SysManager/SysManager/Models/HealthScoreResult.cs
+++ b/SysManager/SysManager/Models/HealthScoreResult.cs
@@ -43,6 +43,22 @@ public sealed record HealthScoreResult
     public int UptimeScore { get; init; } = 100;
     public int BatteryScore { get; init; } = 100;
     public bool HasBattery { get; init; }
+
+    /// <summary>
+    /// Components whose source produced no data at all, by name: "Disk", "Memory", "Uptime".
+    /// </summary>
+    /// <remarks>
+    /// Exists because a score alone cannot distinguish "healthy" from "never read". DiskHealthService
+    /// swallows WMI failures and returns its partially-filled list, so a broken or access-denied Storage
+    /// namespace arrives as an empty list, and the component score used to collapse that onto 100 — which the
+    /// Dashboard rendered as "All SMART indicators healthy". The scores now fall back to the same 80 the
+    /// per-drive unknown rule uses, so a false green is impossible, and this list lets a caller say
+    /// "unavailable" instead of guessing at a verdict from a number.
+    /// </remarks>
+    public IReadOnlyList<string> UnavailableComponents { get; init; } = [];
+
+    /// <summary>True when <paramref name="component"/> reported nothing. See <see cref="UnavailableComponents"/>.</summary>
+    public bool IsUnavailable(string component) => UnavailableComponents.Contains(component);
 }
 
 /// <summary>A single health recommendation shown below the gauge.</summary>

--- a/SysManager/SysManager/Services/HealthScoreService.cs
+++ b/SysManager/SysManager/Services/HealthScoreService.cs
@@ -90,6 +90,17 @@ public sealed class HealthScoreService
         var recommendations = BuildRecommendations(
             diskScore, ramScore, uptimeScore, batteryScore, hasBattery, snapshot, disks, battery);
 
+        // Recorded so a consumer can say "could not read this" instead of reading a verdict out of a
+        // fallback number. The scores above already refuse to claim health; this is what makes the reason
+        // visible.
+        List<string> unavailable = [];
+        if (disks is null || disks.Count == 0) unavailable.Add(DiskComponent);
+        if (snapshot is null)
+        {
+            unavailable.Add(MemoryComponent);
+            unavailable.Add(UptimeComponent);
+        }
+
         return new HealthScoreResult
         {
             Score = overall,
@@ -98,15 +109,36 @@ public sealed class HealthScoreService
             UptimeScore = uptimeScore,
             BatteryScore = batteryScore,
             HasBattery = hasBattery,
-            Recommendations = recommendations
+            Recommendations = recommendations,
+            UnavailableComponents = unavailable
         };
     }
 
+    /// <summary>Component names used in <see cref="HealthScoreResult.UnavailableComponents"/>.</summary>
+    internal const string DiskComponent = "Disk";
+    internal const string MemoryComponent = "Memory";
+    internal const string UptimeComponent = "Uptime";
+
     // ── Component scoring ──────────────────────────────────────────────
+
+    /// <summary>The score for a health component whose source produced nothing at all.</summary>
+    /// <remarks>
+    /// The same value the per-drive unknown rule uses, for the same reason: absent evidence is not a clean
+    /// bill of health. It used to be 100 for a missing source, which is how a machine whose disk health could
+    /// not be read at all was told "All SMART indicators healthy" — the Dashboard's green branch is `>= 90`.
+    /// 80 keeps it out of every green branch while staying out of the alarming range, and
+    /// <see cref="HealthScoreResult.UnavailableComponents"/> is what lets a caller word it as unknown rather
+    /// than as mildly degraded.
+    /// </remarks>
+    internal const int UnknownComponentScore = 80;
 
     internal static int ComputeDiskScore(IReadOnlyList<DiskHealthReport>? disks)
     {
-        if (disks is null || disks.Count == 0) return 100;
+        // Not 100. DiskHealthService swallows ManagementException, UnauthorizedAccessException and
+        // COMException and returns its partially-filled list, so a Storage WMI namespace that is broken or
+        // access-denied arrives here as an empty list rather than as an exception — indistinguishable, at
+        // this point, from a machine with no drives. Either way nothing was measured.
+        if (disks is null || disks.Count == 0) return UnknownComponentScore;
 
         // The worst disk decides. HealthPercent already folds in Windows' own verdict as a ceiling,
         // so there is nothing left to map here.
@@ -118,15 +150,18 @@ public sealed class HealthScoreService
         // while the percentage was quietly ignoring it, and its Warning value (50) disagreed with
         // the real mapping (60).
         //
-        // 80, not 100, for a drive we know nothing about: absent evidence is not a clean bill of
-        // health, and this is the only case that reaches it.
-        int worstScore = disks.Select(d => d.HealthPercent ?? 80).Min();
+        // 80, not 100, for a drive we know nothing about: absent evidence is not a clean bill of health.
+        // The empty-list case above is a STRONGER absence of evidence and used to be scored more
+        // generously — this comment previously claimed a single unknown drive was "the only case that
+        // reaches it", which was how the contradiction survived.
+        int worstScore = disks.Select(d => d.HealthPercent ?? UnknownComponentScore).Min();
         return Math.Clamp(worstScore, 0, 100);
     }
 
     internal static int ComputeRamScore(SystemSnapshot? snapshot)
     {
-        if (snapshot is null) return 100;
+        // Same rule as the disk: a snapshot that never arrived is not evidence of healthy memory.
+        if (snapshot is null) return UnknownComponentScore;
         double usedPct = snapshot.Memory.UsedPercent;
 
         // Linear scale: 0% used = 100 score, 100% used = 0 score
@@ -145,7 +180,8 @@ public sealed class HealthScoreService
 
     internal static int ComputeUptimeScore(SystemSnapshot? snapshot)
     {
-        if (snapshot is null) return 100;
+        // Same rule as the disk and memory arms.
+        if (snapshot is null) return UnknownComponentScore;
         double days = snapshot.Os.Uptime.TotalDays;
 
         return days switch

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.19</Version>
-    <FileVersion>1.75.19.0</FileVersion>
-    <AssemblyVersion>1.75.19.0</AssemblyVersion>
+    <Version>1.75.20</Version>
+    <FileVersion>1.75.20.0</FileVersion>
+    <AssemblyVersion>1.75.20.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -22,6 +22,10 @@ public sealed partial class DashboardViewModel : ViewModelBase
     private readonly TemperatureService _temps;
     private readonly IWingetService _winget;
     private readonly CrashMarkerService _crashMarkers;
+
+    // The 30-day WHEA scan the memory alert is named after. Already a registered singleton; it was simply
+    // never reached from here, so the alert classified on a usage percentage instead.
+    private readonly MemoryTestService _memTest;
     private CancellationTokenSource? _tuneUpCts;
     private CancellationTokenSource? _pollingCts;
 
@@ -106,7 +110,7 @@ public sealed partial class DashboardViewModel : ViewModelBase
     /// </param>
     public DashboardViewModel(SystemInfoService sys, TuneUpService tuneUp,
         HealthScoreService healthScore, TemperatureService temps, IWingetService winget,
-        CrashMarkerService crashMarkers)
+        CrashMarkerService crashMarkers, MemoryTestService memTest)
     {
         _sys = sys;
         _tuneUp = tuneUp;
@@ -114,6 +118,7 @@ public sealed partial class DashboardViewModel : ViewModelBase
         _temps = temps;
         _winget = winget;
         _crashMarkers = crashMarkers;
+        _memTest = memTest;
         IsElevated = AdminHelper.IsElevated();
         InitializeAsync(InitAsync);
     }
@@ -483,25 +488,36 @@ public sealed partial class DashboardViewModel : ViewModelBase
         // Reuse the score LoadHealthScoreAsync already computed (it runs before the alert
         // scans) instead of recomputing the heavy WMI/SMART/battery work; fall back to a fresh
         // compute only if that load produced nothing (e.g. it failed).
-        var diskScore = (HealthResult ?? await _healthScore.ComputeAsync()).DiskScore;
+        var result = HealthResult ?? await _healthScore.ComputeAsync();
+        var (title, severity) = ClassifySmartHealth(
+            result.DiskScore, result.IsUnavailable(HealthScoreService.DiskComponent));
+
         System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
         {
-            if (diskScore >= 90)
-            {
-                alert.Title = "All SMART indicators healthy";
-                alert.Severity = AlertSeverity.Green;
-            }
-            else if (diskScore >= 60)
-            {
-                alert.Title = "Disk health degrading — check System Health";
-                alert.Severity = AlertSeverity.Yellow;
-            }
-            else
-            {
-                alert.Title = "Disk health critical — immediate attention needed";
-                alert.Severity = AlertSeverity.Red;
-            }
+            alert.Title = title;
+            alert.Severity = severity;
         });
+    }
+
+    /// <summary>Pure decision for the SMART alert. Testable without WPF.</summary>
+    /// <remarks>
+    /// The unavailable case has to come first and cannot be inferred from the score. DiskHealthService
+    /// swallows WMI failures and returns an empty list, which used to score 100 and land in the green branch —
+    /// so a machine whose disk health could not be read was told "All SMART indicators healthy". Scoring it as
+    /// unknown instead would put it in the "degrading" branch, which is a different wrong answer: nothing is
+    /// degrading, nothing was measured.
+    /// </remarks>
+    internal static (string Title, AlertSeverity Severity) ClassifySmartHealth(int diskScore, bool unavailable)
+    {
+        if (unavailable)
+            return ("Disk health could not be read — see System Health", AlertSeverity.Yellow);
+
+        return diskScore switch
+        {
+            >= 90 => ("All SMART indicators healthy", AlertSeverity.Green),
+            >= 60 => ("Disk health degrading — check System Health", AlertSeverity.Yellow),
+            _ => ("Disk health critical — immediate attention needed", AlertSeverity.Red)
+        };
     }
 
     private async Task ScanAppUpdatesAsync(DashboardAlert alert)
@@ -540,21 +556,55 @@ public sealed partial class DashboardViewModel : ViewModelBase
 
     private async Task ScanMemoryHealthAsync(DashboardAlert alert)
     {
-        // Reuse the already-computed score (see ScanSmartHealthAsync) rather than recomputing.
-        var result = HealthResult ?? await _healthScore.ComputeAsync();
+        // Reads the log, not the usage meter. This alert is titled after a 30-day hardware-error verdict, and
+        // it used to classify on RamScore — which HealthScoreService derives entirely from memory USAGE
+        // percent, a number with no relation to hardware errors. Both directions were wrong: real WHEA errors
+        // at 40% usage read as "No memory errors", and a healthy machine at 85% usage read as "Memory issues
+        // detected" while the System Health tab said the opposite. CheckErrorLogsAsync is the method whose
+        // whole purpose is this question, and it is already a registered singleton.
+        MemoryTestService.MemoryErrorSummary? summary = null;
+        try
+        {
+            summary = await _memTest.CheckErrorLogsAsync().ConfigureAwait(false);
+        }
+        catch (System.Diagnostics.Eventing.Reader.EventLogException ex)
+        {
+            Log.Warning("Dashboard: memory error scan failed: {Error}", ex.Message);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Log.Warning("Dashboard: memory error scan denied: {Error}", ex.Message);
+        }
+
+        var (title, severity) = ClassifyMemoryHealth(summary);
         System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
         {
-            if (result.RamScore >= 90)
-            {
-                alert.Title = "No memory errors (30 days)";
-                alert.Severity = AlertSeverity.Green;
-            }
-            else
-            {
-                alert.Title = "Memory issues detected — check System Health";
-                alert.Severity = AlertSeverity.Yellow;
-            }
+            alert.Title = title;
+            alert.Severity = severity;
         });
+    }
+
+    /// <summary>Pure decision for the memory alert. Testable without WPF.</summary>
+    /// <remarks>
+    /// Worded to match <c>SystemHealthViewModel</c>'s verdicts for the same summary, so the Dashboard tile and
+    /// the System Health tab can never disagree about the same 30 days. A null summary means the scan itself
+    /// failed, which is reported as unknown rather than as good news.
+    /// </remarks>
+    internal static (string Title, AlertSeverity Severity) ClassifyMemoryHealth(
+        MemoryTestService.MemoryErrorSummary? summary)
+    {
+        if (summary is null)
+            return ("Memory errors could not be checked — see System Health", AlertSeverity.Yellow);
+
+        if (summary.WheaMemoryErrors > 0)
+            return ($"{summary.WheaMemoryErrors} memory hardware error{(summary.WheaMemoryErrors == 1 ? "" : "s")} in 30 days — test your RAM",
+                AlertSeverity.Red);
+
+        if (summary.MemoryDiagnosticResults > 0)
+            return ($"Memory diagnostic ran {summary.MemoryDiagnosticResults} time{(summary.MemoryDiagnosticResults == 1 ? "" : "s")} — check results",
+                AlertSeverity.Yellow);
+
+        return ("No memory errors (30 days)", AlertSeverity.Green);
     }
 
     private Task ScanEventLogAsync(DashboardAlert alert)

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -417,7 +417,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
         return new Dictionary<Type, object>
         {
-            [typeof(DashboardViewModel)] = new DashboardViewModel(sysInfo, tuneUp, healthScore, new TemperatureService(diskHealth), winget, new CrashMarkerService()),
+            [typeof(DashboardViewModel)] = new DashboardViewModel(sysInfo, tuneUp, healthScore, new TemperatureService(diskHealth), winget, new CrashMarkerService(), new MemoryTestService()),
             [typeof(AppUpdatesViewModel)] = new AppUpdatesViewModel(winget),
             [typeof(WindowsUpdateViewModel)] = new WindowsUpdateViewModel(runner, new WindowsUpdateService(), new WindowsUpdatePolicyService()),
             [typeof(SystemHealthViewModel)] = new SystemHealthViewModel(sysInfo, diskHealth, new MemoryTestService(), fixedDrives, runner, new BiosService()),


### PR DESCRIPTION
Two Dashboard tiles asserted facts about the user's hardware that the app had not checked. On a maintenance utility read by a non-technical user as a verdict on their own machine, that is the worst kind of defect available.

## P1 — "All SMART indicators healthy" for drives that were never read

`DiskHealthService.Collect` swallows `ManagementException`, `UnauthorizedAccessException` and `COMException` and returns its **partially-filled** list. So a Storage WMI namespace that is broken, disabled, or access-denied reaches `HealthScoreService` as an **empty list**, never as an exception.

`ComputeDiskScore` returned `100` for that, and `ScanSmartHealthAsync` branches on `>= 90`. Result: a machine whose disk health could not be read at all was told its disks were in good health.

The same shape applied to `ComputeRamScore` and `ComputeUptimeScore` (100 for a null snapshot), while `BuildRecommendations` suppressed everything because each arm requires a non-null source. So a machine where all three reads failed showed **a perfect score with no advice**, and nothing anywhere said why.

The file already argued the opposite principle twelve lines below the bug:

> 80, not 100, for a drive we know nothing about: absent evidence is not a clean bill of health, **and this is the only case that reaches it**.

That last clause was false. The `Count == 0` path is a *stronger* absence of evidence and was scored *more generously*.

## P2 — "No memory errors (30 days)" was reading memory usage

The tile classified on `RamScore`, which `HealthScoreService` derives entirely from `snapshot.Memory.UsedPercent` — a usage percentage with no relation to hardware errors.

The service that answers this question already exists, is a registered singleton, and its own doc reads *"Scans the System event log for hardware-error events (WHEA) in the last 30 days"*: `MemoryTestService.CheckErrorLogsAsync`. It was consumed **only** by `SystemHealthViewModel`, which words the same result correctly.

Both directions were wrong:

- real WHEA errors at 40% memory use → green **"No memory errors (30 days)"**;
- a healthy machine at 85% memory use → yellow **"Memory issues detected"**, which the System Health tab then contradicted.

## Change

- An unread component scores `UnknownComponentScore` (80) — the same value the per-drive unknown rule already used — so it can never reach a green branch.
- `HealthScoreResult.UnavailableComponents` lets a caller say "could not be read" instead of reading a verdict out of a fallback number. Unknown is **not** "degrading" either: nothing is degrading, nothing was measured, so it gets its own wording.
- The memory tile calls `CheckErrorLogsAsync` and words its outcomes to match `SystemHealthViewModel`, so the two surfaces cannot disagree about the same 30 days. A failed scan reports as unknown rather than as good news.
- Both alert decisions are now pure internal statics, matching `ClassifyAppUpdates` in the same file. Previously both lived inside a `Dispatcher.BeginInvoke` callback where no test could reach them.
- `MemoryTestService` injected into `DashboardViewModel`; the one production construction site and all four test sites updated.

## Three existing tests required the defect

`ComputeDiskScore_NullDisks_Returns100`, `ComputeDiskScore_EmptyList_Returns100` and `ComputeRamScore_NullSnapshot_Returns100` asserted that a missing source scores perfect. That requirement *was* the bug, written down — the same shape as the dead `SeverityToLevel` twin in the previous batch. All three are rewritten to pin the rule and renamed after it. The uptime arm had **no test at all**, which is presumably how it survived two rewrites of the other two; it has one now.

## Red before, green after

**Baseline: all 16 green** (12 new/rewritten + 4 pre-existing).

| Mutation | Expected red | Actual |
|---|---|---|
| **A** — an unread disk scores 100 again | the two disk tests | matched |
| **B** — the unavailable branch removed | the SMART test | matched |
| **C** — WHEA errors made invisible | 2 memory tests | matched |
| **D** — a failed scan reported green | the scan-failed test | matched |
| **E** — `UnknownComponentScore` raised to 95 | the test that owns that number | matched |

**Mutation E first exposed a flaw in my own tests.** The four arm tests asserted `Equal(UnknownComponentScore, ...)` — comparing the constant to itself — so raising it moved both sides of the assertion and only one test noticed. The number now has a dedicated test pinning the literal `80` *and* its relationship to the Dashboard's `>= 90` green threshold; the arm tests keep asserting "this arm returns the unknown score", which is their actual job.

Mutation C also had to be rewritten: `if (false)` is `CS0162` unreachable code, an error under warnings-as-errors, and a mutation that cannot compile proves nothing. A threshold no real machine reaches has the same effect.

Both touched files were restored byte-for-byte after each mutation and rebuilt from the restored source.

## Regression sweep

- `dotnet build -c Release`: app, unit tests **and** integration tests — all **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes`: all three projects exit 0.
- Leak scan over the whole branch diff against `main`: 43 patterns, 313 added lines, **0 hits**.
- Local CI gates re-run from the extracted workflow bodies: version consistency (1.75.20 across csproj, CHANGELOG, SECURITY.md), valid bump (v1.75.19 → 1.75.20), CHANGELOG plain-English lead. All pass.
- `README.md` and `ARCHITECTURE.md` do not quote either tile's text, so neither needed a change.

## Scope

The audit's fuller suggestion — nullable component scores with the weights redistributed over the components that actually reported, as the battery arm already does — is a better model. It also changes `HealthScoreResult`'s shape, the CLI's JSON contract (`CliRunner.cs:146`) and the gauge's inputs. That is a separate change; this one makes the missing evidence representable and stops the false verdicts, which is the confirmed defect.

CHANGELOG entry and version bump to 1.75.20 are in this PR.
