### PR TITLE
fix: four TemperatureService defects, including a temperature shown under the wrong drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,40 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.21] - 2026-09-01
+
+A drive's temperature could be shown under a different drive's name, which is worse than showing no name at
+all — you could be looking at a healthy drive while worrying about the wrong one. The Temperatures readings are
+also cheaper to collect now, and a machine where the sensor library will not start no longer keeps retrying it
+every two seconds.
+
+### Fixed
+- **A temperature is no longer shown under the wrong drive's name.** SysManager reads drive temperatures from
+  one source and drive names from another, and it was pairing them purely by their order in each list — with
+  nothing to confirm the first temperature belonged to the first name. When the two lists did not line up, and
+  they do not whenever Windows cannot read one of the drives, every name after that point shifted onto the
+  wrong reading. So a healthy drive's 38 °C could appear under a failing drive's name, hiding the one that was
+  actually hot. Names are now only filled in where SysManager had no name of its own, and only when the two
+  lists are the same length — because a different length is proof the pairing cannot be trusted. When it cannot
+  be trusted, the generic "Drive 2" stays, which is honest rather than confidently wrong.
+- **The Temperatures card no longer goes completely blank because of one drive.** Fetching drive names uses a
+  part of Windows that occasionally reports a temporary error. That error was not being handled, and because
+  the names are fetched before the sensors are read, it wiped out the whole card — processor, graphics card and
+  motherboard readings included, not just the drive names. It is handled now, and a temporary failure is
+  retried on the next reading instead of being remembered for the rest of the session.
+- **A sensor library that cannot start is no longer retried every two seconds.** Reading processor and
+  motherboard temperatures needs a low-level component that will not load on some machines — certain security
+  settings block it. SysManager kept trying to load it on every reading, about thirty times a minute for as
+  long as the app was open, and each failed attempt left something behind. It now tries once, and if that
+  fails, stops trying and cleans up after itself.
+
+### Changed
+- **Drive temperatures are collected far less often when not running as administrator.** In that mode — the
+  normal one — each Dashboard reading was doing a full drive-health inspection, every two seconds. Drive
+  temperature changes over minutes, not seconds, so the result is now reused for up to 30 seconds. That is
+  roughly fifteen times less work for a number that reads the same either way. Running as administrator was
+  already doing this; only the ordinary path was missed.
+
 ## [1.75.20] - 2026-09-01
 
 Two Dashboard tiles were telling you things SysManager had not actually checked. If your drive health could

--- a/SysManager/SysManager.Tests/TemperatureServiceTests.cs
+++ b/SysManager/SysManager.Tests/TemperatureServiceTests.cs
@@ -1,0 +1,145 @@
+// SysManager · TemperatureServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="TemperatureService.ApplyStorageNames"/> — the storage-name substitution that used to
+/// display one drive's temperature under another drive's name.
+/// </summary>
+/// <remarks>
+/// The other three fixes in the same change are not reachable from a unit test and are not pretended to be:
+/// opening LibreHardwareMonitor loads a kernel driver, the WMI disk-name query needs live WMI, and the
+/// storage-temperature time-to-live sits behind <see cref="DiskHealthService"/>, which is sealed with a
+/// non-virtual CollectAsync.
+/// </remarks>
+public class TemperatureServiceTests
+{
+    private static TemperatureReading Storage(string name, bool placeholder) =>
+        new("Storage", name, 38.0, NameIsPlaceholder: placeholder);
+
+    [Fact]
+    public void ApplyStorageNames_GoodLhmName_IsNeverOverwritten()
+    {
+        // The defect. The substitution was unconditional, so a name LibreHardwareMonitor reported correctly was
+        // replaced by whatever name sat at the same ordinal in an independently-ordered WMI list — and the two
+        // lists are ordered by different things, with nothing correlating them. A user reads a healthy NVMe's
+        // temperature under a failing HDD's name.
+        List<TemperatureReading> readings = [Storage("Samsung SSD 990 PRO 2TB", placeholder: false)];
+
+        TemperatureService.ApplyStorageNames(readings, ["WDC WD40EZAZ-00SF3B0"]);
+
+        Assert.Equal("Samsung SSD 990 PRO 2TB", readings[0].SensorName);
+    }
+
+    [Fact]
+    public void ApplyStorageNames_PlaceholderName_IsReplaced()
+    {
+        // The case the substitution exists for: LibreHardwareMonitor gave nothing usable, so a real model name
+        // is an improvement over "Drive 1".
+        List<TemperatureReading> readings = [Storage("Drive 1", placeholder: true)];
+
+        TemperatureService.ApplyStorageNames(readings, ["Samsung SSD 990 PRO 2TB"]);
+
+        Assert.Equal("Samsung SSD 990 PRO 2TB", readings[0].SensorName);
+        Assert.False(readings[0].NameIsPlaceholder, "a real name is no longer a placeholder");
+    }
+
+    [Fact]
+    public void ApplyStorageNames_CountsDisagree_SubstitutesNothing()
+    {
+        // An unequal count is proof the ordinal pairing is broken, and it breaks for a real reason:
+        // DiskHealthService.Collect silently SKIPS any disk with an unreadable WMI field, which shifts every
+        // later index by one. Two placeholders and one name means the one name might belong to either — and
+        // keeping "Drive 1" is better than confidently showing the wrong model.
+        List<TemperatureReading> readings =
+        [
+            Storage("Drive 1", placeholder: true),
+            Storage("Drive 2", placeholder: true)
+        ];
+
+        TemperatureService.ApplyStorageNames(readings, ["Samsung SSD 990 PRO 2TB"]);
+
+        Assert.Equal("Drive 1", readings[0].SensorName);
+        Assert.Equal("Drive 2", readings[1].SensorName);
+    }
+
+    [Fact]
+    public void ApplyStorageNames_MixedPlaceholders_ReplacesOnlyTheGuesses()
+    {
+        // The realistic case, and the one the two guards have to handle together: the counts line up, so
+        // positions are usable, but only one of the two readings needs a name. Replacing both would clobber a
+        // correct one; replacing neither would leave a placeholder that had a perfectly good name available.
+        List<TemperatureReading> readings =
+        [
+            Storage("Samsung SSD 990 PRO 2TB", placeholder: false),
+            Storage("Drive 2", placeholder: true)
+        ];
+
+        TemperatureService.ApplyStorageNames(readings, ["something else entirely", "WDC WD40EZAZ-00SF3B0"]);
+
+        Assert.Equal("Samsung SSD 990 PRO 2TB", readings[0].SensorName);
+        Assert.Equal("WDC WD40EZAZ-00SF3B0", readings[1].SensorName);
+    }
+
+    [Fact]
+    public void ApplyStorageNames_BlankReplacement_LeavesThePlaceholder()
+    {
+        // A blank name is not an improvement on "Drive 1", and MSFT_PhysicalDisk does return empty friendly
+        // names for some virtual and Storage Spaces devices.
+        List<TemperatureReading> readings = [Storage("Drive 1", placeholder: true)];
+
+        TemperatureService.ApplyStorageNames(readings, ["   "]);
+
+        Assert.Equal("Drive 1", readings[0].SensorName);
+    }
+
+    [Fact]
+    public void ApplyStorageNames_NonStorageRows_AreUntouched()
+    {
+        // CPU, GPU and motherboard rows share the list. The count comparison is over STORAGE rows only, so a
+        // machine with three sensors and one disk must not be treated as a mismatch — and the non-storage rows
+        // must never be renamed.
+        List<TemperatureReading> readings =
+        [
+            new("CPU", "CPU Package", 55.0),
+            Storage("Drive 1", placeholder: true),
+            new("GPU", "GPU Core", 47.0)
+        ];
+
+        TemperatureService.ApplyStorageNames(readings, ["Samsung SSD 990 PRO 2TB"]);
+
+        Assert.Equal("CPU Package", readings[0].SensorName);
+        Assert.Equal("Samsung SSD 990 PRO 2TB", readings[1].SensorName);
+        Assert.Equal("GPU Core", readings[2].SensorName);
+    }
+
+    [Fact]
+    public void ApplyStorageNames_NoStorageRows_DoesNothingAndDoesNotThrow()
+    {
+        // A machine whose sensors expose no storage at all, with a disk list that is not empty. The old
+        // index loop happened to survive this; the count guard has to as well.
+        List<TemperatureReading> readings = [new("CPU", "CPU Package", 55.0)];
+
+        TemperatureService.ApplyStorageNames(readings, ["Samsung SSD 990 PRO 2TB"]);
+
+        Assert.Equal("CPU Package", readings[0].SensorName);
+        Assert.Single(readings);
+    }
+
+    [Fact]
+    public void DiskTemperatureTtl_IsLongEnoughToMatterAndShortEnoughToBeCurrent()
+    {
+        // The non-admin arm polls every 2 s and used to do a full Storage-namespace connect plus one SMART
+        // association walk per disk on every tick. The point of the number is the ratio: it has to be many
+        // times the poll interval to cut that work, and short enough that a warming drive still shows up.
+        Assert.True(TemperatureService.DiskTemperatureTtl >= TimeSpan.FromSeconds(10),
+            "a TTL near the 2 s poll interval would not reduce the WMI work it exists to reduce");
+        Assert.True(TemperatureService.DiskTemperatureTtl <= TimeSpan.FromMinutes(2),
+            "a drive warming up must still appear within a sensible time");
+    }
+}

--- a/SysManager/SysManager/Models/TemperatureReading.cs
+++ b/SysManager/SysManager/Models/TemperatureReading.cs
@@ -6,11 +6,18 @@ using SysManager.Helpers;
 
 namespace SysManager.Models;
 
+/// <param name="NameIsPlaceholder">
+/// True when the producer could not get a real name for this sensor and invented one. Only a reading so
+/// flagged may have its name replaced later: the storage enricher used to overwrite every storage name by
+/// list position, so a name LibreHardwareMonitor reported correctly was clobbered with whatever name happened
+/// to sit at the same ordinal in an independently-ordered WMI list.
+/// </param>
 public sealed record TemperatureReading(
     string Component,
     string SensorName,
     double? TemperatureC,
-    bool RequiresAdmin = false)
+    bool RequiresAdmin = false,
+    bool NameIsPlaceholder = false)
 {
     public string DisplayValue => TemperatureC.HasValue
         ? $"{TemperatureC.Value:F0}°C"

--- a/SysManager/SysManager/Services/TemperatureService.cs
+++ b/SysManager/SysManager/Services/TemperatureService.cs
@@ -41,6 +41,19 @@ public sealed class TemperatureService : IDisposable
     private List<string>? _cachedStorageFriendlyNames; // DiskHealthService friendly names, guarded by _enrichGate
     private readonly SemaphoreSlim _enrichGate = new(1, 1);
 
+    // Whether the LibreHardwareMonitor open has been attempted. Guarded by _sensorLock, which is held
+    // wherever this is read or written. Mirrors _nvApiInitTried below: the point is that a FAILED attempt
+    // counts as an attempt, which ??= alone cannot express.
+    private bool _lhmInitTried;
+
+    private readonly TimeProvider _timeProvider;
+
+    // The non-admin storage read, with a short TTL. The elevated arm memoizes its SMART walk for the session;
+    // this arm had no cache at all, so the 2s Dashboard poll paid a full Storage-namespace connect plus one
+    // SMART association walk per disk, 30 times a minute. Guarded by _enrichGate.
+    private List<TemperatureReading>? _cachedDiskTemperatures;
+    private long _diskTemperaturesStamp;
+
     // The sensor TOPOLOGY — which hardware exists and how many temperature sensors each exposes — is
     // static hardware identity, exactly like the disk names above, so it is logged once per session
     // instead of once per hardware item per poll. It was 4 lines every 2 seconds (the Dashboard's
@@ -55,10 +68,19 @@ public sealed class TemperatureService : IDisposable
     // Guarded by _sensorLock, which is already held wherever this is read or written.
     private bool _loggedSensorTopology;
 
-    public TemperatureService(DiskHealthService diskHealth, bool skipHardwareInit = false)
+    /// <param name="diskHealth">Source of the SMART/temperature walk.</param>
+    /// <param name="skipHardwareInit">Set by tests so no kernel driver is loaded.</param>
+    /// <param name="timeProvider">
+    /// Clock for the storage-temperature time-to-live. Optional with a System default, like
+    /// <paramref name="skipHardwareInit"/>, so the ten existing construction sites are unaffected while a test
+    /// can still drive the TTL without sleeping.
+    /// </param>
+    public TemperatureService(DiskHealthService diskHealth, bool skipHardwareInit = false,
+        TimeProvider? timeProvider = null)
     {
         _diskHealth = diskHealth;
         _skipHardwareInit = skipHardwareInit;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     /// <summary>
@@ -103,14 +125,26 @@ public sealed class TemperatureService : IDisposable
             try
             {
                 // Open the kernel-level monitor once and reuse it; subsequent polls
-                // only Update() the already-enumerated hardware.
-                _computer ??= OpenComputer();
+                // only Update() the already-enumerated hardware. Attempted at most ONCE per session:
+                // ??= latches on success only, so a failing open used to be retried on every 2s poll.
+                if (!_lhmInitTried)
+                {
+                    _lhmInitTried = true;
+                    _computer = TryOpenComputer();
+                }
+
+                if (_computer is null) return;
 
                 // Pre-fetch disk names from WMI for cross-reference (skipped on the fast path —
                 // the sampler doesn't need names). Memoized: disk models are static hardware, so
                 // resolve the Win32_DiskDrive query once and reuse it — the 2s poll no longer
                 // re-queries WMI every tick. Guarded by _sensorLock (already held here).
-                var diskNames = includeStorage ? (_cachedWmiDiskNames ??= GetDiskNamesFromWmi()) : [];
+                // ?? [] after the ??=, not instead of it: a null means the query faulted, so nothing is
+                // cached and the next poll retries, while this poll proceeds with no names rather than none of
+                // the other sensors.
+                var diskNames = includeStorage
+                    ? ((_cachedWmiDiskNames ??= GetDiskNamesFromWmi()) ?? [])
+                    : [];
 
                 foreach (var hardware in _computer.Hardware)
                 {
@@ -203,7 +237,8 @@ public sealed class TemperatureService : IDisposable
                             var name = hardware.Name;
 
                             // LHM often returns empty or cryptic names for storage
-                            if (string.IsNullOrWhiteSpace(name) || name.Length <= 3 || name.All(char.IsDigit))
+                            var namedByLhm = !(string.IsNullOrWhiteSpace(name) || name.Length <= 3 || name.All(char.IsDigit));
+                            if (!namedByLhm)
                             {
                                 // Try matching by index from WMI disk list
                                 var storageIndex = readings.Count(r => r.Component == "Storage");
@@ -212,7 +247,11 @@ public sealed class TemperatureService : IDisposable
                                     : $"Drive {storageIndex + 1}";
                             }
 
-                            readings.Add(new TemperatureReading("Storage", name, diskTemp.Value));
+                            // The flag travels with the reading instead of being re-derived downstream. The
+                            // enricher used to overwrite EVERY storage name by list position, clobbering both
+                            // a good LHM name and the WMI model just substituted above.
+                            readings.Add(new TemperatureReading("Storage", name, diskTemp.Value,
+                                NameIsPlaceholder: !namedByLhm));
                         }
                     }
                     else if (component == "Motherboard")
@@ -241,7 +280,21 @@ public sealed class TemperatureService : IDisposable
         }
     }
 
-    private static Computer OpenComputer()
+    /// <summary>
+    /// Opens LibreHardwareMonitor once, or returns null and gives up for the rest of the session.
+    /// </summary>
+    /// <remarks>
+    /// <c>Open()</c> loads a ring0 driver, reads SMBIOS and builds the CPU, motherboard and storage groups.
+    /// All of that is fault-prone under HVCI, Secure Boot, a locked driver or a WMI fault. The previous shape
+    /// was <c>_computer ??= OpenComputer()</c> with no try/catch inside, so a failure left <c>_computer</c>
+    /// null and the next Dashboard poll re-ran the heaviest possible init two seconds later — a kernel-driver
+    /// load and a full hardware enumeration every two seconds for the life of the process, with one Debug
+    /// line each time. The half-opened Computer was also dropped without <c>Close()</c>, abandoning whatever
+    /// Open() had already claimed.
+    /// <para>Same one-shot guard the NvAPI path below already uses (<c>_nvApiInitTried</c>) for exactly this
+    /// failure mode.</para>
+    /// </remarks>
+    private static Computer? TryOpenComputer()
     {
         var computer = new Computer
         {
@@ -250,8 +303,21 @@ public sealed class TemperatureService : IDisposable
             IsStorageEnabled = true,
             IsMotherboardEnabled = true
         };
-        computer.Open();
-        return computer;
+
+        try
+        {
+            computer.Open();
+            return computer;
+        }
+        catch (Exception ex)
+        {
+            // Broad on purpose: Open() reaches a kernel driver, SMBIOS and WMI, and the useful outcome is the
+            // same whatever it throws — give up cleanly rather than retry a driver load 30 times a minute.
+            Log.Debug("LibreHardwareMonitor could not be opened, giving up for this session: {Error}", ex.Message);
+            try { computer.Close(); }
+            catch (Exception closeEx) { Log.Debug("LHM close after a failed open also failed: {Error}", closeEx.Message); }
+            return null;
+        }
     }
 
     public void Dispose()
@@ -288,19 +354,7 @@ public sealed class TemperatureService : IDisposable
             }
             finally { _enrichGate.Release(); }
 
-            var storageReadings = readings
-                .Select((r, i) => (Reading: r, Index: i))
-                .Where(x => x.Reading.Component == "Storage")
-                .ToList();
-
-            for (int i = 0; i < storageReadings.Count; i++)
-            {
-                var (reading, idx) = storageReadings[i];
-                if (i < diskNames.Count && !string.IsNullOrWhiteSpace(diskNames[i]))
-                {
-                    readings[idx] = reading with { SensorName = diskNames[i] };
-                }
-            }
+            ApplyStorageNames(readings, diskNames);
         }
         catch (Exception ex)
         {
@@ -308,7 +362,65 @@ public sealed class TemperatureService : IDisposable
         }
     }
 
-    private static List<string> GetDiskNamesFromWmi()
+    /// <summary>
+    /// Disk models from Win32_DiskDrive, or null when WMI could not answer.
+    /// </summary>
+    /// <remarks>
+    /// Null rather than empty on fault, so the caller's <c>??=</c> memoization does not cache a failure for
+    /// the whole session. A single transient fault on the first elevated poll used to strand LibreHardwareMonitor's
+    /// cryptic labels as "Drive 1", "Drive 2" until the app restarted.
+    /// <para>COMException is caught alongside ManagementException because WMI surfaces transient faults — RPC
+    /// server unavailable, repository errors — as COMException, which every other WMI reader in this codebase
+    /// already guards. It mattered more here than elsewhere: this prefetch runs BEFORE the hardware
+    /// enumeration loop, so an escaping COMException aborted the entire read through the outer catch-all and
+    /// the Temperatures card lost its CPU, GPU and motherboard rows as well.</para>
+    /// </remarks>
+    /// <summary>
+    /// Replaces placeholder storage names with the friendly names at the same position, when — and only
+    /// when — that position means anything.
+    /// </summary>
+    /// <remarks>
+    /// The two sequences are independently ordered. The readings are in LibreHardwareMonitor's device order;
+    /// the names are in MSFT_PhysicalDisk enumeration order. Nothing correlates them, and the substitution
+    /// used to be applied by index, unconditionally, over every storage reading — so a name LHM had reported
+    /// correctly, or a WMI model the producer had already substituted for a placeholder, was overwritten with
+    /// whatever name happened to sit at the same ordinal. A user then read a healthy NVMe's 38 °C under a
+    /// failing HDD's name, or the reverse, which hides a genuinely hot drive.
+    /// <para>Two guards, and each one alone is insufficient. A reading whose name LHM supplied is never
+    /// touched, so a correct name cannot be clobbered. And an unequal count is proof the ordinal pairing is
+    /// already broken — DiskHealthService.Collect silently SKIPS any disk with an unreadable WMI field, which
+    /// shifts every later index by one — so in that case nothing is substituted at all. Keeping "Drive 2" is
+    /// better than confidently showing the wrong model.</para>
+    /// <para>Keying LHM's device identifier against MSFT_PhysicalDisk.DeviceId would remove the guessing
+    /// entirely and is the better long-term shape. It needs a query change and a new property on
+    /// DiskHealthReport, so it is deliberately not part of this change.</para>
+    /// </remarks>
+    internal static void ApplyStorageNames(List<TemperatureReading> readings, IReadOnlyList<string> diskNames)
+    {
+        var storageReadings = readings
+            .Select((r, i) => (Reading: r, Index: i))
+            .Where(x => x.Reading.Component == "Storage")
+            .ToList();
+
+        if (storageReadings.Count != diskNames.Count)
+        {
+            Log.Debug("Storage name enrichment skipped: {Readings} sensors vs {Names} disks — the ordinal "
+                + "pairing would be a guess", storageReadings.Count, diskNames.Count);
+            return;
+        }
+
+        for (var i = 0; i < storageReadings.Count; i++)
+        {
+            var (reading, idx) = storageReadings[i];
+
+            if (!reading.NameIsPlaceholder) continue;
+            if (string.IsNullOrWhiteSpace(diskNames[i])) continue;
+
+            readings[idx] = reading with { SensorName = diskNames[i], NameIsPlaceholder = false };
+        }
+    }
+
+    private static List<string>? GetDiskNamesFromWmi()
     {
         List<string> names = [];
         try
@@ -326,9 +438,12 @@ public sealed class TemperatureService : IDisposable
                 }
             }
         }
-        catch (ManagementException ex)
+        catch (Exception ex) when (ex is ManagementException or System.Runtime.InteropServices.COMException)
         {
             Log.Debug("WMI disk names failed: {Error}", ex.Message);
+            // Whatever was collected before the fault is still correct and still in order; only a completely
+            // empty result is worth retrying, so only that returns null.
+            return names.Count > 0 ? names : null;
         }
         return names;
     }
@@ -394,17 +509,56 @@ public sealed class TemperatureService : IDisposable
         }
     }
 
+    /// <summary>How long a non-admin storage temperature read is reused before collecting again.</summary>
+    /// <remarks>
+    /// The elevated arm memoizes its SMART walk for the whole session because disk NAMES are static hardware
+    /// identity. A temperature is not, so this arm gets a short time-to-live instead of a permanent cache.
+    /// Thirty seconds against a 2-second poll cuts the work about fifteenfold and loses nothing observable:
+    /// drive temperature moves on a minutes timescale.
+    /// </remarks>
+    internal static readonly TimeSpan DiskTemperatureTtl = TimeSpan.FromSeconds(30);
+
     private async Task ReadDiskTemperaturesAsync(List<TemperatureReading> readings)
     {
+        // The Dashboard polls every 2 s with includeStorage: true, and on the NON-elevated path — the default
+        // for most users — this used to call CollectAsync() cold every single tick: a fresh connect to
+        // the Windows Storage WMI namespace, an MSFT_PhysicalDisk query, and one
+        // MSFT_StorageReliabilityCounter association walk PER disk, thirty times a minute for as long as the
+        // Dashboard is on screen. The service's own comments call that "by far the heaviest part of a read";
+        // the memoization that followed was applied to the elevated arm only.
+        await _enrichGate.WaitAsync().ConfigureAwait(false);
         try
         {
-            var disks = await _diskHealth.CollectAsync();
-            foreach (var disk in disks.Where(d => d.TemperatureC.HasValue))
+            // GetElapsedTime over a stored GetTimestamp, not a wall-clock difference. EtwBandwidthSource
+            // spells out why: GetUtcNow moves when the user or NTP changes the clock, which would either
+            // freeze this cache or expire it instantly.
+            if (_cachedDiskTemperatures is not null
+                && _timeProvider.GetElapsedTime(_diskTemperaturesStamp) <= DiskTemperatureTtl)
             {
-                readings.Add(new TemperatureReading("Storage", disk.FriendlyName, disk.TemperatureC));
+                readings.AddRange(_cachedDiskTemperatures);
+                return;
             }
+
+            List<TemperatureReading> fresh = [];
+            try
+            {
+                var disks = await _diskHealth.CollectAsync().ConfigureAwait(false);
+                foreach (var disk in disks.Where(d => d.TemperatureC.HasValue))
+                {
+                    fresh.Add(new TemperatureReading("Storage", disk.FriendlyName, disk.TemperatureC));
+                }
+            }
+            catch (ManagementException ex) { Log.Debug("Disk temp unavailable: {Error}", ex.Message); return; }
+            catch (UnauthorizedAccessException ex) { Log.Debug("Disk temp denied: {Error}", ex.Message); return; }
+            catch (System.Runtime.InteropServices.COMException ex) { Log.Debug("Disk temp WMI COM error: 0x{HResult:X8}", ex.HResult); return; }
+
+            // Only a successful collect is cached. Caching a failure would hide the drives for the next
+            // 30 seconds instead of retrying on the next tick — the same mistake the WMI name query made by
+            // memoizing an empty result for the whole session.
+            _cachedDiskTemperatures = fresh;
+            _diskTemperaturesStamp = _timeProvider.GetTimestamp();
+            readings.AddRange(fresh);
         }
-        catch (ManagementException ex) { Log.Debug("Disk temp unavailable: {Error}", ex.Message); }
-        catch (UnauthorizedAccessException ex) { Log.Debug("Disk temp denied: {Error}", ex.Message); }
+        finally { _enrichGate.Release(); }
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.20</Version>
-    <FileVersion>1.75.20.0</FileVersion>
-    <AssemblyVersion>1.75.20.0</AssemblyVersion>
+    <Version>1.75.21</Version>
+    <FileVersion>1.75.21.0</FileVersion>
+    <AssemblyVersion>1.75.21.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Four defects in one file, each with an existing in-file or in-repo precedent for the fix. All four verified against current source before anything was written.

## 1 — A temperature displayed under the wrong drive's name

`EnrichStorageNamesAsync` paired two sequences **by index, unconditionally**:

- `storageReadings` is in LibreHardwareMonitor's device order;
- `diskNames` is `MSFT_PhysicalDisk` enumeration order.

Nothing correlated them. Worse, the substitution overwrote names LHM had reported **correctly** — and the WMI models the producer at line 206 had already substituted for the placeholder cases.

The misalignment is not hypothetical. `DiskHealthService.Collect` silently **skips** any disk with an unreadable WMI field, which shifts every later index by one. A user then reads a healthy NVMe's 38 °C under a failing HDD's name — hiding the drive that is actually hot, which is worse than showing no name at all.

**Two guards, and neither alone is sufficient:**

- a reading is renamed only if the producer flagged its name as invented — the flag now travels on `TemperatureReading` rather than being re-derived downstream;
- and only when the two sequences are the **same length**, because an unequal length is *proof* the ordinal pairing is broken. Keeping `"Drive 2"` beats confidently showing the wrong model.

Keying LHM's `IHardware.Identifier` device index against `MSFT_PhysicalDisk.DeviceId` would remove the guessing entirely. That needs a query change and a new property on `DiskHealthReport`, so it is deliberately **not** in this PR.

## 2 — One WMI hiccup blanked the entire Temperatures card

`GetDiskNamesFromWmi` caught only `ManagementException`. Every other WMI reader in this codebase also guards `COMException`, because WMI surfaces transient faults — RPC server unavailable, repository errors — that way: `SystemInfoService` at six call sites, and `TrayIconService` with the reason written out.

It mattered more here than elsewhere. The name prefetch runs **before** the hardware enumeration loop, so an escaping `COMException` aborted the entire read through the outer catch-all: the card lost its CPU, GPU, hot-spot and motherboard rows too, with only a `Log.Debug` as evidence.

And a *caught* fault returned a possibly-empty list, which `??=` then cached permanently — one hiccup on the first poll stranded LHM's cryptic labels as `"Drive 1"` for the whole session. It now returns null on a completely empty result so the next poll retries.

## 3 — A sensor library that cannot start, retried every two seconds forever

`_computer ??= OpenComputer()` latches on **success** only, and `OpenComputer` had no try/catch. `Open()` loads a ring0 driver, reads SMBIOS and builds the CPU/motherboard/storage groups — all fault-prone under HVCI, Secure Boot, a locked driver or a WMI fault.

So on such a machine SysManager re-ran a kernel-driver load and a full hardware enumeration **every two seconds for the life of the process**, and dropped each half-opened `Computer` without `Close()`.

Now attempted once, mirroring the `_nvApiInitTried` guard 240 lines below that already solves exactly this failure mode, and a failed attempt releases what it claimed.

## 4 — The non-admin storage read had no cache at all

The Dashboard polls every 2000 ms with `includeStorage: true`. On the **non-elevated** path — the default for most users — that called `CollectAsync()` cold every tick: a Storage-namespace connect, an `MSFT_PhysicalDisk` query, and one `MSFT_StorageReliabilityCounter` association walk **per disk**, thirty times a minute for as long as the Dashboard was on screen.

The service's own comments call that *"by far the heaviest part of a read"*, and the memoization that followed was applied to the elevated arm only.

Now a 30-second TTL over the monotonic `GetTimestamp`/`GetElapsedTime` pair — not `GetUtcNow`, for the reason `EtwBandwidthSource` already spells out — with `TimeProvider` injected as an *optional* parameter like the existing `skipHardwareInit`, so none of the ten construction sites change. Only a successful collect is cached; caching a failure would hide the drives for 30 seconds instead of retrying.

## What is and is not tested

The name substitution is lifted into a pure internal static and covered by 7 tests. **The other three fixes are not covered, and that is stated rather than implied:** `TryOpenComputer` loads a kernel driver, `GetDiskNamesFromWmi` needs live WMI, and the TTL sits behind `DiskHealthService`, which is `sealed` with a non-virtual `CollectAsync`. Introducing an interface there would touch all ten construction sites and belongs in its own change. The TTL *constant* is pinned by a test on its ratio to the poll interval.

## Red before, green after

**Baseline: all 8 green.**

| Mutation | Expected red | Actual |
|---|---|---|
| **A** — substitution unconditional again | 2 tests | matched |
| **B** — count guard removed | the counts test | matched |
| **C** — blank replacement accepted | the blank test | matched |
| **D** — nothing ever substituted | 3 tests | matched |
| **E** — guard counts every row, not just storage | the non-storage test | matched |
| **F** — TTL dropped to the 2 s poll interval | the constant's test | matched |

**D and E are the ones that keep the tests honest.** Two guards whose job is to *skip* work are trivially satisfiable by skipping everything — D proves they are not. And a count comparison over the wrong population is the classic off-by-population bug — E proves the comparison is over storage rows only, so a machine with CPU and GPU rows plus one disk is not mistaken for a mismatch.

`TemperatureService.cs` was restored byte-for-byte after each mutation and rebuilt from the restored source.

## Regression sweep

- `dotnet build -c Release`: app, unit tests and integration tests — all **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes`: all projects exit 0.
- Leak scan over the whole branch diff against `main`: 43 patterns, 378 added lines, **0 hits**.
- Local CI gates re-run from the extracted workflow bodies: version consistency (1.75.21), valid bump (v1.75.20 → 1.75.21), CHANGELOG plain-English lead. All pass.
- `TemperatureReading` gained an optional 5th positional parameter, so every existing construction still compiles unchanged.

CHANGELOG entry and version bump to 1.75.21 are in this PR.
