### PR TITLE
fix: route every programmatic exit through one seam so admin relaunch is not blocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.22] - 2026-09-01
+
+Pressing "Run as administrator" could ask you whether to keep SysManager running in the notification area, and
+then not restart with administrator rights at all. The same thing could happen when quitting from the
+notification-area icon.
+
+### Fixed
+- **"Run as administrator" now actually restarts SysManager with administrator rights.** Every tab that needs
+  administrator rights offers that button, and it works by starting a new copy of SysManager and closing the
+  current one. Closing it went through the same path as pressing the X button — so if you had never told
+  SysManager what X should do, it stopped to ask whether to keep running in the notification area. That
+  question is the right one when you press X and completely wrong here, and while it sat on screen the new
+  copy was waiting for the old one to finish letting go. It gave up after a few seconds. The result was a
+  confusing question followed by nothing happening. The question is now only asked when you press X, which is
+  the only time it makes sense.
+- **Quitting from the notification-area icon no longer asks whether to keep running in the notification area.**
+  The same cause, and the same nonsensical question — you had just told it to quit.
+
 ## [1.75.21] - 2026-09-01
 
 A drive's temperature could be shown under a different drive's name, which is worse than showing no name at

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -4918,4 +4918,84 @@ public partial class ArchitectureTests
     /// <summary>A ResolveSystemTool call, removed so a fixed site is not reported as a bare literal.</summary>
     [GeneratedRegex(@"(SysManager\.Helpers\.)?SystemPaths\.ResolveSystemTool\(\s*""[^""]*""\s*\)")]
     private static partial Regex ResolverCall();
+    [Fact]
+    public void NoViewModel_ShutsTheAppDownDirectly()
+    {
+        // Every admin-requiring tab exits so the elevated instance can take over, and all 38 sites did it as
+        // `Application.Current?.Shutdown()`. WPF's Shutdown force-closes windows with ignoreCancel: true, which
+        // still INVOKES MainWindow.OnClosing — so before the user has ever pressed X, and the close preference
+        // is therefore "Ask", clicking "Run as administrator" put up a modal asking whether to keep running in
+        // the notification area. The single-instance mutex is released in App.OnExit, which cannot run while
+        // that modal waits for a human, so the incoming elevated instance's handover wait timed out and the
+        // relaunch silently did nothing.
+        //
+        // App.RequestShutdown records the intent first. This guard exists because nothing stopped a new tab
+        // copying the old line from its neighbour, which is how it reached 38.
+        var root = Path.Combine(FindRepoRoot(), "SysManager", "SysManager");
+        var files = Directory.GetFiles(root, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")
+                        && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
+                        // App itself is what calls Shutdown; RequestShutdown is the seam in front of it.
+                        && !f.EndsWith("App.xaml.cs", StringComparison.Ordinal))
+            .ToArray();
+        Assert.NotEmpty(files);
+
+        List<string> offenders = [];
+        var inspected = 0;
+
+        foreach (var file in files)
+        {
+            // Comments stripped BEFORE matching: App.xaml.cs and AdminHelper.cs both quote this exact call in
+            // prose to explain why it must not be used, and a guard that matches its own explanation goes red
+            // on correct code.
+            var code = string.Join('\n', File.ReadAllLines(file)
+                .Select(line => CommentTail().Replace(line, string.Empty)));
+
+            inspected++;
+            if (DirectShutdown().IsMatch(code))
+                offenders.Add(Path.GetFileName(file));
+        }
+
+        Assert.True(inspected >= 50,
+            $"the shutdown scan looked at only {inspected} files, so it is no longer looking at the app");
+
+        // A positive control on the pattern itself. Counting files is not enough: a pattern that matches
+        // nothing finds no offenders and passes, so a broken regex would report a clean codebase. These are the
+        // two spellings that were actually in the tree before this change.
+        Assert.Matches(DirectShutdown(), "Application.Current?.Shutdown();");
+        Assert.Matches(DirectShutdown(), "System.Windows.Application.Current?.Shutdown();");
+        Assert.DoesNotMatch(DirectShutdown(), "App.RequestShutdown();");
+
+        Assert.True(offenders.Count == 0,
+            "these call Application.Current.Shutdown() directly, which re-enters MainWindow.OnClosing and puts "
+            + "the close-or-minimise prompt in front of a programmatic exit. Call App.RequestShutdown() "
+            + "instead:\n  " + string.Join("\n  ", offenders));
+    }
+
+    [Fact]
+    public void MainWindowOnClosing_ReturnsEarlyWhenAnExitWasRequested()
+    {
+        // The other half. Routing every caller through App.RequestShutdown achieves nothing unless OnClosing
+        // actually honours the flag it sets, and a source scan for the callers cannot see that.
+        var source = File.ReadAllText(Path.Combine(
+            FindRepoRoot(), "SysManager", "SysManager", "MainWindow.xaml.cs"));
+
+        var onClosing = source.IndexOf("protected override void OnClosing", StringComparison.Ordinal);
+        Assert.True(onClosing > 0, "OnClosing not found — this guard would otherwise pass vacuously");
+
+        // The early return has to come BEFORE the preference is loaded, or the prompt still appears.
+        var guard = source.IndexOf("App.ExitRequested", onClosing, StringComparison.Ordinal);
+        var load = source.IndexOf("_closePreference.Load()", onClosing, StringComparison.Ordinal);
+
+        Assert.True(guard > 0, "MainWindow.OnClosing does not check App.ExitRequested");
+        Assert.True(load > 0, "the close-preference load moved — re-check what this guard is asserting about");
+        Assert.True(guard < load,
+            "the App.ExitRequested check must come before the close preference is loaded, or a programmatic "
+            + "exit still reaches the close-or-minimise prompt");
+    }
+
+    /// <summary>A direct Application.Shutdown call, in any of its qualified forms.</summary>
+    [GeneratedRegex(@"(System\.Windows\.)?Application\.Current\s*\??\.\s*Shutdown\s*\(")]
+    private static partial Regex DirectShutdown();
+
 }

--- a/SysManager/SysManager/App.xaml.cs
+++ b/SysManager/SysManager/App.xaml.cs
@@ -19,6 +19,37 @@ public partial class App : Application
     private const string MutexName = "Global\\SysManager_SingleInstance_laurentiu021";
     private const string PipeName = "SysManager_SingleInstance_Pipe_laurentiu021";
     private Mutex? _instanceMutex;
+
+    /// <summary>
+    /// True once an exit has been requested programmatically rather than by the user pressing X.
+    /// </summary>
+    /// <remarks>
+    /// Read by <c>MainWindow.OnClosing</c>, which must not ask the close-or-minimise question on this path.
+    /// WPF's <see cref="Application.Shutdown()"/> force-closes windows via
+    /// <c>Window.InternalClose(shutdown: true, ignoreCancel: true)</c> — that still INVOKES OnClosing and only
+    /// ignores the cancel. Without this flag, clicking "Run as administrator" produced a modal asking whether
+    /// to keep running in the notification area, and because the single-instance mutex is released in
+    /// <c>OnExit</c> — which cannot run while OnClosing waits on a modal — the elevated instance's
+    /// <see cref="TryWaitForMutexHandover"/> timed out and the relaunch silently did nothing.
+    /// <para>volatile because it is written on the UI thread and read during a shutdown that WPF may drive
+    /// from a different one.</para>
+    /// </remarks>
+    internal static volatile bool ExitRequested;
+
+    /// <summary>
+    /// The single way the app exits itself. Records the intent, then shuts down.
+    /// </summary>
+    /// <remarks>
+    /// Every programmatic exit goes through here — the admin relaunches in the view models and the tray icon's
+    /// Exit command — so that pressing X remains the only route that can reach the close-or-minimise prompt. A
+    /// fitness function asserts no view model calls <c>Application.Current?.Shutdown()</c> directly, because
+    /// this was already true of 38 sites and nothing prevented a 39th.
+    /// </remarks>
+    internal static void RequestShutdown()
+    {
+        ExitRequested = true;
+        Current?.Shutdown();
+    }
     private TrayIconService? _trayService;
     private CancellationTokenSource? _pipeCts;
 

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -180,6 +180,18 @@ public partial class MainWindow : Window
         //
         // Ask once, remember the answer, and honour it silently afterwards. The tray icon's
         // own Exit command still quits directly, since that intent is already unambiguous.
+
+        // A programmatic exit has already decided. Application.Shutdown() force-closes windows with
+        // ignoreCancel: true, which still calls this override — so without this early return, clicking
+        // "Run as administrator" (or the tray's Exit) asked the user whether to keep running in the
+        // notification area, and the modal held the single-instance mutex past the incoming elevated
+        // instance's handover wait. Pressing X is now the only caller that can reach the prompt.
+        if (App.ExitRequested)
+        {
+            base.OnClosing(e);
+            return;
+        }
+
         if (Application.Current is not App app || app.TrayService is null)
         {
             base.OnClosing(e);
@@ -237,7 +249,7 @@ public partial class MainWindow : Window
                 // The single-instance mutex stayed held too, so the next launch handed itself over to
                 // an invisible instance and quit; and because the answer above is REMEMBERED, that
                 // repeated on every launch until the user found it in Task Manager.
-                Application.Current?.Shutdown();
+                App.RequestShutdown();
                 base.OnClosing(e);
                 return;
         }

--- a/SysManager/SysManager/Services/TrayIconService.cs
+++ b/SysManager/SysManager/Services/TrayIconService.cs
@@ -161,7 +161,7 @@ public sealed class TrayIconService : IDisposable
         var exitItem = new System.Windows.Controls.MenuItem { Header = "Exit" };
         exitItem.Click += (_, _) =>
         {
-            Application.Current?.Shutdown();
+            App.RequestShutdown();
         };
         menu.Items.Add(exitItem);
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.21</Version>
-    <FileVersion>1.75.21.0</FileVersion>
-    <AssemblyVersion>1.75.21.0</AssemblyVersion>
+    <Version>1.75.22</Version>
+    <FileVersion>1.75.22.0</FileVersion>
+    <AssemblyVersion>1.75.22.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -782,7 +782,7 @@ public sealed partial class AboutViewModel : ViewModelBase
 
             // Give the applier a moment to start before we exit.
             await Task.Delay(500);
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
         }
         catch (InvalidOperationException ex)
         {
@@ -869,7 +869,7 @@ public sealed partial class AboutViewModel : ViewModelBase
 
             // Let the applier start before this process exits.
             await Task.Delay(500);
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
         }
         catch (InvalidOperationException ex)
         {

--- a/SysManager/SysManager/ViewModels/AppBlockerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppBlockerViewModel.cs
@@ -40,7 +40,7 @@ public sealed partial class AppBlockerViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     private async Task RefreshListAsync()

--- a/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
@@ -81,7 +81,7 @@ public sealed partial class AppUpdatesViewModel : ViewModelBase
     {
         Log.Information("Admin elevation requested from App Updates tab");
         if (SysManager.Helpers.AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     partial void OnSelectAllChanged(bool value)

--- a/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
@@ -531,7 +531,7 @@ public sealed partial class BandwidthMonitorViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     // ── Live chart plumbing (mirrors ResourceHistoryViewModel's idiom) ─────

--- a/SysManager/SysManager/ViewModels/BootAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BootAnalyzerViewModel.cs
@@ -104,7 +104,7 @@ public sealed partial class BootAnalyzerViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     protected override void Dispose(bool disposing)

--- a/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
@@ -187,7 +187,7 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     /// <summary>

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -228,7 +228,7 @@ public sealed partial class CleanupViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     [RelayCommand]
@@ -369,7 +369,7 @@ public sealed partial class CleanupViewModel : ViewModelBase
                 StatusMessage = "SFC cancelled — admin privileges required.";
                 return;
             }
-            if (AdminHelper.RelaunchAsAdmin()) System.Windows.Application.Current?.Shutdown();
+            if (AdminHelper.RelaunchAsAdmin()) App.RequestShutdown();
             return;
         }
 
@@ -476,7 +476,7 @@ public sealed partial class CleanupViewModel : ViewModelBase
                 StatusMessage = "DISM cancelled — admin privileges required.";
                 return;
             }
-            if (AdminHelper.RelaunchAsAdmin()) System.Windows.Application.Current?.Shutdown();
+            if (AdminHelper.RelaunchAsAdmin()) App.RequestShutdown();
             return;
         }
 

--- a/SysManager/SysManager/ViewModels/ContextMenuViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ContextMenuViewModel.cs
@@ -129,7 +129,7 @@ public sealed partial class ContextMenuViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -922,7 +922,7 @@ public sealed partial class DashboardViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     // ── Tune-Up (preserved from original) ─────────────────────────────────

--- a/SysManager/SysManager/ViewModels/DefenderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DefenderViewModel.cs
@@ -51,7 +51,7 @@ public sealed partial class DefenderViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     /// <summary>True when no Defender operation is in flight — gates the mutating

--- a/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
@@ -600,7 +600,7 @@ public sealed partial class DnsHostsViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     // ── Cleanup ──────────────────────────────────────────────────────────

--- a/SysManager/SysManager/ViewModels/EdgeOneDriveViewModel.cs
+++ b/SysManager/SysManager/ViewModels/EdgeOneDriveViewModel.cs
@@ -86,7 +86,7 @@ public sealed partial class EdgeOneDriveViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     [RelayCommand(CanExecute = nameof(NotBusy))]

--- a/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
@@ -307,7 +307,7 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/FileLockViewModel.cs
+++ b/SysManager/SysManager/ViewModels/FileLockViewModel.cs
@@ -40,7 +40,7 @@ public sealed partial class FileLockViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     private bool CanScan => !IsBusy && !string.IsNullOrWhiteSpace(Path);

--- a/SysManager/SysManager/ViewModels/GamingProfileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/GamingProfileViewModel.cs
@@ -248,7 +248,7 @@ public sealed partial class GamingProfileViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     protected override void Dispose(bool disposing)

--- a/SysManager/SysManager/ViewModels/NetworkRepairViewModel.cs
+++ b/SysManager/SysManager/ViewModels/NetworkRepairViewModel.cs
@@ -31,7 +31,7 @@ public sealed partial class NetworkRepairViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
@@ -816,7 +816,7 @@ public sealed partial class PerformanceViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     // CQ-M4: Override Dispose to clean up the PerformanceService's PowerShellRunner

--- a/SysManager/SysManager/ViewModels/PrivacyViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PrivacyViewModel.cs
@@ -120,7 +120,7 @@ public sealed partial class PrivacyViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
@@ -47,7 +47,7 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     private async Task InitAsync()

--- a/SysManager/SysManager/ViewModels/RestorePointsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/RestorePointsViewModel.cs
@@ -195,7 +195,7 @@ public sealed partial class RestorePointsViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     protected override void Dispose(bool disposing)

--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -80,7 +80,7 @@ public sealed partial class ServicesViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     private async Task InitAsync()

--- a/SysManager/SysManager/ViewModels/SettingsWatchdogViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SettingsWatchdogViewModel.cs
@@ -54,7 +54,7 @@ public sealed partial class SettingsWatchdogViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     /// <summary>Re-reads the baseline and live state and rebuilds both the watched list and the drifts.</summary>

--- a/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
@@ -41,7 +41,7 @@ public sealed partial class ShortcutCleanerViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/StandbyMemoryViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StandbyMemoryViewModel.cs
@@ -231,7 +231,7 @@ public sealed partial class StandbyMemoryViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     protected override void Dispose(bool disposing)

--- a/SysManager/SysManager/ViewModels/StartupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StartupViewModel.cs
@@ -75,7 +75,7 @@ public sealed partial class StartupViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     [RelayCommand(CanExecute = nameof(NotBusy))]

--- a/SysManager/SysManager/ViewModels/SystemFixesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemFixesViewModel.cs
@@ -130,7 +130,7 @@ public sealed partial class SystemFixesViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     protected override void Dispose(bool disposing)

--- a/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
@@ -390,7 +390,7 @@ public sealed partial class SystemHealthViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     [GeneratedRegex(@"^[A-Z]:$", RegexOptions.IgnoreCase)]

--- a/SysManager/SysManager/ViewModels/TaskSchedulerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TaskSchedulerViewModel.cs
@@ -65,7 +65,7 @@ public sealed partial class TaskSchedulerViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     [RelayCommand(CanExecute = nameof(NotBusy))]

--- a/SysManager/SysManager/ViewModels/TweaksHubViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TweaksHubViewModel.cs
@@ -45,7 +45,7 @@ public sealed partial class TweaksHubViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
@@ -57,7 +57,7 @@ public sealed partial class WindowsFeaturesViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     [RelayCommand(CanExecute = nameof(NotBusy))]

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -242,7 +242,7 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
     private void RelaunchAsAdmin()
     {
         if (AdminHelper.RelaunchAsAdmin())
-            System.Windows.Application.Current?.Shutdown();
+            App.RequestShutdown();
     }
 
     // Gated on NotBusy like the other runner-driven commands: CheckModule and
@@ -514,7 +514,7 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
         if (!AdminHelper.IsElevated())
         {
             StatusMessage = "Admin required. Relaunching elevated...";
-            if (AdminHelper.RelaunchAsAdmin()) System.Windows.Application.Current?.Shutdown();
+            if (AdminHelper.RelaunchAsAdmin()) App.RequestShutdown();
             return;
         }
 


### PR DESCRIPTION
## Problem

Every admin-requiring tab implements the relaunch as `if (AdminHelper.RelaunchAsAdmin()) Application.Current?.Shutdown();` — **38 sites across 30 files**, counted fresh against current source.

WPF's `Application.Shutdown()` force-closes windows through `Window.InternalClose(shutdown: true, ignoreCancel: true)`. That still **invokes** the `OnClosing` override; only the *cancel* is ignored. `MainWindow.OnClosing` had no "a shutdown is already under way" guard, so it re-ran the ask-and-remember logic:

- before the user has ever pressed X there is no `close-preference.json`, so the preference is `CloseBehavior.Ask`;
- `DialogService.AskCloseOrMinimize` is a blocking modal that short-circuits only when `Application.Current == null` — which is **false** during shutdown.

So clicking "Run as administrator" asked the user whether to keep SysManager running in the notification area.

**And the app already anticipated the handover it was blocking.** `TryWaitForMutexHandover` waits *"up to a few seconds"* for the outgoing instance to release the single-instance mutex — and the mutex is released in `App.OnExit`, which cannot run while `OnClosing` sits on a modal waiting for a human. The elevated instance times out and gives up.

Net result for the target persona: a confusing unrelated question, then **nothing happens**. The tray icon's Exit command hit the same path — asked whether to keep running, immediately after being told to quit.

## Change

`App.RequestShutdown()` records the intent and then shuts down. `OnClosing` returns immediately when that intent is set, **before** the preference is loaded. Pressing X is now the only caller that can reach the prompt.

All 38 sites routed through it, in both spellings present in the tree (`Application.Current?.Shutdown()` and the fully-qualified `System.Windows.Application.Current?.Shutdown()` — the second form is why the first pass of the replacement produced `System.Windows.App.RequestShutdown()` and failed to compile).

## Two guards, because either half alone is worthless

- `NoViewModel_ShutsTheAppDownDirectly` — no view model calls `Application.Current?.Shutdown()` directly. 38 sites all copied the same wrong line from a neighbour, and nothing stopped a 39th.
- `MainWindowOnClosing_ReturnsEarlyWhenAnExitWasRequested` — asserts the `App.ExitRequested` check appears **before** the preference load. A check that runs *after* the prompt is raised would satisfy "does OnClosing mention the flag" while changing nothing for the user, so the guard asserts the **order**, not the presence.

The caller guard carries a **positive control on its own pattern**: it asserts the regex matches both spellings that were in the tree and does not match the replacement. Counting inspected files is not enough — a pattern that matches nothing finds no offenders and reports a clean codebase. Comments are stripped before matching, because both `App.xaml.cs` and `AdminHelper.cs` quote the forbidden call in prose to explain why it is forbidden.

## Red before, green after

**Baseline: all 3 green** (2 new + the pre-existing `ClosingTheWindowToExit_RequestsAnApplicationShutdown`).

| Mutation | Expected red | Actual |
|---|---|---|
| **A** — a view model shuts down directly again | the caller guard | matched |
| **B** — the fully-qualified spelling instead | the caller guard | matched |
| **C** — the early return removed | the order guard | matched |
| **D** — the early return **moved** after the preference load | the order guard | matched |
| **E** — the guard's own regex broken | the caller guard, via its positive control | matched |

**Mutation D initially did not go red, and the mutation was at fault rather than the guard.** My first version *added* a second check without removing the first, so the guard still found the correct one and stayed green. Rewritten to genuinely move it. Worth recording rather than quietly fixing: a mutation that does not reproduce the defect it is named after proves nothing about the test.

All three touched files were restored byte-for-byte after each mutation and rebuilt from the restored source.

## Regression sweep

- `dotnet build -c Release`: app, unit tests, integration tests **and** UI tests — all 0 errors, 0 warnings.
- `dotnet format --verify-no-changes`: exit 0.
- Leak scan over the whole branch diff against `main`: 43 patterns, 218 added lines, **0 hits**.
- Local CI gates: version consistency (1.75.22), valid bump (v1.75.21 → 1.75.22), CHANGELOG plain-English lead. All pass.
- `App.xaml.cs`'s own two bare `Shutdown()` calls are untouched: they run before any window exists (single-instance handoff and the CLI path), so `OnClosing` cannot fire there, and `RequestShutdown` is the method that calls `Shutdown` for everyone else.

CHANGELOG entry and version bump to 1.75.22 are in this PR.
