### PR TITLE
chore: add the XML doc summaries CodeQL flagged on two members

### DIFF
--- a/SysManager/SysManager/Models/TemperatureReading.cs
+++ b/SysManager/SysManager/Models/TemperatureReading.cs
@@ -6,6 +6,13 @@ using SysManager.Helpers;
 
 namespace SysManager.Models;
 
+/// <summary>
+/// One temperature sensor reading: what it belongs to, what it is called, and how hot it is.
+/// </summary>
+/// <param name="Component">Sensor group — "CPU", "GPU", "Storage". The Temperatures card groups by it.</param>
+/// <param name="SensorName">Display name. For storage this may have been supplied by the sensor library or guessed.</param>
+/// <param name="TemperatureC">Degrees Celsius, or null when the value could not be read.</param>
+/// <param name="RequiresAdmin">True when the value is null only because the app is not running elevated.</param>
 /// <param name="NameIsPlaceholder">
 /// True when the producer could not get a real name for this sensor and invented one. Only a reading so
 /// flagged may have its name replaced later: the storage enricher used to overwrite every storage name by

--- a/SysManager/SysManager/Services/TemperatureService.cs
+++ b/SysManager/SysManager/Services/TemperatureService.cs
@@ -68,6 +68,9 @@ public sealed class TemperatureService : IDisposable
     // Guarded by _sensorLock, which is already held wherever this is read or written.
     private bool _loggedSensorTopology;
 
+    /// <summary>
+    /// Creates the reader. No hardware is touched until the first read.
+    /// </summary>
     /// <param name="diskHealth">Source of the SMART/temperature walk.</param>
     /// <param name="skipHardwareInit">Set by tests so no kernel driver is loaded.</param>
     /// <param name="timeProvider">


### PR DESCRIPTION
Two new CodeQL alerts, **both created today by my own edits** in the TemperatureService batch:

| Alert | Rule | Where |
|---|---|---|
| 1726 | `cs/xmldoc/missing-summary` | `TemperatureService.cs:78` — the constructor |
| 1727 | `cs/xmldoc/missing-summary` | `TemperatureReading.cs:15` — the record |

Both members previously had **no XML doc at all**. I added `<param>` blocks to each, and that rule fires on a member with *some* XML doc but no `<summary>` — so partially documenting them is precisely what raised the alerts. Nothing regressed; I made two undocumented members half-documented.

Fixed by finishing the job rather than deleting the docs: a `<summary>` on each, and the record's other four parameters as well, since it now carries a doc comment that would otherwise describe one parameter out of five.

- `dotnet build -c Release`: 0 errors, 0 warnings.
- `dotnet format --verify-no-changes`: exit 0.
- Diff is 10 added lines, 0 deletions — comments only.

No behaviour change, so `chore:` — no release and no CHANGELOG entry. CodeQL re-runs on this PR, which is where the two alerts should disappear.