### PR TITLE
fix: flush AtomicFile's temp onto the device and close the first-save race

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -566,6 +566,13 @@ Key services:
 Key utility classes that don't fit neatly into Services or ViewModels (not an exhaustive list):
 
 - `AdminHelper` — elevation check (`IsElevated()`) and UAC relaunch.
+- `AtomicFile` — the single way every service persists user data. Writes a
+  uniquely-named temp file beside the destination, flushes it onto the device,
+  then swaps it in with one filesystem operation, so an interrupted save leaves
+  either the old file or the new one and never half of each. Load-bearing
+  because the loaders that read these files treat an unparseable file as "no
+  data" at Debug level, so a torn save would erase presets, profiles or history
+  without reporting anything.
 - `BulkObservableCollection<T>` — `ObservableCollection` subclass that
   suppresses change notifications during bulk add/remove for UI performance
   (in `ObservableCollectionExtensions.cs`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.23] - 2026-09-01
+
+If the power went out or the machine was reset while SysManager was saving, a file it had just saved could come
+back empty the next time you opened the app — your presets, gaming profiles or history gone, with nothing on
+screen to say so. The very first save of one of those files could also quietly do nothing.
+
+### Fixed
+- **A power cut can no longer empty a file SysManager had just saved.** Saving works by writing the new
+  contents beside the old file and then swapping the two, so that being interrupted leaves you with one
+  version or the other, never half of each. The swap was reliable, but the contents were not: Windows
+  reports a save as finished once it has the data in memory, and it may write it to the drive seconds
+  later. Pull the plug in between and the swap has happened while the contents have not, so the file
+  exists under the right name and is empty. SysManager now waits for the drive to confirm it has the data
+  before swapping, which is what the promise of "either the old file or the new one" always required.
+  It matters most for the two files you would never think about: the record of what a gaming profile
+  changed on your PC, and the snapshot taken before a performance change. If either came back empty, the
+  app concluded there was nothing to undo while your PC was still changed.
+- **The first save of a preset or profile no longer fails when something else creates it at the same moment.**
+  Saving asked whether the file existed yet and then acted on the answer, and those are two separate steps.
+  Two saves arriving together for a file that did not exist yet could both be told "it does not", and the
+  second one then failed because the first had already created it. Failed saves are only recorded in the
+  diagnostic log, so that save simply vanished. Only ever the first save of a given file; every save after
+  that was already handled.
+
 ## [1.75.22] - 2026-09-01
 
 Pressing "Run as administrator" could ask you whether to keep SysManager running in the notification area, and

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -4998,4 +4998,41 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"(System\.Windows\.)?Application\.Current\s*\??\.\s*Shutdown\s*\(")]
     private static partial Regex DirectShutdown();
 
+    [Fact]
+    public void AtomicFile_FlushesTheTempOntoTheDevice_BeforeEverySwap()
+    {
+        // Closing a handle hands the bytes to the OS write-back cache; it does not ask the drive to persist
+        // them. The swap that follows is a metadata change NTFS journals, so the rename can become durable
+        // while the data blocks are still in volatile cache — after a power cut the destination exists under
+        // its final name and is empty. AtomicFile's summary promises this cannot happen, and the loaders that
+        // read these files treat an unparseable file as "no data" at Debug level, so it never surfaced.
+        //
+        // Structural rather than behavioural because nothing in managed code can observe whether
+        // FlushFileBuffers ran. What IS checkable is that the call is there and that it comes first.
+        var source = File.ReadAllText(Path.Combine(
+            FindRepoRoot(), "SysManager", "SysManager", "Helpers", "AtomicFile.cs"));
+
+        // Comments stripped BEFORE matching: the remarks explain FlushFileBuffers and reference Swap in
+        // prose, and a guard that reads its own explanation passes on code that flushes nothing.
+        var code = string.Join('\n', source.Split('\n')
+            .Select(line => CommentTail().Replace(line, string.Empty)));
+
+        string[] writers = ["private static void Write(", "private static async Task WriteAsync("];
+
+        foreach (var writer in writers)
+        {
+            var start = code.IndexOf(writer, StringComparison.Ordinal);
+            Assert.True(start > 0, $"{writer} was not found — this guard would otherwise pass vacuously");
+
+            var swap = code.IndexOf("Swap(temp, path)", start, StringComparison.Ordinal);
+            Assert.True(swap > start, $"{writer} no longer swaps a temp into place");
+
+            var flush = code.IndexOf("FlushToDisk(temp)", start, StringComparison.Ordinal);
+            Assert.True(flush > start && flush < swap,
+                $"{writer} must flush the temp onto the device before the swap, or a power cut can leave "
+                + "the destination durable under its final name while its contents are still in the "
+                + "operating system's write-back cache");
+        }
+    }
+
 }

--- a/SysManager/SysManager.Tests/AtomicFileTests.cs
+++ b/SysManager/SysManager.Tests/AtomicFileTests.cs
@@ -210,4 +210,47 @@ public class AtomicFileTests : IDisposable
     {
         Assert.Throws<ArgumentNullException>(() => AtomicFile.WriteAllText(Path_("x.json"), null!));
     }
+    [Fact]
+    public void MoveIntoPlace_DestinationAppearedAfterTheProbe_StillSwapsItIn()
+    {
+        // Swap asks File.Exists and then acts on the answer, and those are two operations rather than one.
+        // Two writers saving a file that does not exist yet — the first save of a preset, profile or
+        // history — can both be told "absent", and this is the state the loser then lands in. Its
+        // Move(overwrite: false) threw IOException, and callers log a failed save at Debug, so the loser's
+        // data disappeared without a word. Every later write was already safe: it takes the Replace branch.
+        var path = Path_("first-save.json");
+        var temp = AtomicFile.UniqueTempPath(path);
+        File.WriteAllText(temp, "the writer that lost the race");
+        File.WriteAllText(path, "the writer that won it");
+
+        AtomicFile.MoveIntoPlace(temp, path);
+
+        Assert.Equal("the writer that lost the race", File.ReadAllText(path));
+        Assert.False(File.Exists(temp), "the temp must not be left behind once it has been swapped in");
+    }
+
+    [Fact]
+    public void MoveIntoPlace_TempIsMissing_StillFails()
+    {
+        // The catch filter is narrow on purpose. Only "the destination appeared" is recoverable; a missing
+        // temp is a real failure and must reach the caller rather than being absorbed by the fallback.
+        var path = Path_("never-written.json");
+        var missing = AtomicFile.UniqueTempPath(path);
+
+        Assert.ThrowsAny<IOException>(() => AtomicFile.MoveIntoPlace(missing, path));
+        Assert.False(File.Exists(path));
+    }
+
+    [Fact]
+    public void WriteAllText_FirstCreation_LeavesNoTempBehind()
+    {
+        // The flush opens the temp a second time, between writing it and swapping it. If that handle were
+        // left open the swap would fail on a sharing violation, so this asserts the directory is clean.
+        var path = Path_("clean.json");
+
+        AtomicFile.WriteAllText(path, "{\"a\":1}");
+
+        Assert.Equal(path, Assert.Single(Directory.GetFiles(_dir)));
+    }
+
 }

--- a/SysManager/SysManager/Helpers/AtomicFile.cs
+++ b/SysManager/SysManager/Helpers/AtomicFile.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Text;
+using Serilog;
 
 namespace SysManager.Helpers;
 
@@ -18,8 +19,10 @@ namespace SysManager.Helpers;
 /// history, gaming profiles or volume presets.
 /// </para>
 /// <para>
-/// The fix is to write a temporary file in the same directory and then swap it in with a single
-/// filesystem operation. <see cref="File.Replace(string, string, string?)"/> is used when the
+/// The fix is to write a temporary file in the same directory, push it out of the operating system's
+/// write-back cache onto the device, and then swap it in with a single filesystem operation. The flush is
+/// what makes the power-loss half of the promise true: without it the rename can become durable while the
+/// data blocks are still in volatile cache, leaving an empty file under the final name. <see cref="File.Replace(string, string, string?)"/> is used when the
 /// destination already exists, because it preserves the destination's ACLs and attributes — a plain
 /// <c>Move(overwrite: true)</c> relinks a brand-new inode that inherits only the directory's default
 /// ACL, silently weakening the file. On first creation there is no descriptor to preserve, so a plain
@@ -103,6 +106,7 @@ internal static class AtomicFile
         try
         {
             writeTemp(temp);
+            FlushToDisk(temp);
             Swap(temp, path);
         }
         finally
@@ -117,6 +121,7 @@ internal static class AtomicFile
         try
         {
             await writeTemp(temp).ConfigureAwait(false);
+            FlushToDisk(temp);
             Swap(temp, path);
         }
         finally
@@ -154,12 +159,74 @@ internal static class AtomicFile
         return UniqueTempPath(path);
     }
 
+    /// <summary>
+    /// Pushes the temp file onto the device before the swap turns it into the destination.
+    /// </summary>
+    /// <remarks>
+    /// Closing a handle — which <c>File.WriteAllText</c> and its siblings do — hands the bytes to the
+    /// operating system's write-back cache. It does not ask the drive to persist them. The swap that
+    /// follows is a metadata change NTFS journals, so the rename can become durable while the data blocks
+    /// are still only in volatile cache: after a power cut the destination exists under its final name and
+    /// is empty or torn. That is the one outcome this class exists to prevent, and it is the quietest,
+    /// because the loaders reading these files treat an unparseable file as "no data" at Debug level.
+    /// <para>Stronger than <see cref="FileOptions.WriteThrough"/>, which bypasses the OS cache but leaves
+    /// the drive's own cache alone. This issues FlushFileBuffers, which commits it.</para>
+    /// <para>A device that cannot flush must not cost the caller a write that would otherwise have
+    /// completed — some network and virtual volumes refuse the call outright — so the failure is logged
+    /// and the swap proceeds. The result is then exactly the behaviour that shipped before this existed,
+    /// never a new exception.</para>
+    /// </remarks>
+    private static void FlushToDisk(string temp)
+    {
+        try
+        {
+            using var handle = new FileStream(temp, FileMode.Open, FileAccess.Write, FileShare.None);
+            handle.Flush(flushToDisk: true);
+        }
+        catch (IOException ex)
+        {
+            Log.Debug(ex, "Could not flush {Temp} onto the device; swapping it in regardless", temp);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Log.Debug(ex, "Could not open {Temp} to flush it; swapping it in regardless", temp);
+        }
+    }
+
     private static void Swap(string temp, string path)
     {
         if (File.Exists(path))
             File.Replace(temp, path, destinationBackupFileName: null);
         else
+            MoveIntoPlace(temp, path);
+    }
+
+    /// <summary>
+    /// The first-creation swap: with no destination descriptor to preserve, a plain move is correct.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Swap"/> asks whether the destination exists and then acts on the answer, and those are
+    /// two operations rather than one. Two writers saving a file that does not exist yet — the first save
+    /// of a preset, profile or history — can both be told "absent", and the loser's
+    /// <c>Move(overwrite: false)</c> then throws because the winner got there first. Callers log a failed
+    /// save at Debug, so that writer's data would disappear without a word. Every subsequent write is
+    /// already safe, since it takes the <see cref="File.Replace(string, string, string?)"/> branch.
+    /// <para>The fallback is that same replace rather than <c>Move(overwrite: true)</c>, which would
+    /// relink a new inode inheriting only the directory's default ACL — the thing this class's summary
+    /// argues against. It also makes the last writer win, which is the contract
+    /// <see cref="UniqueTempPath"/> already states.</para>
+    /// <para>Internal so a test can drive the state the race produces without depending on timing.</para>
+    /// </remarks>
+    internal static void MoveIntoPlace(string temp, string path)
+    {
+        try
+        {
             File.Move(temp, path, overwrite: false);
+        }
+        catch (IOException) when (File.Exists(path))
+        {
+            File.Replace(temp, path, destinationBackupFileName: null);
+        }
     }
 
     private static void CleanUp(string temp)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.22</Version>
-    <FileVersion>1.75.22.0</FileVersion>
-    <AssemblyVersion>1.75.22.0</AssemblyVersion>
+    <Version>1.75.23</Version>
+    <FileVersion>1.75.23.0</FileVersion>
+    <AssemblyVersion>1.75.23.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
fix: flush AtomicFile's temp onto the device and close the first-save race

AtomicFile's summary promises that "a crash, power loss or full disk can never
leave a half-written one behind." Crash and full disk were true. The other two
were not.

No flush before the swap. Write() called File.WriteAllText/Bytes and then
Swap(). Closing a handle hands the bytes to the operating system's write-back
cache; it never asks the drive to persist them. The swap that follows is a
metadata change NTFS journals, so the rename can become durable while the data
blocks are still only in volatile cache — after a power cut the destination
exists under its final name and is empty. That is the quietest possible failure
here, because the loaders reading these files catch JsonException and substitute
an empty list at Debug level. It is not limited to cosmetic history:
GamingProfileService writes the store whose ActiveSession is the crash-recovery
record, and PerformanceService writes the revert snapshot. Lose either and the
app concludes there is nothing to undo while the machine stays modified.

FlushToDisk now runs between the write and the swap in both the sync and async
paths. It issues FlushFileBuffers, which is stronger than
FileOptions.WriteThrough — that bypasses the OS cache but leaves the drive's own
cache alone. A device that refuses the call (some network and virtual volumes
do) is logged at Debug and the swap proceeds, so the outcome is never worse than
what shipped before.

First-creation race. Swap() asked File.Exists(path) and then acted on the
answer, and those are two operations. Two writers saving a file that does not
exist yet — the first save of a preset, profile or history — could both be told
"absent", and the loser's Move(overwrite: false) then threw because the winner
got there first. Callers log a failed save at Debug, so that writer's data
vanished without a word. Every later write was already safe: it takes the
File.Replace branch. MoveIntoPlace now falls back to that same replace, which
keeps the ACL-preserving behaviour the class summary argues for rather than
trading it for Move(overwrite: true), and makes the last writer win — the
contract UniqueTempPath already states.

Tests. The race is pinned behaviourally and deterministically: MoveIntoPlace is
internal precisely so a test can produce the state the race produces without
depending on thread timing, since a stress test would be a flaky test. A
negative test asserts a missing temp still fails, proving the catch filter does
not over-catch. The flush is not observable from managed code, so it is pinned
structurally, asserting the order of the two calls with comments stripped first.

Red/green: six mutations, all behaving as expected. Removing the flush, moving
it after the swap, removing it from WriteAsync only, and commenting it out so
only the prose has it each turn the guard red. Reverting MoveIntoPlace to a
plain move reds the race test with the real defect — "Cannot create a file when
that file already exists." Making the fallback swallow reds both.

Propagate: five more sites roll their own write-then-swap without a flush —
BandwidthHistoryService and ResourceHistoryService (both also using a fixed
".tmp" name), UpdateApplier's swap of the .exe itself, UpdateService's download,
and HostsFileService, which repeats the same Exists-then-Move shape. The update
path is the riskiest code in the app and deserves its own reviewable diff, so it
follows immediately rather than riding along here.

Docs: ARCHITECTURE listed neither AtomicFile nor what it guarantees, despite 19
call sites depending on it. Added.
