### PR TITLE
fix: route every temp-then-swap through the one durable swap

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -572,7 +572,12 @@ Key utility classes that don't fit neatly into Services or ViewModels (not an ex
   either the old file or the new one and never half of each. Load-bearing
   because the loaders that read these files treat an unparseable file as "no
   data" at Debug level, so a torn save would erase presets, profiles or history
-  without reporting anything.
+  without reporting anything. Services that must stage their own temp file — the
+  hosts-file writer, which has to keep the system file's hardened DACL — call
+  `SwapIntoPlace` for the same flush-then-swap, and the update path calls
+  `FlushOntoDevice` alone, because replacing the app's own executable must not
+  inherit the outgoing build's attributes. A fitness function asserts nobody
+  swaps a file into place without one of the two.
 - `BulkObservableCollection<T>` — `ObservableCollection` subclass that
   suppresses change notifications during bulk add/remove for UI performance
   (in `ObservableCollectionExtensions.cs`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.24] - 2026-09-01
+
+The previous release stopped a power cut from emptying a file SysManager had just saved. That fix covered the
+shared code every settings file goes through — and five more places had never used it, including the one that
+replaces SysManager's own program file when it updates itself.
+
+### Fixed
+- **An interrupted update can no longer leave SysManager unable to start.** Installing an update copies the
+  new version into place and then swaps it with the old one. Windows reports the copy as finished once it has
+  the data in memory, so losing power in between could leave the program file present and empty — and an
+  empty program file does not open at all, with no obvious way back. SysManager now waits for the drive to
+  confirm it has the new version before the swap.
+- **The hosts-file editor and both history files got the same protection.** Saving your hosts entries,
+  restoring the backup of them, and trimming the bandwidth or resource history all wrote a replacement file
+  and swapped it in, and none of them waited for the drive. All four now go through the same code the rest of
+  the app uses, which also means the hosts file keeps its own Windows permissions exactly as before.
+- **Trimming the history files no longer leaves a leftover file behind.** Both used the same fixed name for
+  the file they write before swapping, and neither deleted it if the swap failed, so a failure left it there
+  for good. They no longer name it themselves.
+- **A downloaded update is confirmed on the drive before it is stored.** The mildest of the five, because a
+  damaged download is already caught by its checksum when it is next used, but it is the same one-line
+  omission.
+
 ## [1.75.23] - 2026-09-01
 
 If the power went out or the machine was reset while SysManager was saving, a file it had just saved could come

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -5017,6 +5017,21 @@ public partial class ArchitectureTests
         var code = string.Join('\n', source.Split('\n')
             .Select(line => CommentTail().Replace(line, string.Empty)));
 
+        // The order lives in SwapIntoPlace now, because five services outside this class stage their own
+        // temp file and need the same two steps in the same order.
+        var swapIntoPlace = code.IndexOf("internal static void SwapIntoPlace(", StringComparison.Ordinal);
+        Assert.True(swapIntoPlace > 0,
+            "AtomicFile.SwapIntoPlace was not found — this guard would otherwise pass vacuously");
+
+        var flush = code.IndexOf("FlushOntoDevice(temp)", swapIntoPlace, StringComparison.Ordinal);
+        var swap = code.IndexOf("Swap(temp, path)", swapIntoPlace, StringComparison.Ordinal);
+        Assert.True(swap > swapIntoPlace, "SwapIntoPlace no longer swaps a temp into place");
+        Assert.True(flush > swapIntoPlace && flush < swap,
+            "SwapIntoPlace must flush the temp onto the device before the swap, or a power cut can leave "
+            + "the destination durable under its final name while its contents are still in the operating "
+            + "system's write-back cache");
+
+        // And neither writer may bypass it and swap on its own.
         string[] writers = ["private static void Write(", "private static async Task WriteAsync("];
 
         foreach (var writer in writers)
@@ -5024,15 +5039,91 @@ public partial class ArchitectureTests
             var start = code.IndexOf(writer, StringComparison.Ordinal);
             Assert.True(start > 0, $"{writer} was not found — this guard would otherwise pass vacuously");
 
-            var swap = code.IndexOf("Swap(temp, path)", start, StringComparison.Ordinal);
-            Assert.True(swap > start, $"{writer} no longer swaps a temp into place");
-
-            var flush = code.IndexOf("FlushToDisk(temp)", start, StringComparison.Ordinal);
-            Assert.True(flush > start && flush < swap,
-                $"{writer} must flush the temp onto the device before the swap, or a power cut can leave "
-                + "the destination durable under its final name while its contents are still in the "
-                + "operating system's write-back cache");
+            var body = code[start..code.IndexOf("finally", start, StringComparison.Ordinal)];
+            Assert.Contains("SwapIntoPlace(temp, path)", body, StringComparison.Ordinal);
         }
     }
+
+    [Fact]
+    public void NoServiceSwapsATempIntoPlaceOnItsOwn()
+    {
+        // Every File.Move and File.Replace in the app was measured before this guard was written: eleven
+        // sites, three of them inside AtomicFile and eight outside, and all eight were a temp-then-swap.
+        // Not one was an unrelated move. None of the eight flushed, so a power cut could make the rename
+        // durable while the contents were still in the write-back cache — including the swap of the app's
+        // own .exe during an update, which would leave a zero-length executable that will not start.
+        //
+        // The two update-path sites keep their own File.Move on purpose: File.Replace copies the outgoing
+        // file's attributes onto the replacement, and inheriting the old build's zone identifier is not a
+        // change worth making to the riskiest code in the app. They are allowlisted BY NAME and still have
+        // to flush, so the allowlist is not a way out of the durability requirement.
+        string[] stagesItsOwnSwap = ["UpdateApplier.cs", "UpdateService.cs"];
+
+        var root = Path.Combine(FindRepoRoot(), "SysManager", "SysManager");
+        var files = Directory.GetFiles(root, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")
+                        && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
+                        // AtomicFile is where the swap lives.
+                        && !f.EndsWith("AtomicFile.cs", StringComparison.Ordinal))
+            .ToArray();
+        Assert.NotEmpty(files);
+
+        List<string> offenders = [];
+        List<string> allowedButNotDurable = [];
+        var inspected = 0;
+
+        foreach (var file in files)
+        {
+            // Stripped BEFORE matching. Defensive rather than currently load-bearing, and the
+            // distinction was measured: no scanned file's prose matches today, because the pattern needs
+            // an opening paren and five comments name these calls without one — in HostsFileService,
+            // UpdateApplier and DnsHostsViewModel. Add a paren to any of them and that file becomes a
+            // reported offender while its code is correct, so the stripping stays.
+            var code = string.Join('\n', File.ReadAllLines(file)
+                .Select(line => CommentTail().Replace(line, string.Empty)));
+
+            inspected++;
+            if (!HandRolledSwap().IsMatch(code)) continue;
+
+            var name = Path.GetFileName(file);
+            if (!stagesItsOwnSwap.Contains(name))
+            {
+                offenders.Add(name);
+                continue;
+            }
+
+            if (!code.Contains("AtomicFile.FlushOntoDevice(", StringComparison.Ordinal)
+                && !code.Contains("Flush(flushToDisk: true)", StringComparison.Ordinal))
+            {
+                allowedButNotDurable.Add(name);
+            }
+        }
+
+        Assert.True(inspected >= 100,
+            $"the swap scan looked at only {inspected} files, so it is no longer looking at the app");
+
+        Assert.True(offenders.Count == 0,
+            "these swap a file into place themselves instead of calling AtomicFile.SwapIntoPlace, which is "
+            + "what flushes the contents onto the device first:\n  " + string.Join("\n  ", offenders));
+
+        Assert.True(allowedButNotDurable.Count == 0,
+            "these are allowed to swap on their own but must still make the contents durable first, either "
+            + "via AtomicFile.FlushOntoDevice or their own Flush(flushToDisk: true):\n  "
+            + string.Join("\n  ", allowedButNotDurable));
+
+        // The pattern has to actually recognise a hand-rolled swap, and has to leave the shared one alone.
+        Assert.Matches(HandRolledSwap(), "File.Move(tmp, _dataPath, overwrite: true);");
+        Assert.Matches(HandRolledSwap(), "File.Replace(tempPath, HostsPath, destinationBackupFileName: null);");
+        Assert.DoesNotMatch(HandRolledSwap(), "AtomicFile.SwapIntoPlace(tempPath, HostsPath);");
+        Assert.DoesNotMatch(HandRolledSwap(), "AtomicFile.MoveIntoPlace(temp, path);");
+
+        // An allowlist that names a file which no longer exists is a rule nobody is checking.
+        var present = files.Select(Path.GetFileName).ToHashSet(StringComparer.Ordinal);
+        Assert.All(stagesItsOwnSwap, name => Assert.Contains(name, present));
+    }
+
+    /// <summary>A file swapped into place by hand, in either of the two forms the app used.</summary>
+    [GeneratedRegex(@"File\.(Move|Replace)\s*\(")]
+    private static partial Regex HandRolledSwap();
 
 }

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1737,8 +1737,14 @@ public partial class ArchitectureTests
             }
         }
 
-        // Vacuity floor: if the regex stopped matching, this would pass while inspecting nothing.
-        Assert.True(scanned >= 5,
+        // Vacuity floor: if the regex stopped matching, this would pass while inspecting nothing. The
+        // number is a MEASURED population, not a target, and it falls every time a service adopts
+        // AtomicFile — it went from five to three when the two history writers moved to
+        // WriteAllLinesAsync. All three survivors are exempt below (ProfileService's export carve-out
+        // and two hash sidecars), so a broken regex still reports zero and still trips this. When the
+        // count legitimately drops again, re-measure and record which call went where; do not simply
+        // lower it, because an unexplained drop is what a broken regex looks like.
+        Assert.True(scanned >= 3,
             $"Only {scanned} raw File.Write* calls were seen across Services — the detection is "
             + "broken, not the code. Fix this guard rather than trusting it.");
 

--- a/SysManager/SysManager.Tests/AtomicFileTests.cs
+++ b/SysManager/SysManager.Tests/AtomicFileTests.cs
@@ -253,4 +253,39 @@ public class AtomicFileTests : IDisposable
         Assert.Equal(path, Assert.Single(Directory.GetFiles(_dir)));
     }
 
+    [Fact]
+    public async Task WriteAllLinesAsync_ReplacesTheContents_AndLeavesNoTempBehind()
+    {
+        var path = Path_("history.log");
+        await File.WriteAllLinesAsync(path, ["old one", "old two", "old three"]);
+
+        await AtomicFile.WriteAllLinesAsync(path, ["kept one", "kept two"]);
+
+        Assert.Equal(["kept one", "kept two"], await File.ReadAllLinesAsync(path));
+        Assert.Equal(path, Assert.Single(Directory.GetFiles(_dir)));
+    }
+
+    [Fact]
+    public async Task WriteAllLinesAsync_WritesTheSameBytesAsTheFrameworkCall()
+    {
+        // Both history writers pruned with File.WriteAllLinesAsync directly and both now go through here,
+        // so this must not change a single byte. They prune by line count, so a trailing newline gained or
+        // lost would change what the next prune reads back.
+        string[] lines = ["one", "two", ""];
+        var viaFramework = Path_("framework.log");
+        var viaHelper = Path_("helper.log");
+
+        await File.WriteAllLinesAsync(viaFramework, lines);
+        await AtomicFile.WriteAllLinesAsync(viaHelper, lines);
+
+        Assert.Equal(await File.ReadAllBytesAsync(viaFramework), await File.ReadAllBytesAsync(viaHelper));
+    }
+
+    [Fact]
+    public async Task WriteAllLinesAsync_RejectsNullLines()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => AtomicFile.WriteAllLinesAsync(Path_("x.log"), null!));
+    }
+
 }

--- a/SysManager/SysManager/Helpers/AtomicFile.cs
+++ b/SysManager/SysManager/Helpers/AtomicFile.cs
@@ -100,14 +100,33 @@ internal static class AtomicFile
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Writes <paramref name="lines"/> to <paramref name="path"/> atomically, one line each followed by a
+    /// newline, matching <see cref="File.WriteAllLinesAsync(string, IEnumerable{string}, CancellationToken)"/>
+    /// byte for byte.
+    /// </summary>
+    /// <remarks>
+    /// Exists so the history writers, which prune line-based files, do not have to name a temp, flush it and
+    /// swap it themselves. Both did, both used a fixed <c>"&lt;path&gt;.tmp"</c>, and neither deleted it when
+    /// the swap failed — so the temp handling had to move in here rather than merely be corrected in place.
+    /// </remarks>
+    public static async Task WriteAllLinesAsync(
+        string path, IEnumerable<string> lines, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(lines);
+
+        await WriteAsync(path, temp => File.WriteAllLinesAsync(temp, lines, ct))
+            .ConfigureAwait(false);
+    }
+
     private static void Write(string path, Action<string> writeTemp)
     {
         var temp = PrepareTempPath(path);
         try
         {
             writeTemp(temp);
-            FlushToDisk(temp);
-            Swap(temp, path);
+            SwapIntoPlace(temp, path);
         }
         finally
         {
@@ -121,8 +140,7 @@ internal static class AtomicFile
         try
         {
             await writeTemp(temp).ConfigureAwait(false);
-            FlushToDisk(temp);
-            Swap(temp, path);
+            SwapIntoPlace(temp, path);
         }
         finally
         {
@@ -176,7 +194,7 @@ internal static class AtomicFile
     /// and the swap proceeds. The result is then exactly the behaviour that shipped before this existed,
     /// never a new exception.</para>
     /// </remarks>
-    private static void FlushToDisk(string temp)
+    internal static void FlushOntoDevice(string temp)
     {
         try
         {
@@ -191,6 +209,21 @@ internal static class AtomicFile
         {
             Log.Debug(ex, "Could not open {Temp} to flush it; swapping it in regardless", temp);
         }
+    }
+
+    /// <summary>
+    /// Makes <paramref name="temp"/> durable and then makes it <paramref name="path"/>, in that order.
+    /// </summary>
+    /// <remarks>
+    /// The one durable swap in the app, for the services that stage their own temp file rather than handing
+    /// contents to <see cref="WriteAllText(string, string)"/> — the hosts file, which must keep its own
+    /// hardened DACL, and the history writers. Before this existed each of them repeated the two-branch
+    /// swap inline, one of them repeated its six-line rationale comment too, and none of them flushed.
+    /// </remarks>
+    internal static void SwapIntoPlace(string temp, string path)
+    {
+        FlushOntoDevice(temp);
+        Swap(temp, path);
     }
 
     private static void Swap(string temp, string path)

--- a/SysManager/SysManager/Services/BandwidthHistoryService.cs
+++ b/SysManager/SysManager/Services/BandwidthHistoryService.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Text.Json;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -97,9 +98,10 @@ public sealed class BandwidthHistoryService
             var lines = await File.ReadAllLinesAsync(_dataPath, ct).ConfigureAwait(false);
             var kept = Prune(lines, DateTime.Now, TimeSpan.FromDays(RetentionDays));
             if (kept.Count == lines.Length) return;
-            var tmp = _dataPath + ".tmp";
-            await File.WriteAllLinesAsync(tmp, kept, ct).ConfigureAwait(false);
-            File.Move(tmp, _dataPath, overwrite: true);
+            // AtomicFile names the temp, flushes it onto the device and swaps it in. Doing it here
+            // meant a fixed "<path>.tmp" that two writers would share, and no cleanup when the swap
+            // failed, so the temp stayed behind for good.
+            await AtomicFile.WriteAllLinesAsync(_dataPath, kept, ct).ConfigureAwait(false);
         }
         catch (OperationCanceledException) { /* shutdown */ }
         catch (IOException ex) { Log.Debug("Bandwidth history prune failed: {Error}", ex.Message); }

--- a/SysManager/SysManager/Services/HostsFileService.cs
+++ b/SysManager/SysManager/Services/HostsFileService.cs
@@ -236,17 +236,11 @@ public sealed partial class HostsFileService
         {
             File.WriteAllLines(tempPath, lines);
 
-            // File.Replace preserves the target's existing ACL/owner and attributes
-            // (it copies the security descriptor of the file being replaced onto the
-            // replacement), so the security-hardened system hosts file keeps its DACL.
-            // File.Move(overwrite:true) would instead relink a brand-new inode that
-            // inherits only the directory's default ACL — silently weakening the file.
-            // File.Replace requires the destination to already exist; on the very first
-            // creation there is no descriptor to preserve, so a plain Move is correct.
-            if (File.Exists(HostsPath))
-                File.Replace(tempPath, HostsPath, destinationBackupFileName: null);
-            else
-                File.Move(tempPath, HostsPath, overwrite: false);
+            // AtomicFile.SwapIntoPlace owns the two-branch swap and the flush that has to precede
+            // it, so the ACL rationale is stated once there instead of twice here: File.Replace copies
+            // the replaced file's security descriptor onto the replacement, which is how the hardened
+            // system hosts file keeps its DACL, and it needs the destination to already exist.
+            AtomicFile.SwapIntoPlace(tempPath, HostsPath);
         }
         finally
         {
@@ -280,10 +274,7 @@ public sealed partial class HostsFileService
         {
             File.Copy(BackupPath, tempPath, overwrite: true);
 
-            if (File.Exists(HostsPath))
-                File.Replace(tempPath, HostsPath, destinationBackupFileName: null);
-            else
-                File.Move(tempPath, HostsPath, overwrite: false);
+            AtomicFile.SwapIntoPlace(tempPath, HostsPath);
         }
         finally
         {

--- a/SysManager/SysManager/Services/ResourceHistoryService.cs
+++ b/SysManager/SysManager/Services/ResourceHistoryService.cs
@@ -251,12 +251,11 @@ public sealed class ResourceHistoryService : IDisposable
             var kept = Prune(lines, DateTime.Now, TimeSpan.FromDays(_retentionDays));
             // Only rewrite when something actually changed, to avoid needless disk churn.
             if (kept.Count == lines.Length) return;
-            // Atomic rewrite: write to a temp file in the same directory, then swap it in
-            // with a single File.Move. A crash mid-write can then only leave a stray .tmp
-            // (never read — the sampler reads _dataPath), never a truncated history file.
-            var tmp = _dataPath + ".tmp";
-            await File.WriteAllLinesAsync(tmp, kept, ct).ConfigureAwait(false);
-            File.Move(tmp, _dataPath, overwrite: true);
+            // Atomic rewrite through AtomicFile: it names the temp, flushes it onto the device and
+            // swaps it in, so an interrupted prune leaves the old history or the new one. Doing it here
+            // covered a crash but not a power cut — the swap became durable while the contents were
+            // still in the write-back cache — and the fixed "<path>.tmp" was never cleaned up.
+            await AtomicFile.WriteAllLinesAsync(_dataPath, kept, ct).ConfigureAwait(false);
         }
         catch (OperationCanceledException) { /* shutdown */ }
         catch (IOException ex) { Log.Debug("Resource history prune failed: {Error}", ex.Message); }

--- a/SysManager/SysManager/Services/UpdateApplier.cs
+++ b/SysManager/SysManager/Services/UpdateApplier.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using Serilog;
+using SysManager.Helpers;
 
 [assembly: InternalsVisibleTo("SysManager.Tests")]
 
@@ -295,6 +296,13 @@ internal static class UpdateApplier
                 // regressions. Best-effort: failing to retain a copy must never abort an update that
                 // is otherwise fine, so PreserveCurrentBuild swallows its own errors.
                 PreserveCurrentBuild(targetExe, updatesDir);
+                // File.Copy reports success once Windows has the bytes in memory. The move that follows
+                // is a metadata change, so a power cut between the two can leave targetExe — the app's
+                // own executable — present and zero-length, which means it will not start at all.
+                // Deliberately NOT AtomicFile.SwapIntoPlace: that replaces via File.Replace, which
+                // copies the outgoing file's attributes onto the replacement, and inheriting the old
+                // build's zone identifier and creation time is not a change worth making here.
+                AtomicFile.FlushOntoDevice(staging);
                 File.Move(staging, targetExe, overwrite: true);
                 return true;
             }

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -208,8 +208,12 @@ public sealed class UpdateService
                 progress?.Report((read, total));
             }
 
-            // Flush before hashing.
+            // Flush before hashing — and onto the device, not merely out of the managed buffer, so
+            // the move below cannot become durable while the download is still in the write-back cache.
+            // The stored hash would catch a torn file on reuse, so this is the mildest of these cases,
+            // but it costs one line.
             await file.FlushAsync(ct).ConfigureAwait(false);
+            file.Flush(flushToDisk: true);
             file.Close();
 
             // Compute SHA-256 on the completed temp file.

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.23</Version>
-    <FileVersion>1.75.23.0</FileVersion>
-    <AssemblyVersion>1.75.23.0</AssemblyVersion>
+    <Version>1.75.24</Version>
+    <FileVersion>1.75.24.0</FileVersion>
+    <AssemblyVersion>1.75.24.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
fix: route every temp-then-swap through the one durable swap

The previous change fixed the shared helper. It did not fix the services that
never adopted it. Every File.Move and File.Replace in the app was measured before
writing a line of this: eleven call sites, three inside AtomicFile and EIGHT
outside, and all eight were a temp-then-swap. Not one was an unrelated move. None
of the eight flushed, so a power cut could make the rename durable while the
contents were still in the operating system's write-back cache.

UpdateApplier is the one that matters most. It copies the new build to a staging
path and then moves it onto targetExe — the app's own executable. File.Copy
reports success once Windows has the bytes in memory, so losing power between the
copy and the move could leave SysManager.exe present and zero-length, which means
it does not start at all and there is no obvious way back.

HostsFileService repeated AtomicFile.Swap inline, twice, including a six-line
copy of the ACL rationale, and carried the same first-creation race. The two
history writers used a FIXED "<path>.tmp" and never deleted it when the swap
failed, so switching only the name to a unique one would have leaked a file per
failed prune forever — the temp handling had to move into the helper rather than
be corrected in place. UpdateService's FlushAsync flushed the managed buffer to
the OS, not the device; it is the mildest case because the stored hash catches a
torn download on reuse.

What changed. AtomicFile gains SwapIntoPlace (flush, then swap) and exposes
FlushOntoDevice; Write and WriteAsync now go through the former, so there is one
implementation rather than six. A WriteAllLinesAsync overload lets the two
history writers stop hand-rolling anything — three lines each become one. Hosts
save and hosts restore call SwapIntoPlace, which keeps File.Replace and therefore
the hardened system DACL, stated once now instead of twice. The two update-path
sites keep their own File.Move on purpose: File.Replace copies the outgoing
file's attributes onto the replacement, and inheriting the old build's zone
identifier and creation time is not a change worth making to the riskiest code in
the app. They get the flush and nothing else.

Guards. The existing flush guard was TIGHTENED rather than duplicated — it
asserted the order inside Write and WriteAsync, which now delegate, so it asserts
it inside SwapIntoPlace and separately that neither writer bypasses it. The new
guard asserts no file outside AtomicFile swaps a temp into place, with the two
update-path files allowlisted BY NAME and still required to flush, so the
allowlist is not a way out of the requirement. It also fails if the allowlist
names a file that no longer exists.

Correction worth recording: I first wrote that the guard's comment-stripping was
load-bearing because HostsFileService's replacement comment names File.Replace.
The mutation refuted it — the guard stayed green with the stripping removed,
because the pattern needs an opening paren and all five prose mentions in scanned
files write the name without one (HostsFileService:240 and :265,
UpdateApplier:145 and :302, DnsHostsViewModel:525). The comment now says the
stripping is defensive and why, and the mutation pair proves it works: adding
matching prose to a file that swaps nothing keeps the guard green, and removing
the stripping with that prose present turns it red.

Red/green: nine mutations, all as expected. Flushing after the swap, not
flushing, and bypassing SwapIntoPlace each red the flush guard. HostsFileService
or BandwidthHistoryService rolling its own swap again reds the new guard, and so
does UpdateApplier keeping its move while dropping the flush. Making
WriteAllLinesAsync join with a plain newline reds the byte-for-byte test, which
exists because both history services prune by line count — a trailing newline
gained or lost would change what the next prune reads back.

Regression: 249 tests across AtomicFile, HostsFileService, both history services,
DnsHostsViewModel and every UpdateService suite, all green.

Follow-up commit on this branch: CI caught that
EveryServiceThatPersistsUserData_WritesItAtomically asserts a floor of five raw
File.Write* calls across Services, and migrating the two history writers took
that measured population from five to three. The guard was right — an
unexplained drop is what a broken regex looks like. Floor re-measured to three
with the reason recorded, and verified that a pattern matching nothing still
reports zero and still trips it. Found by CI rather than locally because the
harness run covered the affected test classes and not ArchitectureTests; the full
66-method sweep is now part of the check.
