### PR TITLE
fix: stop PerformanceViewModel.Dispose blocking the thread its own release needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.25] - 2026-09-02
+
+Closing SysManager immediately after changing something on the Performance tab could leave the window frozen
+for two seconds before it disappeared.
+
+### Fixed
+- **Closing the window during a performance change no longer freezes it for two seconds.** Before it changes
+  anything, the Performance tab records what your settings were, so that "Restore All" can put them back.
+  That recording can take a few seconds, because reading Windows power settings is slow. If you closed the
+  window while it was still going, the shutdown waited for the recording to finish before letting go — and it
+  waited on the very thing the recording needed in order to finish, so it could only ever run out of patience.
+  The result was a two-second freeze that accomplished nothing: it gave up and carried on regardless. Shutdown
+  no longer waits at all. Nothing about your recorded settings changes; the wait was the only thing that was
+  ever going to happen, and now it does not.
+
 ## [1.75.24] - 2026-09-01
 
 The previous release stopped a power cut from emptying a file SysManager had just saved. That fix covered the

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -5270,4 +5270,82 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"EntryPoint\s*=\s*""(?<entry>[^""]+)""", RegexOptions.CultureInvariant)]
     private static partial Regex EntryPointArgument();
 
+    [Fact]
+    public void NoViewModelDispose_BlocksOnAWaitItCannotWin()
+    {
+        // PerformanceViewModel.Dispose used to block on _snapshotGate.Wait(TimeSpan.FromSeconds(2)).
+        // Dispose runs on the UI thread — MainWindow.OnClosed and OnApplicationExit, and the container
+        // disposal in App.OnExit — and every gate-held await in EnsureSnapshotAsync captures the UI
+        // SynchronizationContext, so its finally { ReleaseSnapshotGate(); } can only run as a dispatcher
+        // continuation. Blocking the dispatcher does not wait for the holder to finish; it guarantees the
+        // holder cannot finish. The two seconds were always burned in full, the wait always returned
+        // false, and the snapshot clear it was protecting was skipped in exactly the case it existed for.
+        // Closing the window during an Apply froze the window for two seconds and achieved nothing.
+        //
+        // So a timeout is not "safer" than Wait(0) here, it is strictly worse, and a bare Wait() is the
+        // same deadlock with no exit. Wait(0) is the only defensible form: it clears whenever the gate is
+        // free, which is nearly always, and gives up instantly when it is not.
+        //
+        // Scoped to view models because that is where the dispatcher is, and the scope was measured. The
+        // four Task.Wait calls in Services all wait on a task started with Task.Run, which runs with no
+        // SynchronizationContext, so their continuations resume on the pool and no dispatcher is
+        // involved. GamingProfileService's bounded gate wait is sound for the reason its own source
+        // states: all three of its acquisitions use ConfigureAwait(false).
+        var dir = Path.Combine(FindRepoRoot(), "SysManager", "SysManager", "ViewModels");
+        var files = Directory.GetFiles(dir, "*.cs");
+        Assert.NotEmpty(files);
+
+        List<string> offenders = [];
+        var withDispose = 0;
+
+        foreach (var file in files)
+        {
+            // Comments stripped before matching: the explanation above this guard's own subject lives in
+            // PerformanceViewModel's Dispose and discusses timeouts at length.
+            var code = string.Join('\n', File.ReadAllLines(file)
+                .Select(line => CommentTail().Replace(line, string.Empty)));
+
+            var start = code.IndexOf("protected override void Dispose(bool", StringComparison.Ordinal);
+            if (start < 0) continue;
+
+            withDispose++;
+
+            foreach (var match in BlockingWaitInDispose().Matches(code[start..]).Cast<Match>())
+            {
+                var line = code[..(start + match.Index)].Count(c => c == '\n') + 1;
+                offenders.Add($"{Path.GetFileName(file)}:{line}");
+            }
+        }
+
+        Assert.True(withDispose >= 40,
+            $"only {withDispose} view models were seen to override Dispose(bool) — the scan is broken, "
+            + "not the code. There were 46 when this guard was written.");
+
+        Assert.True(offenders.Count == 0,
+            "these block inside a view model's Dispose, which runs on the UI thread. If whatever they "
+            + "wait on releases from a dispatcher continuation, the wait can never be satisfied — it "
+            + "freezes the window for its full timeout and then gives up. Use Wait(0):\n  "
+            + string.Join("\n  ", offenders));
+
+        // The permitted form is still there, and still inside the gate: deleting the clear entirely would
+        // otherwise satisfy the assertion above while losing the protection.
+        var performance = File.ReadAllText(Path.Combine(dir, "PerformanceViewModel.cs"));
+        Assert.Contains("_snapshotGate.Wait(0)", performance, StringComparison.Ordinal);
+
+        // Positive control: the pattern has to recognise every blocking form and leave Wait(0) alone.
+        Assert.Matches(BlockingWaitInDispose(), ".Wait(TimeSpan.FromSeconds(2))");
+        Assert.Matches(BlockingWaitInDispose(), ".Wait(2000)");
+        Assert.Matches(BlockingWaitInDispose(), ".Wait()");
+        Assert.Matches(BlockingWaitInDispose(), ".Wait(cancellationToken)");
+        Assert.DoesNotMatch(BlockingWaitInDispose(), ".Wait(0)");
+        Assert.DoesNotMatch(BlockingWaitInDispose(), ".Wait(0, ct)");
+    }
+
+    /// <summary>
+    /// A blocking wait that is not the immediate, non-blocking <c>Wait(0)</c> form. A bare <c>Wait()</c>
+    /// and <c>Wait(token)</c> both block indefinitely, so both count.
+    /// </summary>
+    [GeneratedRegex(@"\.Wait\(\s*(?!0\s*[,)])", RegexOptions.CultureInvariant)]
+    private static partial Regex BlockingWaitInDispose();
+
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.24</Version>
-    <FileVersion>1.75.24.0</FileVersion>
-    <AssemblyVersion>1.75.24.0</AssemblyVersion>
+    <Version>1.75.25</Version>
+    <FileVersion>1.75.25.0</FileVersion>
+    <AssemblyVersion>1.75.25.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
@@ -829,9 +829,24 @@ public sealed partial class PerformanceViewModel : ViewModelBase
             // Clear the snapshot INSIDE the gate. Clearing it outside meant a tab closed mid-Apply
             // could null the recovery snapshot while EnsureSnapshotAsync was still capturing or saving
             // it — the exact "a tweak applied with no snapshot left to revert it" outcome the gate
-            // exists to prevent. Bounded, like GamingProfileService's Dispose: the holder finishes in
-            // well under this, and a teardown must never hang waiting for it.
-            if (_snapshotGate.Wait(TimeSpan.FromSeconds(2)))
+            // exists to prevent.
+            //
+            // Wait(0), never a timeout. This runs on the UI thread (MainWindow.OnClosed and
+            // OnApplicationExit, and the container disposal in OnExit), and every gate-held await in
+            // EnsureSnapshotAsync captures the UI SynchronizationContext, so its
+            // finally { ReleaseSnapshotGate(); } can only run as a dispatcher continuation. Blocking the
+            // dispatcher does not "wait for the holder to finish" — it guarantees the holder can never
+            // finish, so a timeout is always burned in full and always returns false. Closing the window
+            // during an Apply froze it for two seconds and then skipped this clear anyway, in exactly the
+            // case the clear was written for. Wait(0) reaches the same outcome without the freeze, and
+            // still clears whenever the gate is free, which is almost always.
+            //
+            // This is why the earlier version's appeal to GamingProfileService.Dispose did not hold:
+            // that service acquires its gate with ConfigureAwait(false) at every site, so its release
+            // continuation runs off the UI thread and its bounded wait really does acquire. Adding the
+            // same discipline here would move HasSnapshot and the _snapshot assignment off the UI
+            // thread, which is a thread-affinity change and not something to make inside a bug fix.
+            if (_snapshotGate.Wait(0))
             {
                 try { _snapshot = null; }
                 finally { _snapshotGate.Release(); }


### PR DESCRIPTION
fix: stop PerformanceViewModel.Dispose blocking the thread its own release needs

Dispose blocked on `_snapshotGate.Wait(TimeSpan.FromSeconds(2))`, described in a
comment as a bounded wait. It is not bounded, it is unsatisfiable.

Dispose runs on the UI thread — MainWindow.OnClosed and OnApplicationExit, and
the container disposal in App.OnExit. The gate holder is EnsureSnapshotAsync, and
every one of its gate-held awaits captures the UI SynchronizationContext:

    _snapshot ??= await Task.Run(_service.LoadSnapshot);
    var captured = await _service.TakeSnapshotAsync();
    var saved = await Task.Run(() => _service.SaveSnapshot(captured));
    finally { ReleaseSnapshotGate(); }

None uses ConfigureAwait(false), so that finally can only run as a dispatcher
continuation. Blocking the dispatcher therefore does not wait for the holder to
finish; it guarantees the holder cannot finish. The two seconds were always burned
in full, the wait always returned false, and `_snapshot = null` — the thing the
block exists for — was skipped in exactly the case it was written to cover.

The user-visible result: apply something on the Performance tab, close the window
while powercfg is still being probed, and the whole window freezes for two seconds
and then closes having achieved nothing.

Fix: Wait(0). Free gate — the overwhelmingly common case at shutdown — acquires
instantly and clears the snapshot exactly as before. Held gate — skips the clear
immediately, which is the same outcome the timeout produced, minus the freeze.

Deliberately NOT "add ConfigureAwait(false) to the four awaits". That would move
`HasSnapshot = true` and the `_snapshot` assignment off the UI thread, changing
the thread affinity of bound-property writes inside a bug fix. Minimal diff.

The comment cited GamingProfileService.Dispose as precedent, and that is where the
copy went wrong. Its premise is real and its own source states it: all three of
its gate acquisitions use ConfigureAwait(false) (lines 201, 249, 304, each with a
comment naming this exact deadlock), so its release continuation runs off the UI
thread and its bounded wait genuinely acquires. The comment now explains the
difference instead of borrowing the conclusion.

Propagate, measured before writing the guard. Every blocking wait in the app:
GamingProfileService:534 is the sound one just described; EtwBandwidthSource:290,
PingMonitorService:62, ResourceHistoryService:393 and TracerouteMonitorService:74
all wait on a task started with Task.Run, which runs with no
SynchronizationContext, so their continuations can only resume on the pool and no
dispatcher is involved. This view model was the only instance. Across all 65 view
models there is exactly one blocking wait, and it is now the permitted form.

Guard: no view model's Dispose may make a blocking wait that is not Wait(0) —
including a bare Wait() and Wait(token), which block indefinitely. It also asserts
the permitted form is still present, because deleting the clear entirely would
otherwise satisfy the offender check while losing the protection.

Red/green: six mutations, all red. The timeout returning; a bare Wait(); a
Wait(token); the clear block deleted; a SECOND view model blocking in its Dispose;
and the pattern broken, which trips the floor rather than passing clean. The first
attempt at two of them did not compile — SemaphoreSlim.Wait() and Wait(token)
return void, so they cannot sit in an `if` — and a mutation that does not compile
proves nothing, so both were rewritten as statements.

Regression: 28 PerformanceViewModel tests green, and the full 68-method
ArchitectureTests sweep run rather than a subset — 72 green, the two exceptions
harness-only and green in CI.
