### PR TITLE
fix: spare every app's bundle-extraction folder, not just this build's leaf

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -588,6 +588,13 @@ Key utility classes that don't fit neatly into Services or ViewModels (not an ex
 - `GatewayHelper` — default gateway IP lookup for network tabs.
 - `EtaCalculator` — estimates time remaining for long-running operations.
 - `KnownFolders` — resolves Windows Known Folder paths via shell API.
+- `SystemPaths` — the one place Windows locations are resolved. Turns a bare tool
+  name into a full System32 path so nothing launches by name off the PATH, and
+  owns the two temp exclusions every wholesale %TEMP% sweep must honour:
+  `BundleExtractionRoot`, the shared folder single-file apps unpack into, and
+  `OwnExtractionDirectory`, this build's own leaf under it. Deleting either
+  breaks a running program's later lazy loads, which no in-use check can
+  prevent because nothing holds those files open yet.
 - `RecycleBinHelper` — empties the Recycle Bin via the shell API; shared by Deep
   Cleanup and the One-Click Tune-Up so the interop has one source of truth.
 - `MarkdownTextBlock` — lightweight Markdown-to-WPF inline renderer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.26] - 2026-09-02
+
+Cleaning temporary files could delete part of another program while it was running, which usually showed up
+later as that program failing to do something it had worked fine at before.
+
+### Fixed
+- **Temporary-file cleanup no longer deletes pieces of other running programs.** Some programs, SysManager
+  included, ship as a single file and unpack the parts they need into a shared folder inside your temp
+  folder while they run. SysManager already knew to leave its own unpacked parts alone — it had learned
+  that the hard way — but it only skipped its own, so everything belonging to every other program in that
+  same shared folder was fair game. Deleting those does not usually fail loudly: the program keeps running
+  on what it had already loaded and then breaks later, when it reaches for a part that is no longer there,
+  with nothing to connect the failure to a cleanup that happened earlier. Both cleanups — the "Temporary
+  files" category in Deep Cleanup and the temp step in One-Click Tune-Up — now leave that whole shared
+  folder alone.
+- **The description of that category no longer promises more than it delivered.** It said anything still in
+  use is skipped automatically, which is only true of files a program is holding open. It now says that,
+  and adds that the folder programs unpack themselves into is skipped entirely.
+
 ## [1.75.25] - 2026-09-02
 
 Closing SysManager immediately after changing something on the Performance tab could leave the window frozen

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -4494,7 +4494,7 @@ public partial class ArchitectureTests
     /// test stay green.</para>
     /// </remarks>
     [Fact]
-    public void EveryTempTreeWalkerCall_PassesTheOwnExtractionExclusion()
+    public void EveryTempTreeWalkerCall_PassesBothExtractionExclusions()
     {
         var servicesDir = Path.Combine(FindAppProjectDir(), "Services");
         string[] sweepers = ["TuneUpService.cs", "DeepCleanupService.cs"];
@@ -4514,6 +4514,14 @@ public partial class ArchitectureTests
                 if (args.Contains("CancellationToken", StringComparison.Ordinal)) continue;
 
                 callsChecked++;
+
+                // BOTH, not either. OwnExtractionDirectory is one LEAF of BundleExtractionRoot, so on
+                // its own it spared this app's unpacked native libraries and left every other
+                // single-file .NET app's siblings under the same root to be deleted — the exact failure
+                // OwnExtractionDirectory's own documentation describes, inflicted on someone else. The
+                // leaf stays because for a non-single-file build BaseDirectory is the output folder,
+                // which no extraction root contains.
+                Assert.Contains("SystemPaths.BundleExtractionRoot", args, StringComparison.Ordinal);
                 Assert.Contains("SystemPaths.OwnExtractionDirectory", args, StringComparison.Ordinal);
             }
         }

--- a/SysManager/SysManager.Tests/SystemPathsTests.cs
+++ b/SysManager/SysManager.Tests/SystemPathsTests.cs
@@ -245,4 +245,55 @@ public class SystemPathsTests
             resolved,
             ignoreCase: true);
     }
+    [Theory]
+    // Redirected by the host variable: taken as given, only normalised.
+    [InlineData(@"D:\bundles\", null, @"D:\bundles")]
+    [InlineData(@"D:\bundles", null, @"D:\bundles")]
+    // Not redirected: <temp>\.net, with or without the trailing separator the environment supplies.
+    [InlineData(null, @"C:\Temp\", @"C:\Temp\.net")]
+    [InlineData(null, @"C:\Temp", @"C:\Temp\.net")]
+    [InlineData("", @"C:\Temp\", @"C:\Temp\.net")]
+    [InlineData("   ", @"C:\Temp\", @"C:\Temp\.net")]
+    public void ResolveBundleExtractionRoot_PrefersTheHostOverrideThenTempDotNet(
+        string? overrideDir, string? tempPath, string expected)
+    {
+        // The root matters more than this app's own leaf under it: excluding only the leaf left every
+        // OTHER single-file .NET app's extracted native libraries exposed to a wholesale %TEMP% sweep.
+        Assert.Equal(expected, SystemPaths.ResolveBundleExtractionRoot(overrideDir, tempPath ?? @"C:\Temp"));
+    }
+
+    [Fact]
+    public void BundleExtractionRoot_IsResolvedAndContainsNothingElsesTemp()
+    {
+        // Resolved once at type initialisation, so a test can only assert shape — which is exactly why
+        // the branching lives in ResolveBundleExtractionRoot above.
+        var root = SystemPaths.BundleExtractionRoot;
+
+        Assert.False(string.IsNullOrWhiteSpace(root));
+        Assert.True(Path.IsPathFullyQualified(root!));
+        Assert.Equal(Path.TrimEndingDirectorySeparator(root!), root);
+
+        // A sibling of the extraction root inside the same temp folder must NOT be excluded, or a sweep
+        // would silently spare unrelated temp files.
+        Assert.False(SystemPaths.IsInsideSubtree(Path.Join(Path.GetTempPath(), "unrelated.tmp"), root));
+    }
+
+    [Fact]
+    public void IsInsideAnySubtree_ExcludesAMatchInAnyPosition_AndIgnoresBlanks()
+    {
+        // The walkers pass the extraction root AND this process's own leaf, so a candidate matching
+        // either has to be excluded regardless of order — and a null among them must exclude nothing,
+        // since BundleExtractionRoot can fail to resolve on an unusual machine.
+        const string other = @"C:\Temp\.net\SomeOtherApp\abc123\native.dll";
+        const string root = @"C:\Temp\.net";
+        const string own = @"C:\Temp\.net\SysManager-v1.0.0\hash";
+
+        Assert.True(SystemPaths.IsInsideAnySubtree(other, root, own));
+        Assert.True(SystemPaths.IsInsideAnySubtree(other, own, root));
+        Assert.True(SystemPaths.IsInsideAnySubtree(other, null, root));
+        Assert.False(SystemPaths.IsInsideAnySubtree(other, null, ""));
+        Assert.False(SystemPaths.IsInsideAnySubtree(@"C:\Temp\unrelated.tmp", root, own));
+        Assert.False(SystemPaths.IsInsideAnySubtree(other));
+    }
+
 }

--- a/SysManager/SysManager.Tests/TuneUpServiceTests.cs
+++ b/SysManager/SysManager.Tests/TuneUpServiceTests.cs
@@ -517,10 +517,47 @@ public class TuneUpServiceTests
     }
 
     [Fact]
+    public void EnumerateFiles_SkipsAnotherAppsExtractionFolder_NotJustOurOwn()
+    {
+        // The half the leaf exclusion above could never cover. Every single-file .NET app unpacks under
+        // the SAME root, so excluding only our own <root>\<app>\<hash> spared our native libraries and
+        // left every sibling to be deleted — inflicting on another running app exactly the failure our
+        // own exclusion exists to prevent, including the "extracted but not yet loaded" case that no
+        // in-use check can see, because nothing holds those files open yet.
+        //
+        // Layout: temp/ordinary.txt                    -> must be enumerated
+        //         temp/.net/ours/hash/ours.dll         -> must NOT be (our leaf)
+        //         temp/.net/theirs/hash/theirs.dll     -> must NOT be (the root, and the actual defect)
+        var root = Path.Combine(Path.GetTempPath(), "smtu_" + Guid.NewGuid().ToString("N"));
+        var extractionRoot = Path.Combine(root, ".net");
+        var ours = Path.Combine(extractionRoot, "ours", "hash");
+        var theirs = Path.Combine(extractionRoot, "theirs", "hash");
+        Directory.CreateDirectory(ours);
+        Directory.CreateDirectory(theirs);
+        File.WriteAllText(Path.Combine(root, "ordinary.txt"), "an unrelated temp file");
+        File.WriteAllText(Path.Combine(ours, "ours.dll"), "a native library this process needs");
+        File.WriteAllText(Path.Combine(theirs, "theirs.dll"), "a native library another app needs");
+
+        try
+        {
+            var found = TuneUpService
+                .EnumerateFilesSkippingReparsePoints(root, CancellationToken.None, extractionRoot, ours)
+                .ToList();
+
+            Assert.Contains(found, f => f.EndsWith("ordinary.txt", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(found, f => f.EndsWith("ours.dll", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(found, f => f.EndsWith("theirs.dll", StringComparison.OrdinalIgnoreCase));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Fact]
     public void EnumerateFiles_WithNoExclusion_StillYieldsEverything()
     {
-        // The exclusion must be opt-in: passing null (what every other caller does) changes nothing,
-        // so this cannot pass by the traversal having quietly become more restrictive for everyone.
+        // A null among the exclusions must exclude NOTHING rather than everything. Real callers pass
+        // SystemPaths.BundleExtractionRoot, which resolves to null on a machine where that path cannot
+        // be formed, and the walkers hand it straight to the comparison — so getting this backwards
+        // would silently turn the temp cleanup into a no-op on exactly those machines.
         var root = Path.Combine(Path.GetTempPath(), "smtu_" + Guid.NewGuid().ToString("N"));
         var sub = Path.Combine(root, ".net", "app");
         Directory.CreateDirectory(sub);
@@ -530,7 +567,7 @@ public class TuneUpServiceTests
         try
         {
             var found = TuneUpService
-                .EnumerateFilesSkippingReparsePoints(root, CancellationToken.None, null)
+                .EnumerateFilesSkippingReparsePoints(root, CancellationToken.None, (string?)null)
                 .ToList();
 
             Assert.Contains(found, f => f.EndsWith("ordinary.txt", StringComparison.OrdinalIgnoreCase));

--- a/SysManager/SysManager/Helpers/SystemPaths.cs
+++ b/SysManager/SysManager/Helpers/SystemPaths.cs
@@ -187,6 +187,43 @@ internal static class SystemPaths
     internal static string? OwnExtractionDirectory { get; } = Normalise(AppContext.BaseDirectory);
 
     /// <summary>
+    /// The root the .NET host extracts single-file bundles into — every app's, not just this one's.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="OwnExtractionDirectory"/> is one LEAF of this root: <c>&lt;root&gt;\&lt;app&gt;\&lt;hash&gt;</c>.
+    /// Excluding only the leaf spared this app's unpacked libraries and left every sibling exposed, so a
+    /// temp sweep deleted the extracted native libraries of any other single-file .NET app the user had
+    /// running — inflicting on them precisely the failure documented on <see cref="OwnExtractionDirectory"/>,
+    /// including the "extracted but not yet loaded" case, which no in-use check can see because nothing
+    /// holds those files open yet.
+    /// <para>Resolved through <see cref="ResolveBundleExtractionRoot"/> so both branches are testable: a
+    /// property computed at type initialisation cannot be re-pointed by a test.</para>
+    /// </remarks>
+    internal static string? BundleExtractionRoot { get; } = ResolveBundleExtractionRoot(
+        Environment.GetEnvironmentVariable("DOTNET_BUNDLE_EXTRACT_BASE_DIR"), Path.GetTempPath());
+
+    /// <summary>
+    /// Where single-file bundles are extracted: <paramref name="overrideDir"/> when the host has been
+    /// redirected with <c>DOTNET_BUNDLE_EXTRACT_BASE_DIR</c>, otherwise <c>&lt;temp&gt;\.net</c>.
+    /// </summary>
+    internal static string? ResolveBundleExtractionRoot(string? overrideDir, string tempPath) =>
+        Normalise(string.IsNullOrWhiteSpace(overrideDir) ? Path.Join(tempPath, ".net") : overrideDir);
+
+    /// <summary>
+    /// True when <paramref name="candidate"/> sits in ANY of <paramref name="subtrees"/>. Nulls and blanks
+    /// among them exclude nothing, so a caller can pass a value that may not resolve on this machine.
+    /// </summary>
+    internal static bool IsInsideAnySubtree(string candidate, params string?[] subtrees)
+    {
+        foreach (var subtree in subtrees)
+        {
+            if (IsInsideSubtree(candidate, subtree)) return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// True when <paramref name="candidate"/> IS <paramref name="subtree"/> or sits inside it.
     /// Compared on a directory boundary, so a sibling such as <c>…\SysManagerX</c> is never mistaken
     /// for <c>…\SysManager</c> — the same boundary rule the system-root checks use elsewhere.

--- a/SysManager/SysManager/Services/DeepCleanupService.cs
+++ b/SysManager/SysManager/Services/DeepCleanupService.cs
@@ -87,7 +87,8 @@ public sealed class DeepCleanupService
                 [Path.Combine(windowsDir, "Installer", "$PatchCache$")]),
 
             new("Temporary files",
-                "Per-user and system TEMP folders. Anything still in use is skipped automatically.",
+                "Per-user and system TEMP folders. Files an app is holding open are skipped, and the "
+                + "folder apps unpack themselves into is left alone entirely.",
                 [tempUser, Path.Combine(windowsDir, "Temp")]),
 
             new("Prefetch files",
@@ -202,7 +203,7 @@ public sealed class DeepCleanupService
             foreach (var p in existing)
             {
                 if (ct.IsCancellationRequested) break;
-                foreach (var file in EnumerateFiles(p, ct, SystemPaths.OwnExtractionDirectory))
+                foreach (var file in EnumerateFiles(p, ct, SystemPaths.BundleExtractionRoot, SystemPaths.OwnExtractionDirectory))
                 {
                     if (ct.IsCancellationRequested) break;
                     try
@@ -359,7 +360,7 @@ public sealed class DeepCleanupService
 
                 try
                 {
-                    foreach (var file in EnumerateFiles(path, ct, SystemPaths.OwnExtractionDirectory))
+                    foreach (var file in EnumerateFiles(path, ct, SystemPaths.BundleExtractionRoot, SystemPaths.OwnExtractionDirectory))
                     {
                         if (ct.IsCancellationRequested) break;
                         try
@@ -381,7 +382,7 @@ public sealed class DeepCleanupService
                             Log.Debug(ex, "Deep cleanup: failed to delete file {File}", file);
                         }
                     }
-                    foreach (var dir in EnumerateDirectoriesDepthFirst(path, ct, SystemPaths.OwnExtractionDirectory))
+                    foreach (var dir in EnumerateDirectoriesDepthFirst(path, ct, SystemPaths.BundleExtractionRoot, SystemPaths.OwnExtractionDirectory))
                     {
                         try { Directory.Delete(dir, recursive: false); }
                         catch (IOException ex) { Log.Debug(ex, "Deep cleanup: failed to delete directory {Dir}", dir); }
@@ -411,22 +412,23 @@ public sealed class DeepCleanupService
     private static long SafeLength(string path)
     { try { return new FileInfo(path).Length; } catch (IOException) { return 0; } catch (UnauthorizedAccessException) { return 0; } }
 
-    /// <param name="excludeSubtree">
-    /// A directory tree to skip entirely, or null for none. Callers pass
+    /// <param name="excludeSubtrees">
+    /// Directory trees to skip entirely. Callers pass <see cref="SystemPaths.BundleExtractionRoot"/> and
     /// <see cref="SystemPaths.OwnExtractionDirectory"/>: the "Temporary files" definition covers all of
-    /// %TEMP%, which for a single-file build is where this process unpacked its own native libraries.
-    /// Deleting those made a clean run report errors (loaded files refuse to delete) and broke a later
-    /// lazy load for anything unpacked but not yet opened.
+    /// %TEMP%, which is where every single-file .NET app unpacks its native libraries. Deleting those made
+    /// a clean run report errors (loaded files refuse to delete) and broke a later lazy load for anything
+    /// unpacked but not yet opened — and excluding only this process's own leaf did that to every OTHER
+    /// app under the same root.
     /// </param>
     private static IEnumerable<string> EnumerateFiles(
-        string root, CancellationToken ct, string? excludeSubtree = null)
+        string root, CancellationToken ct, params string?[] excludeSubtrees)
     {
         // Guard the traversal ROOT itself, not just its children: if a cleanup-root
         // cache path is replaced by a junction/symlink (writable without admin, e.g.
         // %LOCALAPPDATA%\NVIDIA\GLCache), EnumerateFiles(root) would yield the LINK
         // TARGET's files and the caller would delete them — data loss outside the
         // target tree. IsReparsePoint fails safe (returns true on access error).
-        if (IsReparsePoint(root) || SystemPaths.IsInsideSubtree(root, excludeSubtree)) yield break;
+        if (IsReparsePoint(root) || SystemPaths.IsInsideAnySubtree(root, excludeSubtrees)) yield break;
         var stack = new Stack<string>();
         stack.Push(root);
         while (stack.Count > 0 && !ct.IsCancellationRequested)
@@ -454,18 +456,18 @@ public sealed class DeepCleanupService
             // files that live outside the cleanup target tree (data-loss risk).
             foreach (var d in dirs)
             {
-                if (!IsReparsePoint(d) && !SystemPaths.IsInsideSubtree(d, excludeSubtree)) stack.Push(d);
+                if (!IsReparsePoint(d) && !SystemPaths.IsInsideAnySubtree(d, excludeSubtrees)) stack.Push(d);
             }
         }
     }
 
     private static IEnumerable<string> EnumerateDirectoriesDepthFirst(
-        string root, CancellationToken ct, string? excludeSubtree = null)
+        string root, CancellationToken ct, params string?[] excludeSubtrees)
     {
         List<string> all = [];
         // Guard the root (see EnumerateFiles): a junction at the root must not be
         // traversed, or its target's subdirectories could be reached for deletion.
-        if (IsReparsePoint(root) || SystemPaths.IsInsideSubtree(root, excludeSubtree)) return all;
+        if (IsReparsePoint(root) || SystemPaths.IsInsideAnySubtree(root, excludeSubtrees)) return all;
         var stack = new Stack<string>();
         stack.Push(root);
         while (stack.Count > 0 && !ct.IsCancellationRequested)
@@ -477,7 +479,7 @@ public sealed class DeepCleanupService
             // link recursively) could reach outside the cleanup tree.
             foreach (var d in dirs)
             {
-                if (!IsReparsePoint(d) && !SystemPaths.IsInsideSubtree(d, excludeSubtree)) stack.Push(d);
+                if (!IsReparsePoint(d) && !SystemPaths.IsInsideAnySubtree(d, excludeSubtrees)) stack.Push(d);
             }
             if (!string.Equals(cur, root, StringComparison.OrdinalIgnoreCase)) all.Add(cur);
         }

--- a/SysManager/SysManager/Services/TuneUpService.cs
+++ b/SysManager/SysManager/Services/TuneUpService.cs
@@ -185,7 +185,7 @@ public sealed class TuneUpService
                 // symbolic links). SearchOption.AllDirectories follows them, so a
                 // junction inside %TEMP% pointing elsewhere would let this delete real
                 // user data outside TEMP. Mirrors DeepCleanupService's safe traversal.
-                foreach (var file in EnumerateFilesSkippingReparsePoints(dir, ct, SystemPaths.OwnExtractionDirectory))
+                foreach (var file in EnumerateFilesSkippingReparsePoints(dir, ct, SystemPaths.BundleExtractionRoot, SystemPaths.OwnExtractionDirectory))
                 {
                     ct.ThrowIfCancellationRequested();
                     try
@@ -203,7 +203,7 @@ public sealed class TuneUpService
                 // Try to remove empty subdirectories, deepest first. Reparse points are
                 // excluded so a junction is never deleted/recursed as if it were a real
                 // directory. Depth = separator count (a deeper path can be shorter).
-                foreach (var sub in EnumerateDirectoriesSkippingReparsePoints(dir, ct, SystemPaths.OwnExtractionDirectory)
+                foreach (var sub in EnumerateDirectoriesSkippingReparsePoints(dir, ct, SystemPaths.BundleExtractionRoot, SystemPaths.OwnExtractionDirectory)
                              .OrderByDescending(d => d.Count(c => c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar)))
                 {
                     ct.ThrowIfCancellationRequested();
@@ -240,13 +240,13 @@ public sealed class TuneUpService
     /// files.
     /// </param>
     internal static IEnumerable<string> EnumerateFilesSkippingReparsePoints(
-        string root, CancellationToken ct, string? excludeSubtree = null)
+        string root, CancellationToken ct, params string?[] excludeSubtrees)
     {
         // Guard the traversal ROOT too: if the root itself is a junction/symlink,
         // descending into it would follow the link out of the temp tree and yield
         // (then delete) unrelated files — amplified when running elevated. Child dirs
         // are already filtered below; the root needs the same check.
-        if (IsReparsePoint(root) || SystemPaths.IsInsideSubtree(root, excludeSubtree)) yield break;
+        if (IsReparsePoint(root) || SystemPaths.IsInsideAnySubtree(root, excludeSubtrees)) yield break;
         var stack = new Stack<string>();
         stack.Push(root);
         while (stack.Count > 0 && !ct.IsCancellationRequested)
@@ -261,7 +261,7 @@ public sealed class TuneUpService
                 yield return file;
 
             foreach (var d in dirs)
-                if (!IsReparsePoint(d) && !SystemPaths.IsInsideSubtree(d, excludeSubtree)) stack.Push(d);
+                if (!IsReparsePoint(d) && !SystemPaths.IsInsideAnySubtree(d, excludeSubtrees)) stack.Push(d);
         }
     }
 
@@ -270,12 +270,12 @@ public sealed class TuneUpService
     /// skipping reparse points so a junction is never deleted or recursed as a real dir.
     /// </summary>
     private static IEnumerable<string> EnumerateDirectoriesSkippingReparsePoints(
-        string root, CancellationToken ct, string? excludeSubtree = null)
+        string root, CancellationToken ct, params string?[] excludeSubtrees)
     {
         List<string> all = [];
         // Same root guard as EnumerateFilesSkippingReparsePoints: never recurse a
         // junction/symlink root out of the temp tree.
-        if (IsReparsePoint(root) || SystemPaths.IsInsideSubtree(root, excludeSubtree)) return all;
+        if (IsReparsePoint(root) || SystemPaths.IsInsideAnySubtree(root, excludeSubtrees)) return all;
         var stack = new Stack<string>();
         stack.Push(root);
         while (stack.Count > 0 && !ct.IsCancellationRequested)
@@ -284,7 +284,7 @@ public sealed class TuneUpService
             IEnumerable<string> dirs;
             try { dirs = Directory.EnumerateDirectories(cur); } catch (IOException) { continue; } catch (UnauthorizedAccessException) { continue; }
             foreach (var d in dirs)
-                if (!IsReparsePoint(d) && !SystemPaths.IsInsideSubtree(d, excludeSubtree)) { stack.Push(d); all.Add(d); }
+                if (!IsReparsePoint(d) && !SystemPaths.IsInsideAnySubtree(d, excludeSubtrees)) { stack.Push(d); all.Add(d); }
         }
         return all;
     }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.25</Version>
-    <FileVersion>1.75.25.0</FileVersion>
-    <AssemblyVersion>1.75.25.0</AssemblyVersion>
+    <Version>1.75.26</Version>
+    <FileVersion>1.75.26.0</FileVersion>
+    <AssemblyVersion>1.75.26.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
fix: spare every app's bundle-extraction folder, not just this build's leaf

SysManager ships as a single file with IncludeNativeLibrariesForSelfExtract, so
the .NET host unpacks its native libraries into %TEMP%\.net\<app>\<hash> at
startup. Sweeping that tree bit us once, and SystemPaths documents the failure in
its own words: loaded libraries refuse to delete and were counted as errors, so a
clean machine still reported failures, and "anything extracted but not yet loaded
was removed for real, breaking a later lazy load".

The exclusion added then was AppContext.BaseDirectory — one LEAF of a SHARED root.
Every sibling under %TEMP%\.net belongs to another single-file .NET app, and both
sweepers walk all of %TEMP%: Deep Cleanup's "Temporary files" category covers
Path.GetTempPath() and %WINDIR%\Temp and is pre-ticked whenever it has size, and
TuneUpService.CleanTempFiles sweeps the same two roots from the One-Click Tune-Up
button. So the damage we documented and protected ourselves from was inflicted on
any other such app the user happened to be running.

It fails quietly, which is the worst part. The other app keeps running on what it
had already loaded and breaks later, when it reaches for something that is no
longer there, with nothing connecting that to a cleanup minutes earlier. The
category description made it worse by promising the opposite — "Anything still in
use is skipped automatically" — which is true only of files held under an
exclusive lock, never of extracted-but-not-yet-loaded ones.

Fix: exclude the extraction ROOT. SystemPaths.BundleExtractionRoot resolves
DOTNET_BUNDLE_EXTRACT_BASE_DIR when the host has been redirected, else
<temp>\.net. OwnExtractionDirectory stays as a second exclusion, because for a
non-single-file build BaseDirectory is the output folder, which no extraction root
contains. All five walker calls across the two services pass both, and the two
walkers in each service now take a set rather than a single subtree.

The resolver is a separate pure method rather than inline in the property: the
property resolves once at type initialisation and no test can re-point it, which
is why the existing OwnExtractionDirectory test can only assert shape.

Guard TIGHTENED, not duplicated. EveryTempTreeWalkerCall_PassesTheOwnExtraction-
Exclusion already asserted every call passes an exclusion — its own doc explains
that a source guard is the only thing that can, since the walkers are private and
the test host's BaseDirectory never intersects a temp fixture. It now demands BOTH
names and is renamed EveryTempTreeWalkerCall_PassesBothExtractionExclusions.
Adding a second guard for the second exclusion is how a codebase ends up with two
checks that disagree.

Tests. The existing behavioural test excluded one leaf and asserted that leaf was
skipped — the half we already had. The new one lays out all three cases at once:
an ordinary temp file that must be enumerated, our own leaf, and ANOTHER app's
leaf under the same root. That last assertion is the defect, and it is red the
moment a caller goes back to passing only the leaf. Plus a theory for the resolver
covering the override and default branches, and one for IsInsideAnySubtree.

An existing test passed a bare null to prove the exclusion was opt-in, which no
longer compiles now that the parameter is params string?[]. Kept as an explicit
(string?)null element, because that case matters MORE now: BundleExtractionRoot
can resolve to null and the walkers pass it straight through.

Red/green: seven mutations, all as expected. Dropping the root from a call site in
either service reds the guard; handing the walker only our leaf reds the sibling
test with the other app's dll enumerated for deletion; the resolver ignoring the
override or using the wrong folder name reds its theory; IsInsideAnySubtree
reading only its first entry reds the order case. The seventh is the one worth
recording: making null count as a match reds TWO tests, not the one I predicted —
the second being the walker-level test, which enumerates NOTHING, i.e. the temp
cleanup silently becoming a no-op on any machine where the root fails to resolve.
Better than I expected, and the expectation was corrected rather than the test.

Docs: ARCHITECTURE listed neither SystemPaths nor these exclusions, despite both
sweepers depending on them. Added.
