### PR TITLE
ci: require the newest release to carry its executable and checksum

### DIFF
--- a/.github/workflows/release-integrity.yml
+++ b/.github/workflows/release-integrity.yml
@@ -106,10 +106,38 @@ jobs:
           fi
           echo "newest CHANGELOG version: ${NEWEST}"
 
-          if gh release view "v${NEWEST}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-            echo "v${NEWEST} is published."
-            exit 0
+          if ! gh release view "v${NEWEST}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "::error::CHANGELOG.md announces ${NEWEST} but there is no v${NEWEST} release. Either the auto-release tag push failed or the release run was abandoned; publish it by hand and check why the run did not finish."
+            exit 1
           fi
 
-          echo "::error::CHANGELOG.md announces ${NEWEST} but there is no v${NEWEST} release. Either the auto-release tag push failed or the release run was abandoned; publish it by hand and check why the run did not finish."
-          exit 1
+          # Existing is not the same as usable. `gh release view` succeeds for a release with zero
+          # assets, so a run that died after creating the release and before uploading leaves exactly
+          # the outcome this workflow exists to catch — a reader follows the CHANGELOG and finds no
+          # download — while every check above passes. The two names below are the ones the README
+          # tells a user to fetch and verify.
+          ASSETS=$(gh release view "v${NEWEST}" --repo "${GITHUB_REPOSITORY}" \
+            --json assets --jq '.assets[] | "\(.name) \(.size)"')
+
+          MISSING=""
+          for name in "SysManager-v${NEWEST}.exe" "SysManager-v${NEWEST}.exe.sha256"; do
+            if ! printf '%s\n' "${ASSETS}" | grep -qF "${name} "; then
+              MISSING="${MISSING} ${name}"
+            fi
+          done
+
+          if [ -n "${MISSING}" ]; then
+            echo "::error::v${NEWEST} exists but is missing the assets a user downloads:${MISSING}. Re-run the release job's upload step, or upload them with gh release upload."
+            exit 1
+          fi
+
+          # A zero-byte or truncated upload is the failure mode, so the floor is deliberately far below
+          # the real size (~84 MB) rather than tracking it. Tracking it would go red the day the binary
+          # legitimately slims down, which is not a release-integrity problem.
+          EXE_SIZE=$(printf '%s\n' "${ASSETS}" | awk -v n="SysManager-v${NEWEST}.exe" '$1 == n { print $2 }')
+          if [ "${EXE_SIZE:-0}" -lt 10000000 ]; then
+            echo "::error::v${NEWEST}'s executable is only ${EXE_SIZE:-0} bytes, so the upload was truncated or empty. Re-upload it and verify the published SHA256 against the rebuilt binary."
+            exit 1
+          fi
+
+          echo "v${NEWEST} is published with its executable (${EXE_SIZE} bytes) and checksum."


### PR DESCRIPTION
ci: require the newest release to carry its executable and checksum

release-integrity.yml verifies that every version tag has a release and that the
newest CHANGELOG version has one. Neither looks inside the release. `gh release
view` succeeds for a release with zero assets, so the exact outcome this workflow
exists to catch — a reader follows the CHANGELOG and finds no download — still
passed every check.

Not hypothetical for this pipeline. The workflow's own header says it exists
because a release run was abandoned mid-flight during an Actions incident, leaving
a tag with nothing behind it. A run that dies AFTER creating the release and
BEFORE uploading leaves precisely the state described above, and until now nothing
would have said so.

Measured before deciding what to assert: every release carries three assets — the
.exe at ~84.7 MB, its .sha256 at 88-89 bytes, and an SBOM at ~96 KB. The two the
README tells a user to fetch and verify are the .exe and the .sha256, so those are
required by name. The size floor is 10 MB rather than tracking the real 84 MB: it
catches a zero-byte or truncated upload, which is the failure mode, without going
red the day the binary legitimately slims down — that would not be a
release-integrity problem.

Extends the existing step rather than adding a parallel job, so "the newest
version is properly published" stays one check with one message.

Verified by extracting the step body verbatim from the workflow and running it
against the live repository — a retyped copy proves nothing about the gate that
actually runs. Baseline passes and reports the real size. Three mutations, all
red: wrong required asset names, a size floor above the real size, and a version
with no release at all. That last one matters because the rewrite turned an early
`exit 0` into an inverted `if`, which is the shape of edit that silently drops a
branch — it still fires, tested against v1.65.9, one of the five known historical
tags that were never released.

Addresses the detection half of #1997. Whether to backfill those five historical
tags is a separate call and is still open on that issue.
