### PR TITLE
fix: give the toggle thumb a brush per state so the switch is readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.27] - 2026-09-02
+
+On the six light colour themes you could not tell whether a switch was on or off — the little circle was white
+on an almost-white background. On Warm Ember and Dark Forest the same thing happened the other way round, once
+the switch was on.
+
+### Fixed
+- **Switches can now be read on every colour theme.** The circle inside a switch was always white. On the
+  light themes the track behind it is very pale, so the circle was invisible and the only way to tell a
+  switch's state was to click it and watch what happened. Checking every theme turned up the mirror image of
+  the same problem: on Warm Ember and Dark Forest, the track turns amber or green when the switch is on, and a
+  white circle on those is nearly as hard to see. The circle now takes its colour from whatever is behind it,
+  which is different in each state, so it stands out in both. It affects every switch in the app.
+
 ## [1.75.26] - 2026-09-02
 
 Cleaning temporary files could delete part of another program while it was running, which usually showed up

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -4644,6 +4644,44 @@ public partial class ArchitectureTests
             RegexOptions.Singleline);
 
     /// <summary>
+    /// The toggle switch binds a thumb brush in BOTH states, since its backdrop changes with its own state.
+    /// </summary>
+    /// <remarks>
+    /// Asserting the tokens exist and measure well is not the same as asserting the switch uses them. The
+    /// contrast theories in <c>ThemeTextContrastTests</c> would stay green with the XAML back on
+    /// <c>White</c>, which is this codebase's most persistent defect shape: implemented, unit-tested, and
+    /// reaching no pixel. So this reads the style itself — the base thumb binds <c>ToggleThumb</c>, and the
+    /// <c>IsChecked</c> trigger re-points it at <c>TextOnAccent</c> because the track becomes the accent.
+    /// </remarks>
+    [Fact]
+    public void ToggleSwitch_BindsAThumbBrushForEachState()
+    {
+        var appXaml = File.ReadAllText(Path.Combine(FindAppProjectDir(), "App.xaml"));
+
+        var style = TypedStyleWithKey("ToggleSwitch").Match(appXaml);
+        Assert.True(style.Success, "the ToggleSwitch style was not found — this guard would pass vacuously");
+        var body = style.Value;
+
+        Assert.Contains("Background=\"{DynamicResource ToggleThumb}\"", body, StringComparison.Ordinal);
+        Assert.Contains(
+            "<Setter TargetName=\"Thumb\" Property=\"Background\" Value=\"{DynamicResource TextOnAccent}\"/>",
+            body, StringComparison.Ordinal);
+
+        // The ON assertion is only meaningful while the track still turns Accent in the same trigger.
+        Assert.Contains(
+            "<Setter TargetName=\"Track\" Property=\"Background\" Value=\"{DynamicResource Accent}\"/>",
+            body, StringComparison.Ordinal);
+
+        // And the brush has to be DERIVED, not just published. ThemeTextContrastTests computes the
+        // expected colour itself, because Apply no-ops without a WPF Application, so it would stay green
+        // if ThemeService published a literal instead — the same colour would be asserted against itself.
+        // Reading the derivation out of the source is what closes that: a mutation setting ToggleThumb to
+        // Colors.White passed every contrast theory and only this line caught it.
+        var service = File.ReadAllText(Path.Combine(FindAppProjectDir(), "Services", "ThemeService.cs"));
+        Assert.Contains("SetBrush(res, \"ToggleThumb\", OnColor(surface4));", service, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// A control filled with a theme brush must take its foreground from the paired theme token, never a
     /// literal <c>White</c>.
     /// </summary>
@@ -4656,8 +4694,13 @@ public partial class ArchitectureTests
     /// <para>Guarded as a class because the four known instances are not the interesting ones — the fifth
     /// is. It is also invisible on the dark default a maintainer looks at most, and only appears after
     /// switching presets, so review will not catch it.</para>
-    /// <para>The <c>ToggleSwitch</c> thumb is a KNOWN exception, listed below with its reason: it is the
-    /// one filled element whose backdrop changes with its own state, so no single colour can serve it.</para>
+    /// <para>The <c>ToggleSwitch</c> thumb used to be listed as a known exception, on the reasoning that
+    /// it is the one filled element whose backdrop changes with its own state, so no single colour can
+    /// serve it. That reasoning was right and the conclusion was wrong: the answer was a thumb brush PER
+    /// STATE — <c>ToggleThumb</c> off, <c>TextOnAccent</c> on — not an exemption. The exception is gone,
+    /// and with it the hole that made it unnecessary in the first place: this only ever looked for a
+    /// literal White in a foreground or a glyph stroke, and the thumb is a Border BACKGROUND, so the
+    /// defect would have survived here even with no exception listed.</para>
     /// </remarks>
     [Fact]
     public void NoThemedFill_CarriesAHardcodedWhiteForeground()
@@ -4665,12 +4708,12 @@ public partial class ArchitectureTests
         // The fills whose colour is decided by the theme rather than fixed in the XAML.
         string[] themedFills = ["Accent", "Danger"];
 
-        // The thumb sits on Surface4 when off and on Accent when on. Measured across all twelve presets,
-        // no single colour clears 3:1 against both: a mid-dark thumb reads 1.06-1.34:1 on the Accent track
-        // of the six light presets, which is worse than the white it would replace. Fixing it needs a
-        // state-dependent thumb, which is a visual change rather than a token swap, so it is tracked
-        // separately rather than silently tolerated.
-        string[] knownExceptions = ["ToggleSwitch"];
+        // EMPTY. The thumb sits on Surface4 when off and on Accent when on, and the note here used to
+        // say that no single colour clears 3:1 against both — true, and the reason the answer is a brush
+        // per state rather than an exemption. Off it binds ToggleThumb (12.32-15.76:1 across the twelve
+        // presets), on it binds TextOnAccent (4.60-9.78:1). Adding a name back here means accepting a
+        // fill whose contrast depends on which preset is active.
+        string[] knownExceptions = [];
 
         var appXaml = File.ReadAllText(Path.Combine(FindAppProjectDir(), "App.xaml"));
         var offenders = new List<string>();
@@ -4689,8 +4732,15 @@ public partial class ArchitectureTests
             themedFillStyles++;
             if (knownExceptions.Contains(key, StringComparer.Ordinal)) continue;
 
-            // Foreground on the control, or Stroke on a glyph drawn inside it (the checkbox tick).
-            foreach (var literal in new[] { "Property=\"Foreground\" Value=\"White\"", "Stroke=\"White\"" })
+            // Foreground on the control, Stroke on a glyph drawn inside it (the checkbox tick), or
+            // Background on a child element of the template (the toggle thumb). The third was missing,
+            // which is the whole reason the thumb needed an exception entry to stay quiet — a guard that
+            // cannot see the shape of a defect does not need to be told to ignore it.
+            foreach (var literal in new[]
+                     {
+                         "Property=\"Foreground\" Value=\"White\"", "Stroke=\"White\"",
+                         "Background=\"White\"", "Property=\"Background\" Value=\"White\"",
+                     })
             {
                 if (body.Contains(literal, StringComparison.Ordinal))
                     offenders.Add($"{key} fills with {fill} but sets a literal White ({literal})");
@@ -4720,6 +4770,7 @@ public partial class ArchitectureTests
     [Theory]
     [InlineData("TextOnAccent")]
     [InlineData("TextOnDanger")]
+    [InlineData("ToggleThumb")]
     public void EveryPairedForegroundToken_IsBoundBySomeStyle(string token)
     {
         var appDir = FindAppProjectDir();

--- a/SysManager/SysManager.Tests/ThemeTextContrastTests.cs
+++ b/SysManager/SysManager.Tests/ThemeTextContrastTests.cs
@@ -205,4 +205,81 @@ public class ThemeTextContrastTests
             "the uncorrected ramp was expected to fail against the shifted surface — if it now passes, "
             + "this test no longer proves the correction does anything.");
     }
+    // ── The toggle switch has to be readable in BOTH states ─────────────────
+    // The thumb was hardcoded White and the IsChecked trigger moved it without changing its brush, so
+    // one colour had to work on two different backgrounds and failed on each for opposite presets. OFF
+    // sits on Surface4, which is Lerp(Surface2, TextPrimary, 0.1) — near-white on the six light presets,
+    // where a white thumb measured 1.33-1.67:1 and the switch had no readable state at all. ON sits on
+    // Accent, where white measured 2.15:1 on warm-ember and 2.54:1 on dark-forest.
+    //
+    // Two theories rather than one combined assertion: the halves fail on disjoint sets of presets, so a
+    // single check could stay green with one half regressed while the other carried it.
+    //
+    // 3:1 is WCAG 1.4.11 for a non-text UI component. The real margins are far wider (12.32-15.76 OFF,
+    // 4.60-9.78 ON), so this floor exists to catch a future seed edit rather than to be scraped past.
+
+    [Theory]
+    [MemberData(nameof(AllPresets))]
+    public void ToggleThumb_IsReadableOnItsTrack_WhenOff(string presetId)
+    {
+        var p = ThemePreset.Defaults[presetId];
+        var track = Lerp(p.Surface2, p.TextPrimary, 0.1);
+        var thumb = ThemeService.OnColor(track);
+
+        var ratio = ContrastRatio(thumb, track);
+        Assert.True(ratio >= 3.0,
+            $"Preset '{presetId}': the OFF toggle thumb must clear 3:1 against its Surface4 track; "
+            + $"got {ratio:F2}:1. A white thumb was 1.33:1 here before this rule existed.");
+    }
+
+    [Theory]
+    [MemberData(nameof(AllPresets))]
+    public void ToggleThumb_IsReadableOnTheAccent_WhenOn(string presetId)
+    {
+        var p = ThemePreset.Defaults[presetId];
+        // The ON thumb deliberately uses TextOnAccent — the same brush as the primary button's label —
+        // because the IsChecked trigger turns the track into Accent.
+        var thumb = ThemeService.OnColor(p.Accent);
+
+        var ratio = ContrastRatio(thumb, p.Accent);
+        Assert.True(ratio >= 3.0,
+            $"Preset '{presetId}': the ON toggle thumb must clear 3:1 against the Accent track; "
+            + $"got {ratio:F2}:1. A white thumb was 2.15:1 on warm-ember before this rule existed.");
+    }
+
+    [Fact]
+    public void AWhiteToggleThumb_WouldStillFail_OnBothCounts()
+    {
+        // Positive control. Both theories above would pass trivially if OnColor ever returned white
+        // everywhere, so this pins that the OLD value genuinely fails — on the light presets when off,
+        // and on warm-ember and dark-forest when on. If either of these stops failing, the theories
+        // above have stopped proving anything.
+        var white = System.Windows.Media.Colors.White;
+
+        var light = ThemePreset.Defaults["clean-indigo"];
+        var lightTrack = Lerp(light.Surface2, light.TextPrimary, 0.1);
+        Assert.True(ContrastRatio(white, lightTrack) < 3.0,
+            "a white OFF thumb on clean-indigo's track was the defect; if it now clears 3:1 the surface "
+            + "ramp changed and these rules need re-deriving.");
+
+        foreach (var id in new[] { "warm-ember", "dark-forest" })
+        {
+            var accent = ThemePreset.Defaults[id].Accent;
+            Assert.True(ContrastRatio(white, accent) < 3.0,
+                $"a white ON thumb on {id}'s accent was the second defect; if it now clears 3:1 the "
+                + "accent seed changed and these rules need re-deriving.");
+        }
+    }
+
+    /// <summary>
+    /// Mirrors <c>ThemeService.Lerp</c> so the toggle track is derived with the same maths the app uses,
+    /// rather than an approximation of it. <c>ThemeStatusBrushTests</c> keeps the same mirror for the
+    /// same reason; <c>ThemeService.Lerp</c> is private and is not worth widening for a test.
+    /// </summary>
+    private static Color Lerp(Color a, Color b, double t) => Color.FromArgb(
+        255,
+        (byte)(a.R + (b.R - a.R) * t),
+        (byte)(a.G + (b.G - a.G) * t),
+        (byte)(a.B + (b.B - a.B) * t));
+
 }

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -503,8 +503,12 @@
                                      trigger can light the Accent ring without shifting the thumb/track layout. -->
                                 <Border x:Name="Track" CornerRadius="11" Background="{DynamicResource Surface4}"
                                         BorderThickness="1.5" BorderBrush="Transparent"/>
+                                <!-- OFF thumb: derived from the track it sits on, not White. Surface4 is
+                                     near-white on the light presets, where a white thumb measured 1.33-1.67:1
+                                     and the switch had no readable state. The ON thumb is set in the IsChecked
+                                     trigger instead, because the track becomes Accent there. -->
                                 <Border x:Name="Thumb" Width="18" Height="18" CornerRadius="9"
-                                        Background="White" HorizontalAlignment="Left" Margin="2,2,0,2"
+                                        Background="{DynamicResource ToggleThumb}" HorizontalAlignment="Left" Margin="2,2,0,2"
                                         VerticalAlignment="Center">
                                     <Border.Effect>
                                         <DropShadowEffect ShadowDepth="1" BlurRadius="3" Opacity="0.3" Color="Black"/>
@@ -514,6 +518,12 @@
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsChecked" Value="True">
                                     <Setter TargetName="Track" Property="Background" Value="{DynamicResource Accent}"/>
+                                    <!-- The thumb changes brush with the track, not just position. Keeping the
+                                         OFF brush here left a white thumb on the accent fill: 2.15:1 on
+                                         warm-ember and 2.54:1 on dark-forest. TextOnAccent is the brush that
+                                         already exists for "drawn on the accent", used by the primary button's
+                                         label and the checkbox tick. -->
+                                    <Setter TargetName="Thumb" Property="Background" Value="{DynamicResource TextOnAccent}"/>
                                     <Setter TargetName="Thumb" Property="HorizontalAlignment" Value="Right"/>
                                     <Setter TargetName="Thumb" Property="Margin" Value="0,2,2,2"/>
                                 </Trigger>

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -238,7 +238,8 @@ public sealed class ThemeService
         SetBrush(res, "Surface1", theme.Surface);
         SetBrush(res, "Surface2", theme.Surface2);
         SetBrush(res, "Surface3", Lerp(theme.Surface2, theme.TextPrimary, 0.05));
-        SetBrush(res, "Surface4", Lerp(theme.Surface2, theme.TextPrimary, 0.1));
+        var surface4 = Lerp(theme.Surface2, theme.TextPrimary, 0.1);
+        SetBrush(res, "Surface4", surface4);
         SetBrush(res, "Border1", theme.Border);
         SetBrush(res, "Border2", Lerp(theme.Border, theme.TextPrimary, 0.08));
         SetBrush(res, "BorderAccent", Lerp(theme.Border, theme.Accent, 0.2));
@@ -256,6 +257,15 @@ public sealed class ThemeService
         // indigo #6366F1 to amber #F59E0B across the presets, so white measured 2.15:1 on warm-ember and
         // cleared AA on only two of the twelve.
         SetBrush(res, "TextOnAccent", OnColor(theme.Accent));
+
+        // The OFF thumb of a toggle switch, drawn on the Surface4 track. It was hardcoded White, and
+        // Surface4 is near-white on the six light presets, so the thumb measured 1.33 to 1.67:1 there —
+        // the switch had no readable state at all, which is worse than a label at 2:1. The ON thumb is
+        // not this brush: the IsChecked trigger turns the track into Accent, so it uses TextOnAccent
+        // above. That split is load-bearing rather than tidy — a single brush left the ON state at
+        // 2.15:1 on warm-ember and 2.54:1 on dark-forest, a defect the light-preset audit missed
+        // because both are dark presets.
+        SetBrush(res, "ToggleThumb", OnColor(surface4));
 
         SetColor(res, "Surface0Color", theme.Background);
         SetColor(res, "Surface1Color", theme.Surface);

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.26</Version>
-    <FileVersion>1.75.26.0</FileVersion>
-    <AssemblyVersion>1.75.26.0</AssemblyVersion>
+    <Version>1.75.27</Version>
+    <FileVersion>1.75.27.0</FileVersion>
+    <AssemblyVersion>1.75.27.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
fix: give the toggle thumb a brush per state so the switch is readable

Closes #1621.

The thumb was hardcoded `White` and the `IsChecked` trigger moved it without
changing its brush, so one colour had to work on two different backdrops and
failed on each for opposite presets.

OFF sits on `Surface4`, which is `Lerp(Surface2, TextPrimary, 0.1)` — near-white
on the six light presets. Measured from the real preset table, white on it is
1.33 to 1.67:1. That is not a hard-to-read label, it is a control with no
readable state: the only way to tell a switch's position was to click it and
watch what changed.

Measuring it turned up a second defect the issue did not report, and could not
have from a light-preset audit: the ON state is broken on two DARK presets. The
trigger turns the track into `Accent`, and white on `#F59E0B` (warm-ember) is
2.15:1, on `#10B981` (dark-forest) 2.54:1.

  preset          OFF white/Surface4    ON white/Accent
  clean-indigo    1.33                  4.70
  sky-breeze      1.35                  7.58
  warm-sand       1.50                  6.59
  mint-fresh      1.41                  6.37
  soft-blossom    1.67                  4.57
  lavender        1.65                  3.69
  warm-ember      13.20                 2.15   <- ON broken
  dark-forest     12.32                 2.54   <- ON broken

So the answer is a brush per state, not a better single colour:

  OFF -> ToggleThumb, a new key, OnColor(Surface4).  12.32-15.76:1 across twelve.
  ON  -> TextOnAccent, which already exists for exactly this — the primary
         button's label, the checkbox tick.           4.60-9.78:1 across twelve.

Worst case anywhere afterwards is 4.60:1, over the 4.5:1 text floor and well over
the 3:1 WCAG 1.4.11 sets for a non-text component. Neither value is hand-picked:
both come out of the `OnColor` rule already in ThemeService, so there is no lerp
factor to argue about at the next review.

The guard that was written for this class already knew the answer. Its exception
entry read "no single colour clears 3:1 against both" and "fixing it needs a
state-dependent thumb" — right diagnosis, and the exemption was the wrong
conclusion. That entry is gone, and so is the hole that made it unnecessary:
`NoThemedFill_CarriesAHardcodedWhiteForeground` only ever looked for a literal
White in a FOREGROUND or a glyph STROKE, and the thumb is a Border BACKGROUND, so
the defect would have survived even with nothing listed. It now catches the
attribute shape too.

New guard `ToggleSwitch_BindsAThumbBrushForEachState`, because the contrast
theories cannot see the XAML: they compute the expected colour themselves, since
`Apply` no-ops without a WPF `Application`. It reads the style — the base thumb
binds ToggleThumb, the trigger re-points it at TextOnAccent, the track still turns
Accent — and the derivation line in ThemeService, so publishing a literal instead
would assert a colour against itself.

Red/green: five mutations, all as expected after two expectations were widened —
in both cases MORE guards fired than predicted, not fewer. The thumb back to a
literal White reds three; deleting the trigger's setter, dropping the token, or
binding the OFF brush in the ON state each red the binding guard. The
`ToggleThumb := Colors.White` mutation is the one that earned the derivation
assertion: it passed every contrast theory, because a test that computes the
expected value cannot notice the app publishing something else.

Regression: 182 tests across the four theme suites, and the full 74-method
ArchitectureTests sweep. The two exceptions in that sweep are harness-only and
green in CI.
