### PR TITLE
ci: refuse to tag a release whose CHANGELOG date is not the day it publishes

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -124,7 +124,28 @@ jobs:
             echo "::error::The CHANGELOG.md entry for $VERSION is empty. Add the notes under its header, then re-run. No tag was created."
             exit 1
           fi
-          echo "CHANGELOG has a non-empty entry for $VERSION."
+          # The date has to be TODAY in UTC, because the tag pushed in the next step is what triggers
+          # release.yml, and release.yml copies this block verbatim into the release body and the
+          # announcement. A hand-written date is a prediction, and it is wrong whenever preparation and
+          # merge fall on different UTC days — which already published yesterday's date twice.
+          #
+          # Not checkable on the pull request: CI passing at 23:50 says nothing about a merge at 00:05.
+          # Here the tag does not exist yet, so refusing costs a one-line edit and a re-run.
+          HEADER=$(grep -m1 -E "^## \[${ESCAPED}\]" CHANGELOG.md)
+          ENTRY_DATE=$(printf '%s\n' "$HEADER" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' || true)
+          TODAY=$(date -u +%Y-%m-%d)
+
+          if [ -z "$ENTRY_DATE" ]; then
+            echo "::error::The CHANGELOG.md header for $VERSION carries no date. Keep a Changelog expects '## [$VERSION] - $TODAY'. Add it, then re-run. No tag was created."
+            exit 1
+          fi
+
+          if [ "$ENTRY_DATE" != "$TODAY" ]; then
+            echo "::error::The CHANGELOG.md entry for $VERSION is dated $ENTRY_DATE, but this release publishes today, $TODAY (UTC). release.yml copies that header verbatim into the release body and the announcement, so it would publish the wrong date on both. Change the header to '## [$VERSION] - $TODAY' and re-run. No tag was created."
+            exit 1
+          fi
+
+          echo "CHANGELOG has a non-empty entry for $VERSION, dated $ENTRY_DATE (today in UTC)."
 
       - name: Create and push tag
         if: steps.bump.outputs.type != 'none'


### PR DESCRIPTION
ci: refuse to tag a release whose CHANGELOG date is not the day it publishes

Closes #1806.

The header date is written by hand while the PR is prepared; the release it
describes is published when the PR merges. release.yml copies the matched block
VERBATIM into the release body and the announcement discussion, so a merge after
00:00 UTC publishes yesterday's date on three public surfaces at once. Two
consecutive releases were already wrong for this reason — a structural fault, not
an author's slip — and Keep a Changelog defines that date as the release date, so
the file contradicts its own stated format.

Checked at TAG time, and the placement is the whole argument. A check on the pull
request passes at 23:50 and the merge can still land at 00:05, so it cannot close
the window it exists for; the issue's own option 3 notes it would also cry wolf on
any PR left open overnight. The tag is what triggers release.yml, so it is the
last moment the date can still be changed. Option 1 was the issue's preference,
but the half that fixes the file needs a bot commit on main, which this repository
does not permit.

Extends the step that already verifies the CHANGELOG before the tag exists, for
the reason that step's own comment gives: a failure here costs a re-run, while a
failure after the tag leaves a stranded version. A parallel step would split one
question — "is this entry fit to publish?" — across two places.

The cost is real and accepted: a fix: PR prepared late and merged after midnight
blocks its own release until the date line is corrected. The message names the
value to write, so it is a one-line edit and a re-run rather than a puzzle.

Verified by extracting the step verbatim and running it against the real
CHANGELOG, since a retyped gate proves nothing about the gate that runs. Baseline
passes on today's date. Four failure cases all fire, each with the right message:
dated yesterday, no date at all, no entry for the version, and an entry with
nothing under it. The last two are pre-existing branches, checked because the new
guards were appended after them and an edit in the middle of a sequence of exits
is exactly the shape that shadows one.

That caution earned its keep: the first run of this proof left one of the step's
three workflow expressions un-substituted, so bash tried to execute an echo line
and the "no entry" case exited for the wrong reason — passing the proof while
proving nothing about that branch. Fixed by substituting all three.
