### PR TITLE
refactor: give LogService's log directory a seam and empty the path ratchet

### DIFF
--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -92,19 +92,17 @@ public partial class ArchitectureTests
         //   · SettingsWatchdogService and WindowsThemeService — both constructed concretely by tests,
         //     both now behind the shared `string? configDir = null` seam.
         //
-        // The ONE that remains is the hard one:
-        //   · LogService is a `static partial class` by design — Serilog's sink is configured once per
-        //     process — so it has no instance to hang the shared `string? configDir = null` seam on. It
-        //     is also the only offender no test constructs, so its risk is the lowest of the set; it
-        //     needs a design decision (dropping the static-sink model) rather than a mechanical edit.
-        //
         // ThemeService came off in #1741's follow-up: its path moved to an instance field set from the
         // same seam, and its one WPF touch-point (Apply) now no-ops without an Application, so the
         // persistence path is exercised headlessly by ThemeServiceTests instead of being left untested.
-        string[] known =
-        [
-            "LogService.<LogDir>k__BackingField",
-        ];
+        //
+        // EMPTY. The last entry was LogService, which could not take the shared constructor seam: it is a
+        // `static partial class` because Serilog's sink is configured once per process, so there is no
+        // instance to hang a parameter on. It now takes the directory on Init instead, and the assertion
+        // after this loop pins that seam — because a private setter makes the backing field non-readonly,
+        // so the rule below would stop matching it for a reason unrelated to being redirectable. Without
+        // that assertion this entry would have gone quiet rather than being satisfied.
+        string[] known = [];
 
         var profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         Assert.False(string.IsNullOrEmpty(profile));   // else every check below would be vacuous
@@ -146,6 +144,17 @@ public partial class ArchitectureTests
         Assert.True(fixedSince.Count == 0,
             "These no longer hold a static user-profile path, so remove them from the `known` list " +
             "above — a stale allowance silently weakens this guard:\n  " + string.Join("\n  ", fixedSince));
+        // The one service that solved this differently still has to be able to solve it. LogService keeps
+        // a static path because its sink is process-wide, so what makes it testable is that Init accepts
+        // the directory. Checked by reflection rather than by reading the source: what matters is that a
+        // caller can pass one, not how the parameter is written.
+        var init = typeof(LogService).GetMethod("Init", BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(init);
+        var logDirParameter = init!.GetParameters()
+            .FirstOrDefault(p => p.ParameterType == typeof(string) && p.IsOptional);
+        Assert.True(logDirParameter is not null,
+            "LogService.Init must accept an optional directory, or its static LogDir is unredirectable "
+            + "again and the empty allowance above is hiding that rather than recording it.");
     }
 
     /// <summary>

--- a/SysManager/SysManager.Tests/LogServiceLogDirTests.cs
+++ b/SysManager/SysManager.Tests/LogServiceLogDirTests.cs
@@ -1,0 +1,79 @@
+// SysManager · LogServiceLogDirTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// The log directory has to be redirectable, which is what took <c>LogService</c> off the user-data-path
+/// ratchet in <c>ArchitectureTests.Services_DoNotHoldUserDataPathsInStaticFields</c>.
+/// <para><c>LogDir</c> was <c>static readonly</c>. A resolved path in static state cannot be pointed at a
+/// temp directory by any test, because <see cref="Environment.GetFolderPath"/> resolves through the Win32
+/// known-folder function and ignores the <c>LOCALAPPDATA</c> environment variable. That is not a
+/// hypothetical risk: a service holding its path this way had tests that wrote into the user's real
+/// speed-test history.</para>
+/// <para>The usual fix — a constructor-injected <c>string? configDir = null</c> — does not apply, because
+/// <c>LogService</c> is a static class: Serilog's sink is configured once per process, so there is no
+/// instance to hang a parameter on. The seam is <c>Init(string?)</c>, and the decision it makes lives in
+/// <c>ResolveLogDir</c>.</para>
+/// <para>These test the resolver, never <c>Init</c> itself. Calling <c>Init</c> would build a real Serilog
+/// sink and assign the global <c>Log.Logger</c>, which every other test in the run shares.</para>
+/// </summary>
+public class LogServiceLogDirTests
+{
+    [Fact]
+    public void ResolveLogDir_WithNothingRequested_KeepsThePerUserDefault()
+    {
+        var resolved = LogService.ResolveLogDir(null, loggerExists: false);
+
+        var expected = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager", "logs");
+        Assert.Equal(expected, resolved);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveLogDir_WithABlankRequest_KeepsThePerUserDefault(string requested)
+    {
+        // Blank is not a redirect. Taking it as one would point the log at the process directory, which is
+        // Program Files for an installed copy and therefore unwritable.
+        var resolved = LogService.ResolveLogDir(requested, loggerExists: false);
+
+        Assert.Contains("SysManager", resolved, StringComparison.Ordinal);
+        Assert.EndsWith("logs", resolved, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ResolveLogDir_BeforeTheSinkExists_TakesTheRequestedDirectory()
+    {
+        var temp = Path.Combine(Path.GetTempPath(), "smlog_" + Guid.NewGuid().ToString("N"));
+
+        Assert.Equal(temp, LogService.ResolveLogDir(temp, loggerExists: false));
+    }
+
+    [Fact]
+    public void ResolveLogDir_AfterTheSinkExists_RefusesRatherThanIgnoring()
+    {
+        // Refused, not ignored. Ignoring it would leave LogDir naming one directory while the sink wrote to
+        // another, so the crash dialog and the About tab would both send a user to an empty folder.
+        var temp = Path.Combine(Path.GetTempPath(), "smlog_" + Guid.NewGuid().ToString("N"));
+
+        var thrown = Assert.Throws<InvalidOperationException>(
+            () => LogService.ResolveLogDir(temp, loggerExists: true));
+        Assert.Contains("cannot be changed", thrown.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ResolveLogDir_WithNothingRequested_IsAllowedEvenAfterTheSinkExists()
+    {
+        // The app's own two entry points pass nothing, and they are mutually exclusive — the update-applier
+        // branch returns before the normal path — so Init runs once per process. Refusing a no-op call
+        // would break startup rather than protect anything, so only an actual redirect is refused.
+        Assert.Equal(LogService.ResolveLogDir(null, loggerExists: false),
+                     LogService.ResolveLogDir(null, loggerExists: true));
+    }
+}

--- a/SysManager/SysManager/Services/LogService.cs
+++ b/SysManager/SysManager/Services/LogService.cs
@@ -36,8 +36,57 @@ public static partial class LogService
     /// </summary>
     internal const string StartupMessage = "SysManager {Version} started";
 
-    public static string LogDir { get; } =
-        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager", "logs");
+    /// <summary>
+    /// Where the rolling log is written. Settable only through <see cref="Init(string?)"/>, and only
+    /// before the sink exists.
+    /// </summary>
+    /// <remarks>
+    /// This was <c>static readonly</c>, which made it the last entry on the user-data-path ratchet: a
+    /// resolved path in static state cannot be pointed at a temp directory by any test, because
+    /// <see cref="Environment.GetFolderPath"/> resolves through the Win32 known-folder function and
+    /// ignores the <c>LOCALAPPDATA</c> environment variable. That is not a hypothetical — a service
+    /// holding its path this way had tests that wrote into the user's real speed-test history.
+    /// <para>The usual fix, a constructor-injected <c>string? configDir = null</c>, does not apply here:
+    /// this is a static class because Serilog's sink is configured once per process, so there is no
+    /// instance to hang a parameter on. The seam is <see cref="Init(string?)"/> instead.</para>
+    /// </remarks>
+    public static string LogDir { get; private set; } = ResolveLogDir();
+
+    /// <summary>
+    /// Decides the log directory for a call to <see cref="Init(string?)"/>, or refuses. Also produces the
+    /// default, so there is one entry point rather than a resolver beside a parameterless helper.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="Init(string?)"/> and pure, so the refusal can be tested without building
+    /// a real Serilog sink and assigning the global <c>Log.Logger</c> — a test that did that would leak
+    /// into every other test in the run.
+    /// <para>Both parameters are optional so this is also what produces the default, which is what
+    /// <c>StaticPathMethods_AcceptARedirect</c> requires of any static member that can resolve a path
+    /// under the user profile: a default is fine, having no parameter to override is not. A separate
+    /// parameterless <c>DefaultLogDir()</c> failed that rule, and giving it a parameter nobody would pass
+    /// would have satisfied the letter of it and nothing else.</para>
+    /// <para>Redirecting after the sink exists is refused rather than ignored. Ignoring it would leave
+    /// <see cref="LogDir"/> naming one directory while the sink wrote to another, and every reader of
+    /// that property — the crash dialog, the About tab, a support bundle — would point a user at an
+    /// empty folder. Failing loudly at the one call site is cheaper than that.</para>
+    /// </remarks>
+    internal static string ResolveLogDir(string? requested = null, bool loggerExists = false)
+    {
+        if (!string.IsNullOrWhiteSpace(requested))
+        {
+            if (loggerExists)
+            {
+                throw new InvalidOperationException(
+                    "The log directory cannot be changed once the sink is writing: LogDir would name one "
+                    + "directory while the log went to another. Pass it on the first Init call instead.");
+            }
+
+            return requested;
+        }
+
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SysManager", "logs");
+    }
 
     // Dynamically build regex from the actual user profile parent directory
     // (e.g. C:\Users) so it works even if Windows is installed on a non-standard
@@ -64,8 +113,14 @@ public static partial class LogService
     [GeneratedRegex(@"(?i)([A-Z]:\\Users\\)[^\\]+")]
     private static partial Regex FallbackUserPathRegex();
 
-    public static void Init()
+    /// <param name="logDir">
+    /// Where to write. Null keeps the per-user default. Supplied only by a test that must not touch the
+    /// real log directory; the app's two call sites in <c>App.OnStartup</c> pass nothing, and they are
+    /// mutually exclusive, so this runs exactly once per process.
+    /// </param>
+    public static void Init(string? logDir = null)
     {
+        LogDir = ResolveLogDir(logDir, Logger is not null);
         Directory.CreateDirectory(LogDir);
         // Scrub the user name centrally, on the way to the file. SanitizePath already existed and
         // was applied at 15 call sites, while 60 others logged a raw path — so whether the user's


### PR DESCRIPTION
refactor: give LogService's log directory a seam and empty the path ratchet

Closes #1741.

Six of the seven services on that ratchet moved to a constructor-injected
`string? configDir = null`. LogService could not: it is a `static partial class`
because Serilog's sink is configured once per process, so there is no instance to
hang a parameter on. That is why it was the last entry, and why the ratchet's own
comment said it needed a decision rather than a mechanical edit.

Why it matters at all: a resolved path in static state cannot be pointed at a temp
directory by any test, because `Environment.GetFolderPath` resolves through the
Win32 known-folder function and ignores `LOCALAPPDATA`. Not hypothetical — a
service holding its path this way had tests that wrote into the user's real
speed-test history.

The static sink stays. `LogDir` becomes a property with a private setter, assigned
by `Init`, which now takes an optional directory. `Init` already ran exactly once
per process — its two call sites in `App.OnStartup` are mutually exclusive, the
update-applier branch returning before the normal path — so this adds a parameter,
not a lifecycle.

The refusal is the part worth having. Redirecting after the sink exists would
leave `LogDir` naming one directory while the log went to another, so the crash
dialog and the About tab would both send a user to an empty folder. It lives in
`ResolveLogDir`, a pure method, so it can be tested without building a real sink
and assigning the global `Log.Logger` — which every other test in the run shares.

Emptying the ratchet's list needed more than deleting a name. A private setter
makes the backing field non-readonly, so the rule would stop matching it for a
reason unrelated to being redirectable: the entry would go quiet rather than be
satisfied. So the ratchet now asserts the seam exists, by reflection over `Init`'s
signature. Mutation C removes that parameter and the ratchet goes red; mutation D
adds a fresh `static readonly` user path and it goes red too, which is what
distinguishes "the list is empty" from "the rule stopped matching".

Correction earned during this change: the first version added a parameterless
`DefaultLogDir()` helper, which tripped `StaticPathMethods_AcceptARedirect` — a
SECOND ratchet, covering the shape the field scan cannot see. Its rule is right:
a static member that can resolve a path under the user profile must at least offer
an override, and a default is fine while having no parameter to override is not.
Giving that helper a parameter nobody would pass would have satisfied the letter
of it and nothing else, so the helper is gone and `ResolveLogDir` produces the
default too, with both parameters optional. One entry point, and a caller
genuinely can redirect.

Red/green: four mutations, all as expected. Five resolver tests plus the ratchet;
35 tests across the four LogService suites and the full 74-method architecture
sweep green.

No release: refactor: is not a release type here — only fix: and feat: are.
