### PR TITLE
docs: add the missing XML summaries and a guard that keeps them

### DIFF
--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -5416,4 +5416,104 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"\.Wait\(\s*(?!0\s*[,)])", RegexOptions.CultureInvariant)]
     private static partial Regex BlockingWaitInDispose();
 
+    /// <summary>
+    /// A documentation comment that describes parameters, a return value or a thrown exception must also
+    /// carry a <c>&lt;summary&gt;</c>. Those tags describe the pieces and never say what the member is
+    /// for, which is the half a reader needs first.
+    /// <para>This exists because I introduced exactly that defect: adding a <c>&lt;param&gt;</c> to
+    /// <see cref="LogService.Init"/> to explain the new log-directory seam left the member with no
+    /// summary, and CodeQL raised <c>cs/xmldoc/missing-summary</c> against main after the merge.</para>
+    /// <para>CodeQL has this rule already, so the guard looks redundant. It is not, for two measured
+    /// reasons. CodeQL reported ONE instance where a sweep of the whole solution found THREE — it does
+    /// not report a private member (<c>DeepCleanupService.EnumerateFiles</c>) and it does not scan the
+    /// test project (<see cref="DialogAnswer"/>). And CodeQL is not a required check on main, so a fourth
+    /// could merge between scans. This runs in the blocking suite, over every project.</para>
+    /// </summary>
+    [Fact]
+    public void EveryDocumentedMember_CarriesASummary()
+    {
+        var solution = Path.Combine(FindRepoRoot(), "SysManager");
+        var offenders = new List<string>();
+        var documented = 0;
+        var summarised = 0;
+
+        foreach (var path in Directory
+                     .EnumerateFiles(solution, "*.cs", SearchOption.AllDirectories)
+                     .Where(p => !Path.GetRelativePath(solution, p)
+                         .Split(Path.DirectorySeparatorChar)
+                         .Any(segment => segment.Equals("obj", StringComparison.OrdinalIgnoreCase)
+                                         || segment.Equals("bin", StringComparison.OrdinalIgnoreCase))))
+        {
+            var lines = File.ReadAllLines(path);
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (!lines[i].TrimStart().StartsWith("///", StringComparison.Ordinal)) continue;
+
+                // A block is a run of consecutive /// lines. Whatever follows is the member it documents,
+                // which this does not need to parse: the tags inside the block already say whether it
+                // claims to describe parameters.
+                var start = i;
+                var block = new List<string>();
+                while (i < lines.Length
+                       && lines[i].TrimStart().StartsWith("///", StringComparison.Ordinal))
+                {
+                    block.Add(lines[i]);
+                    i++;
+                }
+
+                var text = string.Join('\n', block);
+                var hasSummary = CarriesASummary().IsMatch(text);
+                if (hasSummary) summarised++;
+                if (!DocumentsAMember().IsMatch(text)) continue;
+
+                documented++;
+                if (hasSummary) continue;
+
+                offenders.Add($"{Path.GetFileName(path)}:{start + 1} documents parameters or a return "
+                              + "value but has no <summary>");
+            }
+        }
+
+        // Two vacuity floors, because two separate patterns have to keep working for a clean result to
+        // mean anything. Measured at the time of writing: 35 blocks document a member, and all 2078 carry
+        // a summary. Either detector going quiet would report success while inspecting nothing.
+        Assert.True(documented >= 25,
+            $"Only {documented} documentation blocks were seen to document a parameter, return value or "
+            + "exception — the detection is broken, not the code. Fix this guard rather than trusting it.");
+        Assert.True(summarised >= 1600,
+            $"Only {summarised} documentation blocks were seen to carry a summary — the detection is "
+            + "broken, not the code. Fix this guard rather than trusting it.");
+
+        Assert.True(offenders.Count == 0,
+            "These documentation comments describe parameters, a return value or a thrown exception but "
+            + "never say what the member is for. Add a <summary>:\n  "
+            + string.Join("\n  ", offenders)
+            + $"\n({documented} blocks document a member, {summarised} carry a summary)");
+
+        // The word boundary is load-bearing, not decoration: <paramref/> shares its first six characters
+        // with <param>, and 109 summaries here use one. Without the boundary every one of them would read
+        // as "documents a parameter", and the guard would start demanding a summary from blocks that
+        // already have one — a false red on 109 compliant comments.
+        Assert.Matches(DocumentsAMember(), "/// <param name=\"x\">why</param>");
+        Assert.Matches(DocumentsAMember(), "/// <returns>a thing</returns>");
+        Assert.Matches(DocumentsAMember(), "/// <exception cref=\"IOException\">when</exception>");
+        Assert.DoesNotMatch(DocumentsAMember(), "/// <summary>see <paramref name=\"x\"/> above</summary>");
+        Assert.Matches(CarriesASummary(), "/// <summary>what it is</summary>");
+        Assert.Matches(CarriesASummary(), "/// <inheritdoc/>");
+    }
+
+    /// <summary>
+    /// A documentation tag describing a piece of a member rather than the member itself. The word
+    /// boundary keeps <c>&lt;paramref/&gt;</c> from reading as <c>&lt;param&gt;</c>.
+    /// </summary>
+    [GeneratedRegex(@"<(param|returns|exception|typeparam)\b", RegexOptions.CultureInvariant)]
+    private static partial Regex DocumentsAMember();
+
+    /// <summary>
+    /// Either an explicit summary, or an <c>&lt;inheritdoc/&gt;</c> that supplies one from the base member.
+    /// </summary>
+    [GeneratedRegex(@"<(summary|inheritdoc)\b", RegexOptions.CultureInvariant)]
+    private static partial Regex CarriesASummary();
+
 }

--- a/SysManager/SysManager.Tests/DialogAnswer.cs
+++ b/SysManager/SysManager.Tests/DialogAnswer.cs
@@ -24,6 +24,10 @@ public sealed class DialogAnswer : IDisposable
 {
     private readonly IDialogService _previous;
 
+    /// <summary>
+    /// Swaps in a substitute dialog service that always answers <paramref name="confirm"/>, keeping the
+    /// previous instance for <see cref="Dispose"/> to restore.
+    /// </summary>
     /// <param name="confirm">What <see cref="IDialogService.Confirm"/> returns — the user's click.</param>
     public DialogAnswer(bool confirm)
     {

--- a/SysManager/SysManager/Services/DeepCleanupService.cs
+++ b/SysManager/SysManager/Services/DeepCleanupService.cs
@@ -412,6 +412,12 @@ public sealed class DeepCleanupService
     private static long SafeLength(string path)
     { try { return new FileInfo(path).Length; } catch (IOException) { return 0; } catch (UnauthorizedAccessException) { return 0; } }
 
+    /// <summary>
+    /// Walks <paramref name="root"/> depth-first and yields every file under it, skipping reparse points
+    /// and the excluded subtrees. Enumeration errors skip that directory rather than abort the walk.
+    /// </summary>
+    /// <param name="root">Directory to walk. Yields nothing if it is itself a reparse point or excluded.</param>
+    /// <param name="ct">Stops the walk between directories; a cancelled walk simply ends.</param>
     /// <param name="excludeSubtrees">
     /// Directory trees to skip entirely. Callers pass <see cref="SystemPaths.BundleExtractionRoot"/> and
     /// <see cref="SystemPaths.OwnExtractionDirectory"/>: the "Temporary files" definition covers all of

--- a/SysManager/SysManager/Services/LogService.cs
+++ b/SysManager/SysManager/Services/LogService.cs
@@ -113,6 +113,10 @@ public static partial class LogService
     [GeneratedRegex(@"(?i)([A-Z]:\\Users\\)[^\\]+")]
     private static partial Regex FallbackUserPathRegex();
 
+    /// <summary>
+    /// Builds the rolling log sink and publishes it as both <see cref="Logger"/> and Serilog's global
+    /// <see cref="Log.Logger"/>. Also the only way to set <see cref="LogDir"/>.
+    /// </summary>
     /// <param name="logDir">
     /// Where to write. Null keeps the per-user default. Supplied only by a test that must not touch the
     /// real log directory; the app's two call sites in <c>App.OnStartup</c> pass nothing, and they are


### PR DESCRIPTION
CodeQL raised cs/xmldoc/missing-summary against main after #2065. It is my own
regression: that change added a <param> to LogService.Init explaining the new
log-directory seam, and a doc comment that documents a parameter but never says
what the member is for trips the rule. Before #2065 the member had no doc comment
at all, so nothing fired.

CodeQL reported one instance. Sweeping every doc comment in the solution found
three, and the two it missed are missed for structural reasons rather than by
chance:

  LogService.Init                    public, app project    -> reported
  DeepCleanupService.EnumerateFiles  private                -> not reported
  DialogAnswer(bool)                 test project           -> not scanned

So a clean CodeQL result and a clean codebase are not the same statement here.
Worth writing down, because CodeQL is also not a required check on main: a fourth
instance can merge between scans and only show up on the next run.

Hence the guard, in the blocking suite, over every project: a documentation block
that carries <param>, <returns>, <exception> or <typeparam> must also carry a
<summary> or an <inheritdoc>. 35 blocks in the solution document a member and all
2078 carry a summary, and both counts are asserted as floors -- either detector
going quiet would otherwise report success while inspecting nothing.

One detail is load-bearing rather than decorative. <paramref/> shares its first
six characters with <param>, and 109 summaries here use one, so the pattern needs
a word boundary; without it the guard would demand a summary from 109 comments
that already have one. A positive control pins that, and it is the only thing that
catches the mistake -- dropping the boundary leaves offenders at zero and both
floors satisfied, because those 109 blocks are all compliant.

Red/green: four mutations, each red for its own reason. Removing the summary from
each of the three files named that file, including the private member and the
test-project one. Removing the word boundary went red through the positive control
alone, as predicted. Restore byte-for-byte, green after. 75 green / 2 red on the
70-method architecture sweep, both reds the known runner artefacts (the runner's
own file has no attribution header, and the source-directory lookup cannot work
from an output folder); 50 green / 0 red across the LogService and dialog suites.

Comment-only in the three source files: 14 added lines, nothing removed, no
behaviour change. No release -- docs: is not a release type here.
