### PR TITLE
fix: keep Task Scheduler's run times when the list is filtered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.28] - 2026-09-02
+
+In Task Scheduler, clicking a task looks up when it last ran and when it runs next. Typing anything in the
+search box threw that away: both columns went back to a dash and the task you had selected was deselected.
+
+### Fixed
+- **Task Scheduler keeps the run times after you search.** Selecting a task takes a moment because the app
+  asks Windows for its last and next run time separately, one task at a time. That answer was only ever
+  written to the list on screen, not to the full list the search box filters — so the first character you
+  typed rebuilt the grid from the copy that never got the answer, the two columns reverted to "—", and the
+  selection went with them. Searching again did not help: the information had been discarded, not hidden.
+  Unchecking "Hide system tasks" did the same thing. Enabling or disabling a task was never affected, and
+  the difference is what pointed at the cause — that path already updated both lists.
+
 ## [1.75.27] - 2026-09-02
 
 On the six light colour themes you could not tell whether a switch was on or off — the little circle was white

--- a/SysManager/SysManager.Tests/TaskSchedulerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/TaskSchedulerViewModelTests.cs
@@ -230,4 +230,107 @@ public class TaskSchedulerViewModelTests
             "closing the view left a PowerShell scan running with nothing waiting for it.");
         await vm.InitializationComplete;
     }
+
+    // ── the run info the user waited for survives a filter keystroke ──────
+
+    private static PSObject Row(params (string Name, object? Value)[] properties)
+    {
+        var row = new PSObject();
+        foreach (var (name, value) in properties) row.Properties.Add(new PSNoteProperty(name, value));
+        return row;
+    }
+
+    /// <summary>
+    /// A runner that answers both scripts with real rows, unlike <see cref="RunnerSpy"/> which returns
+    /// empty collections. The list has to be non-empty for the filter to have anything to rebuild, and
+    /// the run-info query has to return dates for there to be anything to lose.
+    /// </summary>
+    private static IPowerShellRunner PopulatedRunner(DateTime lastRun, DateTime nextRun)
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(),
+                        Arg.Any<CancellationToken>())
+              .Returns(ci =>
+              {
+                  var script = (string)ci[0]!;
+                  if (script.Contains(ListMarker, StringComparison.Ordinal))
+                  {
+                      return Task.FromResult(new Collection<PSObject>
+                      {
+                          Row(("TaskName", "Defrag"), ("TaskPath", @"\Microsoft\Windows\Defrag\"),
+                              ("State", "Ready"), ("Author", "Microsoft"), ("Description", "desc")),
+                          Row(("TaskName", "Backup"), ("TaskPath", @"\Custom\"),
+                              ("State", "Ready"), ("Author", "me"), ("Description", "desc")),
+                      });
+                  }
+                  if (script.Contains(InfoParams, StringComparison.Ordinal))
+                  {
+                      return Task.FromResult(new Collection<PSObject>
+                      {
+                          Row(("LastRunTime", lastRun), ("NextRunTime", nextRun)),
+                      });
+                  }
+                  return Task.FromResult(new Collection<PSObject>());
+              });
+        return runner;
+    }
+
+    /// <summary>
+    /// Selecting a row costs a PowerShell round-trip to fill in Last run / Next run. Typing one
+    /// character in the filter box threw that away: the enriched row was written to <c>Tasks</c> and to
+    /// the selection, but never back to the unfiltered backing list the filter rebuilds from — so both
+    /// columns snapped back to "—" and the selection was dropped, while the toggle path (Enable/Disable)
+    /// updated the backing list correctly and kept its result.
+    /// </summary>
+    [Fact]
+    public async Task AFilterKeystroke_KeepsTheRunInfoTheSelectionJustPaidFor()
+    {
+        var lastRun = new DateTime(2026, 8, 30, 14, 5, 0);
+        var nextRun = new DateTime(2026, 9, 3, 6, 0, 0);
+        var vm = new TaskSchedulerViewModel(new TaskSchedulerService(PopulatedRunner(lastRun, nextRun)));
+        await vm.InitializationComplete;
+
+        Assert.Equal(2, vm.Tasks.Count);
+        var defrag = vm.Tasks.Single(t => t.Name == "Defrag");
+        Assert.Null(defrag.LastRun);         // the list scan does not fetch run info
+
+        vm.SelectedTask = defrag;
+
+        // Precondition, not decoration: if the query never landed there would be nothing to lose and
+        // the assertions below would pass on an empty premise.
+        Assert.Equal(lastRun, vm.SelectedTask!.LastRun);
+        Assert.Equal(nextRun, vm.SelectedTask!.NextRun);
+
+        vm.Filter = "Defrag";                // one keystroke, and the grid is rebuilt from the backing list
+
+        var shown = Assert.Single(vm.Tasks);
+        Assert.Equal(lastRun, shown.LastRun);
+        Assert.Equal(nextRun, shown.NextRun);
+        Assert.Same(shown, vm.SelectedTask);
+    }
+
+    /// <summary>
+    /// The same loss through the other filter, because <c>HideSystemTasks</c> and <c>Filter</c> are two
+    /// entry points to one rebuild — fixing only the one a bug report happened to name would leave the
+    /// checkbox still discarding the data.
+    /// </summary>
+    [Fact]
+    public async Task HidingSystemTasks_AlsoKeepsTheRunInfo()
+    {
+        var lastRun = new DateTime(2026, 8, 30, 14, 5, 0);
+        var nextRun = new DateTime(2026, 9, 3, 6, 0, 0);
+        var vm = new TaskSchedulerViewModel(new TaskSchedulerService(PopulatedRunner(lastRun, nextRun)));
+        await vm.InitializationComplete;
+
+        var backup = vm.Tasks.Single(t => t.Name == "Backup");   // third-party, survives the checkbox
+        vm.SelectedTask = backup;
+        Assert.Equal(lastRun, vm.SelectedTask!.LastRun);
+
+        vm.HideSystemTasks = true;
+
+        var shown = Assert.Single(vm.Tasks);
+        Assert.Equal("Backup", shown.Name);
+        Assert.Equal(lastRun, shown.LastRun);
+        Assert.Same(shown, vm.SelectedTask);
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.27</Version>
-    <FileVersion>1.75.27.0</FileVersion>
-    <AssemblyVersion>1.75.27.0</AssemblyVersion>
+    <Version>1.75.28</Version>
+    <FileVersion>1.75.28.0</FileVersion>
+    <AssemblyVersion>1.75.28.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/TaskSchedulerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TaskSchedulerViewModel.cs
@@ -152,11 +152,10 @@ public sealed partial class TaskSchedulerViewModel : ViewModelBase
         // Update the item in place if it's still the selection.
         if (ReferenceEquals(SelectedTask, task))
         {
-            int idx = Tasks.IndexOf(task);
             _reassigningSelection = true;
             try
             {
-                if (idx >= 0) Tasks[idx] = withInfo;
+                ReplaceInBothLists(task, withInfo);
                 SelectedTask = withInfo;
             }
             finally { _reassigningSelection = false; }
@@ -214,12 +213,28 @@ public sealed partial class TaskSchedulerViewModel : ViewModelBase
         base.Dispose(disposing);
     }
 
-    private void ReplaceTask(ScheduledTaskInfo oldTask, ScheduledTaskInfo newTask)
+    /// <summary>
+    /// Swaps a task for an updated copy in BOTH lists. There are two: <c>Tasks</c> is what the grid
+    /// shows, and <c>_all</c> is the unfiltered set <see cref="ApplyFilter"/> rebuilds <c>Tasks</c> from.
+    /// </summary>
+    /// <remarks>
+    /// Extracted because the two update paths had drifted. Enable/Disable wrote to both lists; the
+    /// per-selection run-info query wrote only to <c>Tasks</c>, so one keystroke in the filter box
+    /// rebuilt the grid from the stale copy in <c>_all</c> and the Last run / Next run columns the user
+    /// had just waited for snapped back to "—", taking the selection with them. One method that knows
+    /// about both lists is the difference between fixing that and fixing it again later.
+    /// </remarks>
+    private void ReplaceInBothLists(ScheduledTaskInfo oldTask, ScheduledTaskInfo newTask)
     {
         int allIdx = _all.FindIndex(t => t.FullPath == oldTask.FullPath);
         if (allIdx >= 0) _all[allIdx] = newTask;
         int idx = Tasks.IndexOf(oldTask);
         if (idx >= 0) Tasks[idx] = newTask;
+    }
+
+    private void ReplaceTask(ScheduledTaskInfo oldTask, ScheduledTaskInfo newTask)
+    {
+        ReplaceInBothLists(oldTask, newTask);
         SelectedTask = newTask;
     }
 }


### PR DESCRIPTION
Selecting a task costs a separate PowerShell round-trip: Get-ScheduledTaskInfo is
per-task, so Last run and Next run are fetched lazily for the row you click. One
character in the search box threw that answer away. Both columns reverted to "—",
the selection was dropped, and searching again did not bring them back because the
data had been discarded rather than hidden. Unchecking "Hide system tasks" did the
same thing.

Root cause is two lists and one update path that only knew about one. `Tasks` is
what the grid binds to; `_all` is the unfiltered set ApplyFilter rebuilds `Tasks`
from. The run-info handler wrote the enriched task to `Tasks` and to SelectedTask,
never to `_all`, so the next rebuild sourced the stale copy. The selection went
with it: ReplaceWith swaps in the object from `_all`, and SelectedTask was still
pointing at an instance no longer in the collection.

Enable/Disable was never affected, and that asymmetry is what identified the
cause rather than the symptom — ReplaceTask already updated both lists. So the
fix is not a third write but one method both paths go through,
`ReplaceInBothLists`. There is no longer a way to update one list and forget the
other, which is the property worth having; the previous code was correct in one
place and wrong in the other for no reason a reader could see.

Why only this tab, checked rather than assumed: 65 view models, 40 use
ReplaceWith, 6 hold a private backing List. Of those 6 only this one replaces an
item by index — the other five (Services, Startup, Drivers, ContextMenu,
CpuAffinity) hold mutable CLASS models, so both lists reference the same objects
and mutating one is visible in both. ScheduledTaskInfo is a record, so an update
is a new instance, and a new instance is what can be written to one list only.
ServicesViewModel says as much in its own comment: it "sorts the SAME instances
out of _allServices rather than projecting new ones". Nothing else to propagate.

Two regression tests, one per filter entry point, because Filter and
HideSystemTasks are two doors to the same rebuild and fixing only the one a report
happened to name would leave the checkbox still discarding the data. Both were red
before the fix with "Expected: 2026-08-30T14:05:00, Actual: null" — the run time
reverting to null is the defect itself — and green after. Each asserts the
enrichment landed BEFORE filtering, so neither can pass on an empty premise, and
each asserts the selection survives as well as the values.

The existing RunnerSpy returns empty collections, which is right for the
cancellation tests it was written for but leaves nothing to filter and nothing to
lose, so these use a runner that answers both scripts with real rows.

Regression: 36 green across the three Task Scheduler suites, 75 green on the
70-method architecture sweep (2 reds are the local runner's own artefacts, green in
CI), four projects build with 0 warnings.

No documentation change: README already describes this tab as listing "last and
next run" AND offering "filter by name or path". The defect made those two
sentences mutually exclusive, so the docs described the fixed behaviour all along.
