### PR TITLE
docs: add the last missing README table-of-contents entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ winget install laurentiu021.SysManager
 - [Features](#features) — all 58 tabs, grouped
 - [Screenshots](#screenshots)
 - [Install](#install)
+  - [Verifying the download](#verifying-the-download)
 - [Uninstalling](#uninstalling)
 - [Build from source](#build-from-source)
 - [First-time flow](#first-time-flow)


### PR DESCRIPTION
Closes #1668.

The table of contents shipped earlier and covers nine of the ten sections the issue
named. The tenth is "Verifying the download", which the issue names twice: fifth in
its list of targets, and again in the rationale as one of "the two sections that
convert a visitor" and must therefore be "one click from the top". The other half of
that sentence, the comparison table, is linked. This one was not.

It matters more than its size. The section sits at README.md:1205, 28 lines under
`## Install`, and the only links to it are prose mentions at :967 -- 900 lines away,
inside Features -- and :1297, below the section itself. Someone who wants to check a
download before running an unsigned binary had no way to reach the instructions from
the top of a 1512-line page.

Indented under Install because it is a `###` subsection of it, not a sibling. The
guard's heading pattern is `^#{2,}\s+(.*)$`, so it accepts a level-three heading, and
the `entries >= 10` floor accepts one more entry; no test change was needed.

Red/green, because a new line in a list is exactly the kind of change that can look
guarded without being it: pointing the new anchor at a heading that does not exist
turns `TheReadmeTableOfContents_HasNoDeadAnchors` red naming README.md:45, and
renaming the target heading turns it red naming the same line plus the two prose
links at :967 and :1297. Restore byte-for-byte, green after. 65 internal links across
10 markdown files, 0 broken.

No release: docs: is not a release type here.
