### PR TITLE
fix: make Enter open a sidebar tab or group, not just Space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.29] - 2026-09-02
+
+If you move around the app with the keyboard instead of the mouse, pressing Enter on anything in the
+left-hand menu did nothing at all. Space worked, Enter did not. Both work now.
+
+### Fixed
+- **Enter now opens a page or a group in the left-hand menu.** You could reach every entry with Tab and
+  see where you were, but the key most people press to open the thing they have landed on was ignored —
+  including on the group headings, so a closed group could be reached and then not opened. Only Space
+  did anything. This is the key that opens a folder in File Explorer and an entry in the Start menu, so
+  Enter doing nothing read as the menu being broken rather than as a different key being required.
+
 ## [1.75.28] - 2026-09-02
 
 In Task Scheduler, clicking a task looks up when it last ran and when it runs next. Typing anything in the

--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ changes at all.
 ### Keyboard navigation
 The app is operable without a mouse, and the control you are on is always visible. `Tab` moves
 forward, `Shift+Tab` back, `Space` presses a button or ticks a checkbox, and the arrow keys move
-within a table or a row of filter chips.
+within a table or a row of filter chips. In the sidebar, `Enter` also opens the tab or group you are
+on, the way it opens a folder in File Explorer.
 
 The focus outline is deliberately two thin lines of opposite shade — one light, one dark — rather
 than a single accent-coloured ring. A single colour cannot be visible everywhere: it has to show up

--- a/SysManager/SysManager.Tests/SidebarSelectionContractTests.cs
+++ b/SysManager/SysManager.Tests/SidebarSelectionContractTests.cs
@@ -111,6 +111,11 @@ public class SidebarSelectionContractTests
                 && (string?)trigger.Attribute("Value") == "True");
         AssertSetter(focusTrigger, "BorderBrush", "{DynamicResource Accent}");
 
+        // Focusable is necessary but not sufficient: ButtonBase treats Enter as a click only where
+        // this is set, so without it a row could be tabbed to and then not opened with the key most
+        // people press. Asserted on the style, which is what both the leaf and single-item rows use.
+        AssertSetter(buttonStyle, "KeyboardNavigation.AcceptsReturn", "True");
+
         var navItemsControls = document
             .Descendants(Presentation + "ItemsControl")
             .Where(element =>
@@ -134,6 +139,9 @@ public class SidebarSelectionContractTests
 
         Assert.Equal("True", (string?)header.Attribute("Focusable"));
         Assert.Equal("True", (string?)header.Attribute("KeyboardNavigation.IsTabStop"));
+        // The header is a ToggleButton, so it too answers Space by default and Enter only with this.
+        // Reaching a collapsed group and being unable to open it is the same dead end as not reaching it.
+        Assert.Equal("True", (string?)header.Attribute("KeyboardNavigation.AcceptsReturn"));
         Assert.Equal(
             "{Binding Id, StringFormat={}{0}-header}",
             (string?)header.Attribute("AutomationProperties.AutomationId"));

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -226,6 +226,7 @@
                                               Cursor="Hand" Padding="0" Margin="0"
                                               Focusable="True"
                                               KeyboardNavigation.IsTabStop="True"
+                                              KeyboardNavigation.AcceptsReturn="True"
                                               AutomationProperties.AutomationId="{Binding Id, StringFormat={}{0}-header}"
                                               AutomationProperties.Name="{Binding Label}">
                                     <ToggleButton.Template>

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -24,6 +24,11 @@
             <Setter Property="Padding" Value="0"/>
             <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
             <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <!-- WPF's ButtonBase activates on Space, and on Enter ONLY when this attached property is
+                 set. In a list of navigation rows Enter is the key people reach for first — it is what
+                 opens a folder in Explorer and an entry in the Start menu — so without this the sidebar
+                 answered Space and silently ignored Enter. -->
+            <Setter Property="KeyboardNavigation.AcceptsReturn" Value="True"/>
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="Button">
@@ -381,8 +386,10 @@
                         </StackPanel>
                         <!-- Theme button — a Border rather than a Button (to keep the compact
                              28x28 chip visual), so it needs explicit accessibility: a UIA name,
-                             a tab stop, keyboard focus, and Enter/Space activation, matching what
-                             a real Button would give screen-reader and keyboard users. -->
+                             a tab stop, keyboard focus, and Enter/Space activation.
+                             A Button would supply the peer and Space, but NOT Enter: ButtonBase
+                             honours Enter only where KeyboardNavigation.AcceptsReturn is set, which
+                             is why the nav rows set it explicitly. -->
                         <Border Grid.Column="1" x:Name="ThemeBtn" Width="28" Height="28" CornerRadius="8"
                                 Background="{DynamicResource Surface3}" BorderBrush="{DynamicResource Border1}"
                                 BorderThickness="1" Cursor="Hand" MouseLeftButtonUp="ThemeBtn_Click"

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -266,8 +266,9 @@ public partial class MainWindow : Window
 
     private void ThemeBtn_Click(object sender, MouseButtonEventArgs e) => ToggleThemePopup();
 
-    // Enter/Space activate the theme chip for keyboard users, matching a Button's behaviour
-    // (the chip is a Border, so it does not get this for free).
+    // Enter/Space activate the theme chip for keyboard users. The chip is a Border, so it gets
+    // neither for free — and a Button would only have given it Space, since ButtonBase treats Enter
+    // as a click only where KeyboardNavigation.AcceptsReturn is set.
     private void ThemeBtn_KeyDown(object sender, KeyEventArgs e)
     {
         if (e.Key is Key.Enter or Key.Space)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.28</Version>
-    <FileVersion>1.75.28.0</FileVersion>
-    <AssemblyVersion>1.75.28.0</AssemblyVersion>
+    <Version>1.75.29</Version>
+    <FileVersion>1.75.29.0</FileVersion>
+    <AssemblyVersion>1.75.29.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #1495.

Most of that issue already shipped: the leaf rows and the single-item rows are real
Buttons with UIA ids and names, the group header ToggleButton is focusable and a tab
stop, and both carry an IsKeyboardFocused ring. What was left is the clause the issue
ends on -- "so groups can be opened with Enter" -- and it was still true that they
could not be. Neither could the leaf rows.

The cause is a WPF detail rather than a missing handler. ButtonBase activates on
Space unconditionally, but treats Enter as a click ONLY where
KeyboardNavigation.AcceptsReturn is set. It was set nowhere: `grep -rn AcceptsReturn`
over the whole solution returned nothing, and so did `IsDefault`. So every element in
the one navigation surface answered Space and silently ignored Enter -- the key that
opens a folder in File Explorer and an entry in the Start menu. A user who tabbed to
a collapsed group and pressed Enter got no feedback at all, which reads as a broken
menu rather than as the wrong key.

Two lines, because both surfaces need it and both are declared once: a Setter on the
SidebarNavButton style, which the leaf and single-item rows share, and the attribute
on the HeaderSite ToggleButton in the SidebarExpander template. No code-behind and no
KeyDown handler -- the framework already does this, it just has to be asked.

The misconception was written down, which is why it survived. The theme chip's
comment said its hand-rolled Enter/Space handler was "matching a Button's behaviour",
and the single-item row's comment credited a Button with "keyboard activation that a
ContentControl or bare Border cannot provide". The first is wrong about Enter, and
believing it is exactly why nobody added Enter to the Buttons. Both comments are
corrected here; leaving them would have re-created this.

Scoped to the sidebar deliberately. Space-only activation is correct and conventional
for an ordinary command button -- Windows reserves Enter for the default button of a
dialog -- so this is not applied to the app's other ~100 buttons. A list of navigation
rows is the case where Enter is the convention, and it is the case the issue is about.

Guarded by extending the two existing contract tests rather than adding a parallel
one: LiveRows_ExposeSelectionToInvokableAutomationPeers already resolves the
SidebarNavButton style, and CollapsedGroups_KeepHiddenLeavesOutOfKeyboardNavigation
already resolves HeaderSite.

Red/green, three mutations. Removing the style Setter and removing the header
attribute each go red on their own test. The third is the one I care about: delete the
Setter but leave a comment naming it, and the test stays red -- these assertions parse
XAML with XDocument, so a comment is not a setting. That check is here because a
source-text guard in this repo has gone green on its own prose before.

Regression: 9 green across the sidebar and UIA contract suites, 75 green on the
70-method architecture sweep (the 2 reds are the local runner's own artefacts, green
in CI), app and tests build with 0 warnings.

Not verifiable here: an actual keyboard pass needs the app running, which happens on
a machine that runs the application. What this change pins mechanically is the XAML contract
that makes Enter work; the hands-on tab-and-Enter walk of all 58 rows and 11 headers
is still worth doing there, as the issue's own risk note says.
