### PR TITLE
fix: say so when Windows records no description for a scheduled task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.30] - 2026-09-02
+
+In Task Scheduler, the "What it does" column was simply blank for most tasks, because Windows never
+recorded a description for them — but a blank cell looks like something failed to load. It now says so.
+Hovering a task's name shows the full text, which the column has to cut short.
+
+### Fixed
+- **"What it does" no longer looks broken on tasks Windows never described.** A great many Windows
+  scheduled tasks carry no description at all. The column showed those as an empty cell, which reads as
+  missing data rather than as data that was never there; it now reads "No description provided by
+  Windows." A blank value made of spaces is treated the same way, since it looks identical.
+- **The full description is now readable.** The column is narrow and cuts long text off with an ellipsis,
+  and hovering it showed the publisher instead. Hovering the task's own name now shows the whole
+  description, so nothing is displayed with no way to read the rest of it.
+
 ## [1.75.29] - 2026-09-02
 
 If you move around the app with the keyboard instead of the mouse, pressing Enter on anything in the

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -3707,7 +3707,15 @@ public partial class ArchitectureTests
         (string Fetched, string Bound)[] contract =
         [
             ("@{ n='State'; e={ [string]$_.State } }, Author, Description", "{Binding AuthorDisplay}"),
-            ("Author, Description", "{Binding Description}"),
+            // DescriptionDisplay, not the raw field: most Windows tasks carry no description, and the
+            // raw binding rendered those rows as an empty cell.
+            //
+            // The `Binding="` prefix is load-bearing, unlike the other rows. DescriptionDisplay is bound
+            // TWICE in this view — as the column's own value and as the Task column's tooltip — so a bare
+            // substring check would be satisfied by the tooltip alone, and the column could quietly go
+            // back to the raw field while this guard stayed green. A tooltip is `Value="`, a column is
+            // `Binding="`; only the latter is the cell. Caught by mutating exactly that.
+            ("Author, Description", "Binding=\"{Binding DescriptionDisplay}\""),
             ("Select-Object LastRunTime, NextRunTime", "{Binding NextRunDisplay}"),
             ("Select-Object LastRunTime, NextRunTime", "{Binding LastRunDisplay}"),
         ];

--- a/SysManager/SysManager.Tests/ScheduledTaskInfoTests.cs
+++ b/SysManager/SysManager.Tests/ScheduledTaskInfoTests.cs
@@ -44,4 +44,28 @@ public class ScheduledTaskInfoTests
         Assert.True(Make("Ready", TaskCategory.System).IsSystem);
         Assert.False(Make("Ready", TaskCategory.Telemetry).IsSystem);
     }
+
+    private static ScheduledTaskInfo WithDescription(string? description)
+        => new("MyTask", @"\Vendor\", "Ready", "Vendor", description, TaskCategory.ThirdParty, null, null);
+
+    /// <summary>
+    /// A great many Windows tasks report no description. Whitespace counts as none: a value of " "
+    /// renders exactly like an empty cell, so treating it as real text would leave the blank the
+    /// fallback exists to remove.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void DescriptionDisplay_SaysSoWhenWindowsGivesNothing(string? description)
+        => Assert.Equal(
+            "No description provided by Windows.",
+            WithDescription(description).DescriptionDisplay);
+
+    [Fact]
+    public void DescriptionDisplay_PassesWindowsOwnWordsThrough()
+        => Assert.Equal(
+            "Keeps your printer working.",
+            WithDescription("Keeps your printer working.").DescriptionDisplay);
 }

--- a/SysManager/SysManager/Models/ScheduledTaskInfo.cs
+++ b/SysManager/SysManager/Models/ScheduledTaskInfo.cs
@@ -55,4 +55,13 @@ public sealed record ScheduledTaskInfo(
     public string AuthorDisplay => string.IsNullOrWhiteSpace(Author)
         ? "No publisher recorded for this task."
         : $"Created by: {Author}";
+
+    /// <summary>
+    /// What the task is for, phrased for a cell. A great many Windows tasks carry no description at all,
+    /// and the raw value rendered as an empty cell — which reads as data that failed to load rather than
+    /// data Windows never had. Says so instead.
+    /// </summary>
+    public string DescriptionDisplay => string.IsNullOrWhiteSpace(Description)
+        ? "No description provided by Windows."
+        : Description;
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.29</Version>
-    <FileVersion>1.75.29.0</FileVersion>
-    <AssemblyVersion>1.75.29.0</AssemblyVersion>
+    <Version>1.75.30</Version>
+    <FileVersion>1.75.30.0</FileVersion>
+    <AssemblyVersion>1.75.30.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/TaskSchedulerView.xaml
+++ b/SysManager/SysManager/Views/TaskSchedulerView.xaml
@@ -95,6 +95,13 @@
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+                                <!-- The description on hover over the NAME, which is where someone
+                                     deciding whether to disable "Adobe Acrobat Update Task" is looking.
+                                     It is also the only place the full text is readable: the "What it
+                                     does" column trims, and its own tooltip is the publisher. Each
+                                     column's tooltip therefore shows something that column does not
+                                     already display. -->
+                                <Setter Property="ToolTip" Value="{Binding DescriptionDisplay}"/>
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
@@ -147,8 +154,8 @@
                          what the category chip is derived from, so a user who wonders why something is
                          labelled "System" can now see the answer. Same trimming + hover shape as the
                          Description column in ServicesView. -->
-                    <DataGridTextColumn Header="What it does" Binding="{Binding Description}"
-                                        Width="*" MinWidth="120" SortMemberPath="Description">
+                    <DataGridTextColumn Header="What it does" Binding="{Binding DescriptionDisplay}"
+                                        Width="*" MinWidth="120" SortMemberPath="DescriptionDisplay">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="TextTrimming" Value="CharacterEllipsis"/>


### PR DESCRIPTION
Closes #1580.

The data this issue is about is on screen: the scan already fetched Description
and Author, the per-selection query already fetched both run times, and columns
for all four shipped. Two things the issue explicitly asked for did not, and both
are about a cell you cannot read.

A great many Windows tasks carry no Description at all. The column bound the raw
field, so those rows rendered as an empty cell -- which reads as data that failed
to load, not as data Windows never had. The issue's own risk note called for a
"graceful 'No description provided by Windows' fallback rather than a blank
panel", and every sibling field on the model already had one: LastRunDisplay and
NextRunDisplay show a dash, AuthorDisplay says "No publisher recorded for this
task." Description was the one without. DescriptionDisplay follows exactly that
shape, and treats whitespace as nothing, because " " renders identically to empty.

The other half: the column is `Width="*" MinWidth="120"` with
TextTrimming, so a real description is cut off with an ellipsis, and hovering it
showed the publisher. The full text was therefore unreachable -- displayed and
unreadable at once. The issue asked for `ToolTip="{Binding Description}"` on the
Task column, and that is what this adds, bound to the display value so a task with
no description gets a tooltip that says so rather than an empty box. Each column's
tooltip now shows something that column does not already display: the name shows
what the task is for, the description shows who created it.

Deliberately NOT adding the selection-detail card from the proposed solution. It
was one suggested mechanism for surfacing this data, and the columns that shipped
serve the same stated goal -- "lead with the task's own description", "when will it
next run" -- without the cost the issue itself flagged in the same breath: the view
already has six rows (header, two elevation banners, toolbar, grid, action row) and
a card would take the vertical space from the grid.

The guard needed care, and the red run is why. Extending
EveryScheduledTaskFieldTheQueryFetches_IsBoundInTheView to demand
`{Binding DescriptionDisplay}` LOOKED sufficient, but that value is now bound twice
in this view -- as the cell and as the Task column's tooltip -- so the check was
satisfied by the tooltip alone and the cell could quietly revert to the raw field
while the guard stayed green. The contract entry therefore matches
`Binding="{Binding DescriptionDisplay}"`: a tooltip is `Value="`, a cell is
`Binding="`. Mutation A is exactly that revert, and it goes red only with the
prefix.

Red/green, four mutations, all as expected: the cell reverting to the raw field
(caught by the guard, per above), the fallback text reworded (all four theory rows),
IsNullOrWhiteSpace weakened to IsNullOrEmpty (the two whitespace rows only, which is
the point of having them), and the real description no longer passed through.
Restore byte-for-byte; 6 green after.

One thing is honestly not pinned: nothing asserts WHERE the tooltip lives. The guard
proves the cell binds the display value and the field reaches the view; the tooltip's
placement on the Task column is visible in the diff and explained in a comment beside
it, but a future edit could move it without a test failing. A whitespace-sensitive
text assertion on that one line would have been more brittle than useful.

Regression: 41 green across the three Task Scheduler suites (was 36 before these five
cases), 75 green on the 70-method architecture sweep -- the 2 reds are the local
runner's own artefacts and are green in CI -- app and tests build with 0 warnings.
