### PR TITLE
ci: announce only feature releases, so Discussions has room for people

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -684,7 +684,32 @@ jobs:
             echo "Re-run this workflow once fixed. The release itself does not need to be recreated."
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # One announcement per release turned Discussions into a wall: every one of the 645 discussions
+      # was a release bot post, and the five human categories were empty, so the only low-friction
+      # channel for someone who will not open an issue had no human first screen at all.
+      #
+      # Gated on the patch component rather than on a bump type, because release.yml is also runnable
+      # from a tag and does not otherwise know how the version was decided. Patch 0 is exactly the set
+      # semantic-release produces for feat: and feat!: — 1.76.0, 2.0.0 — while every fix: lands as
+      # 1.75.30 and above. Deliberately NOT `endsWith(version, '.0')`, which is the same test written
+      # so that 1.75.10 makes a reader stop and check.
+      - name: Decide whether this release gets an announcement
+        id: announce
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          patch="${VERSION##*.}"
+          if [ "$patch" = "0" ]; then
+            echo "post=true" >> "$GITHUB_OUTPUT"
+            echo "$VERSION is a feature release — posting an announcement."
+          else
+            echo "post=false" >> "$GITHUB_OUTPUT"
+            echo "$VERSION is a patch release — no announcement, so human threads stay readable."
+          fi
+
       - name: Post announcement to Discussions
+        if: steps.announce.outputs.post == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2134,6 +2134,73 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// The release announcement must stay gated to feature releases.
+    /// </summary>
+    /// <remarks>
+    /// One announcement per release made Discussions unusable: all 645 discussions were release bot
+    /// posts and the five human categories were empty, so the only low-friction channel for someone who
+    /// will not open an issue had no human content on its first screen at all.
+    /// <para>The gate reads the patch component rather than a bump type, because release.yml is also
+    /// runnable from a tag and does not otherwise know how the version was decided. Patch 0 is exactly
+    /// what semantic-release produces for <c>feat:</c> and <c>feat!:</c>.</para>
+    /// <para>Guarded because deleting three lines restores the wall, and nothing else in the suite would
+    /// notice — the sibling guard above asserts only that the announcement step EXISTS and runs after
+    /// the smoke check, which a gated step still does.</para>
+    /// </remarks>
+    [Fact]
+    public void TheAnnouncement_OnlyPostsForFeatureReleases()
+    {
+        var lines = File.ReadAllLines(
+            Path.Combine(FindRepoRoot(), ".github", "workflows", "release.yml"));
+
+        int StepLine(string name)
+        {
+            var at = Array.FindIndex(lines, l => l.Trim() == $"- name: {name}");
+            Assert.True(at >= 0,
+                $"release.yml has no step named \"{name}\". If it was renamed, update this guard in the "
+                + "same PR — do not delete it.");
+            return at;
+        }
+
+        var gate = StepLine("Decide whether this release gets an announcement");
+        var announce = StepLine("Post announcement to Discussions");
+        Assert.True(gate < announce,
+            $"the gate (line {gate + 1}) runs after the announcement it decides (line {announce + 1}).");
+
+        // Each step is sliced to its OWN boundary. A slice that ran to the end of the file would let
+        // either step be satisfied by the other's text, which is how a check like this goes vacuous.
+        //
+        // Comment lines are dropped, and that is not tidiness. Commenting the condition out rather than
+        // deleting it left this guard GREEN on the first draft: `Contains` matches the condition inside
+        // `# if: steps.announce...` just as happily as the real thing, so a disabled gate read as a
+        // working one. Found by mutating exactly that.
+        string Body(int at)
+        {
+            var end = Array.FindIndex(lines, at + 1,
+                l => l.TrimStart().StartsWith("- name:", StringComparison.Ordinal));
+            if (end < 0) end = lines.Length;
+            var code = lines[(at + 1)..end]
+                .Where(l => !l.TrimStart().StartsWith('#'));
+            var slice = string.Join('\n', code);
+            Assert.False(string.IsNullOrWhiteSpace(slice),
+                $"the step at line {at + 1} has no non-comment body, so every assertion on it would "
+                + "pass while inspecting nothing.");
+            return slice;
+        }
+
+        var announceBody = Body(announce);
+        Assert.Contains("if: steps.announce.outputs.post == 'true'", announceBody, StringComparison.Ordinal);
+
+        // The gate has to actually decide. Without the comparison it could emit a constant and the
+        // condition above would be satisfied on every release — the wall back, with a gate in front of it.
+        var gateBody = Body(gate);
+        Assert.Contains("id: announce", gateBody, StringComparison.Ordinal);
+        Assert.Contains("${VERSION##*.}", gateBody, StringComparison.Ordinal);
+        Assert.Contains("post=false", gateBody, StringComparison.Ordinal);
+        Assert.Contains("post=true", gateBody, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// The release workflow must prove the artifact reports the tag it was built from — statically,
     /// and again at runtime.
     /// <para>publish.ps1 injects Version, FileVersion and AssemblyVersion from the tag and nothing


### PR DESCRIPTION
This is the code half of #1665, part 3.

Every one of the 645 discussions on this repo is a release bot post. General,
Ideas, Q&A, Show-and-tell and Polls are all empty, and nothing is pinned. So the
one low-friction channel for someone who will not open a GitHub issue -- the target
persona exactly -- opens on an endless wall of "SysManager X.Y.Z is out!" with no
human content anywhere on the first screen. At one post per patch, and patches being
nearly every release, no human thread could stay visible for long.

The announcement step now runs only when the patch component is 0, which is exactly
the set semantic-release produces for feat: and feat!: -- 1.76.0, 2.0.0 -- while
every fix: lands as 1.75.30 and above. Gated on the version rather than on a bump
type because release.yml is also runnable from a tag and does not otherwise know how
the version was decided.

Written as an explicit step rather than `endsWith(version, '.0')`. That expression is
correct -- 1.75.10 ends with "10", not ".0" -- but it is the kind of correct that
makes a reader stop and work it out, and one day someone works it out wrong. The step
prints which way it went, so the decision is in the log rather than inferred from a
skipped step.

Guarded, because deleting three lines restores the wall and nothing else in the suite
would notice: the sibling guard asserts only that the announcement step EXISTS and
runs after the smoke check, which a gated step still does.

Red/green earned two corrections to my own work, both from the mutations rather than
from review:

  - Commenting the condition out instead of deleting it left the guard GREEN.
    `Contains` matches the condition inside `# if: steps.announce...` exactly as
    happily as the real line, so a disabled gate read as a working one. The slice now
    drops comment lines, and that mutation is red.
  - The proof's own pattern for deleting the gate step was written with \n against a
    CRLF file, so that case reported "PATTERN MISSING" -- it proved nothing while the
    other three passed and the run looked complete.

Four mutations, all red now: the `if:` deleted, the gate step deleted, the gate
emitting a constant so the condition is satisfied on every release, and the `if:`
commented out. Restore byte-for-byte, green after. All five workflows parse
(`yaml.safe_load`), the gate sits immediately before the step it gates, and the shell
expression was checked against 1.75.30, 1.75.10, 1.75.100, 1.76.0, 2.0.0, 1.0.0 and
10.0.0. 76 green on the 71-method architecture sweep; the 2 reds are the local
runner's own artefacts and are green in CI.

The trade-off is the one #1665 names: slightly less per-release visibility. The
release itself, its notes, its assets and the winget submission are untouched -- only
the Discussions post is gated.

What is left on #1665 needs the maintainer and cannot be automated: pinning a Roadmap
post and a "start here" post, and seeding a Q&A and a Show-and-tell entry. GraphQL has
no `pinDiscussion` mutation -- introspection lists only pinEnvironment, pinIssue,
pinIssueComment, unpinIssue and unpinIssueComment -- so pinning is a web-UI action,
and seeding is public content that is not mine to write.

No release: ci: is not a release type here.
