### PR TITLE
chore: make every issue template apply a label that exists

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug report
 description: Something is broken or behaves unexpectedly
 title: "[Bug]: "
-labels: [bug, needs-triage]
+labels: [bug]
 assignees: []
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: Suggest a new feature or an improvement
 title: "[Feature]: "
-labels: ["enhancement", "needs-triage"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/general_issue.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue.yml
@@ -1,7 +1,7 @@
 name: Report a bug or general issue
 description: Report a crash, stability problem, unexpected behaviour, or anything else
 title: "[Issue]: "
-labels: [needs-triage]
+labels: [bug]
 assignees: []
 body:
   - type: markdown

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -898,6 +898,102 @@ public partial class ArchitectureTests
     private static partial Regex CategoryLink();
 
     /// <summary>
+    /// Every issue template must apply at least one label, and every label it names must be one this
+    /// repository actually defines.
+    /// </summary>
+    /// <remarks>
+    /// GitHub SILENTLY DROPS a label a template names but the repository does not define. All three
+    /// templates asked for <c>needs-triage</c>, which never existed here, so <c>bug_report</c> applied
+    /// only <c>bug</c>, <c>feature_request</c> only <c>enhancement</c>, and <c>general_issue</c> — whose
+    /// sole label it was — applied NOTHING. Every issue opened through the template a reporter is most
+    /// likely to pick arrived unlabelled, and no error said so.
+    /// <para>The label list is held here rather than fetched, because a unit test must not depend on the
+    /// network or on a token. That makes it a ratchet: naming a new label in a template fails this test
+    /// until someone adds it here, which is the moment to check the label exists.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryIssueTemplate_AppliesALabelThisRepositoryDefines()
+    {
+        string[] defined =
+        [
+            "bug", "documentation", "duplicate", "enhancement", "good first issue", "help wanted",
+            "invalid", "manual", "performance", "question", "security", "ux", "wontfix",
+        ];
+
+        var dir = Path.Combine(FindRepoRoot(), ".github", "ISSUE_TEMPLATE");
+        var offenders = new List<string>();
+        var templates = 0;
+        var matched = 0;
+        var labelsChecked = 0;
+
+        foreach (var path in Directory.EnumerateFiles(dir, "*.yml").OrderBy(p => p, StringComparer.Ordinal))
+        {
+            var name = Path.GetFileName(path);
+            // config.yml is the chooser, not a template: it has no labels: key and is not meant to.
+            if (name.Equals("config.yml", StringComparison.OrdinalIgnoreCase)) continue;
+
+            templates++;
+            var declared = TemplateLabels().Match(File.ReadAllText(path));
+            if (!declared.Success)
+            {
+                offenders.Add($"{name} declares no labels: key, so issues from it arrive unlabelled");
+                continue;
+            }
+
+            matched++;
+            var labels = declared.Groups["list"].Value
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(l => l.Trim('"', '\''))
+                .Where(l => l.Length > 0)
+                .ToArray();
+
+            if (labels.Length == 0)
+            {
+                offenders.Add($"{name} has an empty labels: list, so issues from it arrive unlabelled");
+                continue;
+            }
+
+            foreach (var label in labels)
+            {
+                labelsChecked++;
+                if (!defined.Contains(label, StringComparer.Ordinal))
+                {
+                    offenders.Add($"{name} asks for '{label}', which this repository does not define — "
+                                  + "GitHub will drop it without an error");
+                }
+            }
+        }
+
+        // Three assertions, in this order, because each has to be able to name its own cause.
+        //
+        // The first draft put a `labelsChecked >= 3` floor ahead of the rule. There are exactly three
+        // labels across the three templates, so emptying one dropped the count to 2 and the FLOOR fired
+        // first — reporting "the pattern is broken, not the templates" about a genuinely broken template.
+        // A floor set that tight cannot coexist with the rule it protects; found by mutating a template
+        // and reading which message came back.
+        Assert.True(templates >= 3,
+            $"only {templates} issue template(s) were found — the path is wrong, not the templates.");
+
+        // A pattern that stopped matching reports every template as unlabelled, which reads as three
+        // broken templates rather than one broken regex. None matching AT ALL is the pattern's fault.
+        Assert.True(matched > 0,
+            $"the labels: pattern matched none of the {templates} templates — the pattern is broken, "
+            + "not the templates.");
+
+        Assert.True(offenders.Count == 0,
+            "an issue template applies a label that does not exist, or none at all:\n  "
+            + string.Join("\n  ", offenders)
+            + $"\n({templates} templates, {matched} with a labels: key, {labelsChecked} labels checked)");
+    }
+
+    /// <summary>
+    /// The <c>labels:</c> list at the top of an issue-form template, in either YAML flow style
+    /// (<c>[bug, ux]</c> or <c>["bug", "ux"]</c>).
+    /// </summary>
+    [GeneratedRegex(@"^labels:\s*\[(?<list>[^\]]*)\]\s*$", RegexOptions.Multiline)]
+    private static partial Regex TemplateLabels();
+
+    /// <summary>
     /// A field a search box matches against must be visible somewhere in that tab's view. Otherwise the
     /// user is invited to filter by text the app never shows them — and it hides a whole unreachable
     /// field: the Process Manager loaded a plain-English description and a category from its 108-entry


### PR DESCRIPTION
All three issue templates asked for `needs-triage`. This repository has never
defined it. GitHub drops a label a template names but the repo does not have, and
says nothing, so the effect was invisible in the template and visible only on the
issues:

  bug_report.yml      labels: [bug, needs-triage]           -> applied `bug`
  feature_request.yml labels: ["enhancement", ...]          -> applied `enhancement`
  general_issue.yml   labels: [needs-triage]                -> applied NOTHING

The third is the one that matters. `general_issue.yml` is titled "Report a bug or
general issue" and covers crashes, freezes and stability problems, and
`blank_issues_enabled: false` makes the chooser the only route in — so the template
a reporter is most likely to pick produced unlabelled issues, every time.

Removed rather than created, because nothing here consumes it. The label scheme this
project documents is base type (`bug`, `enhancement`, `documentation`, `manual`) plus
`performance` / `security` / `ux` as combiners, with an explicit instruction to keep
labels minimal. `needs-triage` is not part of it, no automation reads it, and there
is one maintainer who sees every issue — so a label that lands on every new issue and
nobody clears is noise, not triage. `general_issue.yml` gets `bug`, which is the
accurate base type for what it collects.

Guarded, since the failure mode is silence: nothing in the repo or on GitHub reports
a dropped label, so this can only be caught by asserting it. The list of defined
labels is held in the test rather than fetched -- a unit test must not need the
network or a token -- which makes it a ratchet: naming a new label in a template
fails until someone adds it here, and that is the moment to check the label exists.

The red run corrected the guard twice, both times about the guard rather than the
templates:

  - A `labelsChecked >= 3` floor sat ahead of the rule. There are exactly three labels
    across three templates, so emptying one dropped the count to 2 and the FLOOR
    answered first -- reporting "the pattern is broken, not the templates" about a
    template that was genuinely broken. A floor sized to the exact population cannot
    coexist with the rule it protects.
  - Replaced with "did the pattern match ANY template at all", which is the question a
    floor should ask. A broken regex now says so; a broken template says so; and they
    no longer answer for each other.

Four mutations, each now red with its true cause: needs-triage restored (names an
undefined label), the list emptied (arrives unlabelled), the labels: key removed
(declares none), and the pattern broken (matched no template at all). Restore
byte-for-byte, green after. 77 green on the 72-method architecture sweep; the 2 reds
are the local runner's own artefacts and are green in CI.

The 13 labels in the list were read from the live label set in this session, not from
memory.

No release: chore: is not a release type here.
