### PR TITLE
fix: carry the app-icon fetching choice in an exported profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.31] - 2026-09-02
+
+Exporting your settings and importing them on another PC carried everything except one choice: whether
+the Bulk Installer may download app icons from the web. That one was quietly reset to off. It travels
+with the profile now.
+
+### Fixed
+- **A profile now carries your app-icon choice.** Every other preference the app remembers was included
+  in an exported profile — theme, dark-mode schedule, gaming profiles, volume presets, close-button
+  behaviour, standby memory, the update check — but the "Load app icons from the web" switch was not, so
+  importing on a second PC left it off no matter what you had chosen. It is a choice like the others and
+  is now part of the export. As with everything in a profile, restart SysManager afterwards for it to
+  take effect.
+
 ## [1.75.30] - 2026-09-02
 
 In Task Scheduler, the "What it does" column was simply blank for most tasks, because Windows never

--- a/README.md
+++ b/README.md
@@ -989,7 +989,7 @@ offers, "rate us" prompts:
 - Export your SysManager settings to a single portable JSON file and import them on
   another PC: **theme and appearance, dark-mode schedule, gaming profiles, volume
   presets, close-button behaviour, standby-memory preference, update-check preference,
-  and speed-test history**
+  app-icon fetching preference, and speed-test history**
 - **Selective export** (tick which sections to include) and **selective import**
   (confirm what a profile contains before anything is overwritten)
 - **Version-aware** — refuses profiles created by a newer, incompatible build

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -898,6 +898,99 @@ public partial class ArchitectureTests
     private static partial Regex CategoryLink();
 
     /// <summary>
+    /// Every JSON file the services persist must be a decision: carried by a profile, or deliberately
+    /// left out of one. A new state file that is neither is a silent gap.
+    /// </summary>
+    /// <remarks>
+    /// The app writes 18 distinct JSON files under its config folders and a profile carries 9 of them.
+    /// What kept the other 9 out was their absence from a list — nothing asserted the absence was
+    /// intentional, so a 19th could be added and never classified. That is how <c>icon-fetch.json</c>
+    /// went unnoticed: it holds the network-consent bit for icon fetching, it is a user preference by any
+    /// reading, and a profile silently reset it.
+    /// <para>The excluded set is read by reflection from
+    /// <see cref="ProfileServiceTests.AvailableSections_NeverCarriesMachineSpecificState"/>'s own
+    /// <c>[InlineData]</c> rows rather than restated here. Two copies of that list would drift, and the
+    /// drift would be invisible: this guard would pass on a file the other test no longer covers.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryPersistedStateFile_IsEitherInAProfileOrDeliberatelyNot()
+    {
+        // Not persisted state at all, with the reason. Anything added here is claiming "this literal is
+        // not a file this app writes", which is checkable by reading the owning service.
+        var notState = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["ProcessDescriptions.json"] =
+                "an embedded resource read through GetManifestResourceStream — shipped data, never written",
+        };
+
+        var services = Path.Combine(FindAppProjectDir(), "Services");
+        var catalog = File.ReadAllText(Path.Combine(services, "ProfileService.cs"));
+        var carried = JsonStateFile().Matches(catalog).Cast<Match>()
+            .Select(m => m.Groups[1].Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var excluded = typeof(ProfileServiceTests)
+            .GetMethod(nameof(ProfileServiceTests.AvailableSections_NeverCarriesMachineSpecificState))!
+            .GetCustomAttributes<Xunit.InlineDataAttribute>()
+            .Select(a => (string)a.GetData(null!).First()[0]!)
+            .ToHashSet(StringComparer.Ordinal);
+
+        // Both sources must yield SOMETHING, and deliberately not a population-sized floor. A floor of
+        // "at least 9 exclusions" would fire the moment someone deletes one row — reporting "the
+        // reflection is broken" about a file that had simply stopped being classified, which is the
+        // report the rule below gives correctly and by name. Only "read nothing at all" is this check's
+        // business.
+        Assert.True(carried.Count > 0,
+            "no files were parsed out of the profile catalog — its shape changed and this guard is no "
+            + "longer reading it.");
+        Assert.True(excluded.Count > 0,
+            "no deliberate exclusions were read from the machine-specific theory — the reflection is "
+            + "broken, not the code.");
+
+        var unclassified = new List<string>();
+        var literals = 0;
+
+        foreach (var path in Directory.EnumerateFiles(services, "*.cs")
+                     .OrderBy(p => p, StringComparer.Ordinal))
+        {
+            // Comment lines dropped: several services name a sibling's file in prose to explain a
+            // convention, and prose is not persistence.
+            var code = string.Join('\n', File.ReadAllLines(path)
+                .Where(l => !l.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+
+            foreach (var match in JsonStateFile().Matches(code).Cast<Match>())
+            {
+                var file = match.Groups[1].Value;
+                literals++;
+                if (carried.Contains(file) || excluded.Contains(file) || notState.ContainsKey(file)) continue;
+                unclassified.Add($"{file}  (written by {Path.GetFileName(path)})");
+            }
+        }
+
+        Assert.True(literals >= 15,
+            $"only {literals} .json literals were found across Services/ — the pattern is broken, not "
+            + "the code.");
+
+        // "named by", not "persisted by": this cannot tell a write from a read, which is precisely why
+        // the third option exists. Naming all three keeps the reader from assuming the only fix is a
+        // catalog entry.
+        Assert.True(unclassified.Count == 0,
+            "these JSON files are named by a service and appear in none of the three lists, so nobody has "
+            + "decided whether a profile should carry them — add a catalog entry, an [InlineData] row on "
+            + "AvailableSections_NeverCarriesMachineSpecificState with the reason, or an entry in this "
+            + "guard's notState map if it is not a file the app writes at all:\n  "
+            + string.Join("\n  ", unclassified.Distinct(StringComparer.Ordinal))
+            + $"\n({literals} literals seen, {carried.Count} carried, {excluded.Count} excluded)");
+    }
+
+    /// <summary>
+    /// A JSON file name in a string literal. Deliberately narrow: it must start with an alphanumeric, so
+    /// a path fragment or a format string is not mistaken for a file the app persists.
+    /// </summary>
+    [GeneratedRegex(@"""([A-Za-z0-9][A-Za-z0-9._-]*\.json)""", RegexOptions.Compiled)]
+    private static partial Regex JsonStateFile();
+
+    /// <summary>
     /// Every issue template must apply at least one label, and every label it names must be one this
     /// repository actually defines.
     /// </summary>

--- a/SysManager/SysManager.Tests/ProfileServiceTests.cs
+++ b/SysManager/SysManager.Tests/ProfileServiceTests.cs
@@ -233,7 +233,7 @@ public class ProfileServiceTests : IDisposable
         [
             "theme.json", "speedtest-history.json", "update-check.json", "darkmode-schedule.json",
             "gaming-profiles.json", "volume-presets.json", "close-preference.json",
-            "standby-preference.json",
+            "standby-preference.json", "icon-fetch.json",
         ];
         foreach (var f in files) WriteConfig(f, "{}");
 
@@ -241,7 +241,8 @@ public class ProfileServiceTests : IDisposable
 
         Assert.Equal(files.Length, keys.Length);
         Assert.Equal(
-            new[] { "closebehaviour", "darkmode", "gaming", "speedtest", "standby", "theme", "updatecheck", "volume" },
+            new[] { "appicons", "closebehaviour", "darkmode", "gaming", "speedtest", "standby", "theme",
+                    "updatecheck", "volume" },
             keys);
     }
 
@@ -259,6 +260,9 @@ public class ProfileServiceTests : IDisposable
     [InlineData("activity.json")]
     [InlineData("resource-history-config.json")]
     [InlineData("disk-scan-history.json")]   // folder paths + sizes on THIS disk; meaningless on another PC
+    // A count of how many times the master toggle was written on THIS machine, used to decide whether a
+    // restore point is still needed. Carried over, it would claim work had been done here that was not.
+    [InlineData("notification-master-writes.json")]
     public void AvailableSections_NeverCarriesMachineSpecificState(string fileName)
     {
         WriteConfig(fileName, "{\"machine\":\"specific\"}");

--- a/SysManager/SysManager/Services/ProfileService.cs
+++ b/SysManager/SysManager/Services/ProfileService.cs
@@ -73,6 +73,12 @@ public sealed class ProfileService
         ("volume", "Volume presets", "volume-presets.json", Base.Local, null),   // VolumePresetService → Local
         ("closebehaviour", "Close-button behaviour", "close-preference.json", Base.Local, null), // ClosePreferenceService → Local
         ("standby", "Standby-memory preference", "standby-preference.json", Base.Local, null), // StandbyPreferenceService → Local
+        // AppIconService → Local. This is a consent bit, not a cache: it records whether the Bulk
+        // Installer may fetch icons from the web, and it defaults to off. It was the only user
+        // preference the app persists that a profile did not carry, so exporting on one PC and
+        // importing on another silently reset the choice — the same shape as "updatecheck", which is
+        // also a network-consent preference and has always been carried.
+        ("appicons", "App-icon fetching", "icon-fetch.json", Base.Local, null),
     ];
 
     /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.30</Version>
-    <FileVersion>1.75.30.0</FileVersion>
-    <AssemblyVersion>1.75.30.0</AssemblyVersion>
+    <Version>1.75.31</Version>
+    <FileVersion>1.75.31.0</FileVersion>
+    <AssemblyVersion>1.75.31.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Every preference the app persists was carried by Profile Export/Import except one:
`icon-fetch.json`, the consent bit for downloading app icons from the web. Export on
one PC, import on another, and that choice was silently back to off.

It is a preference, not a cache. AppIconService writes
`IconFetchPreference(NetworkFetchEnabled)` from `SetNetworkFetchEnabled` and reads it
back in its constructor; the cached icons live separately under `IconCache`. The
closest precedent settles the question of whether a network-consent bit belongs in a
profile: `update-check.json` is also network consent, also defaults to a conservative
value, and has always been carried. Catalogued as Base.Local, which is where the file
actually lives.

Found by re-checking #1648, which asked for a generic app-level state service to hold
a "user has seen X" bit. That premise has moved. Three purpose-built preference
services have appeared since it was filed (close, standby, update-check), each with an
injectable config dir and its own tests, so a new preference bit has a clear pattern
to copy and nothing is blocked. Building `AppStateService` with an
`OnboardingSeenVersion` nobody reads would be placeholder code for an onboarding
feature that does not exist. What the issue's premise actually pointed at, once
measured, was this: 18 JSON state files, 8 carried by a profile, and no mechanism
requiring the other 10 to be a decision rather than an oversight.

So the guard is the substance here. `EveryPersistedStateFile_IsEitherInAProfileOrDeliberatelyNot`
requires every JSON file named by a service to be in one of three lists: the profile
catalog, the machine-specific exclusions, or a small map of literals that are not
files the app writes at all — currently just `ProcessDescriptions.json`, an embedded
resource read through `GetManifestResourceStream`. A nineteenth state file now fails
the build until someone classifies it.

The excluded set is read by REFLECTION from
`AvailableSections_NeverCarriesMachineSpecificState`'s own `[InlineData]` rows rather
than restated. Two copies would drift, and the drift would be invisible in the worst
direction: this guard would pass on a file the other test had stopped covering.

`notification-master-writes.json` is added to those rows with its reason — it counts
how many times the master toggle was written on THIS machine, so carried over it would
claim work had been done here that was not.

One correction applied from a lesson learned earlier today rather than from this run:
the floors are `> 0`, not `>= 8` and `>= 9`. A floor sized to the exact population
fires the moment a real violation shrinks it, and then answers with the wrong cause —
"the reflection is broken" about a file that had simply stopped being classified.
Mutation C is that exact case and now names the file.

Red/green, five mutations, all as expected: the catalog entry removed (names
icon-fetch.json), a brand-new state file appearing unclassified, an exclusion row
deleted, the literal pattern broken (the catalog read empties first, which is the
honest cause — a guard that cannot read the catalog cannot judge anything), and the
embedded-resource entry removed. Restore byte-for-byte, 2 green after.

Two proof-script errors are worth recording, because both produced a result that looked
like a finding: dropping only the KEY line of the not-state entry left an orphaned
string and reported BUILD FAILED, and mutation D was written expecting the wrong
message.

Considered and not done: a guard tying the README's profile list to the catalog. The
README deliberately reads friendlier than the catalog labels ("theme and appearance"
vs "Theme & appearance"), so a guard over that prose would be either brittle or
vacuous. The README line is updated here and is visible in the diff.

Regression: 36 green across the profile and icon-service suites, 80 green on the
75-method architecture sweep — the 2 reds are the local runner's own artefacts and are
green in CI — app and tests build with 0 warnings.
