### PR TITLE
fix: make the appearance popup reachable and dismissable from the keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.75.32] - 2026-09-02
+
+If you opened the appearance panel with the keyboard, you landed nowhere: the panel appeared but the
+keyboard was still outside it, so you could not reach any of the themes, and there was no key that closed
+it again. Opening it now puts you inside it, Tab moves between the themes, and Escape closes it.
+
+### Fixed
+- **The appearance panel can now be used without a mouse.** Every theme in that panel was already set up
+  to be reached with Tab and chosen with Enter, but opening the panel never moved the keyboard into it, so
+  none of that could be got at — and nothing closed the panel except clicking outside it. Escape now
+  closes it and returns you to the button you opened it from, so the next Tab carries on where you were
+  instead of starting again at the top of the window.
+
 ## [1.75.31] - 2026-09-02
 
 Exporting your settings and importing them on another PC carried everything except one choice: whether

--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ changes at all.
 The app is operable without a mouse, and the control you are on is always visible. `Tab` moves
 forward, `Shift+Tab` back, `Space` presses a button or ticks a checkbox, and the arrow keys move
 within a table or a row of filter chips. In the sidebar, `Enter` also opens the tab or group you are
-on, the way it opens a folder in File Explorer.
+on, the way it opens a folder in File Explorer. Opening the appearance panel moves focus into it, `Tab`
+cycles the themes inside it, and `Escape` closes it and puts focus back on the button you opened it from.
 
 The focus outline is deliberately two thin lines of opposite shade — one light, one dark — rather
 than a single accent-coloured ring. A single colour cannot be visible everywhere: it has to show up

--- a/SysManager/SysManager.Tests/SidebarSelectionContractTests.cs
+++ b/SysManager/SysManager.Tests/SidebarSelectionContractTests.cs
@@ -276,6 +276,51 @@ public class SidebarSelectionContractTests
                 (string?)setter.Attribute("Property") == property
                 && (string?)setter.Attribute("Value") == value);
 
+    /// <summary>
+    /// The appearance popup must take focus when it opens, give it back when it closes, and close on
+    /// Escape.
+    /// </summary>
+    /// <remarks>
+    /// A <c>Popup</c> is not a <c>Window</c>: it gets no Escape-to-close and no focus containment. Every
+    /// preset card inside was already <c>Focusable</c>, a tab stop, and Enter-activatable — someone had
+    /// clearly built for the keyboard — but opening the panel left focus behind on the chip, so none of
+    /// it could be reached and there was no way out but the mouse. <c>Key.Escape</c> appeared nowhere in
+    /// the app.
+    /// <para>Asserted rather than demonstrated: the behaviour needs the app running, which happens on the
+    /// other workstation. What is pinned here is the wiring that makes it possible, on both sides — the
+    /// XAML hooks and the handlers they name. Half of it is useless alone: an <c>Opened</c> attribute
+    /// with a handler that does not move focus reads as fixed and is not.</para>
+    /// </remarks>
+    [Fact]
+    public void TheAppearancePopup_TakesFocusAndGivesItBack()
+    {
+        var document = LoadProjectXaml("MainWindow.xaml");
+        var popup = document
+            .Descendants(Presentation + "Popup")
+            .Single(element => (string?)element.Attribute(Xaml + "Name") == "ThemePopupHost");
+
+        Assert.Equal("True", (string?)popup.Attribute("Focusable"));
+        // Without Cycle, Tab walks out of the panel and behind it, which is worse than not focusing it.
+        Assert.Equal("Cycle", (string?)popup.Attribute("KeyboardNavigation.TabNavigation"));
+        Assert.Equal("ThemePopupHost_Opened", (string?)popup.Attribute("Opened"));
+        Assert.Equal("ThemePopupHost_Closed", (string?)popup.Attribute("Closed"));
+
+        // The handlers have to DO the thing. Comments are stripped first: this file explains the focus
+        // moves in prose beside them, and a Contains against the raw text would be satisfied by the
+        // explanation of a handler that had been emptied.
+        var code = string.Join('\n', LoadProjectSource("MainWindow.xaml.cs")
+            .Where(l => !l.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+
+        Assert.Contains("MoveFocus(new TraversalRequest(FocusNavigationDirection.First))", code,
+                        StringComparison.Ordinal);
+        Assert.Contains("ThemePopupHost_Closed(object sender, EventArgs e) => ThemeBtn.Focus()", code,
+                        StringComparison.Ordinal);
+        // Escape must be handled on the CHILD: with AllowsTransparency the popup has its own
+        // PresentationSource, so a handler on the Popup element never sees the key.
+        Assert.Contains("popup.PreviewKeyDown += ThemePopup_PreviewKeyDown", code, StringComparison.Ordinal);
+        Assert.Contains("Key.Escape", code, StringComparison.Ordinal);
+    }
+
     private static XDocument LoadProjectXaml(string fileName)
     {
         for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
@@ -284,6 +329,19 @@ public class SidebarSelectionContractTests
         {
             var candidate = Path.Combine(directory.FullName, "SysManager", fileName);
             if (File.Exists(candidate)) return XDocument.Load(candidate);
+        }
+
+        throw new FileNotFoundException($"Could not locate SysManager/{fileName} from the test output.");
+    }
+
+    private static string[] LoadProjectSource(string fileName)
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory is not null;
+             directory = directory.Parent)
+        {
+            var candidate = Path.Combine(directory.FullName, "SysManager", fileName);
+            if (File.Exists(candidate)) return File.ReadAllLines(candidate);
         }
 
         throw new FileNotFoundException($"Could not locate SysManager/{fileName} from the test output.");

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -415,8 +415,16 @@
                         </Border>
                     </Grid>
                     <!-- Theme popup -->
+                    <!-- A Popup is not a Window: it gets no Escape-to-close and no focus containment of
+                         its own. Every preset card inside is already Focusable, a tab stop, and
+                         Enter-activatable, and none of that was reachable, because opening the panel left
+                         focus behind on the chip. TabNavigation=Cycle keeps Tab inside the panel instead
+                         of walking out behind it; Opened moves focus in; Closed puts it back on the chip,
+                         so dismissing does not leave focus nowhere. -->
                     <Popup x:Name="ThemePopupHost" Placement="Top" PlacementTarget="{Binding ElementName=ThemeBtn}"
                            StaysOpen="False" AllowsTransparency="True" PopupAnimation="Fade"
+                           Focusable="True" KeyboardNavigation.TabNavigation="Cycle"
+                           Opened="ThemePopupHost_Opened" Closed="ThemePopupHost_Closed"
                            HorizontalOffset="0" VerticalOffset="-8"/>
                 </StackPanel>
             </Grid>

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -281,7 +281,33 @@ public partial class MainWindow : Window
     private void ToggleThemePopup()
     {
         if (ThemePopupHost.Child is null)
-            ThemePopupHost.Child = new Views.ThemePopup();
+        {
+            var popup = new Views.ThemePopup();
+            // Escape is handled on the CHILD, not on the Popup. With AllowsTransparency the popup lives
+            // in its own PresentationSource, so key events route through the child's tree; a handler on
+            // the Popup element itself never sees them.
+            popup.PreviewKeyDown += ThemePopup_PreviewKeyDown;
+            ThemePopupHost.Child = popup;
+        }
+
         ThemePopupHost.IsOpen = !ThemePopupHost.IsOpen;
+    }
+
+    // Focus is moved on Opened rather than straight after setting IsOpen: at that point the child has
+    // been realised, so there is something focusable to move to.
+    private void ThemePopupHost_Opened(object sender, EventArgs e) =>
+        ThemePopupHost.Child?.MoveFocus(new TraversalRequest(FocusNavigationDirection.First));
+
+    // Covers both exits — Escape below and the outside click StaysOpen="False" already handles. Without
+    // it, focus is left on a panel that no longer exists and the next Tab restarts from the top of the
+    // window. Selecting a preset does NOT close the popup, so this does not fight trying several themes.
+    private void ThemePopupHost_Closed(object sender, EventArgs e) => ThemeBtn.Focus();
+
+    private void ThemePopup_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key is not Key.Escape) return;
+
+        ThemePopupHost.IsOpen = false;
+        e.Handled = true;
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.31</Version>
-    <FileVersion>1.75.31.0</FileVersion>
-    <AssemblyVersion>1.75.31.0</AssemblyVersion>
+    <Version>1.75.32</Version>
+    <FileVersion>1.75.32.0</FileVersion>
+    <AssemblyVersion>1.75.32.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #1560.

Opening the theme panel with the keyboard put you in front of a panel you were not
in. A `Popup` is not a `Window`: it gets no Escape-to-close and no focus containment,
and `ToggleThemePopup()` only set `IsOpen`. So focus stayed on the chip behind it,
and nothing closed the panel but a mouse click somewhere else. `Key.Escape` appeared
nowhere in the app — zero hits across the whole solution.

The frustrating part is that the panel was already built for the keyboard. Every
preset card is `Focusable`, a tab stop, and Enter/Space-activatable, and each carries
an `AutomationProperties.Name`. Someone did that work deliberately and none of it
could be reached, because the one step that hands focus over was missing.

Three hooks, all on the existing handler:

  Opened   moves focus into the child. On Opened rather than straight after setting
           IsOpen, because only by then has the child been realised and is there
           something focusable to move to.
  Closed   puts focus back on the chip. This covers BOTH exits — Escape below and the
           outside click that StaysOpen="False" already handled — and without it focus
           is left on a panel that no longer exists, so the next Tab restarts from the
           top of the window.
  Escape   on the child, not on the Popup. With AllowsTransparency the popup has its
           own PresentationSource, so key events route through the child's tree and a
           handler on the Popup element never sees them.

`KeyboardNavigation.TabNavigation="Cycle"` on the Popup keeps Tab inside the panel.
Without it, focusing the panel and then tabbing walks out behind it, which is worse
than not focusing it at all.

Selecting a preset does not close the popup — deliberate, so you can try several
themes — so restoring focus on Closed does not fight that.

Guarded on both sides, because half of this wiring is useless alone: an `Opened`
attribute whose handler does not move focus reads as fixed and is not. The XAML hooks
are asserted with XDocument (whitespace-insensitive), and the handlers are asserted to
actually do the thing, with comment lines stripped first — this file explains the focus
moves in prose right beside them, and a Contains against the raw text would be
satisfied by the explanation of a handler that had been emptied.

Red/green, six mutations, all red: Focusable removed, Cycle removed, the Opened hook
removed, the Opened handler emptied while the XAML still looks right, the Closed
handler emptied, and Escape swapped for another key. Restore byte-for-byte, green
after.

One proof error worth recording: the first version of mutation A removed the FIRST
` Focusable="True"` in MainWindow.xaml, which belongs to the chip, not the Popup — and
the guard stayed green, correctly, because the Popup was untouched. Anchoring on the
`Focusable` + `TabNavigation` pair, which occurs only on the Popup, made it falsifiable.

Not verifiable here: whether focus visibly lands where it should needs the app running,
which needs the app actually running. What is pinned mechanically is the wiring that makes it
possible; the hands-on check — open with Enter, Tab through the themes, Escape, confirm
focus is back on the chip — is still worth doing there.

Regression: 10 green across the sidebar and appearance contract suites, 80 green on the
75-method architecture sweep (the 2 reds are the local runner's own artefacts, green in
CI), app and tests build with 0 warnings.
